### PR TITLE
Restore Jakarta search and stats routes

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -19,12 +19,14 @@ import org.waveprotocol.box.server.frontend.ClientFrontend;
 import org.waveprotocol.box.server.frontend.ClientFrontendImpl;
 import org.waveprotocol.box.server.frontend.WaveClientRpcImpl;
 import org.waveprotocol.box.server.frontend.WaveletInfo;
+import org.waveprotocol.box.server.dev.ClientApplierStatsJakartaServlet;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.PersistenceModule;
 import org.waveprotocol.box.server.persistence.SignerInfoStore;
 import org.waveprotocol.box.server.rpc.*;
 import org.waveprotocol.box.server.robots.ProfileFetcherModule;
+import org.waveprotocol.box.server.robots.JakartaRobotApiBindingsModule;
 import org.waveprotocol.box.server.robots.RobotRegistrationServlet;
 import org.waveprotocol.box.server.shutdown.ShutdownManager;
 import org.waveprotocol.box.server.shutdown.ShutdownPriority;
@@ -91,9 +93,10 @@ public class ServerMain {
     PersistenceModule persistenceModule = injector.getInstance(PersistenceModule.class);
     Module searchModule = injector.getInstance(SearchModule.class);
     Module profileFetcherModule = injector.getInstance(ProfileFetcherModule.class);
+    Module robotApiModule = new JakartaRobotApiBindingsModule();
 
     injector = injector.createChildInjector(serverModule, persistenceModule,
-        searchModule, federationModule, profileFetcherModule);
+        robotApiModule, searchModule, federationModule, profileFetcherModule);
 
     ServerRpcProvider server = injector.getInstance(ServerRpcProvider.class);
     WaveBus waveBus = injector.getInstance(WaveBus.class);
