### PR TITLE
fix: resolve GWT Log import in ActionsImpl for deploy compilation

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
@@ -45,7 +45,7 @@ import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.waveref.WaveRef;
 import org.waveprotocol.wave.util.escapers.GwtWaverefEncoder;
-import org.waveprotocol.wave.util.logging.Log;
+import java.util.logging.Logger;
 
 /**
  * Defines the UI actions that can be performed as part of the editing feature.
@@ -53,7 +53,7 @@ import org.waveprotocol.wave.util.logging.Log;
  *
  */
 public final class ActionsImpl implements Actions {
-  private static final Log LOG = Log.get(ActionsImpl.class);
+  private static final Logger LOG = Logger.getLogger(ActionsImpl.class.getName());
   private static final ActionMessages messages = GWT.create(ActionMessages.class);
 
   private final ModelAsViewProvider views;


### PR DESCRIPTION
## Summary
- Replaced `org.waveprotocol.wave.util.logging.Log` import with `java.util.logging.Logger` in `ActionsImpl.java`
- The `Log` class uses `ThreadLocal`, `StackTraceElement`, and Guava `Maps` which are server-side JVM constructs not available on the GWT client compile classpath, causing GWT compilation failure
- `java.util.logging.Logger` is already used in other GWT client files (e.g., `ImageThumbnailRenderer.java`) and is properly emulated by GWT

## Test plan
- [x] `sbt --batch pst/compile wave/compile` passes with no errors
- [ ] Verify GWT dev mode / super dev mode compiles successfully
- [ ] Confirm deploy pipeline no longer fails on this import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging framework to use standard JDK utilities for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->