### PR TITLE
fix: update Contact Messages tab badge after status changes

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4043,10 +4043,14 @@ public final class HtmlRenderer {
     sb.append("  var cStatsBar = document.getElementById('contactsStatsBar');\n");
     sb.append("  var contactBadge = document.getElementById('contactBadge');\n");
 
-    // Fetch unread count for badge
-    sb.append("  fetch('/admin/api/contacts?status=new&limit=0').then(function(r){return r.json();}).then(function(data){\n");
-    sb.append("    if(data.total>0){contactBadge.textContent=data.total;contactBadge.classList.remove('hidden');}\n");
-    sb.append("  }).catch(function(){});\n");
+    // Refresh unread count badge
+    sb.append("  function refreshContactBadge() {\n");
+    sb.append("    fetch('/admin/api/contacts?status=new&limit=0').then(function(r){return r.json();}).then(function(data){\n");
+    sb.append("      if(data.total>0){contactBadge.textContent=data.total;contactBadge.classList.remove('hidden');}\n");
+    sb.append("      else{contactBadge.textContent='0';contactBadge.classList.add('hidden');}\n");
+    sb.append("    }).catch(function(){});\n");
+    sb.append("  }\n");
+    sb.append("  refreshContactBadge();\n");
 
     // Fetch contacts
     sb.append("  function fetchContacts() {\n");
@@ -4126,7 +4130,7 @@ public final class HtmlRenderer {
     sb.append("      method: 'POST', headers: {'Content-Type':'application/json'},\n");
     sb.append("      body: JSON.stringify({status: newStatus})\n");
     sb.append("    }).then(function(r){return r.json();}).then(function(data){\n");
-    sb.append("      if(data.ok) { showToast('Status updated', 'success'); fetchContacts(); }\n");
+    sb.append("      if(data.ok) { showToast('Status updated', 'success'); fetchContacts(); refreshContactBadge(); }\n");
     sb.append("      else showToast(data.error || 'Failed', 'error');\n");
     sb.append("    }).catch(function(e){ showToast('Error: '+e.message,'error'); });\n");
     sb.append("  };\n");
@@ -4139,7 +4143,7 @@ public final class HtmlRenderer {
     sb.append("      method: 'POST', headers: {'Content-Type':'application/json'},\n");
     sb.append("      body: JSON.stringify({body: ta.value.trim()})\n");
     sb.append("    }).then(function(r){return r.json();}).then(function(data){\n");
-    sb.append("      if(data.ok) { showToast('Reply sent', 'success'); fetchContacts(); }\n");
+    sb.append("      if(data.ok) { showToast('Reply sent', 'success'); fetchContacts(); refreshContactBadge(); }\n");
     sb.append("      else showToast(data.error || 'Failed to send reply', 'error');\n");
     sb.append("    }).catch(function(e){ showToast('Error: '+e.message,'error'); });\n");
     sb.append("  };\n");


### PR DESCRIPTION
## Summary
- The "Contact Messages" tab badge showed the unread count on page load but never updated after marking messages as Read, archiving, or sending a reply
- Extracted the one-shot badge fetch into a reusable `refreshContactBadge()` function that both sets the count when > 0 and hides the badge when the count reaches 0
- Call `refreshContactBadge()` after every successful `contactAction()` (Mark Read, Archive) and `sendReply()`

## Test plan
- [ ] Open admin page with unread contact messages -- badge should show count
- [ ] Click "Mark Read" on a new message -- badge count should decrement (or hide if 0)
- [ ] Click "Archive" on a new message -- badge count should decrement
- [ ] Send a reply to a new message -- badge count should decrement
- [ ] When all new messages are handled, badge should disappear entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin contact-submission badge to properly refresh and display updated unread counts after status changes or reply submissions. Badge now correctly hides when there are no pending submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->