### PR TITLE
feat: add contacts search API endpoint (closes #346)

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -264,6 +264,7 @@ public class ServerMain {
     server.addServlet("/account/settings", AccountSettingsServlet.class);
     server.addServlet("/account/settings/*", AccountSettingsServlet.class);
     server.addServlet("/contacts", FetchContactsServlet.class);
+    server.addServlet("/contacts/search/*", ContactSearchServlet.class);
     server.addServlet("/iniavatars/*", org.apache.wave.box.server.rpc.InitialsAvatarsServlet.class);
     server.addServlet("/wave/public/*", PublicWaveFetchServlet.class);
     server.addServlet("/waveref/*", WaveRefServlet.class);

--- a/wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
@@ -428,6 +428,7 @@ public class ServerMain {
     }
     server.addServlet("/profile/*", FetchProfilesServlet.class);
     server.addServlet("/contacts", FetchContactsServlet.class);
+    server.addServlet("/contacts/search/*", ContactSearchServlet.class);
     // Dev endpoint: client-side fragments applier stats (session-based)
     server.addServlet("/dev/client-applier-stats", ClientApplierStatsServlet.class);
     server.addServlet("/iniavatars/*", InitialsAvatarsServlet.class);

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/ContactSearchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/ContactSearchServlet.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.contact.Contact;
+import org.waveprotocol.box.server.contact.ContactManager;
+import org.waveprotocol.box.server.persistence.PersistenceException;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.util.logging.Log;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet that searches the authenticated user's contacts by address prefix.
+ *
+ * <p>Request: {@code GET /contacts/search?q=<prefix>&limit=<n>}
+ * <ul>
+ *   <li>{@code q} -- address prefix to match (case-insensitive). Empty or absent returns all.</li>
+ *   <li>{@code limit} -- maximum number of results (default 20, max 100).</li>
+ * </ul>
+ *
+ * <p>Response (JSON):
+ * <pre>{
+ *   "contacts": [
+ *     {"address": "alice@example.com", "score": 42.0},
+ *     ...
+ *   ]
+ * }</pre>
+ *
+ * <p>Results are sorted by score descending (higher score = more interaction).
+ */
+@SuppressWarnings("serial")
+@Singleton
+public final class ContactSearchServlet extends HttpServlet {
+
+  private static final Log LOG = Log.get(ContactSearchServlet.class);
+
+  private static final int DEFAULT_LIMIT = 20;
+  private static final int MAX_LIMIT = 100;
+
+  private final SessionManager sessionManager;
+  private final ContactManager contactManager;
+
+  @Inject
+  public ContactSearchServlet(SessionManager sessionManager, ContactManager contactManager) {
+    this.sessionManager = sessionManager;
+    this.contactManager = contactManager;
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
+    if (user == null) {
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    String query = req.getParameter("q");
+    if (query == null) {
+      query = "";
+    }
+    String queryLower = query.toLowerCase(Locale.ENGLISH);
+
+    int limit = parseLimit(req.getParameter("limit"));
+
+    long currentTime = Calendar.getInstance().getTimeInMillis();
+
+    List<Contact> allContacts;
+    try {
+      allContacts = contactManager.getContacts(user, 0);
+    } catch (PersistenceException ex) {
+      LOG.severe("Contact search error", ex);
+      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to retrieve contacts");
+      return;
+    }
+
+    // Filter by prefix and compute scores
+    List<ScoredContact> scored = new ArrayList<>();
+    for (Contact contact : allContacts) {
+      String address = contact.getParticipantId().getAddress();
+      if (queryLower.isEmpty() || address.toLowerCase(Locale.ENGLISH).startsWith(queryLower)) {
+        double score = contactManager.getScoreBonusAtTime(contact, currentTime);
+        scored.add(new ScoredContact(address, score));
+      }
+    }
+
+    // Sort by score descending
+    Collections.sort(scored, new Comparator<ScoredContact>() {
+      @Override
+      public int compare(ScoredContact a, ScoredContact b) {
+        return Double.compare(b.score, a.score);
+      }
+    });
+
+    // Apply limit
+    if (scored.size() > limit) {
+      scored = scored.subList(0, limit);
+    }
+
+    // Build JSON response
+    resp.setContentType("application/json; charset=utf-8");
+    resp.setStatus(HttpServletResponse.SC_OK);
+    resp.setHeader("Cache-Control", "no-store");
+
+    JsonObject json = new JsonObject();
+    JsonArray contactsArray = new JsonArray();
+    for (ScoredContact sc : scored) {
+      JsonObject c = new JsonObject();
+      c.addProperty("address", sc.address);
+      c.addProperty("score", sc.score);
+      contactsArray.add(c);
+    }
+    json.add("contacts", contactsArray);
+    resp.getWriter().append(json.toString());
+  }
+
+  private static int parseLimit(String param) {
+    if (param == null || param.isEmpty()) {
+      return DEFAULT_LIMIT;
+    }
+    try {
+      int value = Integer.parseInt(param);
+      if (value <= 0) {
+        return DEFAULT_LIMIT;
+      }
+      return Math.min(value, MAX_LIMIT);
+    } catch (NumberFormatException e) {
+      return DEFAULT_LIMIT;
+    }
+  }
+
+  /** Simple holder for a contact address and its computed score. */
+  static final class ScoredContact {
+    final String address;
+    final double score;
+
+    ScoredContact(String address, double score) {
+      this.address = address;
+      this.score = score;
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/ContactSearchServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/ContactSearchServletTest.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import junit.framework.TestCase;
+
+import org.mockito.Mockito;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.contact.Contact;
+import org.waveprotocol.box.server.contact.ContactImpl;
+import org.waveprotocol.box.server.contact.ContactManager;
+import org.waveprotocol.box.server.contact.ContactManagerImpl;
+import org.waveprotocol.box.server.persistence.memory.MemoryStore;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Tests for {@link ContactSearchServlet}.
+ */
+public class ContactSearchServletTest extends TestCase {
+
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@example.com");
+  private static final ParticipantId ALICE = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId BOB = ParticipantId.ofUnsafe("bob@example.com");
+  private static final ParticipantId CHARLIE = ParticipantId.ofUnsafe("charlie@example.com");
+
+  private ScheduledExecutorService executor;
+  private ContactManager contactManager;
+  private SessionManager sessionManager;
+  private ContactSearchServlet servlet;
+
+  @Override
+  protected void setUp() throws Exception {
+    executor = Executors.newSingleThreadScheduledExecutor();
+    contactManager = new ContactManagerImpl(new MemoryStore(), executor);
+    sessionManager = mock(SessionManager.class);
+    servlet = new ContactSearchServlet(sessionManager, contactManager);
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  public void testUnauthenticatedRequestReturns403() throws Exception {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+
+    // No session on the request => WebSessions.from returns null => getLoggedInUser(null) => null
+    servlet.doGet(req, resp);
+
+    verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+  }
+
+  public void testEmptyPrefixReturnsAllContacts() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, BOB, now, true);
+
+    JsonArray contacts = doSearch("", null);
+    assertEquals(2, contacts.size());
+  }
+
+  public void testPrefixFiltersContacts() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, BOB, now, true);
+    contactManager.newCall(USER, CHARLIE, now, true);
+
+    JsonArray contacts = doSearch("ali", null);
+    assertEquals(1, contacts.size());
+    assertEquals("alice@example.com", contacts.get(0).getAsJsonObject().get("address").getAsString());
+  }
+
+  public void testPrefixIsCaseInsensitive() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, BOB, now, true);
+
+    JsonArray contacts = doSearch("ALI", null);
+    assertEquals(1, contacts.size());
+    assertEquals("alice@example.com", contacts.get(0).getAsJsonObject().get("address").getAsString());
+  }
+
+  public void testResultsSortedByScoreDescending() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    // Alice gets more interactions (higher score)
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, ALICE, now, true);
+    // Bob gets fewer interactions (lower score)
+    contactManager.newCall(USER, BOB, now, true);
+
+    JsonArray contacts = doSearch("", null);
+    assertEquals(2, contacts.size());
+
+    double score0 = contacts.get(0).getAsJsonObject().get("score").getAsDouble();
+    double score1 = contacts.get(1).getAsJsonObject().get("score").getAsDouble();
+    assertTrue("Results should be sorted by score descending", score0 >= score1);
+  }
+
+  public void testLimitParameter() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+    contactManager.newCall(USER, BOB, now, true);
+    contactManager.newCall(USER, CHARLIE, now, true);
+
+    JsonArray contacts = doSearch("", "2");
+    assertEquals(2, contacts.size());
+  }
+
+  public void testNoMatchingContactsReturnsEmptyArray() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+
+    JsonArray contacts = doSearch("zzz", null);
+    assertEquals(0, contacts.size());
+  }
+
+  public void testResponseContainsAddressAndScore() throws Exception {
+    when(sessionManager.getLoggedInUser(Mockito.any(WebSession.class))).thenReturn(USER);
+
+    long now = System.currentTimeMillis();
+    contactManager.newCall(USER, ALICE, now, true);
+
+    JsonArray contacts = doSearch("ali", null);
+    assertEquals(1, contacts.size());
+
+    JsonObject contact = contacts.get(0).getAsJsonObject();
+    assertTrue("Contact should have 'address' field", contact.has("address"));
+    assertTrue("Contact should have 'score' field", contact.has("score"));
+    assertEquals("alice@example.com", contact.get("address").getAsString());
+    assertTrue("Score should be non-negative", contact.get("score").getAsDouble() >= 0);
+  }
+
+  // --- helper methods ---
+
+  private JsonArray doSearch(String query, String limit) throws Exception {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    HttpSession httpSession = mock(HttpSession.class);
+
+    when(req.getSession(false)).thenReturn(httpSession);
+    when(req.getParameter("q")).thenReturn(query);
+    when(req.getParameter("limit")).thenReturn(limit);
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    when(resp.getWriter()).thenReturn(writer);
+
+    servlet.doGet(req, resp);
+
+    writer.flush();
+    String json = stringWriter.toString();
+    JsonElement parsed = JsonParser.parseString(json);
+    return parsed.getAsJsonObject().getAsJsonArray("contacts");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /contacts/search?q=<prefix>&limit=<n>` endpoint for searching contacts by address prefix
- Leverages existing `ContactManager` infrastructure to return contacts sorted by interaction score (descending)
- Returns JSON: `{"contacts": [{"address": "user@example.com", "score": 42.0}]}`
- Returns 403 for unauthenticated requests; empty prefix returns all contacts
- Registered in both jakarta-overrides and main `ServerMain.java` variants

## Test plan
- [x] `sbt wave/compile` passes
- [x] 8 unit tests pass (`ContactSearchServletTest`):
  - Unauthenticated request returns 403
  - Empty prefix returns all contacts
  - Prefix filters contacts correctly
  - Prefix matching is case-insensitive
  - Results sorted by score descending
  - Limit parameter caps result count
  - No matches returns empty array
  - Response contains address and score fields

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added contact search functionality allowing users to search contacts by address prefix with case-insensitive matching
- Search results automatically ranked by interaction frequency and recency
- Customizable result limit parameter to control response size
- Authentication required; unauthenticated requests are rejected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->