### PR TITLE
feat: exact wave count + infinite scroll (page size 30)

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SearchServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SearchServlet.java
@@ -154,7 +154,11 @@ public class SearchServlet extends HttpServlet {
   }
 
   private static int computeTotalResultsNumberGuess(SearchRequest req, SearchResult res) {
-    // Use -1 to denote unknown size (avoids depending on client constants)
+    // If the search provider set an exact total, use it directly.
+    if (res.getTotalResults() >= 0) {
+      return res.getTotalResults();
+    }
+    // Fallback: guess based on whether the result page is full.
     return (res.getNumResults() >= req.getNumResults()) ? -1 : req.getIndex() + res.getNumResults();
   }
 

--- a/wave/src/main/java/com/google/wave/api/SearchResult.java
+++ b/wave/src/main/java/com/google/wave/api/SearchResult.java
@@ -88,6 +88,7 @@ public class SearchResult {
 
   private final String query;
   private int numResults;
+  private int totalResults = -1; // -1 means unknown
   private final List<Digest> digests = new ArrayList<Digest>(10);
 
   public SearchResult(String query) {
@@ -116,6 +117,21 @@ public class SearchResult {
    */
   public int getNumResults() {
     return numResults;
+  }
+
+  /**
+   * @returns the total number of matching results (before pagination), or -1 if unknown.
+   */
+  public int getTotalResults() {
+    return totalResults;
+  }
+
+  /**
+   * Sets the total number of matching results (before pagination).
+   * @param totalResults the exact total, or -1 if unknown.
+   */
+  public void setTotalResults(int totalResults) {
+    this.totalResults = totalResults;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/SearchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/SearchServlet.java
@@ -150,12 +150,11 @@ public class SearchServlet extends AbstractSearchServlet {
   }
 
   private int computeTotalResultsNumberGuess(SearchRequest searchRequest, SearchResult searchResult) {
-    // The Data API does not return the total size of the search result, even
-    // though the searcher knows it. The only approximate knowledge that can be
-    // gleaned from the Data API is whether there are more search results beyond
-    // those returned. If the searcher returns as many (or more) results as
-    // requested, then assume that more results exist, but the total is unknown.
-    // Otherwise, the total has been reached.
+    // If the search provider set an exact total, use it directly.
+    if (searchResult.getTotalResults() >= 0) {
+      return searchResult.getTotalResults();
+    }
+    // Fallback: guess based on whether the result page is full.
     int totalGuess;
     if (searchResult.getNumResults() >= searchRequest.getNumResults()) {
       totalGuess = SearchService.UNKNOWN_SIZE;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -159,11 +159,16 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
       sortedResults = promotePinnedWaves(sortedResults, user);
     }
 
+    // Capture the total count BEFORE pagination so the client knows the full result set size.
+    int totalBeforePagination = sortedResults.size();
+
     Collection<WaveViewData> searchResult =
         computeSearchResult(user, startAt, numResults, sortedResults);
-    LOG.info("Search response to '" + query + "': " + searchResult.size() + " results, user: "
-        + user);
-    return digester.generateSearchResult(user, query, searchResult);
+    LOG.info("Search response to '" + query + "': " + searchResult.size() + " results"
+        + " (total " + totalBeforePagination + "), user: " + user);
+    SearchResult result = digester.generateSearchResult(user, query, searchResult);
+    result.setTotalResults(totalBeforePagination);
+    return result;
   }
 
   private LinkedHashMultimap<WaveId, WaveletId> createWavesViewToFilter(final ParticipantId user,

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -73,7 +73,7 @@ public final class SearchPresenter
   /** How often to repeat the search query. */
   private final static int POLLING_INTERVAL_MS = 15000; // 15s
   private final static String DEFAULT_SEARCH = "in:inbox";
-  private final static int DEFAULT_PAGE_SIZE = 20;
+  private final static int DEFAULT_PAGE_SIZE = 30;
   /**
    * Delay before refreshing search results after a wave is closed (ms).
    * This gives the server time to process any pending deltas (e.g., tag
@@ -538,23 +538,36 @@ public final class SearchPresenter
    */
   private void renderWaveCount() {
     int total = search.getTotal();
-    if (total == Search.UNKNOWN_SIZE) {
-      total = search.getMinimumTotal();
-    }
+    boolean totalKnown = total != Search.UNKNOWN_SIZE;
+    int loaded = search.getMinimumTotal();
     int unread = 0;
-    for (int i = 0, size = search.getMinimumTotal(); i < size; i++) {
+    for (int i = 0; i < loaded; i++) {
       Digest digest = search.getDigest(i);
       if (digest != null && digest.getUnreadCount() > 0) {
         unread++;
       }
     }
     String text;
-    if (total <= 0) {
+    if (totalKnown && total <= 0) {
       text = "";
-    } else if (unread > 0) {
-      text = total + " waves \u00b7 " + unread + " unread";
-    } else {
+    } else if (totalKnown && loaded < total) {
+      // Showing a partial page of a known total: "5 of 28 waves"
+      text = loaded + " of " + total + " waves";
+      if (unread > 0) {
+        text += " \u00b7 " + unread + " unread";
+      }
+    } else if (totalKnown) {
+      // All results loaded
       text = total + " waves";
+      if (unread > 0) {
+        text += " \u00b7 " + unread + " unread";
+      }
+    } else {
+      // Total unknown, show loaded count
+      text = loaded + " waves";
+      if (unread > 0) {
+        text += " \u00b7 " + unread + " unread";
+      }
     }
     searchUi.setWaveCountText(text);
   }


### PR DESCRIPTION
## Summary
- **Server returns exact total count**: `SimpleSearchProviderImpl.search()` now captures the total number of matching waves before pagination and sets it on `SearchResult.totalResults`. Both javax and jakarta `SearchServlet` use this exact total instead of guessing based on page fullness.
- **Page size increased to 30**: `SearchPresenter.DEFAULT_PAGE_SIZE` changed from 20 to 30 for better initial load density. Infinite scroll (already wired in `SearchPanelWidget`) triggers at 200px from bottom.
- **Wave count shows "N of M waves"**: When a known total exceeds loaded results, the count bar displays e.g. "5 of 28 waves · 3 unread". When all results are loaded it shows "28 waves · 3 unread". Falls back to loaded count when total is unknown.

## Test plan
- [ ] Deploy and verify wave count bar shows "N of M waves" format when total exceeds loaded page
- [ ] Scroll to bottom of wave list and confirm infinite scroll loads more results with spinner
- [ ] Verify count updates to "M waves" once all results are loaded
- [ ] Verify unread count displays correctly in both partial and full views
- [ ] Check that initial load fetches 30 results instead of 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search now displays accurate total result counts when available, replacing previous estimates.
  * Improved result count display to clarify whether all results are loaded and unread count status.

* **Improvements**
  * Increased default search results per page from 20 to 30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->