### PR TITLE
fix: tag search fails for recently-added tags due to annotation text splitting

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -494,11 +494,17 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
    * <pre>{@code <tag>name1</tag><tag>name2</tag> ...}</pre>
    * In DocOp terms this is: elementStart("tag") + characters("name") + elementEnd("tag"),
    * repeated once per tag.
+   *
+   * <p>Note: annotation boundaries in the DocInitialization can split a single
+   * tag's text into multiple {@code characters()} calls, so we must accumulate
+   * text with a StringBuilder until the closing elementEnd().
    */
-  private static Set<String> readTagsFromWaveletData(ObservableWaveletData waveletData) {
+  private Set<String> readTagsFromWaveletData(ObservableWaveletData waveletData) {
     org.waveprotocol.wave.model.wave.data.ReadableBlipData tagsBlip =
         waveletData.getDocument(org.waveprotocol.wave.model.id.IdConstants.TAGS_DOC_ID);
     if (tagsBlip == null) {
+      LOG.info("readTagsFromWaveletData: wave " + waveletData.getWaveId()
+          + " has no tags document");
       return java.util.Collections.emptySet();
     }
     // The content of a BlipData is a DocumentOperationSink which implements
@@ -509,29 +515,42 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
 
     final Set<String> tags = new java.util.HashSet<>();
     final boolean[] insideTag = {false};
+    final StringBuilder tagText = new StringBuilder();
     docOp.apply(new org.waveprotocol.wave.model.document.operation.DocInitializationCursor() {
       @Override
       public void elementStart(String type, org.waveprotocol.wave.model.document.operation.Attributes attrs) {
-        insideTag[0] = "tag".equals(type);
+        if ("tag".equals(type)) {
+          insideTag[0] = true;
+          tagText.setLength(0);
+        }
       }
 
       @Override
       public void elementEnd() {
-        insideTag[0] = false;
+        if (insideTag[0]) {
+          String text = tagText.toString().trim();
+          if (!text.isEmpty()) {
+            tags.add(text);
+          }
+          insideTag[0] = false;
+        }
       }
 
       @Override
       public void characters(String chars) {
-        if (insideTag[0] && chars != null && !chars.isEmpty()) {
-          tags.add(chars);
+        if (insideTag[0] && chars != null) {
+          tagText.append(chars);
         }
       }
 
       @Override
       public void annotationBoundary(org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap map) {
-        // ignore
+        // Annotation boundaries can appear between characters() calls within
+        // the same element. We simply ignore them and keep accumulating text.
       }
     });
+    LOG.info("readTagsFromWaveletData: wave " + waveletData.getWaveId()
+        + " tags = " + tags);
     return tags;
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `readTagsFromWaveletData()` in `SimpleSearchProviderImpl` treated each `characters()` callback from the DocInitialization cursor as a complete tag name. However, `IndexedDocumentImpl.asOperation()` composes the DOM with annotations, which can insert `annotationBoundary` calls that split a single tag's text across multiple `characters()` calls. This caused tag names to be fragmented (e.g., "bad3" became "ba" + "d3"), so the search filter never matched.
- **Fix**: Use a `StringBuilder` to accumulate text between `elementStart("tag")` and `elementEnd()`, matching the correct pattern already used in `TagsServlet.extractTags()`.
- **Logging**: Added INFO-level logging in `readTagsFromWaveletData()` so production logs show exactly which tags are parsed per wave during `tag:` searches.

## Why some tags worked and others didn't
Tags added earlier in a wavelet's history tend to have their text in a single `characters()` node. Tags added later may coincide with annotation boundaries (from the DocOp compose step), splitting their text. This explains why `tag:bad2` worked but `tag:bad3` did not, even though both tags existed on the same wave.

## Test plan
- [ ] Deploy and search `tag:bad3` -- should now return the wave
- [ ] Verify server logs show `readTagsFromWaveletData: wave ... tags = [bad2, bad3, ...]`
- [ ] Verify `tag:bad2` still works
- [ ] Test adding a new tag and immediately searching for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)