### PR TITLE
fix: handle Binary type in MongoDB v4 delta deserialization

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStoreUtil.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStoreUtil.java
@@ -276,8 +276,11 @@ public class Mongo4DeltaStoreUtil {
 
   private static DocOp deserializeDocOp(Document document) throws PersistenceException {
     try {
-      return CoreWaveletOperationSerializer.deserialize(ProtocolDocumentOperation
-          .parseFrom(((byte[]) document.get(FIELD_BYTES))));
+      byte[] bytes = deserializeBinary(document.get(FIELD_BYTES));
+      if (bytes == null) {
+        throw new PersistenceException("Missing or invalid '" + FIELD_BYTES + "' in DocOp document");
+      }
+      return CoreWaveletOperationSerializer.deserialize(ProtocolDocumentOperation.parseFrom(bytes));
     } catch (InvalidProtocolBufferException e) {
       throw new PersistenceException(e);
     }


### PR DESCRIPTION
## Summary
Data migrated from file-based store via `DataMigrationTool` uses the legacy v2 MongoDB driver which stores byte arrays as `org.bson.types.Binary` objects. The v4 `Mongo4DeltaStoreUtil.deserializeDocOp()` cast directly to `byte[]`, causing `ClassCastException` on server startup.

Fix: use the existing `deserializeBinary()` helper which handles both `Binary` and `byte[]` types.

## Context
After migrating 207 deltas (10 waves) from file store to MongoDB using `DataMigrationTool`, the server crashed on startup with:
```
ClassCastException: class org.bson.types.Binary cannot be cast to class [B
```

## Test plan
- [ ] CI build passes
- [ ] Deploy and verify server starts with migrated data
- [ ] Verify waves appear in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)