@@ -143,6 +146,7 @@ public class ServerMain {
     server.addServlet("/locale/*", LocaleServlet.class);
     server.addServlet("/fetch/*", FetchServlet.class);
     server.addServlet("/search/*", SearchServlet.class);
+    server.addServlet("/dev/client-applier-stats", ClientApplierStatsJakartaServlet.class);
     server.addServlet("/healthz", HealthServlet.class);
     server.addServlet("/readyz", HealthServlet.class);
     server.addServlet("/profile/*", FetchProfilesServlet.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/dev/ClientApplierStatsJakartaServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/dev/ClientApplierStatsJakartaServlet.java
@@ -1,0 +1,67 @@
+package org.waveprotocol.box.server.dev;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.io.PrintWriter;
+import org.waveprotocol.wave.util.logging.Log;
+
+public final class ClientApplierStatsJakartaServlet extends HttpServlet {
+  private static final Log LOG = Log.get(ClientApplierStatsJakartaServlet.class);
+  private static final String ATTR = "clientApplierStats";
+
+  @Override
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    HttpSession session = req.getSession(true);
+    int applied = parseIntSafe(req.getParameter("applied"), "applied");
+    int rejected = parseIntSafe(req.getParameter("rejected"), "rejected");
+    session.setAttribute(ATTR, new Stats(applied, rejected));
+    resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    HttpSession session = req.getSession(false);
+    Stats stats = session != null ? (Stats) session.getAttribute(ATTR) : null;
+    resp.setContentType("application/json;charset=UTF-8");
+    try (PrintWriter writer = resp.getWriter()) {
+      if (stats == null) {
+        writer.write("{\"applied\":0,\"rejected\":0}");
+      } else {
+        writer.write("{\"applied\":" + stats.applied + ",\"rejected\":" + stats.rejected + "}");
+      }
+    }
+  }
+
+  private static int parseIntSafe(String value, String field) {
+    int parsed = 0;
+    if (value == null) {
+      LOG.fine("client-applier-stats: missing '" + field + "' parameter; defaulting to 0");
+    } else {
+      try {
+        parsed = Integer.parseInt(value.trim());
+      } catch (NumberFormatException e) {
+        LOG.warning("client-applier-stats: invalid integer for '" + field + "': '" + value + "'", e);
+        parsed = 0;
+      } catch (Throwable t) {
+        LOG.warning("client-applier-stats: error parsing '" + field + "': '" + value + "'", t);
+        parsed = 0;
+      }
+    }
+    return parsed;
+  }
+
+  private static final class Stats implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int applied;
+    private final int rejected;
+
+    private Stats(int applied, int rejected) {
+      this.applied = applied;
+      this.rejected = rejected;
+    }
+  }
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/JakartaRobotApiBindingsModule.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/JakartaRobotApiBindingsModule.java
@@ -1,0 +1,34 @@
+package org.waveprotocol.box.server.robots;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.wave.api.data.converter.EventDataConverterModule;
+import org.waveprotocol.box.server.robots.active.ActiveApiOperationServiceRegistry;
+import org.waveprotocol.box.server.robots.dataapi.DataApiOperationServiceRegistry;
+
+public final class JakartaRobotApiBindingsModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    install(new EventDataConverterModule());
+  }
+
+  @Provides
+  @Singleton
+  @Inject
+  @Named("ActiveApiRegistry")
+  protected OperationServiceRegistry provideActiveApiRegistry(Injector injector) {
+    return new ActiveApiOperationServiceRegistry(injector);
+  }
+
+  @Provides
+  @Singleton
+  @Inject
+  @Named("DataApiRegistry")
+  protected OperationServiceRegistry provideDataApiRegistry(Injector injector) {
+    return new DataApiOperationServiceRegistry(injector);
+  }
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/ClientApplierStatsJakartaIT.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/ClientApplierStatsJakartaIT.java
@@ -1,0 +1,89 @@
+package org.waveprotocol.box.server.jakarta;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.waveprotocol.box.server.dev.ClientApplierStatsJakartaServlet;
+
+public class ClientApplierStatsJakartaIT {
+  private Server server;
+  private int port;
+
+  @Before
+  public void startServer() throws Exception {
+    port = reservePort();
+    server = new Server();
+    ServerConnector connector = new ServerConnector(server);
+    connector.setPort(port);
+    server.addConnector(connector);
+    ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+    context.setContextPath("/");
+    context.addServlet(ClientApplierStatsJakartaServlet.class, "/dev/client-applier-stats");
+    server.setHandler(context);
+    server.start();
+  }
+
+  @After
+  public void stopServer() throws Exception {
+    if (server != null) {
+      server.stop();
+      server.join();
+    }
+  }
+
+  @Test
+  public void postThenGetReturnsStoredStats() throws Exception {
+    HttpURLConnection post = open("/dev/client-applier-stats", "POST");
+    post.setDoOutput(true);
+    post.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+    try (OutputStream out = post.getOutputStream()) {
+      out.write("applied=7&rejected=2".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+    assertEquals(204, post.getResponseCode());
+    String cookie = post.getHeaderField("Set-Cookie");
+    assertTrue(cookie != null && !cookie.isEmpty());
+
+    HttpURLConnection get = open("/dev/client-applier-stats", "GET");
+    get.setRequestProperty("Cookie", cookie);
+    assertEquals(200, get.getResponseCode());
+    assertEquals("application/json;charset=UTF-8", get.getContentType());
+    assertEquals("{\"applied\":7,\"rejected\":2}", slurp(get));
+  }
+
+  private HttpURLConnection open(String path, String method) throws Exception {
+    URL url = new URL("http://localhost:" + port + path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod(method);
+    return connection;
+  }
+
+  private static String slurp(HttpURLConnection connection) throws Exception {
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(connection.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
+      StringBuilder builder = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        builder.append(line);
+      }
+      return builder.toString();
+    }
+  }
+
+  private static int reservePort() throws Exception {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- restore the Jakarta bindings needed for SearchServlet on /search
- add a Jakarta servlet for /dev/client-applier-stats
- add a focused Jakarta IT for the stats servlet

## Verification
- ./gradlew --no-daemon --warning-mode all :wave:testJakartaIT --tests org.waveprotocol.box.server.jakarta.ClientApplierStatsJakartaIT --tests org.waveprotocol.box.server.jakarta.SearchServletJakartaIT
- local server login with fresh user, new wave creation, text entry, and endpoint verification
- Claude review: no blockers, ship it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint for tracking client applier statistics, enabling POST requests to record operation metrics and GET requests to retrieve stored statistics.

* **Tests**
  * Added integration test to verify the client applier statistics endpoint functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->