### PR TITLE
fix: derive wave title only from root blip content

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
@@ -20,7 +20,6 @@
 package org.waveprotocol.box.common;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 
 import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
 import org.waveprotocol.wave.model.document.operation.Attributes;
@@ -158,28 +157,28 @@ public final class Snippets {
 
   /**
    * Returns a snippet or null.
+   *
+   * Renders blips in conversation manifest order so the root blip content
+   * always comes first.  This ensures the wave title (derived from the root
+   * blip) can be reliably stripped from the snippet prefix and that reply
+   * blip content never displaces the root blip content at the start of the
+   * snippet.
    */
   public static String renderSnippet(final ReadableWaveletData wavelet,
       final int maxSnippetLength) {
     final StringBuilder sb = new StringBuilder();
     Set<String> docsIds = wavelet.getDocumentIds();
-    long newestLmt = -1;
-    ReadableBlipData newestBlip = null;
-    for (String docId : docsIds) {
-      ReadableBlipData blip = wavelet.getDocument(docId);
-      long currentLmt = blip.getLastModifiedTime();
-      if (currentLmt > newestLmt) {
-        newestLmt = currentLmt;
-        newestBlip = blip;
-      }
+
+    // Find the conversation manifest document.
+    ReadableBlipData manifestDoc = null;
+    if (docsIds.contains(DocumentConstants.MANIFEST_DOCUMENT_ID)) {
+      manifestDoc = wavelet.getDocument(DocumentConstants.MANIFEST_DOCUMENT_ID);
     }
-    if (newestBlip == null) {
-      // Render whatever data we have and hope its good enough
-      sb.append(collateTextForWavelet(wavelet));
-    } else {
-      DocOp docOp = newestBlip.getContent().asOperation();
-      sb.append(collateTextForOps(Lists.newArrayList(docOp)));
-      sb.append(" ");
+
+    if (manifestDoc != null) {
+      // Walk the conversation manifest to render blips in their natural
+      // (root-first) order instead of picking the most-recently-modified blip.
+      DocOp docOp = manifestDoc.getContent().asOperation();
       docOp.apply(InitializationCursorAdapter.adapt(new DocInitializationCursor() {
         @Override
         public void annotationBoundary(AnnotationBoundaryMap map) {
@@ -214,6 +213,9 @@ public final class Snippets {
           }
         }
       }));
+    } else {
+      // No conversation manifest found – fall back to collating all text.
+      sb.append(collateTextForWavelet(wavelet));
     }
     if (sb.length() > maxSnippetLength) {
       return sb.substring(0, maxSnippetLength);

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/DigestDomImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/DigestDomImpl.java
@@ -61,6 +61,8 @@ public final class DigestDomImpl implements DigestView {
 
     String info();
 
+    String title();
+
     String unread();
 
     String unreadCount();

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/DigestDomImpl.ui.xml
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/DigestDomImpl.ui.xml
@@ -38,7 +38,7 @@
         <div ui:field='time'/>
         <div ui:field='msgs'/>
       </div>
-      <span ui:field='title'/>
+      <span ui:field='title' class='{css.title}'/>
       &mdash;
       <span ui:field='snippet'/>
     </div>

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/mock/digest.css
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/mock/digest.css
@@ -75,6 +75,10 @@
   -webkit-border-radius: 50%;
 }
 
+.title {
+  font-weight: bold;
+}
+
 .unread {
   font-weight: 600;
   color: #1a202c;


### PR DESCRIPTION
## Summary
- Wave title in the search/digest panel now derives only from the root blip's first line
- `Snippets.renderSnippet` now walks the conversation manifest in document order (root blip first) instead of starting with the most-recently-modified blip, so reply content never displaces the root blip text at the start of the snippet
- Root blip first line rendered bold in the digest panel to indicate it serves as the wave title

Fixes #150

## Test plan
- [ ] Create a wave, add title text in root blip — title appears in left panel
- [ ] Add a reply blip — title should NOT change to reply content
- [ ] Edit root blip first line — title should update accordingly
- [ ] Verify root blip first line appears bold in the search/digest panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated snippet content ordering and display logic.
  * Enhanced fallback behavior for content rendering.

* **Style**
  * Digest titles now display in bold font weight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->