### PR TITLE
fix: SBT test compilation — add testcontainers dep, exclude IT tests, suppress warnings

### DIFF
--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -68,7 +68,7 @@ incubator-wave/
 | Logging | SLF4J 2.x + Logback 1.5.6 |
 | Metrics | Micrometer + Prometheus registry |
 | Crypto | BouncyCastle |
-| Test | JUnit 4.12, Mockito 2.2.21, TestContainers 1.19.7 |
+| Test | JUnit 4.12, Mockito 2.2.21, TestContainers 1.21.4 |
 | Deploy | Docker, Caddy, SystemD, GitHub Actions |
 
 ### Entry Points

--- a/build.sbt
+++ b/build.sbt
@@ -213,8 +213,8 @@ libraryDependencies ++= Seq(
   "com.novocode"                   % "junit-interface"            % "0.11"     % Test,
   "org.hamcrest"                   % "hamcrest-junit"             % "2.0.0.0"  % Test,
   "org.mockito"                    % "mockito-core"               % "2.2.21"   % Test,
-  "org.testcontainers"             % "testcontainers"             % "1.19.7"   % Test,
-  "org.testcontainers"             % "mongodb"                    % "1.19.7"   % Test,
+  "org.testcontainers"             % "testcontainers"             % "1.21.4"   % Test,
+  "org.testcontainers"             % "mongodb"                    % "1.21.4"   % Test,
 
   // --- Protobuf ---
   "com.google.protobuf"            % "protobuf-java"              % ProtobufV,

--- a/wave/build.gradle
+++ b/wave/build.gradle
@@ -444,8 +444,8 @@ dependencies {
             [group: 'junit', name: 'junit', version: '4.12'],
             [group: "org.hamcrest", name: "hamcrest-junit", version: "2.0.0.0"],
             [group: "org.mockito", name: "mockito-core", version: "2.2.21"],
-            [group: "org.testcontainers", name: "testcontainers", version: "1.19.7"],
-            [group: "org.testcontainers", name: "mongodb", version: "1.19.7"],
+            [group: "org.testcontainers", name: "testcontainers", version: "1.21.4"],
+            [group: "org.testcontainers", name: "mongodb", version: "1.21.4"],
             [group: 'org.gwtproject', name: 'gwt-user', version: gwtVersion],
             [group: 'org.gwtproject', name: 'gwt-dev', version: gwtVersion]
     )


### PR DESCRIPTION
## Summary
- **Add testcontainers test dependencies**: `org.testcontainers:testcontainers:1.19.7` and `org.testcontainers:mongodb:1.19.7` as `% Test` so MongoDB IT files can compile
- **Exclude IT tests from `sbt test` scope**: Filter out `*IT.java` and `MongoItTestUtil.java` from `Test / unmanagedSources`, matching Gradle's separate `itTest` source set
- **Fix duplicate source warnings**: Exclude `SecurityHeadersFilter.java`, `NoCacheFilter.java`, `StaticCacheFilter.java` from `src/main/java` so the jakarta-overrides versions win (resolves "Multiple sources matched" and "Could not determine source" warnings)
- **Suppress 14 unused-key lint warnings**: Add `excludeLintKeys` for `javaSource`, `scalaSource`, `resourceDirectory`, `semanticdbTargetRoot` across all four custom test configs (JakartaTest, JakartaIT, StacktraceTest, ThumbTest)
- **Fix SBT macro linter warning**: Extract `(Compile / dependencyClasspath).value` outside the `if/else` block in `generateFlags` task

## Test plan
- [x] `sbt 'Test / compile'` succeeds with no warnings (only protobuf unused-import warning remains, which is upstream)
- [x] `sbt test` compiles and runs 1542 tests successfully (21 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added MongoDB integration test dependencies, upgraded test container versions, and configured integration tests to run outside the default unit test execution.

* **Chores**
  * Improved build configuration for test filtering and source resolution, suppressed spurious linter warnings for custom test tasks, and streamlined code-generation task processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->