### PR TITLE
fix: style hyperlinks in blip content with animated underline

### DIFF
--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -250,6 +250,49 @@
 
 .contentContainer, .replies, .privateReplies{word-wrap: break-word;}
 
+/* ---- Links inside blip content ---- */
+.contentContainer a {
+  color: #0077b6;
+  text-decoration: none;
+  position: relative;
+  cursor: pointer;
+  transition: color 0.2s ease;
+  -webkit-transition: color 0.2s ease;
+  -moz-transition: color 0.2s ease;
+}
+
+.contentContainer a::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #0077b6, #00b4d8);
+  transition: width 0.3s ease;
+  -webkit-transition: width 0.3s ease;
+  -moz-transition: width 0.3s ease;
+  border-radius: 1px;
+  -moz-border-radius: 1px;
+  -webkit-border-radius: 1px;
+}
+
+.contentContainer a:hover {
+  color: #00b4d8;
+}
+
+.contentContainer a:hover::after {
+  width: 100%;
+}
+
+.contentContainer a:visited {
+  color: #6b5b95;
+}
+
+.contentContainer a:visited::after {
+  background: linear-gradient(90deg, #6b5b95, #8b7db5);
+}
+
 /* Quasi-deleted / soft-delete state (client-side visual only).
  * When a blip is soft-deleted, the content collapses, the metabar turns
  * red-ish, and text is struck through. An undo toast is shown separately. */


### PR DESCRIPTION
## Summary
- Links inside blip content were visually indistinguishable from regular text (no color, no underline, no cursor change)
- Added CSS rules to `.contentContainer a` in `Blip.css` that give links ocean blue color (#0077b6), pointer cursor, and a gradient underline that slides in on hover via `::after` pseudo-element
- Visited links display a distinct purple (#6b5b95) shade with matching gradient underline

## Details
The `<a>` elements are created by `AnnotationSpreadRenderer` when a link annotation is present on text. They live inside the `.contentContainer` div (which has `kind="document"`). Previously there was zero link styling in `Blip.css`, so links inherited the surrounding text appearance and were invisible to users.

### Styling added:
| State | Color | Effect |
|-------|-------|--------|
| Default | `#0077b6` (ocean blue) | No underline, pointer cursor |
| Hover | `#00b4d8` (lighter blue) | Gradient underline slides in (0.3s ease) |
| Visited | `#6b5b95` (muted purple) | Purple gradient underline on hover |

Vendor prefixes included for `-webkit-` and `-moz-` transitions and border-radius for compatibility.

## Test plan
- [ ] Open a wave containing blips with hyperlinks (both auto-detected and manually added)
- [ ] Verify links display in ocean blue and are clearly distinguishable from regular text
- [ ] Hover over a link and confirm the gradient underline animates in from left to right
- [ ] Click a link to visit it, then return — verify visited color changes to purple
- [ ] Confirm cursor changes to pointer on link hover
- [ ] Test in edit mode: links should still be styled while editing
- [ ] Verify no visual regressions on blip content, metabar, or reply areas

🤖 Generated with [Claude Code](https://claude.com/claude-code)