### PR TITLE
feat: implement wave version restore

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
@@ -673,7 +673,7 @@ public final class VersionHistoryServlet extends HttpServlet {
         return;
       }
 
-      // 5. Return success
+      // Return success response
       LOG.info("Restored " + waveletName + " to version " + targetVersion
           + " (" + appliedOps[0] + " ops applied) by " + user.getAddress());
       setJsonUtf8(resp);


### PR DESCRIPTION
## Summary
- Implements the version restore functionality in `VersionHistoryServlet.handleRestoreApi()`, replacing the HTTP 501 stub
- Restores a wave to a historical version by reconstructing the target state from deltas, computing document-replacement DocOps (invert current + compose with historical), and submitting through the standard WaveletProvider delta pipeline
- Adds a "Restore to vN" button in the version history UI toolbar with toast notifications for success/failure

## Test plan
- [ ] Navigate to version history page for a wave with multiple versions
- [ ] Select a historical version and verify the "Restore to vN" button appears
- [ ] Click restore and verify the wave content is updated to match the historical version
- [ ] Verify the restore button does not appear when the current (latest) version is selected
- [ ] Verify only the wave creator can perform restores (non-creators get 403)
- [ ] Verify appropriate error handling for invalid versions, non-delta-boundary versions, and network failures
- [ ] Verify the toast notification appears on success and error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version restoration: Users can restore previous document versions via a "Restore this version" button, shown only for historical versions.
* **Improvements**
  * Safe restore flow: Server validates requests and returns clear errors for invalid targets or timeouts.
  * UI feedback: Button is disabled during restore, shows success/error toasts (including applied-ops info when available), and refreshes timeline and snapshot on completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->