### PR TITLE
fix: make topbar logo navigate to landing page

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2050,7 +2050,7 @@ public final class HtmlRenderer {
     sb.append("  position: relative; z-index: 1;\n");
     sb.append("  display: flex; align-items: center;\n");
     sb.append("}\n");
-    sb.append(".topbar-brand { display: flex; align-items: center; text-decoration: none; color: inherit; gap: 8px; }\n");
+    sb.append(".topbar-brand { display: flex; align-items: center; text-decoration: none; color: inherit; gap: 8px; cursor: pointer; }\n");
     sb.append(".topbar-brand svg { flex-shrink: 0; }\n");
     sb.append(".title {\n");
     sb.append("  font-size: 17px; font-weight: 700; color: #fff;\n");
@@ -3012,7 +3012,7 @@ public final class HtmlRenderer {
     sb.append("<div class=\"topbar\">\n");
     sb.append("  <button class=\"mobile-hamburger\" id=\"mobileHamburger\" aria-label=\"Open navigation\">&#9776;</button>\n");
     sb.append("  <button class=\"mobile-back\" id=\"mobileBack\" aria-label=\"Back to inbox\">&#8592;</button>\n");
-    sb.append("  <a href=\"/\" class=\"topbar-brand\">").append(WAVE_LOGO_SVG_SMALL);
+    sb.append("  <a href=\"/?view=landing\" class=\"topbar-brand\" onclick=\"window.location.href='/?view=landing';return false;\">").append(WAVE_LOGO_SVG_SMALL);
     sb.append("<span class=\"title\">SupaWave</span></a>\n");
     sb.append("  <div class=\"banner\" id=\"banner\"></div>\n");
     sb.append("  <div class=\"info\">\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -113,7 +113,11 @@ public class WaveClientServlet extends HttpServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
     ParticipantId id = sessionManager.getLoggedInUser(WebSessions.from(request, false));
-    if (id == null) {
+
+    // Show the landing page for unauthenticated visitors, or when an
+    // authenticated user explicitly requests it via ?view=landing (e.g.
+    // clicking the logo in the top bar).
+    if (id == null || "landing".equals(request.getParameter("view"))) {
       response.setContentType("text/html");
       response.setCharacterEncoding("UTF-8");
       response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
## Summary
- The SupaWave logo `<a href="/">` in the top bar did not navigate to the landing page for logged-in users because `/` serves the GWT client app when authenticated
- Added `?view=landing` query parameter support in `WaveClientServlet` so authenticated users can reach the landing page
- Updated the logo `<a>` tag to use `onclick="window.location.href='/?view=landing'"` for reliable navigation past any GWT event interception
- Added `cursor: pointer` to `.topbar-brand` CSS for clear click affordance

## Test plan
- [ ] As an unauthenticated user, verify `/` still shows the landing page
- [ ] As a logged-in user, click the SupaWave logo in the top bar and verify it navigates to the landing page
- [ ] As a logged-in user, verify `/?view=landing` shows the landing page
- [ ] As a logged-in user, verify `/` (without query param) still shows the GWT wave client
- [ ] Verify the logo shows a pointer cursor on hover
- [ ] Verify `sbt wave/compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)