### PR TITLE
feat: add contact search dialog translations for 7 languages

### DIFF
--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_de.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_de.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = Kontakte suchen
+searchPlaceholder = Name oder E-Mail eingeben, um zu suchen...
+searching = Suche l\u00e4uft...
+noResults = Keine Kontakte gefunden
+typeToSearch = Tippen Sie, um Ihre Kontakte zu durchsuchen
+lastContact = Letzter Kontakt: {0}
+addParticipant = Teilnehmer hinzuf\u00fcgen
+add = Hinzuf\u00fcgen
+done = Fertig
+addingParticipant = Teilnehmer wird hinzugef\u00fcgt...
+searchError = Kontaktsuche fehlgeschlagen
+resultsCount = {0} Kontakte gefunden

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_en.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_en.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = Search contacts
+searchPlaceholder = Type a name or email to search...
+searching = Searching...
+noResults = No contacts found
+typeToSearch = Type to search your contacts
+lastContact = Last contact: {0}
+addParticipant = Add participant
+add = Add
+done = Done
+addingParticipant = Adding participant...
+searchError = Failed to search contacts
+resultsCount = {0} contacts found

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_es.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_es.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = Buscar contactos
+searchPlaceholder = Escribe un nombre o correo para buscar...
+searching = Buscando...
+noResults = No se encontraron contactos
+typeToSearch = Escribe para buscar en tus contactos
+lastContact = \u00daltimo contacto: {0}
+addParticipant = A\u00f1adir participante
+add = A\u00f1adir
+done = Listo
+addingParticipant = A\u00f1adiendo participante...
+searchError = Error al buscar contactos
+resultsCount = {0} contactos encontrados

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_fr.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_fr.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = Rechercher des contacts
+searchPlaceholder = Saisissez un nom ou un e-mail pour rechercher...
+searching = Recherche en cours...
+noResults = Aucun contact trouv\u00e9
+typeToSearch = Saisissez pour rechercher dans vos contacts
+lastContact = Dernier contact : {0}
+addParticipant = Ajouter un participant
+add = Ajouter
+done = Termin\u00e9
+addingParticipant = Ajout du participant en cours...
+searchError = \u00c9chec de la recherche de contacts
+resultsCount = {0} contacts trouv\u00e9s

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_ru.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_ru.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = \u041f\u043e\u0438\u0441\u043a \u043a\u043e\u043d\u0442\u0430\u043a\u0442\u043e\u0432
+searchPlaceholder = \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u0438\u043c\u044f \u0438\u043b\u0438 \u044d\u043b\u0435\u043a\u0442\u0440\u043e\u043d\u043d\u0443\u044e \u043f\u043e\u0447\u0442\u0443 \u0434\u043b\u044f \u043f\u043e\u0438\u0441\u043a\u0430...
+searching = \u041f\u043e\u0438\u0441\u043a...
+noResults = \u041a\u043e\u043d\u0442\u0430\u043a\u0442\u044b \u043d\u0435 \u043d\u0430\u0439\u0434\u0435\u043d\u044b
+typeToSearch = \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u0442\u0435\u043a\u0441\u0442 \u0434\u043b\u044f \u043f\u043e\u0438\u0441\u043a\u0430 \u043a\u043e\u043d\u0442\u0430\u043a\u0442\u043e\u0432
+lastContact = \u041f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0439 \u043a\u043e\u043d\u0442\u0430\u043a\u0442: {0}
+addParticipant = \u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430
+add = \u0414\u043e\u0431\u0430\u0432\u0438\u0442\u044c
+done = \u0413\u043e\u0442\u043e\u0432\u043e
+addingParticipant = \u0414\u043e\u0431\u0430\u0432\u043b\u0435\u043d\u0438\u0435 \u0443\u0447\u0430\u0441\u0442\u043d\u0438\u043a\u0430...
+searchError = \u041d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c \u043d\u0430\u0439\u0442\u0438 \u043a\u043e\u043d\u0442\u0430\u043a\u0442\u044b
+resultsCount = \u041d\u0430\u0439\u0434\u0435\u043d\u043e \u043a\u043e\u043d\u0442\u0430\u043a\u0442\u043e\u0432: {0}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_sl.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_sl.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = Iskanje kontaktov
+searchPlaceholder = Vnesite ime ali e-po\u0161to za iskanje...
+searching = Iskanje...
+noResults = Ni najdenih kontaktov
+typeToSearch = Vnesite besedilo za iskanje med kontakti
+lastContact = Zadnji kontakt: {0}
+addParticipant = Dodaj udele\u017eenca
+add = Dodaj
+done = Kon\u010dano
+addingParticipant = Dodajanje udele\u017eenca...
+searchError = Iskanje kontaktov ni uspelo
+resultsCount = Najdenih kontaktov: {0}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_zh_TW.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ContactSearchMessages_zh_TW.properties
@@ -1,0 +1,33 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+
+dialogTitle = \u641c\u5c0b\u806f\u7d61\u4eba
+searchPlaceholder = \u8f38\u5165\u59d3\u540d\u6216\u96fb\u5b50\u90f5\u4ef6\u4f86\u641c\u5c0b...
+searching = \u641c\u5c0b\u4e2d...
+noResults = \u627e\u4e0d\u5230\u806f\u7d61\u4eba
+typeToSearch = \u8f38\u5165\u4ee5\u641c\u5c0b\u60a8\u7684\u806f\u7d61\u4eba
+lastContact = \u6700\u5f8c\u806f\u7d61\uff1a{0}
+addParticipant = \u65b0\u589e\u53c3\u8207\u8005
+add = \u65b0\u589e
+done = \u5b8c\u6210
+addingParticipant = \u6b63\u5728\u65b0\u589e\u53c3\u8207\u8005...
+searchError = \u641c\u5c0b\u806f\u7d61\u4eba\u5931\u6557
+resultsCount = \u627e\u5230 {0} \u4f4d\u806f\u7d61\u4eba


### PR DESCRIPTION
## Summary
- Add GWT i18n `.properties` files for the `ContactSearchMessages` interface (from PR #357)
- All 12 message keys translated into 7 languages: English, German, Spanish, French, Russian, Slovenian, and Traditional Chinese
- Properties placed in `wave/src/main/resources/.../i18n/` alongside existing `ParticipantMessages` translations

## Languages
| File | Language |
|------|----------|
| `ContactSearchMessages_en.properties` | English (base) |
| `ContactSearchMessages_de.properties` | German |
| `ContactSearchMessages_es.properties` | Spanish |
| `ContactSearchMessages_fr.properties` | French |
| `ContactSearchMessages_ru.properties` | Russian |
| `ContactSearchMessages_sl.properties` | Slovenian |
| `ContactSearchMessages_zh_TW.properties` | Traditional Chinese |

## Test plan
- [x] Verified `sbt compileGwt` succeeds — GWT i18n binding resolved all 7 locale files
- [ ] Manual spot-check: switch browser locale and confirm dialog strings render correctly

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for contact search functionality in German, English, Spanish, French, Russian, Slovenian, and Traditional Chinese languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->