### PR TITLE
fix: DM wave History visibility and participant limit

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -53,6 +53,8 @@ import org.waveprotocol.wave.model.waveref.WaveRef;
 
 import java.util.Set;
 
+import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+
 /**
  * Stages for loading the undercurrent Wave Panel
  *
@@ -249,7 +251,7 @@ public class StagesProvider extends Stages {
       return;
     }
 
-    // --- Owner check: only the wave creator sees the History button ---
+    // --- Owner / DM-participant check: decide who sees the History button ---
     String currentUserAddress = Session.get().getAddress();
     Wavelet rootWavelet = two.getWave().getRoot();
     if (rootWavelet == null || currentUserAddress == null) {
@@ -258,14 +260,42 @@ public class StagesProvider extends Stages {
       return;
     }
 
+    boolean isCreator = false;
     ParticipantId creator = rootWavelet.getCreatorId();
-    if (creator == null || !currentUserAddress.equals(creator.getAddress())) {
-      // Not the owner -- hide the history button.
+    if (creator != null && currentUserAddress.equals(creator.getAddress())) {
+      isCreator = true;
+    }
+
+    // In a DM wave (exactly 2 real participants, no domain participant),
+    // both participants should see the History button.
+    boolean isDmParticipant = false;
+    if (!isCreator) {
+      Set<ParticipantId> waveletParticipants = rootWavelet.getParticipantIds();
+      boolean hasDomainParticipant = false;
+      boolean currentUserIsParticipant = false;
+      int realParticipantCount = 0;
+      for (ParticipantId pid : waveletParticipants) {
+        if (ParticipantIdUtil.isDomainAddress(pid.getAddress())) {
+          hasDomainParticipant = true;
+        } else {
+          realParticipantCount++;
+          if (currentUserAddress.equals(pid.getAddress())) {
+            currentUserIsParticipant = true;
+          }
+        }
+      }
+      isDmParticipant = !hasDomainParticipant
+          && realParticipantCount == 2
+          && currentUserIsParticipant;
+    }
+
+    if (!isCreator && !isDmParticipant) {
+      // Not the owner and not a DM participant -- hide the history button.
       three.getViewToolbar().setHistoryButtonVisible(false);
       return;
     }
 
-    // --- Owner confirmed: wire up history mode ---
+    // --- Authorized: wire up history mode ---
 
     // Determine the wave/wavelet coordinates for the history API.
     WaveId wId = waveRef.getWaveId();

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
@@ -287,6 +287,23 @@ public final class ParticipantController {
   }
 
   /**
+   * Returns true if the given conversation is a direct message (exactly 2 real
+   * participants and no shared-domain participant).
+   */
+  private static boolean isDirectMessage(Conversation conversation) {
+    Set<ParticipantId> participants = conversation.getParticipantIds();
+    int realCount = 0;
+    for (ParticipantId pid : participants) {
+      if (ParticipantIdUtil.isDomainAddress(pid.getAddress())) {
+        // Has a domain participant -- not a DM.
+        return false;
+      }
+      realCount++;
+    }
+    return realCount == 2;
+  }
+
+  /**
    * Shows an add-participant popup with contact autocomplete suggestions.
    * If no contact manager is available, falls back to a plain browser prompt.
    */
@@ -298,6 +315,12 @@ public final class ParticipantController {
 
     final ParticipantsView participantsUi = views.fromAddButton(context);
     final Conversation conversation = models.getParticipants(participantsUi);
+
+    // Block adding participants to DM waves.
+    if (isDirectMessage(conversation)) {
+      ToastNotification.showWarning(messages.cannotAddParticipantToDm());
+      return;
+    }
 
     ParticipantAddWidget addWidget = new ParticipantAddWidget();
     addWidget.setContactManager(contactManager);
@@ -336,6 +359,14 @@ public final class ParticipantController {
    * Legacy add-participant using a styled prompt dialog (no autocomplete).
    */
   private void handleAddButtonClickedLegacy(final Element context) {
+    // Block adding participants to DM waves.
+    ParticipantsView dmCheckUi = views.fromAddButton(context);
+    Conversation dmCheckConv = models.getParticipants(dmCheckUi);
+    if (isDirectMessage(dmCheckConv)) {
+      ToastNotification.showWarning(messages.cannotAddParticipantToDm());
+      return;
+    }
+
     PromptDialog.show("Add a participant(s) (separate with comma ','):", "",
         new PromptDialog.Listener() {
           @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
@@ -47,4 +47,7 @@ public interface ParticipantMessages extends Messages {
 
   @DefaultMessage("This wave is private. Click to make public")
   String waveIsPrivateClickToMakePublic();
+
+  @DefaultMessage("This is a direct message. Create a new wave to include more participants.")
+  String cannotAddParticipantToDm();
 }


### PR DESCRIPTION
## Summary
- **History button for both DM participants**: In a DM wave (exactly 2 real participants, no domain participant), both users now see the History button. Previously only the wave creator could access it.
- **Block adding participants to DMs**: The "Add participant" button now shows a toast ("This is a direct message. Create a new wave to include more participants.") when used on a DM wave, preventing it from becoming a group conversation.

## Changes
- `StagesProvider.java` — Extended the owner check in `wireHistoryMode()` to also grant History access when the wave is a DM and the current user is one of its two participants.
- `ParticipantController.java` — Added `isDirectMessage()` helper and DM guards in both `handleAddButtonClicked()` and `handleAddButtonClickedLegacy()`.
- `ParticipantMessages.java` — Added `cannotAddParticipantToDm()` i18n message.

## Test plan
- [ ] Open a DM wave as the creator — verify History button is visible and functional
- [ ] Open the same DM wave as the other participant — verify History button is visible and functional
- [ ] In a DM wave, click "Add participant" — verify toast appears and no participant is added
- [ ] In a regular (non-DM) wave, verify History button visibility is unchanged (creator only)
- [ ] In a regular wave, verify "Add participant" still works normally
- [ ] Verify `sbt wave/compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)