### PR TITLE
fix: clear JWT cookie on sign-out to prevent session restoration

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
@@ -24,10 +24,12 @@ import com.google.inject.Singleton;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwt;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.io.IOException;
@@ -49,8 +51,24 @@ public class SignOutServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    // 1. Remove the logged-in user from the session attributes.
     WebSession session = WebSessions.from(req, false);
     sessionManager.logout(session);
+
+    // 2. Clear the JWT session cookie so the JwtSessionRestorationFilter
+    //    does not immediately re-establish the session on the next request.
+    resp.addHeader("Set-Cookie",
+        BrowserSessionJwt.COOKIE_NAME + "=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax");
+
+    // 3. Invalidate the underlying HTTP session to discard all server-side state.
+    HttpSession httpSession = req.getSession(false);
+    if (httpSession != null) {
+      try {
+        httpSession.invalidate();
+      } catch (IllegalStateException ignored) {
+        // Already invalidated — safe to ignore.
+      }
+    }
 
     String redirectUrl = req.getParameter("r");
     if (isSafeLocalRedirect(redirectUrl)) {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/SignOutServletJakartaIT.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/SignOutServletJakartaIT.java
@@ -61,6 +61,20 @@ public class SignOutServletJakartaIT {
   }
 
   @Test
+  public void signout_clearsJwtCookie() throws Exception {
+    URL url = new URL("http://localhost:" + port + "/auth/signout");
+    HttpURLConnection c = TestSupport.openConnection(url);
+    assertEquals(200, c.getResponseCode());
+    // Verify the Set-Cookie header clears wave-session-jwt with Max-Age=0
+    String setCookie = c.getHeaderField("Set-Cookie");
+    assertNotNull("Expected Set-Cookie header to clear JWT cookie", setCookie);
+    assertTrue("Set-Cookie should reference wave-session-jwt",
+        setCookie.contains("wave-session-jwt"));
+    assertTrue("Set-Cookie should set Max-Age=0",
+        setCookie.contains("Max-Age=0"));
+  }
+
+  @Test
   public void rejectsAbsoluteUrlOrSchemeRelativeOrTraversal() throws Exception {
     // Absolute URL -> no redirect, simple 200 HTML
     URL u1 = new URL("http://localhost:" + port + "/auth/signout?r=http%3A%2F%2Fevil.example%2Fout");


### PR DESCRIPTION
## Summary
- **Root cause**: `SignOutServlet` removed the user attribute from the HTTP session but did not clear the `wave-session-jwt` cookie. On the next request, `JwtSessionRestorationFilter` (added in PR #303) would validate the still-present JWT and silently re-establish the session, making sign-out appear to do nothing.
- **Fix**: Sign-out now sets `Max-Age=0` on the `wave-session-jwt` cookie so the browser discards it, and also calls `HttpSession.invalidate()` to fully destroy the server-side session.
- Adds integration test verifying the `Set-Cookie` header is emitted on sign-out responses.

## Test plan
- [ ] `sbt wave/compile` passes (verified)
- [ ] Run `SignOutServletJakartaIT` -- new `signout_clearsJwtCookie` test verifies the `Set-Cookie: wave-session-jwt=; Max-Age=0` header
- [ ] Manual: log in, click sign out, confirm you are redirected to the login page and not silently re-authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)