### PR TITLE
fix: scroll to and focus linked blip when clicking internal wave links

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -397,6 +397,30 @@ public class StagesProvider extends Stages {
   }
 
   /**
+   * Returns the wave ID of the currently open wave.
+   */
+  public WaveId getWaveId() {
+    return waveRef.getWaveId();
+  }
+
+  /**
+   * Navigates to and focuses a specific blip within this already-open wave.
+   * This avoids the overhead of closing and reopening the wave.
+   *
+   * @param targetRef the wave reference containing the blip to focus on.
+   *        Must reference the same wave as this provider.
+   * @return true if the blip was found and focused, false otherwise.
+   */
+  public boolean focusBlip(WaveRef targetRef) {
+    if (one == null || two == null || closed) {
+      return false;
+    }
+    selectAndFocusOnBlip(two.getReader(), two.getModelAsViewProvider(), two.getConversations(),
+        one.getFocusFrame(), targetRef);
+    return true;
+  }
+
+  /**
    * @return a halting provider if this stage is closed. Otherwise, returns the
    *         given provider.
    */

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
@@ -706,6 +706,16 @@ public class WebClient implements EntryPoint {
     final org.waveprotocol.box.stat.Timer timer = Timing.startRequest("Open Wave");
     LOG.info("WebClient.openWave()");
 
+    // If the same wave is already open and the reference includes a blip ID,
+    // navigate to that blip without reopening the wave.
+    if (!isNewWave && wave != null && waveRef.hasDocumentId()
+        && wave.getWaveId().equals(waveRef.getWaveId())) {
+      LOG.info("Navigating to blip within same wave: " + waveRef.getDocumentId());
+      wave.focusBlip(waveRef);
+      Timing.stop(timer);
+      return;
+    }
+
     if (wave != null) {
       wave.destroy();
       wave = null;

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
 import org.waveprotocol.wave.client.debug.FragmentsDebugIndicator;
 
 import org.waveprotocol.wave.client.account.ProfileManager;
@@ -49,8 +50,12 @@ import org.waveprotocol.wave.client.doodad.link.LinkAnnotationHandler;
 import org.waveprotocol.wave.client.doodad.link.LinkAnnotationHandler.LinkAttributeAugmenter;
 import org.waveprotocol.wave.client.doodad.selection.SelectionAnnotationHandler;
 import org.waveprotocol.wave.client.doodad.title.TitleAnnotationHandler;
+import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.content.Registries;
+import org.waveprotocol.wave.client.editor.content.misc.AnnotationPaint;
 import org.waveprotocol.wave.client.editor.content.misc.StyleAnnotationHandler;
+import org.waveprotocol.wave.client.events.ClientEvents;
+import org.waveprotocol.wave.client.events.WaveSelectionEvent;
 import org.waveprotocol.wave.client.gadget.Gadget;
 import org.waveprotocol.wave.client.render.ReductionBasedRenderer;
 import org.waveprotocol.wave.client.render.RenderingRules;
@@ -162,6 +167,9 @@ import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 import org.waveprotocol.wave.model.wave.opbased.WaveViewImpl;
 import org.waveprotocol.wave.model.wave.opbased.WaveViewImpl.WaveletConfigurator;
 import org.waveprotocol.wave.model.wave.opbased.WaveViewImpl.WaveletFactory;
+
+import org.waveprotocol.wave.model.waveref.WaveRef;
+import org.waveprotocol.wave.util.escapers.GwtWaverefEncoder;
 
 import java.util.Collections;
 import java.util.Map;
@@ -853,11 +861,80 @@ public interface StageTwo {
             }
         }-*/;
 
+        /**
+         * Key used to register the internal-link click handler in the
+         * {@link AnnotationPaint} event-handler registry.
+         */
+        private static final String INTERNAL_LINK_HANDLER_KEY = "internalLink";
+
+        /**
+         * True once the static internal-link event handler has been registered.
+         * Guarded by the class-level monitor since {@code installDoodads} can
+         * theoretically be called more than once.
+         */
+        private static boolean internalLinkHandlerRegistered = false;
+
+        /**
+         * Ensures the internal-link click handler is registered exactly once
+         * with {@link AnnotationPaint}.
+         */
+        private static void ensureInternalLinkHandlerRegistered() {
+            if (!internalLinkHandlerRegistered) {
+                AnnotationPaint.registerEventHandler(INTERNAL_LINK_HANDLER_KEY,
+                    new AnnotationPaint.EventHandler() {
+                        @Override
+                        public void onEvent(ContentElement node, Event event) {
+                            if (event.getTypeInt() != Event.ONCLICK) {
+                                return;
+                            }
+                            Element target = Element.as(event.getEventTarget());
+                            // Walk up to find the anchor element (the click may
+                            // be on an inner text node).
+                            while (target != null
+                                    && !"a".equalsIgnoreCase(target.getTagName())) {
+                                target = target.getParentElement();
+                            }
+                            if (target == null) {
+                                return;
+                            }
+                            String href = target.getAttribute("href");
+                            if (href == null || !href.startsWith("#")) {
+                                return;
+                            }
+                            // Prevent the browser from performing default anchor navigation.
+                            event.preventDefault();
+
+                            String encodedRef = href.substring(1);
+                            try {
+                                WaveRef ref = GwtWaverefEncoder.decodeWaveRefFromPath(encodedRef);
+                                ClientEvents.get().fireEvent(new WaveSelectionEvent(ref));
+                            } catch (Exception e) {
+                                // Malformed ref -- nothing we can do, just ignore.
+                            }
+                        }
+                    });
+                internalLinkHandlerRegistered = true;
+            }
+        }
+
         protected LinkAttributeAugmenter createLinkAttributeAugmenter() {
+            // Make sure the static click handler is available.
+            ensureInternalLinkHandlerRegistered();
+
             return new LinkAttributeAugmenter() {
                 @Override
                 public Map<String, String> augment(Map<String, Object> annotations, boolean isEditing,
                                                    Map<String, String> current) {
+                    String link = current.get(AnnotationPaint.LINK_ATTR);
+                    if (link != null && link.startsWith("#")) {
+                        // Internal link -- attach the click handler so that
+                        // navigation works even when the editor is in edit mode.
+                        java.util.HashMap<String, String> augmented =
+                            new java.util.HashMap<String, String>(current);
+                        augmented.put(AnnotationPaint.MOUSE_LISTENER_ATTR,
+                            INTERNAL_LINK_HANDLER_KEY);
+                        return augmented;
+                    }
                     return current;
                 }
             };


### PR DESCRIPTION
## Summary
- When clicking an internal link (wave:// URL pointing to a blip in the same wave), the view now scrolls to and focuses the target blip
- Previously, internal links either did nothing (in edit mode) or wastefully destroyed and reopened the entire wave panel
- Registers a click event handler on internal link annotations that intercepts the click, decodes the wave reference, and fires a `WaveSelectionEvent`
- Short-circuits `WebClient.openWave()` to navigate to the blip in-place when the same wave is already open

## Changes
- **`StageTwo.java`**: Added internal link click handler registered via `AnnotationPaint.EventHandler`, and augmented `LinkAttributeAugmenter` to attach the handler to `#`-prefixed (internal) link paint elements
- **`WebClient.java`**: Added early return in `openWave()` that calls `focusBlip()` instead of destroying/recreating the wave when navigating to a blip within the already-open wave
- **`StagesProvider.java`**: Added `focusBlip(WaveRef)` method for in-place blip navigation and `getWaveId()` accessor

## Test plan
- [ ] Create a wave with multiple blips
- [ ] Add an internal link to another blip in the same wave (e.g., `wave://domain/waveId/~/conv+root/blipId`)
- [ ] Click the link while in read mode -- verify the view scrolls to and focuses the target blip
- [ ] Click the link while in edit mode -- verify same navigation behavior
- [ ] Click an external link (http/https) -- verify it still opens in a new tab
- [ ] Open a wave via URL with a blip reference -- verify initial load still focuses the correct blip
- [ ] Verify `sbt wave/compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)