### PR TITLE
fix: harden tag search filtering and tag DOM display

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -326,8 +326,13 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
           continue;
         }
         Set<String> waveTags = rootConversation.getTags();
+        // Build a lowercase set of the wave's tags for case-insensitive matching.
+        Set<String> lowerCaseTags = new java.util.HashSet<>();
+        for (String wt : waveTags) {
+          lowerCaseTags.add(wt.toLowerCase(java.util.Locale.ROOT));
+        }
         for (String requiredTag : requiredTags) {
-          if (!waveTags.contains(requiredTag)) {
+          if (!lowerCaseTags.contains(requiredTag.toLowerCase(java.util.Locale.ROOT))) {
             it.remove();
             break;
           }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -40,6 +40,7 @@ import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
 import org.waveprotocol.wave.util.logging.Log;
@@ -47,8 +48,13 @@ import org.waveprotocol.wave.util.logging.Log;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -156,8 +162,16 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     LinkedHashMap<WaveId, WaveViewData> results =
         createResults(user, isAllQuery, currentUserWavesView);
 
+    List<WaveViewData> resultsList = Lists.newArrayList(results.values());
+
+    // Solr does not index tags, so perform post-filtering for tag: queries.
+    Set<String> tagValues = extractTagValues(query);
+    if (!tagValues.isEmpty()) {
+      filterByTags(resultsList, tagValues);
+    }
+
     Collection<WaveViewData> searchResult =
-        computeSearchResult(user, startAt, numResults, Lists.newArrayList(results.values()));
+        computeSearchResult(user, startAt, numResults, resultsList);
     LOG.info("Search response to '" + query + "': " + searchResult.size() + " results, user: "
         + user);
 
@@ -232,6 +246,8 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     }
   }
 
