### PR TITLE
fix: replace last Window.alert/confirm calls with styled widgets

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/HistoryModeController.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/HistoryModeController.java
@@ -28,6 +28,9 @@ import com.google.gwt.http.client.Response;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Window;
 
+import org.waveprotocol.wave.client.widget.dialog.ConfirmDialog;
+import org.waveprotocol.wave.client.widget.toast.ToastNotification;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -299,13 +302,26 @@ public final class HistoryModeController {
 
     final long targetVersion = groups.get(currentGroupIndex).getEndVersion();
 
-    boolean confirmed = Window.confirm(
+    ConfirmDialog.show(
+        "Restore version",
         "Restore wave to version " + targetVersion + "?\n\n"
-        + "This will revert all changes made after this version.");
-    if (!confirmed) {
-      return;
-    }
+            + "This will revert all changes made after this version.",
+        "Restore", "Cancel",
+        new ConfirmDialog.Listener() {
+          @Override
+          public void onConfirm() {
+            doRestore(targetVersion);
+          }
 
+          @Override
+          public void onCancel() {
+            // User cancelled -- nothing to do.
+          }
+        });
+  }
+
+  /** Sends the POST request to restore a wave to the given version. */
+  private void doRestore(long targetVersion) {
     String url = "/history/" + enc(waveDomain) + "/" + enc(waveId) + "/"
         + enc(waveletDomain) + "/" + enc(waveletId)
         + "/api/restore?version=" + targetVersion;
@@ -319,20 +335,22 @@ public final class HistoryModeController {
           // Force a page reload to pick up the new wave state
           Window.Location.reload();
         } else {
-          Window.alert("Failed to restore version: HTTP "
+          ToastNotification.showWarning("Failed to restore version: HTTP "
               + response.getStatusCode() + " " + response.getStatusText());
         }
       }
 
       public void onError(Request request, Throwable exception) {
-        Window.alert("Failed to restore version: " + exception.getMessage());
+        ToastNotification.showWarning(
+            "Failed to restore version: " + exception.getMessage());
       }
     });
 
     try {
       rb.send();
     } catch (RequestException e) {
-      Window.alert("Failed to send restore request: " + e.getMessage());
+      ToastNotification.showWarning(
+          "Failed to send restore request: " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
## Summary
- Replaced the last remaining `Window.confirm()` call in `HistoryModeController.restoreCurrentVersion()` with `ConfirmDialog.show()` (async, styled modal with "Restore" / "Cancel" buttons)
- Replaced all 3 remaining `Window.alert()` calls (HTTP error, exception error, request send error) with `ToastNotification.showWarning()` non-blocking toasts
- Extracted the HTTP restore logic into a private `doRestore()` helper method called from the ConfirmDialog callback

After this change, **zero** `Window.alert()`, `Window.confirm()`, or `Window.prompt()` calls remain in the GWT client code (verified via grep).

## Test plan
- [ ] Open a wave, enter History mode, navigate to an older version, and click Restore -- verify a styled confirmation dialog appears (not a browser native confirm)
- [ ] Click Cancel on the dialog -- verify nothing happens
- [ ] Click Restore on the dialog -- verify the restore proceeds normally
- [ ] Simulate a restore failure (e.g., disconnect network) -- verify a toast notification appears at bottom-center instead of a browser alert
- [ ] Verify `sbt wave/compile` and `sbt compileGwt` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confirmation dialog and error notifications for document restoration, providing clearer user feedback and a more polished experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->