### PR TITLE
Allow CodeRabbit to satisfy the review gate

### DIFF
--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -45,6 +45,28 @@ jobs:
                     labels(first: 100) {
                       nodes { name }
                     }
+                    commits(last: 1) {
+                      nodes {
+                        commit {
+                          statusCheckRollup {
+                            contexts(first: 100) {
+                              nodes {
+                                __typename
+                                ... on StatusContext {
+                                  context
+                                  state
+                                }
+                                ... on CheckRun {
+                                  name
+                                  conclusion
+                                  status
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
                     reviewThreads(first: 100) {
                       nodes { isResolved }
                     }
@@ -67,12 +89,25 @@ jobs:
 
             const labels = pullRequest.labels.nodes.map((label) => label.name);
             const unresolved = pullRequest.reviewThreads.nodes.filter((thread) => !thread.isResolved).length;
+            const statusNodes =
+              pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? [];
+            const codeRabbitPassed = statusNodes.some((node) => {
+              if (node.__typename === "StatusContext") {
+                return node.context === "CodeRabbit" && node.state === "SUCCESS";
+              }
+              if (node.__typename === "CheckRun") {
+                return node.name === "CodeRabbit" && node.conclusion === "SUCCESS";
+              }
+              return false;
+            });
 
             const approvedByReviewBot =
-              labels.includes("codex-reviewed") || labels.includes("coderabbitai-reviewed");
+              labels.includes("codex-reviewed") ||
+              labels.includes("coderabbitai-reviewed") ||
+              codeRabbitPassed;
 
             if (!approvedByReviewBot) {
-              core.setFailed("Missing required review label: `codex-reviewed` or `coderabbitai-reviewed`");
+              core.setFailed("Missing required review signal: `codex-reviewed`, `coderabbitai-reviewed`, or successful CodeRabbit status");
               return;
             }
 


### PR DESCRIPTION
## Summary
- let `Codex Review Gate` pass when either a Codex review label is present or `CodeRabbit` has a successful status
- keep unresolved review conversations as a hard blocker
- preserve the required build checks on `main`

## Notes
- this finishes the policy adjustment so one of the two reviewers is enough
- after merge, branch protection should continue to require only `Codex Review Gate`, `Server Build (JDK 17)`, and `Jakarta Profile (Jetty 12, non-blocking)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request review gate workflow to recognize CodeRabbit status checks as valid approval signals, providing an additional path for pull requests to meet approval requirements beyond existing label-based checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->