### PR TITLE
feat: hide add-participant in DM waves, show Direct Message label

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/FullDomRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/FullDomRenderer.java
@@ -165,14 +165,20 @@ public final class FullDomRenderer implements RenderingRules<UiBuilder> {
   public UiBuilder render(Conversation conversation, StringMap<UiBuilder> participantUis) {
     HtmlClosureCollection participantsUi = new HtmlClosureCollection();
     boolean isPublic = false;
+    int realCount = 0;
+    boolean hasDomain = false;
     for (ParticipantId participant : conversation.getParticipantIds()) {
       participantsUi.add(participantUis.get(participant.getAddress()));
       if (ParticipantIdUtil.isDomainAddress(participant.getAddress())) {
         isPublic = true;
+        hasDomain = true;
+      } else {
+        realCount++;
       }
     }
+    boolean isDm = !hasDomain && realCount == 2;
     String id = viewIdMapper.participantsOf(conversation);
-    return ParticipantsViewBuilder.create(id, participantsUi, isPublic);
+    return ParticipantsViewBuilder.create(id, participantsUi, isPublic, isDm);
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
@@ -77,6 +77,7 @@ public final class ParticipantsViewBuilder implements UiBuilder {
     String addButton();
     String newWaveWithParticipantsButton();
     String publicToggleButton();
+    String dmLabel();
   }
 
   private final static ParticipantMessages messages = GWT.create(ParticipantMessages.class);
@@ -103,13 +104,15 @@ public final class ParticipantsViewBuilder implements UiBuilder {
   private final HtmlClosureCollection participantUis;
   private final String id;
   private final boolean isPublic;
+  private final boolean isDm;
   @VisibleForTesting
   ParticipantsViewBuilder(Css css, String id, HtmlClosureCollection participantUis,
-      boolean isPublic) {
+      boolean isPublic, boolean isDm) {
     this.css = css;
     this.id = id;
     this.participantUis = participantUis;
     this.isPublic = isPublic;
+    this.isDm = isDm;
   }
 
   /**
@@ -119,19 +122,21 @@ public final class ParticipantsViewBuilder implements UiBuilder {
    */
   public static ParticipantsViewBuilder create(String id, HtmlClosureCollection participantUis) {
     return new ParticipantsViewBuilder(
-        WavePanelResourceLoader.getParticipants().css(), id, participantUis, false);
+        WavePanelResourceLoader.getParticipants().css(), id, participantUis, false, false);
   }
 
   /**
-   * Creates a new ParticipantsViewBuilder with public/private state.
+   * Creates a new ParticipantsViewBuilder with public/private and DM state.
    *
    * @param id attribute-HTML-safe encoding of the view's HTML id
    * @param isPublic true if the wave is currently public (shared with domain)
+   * @param isDm true if this is a direct message (exactly 2 real participants,
+   *             no domain participant)
    */
   public static ParticipantsViewBuilder create(String id, HtmlClosureCollection participantUis,
-      boolean isPublic) {
+      boolean isPublic, boolean isDm) {
     return new ParticipantsViewBuilder(
-        WavePanelResourceLoader.getParticipants().css(), id, participantUis, isPublic);
+        WavePanelResourceLoader.getParticipants().css(), id, participantUis, isPublic, isDm);
   }
 
   @Override
@@ -144,48 +149,75 @@ public final class ParticipantsViewBuilder implements UiBuilder {
         {
           participantUis.outputHtml(output);
 
-          // Overflow-mode panel (toggle + add, but NO new-wave button to
-          // avoid duplication with the single-line panel).
-          openSpan(output, null, css.extra(), null);
-          {
-            openSpanWith(output, null, css.toggleGroup(), null, "onclick=\"" + onClickJs() + "\"");
+          if (isDm) {
+            // DM wave: show only the "Direct Message" label, hide action buttons.
+            openSpan(output, null, css.extra(), null);
             {
-              appendSpan(output, null, css.expandButton(), null);
-              openSpan(output, null, null, null);
+              openSpanWith(output, null, css.toggleGroup(), null, "onclick=\"" + onClickJs() + "\"");
               {
-                output.appendPlainText(messages.more());
+                appendSpan(output, null, css.expandButton(), null);
+                openSpan(output, null, null, null);
+                {
+                  output.appendPlainText(messages.more());
+                }
+                closeSpan(output);
               }
               closeSpan(output);
+              dmLabel(output, css.dmLabel(), messages.directMessage());
             }
             closeSpan(output);
-            addParticipantIcon(output, css.addButton(),
-                TypeCodes.kind(Type.ADD_PARTICIPANT),
-                messages.addParticipantToThisWave());
-            newWaveIcon(output, css.newWaveWithParticipantsButton(),
-                TypeCodes.kind(Type.NEW_WAVE_WITH_PARTICIPANTS),
-                messages.newWaveWithParticipantsOfCurrentWave());
-            publicToggleIcon(output, css.publicToggleButton(),
-                TypeCodes.kind(Type.TOGGLE_PUBLIC),
-                isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
-                isPublic);
-          }
-          closeSpan(output);
 
-          // Single-line mode panel.
-          openSpan(output, null, css.simple(), null);
-          {
-            addParticipantIcon(output, css.addButton(),
-                TypeCodes.kind(Type.ADD_PARTICIPANT),
-                messages.addParticipantToThisWave());
-            newWaveIcon(output, css.newWaveWithParticipantsButton(),
-                TypeCodes.kind(Type.NEW_WAVE_WITH_PARTICIPANTS),
-                messages.newWaveWithParticipantsOfCurrentWave());
-            publicToggleIcon(output, css.publicToggleButton(),
-                TypeCodes.kind(Type.TOGGLE_PUBLIC),
-                isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
-                isPublic);
+            openSpan(output, null, css.simple(), null);
+            {
+              dmLabel(output, css.dmLabel(), messages.directMessage());
+            }
+            closeSpan(output);
+          } else {
+            // Normal wave: show action buttons.
+
+            // Overflow-mode panel (toggle + add, but NO new-wave button to
+            // avoid duplication with the single-line panel).
+            openSpan(output, null, css.extra(), null);
+            {
+              openSpanWith(output, null, css.toggleGroup(), null, "onclick=\"" + onClickJs() + "\"");
+              {
+                appendSpan(output, null, css.expandButton(), null);
+                openSpan(output, null, null, null);
+                {
+                  output.appendPlainText(messages.more());
+                }
+                closeSpan(output);
+              }
+              closeSpan(output);
+              addParticipantIcon(output, css.addButton(),
+                  TypeCodes.kind(Type.ADD_PARTICIPANT),
+                  messages.addParticipantToThisWave());
+              newWaveIcon(output, css.newWaveWithParticipantsButton(),
+                  TypeCodes.kind(Type.NEW_WAVE_WITH_PARTICIPANTS),
+                  messages.newWaveWithParticipantsOfCurrentWave());
+              publicToggleIcon(output, css.publicToggleButton(),
+                  TypeCodes.kind(Type.TOGGLE_PUBLIC),
+                  isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
+                  isPublic);
+            }
+            closeSpan(output);
+
+            // Single-line mode panel.
+            openSpan(output, null, css.simple(), null);
+            {
+              addParticipantIcon(output, css.addButton(),
+                  TypeCodes.kind(Type.ADD_PARTICIPANT),
+                  messages.addParticipantToThisWave());
+              newWaveIcon(output, css.newWaveWithParticipantsButton(),
+                  TypeCodes.kind(Type.NEW_WAVE_WITH_PARTICIPANTS),
+                  messages.newWaveWithParticipantsOfCurrentWave());
+              publicToggleIcon(output, css.publicToggleButton(),
+                  TypeCodes.kind(Type.TOGGLE_PUBLIC),
+                  isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
+                  isPublic);
+            }
+            closeSpan(output);
           }
-          closeSpan(output);
         }
         close(output);
       }
@@ -294,6 +326,27 @@ public final class ParticipantsViewBuilder implements UiBuilder {
         + (escapedTitle != null ? " aria-label='" + escapedTitle + "'" : "")
         + ">"
         + svgIcon
+        + "</span>");
+  }
+
+  /**
+   * Renders a subtle "Direct Message" label for DM waves. Uses a small
+   * chat-bubble SVG icon followed by the label text.
+   */
+  private static void dmLabel(SafeHtmlBuilder output, String clazz, String label) {
+    String escapedClazz = clazz != null ? EscapeUtils.htmlEscape(clazz) : null;
+    String escapedLabel = label != null ? EscapeUtils.htmlEscape(label) : "";
+    output.appendHtmlConstant(
+        "<span"
+        + (escapedClazz != null ? " class='" + escapedClazz + "'" : "")
+        + " title='" + escapedLabel + "'"
+        + ">"
+        // Small chat-bubble icon
+        + "<svg width='12' height='12' viewBox='0 0 24 24' fill='currentColor' "
+        + "style='vertical-align: middle; margin-right: 3px;'>"
+        + "<path d='M20 2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4V4c0-1.1-.9-2-2-2z'/>"
+        + "</svg>"
+        + escapedLabel
         + "</span>");
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/ParticipantMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/ParticipantMessages.java
@@ -46,4 +46,7 @@ public interface ParticipantMessages extends Messages {
 
   @DefaultMessage("Add participant to this wave")
   String addParticipantToThisWave();
+
+  @DefaultMessage("Direct Message")
+  String directMessage();
  }

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Participants.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Participants.css
@@ -253,3 +253,16 @@ img.participant:hover {
   color: #005f8a;
   background: rgba(0, 119, 182, 0.1);
 }
+
+.dmLabel {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  color: #64748b;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  vertical-align: middle;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: rgba(100, 116, 139, 0.08);
+}


### PR DESCRIPTION
## Summary
- In DM waves (exactly 2 non-domain participants), the add-participant, new-wave-with-participants, and public-toggle buttons are now **hidden entirely** at render time rather than just blocked with a toast notification
- A subtle "Direct Message" label with a chat-bubble icon is rendered in place of the action buttons, making it visually clear the wave is a DM
- The existing toast-based blocking in `ParticipantController.isDirectMessage()` remains as a safety net

## Changes
- **`FullDomRenderer`**: Detects DM state during participant rendering (same logic as `ParticipantController.isDirectMessage()`) and passes `isDm` flag to the view builder
- **`ParticipantsViewBuilder`**: Accepts `isDm` flag; when true, skips rendering add/new-wave/public-toggle buttons and renders a "Direct Message" label instead
- **`ParticipantMessages` (view i18n)**: Added `directMessage()` message with default "Direct Message"
- **`Participants.css`**: Added `.dmLabel` style (subtle gray pill with 11px font)

## Test plan
- [ ] Open a DM wave (exactly 2 participants, no domain participant) and verify:
  - No add-participant button is visible
  - No new-wave-with-participants button is visible
  - No public-toggle button is visible
  - "Direct Message" label with chat icon appears in the participants panel
- [ ] Open a non-DM wave (3+ participants or has domain participant) and verify all action buttons render normally
- [ ] Verify `sbt wave/compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversations between two participants now display a "Direct Message" label.
  * Participant action buttons are hidden in direct message conversations.

* **UI Improvements**
  * Direct Message label includes an icon and styled badge for visual distinction.

* **Internationalization**
  * Added localization support for Direct Message messaging strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->