### PR TITLE
fix: tags panel overlaps blip scroll area

### DIFF
--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Conversation.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Conversation.css
@@ -46,6 +46,9 @@
   bottom: 0;
   /* Layout under siblings (participant panel etc). */
   z-index: -1;
+  /* Reserve space so the last blip / "Click here to reply" is not hidden
+   * behind the absolutely-positioned tags panel (height 36px + bottom -4px). */
+  padding-bottom: 40px;
 }
 
 @sprite .toolbar {


### PR DESCRIPTION
## Summary
- The tags panel (`position: absolute; bottom: -4px; height: 36px`) at the bottom of the wave panel overlaps the blip scroll container, hiding the last blip and the "Click here to reply" prompt.
- Adds `padding-bottom: 40px` to the `.fixedThread` scroll container in `Conversation.css` so scrollable content clears the tags bar.

## Test plan
- [ ] Open a wave with multiple blips and scroll to the bottom
- [ ] Verify "Click here to reply" is fully visible and not hidden behind the tags panel
- [ ] Verify the tags panel still renders correctly at the bottom
- [ ] Verify scrolling works properly with the extra padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a layout issue where the last message or reply prompt in conversations was obscured by the tags panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->