### PR TITLE
fix: enforce white-only topbar SVG icons

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2089,10 +2089,8 @@ public final class HtmlRenderer {
     sb.append("  display: inline-flex; align-items: center; justify-content: center;\n");
     sb.append("}\n");
     sb.append("#netstatus svg { width: 20px; height: 20px; }\n");
-    // Icon color is white by default; saving state uses amber for visibility
+    // All topbar icons are white; state is shown only by ::after dots
     sb.append(".topbar-icon svg { stroke: white; color: white; }\n");
-    sb.append(".topbar-icon.saving svg { stroke: #ecc94b !important; color: #ecc94b !important; }\n");
-    sb.append(".topbar-icon.saved svg { stroke: #3fb950 !important; color: #3fb950 !important; }\n");
     // -- Status indicator dots (::after pseudo-element badges) --
     sb.append(".topbar-icon::after {\n");
     sb.append("  content: ''; position: absolute; bottom: 2px; right: 2px;\n");
@@ -2125,9 +2123,8 @@ public final class HtmlRenderer {
     sb.append(".info { margin-left: auto; display: flex; align-items: center; gap: 8px; font-size: 13px; color: rgba(255,255,255,0.9); }\n");
     sb.append(".info a { color: #fff; text-decoration: none; font-weight: 500; }\n");
     sb.append(".info a:hover { text-decoration: underline; }\n");
-    sb.append(".online svg { color: #3fb950; stroke: #3fb950; }\n");
-    sb.append(".connecting svg { color: #d29922; stroke: #d29922; }\n");
-    sb.append(".offline svg { color: #f85149; stroke: #f85149; }\n");
+    // Icon color stays white; state is conveyed by ::after dots only
+    sb.append(".online svg, .connecting svg, .offline svg { color: white; stroke: white; }\n");
     sb.append("@keyframes status-pulse {\n");
     sb.append("  0%, 100% { opacity: 1; }\n");
     sb.append("  50% { opacity: 0.5; }\n");
@@ -3078,9 +3075,9 @@ public final class HtmlRenderer {
       + "<path d=\"M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10\"/>"
       + "</svg>";
 
-  /** Cloud with checkmark icon for saved state — green #3fb950. */
+  /** Cloud with checkmark icon for saved state — white on dark topbar. */
   private static final String ICON_CLOUD_CHECK =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"#3fb950\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
       + "<path d=\"M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z\"/>"
       + "<path d=\"M9 15l2 2 4-4\" stroke-width=\"2\"/>"
       + "</svg>";

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
@@ -67,17 +67,17 @@ public class SavedStateIndicator implements UnsavedDataListener {
   private SavedState visibleSavedState = SavedState.SAVED;
   private SavedState currentSavedState = SavedState.SAVED;
 
-  /** Cloud-check SVG icon for saved state (green for contrast on dark topbar). */
+  /** Cloud-check SVG icon for saved state (white on dark topbar; dot shows state). */
   private static final String SAVED_ICON_SVG =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"#3fb950\" stroke-width=\"1.8\""
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\""
           + " stroke-linecap=\"round\" stroke-linejoin=\"round\" style=\"width:20px;height:20px;\">"
           + "<path d=\"M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z\"/>"
           + "<path d=\"M9 15l2 2 4-4\" stroke-width=\"2\"/>"
           + "</svg>";
 
-  /** Cloud-upload SVG icon for unsaved/saving state (amber for visibility on dark topbar). */
+  /** Cloud-upload SVG icon for unsaved/saving state (white on dark topbar; dot shows state). */
   private static final String UNSAVED_ICON_SVG =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"#ecc94b\" stroke-width=\"1.8\""
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\""
           + " stroke-linecap=\"round\" stroke-linejoin=\"round\""
           + " style=\"width:20px;height:20px;\" class=\"saving-icon\">"
           + "<path d=\"M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z\"/>"


### PR DESCRIPTION
## Summary
- **Removes** CSS rules that turned topbar SVG icons green (`#3fb950`) or amber (`#ecc94b`) based on saved/online/connecting/offline state
- **Changes** inline SVG `stroke` attributes in `ICON_CLOUD_CHECK`, `SAVED_ICON_SVG`, and `UNSAVED_ICON_SVG` from colored to `white`
- **Preserves** the small colored `::after` indicator dots which are the correct way to convey state

PR #304 reintroduced colored icon overrides that violated the white-only topbar icon policy established in PR #167. The rule is: all topbar SVG icons are always white; saved/unsaved and online/offline state is shown only by the small colored dot badges.

### Files changed
- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` — removed 5 CSS color override rules, fixed `ICON_CLOUD_CHECK` stroke
- `wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java` — fixed `SAVED_ICON_SVG` and `UNSAVED_ICON_SVG` strokes

## Test plan
- [ ] Load the app, verify all topbar icons (cloud, wifi, globe) render in white
- [ ] Trigger saving state — icon stays white, amber dot pulses
- [ ] Confirm saved state — icon stays white, green dot appears
- [ ] Disconnect network — wifi icon stays white, red dot appears
- [ ] Reconnect — wifi icon stays white, amber dot pulses then green dot shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated top-bar icon styling for visual consistency—all icons now display in white
  * State indicators (saving, saved, connection status) are now conveyed through status dots instead of icon color variations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->