### PR TITLE
fix: repair saved state indicator visibility and onClose state bug

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2089,8 +2089,10 @@ public final class HtmlRenderer {
     sb.append("  display: inline-flex; align-items: center; justify-content: center;\n");
     sb.append("}\n");
     sb.append("#netstatus svg { width: 20px; height: 20px; }\n");
-    // Icon color is always white; state is shown by a small colored dot via ::after
-    sb.append(".topbar-icon svg { stroke: white !important; color: white !important; }\n");
+    // Icon color is white by default; saving state uses amber for visibility
+    sb.append(".topbar-icon svg { stroke: white; color: white; }\n");
+    sb.append(".topbar-icon.saving svg { stroke: #ecc94b !important; color: #ecc94b !important; }\n");
+    sb.append(".topbar-icon.saved svg { stroke: #3fb950 !important; color: #3fb950 !important; }\n");
     // -- Status indicator dots (::after pseudo-element badges) --
     sb.append(".topbar-icon::after {\n");
     sb.append("  content: ''; position: absolute; bottom: 2px; right: 2px;\n");

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
@@ -28,6 +28,8 @@ import org.waveprotocol.wave.client.scheduler.SchedulerInstance;
 import org.waveprotocol.wave.client.scheduler.TimerService;
 import org.waveprotocol.wave.concurrencycontrol.common.UnsavedDataListener;
 
+import java.util.logging.Logger;
+
 /**
  * Simple saved state indicator.
  *
@@ -36,6 +38,7 @@ import org.waveprotocol.wave.concurrencycontrol.common.UnsavedDataListener;
  */
 public class SavedStateIndicator implements UnsavedDataListener {
 
+  private static final Logger LOG = Logger.getLogger(SavedStateIndicator.class.getName());
   private static final SavedStateMessages messages = GWT.create(SavedStateMessages.class);
 
   private enum SavedState {
@@ -62,9 +65,9 @@ public class SavedStateIndicator implements UnsavedDataListener {
   private final TimerService scheduler;
 
   private SavedState visibleSavedState = SavedState.SAVED;
-  private SavedState currentSavedState = null;
+  private SavedState currentSavedState = SavedState.SAVED;
 
-  /** Cloud-check SVG icon for saved state (white for contrast on dark topbar). */
+  /** Cloud-check SVG icon for saved state (green for contrast on dark topbar). */
   private static final String SAVED_ICON_SVG =
       "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"#3fb950\" stroke-width=\"1.8\""
           + " stroke-linecap=\"round\" stroke-linejoin=\"round\" style=\"width:20px;height:20px;\">"
@@ -72,10 +75,11 @@ public class SavedStateIndicator implements UnsavedDataListener {
           + "<path d=\"M9 15l2 2 4-4\" stroke-width=\"2\"/>"
           + "</svg>";
 
-  /** Cloud-upload SVG icon for unsaved/saving state (white for contrast on dark topbar). */
+  /** Cloud-upload SVG icon for unsaved/saving state (amber for visibility on dark topbar). */
   private static final String UNSAVED_ICON_SVG =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\""
-          + " stroke-linecap=\"round\" stroke-linejoin=\"round\" style=\"width:20px;height:20px;\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"#ecc94b\" stroke-width=\"1.8\""
+          + " stroke-linecap=\"round\" stroke-linejoin=\"round\""
+          + " style=\"width:20px;height:20px;\" class=\"saving-icon\">"
           + "<path d=\"M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z\"/>"
           + "<path d=\"M12 18v-6m-3 3l3-3 3 3\" stroke-width=\"2\"/>"
           + "</svg>";
@@ -85,25 +89,25 @@ public class SavedStateIndicator implements UnsavedDataListener {
 
   public SavedStateIndicator(Element element) {
     this.element = element;
+    if (element == null) {
+      LOG.warning("SavedStateIndicator: element is null, indicator will not display");
+    }
     this.scheduler = SchedulerInstance.getLowPriorityTimer();
-    scheduler.schedule(updateTask);
-  }
-
-  public void saved() {
-    maybeUpdateDisplay();
-  }
-
-  public void unsaved() {
-    maybeUpdateDisplay();
+    // Initial display is already correct (SAVED), no need to schedule immediate update.
   }
 
   private void maybeUpdateDisplay() {
+    if (element == null) {
+      return;
+    }
     if (needsUpdating()) {
       switch (currentSavedState) {
         case SAVED:
           scheduler.scheduleDelayed(updateTask, UPDATE_DELAY_MS);
           break;
         case UNSAVED:
+          // Show unsaved state immediately so users see feedback.
+          scheduler.cancel(updateTask);
           updateDisplay();
           break;
         default:
@@ -119,6 +123,9 @@ public class SavedStateIndicator implements UnsavedDataListener {
   }
 
   private void updateDisplay() {
+    if (element == null) {
+      return;
+    }
     visibleSavedState = currentSavedState;
     String innerHtml = visibleSavedState == SavedState.SAVED ? SAVED_HTML : UNSAVED_HTML;
     String tooltip = visibleSavedState == SavedState.SAVED
@@ -133,19 +140,19 @@ public class SavedStateIndicator implements UnsavedDataListener {
   public void onUpdate(UnsavedDataInfo unsavedDataInfo) {
     if (unsavedDataInfo.estimateUnacknowledgedSize() != 0) {
       currentSavedState = SavedState.UNSAVED;
-      unsaved();
     } else {
       currentSavedState = SavedState.SAVED;
-      saved();
     }
+    maybeUpdateDisplay();
   }
 
   @Override
   public void onClose(boolean everythingCommitted) {
     if (everythingCommitted) {
-      saved();
+      currentSavedState = SavedState.SAVED;
     } else {
-      unsaved();
+      currentSavedState = SavedState.UNSAVED;
     }
+    maybeUpdateDisplay();
   }
 }


### PR DESCRIPTION
## Summary
- **Bug 1 (null initial state)**: `currentSavedState` was initialized to `null` instead of `SAVED`, causing the constructor's scheduled `updateTask` to set `visibleSavedState=null`. This made `needsUpdating()` comparisons against `null` unreliable, and the initial display showed the wrong state class.
- **Bug 2 (onClose state not set)**: `onClose()` called `saved()`/`unsaved()` without first setting `currentSavedState`, so `maybeUpdateDisplay()` used the stale value in its switch statement. When `onClose(true)` was called with `currentSavedState=UNSAVED`, the switch dispatched to `case UNSAVED` and showed the unsaved indicator even though the channel was fully committed.
- **Bug 3 (CSS forcing both icons white)**: The rule `.topbar-icon svg { stroke: white !important }` made the saved (cloud-check) and unsaved (cloud-upload) SVG icons visually identical. Users could not see any save state transition because both states rendered as the same white icon. Now the saved state renders in green (#3fb950) and the saving/unsaved state in amber (#ecc94b), with the CSS `!important` moved to the state-specific selectors.

Additional hardening:
- Null-safety guard on the indicator DOM element with a warning log
- Cancel any pending delayed-save task before immediate unsaved display
- Removed the unnecessary constructor-scheduled `updateTask` since both `visibleSavedState` and `currentSavedState` now start at `SAVED` (matching the server-rendered HTML)

## Test plan
- [ ] Create a new wave, type text in root blip -- verify the amber cloud-upload icon appears briefly, then transitions to the green cloud-check
- [ ] Edit an existing wave -- verify amber/green transitions are visible
- [ ] Check the connection status icon (wifi) still shows correct colors (green/amber/red)
- [ ] Verify `sbt wave/compile` and `sbt compileGwt` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Topbar icons now display state-specific colors: amber while saving, green when saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->