### PR TITLE
fix: resolve 6 production regressions from CSS selector conflicts

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -106,21 +106,21 @@ public final class HtmlRenderer {
       + "}\n"
 
       // --- Search help panel overrides ---
-      // Ensure the search area container is positioned so the help panel
-      // can appear as an absolute-positioned dropdown below it.
-      + "#app [kind=\"c\"] { position: relative; overflow: visible !important; }\n"
+      // The search widget (.self in Search.css) already has position:relative,
+      // so the help panel's absolute positioning works out of the box.
+      // NOTE: Do NOT add position:relative to [kind="c"] here -- that selector
+      // matches the ROOT_CONVERSATION element (.fixedSelf) and overriding its
+      // position:absolute collapses the wave panel (#285).
+      // Ensure the root conversation container allows the tags panel (which has
+      // bottom:-4px) to overflow visually.
+      + "#app [kind=\"c\"] { overflow: visible; }\n"
 
       // --- Unified toolbar row: compact 32px action icons ---
-      // The toolbar sits directly below the search box. All action and filter
-      // icons live here in logical groups separated by thin vertical dividers.
-      + "#app [kind=\"c\"] + div {\n"
-      + "  height: 32px !important;\n"
-      + "  display: flex;\n"
-      + "  align-items: center;\n"
-      + "}\n"
-
-      // Toolbar icon buttons — minimal icon circles
-      + "#app [kind=\"c\"] ~ div .gwt-PushButton {\n"
+      // The toolbar sits directly below the search box inside the search
+      // panel (left sidebar).  We use [data-mobile-role="search-panel"] as
+      // a stable anchor because [kind="c"] matches the ROOT_CONVERSATION
+      // element in the wave panel, not the search area (#290).
+      + "[data-mobile-role=\"search-panel\"] .gwt-PushButton {\n"
       + "  display: inline-flex !important;\n"
       + "  align-items: center !important;\n"
       + "  justify-content: center !important;\n"
@@ -136,22 +136,22 @@ public final class HtmlRenderer {
       + "  transition: all 0.15s ease;\n"
       + "  line-height: 1;\n"
       + "}\n"
-      + "#app [kind=\"c\"] ~ div .gwt-PushButton:hover {\n"
+      + "[data-mobile-role=\"search-panel\"] .gwt-PushButton:hover {\n"
       + "  border-color: " + WAVE_PRIMARY + ";\n"
       + "  color: " + WAVE_PRIMARY + ";\n"
       + "  background: rgba(0,119,182,0.06);\n"
       + "}\n"
-      + "#app [kind=\"c\"] ~ div .gwt-PushButton:active {\n"
+      + "[data-mobile-role=\"search-panel\"] .gwt-PushButton:active {\n"
       + "  background: rgba(0,119,182,0.18);\n"
       + "  transform: scale(0.92);\n"
       + "}\n"
-      + "#app [kind=\"c\"] ~ div .gwt-PushButton svg {\n"
+      + "[data-mobile-role=\"search-panel\"] .gwt-PushButton svg {\n"
       + "  display: block;\n"
       + "}\n"
 
       // Mobile: enlarge touch targets on narrow screens
       + "@media (max-width: 480px) {\n"
-      + "  #app [kind=\"c\"] ~ div .gwt-PushButton {\n"
+      + "  [data-mobile-role=\"search-panel\"] .gwt-PushButton {\n"
       + "    width: 34px;\n"
       + "    height: 34px;\n"
       + "    min-width: 34px;\n"

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -320,13 +320,18 @@ public class StagesProvider extends Stages {
   }
 
   public void destroy() {
-    if (historyController != null) {
-      historyController.exitHistoryMode();
-      historyController = null;
-    }
+    // Detach the scrubber widget BEFORE exiting history mode, because
+    // exitHistoryMode() restores savedWavePanelHtml via setInnerHTML()
+    // which removes the scrubber DOM element from the tree.  If we call
+    // removeFromParent() after that, the element is already detached and
+    // GWT throws a removeChild-null error (#288).
     if (versionScrubber != null) {
       versionScrubber.removeFromParent();
       versionScrubber = null;
+    }
+    if (historyController != null) {
+      historyController.exitHistoryMode();
+      historyController = null;
     }
     if (wave != null) {
       waveStore.remove(wave);

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
@@ -76,7 +76,7 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
 
   private final static Binder BINDER = GWT.create(Binder.class);
 
-  private final static String DEFAULT_QUERY = "";
+  private final static String DEFAULT_QUERY = "in:inbox";
 
   @UiField
   TextBox query;
@@ -191,8 +191,8 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
 
   @Override
   public void onChange(ChangeEvent event) {
-    if (query.getValue() == null || query.getValue().isEmpty()) {
-      query.setText(DEFAULT_QUERY);
+    if (query.getValue() == null || query.getValue().trim().isEmpty()) {
+      query.setValue(DEFAULT_QUERY);
     }
     onQuery();
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
@@ -9,13 +9,14 @@
   background-color: #C9E2FC;
   overflow: hidden;
   min-width: 50px;
-  bottom: -4px;
+  bottom: 0;
   position: absolute;
   right: 0;
   left: 0;
   height: 36px;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
+  z-index: 1;
 }
 
 .flow {

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanel.css
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanel.css
@@ -42,7 +42,9 @@
   border-bottom: 1px solid #e2e8f0;
   border-left: none;
   background-color: #fff;
-  overflow: hidden;
+  /* overflow must be visible so the search help panel dropdown (#289)
+     can appear below the search bar without being clipped. */
+  overflow: visible;
 }
 
 @sprite .toolbar {


### PR DESCRIPTION
## Summary
Fixes 6 production bugs found after deploying ~100 PRs. The root cause of most issues was that CSS selectors in HtmlRenderer used `[kind="c"]` to target the search area, but this attribute actually matches the ROOT_CONVERSATION element in the wave panel.

- **#285 Wave panel collapsed**: Removed `position: relative` from `#app [kind="c"]` rule that was overriding `.fixedSelf`'s `position: absolute`, collapsing the wave content panel
- **#286 Tags panel not visible**: Changed tags panel from `bottom: -4px` to `bottom: 0` so it stays within the fixedSelf container (not clipped by GWT layout overflow), added `z-index: 1`
- **#287 Empty search defaults to nothing**: Changed `DEFAULT_QUERY` from `""` to `"in:inbox"` so clearing the search box triggers an inbox search
- **#288 Error switching waves after History mode**: Reordered `StagesProvider.destroy()` to detach the scrubber widget before `exitHistoryMode()` restores innerHTML (which removes the scrubber DOM)
- **#289 Search help ? button clipped**: Changed `overflow: hidden` to `overflow: visible` on `.search` in SearchPanel.css so the help dropdown is not clipped
- **#290 Missing toolbar filter icons**: Changed toolbar button CSS selectors from `#app [kind="c"] ~ div` to `[data-mobile-role="search-panel"]` which correctly targets the search panel

## Test plan
- [ ] Open a wave and verify the wave panel fills the full height (blips visible, scrollable)
- [ ] Verify the tags panel is visible at the bottom of a wave with tags
- [ ] Clear the search box and verify it triggers an `in:inbox` search
- [ ] Enter History mode on a wave, then click a different wave in the sidebar -- no JS error
- [ ] Click the `?` button next to the search box -- help panel should appear as a dropdown
- [ ] Verify Inbox, Public (globe), and Archive filter icons are visible and styled in the toolbar

Closes #285, closes #286, closes #287, closes #288, closes #289, closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search input to properly recognize whitespace-only entries as empty
  * Corrected panel vertical alignment and stacking order for proper layering
  * Improved search help panel rendering to prevent dropdown clipping
  * Enhanced toolbar styling for better cross-browser compatibility

* **Improvements**
  * Updated default search query to display inbox items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->