### PR TITLE
fix: skip conversation model in pin/unpin and add search refresh button

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/FolderServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/FolderServlet.java
@@ -167,7 +167,9 @@ public final class FolderServlet extends HttpServlet {
   }
 
   /**
-   * Pins or unpins a wave for a given participant.
+   * Pins or unpins a wave for a given participant by writing directly to the
+   * UDW folder document. This avoids building the conversation model, which
+   * can fail for waves with malformed manifest documents.
    */
   public void setPinState(WaveId waveId, boolean pin, ParticipantId participant)
       throws InvalidRequestException, OperationException, InterruptedException, ExecutionException {
@@ -175,23 +177,20 @@ public final class FolderServlet extends HttpServlet {
     OperationContextImpl context = new OperationContextImpl(waveletProvider,
         converterManager.getEventDataConverter(ProtocolVersion.DEFAULT), conversationUtil);
 
-    OpBasedWavelet wavelet = context.openWavelet(waveId,
-        WaveletId.of(waveId.getDomain(), IdConstants.CONVERSATION_ROOT_WAVELET), participant);
-    ConversationView conversationView = context.getConversationUtil().buildConversation(wavelet);
-
     WaveletId udwId =
         WaveletId.of(waveId.getDomain(),
             IdUtil.join(IdConstants.USER_DATA_WAVELET_PREFIX, participant.getAddress()));
     OpBasedWavelet udw = context.openWavelet(waveId, udwId, participant);
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
-
-    SupplementedWave supplement =
-        SupplementedWaveImpl.create(udwState, conversationView, participant, DefaultFollow.ALWAYS);
     if (pin) {
-      supplement.pin();
+      if (!udwState.isInFolder(SupplementedWaveImpl.PINNED_FOLDER)) {
+        udwState.addFolder(SupplementedWaveImpl.PINNED_FOLDER);
+      }
     } else {
-      supplement.unpin();
+      if (udwState.isInFolder(SupplementedWaveImpl.PINNED_FOLDER)) {
+        udwState.removeFolder(SupplementedWaveImpl.PINNED_FOLDER);
+      }
     }
     OperationUtil.submitDeltas(context, waveletProvider, LOGGING_REQUEST_LISTENER);
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FolderServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FolderServlet.java
@@ -171,7 +171,9 @@ public final class FolderServlet extends HttpServlet {
   }
 
   /**
-   * Pins or unpins a wave for a given participant.
+   * Pins or unpins a wave for a given participant by writing directly to the
+   * UDW folder document. This avoids building the conversation model, which
+   * can fail for waves with malformed manifest documents.
    */
   public void setPinState(WaveId waveId, boolean pin, ParticipantId participant)
       throws InvalidRequestException, OperationException, InterruptedException, ExecutionException {
@@ -179,23 +181,20 @@ public final class FolderServlet extends HttpServlet {
     OperationContextImpl context = new OperationContextImpl(waveletProvider,
         converterManager.getEventDataConverter(ProtocolVersion.DEFAULT), conversationUtil);
 
-    OpBasedWavelet wavelet = context.openWavelet(waveId,
-        WaveletId.of(waveId.getDomain(), IdConstants.CONVERSATION_ROOT_WAVELET), participant);
-    ConversationView conversationView = context.getConversationUtil().buildConversation(wavelet);
-
     WaveletId udwId =
         WaveletId.of(waveId.getDomain(),
             IdUtil.join(IdConstants.USER_DATA_WAVELET_PREFIX, participant.getAddress()));
     OpBasedWavelet udw = context.openWavelet(waveId, udwId, participant);
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
-
-    SupplementedWave supplement =
-        SupplementedWaveImpl.create(udwState, conversationView, participant, DefaultFollow.ALWAYS);
     if (pin) {
-      supplement.pin();
+      if (!udwState.isInFolder(SupplementedWaveImpl.PINNED_FOLDER)) {
+        udwState.addFolder(SupplementedWaveImpl.PINNED_FOLDER);
+      }
     } else {
-      supplement.unpin();
+      if (udwState.isInFolder(SupplementedWaveImpl.PINNED_FOLDER)) {
+        udwState.removeFolder(SupplementedWaveImpl.PINNED_FOLDER);
+      }
     }
     OperationUtil.submitDeltas(context, waveletProvider, LOGGING_REQUEST_LISTENER);
   }

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -134,6 +134,11 @@ public final class SearchPresenter
       + "<path d=\"M5 17h14v-1.76a2 2 0 00-1.11-1.79l-1.78-.9A2 2 0 0115 10.76V6h1a2 2 0 000-4H8"
       + "a2 2 0 000 4h1v4.76a2 2 0 01-1.11 1.79l-1.78.9A2 2 0 005 15.24z\"></path></svg>";
 
+  /** Refresh: rotate-cw icon. */
+  private static final String ICON_REFRESH = SVG_OPEN
+      + "<polyline points=\"23 4 23 10 17 10\"></polyline>"
+      + "<path d=\"M20.49 15a9 9 0 11-2.12-9.36L23 10\"></path></svg>";
+
   // External references
   private final TimerService scheduler;
   private final Search search;
@@ -415,6 +420,15 @@ public final class SearchPresenter
           }
         }).setVisualElement(createSvgIcon(ICON_PIN));
 
+    new ToolbarButtonViewBuilder()
+        .setTooltip("Refresh search results")
+        .applyTo(filterGroup.addClickButton(), new ToolbarClickButton.Listener() {
+          @Override
+          public void onClicked() {
+            forceRefresh();
+          }
+        }).setVisualElement(createSvgIcon(ICON_REFRESH));
+
     // Saved searches are loaded lazily after the first search result arrives
     // (see onStateChanged) to avoid competing with the critical /search request.
   }
@@ -645,9 +659,20 @@ public final class SearchPresenter
   @Override
   public void onQueryEntered() {
     queryText = searchUi.getSearch().getQuery();
+    forceRefresh();
+  }
+
+  /**
+   * Forces an immediate search refresh and resets the polling timer so the
+   * user sees updated results right away (e.g. after pin/unpin or Enter on
+   * the same query).
+   */
+  private void forceRefresh() {
     querySize = getPageSize();
     searchUi.setTitleText(messages.searching());
+    search.cancel();
     doSearch();
+    scheduler.scheduleRepeating(searchUpdater, POLLING_INTERVAL_MS, POLLING_INTERVAL_MS);
   }
 
   @Override


### PR DESCRIPTION
## Summary
- **Pin 500 fix**: `setPinState()` was building the full conversation model via `buildConversation()`, which fails for waves with malformed manifest documents. Pin/unpin only modifies the UDW folder document, so the conversation model is unnecessary. Now writes directly to `PrimitiveSupplement`.
- **Refresh button**: Added a refresh icon (rotate-cw) to the search toolbar that forces an immediate search refresh.
- **Enter re-query**: Pressing Enter on the same query now cancels any in-flight request and resets the polling timer, ensuring fresh results.

## Test plan
- [ ] Pin a wave — verify no 500 error
- [ ] Unpin a wave — verify no 500 error
- [ ] Click refresh button — verify search results update immediately
- [ ] Press Enter on same search query — verify results refresh
- [ ] Verify pinned waves appear at top of search results after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Refresh search results" button to the search toolbar, enabling users to manually trigger search updates and reset pagination to view fresh results immediately.

* **Performance Improvements**
  * Optimized the pin/unpin operation workflow to reduce latency and improve responsiveness when pinning, unpinning, and managing items across folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->