### PR TITLE
fix: restore host port binding in compose.yml (deploy health check broken)

### DIFF
--- a/deploy/caddy/compose.yml
+++ b/deploy/caddy/compose.yml
@@ -45,12 +45,9 @@ services:
       interval: 5s
       timeout: 5s
       retries: 30
-      start_period: 30s
-    # No host port binding — Caddy reaches wave via Docker network (wave:9898).
-    # This avoids port conflicts during start-first rolling updates when both
-    # old and new containers run simultaneously.
-    expose:
-      - "9898"
+      start_period: 60s
+    ports:
+      - "127.0.0.1:9898:9898"
     volumes:
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/accounts:/opt/wave/_accounts
       - ${DEPLOY_ROOT:?set DEPLOY_ROOT before running compose}/shared/attachments:/opt/wave/_attachments


### PR DESCRIPTION
PR #248 changed ports to expose, breaking deploy.sh health check which uses 127.0.0.1:9898. Also increased healthcheck start_period to 60s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Wave service healthcheck startup period for improved initialization reliability
  * Restricted Wave service network accessibility to localhost-only binding for enhanced security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->