+  private static final Pattern TAG_PATTERN = Pattern.compile("\\btag:(\\S+)");
+
   private static final Pattern IN_ALL_PATTERN = Pattern.compile("\\bin:all\\b");
 
   private static boolean isAllQuery(String query) {
@@ -241,7 +257,9 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {
-    return query.replaceAll(WORD_START + TokenQueryType.IN.getToken() + ":", IN + ":")
+    // Strip tag: tokens from the Solr query since they are handled by post-filtering.
+    String cleanedQuery = TAG_PATTERN.matcher(query).replaceAll("").trim();
+    return cleanedQuery.replaceAll(WORD_START + TokenQueryType.IN.getToken() + ":", IN + ":")
         .replaceAll(WORD_START + TokenQueryType.WITH.getToken() + ":@",
             WITH + ":" + sharedDomainParticipantId.getAddress())
         .replaceAll(WORD_START + TokenQueryType.WITH.getToken() + ":", WITH_FUZZY + ":")
@@ -260,9 +278,82 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
       fq = FILTER_QUERY_PREFIX + addressOfRequiredParticipant;
     }
     if (query.length() > 0) {
-
-      fq += " AND (" + buildUserQuery(query, sharedDomainParticipantId) + ")";
+      String userQuery = buildUserQuery(query, sharedDomainParticipantId);
+      if (!userQuery.isEmpty()) {
+        fq += " AND (" + userQuery + ")";
+      }
     }
     return fq;
+  }
+
+  /**
+   * Extracts tag filter values from the raw query string.
+   *
+   * @param query the raw search query
+   * @return a set of tag names, empty if none
+   */
+  private static Set<String> extractTagValues(String query) {
+    Set<String> tags = new HashSet<>();
+    java.util.regex.Matcher m = TAG_PATTERN.matcher(query);
+    while (m.find()) {
+      tags.add(m.group(1));
+    }
+    return tags;
+  }
+
+  /**
+   * Filters wave results by tags. Only waves whose conversation root wavelet
+   * contains all of the requested tags are kept. Uses case-insensitive matching.
+   *
+   * @param results the mutable list of wave views to filter in place.
+   * @param requiredTags the set of tag names that must all be present.
+   */
+  private void filterByTags(List<WaveViewData> results, Set<String> requiredTags) {
+    Iterator<WaveViewData> it = results.iterator();
+    while (it.hasNext()) {
+      WaveViewData wave = it.next();
+      try {
+        ObservableWaveletData convWavelet = null;
+        for (ObservableWaveletData wd : wave.getWavelets()) {
+          if (org.waveprotocol.wave.model.id.IdUtil.isConversationRootWaveletId(wd.getWaveletId())) {
+            convWavelet = wd;
+            break;
+          }
+        }
+        if (convWavelet == null) {
+          it.remove();
+          continue;
+        }
+        org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet opWavelet =
+            org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet.createReadOnly(convWavelet);
+        if (!org.waveprotocol.wave.model.conversation.WaveletBasedConversation
+            .waveletHasConversation(opWavelet)) {
+          it.remove();
+          continue;
+        }
+        org.waveprotocol.wave.model.conversation.ObservableConversationView conversations =
+            digester.getConversationUtil().buildConversation(opWavelet);
+        org.waveprotocol.wave.model.conversation.ObservableConversation rootConversation =
+            conversations.getRoot();
+        if (rootConversation == null) {
+          it.remove();
+          continue;
+        }
+        Set<String> waveTags = rootConversation.getTags();
+        Set<String> lowerCaseTags = new HashSet<>();
+        for (String wt : waveTags) {
+          lowerCaseTags.add(wt.toLowerCase(Locale.ROOT));
+        }
+        for (String requiredTag : requiredTags) {
+          if (!lowerCaseTags.contains(requiredTag.toLowerCase(Locale.ROOT))) {
+            it.remove();
+            break;
+          }
+        }
+      } catch (Exception e) {
+        LOG.warning("Failed to check tags for wave " + wave.getWaveId(), e);
+        it.remove();
+      }
+    }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java
@@ -591,13 +591,20 @@ public class FullStructure implements UpgradeableDomAsViewProvider {
           TagsViewBuilder.Css tagsCss = WavePanelResourceLoader.getTags().css();
           // Tag DOM id format matches FullDomRenderer: tagsId + "." + tag
           String tagId = impl.getId() + "." + tag;
+          // Avoid creating a duplicate DOM element if the tag is already rendered.
+          Element existingEl = Document.get().getElementById(tagId);
+          if (existingEl != null) {
+            return asTag(existingEl);
+          }
           Element tagEl = Document.get().createDivElement();
           tagEl.setId(tagId);
           tagEl.setClassName(tagsCss.tag() + " " + tagsCss.normal());
           tagEl.setAttribute(KIND_ATTRIBUTE, kind(Type.TAG));
           tagEl.setInnerText(tag);
           // Insert before the overflow-mode panel (extra span), which is the
-          // second-to-last child of the tag container.
+          // second-to-last child of the tag container.  getSimpleMenu() may
+          // return null if the container structure is unexpected; in that case
+          // attachBefore falls back to appendChild.
           DomViewHelper.attachBefore(
               impl.getTagContainer(), impl.getSimpleMenu(), tagEl);
           return asTag(tagEl);

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/TagsDomImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/TagsDomImpl.java
@@ -20,6 +20,7 @@
 package org.waveprotocol.wave.client.wavepanel.view.dom;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Node;
 
 import org.waveprotocol.wave.client.wavepanel.view.IntrinsicTagsView;
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.TagsViewBuilder.Components;
@@ -73,14 +74,31 @@ public final class TagsDomImpl implements DomView, IntrinsicTagsView {
 
   Element getTagsCaption() {
     if (tagsCaption == null) {
-      tagsCaption = getTagContainer().getFirstChild().cast();
+      // Find the first element child, skipping any text nodes.
+      for (Node n = getTagContainer().getFirstChild(); n != null; n = n.getNextSibling()) {
+        if (n.getNodeType() == Node.ELEMENT_NODE) {
+          tagsCaption = n.cast();
+          break;
+        }
+      }
     }
     return tagsCaption;
   }
 
   Element getSimpleMenu() {
     if (simpleMenu == null) {
-      simpleMenu = getTagContainer().getLastChild().getPreviousSibling().cast();
+      // Navigate backwards through container children to find the second-to-last
+      // element node (the "extra" overflow-mode panel), skipping any text nodes.
+      Element container = getTagContainer();
+      Element lastElement = null;
+      Element secondToLastElement = null;
+      for (Node n = container.getFirstChild(); n != null; n = n.getNextSibling()) {
+        if (n.getNodeType() == Node.ELEMENT_NODE) {
+          secondToLastElement = lastElement;
+          lastElement = n.cast();
+        }
+      }
+      simpleMenu = secondToLastElement;
     }
     return simpleMenu;
   }


### PR DESCRIPTION
## Summary
- **Bug 1 (tag:nice search shows ALL waves)**: `SolrSearchProviderImpl` had zero tag filtering -- `tag:` tokens were passed verbatim to Solr as text search instead of being treated as tag filters. Added `filterByTags()` post-filter (matching `SimpleSearchProviderImpl`), stripped `tag:` tokens from the Solr query, and made tag comparison case-insensitive in both search providers.
- **Bug 2 (tags not displayed immediately after adding)**: `TagsDomImpl.getSimpleMenu()` used `getLastChild().getPreviousSibling()` which can return text nodes instead of element nodes, causing the new tag element to be inserted in the wrong position or failing silently. Replaced with robust element-only iteration. Also added a duplicate-element guard in `FullStructure.tagsHelper.append()` to prevent double-rendering.

## Changed files
- `SimpleSearchProviderImpl.java` -- case-insensitive tag matching
- `SolrSearchProviderImpl.java` -- full tag filtering support (extractTagValues + filterByTags + strip tag: from Solr query)
- `FullStructure.java` -- duplicate DOM element guard in tag append
- `TagsDomImpl.java` -- robust element-child navigation for getSimpleMenu/getTagsCaption

## Test plan
- [ ] `sbt wave/compile` passes
- [ ] `sbt compileGwt` passes
- [ ] Create two waves, tag one with "nice", search `tag:nice` -- only the tagged wave appears
- [ ] Search `tag:Nice` (mixed case) -- still finds the wave tagged "nice"
- [ ] Search `tag:nice tag:cool` -- only waves with both tags appear
- [ ] Add a tag via the UI -- tag appears immediately without page reload
- [ ] Add multiple comma-separated tags -- all appear immediately
- [ ] Click a tag to remove -- tag disappears immediately without reload
- [ ] Verify Solr-based search also filters by tags (if Solr backend configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag filtering in search now performs case-insensitive matching, improving consistency across different tag formats.
  * Improved tag display rendering in the user interface by preventing duplicate tag elements and enhancing DOM element navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->