### PR TITLE
feat: add wave count summary bar to search panel

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelView.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelView.java
@@ -52,6 +52,9 @@ public interface SearchPanelView {
   /** Sets the title bar text. */
   void setTitleText(String text);
 
+  /** Sets the wave count summary text (e.g. "23 waves, 5 unread"). */
+  void setWaveCountText(String text);
+
   /** @return the search area. */
   SearchView getSearch();
 

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
@@ -68,6 +68,8 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
 
     String toolbar();
 
+    String waveCount();
+
     String list();
 
     String showMore();
@@ -81,11 +83,15 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
     private static int TOOLBAR_HEIGHT_PX =
         SearchPanelResourceLoader.getPanel().emptyToolbar().getHeight();
     private static int TOOLBAR_TOP_PX = 0 + SEARCH_HEIGHT_PX;
-    private static int LIST_TOP_PX = TOOLBAR_TOP_PX + TOOLBAR_HEIGHT_PX;
+    /** Height of the wave count info bar (24px content + 1px border). */
+    private static int WAVE_COUNT_HEIGHT_PX = 25;
+    private static int WAVE_COUNT_TOP_PX = TOOLBAR_TOP_PX + TOOLBAR_HEIGHT_PX;
+    private static int LIST_TOP_PX = WAVE_COUNT_TOP_PX + WAVE_COUNT_HEIGHT_PX;
 
     // CSS constants exported to .css files
     static String SEARCH_HEIGHT = SEARCH_HEIGHT_PX + "px";
     static String TOOLBAR_TOP = TOOLBAR_TOP_PX + "px";
+    static String WAVE_COUNT_TOP = WAVE_COUNT_TOP_PX + "px";
     static String LIST_TOP = LIST_TOP_PX + "px";
   }
 
@@ -102,6 +108,8 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
   SearchWidget search;
   @UiField
   ToplevelToolbarWidget toolbar;
+  @UiField
+  Element waveCount;
   @UiField
   Element list;
   @UiField
@@ -236,6 +244,17 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
   @Override
   public void setTitleText(String text) {
     frame.setTitleText(text);
+  }
+
+  @Override
+  public void setWaveCountText(String text) {
+    if (text == null || text.isEmpty()) {
+      waveCount.setInnerText("");
+      waveCount.getStyle().setProperty("display", "none");
+    } else {
+      waveCount.setInnerText(text);
+      waveCount.getStyle().clearProperty("display");
+    }
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -466,6 +466,7 @@ public final class SearchPresenter
    */
   private void render() {
     renderTitle();
+    renderWaveCount();
     renderDigests();
     renderShowMore();
   }
@@ -483,6 +484,34 @@ public final class SearchPresenter
       totalStr = messages.ofUnknown();
     }
     searchUi.setTitleText(queryText + " (0-" + resultEnd + " of " + totalStr + ")");
+  }
+
+  /**
+   * Renders the wave count summary line (e.g. "23 waves, 5 unread").
+   * Counts total waves from the search result and tallies unread by
+   * checking each digest's unread count.
+   */
+  private void renderWaveCount() {
+    int total = search.getTotal();
+    if (total == Search.UNKNOWN_SIZE) {
+      total = search.getMinimumTotal();
+    }
+    int unread = 0;
+    for (int i = 0, size = search.getMinimumTotal(); i < size; i++) {
+      Digest digest = search.getDigest(i);
+      if (digest != null && digest.getUnreadCount() > 0) {
+        unread++;
+      }
+    }
+    String text;
+    if (total <= 0) {
+      text = "";
+    } else if (unread > 0) {
+      text = total + " waves \u00b7 " + unread + " unread";
+    } else {
+      text = total + " waves";
+    }
+    searchUi.setWaveCountText(text);
   }
 
   private void renderDigests() {
@@ -573,6 +602,7 @@ public final class SearchPresenter
     //
     if (search.getState() == State.READY) {
       renderTitle();
+      renderWaveCount();
       renderShowMore();
       // Deferred load: fetch saved searches after the first search result
       // arrives so the /searches request does not block wave list display.

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanel.css
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanel.css
@@ -22,6 +22,7 @@
  */
 @eval listTop org.waveprotocol.box.webclient.search.SearchPanelWidget.CssConstants.LIST_TOP;
 @eval toolbarTop org.waveprotocol.box.webclient.search.SearchPanelWidget.CssConstants.TOOLBAR_TOP;
+@eval waveCountTop org.waveprotocol.box.webclient.search.SearchPanelWidget.CssConstants.WAVE_COUNT_TOP;
 
 /* Size to container. */
 .self {
@@ -54,6 +55,25 @@
   right: 0;
   left: 0;
   border-left: none;
+}
+
+.waveCount {
+  position: absolute;
+  top: waveCountTop;
+  left: 0;
+  right: 0;
+  height: 24px;
+  line-height: 24px;
+  padding: 0 12px;
+  font-size: 11px;
+  font-weight: 500;
+  color: #64748b;
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  z-index: 0;
 }
 
 .list {

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanelWidget.ui.xml
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanelWidget.ui.xml
@@ -35,6 +35,7 @@
     <w:ImplPanel ui:field='self' styleName='{css.self}'>
       <s:SearchWidget ui:field='search' addStyleNames='{css.search}'/>
       <t:ToplevelToolbarWidget ui:field='toolbar' addStyleNames='{css.toolbar}'/>
+      <div ui:field='waveCount' class='{css.waveCount}'/>
       <div ui:field='list' class='{css.list}'>
         <div ui:field='showMore' class='{css.showMore}' style='visibility:hidden'>
         </div>


### PR DESCRIPTION
## Summary
- Adds a dynamic "23 waves · 5 unread" info bar between the toolbar and wave list in the search panel
- The bar updates automatically when search results change or waves are read
- When no results exist, the bar is hidden; when all waves are read, only the count is shown (e.g. "23 waves")
- Verified that PR #302 infinite scroll is working correctly: "Show more results" text removed, scroll-near-bottom triggers automatic fetch, spinner shows during loading

## Implementation details
- **SearchPanelView.java**: Added `setWaveCountText(String)` to the view interface
- **SearchPanelWidget.java**: New `waveCount` UiField element; `CssConstants` updated with `WAVE_COUNT_HEIGHT_PX` (25px) and `WAVE_COUNT_TOP` to position the bar between toolbar and list; `LIST_TOP` recalculated to account for the new bar
- **SearchPresenter.java**: New `renderWaveCount()` method iterates loaded digests to tally unread count, called from both `render()` and `onStateChanged()`
- **SearchPanel.css**: New `.waveCount` rule (absolute positioned, 24px + 1px border, subtle gray styling)
- **SearchPanelWidget.ui.xml**: Added `<div ui:field='waveCount'>` between toolbar and list

## Test plan
- [ ] Load the app and verify the wave count bar appears below the toolbar
- [ ] Confirm it shows "N waves · M unread" when there are unread waves
- [ ] Confirm it shows "N waves" when all waves are read
- [ ] Confirm it hides when there are no search results
- [ ] Switch between Inbox/Public/Archive filters and verify count updates
- [ ] Scroll to the bottom and verify infinite scroll still triggers correctly
- [ ] Verify no layout gaps between toolbar, count bar, and first wave entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)