### PR TITLE
Improve search help panel: wider modal, username queries, in:pinned

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
@@ -59,6 +59,7 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
     String query();
     String helpButton();
     String helpPanel();
+    String helpBackdrop();
     String helpHeader();
     String helpTitle();
     String helpClose();
@@ -85,6 +86,8 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
   @UiField
   Element helpPanel;
   @UiField
+  Element helpBackdrop;
+  @UiField
   Element helpCloseButton;
   @UiField
   SpanElement exInbox;
@@ -92,6 +95,8 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
   SpanElement exArchive;
   @UiField
   SpanElement exAll;
+  @UiField
+  SpanElement exPinned;
   @UiField
   SpanElement exWith;
   @UiField
@@ -128,7 +133,9 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
     Event.setEventListener(helpButton, event -> {
       if (Event.ONCLICK == event.getTypeInt()) {
         boolean visible = !"none".equals(helpPanel.getStyle().getDisplay());
-        helpPanel.getStyle().setProperty("display", visible ? "none" : "block");
+        String display = visible ? "none" : "block";
+        helpPanel.getStyle().setProperty("display", display);
+        helpBackdrop.getStyle().setProperty("display", display);
       }
     });
 
@@ -137,6 +144,16 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
     Event.setEventListener(helpCloseButton, event -> {
       if (Event.ONCLICK == event.getTypeInt()) {
         helpPanel.getStyle().setProperty("display", "none");
+        helpBackdrop.getStyle().setProperty("display", "none");
+      }
+    });
+
+    // Clicking backdrop closes the panel
+    Event.sinkEvents(helpBackdrop, Event.ONCLICK);
+    Event.setEventListener(helpBackdrop, event -> {
+      if (Event.ONCLICK == event.getTypeInt()) {
+        helpPanel.getStyle().setProperty("display", "none");
+        helpBackdrop.getStyle().setProperty("display", "none");
       }
     });
 
@@ -144,6 +161,7 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
     wireExample(exInbox);
     wireExample(exArchive);
     wireExample(exAll);
+    wireExample(exPinned);
     wireExample(exWith);
     wireExample(exPublic);
     wireExample(exCreator);
@@ -161,6 +179,7 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
       if (Event.ONCLICK == event.getTypeInt()) {
         query.setValue(example.getInnerText());
         helpPanel.getStyle().setProperty("display", "none");
+        helpBackdrop.getStyle().setProperty("display", "none");
         onQuery();
       }
     });

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/Search.css
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/Search.css
@@ -95,19 +95,31 @@ input.query:focus {
 }
 
 .helpPanel {
-  position: absolute;
-  top: 100%;
-  left: 4px;
-  right: 4px;
-  z-index: 100;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 660px;
+  max-width: 90vw;
+  z-index: 1001;
   background: #f8fbff;
   border: 1.5px solid #b0c4d8;
   border-radius: 10px;
-  box-shadow: 0 4px 16px rgba(0,60,120,0.12);
-  padding: 10px 12px 8px;
-  font-size: 12px;
+  box-shadow: 0 8px 32px rgba(0,60,120,0.18);
+  padding: 16px 20px 12px;
+  font-size: 13px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   color: #1a3a52;
+}
+
+.helpBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.25);
+  z-index: 1000;
 }
 
 .helpHeader {

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml
@@ -32,6 +32,7 @@
      <g:TextBox ui:field='query' styleName='{css.query}'/>
      <div ui:field='helpButton' class='{css.helpButton}' title='Search help'>?</div>
    </div>
+   <div ui:field='helpBackdrop' class='{css.helpBackdrop}' style='display:none'/>
    <div ui:field='helpPanel' class='{css.helpPanel}' style='display:none'>
      <div class='{css.helpHeader}'>
        <span class='{css.helpTitle}'>Search Help</span>
@@ -57,9 +58,14 @@
          <td><span ui:field='exAll' class='{css.helpExample}'>in:all</span></td>
        </tr>
        <tr>
-         <td><code>with:user@domain</code></td>
+         <td><code>in:pinned</code></td>
+         <td>Your pinned waves</td>
+         <td><span ui:field='exPinned' class='{css.helpExample}'>in:pinned</span></td>
+       </tr>
+       <tr>
+         <td><code>with:username</code></td>
          <td>Waves shared with a specific user</td>
-         <td><span ui:field='exWith' class='{css.helpExample}'>with:test@supawave.ai</span></td>
+         <td><span ui:field='exWith' class='{css.helpExample}'>with:test</span></td>
        </tr>
        <tr>
          <td><code>with:@</code></td>
@@ -67,9 +73,9 @@
          <td><span ui:field='exPublic' class='{css.helpExample}'>with:@</span></td>
        </tr>
        <tr>
-         <td><code>creator:user@domain</code></td>
-         <td>Waves created by a specific user</td>
-         <td><span ui:field='exCreator' class='{css.helpExample}'>creator:vega@supawave.ai</span></td>
+         <td><code>creator:username</code></td>
+         <td>Waves created by a user. Just the username is enough — domain is added automatically.</td>
+         <td><span ui:field='exCreator' class='{css.helpExample}'>creator:vega</span></td>
        </tr>
        <tr>
          <td><code>tag:tagname</code></td>


### PR DESCRIPTION
## Summary
- **Updated `creator:` and `with:` descriptions**: Changed from `user@domain` format to just `username` — domain is added automatically. Updated examples accordingly (`creator:vega`, `with:test`).
- **Added `in:pinned` row**: Documents the pinned waves search query added in PR #298.
- **Converted panel to centered modal**: The help panel was a narrow dropdown that caused text wrapping. It is now a `position: fixed` centered modal (660px wide) with a semi-transparent backdrop overlay. Clicking the backdrop or the "Got it" button dismisses it.

## Test plan
- [ ] Click the "?" button next to search — panel should appear as a centered modal with backdrop
- [ ] Verify `creator:username` and `with:username` rows show updated text and examples
- [ ] Verify `in:pinned` row appears between `in:all` and `with:username`
- [ ] Click backdrop — modal should close
- [ ] Click "Got it" — modal should close
- [ ] Click any example — search box should fill and modal should close
- [ ] Verify no text wrapping in the wider panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)