### PR TITLE
fix: make smoke test PID handling robust + add stop timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -653,18 +653,32 @@ smokeInstalled := {
   // Depend on Universal/stage to produce the install directory
   val stageDir = (Universal / stage).value
   val script = base / "scripts" / "wave-smoke.sh"
-  val env = Map("INSTALL_DIR" -> stageDir.getAbsolutePath)
+  val env = Map("INSTALL_DIR" -> stageDir.getAbsolutePath, "STOP_TIMEOUT" -> "30")
   log.info(s"Running smoke test against staged distribution at ${stageDir}")
   def runSmoke(cmd: String): Int =
     scala.sys.process.Process(Seq("bash", script.getAbsolutePath, cmd), base, env.toSeq: _*)
       .!(scala.sys.process.ProcessLogger(s => log.info(s), e => log.error(e)))
+  def runSmokeWithTimeout(cmd: String, timeoutSec: Int): Int = {
+    val proc = scala.sys.process.Process(Seq("bash", script.getAbsolutePath, cmd), base, env.toSeq: _*)
+      .run(scala.sys.process.ProcessLogger(s => log.info(s), e => log.error(e)))
+    val future = scala.concurrent.Future(proc.exitValue())(scala.concurrent.ExecutionContext.global)
+    try {
+      scala.concurrent.Await.result(future, scala.concurrent.duration.Duration(timeoutSec, "seconds"))
+    } catch {
+      case _: java.util.concurrent.TimeoutException =>
+        log.error(s"wave-smoke.sh $cmd timed out after ${timeoutSec}s — destroying process")
+        proc.destroy()
+        1
+    }
+  }
   try {
     val startCode = runSmoke("start")
     if (startCode != 0) sys.error(s"wave-smoke.sh start failed with exit code $startCode")
     val checkCode = runSmoke("check")
     if (checkCode != 0) sys.error(s"wave-smoke.sh check failed with exit code $checkCode")
   } finally {
-    runSmoke("stop")
+    // Use a timeout for stop to prevent CI hangs if the process can't be killed
+    runSmokeWithTimeout("stop", 60)
   }
 }
 

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -21,6 +21,40 @@ else
 fi
 PID_FILE="$INSTALL_DIR/wave_server.pid"
 PORT=9898
