### PR TITLE
fix: sort sidebar wave list by last modified time descending

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -631,12 +631,31 @@ public final class SearchPresenter
    * The existing DOM node is reused — only changed text/attributes are
    * written — so the browser does not tear down and rebuild the element,
    * which eliminates the visible flicker in the sidebar wave list.
+   *
+   * If the updated digest has a newer last-modified time than the first
+   * item in the list, the entire list is re-rendered so that the most
+   * recently modified wave appears at the top (matching the server's
+   * default descending-LMT sort order).
    */
   private void applyDigestReady(int index, Digest digest) {
     DigestView digestUi = findDigestView(digest);
     if (digestUi == null) {
       return;
     }
+
+    // Check whether the modified digest should move to the top.
+    DigestView firstUi = searchUi.getFirst();
+    if (firstUi != null && firstUi != digestUi) {
+      Digest firstDigest = digestUis.get(firstUi);
+      if (firstDigest != null && digest.getLastModifiedTime() > firstDigest.getLastModifiedTime()) {
+        // The updated digest is newer than the current first item — trigger
+        // a full re-render via the next polling cycle so the server provides
+        // the authoritative sort order.
+        doSearch();
+        return;
+      }
+    }
+
     searchUi.renderDigest(digestUi, digest);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/WaveBasedDigest.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/WaveBasedDigest.java
@@ -157,7 +157,6 @@ public final class WaveBasedDigest
     }
   }
 
-  @SuppressWarnings("unused")
   private void invalidateLmt() {
     lastModified = NO_TIME;
   }
@@ -270,6 +269,7 @@ public final class WaveBasedDigest
   @Override
   public void onLastModifiedTimeChanged(ObservableWavelet wavelet, long oldTime, long newTime) {
     if (newTime != oldTime) {
+      invalidateLmt();
       fireOnChanged();
     }
   }


### PR DESCRIPTION
## Summary
- **WaveBasedDigest**: `invalidateLmt()` was never called (`@SuppressWarnings("unused")`), so the live digest cached a stale `lastModifiedTime` after first access. Now called from `onLastModifiedTimeChanged()` so the timestamp refreshes when the wavelet is modified.
- **SearchPresenter**: `applyDigestReady()` only re-rendered the digest DOM node in-place without checking sort order. Now compares the updated digest's LMT against the first item — if the updated wave is newer, triggers a server re-fetch so the list reflects the correct descending-LMT sort order.

The server-side sort (QueryHelper `DEFAULT_ORDERING = DESC_LMT_ORDERING`) was already correct. These were purely client-side bugs that prevented the sidebar from reflecting real-time sort order changes.

## Test plan
- [ ] Open two browser tabs logged in as different users
- [ ] In tab A, observe the sidebar wave list order
- [ ] In tab B, edit a wave that is NOT at the top of tab A's sidebar
- [ ] Verify that the edited wave moves to the top of tab A's sidebar within a few seconds
- [ ] Verify that editing the wave currently at the top does not cause unnecessary flickering
- [ ] Verify `sbt wave/compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search results now automatically refresh and re-execute when newer items are detected, ensuring your search list always displays the most current data.
  * Enhanced data consistency and synchronization for search results when items are updated in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->