### PR TITLE
fix: add isPinned() to SimpleSearch.DigestProxy for GWT compilation

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SimpleSearch.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SimpleSearch.java
@@ -166,6 +166,11 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
       return getDelegate().getInboxState();
     }
 
+    @Override
+    public boolean isPinned() {
+      return getDelegate().isPinned();
+    }
+
     //
     // Events.
     //


### PR DESCRIPTION
## Summary
- Adds missing `isPinned()` method to `SimpleSearch.DigestProxy`, delegating to the underlying `Digest` via `getDelegate().isPinned()`
- PR #298 (pinning feature) added `isPinned()` to the `Digest` interface but missed this proxy implementation, causing GWT compilation to fail
- Closes #300

## Test plan
- [x] `sbt pst/compile wave/compile` passes successfully
- [ ] Verify GWT compilation succeeds in CI
- [ ] Verify pinned state displays correctly in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pin state information for search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->