### PR TITLE
fix: resolve FragmentsServlet manifestOrder UnsupportedOperationException

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/model/wave/data/IndexedDocumentFactory.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/wave/data/IndexedDocumentFactory.java
@@ -77,8 +77,10 @@ public final class IndexedDocumentFactory implements DocumentFactory<DocumentOpe
 
       @Override
       public void init(SilentOperationSink<? super DocOp> outputSink) {
-        throw new UnsupportedOperationException(
-            "This document implementation does not support mutable documents");
+        // No-op: immutable indexed documents never produce operations,
+        // so the output sink is accepted but ignored. This allows
+        // IndexedDocumentFactory to be used with OpBasedWavelet in
+        // read-only scenarios (e.g., manifest order extraction).
       }
     };
   }


### PR DESCRIPTION
## Summary
- **Fixes #67**: `IndexedDocumentFactory.init()` threw `UnsupportedOperationException` when `FragmentsFetcherCompat.manifestOrder()` built a read-only `OpBasedWavelet` to extract conversation manifest ordering.
- Changed `init()` from throwing to no-op, since immutable indexed documents never produce operations and the output sink can safely be ignored.
- This eliminates the WARN-level fallback to time-based ordering, restoring proper manifest-based fragment ordering.

## Root cause
`OpBasedBlip` constructor calls `blip.getContent().init(outputSink)` to register an operation output sink. `IndexedDocumentFactory` (used by the fragments code path) rejected this call because it was designed as strictly immutable. But `init()` for a read-only document just needs to accept and discard the sink -- no mutations occur.

## Test plan
- [x] `./gradlew :wave:compileJava` passes
- [x] `FragmentsOrderingTest` passes
- [x] Pattern matches existing test document factories (`ReadableBlipDataStub`, `RemoteWaveViewServiceFragmentsTest`, `CcBasedWaveViewTest`) which all use empty `init()` implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical issue where indexed document initialization would fail unexpectedly during certain operation workflows. Previously, the system would error out when attempting to initialize documents in specific code paths. The system now properly handles document initialization in all standard scenarios, ensuring reliable operation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->