### PR TITLE
fix: cancel polling timer before rescheduling in forceRefresh

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -672,6 +672,7 @@ public final class SearchPresenter
     searchUi.setTitleText(messages.searching());
     search.cancel();
     doSearch();
+    scheduler.cancel(searchUpdater);
     scheduler.scheduleRepeating(searchUpdater, POLLING_INTERVAL_MS, POLLING_INTERVAL_MS);
   }
 


### PR DESCRIPTION
## Summary
- Adds `scheduler.cancel(searchUpdater)` before `scheduler.scheduleRepeating(...)` in `SearchPresenter.forceRefresh()` to prevent timer accumulation when the method is called rapidly (e.g. repeated clicks on Refresh or quick successive query changes).
- Without this fix, each call to `forceRefresh()` would stack a new repeating timer on top of any existing one, leading to progressively more frequent polling.

## Test plan
- [x] `sbt wave/compile` passes
- [x] `sbt compileGwt` passes
- [ ] Manual: rapidly click the Refresh button and verify in browser devtools that only one polling timer is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved a search refresh stability issue by preventing duplicate or overlapping update operations during manual refresh. This enhancement improves overall search performance by eliminating unnecessary processing cycles and ensures search results display more reliably and consistently, providing users with a more responsive search experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->