### PR TITLE
fix: render search help panel above all GWT panels

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java
@@ -21,6 +21,7 @@ package org.waveprotocol.box.webclient.search;
 
 import com.google.common.base.Preconditions;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -126,8 +127,14 @@ public class SearchWidget extends Composite implements SearchView, ChangeHandler
 
   /**
    * Wires up the search-help "?" button, close button, and clickable examples.
+   * The help panel and backdrop are re-parented to document.body so they escape
+   * any stacking context created by GWT's SplitLayoutPanel or other containers.
    */
   private void initHelpPanel() {
+    // Move help panel and backdrop to document.body to avoid stacking context issues
+    Document.get().getBody().appendChild(helpBackdrop);
+    Document.get().getBody().appendChild(helpPanel);
+
     // Toggle help panel visibility on "?" button click
     Event.sinkEvents(helpButton, Event.ONCLICK);
     Event.setEventListener(helpButton, event -> {

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/Search.css
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/Search.css
@@ -101,7 +101,7 @@ input.query:focus {
   transform: translate(-50%, -50%);
   width: 660px;
   max-width: 90vw;
-  z-index: 1001;
+  z-index: 99999;
   background: #f8fbff;
   border: 1.5px solid #b0c4d8;
   border-radius: 10px;
@@ -119,7 +119,7 @@ input.query:focus {
   right: 0;
   bottom: 0;
   background: rgba(0,0,0,0.25);
-  z-index: 1000;
+  z-index: 99998;
 }
 
 .helpHeader {


### PR DESCRIPTION
## Summary
- The search help "?" panel was invisible because it rendered behind GWT's SplitLayoutPanel due to CSS stacking context isolation
- Re-parent `helpPanel` and `helpBackdrop` elements to `document.body` so they escape the search panel's stacking context entirely
- Increase z-index from 1001/1000 to 99999/99998 to layer above all other overlays (lightbox uses 10000, error indicator uses 99999)

## Test plan
- [ ] Click the "?" button next to the search box and verify the help panel appears centered on screen, fully visible on top of all other panels
- [ ] Verify the dark backdrop covers the entire viewport behind the help panel
- [ ] Click the backdrop to dismiss -- panel and backdrop should disappear
- [ ] Click "Got it" button to dismiss -- same behavior
- [ ] Click a search example in the help panel -- search box should fill and panel should close
- [ ] Open the help panel while a wave conversation is open to confirm it renders above the wave content panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)