### PR TITLE
feat: show subtle blip ID in metabar for debugging

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java
@@ -297,6 +297,23 @@ public final class BlipMetaViewBuilder implements UiBuilder, IntrinsicBlipMetaVi
         }
         close(output);
 
+        // Blip ID (for debugging / internal links).
+        // The meta DOM id is "{blipId}M", so strip the trailing suffix to recover the model id.
+        {
+          String displayId = id.endsWith("M") ? id.substring(0, id.length() - 1) : id;
+          String escaped = EscapeUtils.htmlEscape(displayId);
+          output.appendHtmlConstant(
+              "<span class='blipId' title='Click to copy blip ID'"
+              + " onclick=\"(function(el,e){e.stopPropagation();e.preventDefault();"
+              + "var t=el.textContent||el.innerText;"
+              + "if(navigator.clipboard){navigator.clipboard.writeText(t)"
+              + ".then(function(){el.dataset.orig=el.textContent;el.textContent='Copied!';"
+              + "setTimeout(function(){el.textContent=el.dataset.orig;},1200);});}"
+              + "})(this,event)\">"
+              + escaped
+              + "</span>");
+        }
+
         // Metaline.
         open(output, Components.METALINE.getDomId(id), css.metaline(), null);
         if (metaline != null) {

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -304,6 +304,24 @@
   font-style: italic;
 }
 
+/* ---- Blip ID display (debugging / internal links) ---- */
+@external .blipId;
+.blipId {
+  font-family: 'SF Mono', Consolas, monospace;
+  font-size: 10px;
+  color: #94a3b8;
+  opacity: 0.4;
+  cursor: pointer;
+  margin-left: 8px;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+  order: 1;
+  flex-shrink: 0;
+}
+.blipId:hover {
+  opacity: 0.8;
+}
+
 /* ---- Draft-mode active indicator ---- */
 
 /* Marker class to ensure CssResource maps 'draftActive' */


### PR DESCRIPTION
## Summary
- Adds a subtle blip model ID display (e.g. `b+W2MAWXxJP0A`) in the top-right area of each blip's metabar, next to the timestamp
- Styled as very small (10px), monospace, light gray text at 0.4 opacity — increases to 0.8 on hover
- Clicking the blip ID copies it to the clipboard with brief "Copied!" toast feedback
- Does not interfere with existing menu action icons

## Changes
- **`BlipMetaViewBuilder.java`** — Added a `<span class='blipId'>` after the time element, with inline onclick handler for clipboard copy. The blip model ID is derived by stripping the trailing `M` suffix from the meta DOM ID.
- **`Blip.css`** — Added `.blipId` and `.blipId:hover` styles with `@external` annotation to prevent GWT obfuscation.

## Test plan
- [ ] Verify each blip in a wave shows its model ID in small gray monospace text next to the timestamp
- [ ] Hover over the blip ID and confirm opacity increases from subtle to more visible
- [ ] Click the blip ID and confirm it copies to clipboard with "Copied!" feedback
- [ ] Verify existing menu icons (reply, edit, delete, link) still work correctly
- [ ] Verify `sbt wave/compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a clickable blip identifier in the meta bar that allows you to copy the unique ID with a single click and provides visual confirmation of the action through temporary feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->