### PR TITLE
Reload per-user inbox views from storage

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -60,36 +60,39 @@ public class MemoryPerUserWaveViewHandlerImpl implements PerUserWaveViewHandler 
   public MemoryPerUserWaveViewHandlerImpl(final WaveMap waveMap) {
     // Let the view expire if it not accessed for some time.
     explicitPerUserWaveViews =
-        CacheBuilder.newBuilder().expireAfterAccess(PER_USER_WAVES_VIEW_CACHE_MINUTES, TimeUnit.MINUTES)
-            .<ParticipantId, Multimap<WaveId, WaveletId>>build(new CacheLoader<ParticipantId, Multimap<WaveId, WaveletId>>() {
+        CacheBuilder.newBuilder().expireAfterAccess(PER_USER_WAVES_VIEW_CACHE_MINUTES,
+            TimeUnit.MINUTES).<ParticipantId, Multimap<WaveId, WaveletId>>build(
+                new CacheLoader<ParticipantId, Multimap<WaveId, WaveletId>>() {
 
-              @Override
-              public Multimap<WaveId, WaveletId> load(final ParticipantId user) {
-                Multimap<WaveId, WaveletId> userView = HashMultimap.create();
+          @Override
+          public Multimap<WaveId, WaveletId> load(final ParticipantId user) {
+            Multimap<WaveId, WaveletId> userView = HashMultimap.create();
+            try {
+              waveMap.loadAllWavelets();
+            } catch (WaveletStateException e) {
+              throw new RuntimeException("Failed to load waves for " + user.getAddress(), e);
+            }
 
-                // Create initial per user waves view by looping over all waves
-                // in the waves store.
-                Map<WaveId, Wave> waves = waveMap.getWaves();
-                for (Map.Entry<WaveId, Wave> entry : waves.entrySet()) {
-                  Wave wave = entry.getValue();
-                  for (WaveletContainer c : wave) {
-                    WaveletId waveletId = c.getWaveletName().waveletId;
-                    try {
-                      if (!c.hasParticipant(user)) {
-                        continue;
-                      }
-                      // Add this wave to the user view.
-                      userView.put(entry.getKey(), waveletId);
-                    } catch (WaveletStateException e) {
-                      LOG.warning("Failed to access wavelet " + c.getWaveletName(), e);
-                    }
+            Map<WaveId, Wave> waves = waveMap.getWaves();
+            for (Map.Entry<WaveId, Wave> entry : waves.entrySet()) {
+              Wave wave = entry.getValue();
+              for (WaveletContainer c : wave) {
+                WaveletId waveletId = c.getWaveletName().waveletId;
+                try {
+                  if (!c.hasParticipant(user)) {
+                    continue;
                   }
+                  userView.put(entry.getKey(), waveletId);
+                } catch (WaveletStateException e) {
+                  LOG.warning("Failed to access wavelet " + c.getWaveletName(), e);
                 }
-                LOG.info("Initalized waves view for user: " + user.getAddress()
-                    + ", number of waves in view: " + userView.size());
-                return userView;
               }
-            });
+            }
+            LOG.info("Initalized waves view for user: " + user.getAddress()
+                + ", number of waves in view: " + userView.size());
+            return userView;
+          }
+        });
   }
 
   @Override

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.persistence.PersistenceException;
+import org.waveprotocol.wave.federation.Proto.ProtocolAppliedWaveletDelta;
+import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.OperationException;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import java.io.IOException;
+import java.security.AccessControlException;
+import java.util.Map;
+
+public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
+
+  private static final String DOMAIN = "example.com";
+  private static final WaveId WAVE_ID = WaveId.of(DOMAIN, "abc123");
+  private static final WaveletId WAVELET_ID = WaveletId.of(DOMAIN, "conv+root");
+  private static final WaveletName WAVELET_NAME = WaveletName.of(WAVE_ID, WAVELET_ID);
+  private static final ParticipantId PARTICIPANT = ParticipantId.ofUnsafe("user1@" + DOMAIN);
+  private static final Config CONFIG = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
+      "core.wave_cache_size", 1000,
+      "core.wave_cache_expire", "60m"));
+  private static final WaveletNotificationSubscriber NO_OP_NOTIFIEE =
+      new WaveletNotificationSubscriber() {
+        @Override
+        public void waveletUpdate(ReadableWaveletData wavelet,
+            ImmutableList<WaveletDeltaRecord> deltas, ImmutableSet<String> domainsToNotify) {
+        }
+
+        @Override
+        public void waveletCommitted(WaveletName waveletName, HashedVersion version,
+            ImmutableSet<String> domainsToNotify) {
+        }
+      };
+
+  private WaveMap waveMap;
+
+  @Override
+  protected void setUp() throws Exception {
+    LocalWaveletContainer.Factory localFactory = new LocalWaveletContainer.Factory() {
+      @Override
+      public LocalWaveletContainer create(WaveletNotificationSubscriber notifiee,
+          WaveletName waveletName, String domain) {
+        return new FakeLocalWavelet(waveletName);
+      }
+    };
+    RemoteWaveletContainer.Factory remoteFactory = new RemoteWaveletContainer.Factory() {
+      @Override
+      public RemoteWaveletContainer create(WaveletNotificationSubscriber notifiee,
+          WaveletName waveletName, String domain) {
+        throw new UnsupportedOperationException();
+      }
+    };
+
+    SettableFuture<ImmutableSet<WaveletId>> lookedupWavelets = SettableFuture.create();
+    lookedupWavelets.set(ImmutableSet.of(WAVELET_ID));
+
+    Wave wave = new Wave(WAVE_ID, lookedupWavelets, NO_OP_NOTIFIEE, localFactory, remoteFactory,
+        DOMAIN);
+    wave.getOrCreateLocalWavelet(WAVELET_ID);
+
+    waveMap = new ReloadingWaveMap(
+        new DeltaStoreBasedSnapshotStore(new org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore()),
+        localFactory, remoteFactory, ImmutableMap.of(WAVE_ID, wave));
+  }
+
+  public void testRetrievePerUserWaveViewReloadsColdWaveMap() {
+    MemoryPerUserWaveViewHandlerImpl handler = new MemoryPerUserWaveViewHandlerImpl(waveMap);
+
+    Multimap<WaveId, WaveletId> waveView = handler.retrievePerUserWaveView(PARTICIPANT);
+
+    assertEquals(1, waveView.size());
+    assertTrue(waveView.containsEntry(WAVE_ID, WAVELET_ID));
+  }
+
+  private static final class ReloadingWaveMap extends WaveMap {
+    private final ImmutableMap<WaveId, Wave> loadedWaves;
+    private boolean loaded;
+
+    private ReloadingWaveMap(DeltaAndSnapshotStore store,
+        LocalWaveletContainer.Factory localFactory, RemoteWaveletContainer.Factory remoteFactory,
+        ImmutableMap<WaveId, Wave> loadedWaves) {
+      super(store, NO_OP_NOTIFIEE, localFactory, remoteFactory, DOMAIN, CONFIG,
+          MoreExecutors.directExecutor());
+      this.loadedWaves = loadedWaves;
+    }
+
+    @Override
+    public void loadAllWavelets() {
+      loaded = true;
+    }
+
+    @Override
+    Map<WaveId, Wave> getWaves() {
+      return loaded ? loadedWaves : ImmutableMap.of();
+    }
+  }
+
+  private static final class FakeLocalWavelet implements LocalWaveletContainer {
+    private final WaveletName waveletName;
+
+    private FakeLocalWavelet(WaveletName waveletName) {
+      this.waveletName = waveletName;
+    }
+
+    @Override
+    public WaveletName getWaveletName() {
+      return waveletName;
+    }
+
+    @Override
+    public ObservableWaveletData copyWaveletData() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CommittedWaveletSnapshot getSnapshot() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T applyFunction(com.google.common.base.Function<ReadableWaveletData, T> function) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void requestHistory(HashedVersion versionStart, HashedVersion versionEnd,
+        Receiver<ByteStringMessage<ProtocolAppliedWaveletDelta>> receiver) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void requestTransformedHistory(HashedVersion versionStart, HashedVersion versionEnd,
+        Receiver<TransformedWaveletDelta> receiver) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkAccessPermission(ParticipantId participantId) {
+      return true;
+    }
+
+    @Override
+    public HashedVersion getLastCommittedVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasParticipant(ParticipantId participant) {
+      return PARTICIPANT.equals(participant);
+    }
+
+    @Override
+    public ParticipantId getCreator() {
+      return PARTICIPANT;
+    }
+
+    @Override
+    public ParticipantId getSharedDomainParticipant() {
+      return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public WaveletDeltaRecord submitRequest(WaveletName waveletName, ProtocolSignedDelta delta)
+        throws OperationException, InvalidProtocolBufferException, InvalidHashException,
+        PersistenceException, WaveletStateException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDeltaSigner(HashedVersion hashedVersion, ByteString signerId) {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild per-user inbox/search views from persisted wave storage instead of only the in-memory WaveMap cache
- fix the empty left-panel/inbox regression after cache eviction or cold node state
- add a targeted regression test for the cold-cache rebuild path

## Verification
- ./gradlew :wave:compileJava
- targeted regression run of MemoryPerUserWaveViewHandlerImplTest
- git diff --check
- Claude review: no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-user wave view loading by explicitly ensuring wavelets are fully loaded before constructing user-specific views, enhancing data consistency and reliability.

* **Tests**
  * Added test coverage for per-user wave view retrieval, validating proper wave map loading behavior when accessing user-specific wave information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->