### PR TITLE
fix: allow any participant to restore wave versions

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
@@ -517,24 +517,6 @@ public final class VersionHistoryServlet extends HttpServlet {
       return;
     }
 
-    // Check that the requesting user is the wave creator
-    try {
-      CommittedWaveletSnapshot currentSnapshot = waveletProvider.getSnapshot(waveletName);
-      if (currentSnapshot == null) {
-        resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Wavelet not found");
-        return;
-      }
-      ParticipantId creator = currentSnapshot.snapshot.getCreator();
-      if (!user.equals(creator)) {
-        resp.sendError(HttpServletResponse.SC_FORBIDDEN,
-            "Only the wave creator can restore versions");
-        return;
-      }
-    } catch (WaveServerException e) {
-      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      return;
-    }
-
     String versionParam = req.getParameter("version");
     if (versionParam == null) {
       resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing version parameter");


### PR DESCRIPTION
## Summary
- Removed the creator-only restriction from the version restore API in `VersionHistoryServlet`
- Previously, non-creator participants got a 403 "Only the wave creator can restore versions" error
- The existing `checkAccessPermission()` call already ensures only authorized participants can reach the restore logic, so the additional creator check was unnecessarily restrictive

## Test plan
- [ ] Verify that wave creators can still restore versions (no regression)
- [ ] Verify that non-creator participants can now restore versions without getting 403
- [ ] Verify that non-participants still get access denied (403) from the `checkAccessPermission` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed version restoration authorization checks. The method now returns "Not Implemented" status instead of validating user permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->