### PR TITLE
fix: derive wave title only from root blip content (closes #150)

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
@@ -20,7 +20,6 @@
 package org.waveprotocol.box.common;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 
 import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
 import org.waveprotocol.wave.model.document.operation.Attributes;
@@ -163,23 +162,22 @@ public final class Snippets {
       final int maxSnippetLength) {
     final StringBuilder sb = new StringBuilder();
     Set<String> docsIds = wavelet.getDocumentIds();
-    long newestLmt = -1;
-    ReadableBlipData newestBlip = null;
-    for (String docId : docsIds) {
-      ReadableBlipData blip = wavelet.getDocument(docId);
-      long currentLmt = blip.getLastModifiedTime();
-      if (currentLmt > newestLmt) {
-        newestLmt = currentLmt;
-        newestBlip = blip;
-      }
+
+    // Always use the conversation manifest to walk blips in thread order.
+    // This ensures the snippet starts with the root blip content, not the
+    // most recently modified blip (which could be a reply).
+    ReadableBlipData manifestDoc = null;
+    if (docsIds.contains(DocumentConstants.MANIFEST_DOCUMENT_ID)) {
+      manifestDoc = wavelet.getDocument(DocumentConstants.MANIFEST_DOCUMENT_ID);
     }
-    if (newestBlip == null) {
-      // Render whatever data we have and hope its good enough
+
+    if (manifestDoc == null) {
+      // No conversation manifest found; fall back to collating all text.
       sb.append(collateTextForWavelet(wavelet));
     } else {
-      DocOp docOp = newestBlip.getContent().asOperation();
-      sb.append(collateTextForOps(Lists.newArrayList(docOp)));
-      sb.append(" ");
+      // Walk the conversation manifest to collect blip text in thread order
+      // (root blip first, then replies).
+      DocOp docOp = manifestDoc.getContent().asOperation();
       docOp.apply(InitializationCursorAdapter.adapt(new DocInitializationCursor() {
         @Override
         public void annotationBoundary(AnnotationBoundaryMap map) {

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
@@ -99,6 +99,15 @@ public class TestingWaveletData {
     TitleHelper.maybeFindAndSetImplicitTitle(blip.getContent());
   }
 
+  /**
+   * Appends a reply blip to the first blip in the root thread.
+   */
+  public void appendReplyToFirstBlip(String text) {
+    ConversationBlip firstBlip = conversation.getRootThread().getFirstBlip();
+    ConversationBlip reply = firstBlip.addReplyThread().appendBlip();
+    LineContainers.appendToLastLine(reply.getContent(), XmlStringBuilder.createText(text));
+  }
+
   public List<ObservableWaveletData> copyWaveletData() {
     // This data object already has an op-based owner on top. Must copy it.
     return ImmutableList.of(WaveletDataUtil.copyWavelet(waveletData),

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
@@ -112,6 +112,36 @@ public class WaveDigesterTest extends TestCase {
     assertEquals(1, digest.getBlipCount());
   }
 
+  /**
+   * Tests that the wave title is derived from the root blip, not from a reply blip.
+   * This is a regression test for issue #150.
+   */
+  public void testTitleDerivedFromRootBlipNotReply() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    String rootTitle = "Root blip title";
+    data.appendBlipWithText(rootTitle);
+    data.appendReplyToFirstBlip("Reply blip content");
+    ObservableWaveletData observableWaveletData = data.copyWaveletData().get(0);
+    ObservableWavelet wavelet = OpBasedWavelet.createReadOnly(observableWaveletData);
+    ObservableConversationView conversation = conversationUtil.buildConversation(wavelet);
+
+    SupplementedWave supplement = mock(SupplementedWave.class);
+    when(supplement.isUnread(any(ConversationBlip.class))).thenReturn(true);
+
+    Digest digest =
+        digester.generateDigest(
+            conversation,
+            supplement,
+            observableWaveletData,
+            Collections.singletonList(observableWaveletData));
+
+    assertEquals(rootTitle, digest.getTitle());
+    // The snippet should start with the root blip content, not the reply content
+    assertTrue("Snippet should start with root blip text, but was: " + digest.getSnippet(),
+        digest.getSnippet().startsWith("Reply") == false);
+  }
+
   public void testUnreadCount() {
     TestingWaveletData data =
         new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);


### PR DESCRIPTION
## Summary
- Fixed `Snippets.renderSnippet()` to always use the conversation manifest document to walk blips in thread order, instead of selecting the most recently modified document
- Previously, when a reply blip was the newest document, the snippet would start with the reply's content, causing the wave title in the search/digest panel to appear as the reply blip content instead of the root blip content
- Added regression test `testTitleDerivedFromRootBlipNotReply` and helper method `appendReplyToFirstBlip` in `TestingWaveletData`

## Test plan
- [x] Existing `WaveDigesterTest` tests pass (3 tests)
- [x] New regression test `testTitleDerivedFromRootBlipNotReply` passes
- [x] `sbt pst/compile wave/compile` succeeds
- [ ] Manual verification: create a wave, add a reply, confirm the wave title in the search panel remains the root blip's first line

🤖 Generated with [Claude Code](https://claude.com/claude-code)