### PR TITLE
fix: use _dm tag instead of participant count for DM wave detection

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2786,8 +2786,8 @@ public final class HtmlRenderer {
     sb.append("  pcMessage.addEventListener('click', function() {\n");
     sb.append("    if (!currentAddress) return;\n");
     sb.append("    overlay.style.display = 'none';\n");
-    sb.append("    // Search for existing 1:1 wave with this user\n");
-    sb.append("    fetch('/search/waves?query=with:' + encodeURIComponent(currentAddress) + '+is:dm&index=0&numResults=1')\n");
+    sb.append("    // Search for existing DM wave with this user (tagged with _dm)\n");
+    sb.append("    fetch('/search/waves?query=with:' + encodeURIComponent(currentAddress) + '+tag:_dm&index=0&numResults=1')\n");
     sb.append("      .then(function(r) { return r.json(); })\n");
     sb.append("      .then(function(data) {\n");
     sb.append("        if (data && data.digests && data.digests.length > 0) {\n");
@@ -2799,7 +2799,7 @@ public final class HtmlRenderer {
     sb.append("          if (window.__createDirectWave) {\n");
     sb.append("            window.__createDirectWave(currentAddress);\n");
     sb.append("          } else {\n");
-    sb.append("            alert('Direct messaging will open a new wave with ' + currentAddress);\n");
+    sb.append("            console.warn('__createDirectWave not available for ' + currentAddress);\n");
     sb.append("          }\n");
     sb.append("        }\n");
     sb.append("      })\n");

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StageTwoProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StageTwoProvider.java
@@ -48,6 +48,7 @@ public class StageTwoProvider extends StageTwo.DefaultProvider {
   private final WaveRef waveRef;
   private final RemoteViewServiceMultiplexer channel;
   private final boolean isNewWave;
+  private final boolean isDirectMessage;
   // TODO: Remove this after WebClientBackend is deleted.
   private final IdGenerator idGenerator;
 
@@ -73,6 +74,21 @@ public class StageTwoProvider extends StageTwo.DefaultProvider {
   public StageTwoProvider(StageOne stageOne, WaveRef waveRef, RemoteViewServiceMultiplexer channel,
       boolean isNewWave, IdGenerator idGenerator, ProfileManager profiles,
       UnsavedDataListener unsavedDataListener, Set<ParticipantId> otherParticipants) {
+    this(stageOne, waveRef, channel, isNewWave, false, idGenerator, profiles,
+        unsavedDataListener, otherParticipants);
+  }
+
+  /**
+   * Full constructor including direct-message flag.
+   *
+   * @param isDirectMessage true if the wave is a DM created via the "Send
+   *        Message" profile action. When true, the {@code _dm} tag is applied
+   *        to the conversation on creation.
+   */
+  public StageTwoProvider(StageOne stageOne, WaveRef waveRef, RemoteViewServiceMultiplexer channel,
+      boolean isNewWave, boolean isDirectMessage, IdGenerator idGenerator,
+      ProfileManager profiles, UnsavedDataListener unsavedDataListener,
+      Set<ParticipantId> otherParticipants) {
     super(stageOne, unsavedDataListener);
     Preconditions.checkArgument(stageOne != null);
     Preconditions.checkArgument(waveRef != null);
@@ -80,6 +96,7 @@ public class StageTwoProvider extends StageTwo.DefaultProvider {
     this.waveRef = waveRef;
     this.channel = channel;
     this.isNewWave = isNewWave;
+    this.isDirectMessage = isDirectMessage;
     this.idGenerator = idGenerator;
     this.profiles = profiles;
     this.otherParticipants = otherParticipants;
@@ -121,6 +138,12 @@ public class StageTwoProvider extends StageTwo.DefaultProvider {
 
       // Adding any initial participant to the new wave
       getConversations().getRoot().addParticipantIds(otherParticipants);
+
+      // Tag the wave as a DM if it was created via the "Send Message" action.
+      if (isDirectMessage) {
+        getConversations().getRoot().addTag(
+            org.waveprotocol.wave.model.conversation.Conversation.DM_TAG);
+      }
       super.install();
       whenReady.use(StageTwoProvider.this);
     } else {

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -53,7 +53,6 @@ import org.waveprotocol.wave.model.waveref.WaveRef;
 
 import java.util.Set;
 
-import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
 
 /**
  * Stages for loading the undercurrent Wave Panel
@@ -79,6 +78,7 @@ public class StagesProvider extends Stages {
   private final ProfileManager profiles;
   private final WaveStore waveStore;
   private final boolean isNewWave;
+  private final boolean isDirectMessage;
   private final String localDomain;
   private final ContactManager contactManager;
 
@@ -113,6 +113,22 @@ public class StagesProvider extends Stages {
       LogicalPanel rootPanel, FramedPanel waveFrame, WaveRef waveRef, RemoteViewServiceMultiplexer channel,
       IdGenerator idGenerator, ProfileManager profiles, WaveStore store, boolean isNewWave,
       String localDomain, Set<ParticipantId> participants, ContactManager contactManager) {
+    this(wavePanelElement, unsavedIndicatorElement, rootPanel, waveFrame, waveRef, channel,
+        idGenerator, profiles, store, isNewWave, false, localDomain, participants, contactManager);
+  }
+
+  /**
+   * Full constructor including direct-message flag.
+   *
+   * @param isDirectMessage true if the wave is a direct message created via
+   *        the "Send Message" profile action. The DM tag will be added to
+   *        the conversation on creation.
+   */
+  public StagesProvider(Element wavePanelElement, Element unsavedIndicatorElement,
+      LogicalPanel rootPanel, FramedPanel waveFrame, WaveRef waveRef, RemoteViewServiceMultiplexer channel,
+      IdGenerator idGenerator, ProfileManager profiles, WaveStore store, boolean isNewWave,
+      boolean isDirectMessage, String localDomain, Set<ParticipantId> participants,
+      ContactManager contactManager) {
     this.wavePanelElement = wavePanelElement;
     this.unsavedIndicatorElement = unsavedIndicatorElement;
     this.waveFrame = waveFrame;
@@ -123,6 +139,7 @@ public class StagesProvider extends Stages {
     this.profiles = profiles;
     this.waveStore = store;
     this.isNewWave = isNewWave;
+    this.isDirectMessage = isDirectMessage;
     this.localDomain = localDomain;
     this.participants = participants;
     this.contactManager = contactManager;
@@ -151,7 +168,8 @@ public class StagesProvider extends Stages {
   @Override
   protected AsyncHolder<StageTwo> createStageTwoLoader(StageOne one) {
     return haltIfClosed(new StageTwoProvider(this.one = one, waveRef, channel, isNewWave,
-        idGenerator, profiles, new SavedStateIndicator(unsavedIndicatorElement), participants));
+        isDirectMessage, idGenerator, profiles, new SavedStateIndicator(unsavedIndicatorElement),
+        participants));
   }
 
   @Override
@@ -266,27 +284,16 @@ public class StagesProvider extends Stages {
       isCreator = true;
     }
 
-    // In a DM wave (exactly 2 real participants, no domain participant),
-    // both participants should see the History button.
+    // In a DM wave (tagged with Conversation.DM_TAG), both participants
+    // should see the History button.
     boolean isDmParticipant = false;
     if (!isCreator) {
-      Set<ParticipantId> waveletParticipants = rootWavelet.getParticipantIds();
-      boolean hasDomainParticipant = false;
-      boolean currentUserIsParticipant = false;
-      int realParticipantCount = 0;
-      for (ParticipantId pid : waveletParticipants) {
-        if (ParticipantIdUtil.isDomainAddress(pid.getAddress())) {
-          hasDomainParticipant = true;
-        } else {
-          realParticipantCount++;
-          if (currentUserAddress.equals(pid.getAddress())) {
-            currentUserIsParticipant = true;
-          }
-        }
+      ConversationView conversations = two.getConversations();
+      if (conversations != null && conversations.getRoot() != null) {
+        java.util.Set<String> tags = conversations.getRoot().getTags();
+        isDmParticipant = tags != null && tags.contains(
+            org.waveprotocol.wave.model.conversation.Conversation.DM_TAG);
       }
-      isDmParticipant = !hasDomainParticipant
-          && realParticipantCount == 2
-          && currentUserIsParticipant;
     }
 
     if (!isCreator && !isDmParticipant) {

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
@@ -421,6 +421,9 @@ public class WebClient implements EntryPoint {
 
   /**
    * Creates a new wave with the specified participant for direct messaging.
+   * The wave is tagged with {@link org.waveprotocol.wave.model.conversation.Conversation#DM_TAG}
+   * so it can be distinguished from regular waves that happen to have two
+   * participants.
    */
   private void createDirectWave(String address) {
     if (channel == null) {
@@ -428,7 +431,7 @@ public class WebClient implements EntryPoint {
     }
     java.util.Set<ParticipantId> participants = new java.util.HashSet<>();
     participants.add(new ParticipantId(address));
-    openWave(WaveRef.of(idGenerator.newWaveId()), true, participants);
+    openWave(WaveRef.of(idGenerator.newWaveId()), true, true, participants);
   }
 
   private void setupUi() {
@@ -703,6 +706,20 @@ public class WebClient implements EntryPoint {
    *        {@code null} if only the creator should be added
    */
   private void openWave(WaveRef waveRef, boolean isNewWave, Set<ParticipantId> participants) {
+    openWave(waveRef, isNewWave, false, participants);
+  }
+
+  /**
+   * Shows a wave in a wave panel.
+   *
+   * @param waveRef wave id to open
+   * @param isNewWave whether the wave is being created by this client session.
+   * @param isDirectMessage true if the wave is a DM created via "Send Message".
+   * @param participants the participants to add to the newly created wave.
+   *        {@code null} if only the creator should be added
+   */
+  private void openWave(WaveRef waveRef, boolean isNewWave, boolean isDirectMessage,
+      Set<ParticipantId> participants) {
     final org.waveprotocol.box.stat.Timer timer = Timing.startRequest("Open Wave");
     LOG.info("WebClient.openWave()");
 
@@ -718,7 +735,8 @@ public class WebClient implements EntryPoint {
     Element unsavedIndicator = Document.get().getElementById("unsavedStateContainer");
     StagesProvider wave =
         new StagesProvider(holder, unsavedIndicator, waveHolder, waveFrame, waveRef, channel, idGenerator,
-            profiles, waveStore, isNewWave, Session.get().getDomain(), participants, contactManager);
+            profiles, waveStore, isNewWave, isDirectMessage, Session.get().getDomain(),
+            participants, contactManager);
     this.wave = wave;
     wave.load(new Command() {
       @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
@@ -189,6 +189,13 @@ public final class ParticipantController {
   private void handleTogglePublicClicked(Element context) {
     ParticipantsView participantsUi = views.fromTogglePublicButton(context);
     Conversation conversation = models.getParticipants(participantsUi);
+
+    // Block making DM waves public.
+    if (isDirectMessage(conversation)) {
+      ToastNotification.showWarning(messages.cannotMakeDmPublic());
+      return;
+    }
+
     Set<ParticipantId> participants = conversation.getParticipantIds();
 
     // The wave creator is the first participant in the ordered set.
@@ -282,20 +289,14 @@ public final class ParticipantController {
   }
 
   /**
-   * Returns true if the given conversation is a direct message (exactly 2 real
-   * participants and no shared-domain participant).
+   * Returns true if the given conversation is a direct message, identified by
+   * the presence of the {@link Conversation#DM_TAG} tag. Only waves explicitly
+   * created via the "Send Message" profile action carry this tag; regular waves
+   * with two participants are NOT considered DMs.
    */
   private static boolean isDirectMessage(Conversation conversation) {
-    Set<ParticipantId> participants = conversation.getParticipantIds();
-    int realCount = 0;
-    for (ParticipantId pid : participants) {
-      if (ParticipantIdUtil.isDomainAddress(pid.getAddress())) {
-        // Has a domain participant -- not a DM.
-        return false;
-      }
-      realCount++;
-    }
-    return realCount == 2;
+    Set<String> tags = conversation.getTags();
+    return tags != null && tags.contains(Conversation.DM_TAG);
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
@@ -50,4 +50,7 @@ public interface ParticipantMessages extends Messages {
 
   @DefaultMessage("This is a direct message. Create a new wave to include more participants.")
   String cannotAddParticipantToDm();
+
+  @DefaultMessage("Direct messages cannot be made public.")
+  String cannotMakeDmPublic();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/Conversation.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/Conversation.java
@@ -37,6 +37,18 @@ import java.util.Set;
  * @author anorth@google.com (Alex North)
  */
 public interface Conversation {
+
+  /**
+   * Tag applied to direct-message waves. A DM wave is created exclusively via
+   * the "Send Message" action on a user's profile card. Regular waves that
+   * happen to have exactly two participants are NOT DMs.
+   *
+   * <p>This tag is stored in the conversation's tags document and is used by
+   * both the client (to gate add-participant and toggle-public actions) and
+   * the server (to support {@code tag:_dm} search queries).
+   */
+  String DM_TAG = "_dm";
+
   /**
    * An anchor point inside a conversation.
    */


### PR DESCRIPTION
## Summary
- **Replaces broken DM heuristic**: The old code treated any wave with exactly 2 participants as a DM, which incorrectly blocked adding participants to regular 2-person waves and showed DM-specific behavior (hidden add-participant button, History for both users). Now only waves explicitly created via the "Send Message" profile action are DMs.
- **Introduces `_dm` tag**: A `Conversation.DM_TAG` (`"_dm"`) constant is stored in the conversation's tags document. This tag is set during wave creation in `StageTwoProvider.install()` and checked everywhere DM detection occurs.
- **Fixes search query**: The HtmlRenderer's "Send Message" button searched for existing DMs using `is:dm` which was an invalid query token (would throw `InvalidQueryException`). Now uses `tag:_dm` which is properly supported by `SimpleSearchProviderImpl.filterByTags()`.
- **Blocks making DMs public**: Adds a guard in `handleTogglePublicClicked()` to prevent toggling DM waves to public.
- **Removes `alert()` fallback**: Replaces `window.alert()` with `console.warn()` in the HtmlRenderer fallback path.

### Files changed
| File | Change |
|------|--------|
| `Conversation.java` | Add `DM_TAG = "_dm"` constant |
| `StageTwoProvider.java` | Accept `isDirectMessage` flag; add `_dm` tag on DM wave creation |
| `StagesProvider.java` | Thread `isDirectMessage` flag; fix History button DM check to use tag |
| `WebClient.java` | Thread `isDirectMessage` flag from `createDirectWave()` through `openWave()` |
| `ParticipantController.java` | Rewrite `isDirectMessage()` to check `_dm` tag; block making DMs public |
| `ParticipantMessages.java` | Add `cannotMakeDmPublic` i18n message |
| `HtmlRenderer.java` | Use `tag:_dm` search query; replace `alert()` with `console.warn()` |

## Test plan
- [ ] Create a normal wave, add one participant -- should NOT be treated as a DM (add-participant button visible, public toggle works)
- [ ] Click "Send Message" on a user profile -- creates a DM wave tagged with `_dm`
- [ ] Open the DM wave -- add-participant button shows toast when clicked, public toggle shows toast
- [ ] Both DM participants see the History button
- [ ] Click "Send Message" on same user profile again -- should find and open existing DM (via `tag:_dm` search)
- [ ] Verify `sbt wave/compile` passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct messages are now protected from being made public, preventing accidental visibility changes.

* **Improvements**
  * Refined direct message discovery and search mechanisms.
  * Enhanced error handling and feedback for direct message creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->