### PR TITLE
fix: make SupaWave logo in top bar a clickable link to landing page

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2050,7 +2050,7 @@ public final class HtmlRenderer {
     sb.append("  position: relative; z-index: 1;\n");
     sb.append("  display: flex; align-items: center;\n");
     sb.append("}\n");
-    sb.append(".topbar-brand { display: flex; align-items: center; text-decoration: none; gap: 8px; }\n");
+    sb.append(".topbar-brand { display: flex; align-items: center; text-decoration: none; color: inherit; gap: 8px; }\n");
     sb.append(".topbar-brand svg { flex-shrink: 0; }\n");
     sb.append(".title {\n");
     sb.append("  font-size: 17px; font-weight: 700; color: #fff;\n");


### PR DESCRIPTION
## Summary
- Added `color: inherit` to the `.topbar-brand` CSS rule in `HtmlRenderer.java` so the logo link properly inherits the white text color from the topbar instead of potentially displaying browser default link colors (blue/purple).
- The logo and "SupaWave" text were already wrapped in `<a href="/">`, but the missing `color: inherit` could cause visual inconsistencies across browsers.

## Test plan
- [ ] Load the Wave client in a browser and verify the SupaWave logo + text in the top bar appears in white (not blue/purple link color)
- [ ] Click the logo/text and verify it navigates to `/` (landing page)
- [ ] Verify hover state does not change the text to a default link color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Fixed top-bar brand link color styling to properly inherit surrounding text colors, ensuring consistent color appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->