### PR TITLE
feat: finish DynamicRenderer public entrypoints for targeted blip navigation

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/DynamicRendererImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/DynamicRendererImpl.java
@@ -91,6 +91,7 @@ public final class DynamicRendererImpl implements ObservableDynamicRenderer<Elem
   private int totalBlips = 0;
   private double startMs = -1;
 
+  private boolean bootstrapFlushPending = false;
   private boolean updateQueued = false;
   private double lastUpdateMs = 0;
   private int lastTopSeen = 0;
@@ -194,8 +195,12 @@ public final class DynamicRendererImpl implements ObservableDynamicRenderer<Elem
     fireBeforeRenderingStarted();
     fireBeforePhaseStarted();
     updateWindow();
-    firePhaseFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
-    fireRenderingFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+    if (!bootstrapFlushPending) {
+      firePhaseFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+      fireRenderingFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+    }
+    // When bootstrapFlushPending is true, COMPLETE will be fired after the
+    // deferred flush completes inside enqueueBootstrapWindow().
   }
 
   @Override
@@ -232,8 +237,12 @@ public final class DynamicRendererImpl implements ObservableDynamicRenderer<Elem
 
     // Update the window around the new scroll position so surrounding blips are paged in.
     updateWindow();
-    firePhaseFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
-    fireRenderingFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+    if (!bootstrapFlushPending) {
+      firePhaseFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+      fireRenderingFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+    }
+    // When bootstrapFlushPending is true, COMPLETE will be fired after the
+    // deferred flush completes inside enqueueBootstrapWindow().
   }
 
   @Override
@@ -664,6 +673,9 @@ public final class DynamicRendererImpl implements ObservableDynamicRenderer<Elem
         return true;
       }
     }, view);
+    // Mark that the bootstrap flush is pending so callers don't emit COMPLETE
+    // before the queued blips have actually been flushed.
+    bootstrapFlushPending = true;
     // Defer flush so we don't block the current UI turn.
     Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
       @Override public void execute() {
@@ -671,6 +683,11 @@ public final class DynamicRendererImpl implements ObservableDynamicRenderer<Elem
           queue.flush();
         } catch (Throwable t) {
           GWT.log("DynamicRenderer: bootstrap flush failed", t);
+        } finally {
+          bootstrapFlushPending = false;
+          // Now that the bootstrap render has flushed, notify listeners.
+          firePhaseFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
+          fireRenderingFinished(ObservableDynamicRenderer.RenderResult.COMPLETE);
         }
       }
     });


### PR DESCRIPTION
## Summary
- Implement the three `dynamicRendering()` TODO stubs in `DynamicRendererImpl` that were identified in the smoke verification (PR #60)
- `dynamicRendering()` triggers a viewport window update from the current scroll position with full listener lifecycle
- `dynamicRendering(ConversationBlip)` ensures the target blip is paged in, scrolls the viewport to it, and updates the surrounding window
- `dynamicRendering(String)` resolves a blip ID across all conversations then delegates to the blip overload
- Add listener notification helpers (`fire*` methods) with try/catch guards for all `ObservableDynamicRenderer.Listener` callbacks
- Add `findBlipById` helper for cross-conversation blip lookup

Closes incubator-wave-wiab-core.2

## Test plan
- [x] `./gradlew :wave:compileJava` passes (BUILD SUCCESSFUL, no new warnings)
- [ ] Manual: verify targeted blip navigation scrolls to the correct blip when invoked via client code
- [ ] Manual: verify listener callbacks fire in the correct order (onBeforeRenderingStarted -> onBeforePhaseStarted -> onBlipRendered -> onBlipReady -> onPhaseFinished -> onRenderingFinished)
- [ ] Manual: verify fallback to current-position rendering when blip ID is null/empty/not-found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigate directly to a specific conversation blip with automatic viewport positioning and reliable paging.
  * Rendering now emits clear lifecycle events so extensions and tools can react to render phases.

* **Bug Fixes**
  * Restored a complete, reliable render lifecycle, including proper start/finish notifications.
  * More robust paging and listener notifications with safer callbacks and conditional logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->