### PR TITLE
fix: create /opt/wave/logs directory to prevent startup crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR ${WAVE_HOME}
 COPY --from=build /workspace/target/universal/stage/ ${WAVE_HOME}/
+RUN mkdir -p ${WAVE_HOME}/logs
 
 EXPOSE 9898
 

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -32,6 +32,7 @@ RUN groupadd --system wave \
     && useradd --system --gid wave --home-dir ${WAVE_HOME} --shell /usr/sbin/nologin wave
 WORKDIR ${WAVE_HOME}
 COPY --chown=wave:wave . ${WAVE_HOME}/
+RUN mkdir -p ${WAVE_HOME}/logs && chown wave:wave ${WAVE_HOME}/logs
 USER wave
 
 EXPOSE 9898

--- a/deploy/caddy/compose.yml
+++ b/deploy/caddy/compose.yml
@@ -59,6 +59,7 @@ services:
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/indexes:/opt/wave/_indexes
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/sessions:/opt/wave/_sessions
       - ./application.conf:/opt/wave/config/application.conf:ro
+      - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/logs:/opt/wave/logs
     environment:
       - RESEND_API_KEY=${RESEND_API_KEY:-}
       - WAVE_EMAIL_FROM=${WAVE_EMAIL_FROM:-noreply@supawave.ai}

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -46,7 +46,7 @@ require_docker() {
 ensure_layout() {
   mkdir -p "$deploy_root"/incoming
   mkdir -p "$deploy_root"/releases
-  mkdir -p "$deploy_root"/shared/{accounts,attachments,caddy-config,caddy-data,certificates,deltas,indexes,mongo/db,sessions}
+  mkdir -p "$deploy_root"/shared/{accounts,attachments,caddy-config,caddy-data,certificates,deltas,indexes,logs,mongo/db,sessions}
 }
 
 load_deploy_env() {

--- a/deploy/contabo/compose.yml
+++ b/deploy/contabo/compose.yml
@@ -46,6 +46,7 @@ services:
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/indexes:/opt/wave/_indexes
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/sessions:/opt/wave/_sessions
       - ./application.conf:/opt/wave/config/application.conf:ro
+      - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/logs:/opt/wave/logs
 
   caddy:
     image: caddy:2.8.4-alpine

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -45,7 +45,7 @@ require_docker() {
 ensure_layout() {
   mkdir -p "$deploy_root"/incoming
   mkdir -p "$deploy_root"/releases
-  mkdir -p "$deploy_root"/shared/{accounts,attachments,caddy-config,caddy-data,certificates,deltas,indexes,mongo/db,sessions}
+  mkdir -p "$deploy_root"/shared/{accounts,attachments,caddy-config,caddy-data,certificates,deltas,indexes,logs,mongo/db,sessions}
 }
 
 load_deploy_env() {


### PR DESCRIPTION
## Summary
- **Fixes #282** — the Wave server fails to start because logback's FILE appender tries to write to `/opt/wave/logs/wave.log` but the `logs/` directory does not exist in the container image
- Adds `RUN mkdir -p /opt/wave/logs` to both `Dockerfile` and `Dockerfile.prebuilt` so the directory is baked into the image
- Mounts a persistent `logs` volume in both compose files (caddy and contabo) so logs survive container restarts
- Updates both deploy scripts' `ensure_layout()` to create the `shared/logs` host directory

## Root cause
The logback configuration at `wave/config/logback.xml` defines a `RollingFileAppender` that writes to `logs/wave.log` (relative to `WORKDIR /opt/wave`). Neither Dockerfile created this directory, so on first startup logback fails to open the file and the JVM crashes.

## Test plan
- [ ] Build the image locally: `docker build -t wave-test .` — verify the image builds successfully
- [ ] Run the container: `docker run --rm wave-test` — verify it starts without logback errors
- [ ] Check that `/opt/wave/logs` exists inside the running container: `docker exec <id> ls -la /opt/wave/logs`
- [ ] For `Dockerfile.prebuilt`: verify the `logs/` dir is owned by `wave:wave`
- [ ] Deploy to staging with the caddy compose stack and confirm logs are persisted to `shared/logs/` on the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker and deployment configurations to establish persistent log directories across production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->