### PR TITLE
chore: GWT PRETTY mode for debuggable client errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,14 @@ jobs:
       - name: Install sbt
         run: |
           set -euo pipefail
+          SBT_VERSION=1.10.2
+          SBT_SHA256=a716dd018bd68bc7a95a2dd10337663aa76f443ad6c99deabe5eadd1adfc7639
+          SBT_TGZ=/tmp/sbt-${SBT_VERSION}.tgz
           curl --fail --show-error --location --retry 3 \
-            "https://github.com/sbt/sbt/releases/download/v1.10.7/sbt-1.10.7.tgz" \
-            --output /tmp/sbt.tgz
-          sudo tar xzf /tmp/sbt.tgz -C /usr/local
+            "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
+            --output "${SBT_TGZ}"
+          echo "${SBT_SHA256}  ${SBT_TGZ}" | sha256sum --check --status
+          sudo tar xzf "${SBT_TGZ}" -C /usr/local
           sudo ln -sf /usr/local/sbt/bin/sbt /usr/local/bin/sbt
 
       - name: Validate canonical deployment assets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,10 +27,14 @@ jobs:
       - name: Install sbt
         run: |
           set -euo pipefail
+          SBT_VERSION=1.10.2
+          SBT_SHA256=a716dd018bd68bc7a95a2dd10337663aa76f443ad6c99deabe5eadd1adfc7639
+          SBT_TGZ=/tmp/sbt-${SBT_VERSION}.tgz
           curl --fail --show-error --location --retry 3 \
-            "https://github.com/sbt/sbt/releases/download/v1.10.7/sbt-1.10.7.tgz" \
-            --output /tmp/sbt.tgz
-          sudo tar xzf /tmp/sbt.tgz -C /usr/local
+            "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
+            --output "${SBT_TGZ}"
+          echo "${SBT_SHA256}  ${SBT_TGZ}" | sha256sum --check --status
+          sudo tar xzf "${SBT_TGZ}" -C /usr/local
           sudo ln -sf /usr/local/sbt/bin/sbt /usr/local/bin/sbt
 
       - name: Compile PST and Wave

--- a/build.sbt
+++ b/build.sbt
@@ -1106,6 +1106,8 @@ ThisBuild / compileGwt := {
 
       val gwtArgs = Seq(
         "-war", warDir,
+        // TODO(#273): Revert PRETTY mode and restore OBFUSCATED with
+        // -XdisableClassMetadata and -XdisableCastChecking after debug cycle.
         "-style", "PRETTY",
         "-localWorkers", "4",
         "org.waveprotocol.box.webclient.WebClientProd"


### PR DESCRIPTION
Temporary switch from OBFUSCATED to PRETTY for debugging. Stack traces will show real names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GWT build now produces more readable output and restores class metadata and cast checking to improve debuggability.
  * CI workflows install a pinned sbt release archive directly, verify its integrity before extraction, use stricter shell options, and reduce download retry attempts to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->