### PR TITLE
feat: create welcome wave for new users on registration

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
@@ -48,17 +48,20 @@ public final class UserRegistrationServlet extends HttpServlet {
   private final String domain;
   private final boolean registrationDisabled;
   private final String analyticsAccount;
+  private final WelcomeWaveCreator welcomeWaveCreator;
 
   @Inject
   public UserRegistrationServlet(AccountStore accountStore,
                                  @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
-                                 Config config) {
+                                 Config config,
+                                 WelcomeWaveCreator welcomeWaveCreator) {
     this.accountStore = accountStore;
     this.domain = domain;
     this.registrationDisabled = config.getBoolean("administration.disable_registration");
     this.analyticsAccount = config.hasPath("administration.analytics_account")
         ? config.getString("administration.analytics_account")
         : "";
+    this.welcomeWaveCreator = welcomeWaveCreator;
   }
 
   @Override
@@ -116,6 +119,12 @@ public final class UserRegistrationServlet extends HttpServlet {
 
     if (!RegistrationSupport.createAccount(accountStore, id, digest)) {
       return "An unexpected error occurred while trying to create the account";
+    }
+
+    try {
+      welcomeWaveCreator.createWelcomeWave(id);
+    } catch (Exception e) {
+      // Welcome wave failure must not block registration.
     }
 
     return null;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WelcomeWaveCreator.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WelcomeWaveCreator.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
+import org.waveprotocol.box.server.robots.RobotWaveletData;
+import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.box.server.robots.util.LoggingRequestListener;
+import org.waveprotocol.box.server.robots.util.RobotsUtil;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
+import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.conversation.ObservableConversationBlip;
+import org.waveprotocol.wave.model.conversation.ObservableConversationView;
+import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
+import org.waveprotocol.wave.model.document.util.LineContainers;
+import org.waveprotocol.wave.model.document.util.XmlStringBuilder;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.WaveletDelta;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Creates a welcome wave for newly registered users using direct server-side
+ * wave creation. This avoids the robot framework and OAuth dependencies required
+ * by the legacy {@code WelcomeRobot}.
+ */
+@Singleton
+public class WelcomeWaveCreator {
+
+  private static final Log LOG = Log.get(WelcomeWaveCreator.class);
+
+  private static final SubmitRequestListener LOGGING_REQUEST_LISTENER =
+      new LoggingRequestListener(LOG);
+
+  private final WaveletProvider waveletProvider;
+  private final ConversationUtil conversationUtil;
+
+  @Inject
+  public WelcomeWaveCreator(WaveletProvider waveletProvider, ConversationUtil conversationUtil) {
+    this.waveletProvider = waveletProvider;
+    this.conversationUtil = conversationUtil;
+  }
+
+  /**
+   * Creates a welcome wave for the given new user. The wave contains a single
+   * blip with a brief welcome message.
+   *
+   * <p>This method is designed to be called after successful account creation.
+   * Failures are logged but do not propagate -- callers should not let welcome
+   * wave issues block registration.
+   *
+   * @param newUser the participant id of the newly registered user.
+   */
+  public void createWelcomeWave(ParticipantId newUser) {
+    try {
+      WaveletName waveletName = conversationUtil.generateWaveletName();
+      RobotWaveletData newWavelet = RobotsUtil.createEmptyRobotWavelet(newUser, waveletName);
+      OpBasedWavelet opBasedWavelet = newWavelet.getOpBasedWavelet(newUser);
+
+      // Set up the conversational structure (manifest document).
+      WaveletBasedConversation.makeWaveletConversational(opBasedWavelet);
+
+      // Build a conversation view and create the root blip.
+      ObservableConversationView conversation = conversationUtil.buildConversation(opBasedWavelet);
+      ObservableConversationBlip rootBlip = conversation.getRoot().getRootThread().appendBlip();
+
+      // Add the new user as a participant on the wavelet.
+      opBasedWavelet.addParticipant(newUser);
+
+      // Insert welcome text into the root blip.
+      String welcomeText = "Welcome to Wave!\n"
+          + "You can create new waves, add participants, and collaborate in real-time.\n"
+          + "Try clicking 'New Wave' to get started.";
+      XmlStringBuilder content = XmlStringBuilder.createText(welcomeText);
+      LineContainers.appendToLastLine(rootBlip.getContent(), content);
+
+      // Submit the accumulated deltas to the wave server.
+      for (WaveletDelta delta : newWavelet.getDeltas()) {
+        ProtocolWaveletDelta protocolDelta = CoreWaveletOperationSerializer.serialize(delta);
+        waveletProvider.submitRequest(waveletName, protocolDelta, LOGGING_REQUEST_LISTENER);
+      }
+
+      LOG.info("Created welcome wave for " + newUser.getAddress()
+          + " (" + waveletName.waveId + ")");
+    } catch (Exception e) {
+      LOG.warning("Failed to create welcome wave for " + newUser.getAddress(), e);
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
@@ -47,6 +47,8 @@ import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.waveprotocol.box.server.rpc.WelcomeWaveCreator;
+
 /**
  * @author josephg@gmail.com (Joseph Gentle)
  */
@@ -54,6 +56,7 @@ public class UserRegistrationServletTest extends TestCase {
   private final AccountData account = new HumanAccountDataImpl(
       ParticipantId.ofUnsafe("frodo@example.com"), new PasswordDigest("password".toCharArray()));
   private AccountStore store;
+  private WelcomeWaveCreator welcomeWaveCreator;
 
   @Mock private HttpServletRequest req;
   @Mock private HttpServletResponse resp;
@@ -63,7 +66,7 @@ public class UserRegistrationServletTest extends TestCase {
     MockitoAnnotations.initMocks(this);
     store = new MemoryStore();
     store.putAccount(account);
-
+    welcomeWaveCreator = mock(WelcomeWaveCreator.class);
   }
 
   public void testRegisterNewUserEnabled() throws Exception {
@@ -133,14 +136,14 @@ public class UserRegistrationServletTest extends TestCase {
       "administration.analytics_account", "UA-someid")
     );
     UserRegistrationServlet enabledServlet =
-        new UserRegistrationServlet(store, "example.com", config1);
+        new UserRegistrationServlet(store, "example.com", config1, welcomeWaveCreator);
 
     Config config2 = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
       "administration.disable_registration", true,
       "administration.analytics_account", "UA-someid")
     );
     UserRegistrationServlet disabledServlet =
-        new UserRegistrationServlet(store, "example.com", config2);
+        new UserRegistrationServlet(store, "example.com", config2, welcomeWaveCreator);
 
     when(req.getParameter("address")).thenReturn(address);
     when(req.getParameter("password")).thenReturn(password);


### PR DESCRIPTION
## Summary
- Adds a new `WelcomeWaveCreator` class that creates a welcome wave using direct server-side APIs (WaveletProvider + ConversationUtil), bypassing the robot framework and OAuth
- Integrates it into the Jakarta `UserRegistrationServlet` -- after successful account creation, a welcome wave with introductory text is created for the new user
- Updates `UserRegistrationServletTest` to pass a mock `WelcomeWaveCreator` to the servlet constructor

## Test plan
- [x] `./gradlew :wave:compileJava` passes
- [x] `./gradlew :wave:compileTestJava` passes
- [x] Existing `UserRegistrationServletTest` failures are pre-existing (verified by stashing changes and re-running)
- [ ] Manual: register a new user and verify the welcome wave appears in their inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New users automatically receive a welcome wave message upon registration completion.
  * The welcome wave is generated with predefined content to help new users get started.
  * Registration succeeds even if welcome wave creation encounters issues, ensuring a reliable signup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->