+# Hard timeout (seconds) for the stop command to prevent CI hangs
+STOP_TIMEOUT=${STOP_TIMEOUT:-30}
+
+# Find PIDs listening on $PORT using the best available tool.
+# Tries lsof first, then ss+/proc (Linux), then fuser.
+find_port_pids() {
+  local pids=""
+
+  # Method 1: lsof (macOS + most Linux)
+  if command -v lsof >/dev/null 2>&1; then
+    pids=$(lsof -tiTCP:$PORT -sTCP:LISTEN 2>/dev/null || true)
+  fi
+
+  # Method 2: ss + /proc (Linux, available on minimal Ubuntu where lsof may be absent)
+  if [[ -z "${pids:-}" ]] && command -v ss >/dev/null 2>&1; then
+    # ss -tlnp output contains "pid=NNN" fragments for listeners on our port
+    pids=$(ss -tlnp "sport = :$PORT" 2>/dev/null \
+      | grep -oP 'pid=\K[0-9]+' 2>/dev/null || true)
+  fi
+
+  # Method 3: fuser (Linux fallback)
+  if [[ -z "${pids:-}" ]] && command -v fuser >/dev/null 2>&1; then
+    pids=$(fuser $PORT/tcp 2>/dev/null | tr -s ' ' '\n' || true)
+  fi
+
+  echo "${pids:-}"
+}
+
+# Returns true (0) if something is listening on $PORT.
+port_in_use() {
+  local pids
+  pids=$(find_port_pids)
+  [[ -n "${pids:-}" ]]
+}
 
 start() {
   if [[ ! -x "$INSTALL_DIR/bin/wave" ]]; then
@@ -28,8 +62,19 @@ start() {
     exit 1
   fi
   (cd "$INSTALL_DIR" && nohup ./bin/wave > wave_server.out 2>&1 & echo $! > wave_server.pid)
-  echo "Started. PID=$(cat "$PID_FILE")"
+  echo "Started. Wrapper PID=$(cat "$PID_FILE" 2>/dev/null || echo unknown)"
   wait_ready
+
+  # Re-capture the real Java PID via port detection. The sbt-native-packager
+  # wrapper script may fork+exec the JVM, making the original $! stale.
+  local real_pid
+  real_pid=$(find_port_pids | head -1)
+  if [[ -n "${real_pid:-}" ]]; then
+    echo "$real_pid" > "$PID_FILE"
+    echo "Resolved server PID=$real_pid (via port $PORT)"
+  else
+    echo "WARNING: could not resolve server PID via port detection" >&2
+  fi
 }
 
 wait_ready() {
@@ -71,48 +116,83 @@ check() {
 }
 
 stop() {
+  local deadline=$(( $(date +%s) + STOP_TIMEOUT ))
+
   # Collect all PIDs to kill (port listeners + PID file)
   all_pids=""
 
-  # PIDs from port listener
-  port_pids=$(lsof -tiTCP:$PORT -sTCP:LISTEN 2>/dev/null || true)
+  # PIDs from port listener (primary detection method)
+  port_pids=$(find_port_pids)
   if [[ -n "${port_pids:-}" ]]; then
     all_pids="$port_pids"
   fi
 
-  # PID from PID file
+  # PID from PID file (secondary)
   if [[ -f "$PID_FILE" ]]; then
-    file_pid=$(cat "$PID_FILE")
-    if [[ -n "${file_pid:-}" ]]; then
+    file_pid=$(cat "$PID_FILE" 2>/dev/null || true)
+    if [[ -n "${file_pid:-}" && "${file_pid:-}" =~ ^[0-9]+$ ]]; then
       all_pids="${all_pids:+$all_pids$'\n'}$file_pid"
     fi
   fi
 
   if [[ -z "${all_pids:-}" ]]; then
     echo "No running server detected on port $PORT"
+    rm -f "$PID_FILE"
     return 0
   fi
 
   # Deduplicate and send SIGTERM
   all_pids=$(echo "$all_pids" | sort -u)
+  echo "Sending SIGTERM to PIDs: $(echo $all_pids | tr '\n' ' ')"
   echo "$all_pids" | xargs -I{} kill {} 2>/dev/null || true
 
-  # Wait up to 5 seconds for graceful shutdown
+  # Wait for graceful shutdown (up to 5 seconds or until deadline)
   for i in {1..5}; do
+    if [[ $(date +%s) -ge $deadline ]]; then
+      echo "Hard timeout reached during graceful shutdown" >&2
+      break
+    fi
     sleep 1
-    if ! lsof -tiTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; then
+    if ! port_in_use; then
       echo "Stopped server on port $PORT"
       rm -f "$PID_FILE"
       return 0
     fi
   done
 
-  # Force kill if still running
+  # Force kill: re-detect PIDs (they may have changed) and send SIGKILL
   echo "Graceful shutdown timed out; sending SIGKILL"
-  echo "$all_pids" | xargs -I{} kill -9 {} 2>/dev/null || true
-  sleep 1
+  fresh_pids=$(find_port_pids)
+  # Merge with original PIDs in case port detection misses something
+  kill_pids=$(printf '%s\n%s' "${fresh_pids:-}" "${all_pids:-}" | grep -v '^$' | sort -u)
+  echo "$kill_pids" | xargs -I{} kill -9 {} 2>/dev/null || true
+
+  # Wait briefly for SIGKILL to take effect
+  for i in {1..3}; do
+    if [[ $(date +%s) -ge $deadline ]]; then
+      break
+    fi
+    sleep 1
+    if ! port_in_use; then
+      echo "Force-stopped server on port $PORT"
+      rm -f "$PID_FILE"
+      return 0
+    fi
+  done
+
+  # Last resort: fuser -k (sends SIGKILL to anything on the port)
+  if port_in_use; then
+    echo "Attempting fuser -k as last resort"
+    fuser -k $PORT/tcp 2>/dev/null || true
+    sleep 1
+  fi
+
   rm -f "$PID_FILE"
-  echo "Force-stopped server on port $PORT"
+  if port_in_use; then
+    echo "WARNING: port $PORT still in use after all stop attempts" >&2
+    return 1
+  fi
+  echo "Stopped server on port $PORT"
 }
 
 cmd=${1:-}
@@ -122,4 +202,4 @@ case "$cmd" in
   check) check ;;
   stop) stop ;;
   *) echo "Usage: $0 {start|status|check|stop}" >&2; exit 1 ;;
- esac
+esac


### PR DESCRIPTION
## Summary
- **Root cause**: The deploy smoke test hangs because `$!` captures the sbt-native-packager shell wrapper PID (which exits), not the actual Java process PID. When `stop` runs, the PID file is stale and `lsof` may not be available on minimal Ubuntu CI runners.
- **Fix in `scripts/wave-smoke.sh`**: Added `find_port_pids()` helper that tries `lsof`, `ss`+`/proc`, and `fuser` for cross-platform PID detection. After server readiness, re-resolves the real Java PID via port detection. Added `STOP_TIMEOUT` (30s default) hard deadline so `stop()` never hangs. Added `fuser -k` as last-resort kill.
- **Fix in `build.sbt`**: Added `runSmokeWithTimeout()` with a 60-second Scala-level timeout that destroys the process on expiry, preventing SBT from blocking forever.

## Test plan
- [ ] Verify `sbt smokeInstalled` completes on Ubuntu CI (build workflow)
- [ ] Verify deploy workflow `smokeInstalled` step no longer hangs
- [ ] Verify `scripts/wave-smoke.sh start && check && stop` works locally on macOS
- [ ] Verify stop returns within 30s even if server is unresponsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to smoke test teardown to prevent infinite CI hangs during service shutdown
  * Improved process termination with escalating cleanup strategies (graceful shutdown with deadline, forced termination, and final port cleanup)
  * Enhanced process detection for reliable service stopping across different system configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->