### PR TITLE
fix: GWT outputs to wave/war/ so webclient is in Docker image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1087,7 +1087,11 @@ ThisBuild / compileGwt := {
       val forkOpts = ForkOptions()
         .withRunJVMOptions(Vector("-Xmx1024M"))
 
+      // Output to wave/war/ so Universal/stage mappings pick it up
+      val warDir = (base / "wave" / "war").getAbsolutePath
+
       val gwtArgs = Seq(
+        "-war", warDir,
         "-style", "OBFUSCATED",
         "-XdisableClassMetadata",
         "-XdisableCastChecking",


### PR DESCRIPTION
webclient.nocache.js was 404 because GWT output went to ./war/ not wave/war/. Added -war flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted build configuration to optimize compiler output directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->