### PR TITLE
fix: show Last seen and Member since on profile card

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2711,11 +2711,18 @@ public final class HtmlRenderer {
     sb.append("    if (!epochMs || epochMs <= 0) return '';\n");
     sb.append("    var now = Date.now();\n");
     sb.append("    var diff = now - epochMs;\n");
-    sb.append("    if (diff < 60000) return 'Last seen just now';\n");
+    sb.append("    if (diff < 120000) return '\\ud83d\\udfe2 Online';\n");
     sb.append("    if (diff < 3600000) return 'Last seen ' + Math.floor(diff/60000) + ' min ago';\n");
     sb.append("    if (diff < 86400000) return 'Last seen ' + Math.floor(diff/3600000) + ' hours ago';\n");
     sb.append("    if (diff < 172800000) return 'Last seen yesterday';\n");
     sb.append("    return 'Last seen ' + Math.floor(diff/86400000) + ' days ago';\n");
+    sb.append("  }\n\n");
+    sb.append("  function formatMemberSince(epochMs) {\n");
+    sb.append("    if (!epochMs || epochMs <= 0) return '';\n");
+    sb.append("    var d = new Date(epochMs);\n");
+    sb.append("    var months = ['January','February','March','April','May','June',\n");
+    sb.append("      'July','August','September','October','November','December'];\n");
+    sb.append("    return 'Member since ' + months[d.getMonth()] + ' ' + d.getFullYear();\n");
     sb.append("  }\n\n");
 
     // Show profile card
@@ -2738,8 +2745,12 @@ public final class HtmlRenderer {
     sb.append("        pcBio.textContent = data.bio || '';\n");
     sb.append("        pcBio.style.display = data.bio ? 'block' : 'none';\n");
     sb.append("        var ls = formatLastSeen(data.lastSeenTime);\n");
-    sb.append("        pcLastSeen.textContent = ls;\n");
-    sb.append("        pcLastSeen.style.display = ls ? 'block' : 'none';\n");
+    sb.append("        var ms = formatMemberSince(data.registrationTime);\n");
+    sb.append("        var parts = [];\n");
+    sb.append("        if (ls) parts.push('<div>' + ls + '</div>');\n");
+    sb.append("        if (ms) parts.push('<div>' + ms + '</div>');\n");
+    sb.append("        pcLastSeen.innerHTML = parts.join('');\n");
+    sb.append("        pcLastSeen.style.display = parts.length ? 'block' : 'none';\n");
     sb.append("        // Show edit button only for own profile\n");
     sb.append("        var loggedInUser = document.querySelector('.user-info');\n");
     sb.append("        var isOwnProfile = loggedInUser && loggedInUser.textContent.trim() === address;\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
@@ -432,6 +432,8 @@ public final class ProfileServlet extends HttpServlet {
     if (includeSensitive || h.isShowLastSeen()) {
       w.append(",\"lastSeenTime\":").append(String.valueOf(h.getLastActivityTime()));
     }
+    // Registration time is always public
+    w.append(",\"registrationTime\":").append(String.valueOf(h.getRegistrationTime()));
     w.append('}');
   }
 


### PR DESCRIPTION
## Summary

- **Add `registrationTime` to profile card JSON API** so the frontend can display it
- **Show "Online" with green circle** when user was active within the last 2 minutes (previously showed "Last seen just now")
- **Show "Member since [Month Year]"** below the last-seen line on the profile card popup
- Last seen continues to respect the `showLastSeen` privacy toggle; registration date is always public

## Changes

- `ProfileServlet.java`: Added `registrationTime` field to `writeProfileJson()` output
- `HtmlRenderer.java`: 
  - Updated `formatLastSeen()` threshold from 60s to 120s, returns green-circle "Online" instead of "Last seen just now"
  - Added `formatMemberSince()` JS helper
  - Updated profile card rendering to show both fields as stacked lines

## Test plan

- [ ] Open a profile card for another user — verify "Last seen X ago" and "Member since Month Year" both appear
- [ ] Verify a user active within 2 minutes shows green circle "Online"
- [ ] Verify a user with `showLastSeen` disabled does NOT show last seen, but still shows "Member since"
- [ ] Verify own profile card shows both fields
- [ ] Verify user with no registration time (0 or missing) gracefully hides "Member since"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile cards now display an "🟢 Online" indicator for users active within the past 2 minutes (extended from 1 minute threshold)
  * Added "Member since" information on profile cards, showing user registration month and year

<!-- end of auto-generated comment: release notes by coderabbit.ai -->