### PR TITLE
fix: backfill registrationTime for legacy accounts on startup

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -53,6 +53,7 @@ import org.waveprotocol.wave.util.logging.Log;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
+import java.util.List;
 
 public class ServerMain {
   private static final Log LOG = Log.get(ServerMain.class);
@@ -121,6 +122,7 @@ public class ServerMain {
 
     initializeServer(injector, domain);
     bootstrapOwner(injector.getInstance(AccountStore.class), config, domain);
+    backfillRegistrationTimes(injector.getInstance(AccountStore.class));
     initializeServlets(server, config);
     initializeRobots(injector, waveBus);
     initializeRobotAgents(injector);
@@ -207,6 +209,36 @@ public class ServerMain {
       }
     } catch (PersistenceException e) {
       LOG.severe("Failed to bootstrap owner for " + ownerAddress, e);
+    }
+  }
+
+  /**
+   * Backfills {@code registrationTime} for accounts created before the field
+   * was introduced (PR #183). Any human account with {@code registrationTime == 0}
+   * gets stamped with the current time so the admin dashboard no longer shows "--".
+   * This is a one-time migration: once the value is set and persisted it will be
+   * read back on subsequent startups and this method becomes a no-op.
+   */
+  private static void backfillRegistrationTimes(AccountStore accountStore) {
+    try {
+      List<AccountData> allAccounts = accountStore.getAllAccounts();
+      long now = System.currentTimeMillis();
+      int backfilled = 0;
+      for (AccountData acct : allAccounts) {
+        if (!acct.isHuman()) continue;
+        HumanAccountData human = acct.asHuman();
+        if (human.getRegistrationTime() == 0) {
+          human.setRegistrationTime(now);
+          accountStore.putAccount(acct);
+          backfilled++;
+        }
+      }
+      if (backfilled > 0) {
+        LOG.info("Backfilled registrationTime for " + backfilled
+            + " legacy account(s) (set to current time)");
+      }
+    } catch (PersistenceException e) {
+      LOG.warning("Failed to backfill registration times — legacy accounts will still show '--'", e);
     }
   }
 


### PR DESCRIPTION
## Summary
- Accounts created before PR #183 have `registrationTime=0` in the database, causing the admin dashboard "Registered" column to display "--" instead of a date.
- Added `backfillRegistrationTimes()` method to `ServerMain` that runs on startup, right after `bootstrapOwner()`. It iterates all human accounts and stamps any with `registrationTime==0` with the current time, then persists the change.
- This is a one-time migration: once backfilled values are persisted, subsequent startups become a no-op (all accounts already have non-zero values).
- Verified that both `Mongo4AccountStore` and `ProtoAccountDataSerializer` already correctly persist/read `registrationTime` -- no changes needed there.

## Test plan
- [ ] Deploy to a server with pre-existing accounts that have no `registrationTime` field in MongoDB
- [ ] Verify server logs show "Backfilled registrationTime for N legacy account(s)"
- [ ] Check admin dashboard -- all users should now show a date in the Registered column instead of "--"
- [ ] Restart server again and verify no backfill log message appears (no-op on second run)
- [ ] Create a new account and verify it still gets `registrationTime` set at registration time (not at next startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)