### PR TITLE
fix: prevent tags panel from hiding bottom blips and reply button

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TagsViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TagsViewBuilder.java
@@ -129,16 +129,6 @@ public final class TagsViewBuilder implements UiBuilder {
           output.appendPlainText(messages.tags());
           OutputHelper.close(output);
 
-          // Search tip for tags
-          output.appendHtmlConstant(
-              "<span class=\"" + css.title() + "\" style=\"font-size:10px;color:#64748b;"
-              + "font-style:italic;margin-left:4px;line-height:28px;float:left;"
-              + "font-weight:normal;\" title=\"Tags help you categorize waves. "
-              + "Use tag:name in search to find tagged waves.\">"
-              + "(<code style=\"background:#e6f0fa;padding:0 3px;border-radius:2px;"
-              + "font-size:10px;\">tag:name</code> in search)"
-              + "</span>");
-
           tagUis.outputHtml(output);
 
           // Overflow-mode panel.

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Conversation.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Conversation.css
@@ -43,12 +43,10 @@
   top: threadTop;
   left: 0;
   right: 0;
-  bottom: 0;
+  /* Stop the scroll area above the tags panel (height 36px in Tags.css). */
+  bottom: 36px;
   /* Layout under siblings (participant panel etc). */
   z-index: -1;
-  /* Reserve space so the last blip / "Click here to reply" is not hidden
-   * behind the absolutely-positioned tags panel (height 36px + bottom -4px). */
-  padding-bottom: 40px;
 }
 
 @sprite .toolbar {


### PR DESCRIPTION
## Summary
- **Fixed scroll overlap**: Changed `.fixedThread` from `bottom: 0` + `padding-bottom: 40px` to `bottom: 36px`, so the scroll area stops above the tags panel instead of extending behind it. The previous `padding-bottom` workaround (from PR #274) was insufficient because the scroll container still rendered underneath the absolutely-positioned tags panel.
- **Removed hint text**: Removed the `(tag:name in search)` hint span from the tags panel in `TagsViewBuilder.java` that was supposed to have been removed earlier.

## Test plan
- [ ] Open a wave with multiple blips — verify the last blip and "Click here to reply" are fully visible above the tags panel
- [ ] Scroll to the very bottom of a conversation — confirm no content is hidden behind the tags bar
- [ ] Verify the tags panel still displays correctly (title, add button, tag chips)
- [ ] Confirm the "(tag:name in search)" hint text no longer appears on the tags panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted conversation thread layout to prevent tags panel overlap
  * Removed search tip text from tags section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->