### PR TITLE
feat: deploy failure alerting via GitHub issues

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -131,6 +131,7 @@ jobs:
 
       - name: Close deploy-failure issues on success
         if: success()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- When the Contabo deploy fails, automatically creates a GitHub issue with failure details (commit, branch, run link, actor, timestamp)
- Duplicate detection: subsequent failures add a comment to the existing open issue instead of creating a new one
- On successful deploy, auto-closes any open `deploy-failure` issues with a resolution comment
- The `deploy-failure` label is auto-created on first use (red `#e11d48`)

## Test plan
- [ ] Verify YAML is valid (validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger a deploy — on success, the close-issues step should be a no-op (no open issues)
- [ ] To test failure path: temporarily break a step, push, verify issue is created with correct details
- [ ] Push another failing commit — verify it comments on the existing issue instead of creating a duplicate
- [ ] Fix and push — verify the open deploy-failure issue is auto-closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now files a labeled "deploy-failure" GitHub issue on deploy failures with commit, branch, actor, run link, timestamp, and “Next Steps” guidance.
  * If a failure issue already exists, the workflow comments on it (with details) instead of creating a duplicate.
  * On subsequent successful deployments, the workflow automatically closes and comments on those failure issues, linking the resolving commit and run.
  * Ensures the failure label exists before creating an issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->