### PR TITLE
fix: guard against null snapshot in getSnapshot() for new wavelets

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -316,7 +316,12 @@ abstract class WaveletContainerImpl implements WaveletContainer {
     acquireReadLock();
     try {
       checkStateOk();
-      return new CommittedWaveletSnapshot(waveletState.getSnapshot(),
+      ReadableWaveletData snapshot = waveletState.getSnapshot();
+      if (snapshot == null) {
+        // New wavelet at version 0 with no deltas applied yet.
+        return null;
+      }
+      return new CommittedWaveletSnapshot(snapshot,
           waveletState.getLastPersistedVersion());
     } finally {
       releaseReadLock();


### PR DESCRIPTION
## Summary
- Fixes a `NullPointerException` when creating a new wave. The NPE occurs because `WaveletContainerImpl.getSnapshot()` passes a null snapshot (from a brand new wavelet with no deltas) into `CommittedWaveletSnapshot`'s constructor, which calls `Preconditions.checkNotNull`.
- The regression was introduced by PR #261 which added `ReplyDepthValidator` to `WaveServerImpl.submitDelta()`. The validator calls `getSnapshot()` before the first delta is applied, when the wavelet state is still null.
- Adds a null guard in `getSnapshot()` to return null when the wavelet state snapshot is null. All callers already handle null returns correctly.

## Test plan
- [ ] Create a new wave and verify it succeeds without NPE
- [ ] Verify reply depth validation still works on existing wavelets with threads
- [ ] Verify `WaveServerImpl.getSnapshot()` for non-existent wavelets still returns null gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare error when opening a brand-new wave/conversation with no history. The app now correctly recognizes truly empty content and avoids creating an invalid snapshot, preventing crashes and misleading empty views. This improves stability and reliability when starting new conversations or documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->