### PR TITLE
feat: add share button, public waves directory, and auto-refresh

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -267,6 +267,7 @@ public class ServerMain {
     server.addServlet("/contacts/search/*", ContactSearchServlet.class);
     server.addServlet("/iniavatars/*", org.apache.wave.box.server.rpc.InitialsAvatarsServlet.class);
     server.addServlet("/wave/public/*", PublicWaveFetchServlet.class);
+    server.addServlet("/public", PublicDirectoryServlet.class);
     server.addServlet("/waveref/*", WaveRefServlet.class);
     server.addServlet("/history/*", VersionHistoryServlet.class);
     server.addServlet("/admin", AdminServlet.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -18,6 +18,8 @@
  */
 package org.waveprotocol.box.server.rpc;
 
+import com.google.wave.api.SearchResult;
+import java.util.List;
 import org.json.JSONObject;
 import org.waveprotocol.box.server.account.HumanAccountData;
 
@@ -1934,6 +1936,7 @@ public final class HtmlRenderer {
     sb.append("    <div class=\"hero-buttons\">\n");
     sb.append("      <a href=\"/auth/register\" class=\"hero-btn hero-btn-primary\">Get Started</a>\n");
     sb.append("      <a href=\"/auth/signin\" class=\"hero-btn hero-btn-secondary\">Sign In</a>\n");
+    sb.append("      <a href=\"/public\" class=\"hero-btn hero-btn-secondary\">Explore Public Waves</a>\n");
     sb.append("    </div>\n");
     sb.append("  </div>\n");
     // Hero bottom wave divider
@@ -5369,8 +5372,401 @@ public final class HtmlRenderer {
     sb.append("<a href=\"/privacy\">Privacy</a></p>\n");
     sb.append("</footer>\n");
 
+    // Auto-refresh script: fetches updated content every 30 seconds
+    // via the /wave/public/{waveRef} JSON API and updates in place.
+    sb.append("<div id=\"pw-last-updated\" style=\"text-align:center;font-size:12px;color:");
+    sb.append(WAVE_TEXT_MUTED).append(";padding:8px 0;\">Content loaded just now</div>\n");
+    sb.append("<script>\n");
+    sb.append("(function() {\n");
+    sb.append("  var waveId = '").append(eWaveId.replace("'", "\\'")).append("';\n");
+    sb.append("  var bodyEl = document.querySelector('.pw-body');\n");
+    sb.append("  var titleEl = document.querySelector('.pw-title');\n");
+    sb.append("  var updatedEl = document.getElementById('pw-last-updated');\n");
+    sb.append("  var lastRefresh = Date.now();\n");
+    sb.append("  function updateTimestamp() {\n");
+    sb.append("    if (!updatedEl) return;\n");
+    sb.append("    var secs = Math.floor((Date.now() - lastRefresh) / 1000);\n");
+    sb.append("    if (secs < 5) updatedEl.textContent = 'Content loaded just now';\n");
+    sb.append("    else if (secs < 60) updatedEl.textContent = 'Last updated ' + secs + ' seconds ago';\n");
+    sb.append("    else updatedEl.textContent = 'Last updated ' + Math.floor(secs / 60) + ' minute(s) ago';\n");
+    sb.append("  }\n");
+    sb.append("  setInterval(updateTimestamp, 5000);\n");
+    sb.append("  setInterval(function() {\n");
+    sb.append("    fetch('/wave/' + waveId)\n");
+    sb.append("      .then(function(r) { return r.ok ? r.text() : null; })\n");
+    sb.append("      .then(function(html) {\n");
+    sb.append("        if (!html) return;\n");
+    sb.append("        var parser = new DOMParser();\n");
+    sb.append("        var doc = parser.parseFromString(html, 'text/html');\n");
+    sb.append("        var newBody = doc.querySelector('.pw-body');\n");
+    sb.append("        var newTitle = doc.querySelector('.pw-title');\n");
+    sb.append("        if (newBody && bodyEl) bodyEl.innerHTML = newBody.innerHTML;\n");
+    sb.append("        if (newTitle && titleEl) titleEl.innerHTML = newTitle.innerHTML;\n");
+    sb.append("        lastRefresh = Date.now();\n");
+    sb.append("        updateTimestamp();\n");
+    sb.append("      })\n");
+    sb.append("      .catch(function() {});\n");
+    sb.append("  }, 30000);\n");
+    sb.append("})();\n");
+    sb.append("</script>\n");
+
     sb.append("</body>\n</html>\n");
     return sb.toString();
+  }
+
+  // =========================================================================
+  // Public Directory Page
+  // =========================================================================
+
+  /**
+   * Renders the public waves directory page listing all public waves
+   * in a responsive card grid with ocean/light theme.
+   *
+   * @param domain      the wave server domain
+   * @param digests     the list of wave digests to display
+   * @param page        the current page number (1-based)
+   * @param hasNextPage true if there are more results after this page
+   * @param hasPrevPage true if there are results before this page
+   * @param totalResults total number of matching waves, or -1 if unknown
+   * @return complete HTML page as a string
+   */
+  public static String renderPublicDirectoryPage(
+      String domain, List<SearchResult.Digest> digests,
+      int page, boolean hasNextPage, boolean hasPrevPage, int totalResults) {
+    StringBuilder sb = new StringBuilder(16384);
+    sb.append("<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"en\">\n<head>\n");
+    sb.append("<meta charset=\"UTF-8\">\n");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
+    sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
+    sb.append("<title>Public Waves - SupaWave</title>\n");
+    sb.append("<meta name=\"description\" content=\"Browse public waves on SupaWave. ");
+    sb.append("Discover real-time collaborative conversations shared by the community.\">\n");
+
+    // Styles
+    sb.append("<style>\n");
+    sb.append("*, *::before, *::after { box-sizing: border-box; }\n");
+    sb.append("body {\n");
+    sb.append("  margin: 0; padding: 0;\n");
+    sb.append("  font-family: ").append(WAVE_FONT).append(";\n");
+    sb.append("  color: ").append(WAVE_TEXT).append("; background: ").append(WAVE_BG).append(";\n");
+    sb.append("  min-height: 100vh;\n");
+    sb.append("}\n");
+    sb.append("a { color: ").append(WAVE_PRIMARY).append("; text-decoration: none; }\n");
+    sb.append("a:hover { text-decoration: underline; }\n");
+
+    // Header
+    sb.append(".pd-header {\n");
+    sb.append("  background: ").append(WAVE_GRADIENT).append(";\n");
+    sb.append("  padding: 16px 32px; display: flex; align-items: center;\n");
+    sb.append("  justify-content: space-between;\n");
+    sb.append("}\n");
+    sb.append(".pd-brand { display: flex; align-items: center; gap: 10px; ");
+    sb.append("color: #fff; font-size: 20px; font-weight: 700; text-decoration: none; }\n");
+    sb.append(".pd-brand:hover { text-decoration: none; }\n");
+    sb.append(".pd-header-actions { display: flex; gap: 12px; }\n");
+    sb.append(".pd-btn {\n");
+    sb.append("  padding: 8px 20px; font-size: 14px; font-weight: 600;\n");
+    sb.append("  border-radius: 8px; text-decoration: none; transition: all 0.2s;\n");
+    sb.append("}\n");
+    sb.append(".pd-btn-signin { color: #fff; border: 1.5px solid rgba(255,255,255,0.6); background: transparent; }\n");
+    sb.append(".pd-btn-signin:hover { background: rgba(255,255,255,0.15); text-decoration: none; }\n");
+    sb.append(".pd-btn-register { color: ").append(WAVE_PRIMARY).append("; background: #fff; }\n");
+    sb.append(".pd-btn-register:hover { background: #f0f8ff; text-decoration: none; }\n");
+
+    // Hero banner
+    sb.append(".pd-hero {\n");
+    sb.append("  background: ").append(WAVE_GRADIENT).append(";\n");
+    sb.append("  padding: 40px 32px 48px; text-align: center; color: #fff;\n");
+    sb.append("}\n");
+    sb.append(".pd-hero h1 { font-size: 36px; font-weight: 800; margin: 0 0 8px; }\n");
+    sb.append(".pd-hero p { font-size: 16px; opacity: 0.9; margin: 0; }\n");
+
+    // Content
+    sb.append(".pd-content {\n");
+    sb.append("  max-width: 1100px; margin: -24px auto 0; padding: 0 24px 48px;\n");
+    sb.append("  position: relative; z-index: 1;\n");
+    sb.append("}\n");
+
+    // Wave cards grid
+    sb.append(".pd-grid {\n");
+    sb.append("  display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));\n");
+    sb.append("  gap: 20px; margin-bottom: 32px;\n");
+    sb.append("}\n");
+    sb.append(".pd-card {\n");
+    sb.append("  background: #fff; border-radius: 12px; padding: 24px;\n");
+    sb.append("  border: 1px solid ").append(WAVE_BORDER).append(";\n");
+    sb.append("  box-shadow: 0 2px 8px rgba(0,0,0,0.06);\n");
+    sb.append("  transition: transform 0.2s, box-shadow 0.2s;\n");
+    sb.append("  display: flex; flex-direction: column;\n");
+    sb.append("}\n");
+    sb.append(".pd-card:hover {\n");
+    sb.append("  transform: translateY(-3px);\n");
+    sb.append("  box-shadow: 0 8px 24px rgba(0,119,182,0.12);\n");
+    sb.append("}\n");
+    sb.append(".pd-card-title {\n");
+    sb.append("  font-size: 17px; font-weight: 700; margin: 0 0 8px;\n");
+    sb.append("  color: ").append(WAVE_TEXT).append("; line-height: 1.3;\n");
+    sb.append("}\n");
+    sb.append(".pd-card-title a { color: ").append(WAVE_TEXT).append("; }\n");
+    sb.append(".pd-card-title a:hover { color: ").append(WAVE_PRIMARY).append("; text-decoration: none; }\n");
+    sb.append(".pd-card-snippet {\n");
+    sb.append("  font-size: 14px; color: ").append(WAVE_TEXT_MUTED).append(";\n");
+    sb.append("  line-height: 1.5; margin-bottom: 12px; flex: 1;\n");
+    sb.append("  overflow: hidden; display: -webkit-box;\n");
+    sb.append("  -webkit-line-clamp: 3; -webkit-box-orient: vertical;\n");
+    sb.append("}\n");
+    sb.append(".pd-card-meta {\n");
+    sb.append("  display: flex; align-items: center; gap: 10px;\n");
+    sb.append("  font-size: 12px; color: ").append(WAVE_TEXT_MUTED).append(";\n");
+    sb.append("  border-top: 1px solid ").append(WAVE_BORDER).append(";\n");
+    sb.append("  padding-top: 12px; margin-top: 4px;\n");
+    sb.append("}\n");
+    sb.append(".pd-avatar {\n");
+    sb.append("  width: 28px; height: 28px; border-radius: 50%;\n");
+    sb.append("  background: ").append(WAVE_BG).append(";\n");
+    sb.append("}\n");
+    sb.append(".pd-meta-text { flex: 1; }\n");
+    sb.append(".pd-participants {\n");
+    sb.append("  display: inline-flex; align-items: center; gap: 2px;\n");
+    sb.append("  color: ").append(WAVE_TEXT_MUTED).append(";\n");
+    sb.append("}\n");
+
+    // Pagination
+    sb.append(".pd-pagination {\n");
+    sb.append("  display: flex; justify-content: center; gap: 12px;\n");
+    sb.append("  align-items: center;\n");
+    sb.append("}\n");
+    sb.append(".pd-page-btn {\n");
+    sb.append("  display: inline-block; padding: 10px 24px;\n");
+    sb.append("  background: ").append(WAVE_PRIMARY).append("; color: #fff;\n");
+    sb.append("  border-radius: 8px; font-size: 14px; font-weight: 600;\n");
+    sb.append("  text-decoration: none; transition: all 0.2s;\n");
+    sb.append("}\n");
+    sb.append(".pd-page-btn:hover { background: #005f8f; text-decoration: none; }\n");
+    sb.append(".pd-page-btn-disabled {\n");
+    sb.append("  background: #cbd5e0; pointer-events: none; color: #fff;\n");
+    sb.append("}\n");
+    sb.append(".pd-page-info { font-size: 14px; color: ").append(WAVE_TEXT_MUTED).append("; }\n");
+
+    // Empty state
+    sb.append(".pd-empty {\n");
+    sb.append("  text-align: center; padding: 64px 24px;\n");
+    sb.append("  color: ").append(WAVE_TEXT_MUTED).append(";\n");
+    sb.append("}\n");
+    sb.append(".pd-empty h2 { font-size: 24px; margin: 0 0 8px; color: ").append(WAVE_TEXT).append("; }\n");
+    sb.append(".pd-empty p { font-size: 16px; }\n");
+
+    // Footer
+    sb.append(".pd-footer {\n");
+    sb.append("  text-align: center; padding: 24px; font-size: 13px;\n");
+    sb.append("  color: ").append(WAVE_TEXT_MUTED).append(";\n");
+    sb.append("}\n");
+    sb.append(".pd-footer a { color: ").append(WAVE_PRIMARY).append("; }\n");
+
+    // Responsive
+    sb.append("@media (max-width: 640px) {\n");
+    sb.append("  .pd-header { padding: 12px 16px; }\n");
+    sb.append("  .pd-hero { padding: 28px 16px 36px; }\n");
+    sb.append("  .pd-hero h1 { font-size: 26px; }\n");
+    sb.append("  .pd-content { padding: 0 12px 32px; }\n");
+    sb.append("  .pd-grid { grid-template-columns: 1fr; }\n");
+    sb.append("}\n");
+    sb.append("</style>\n");
+    sb.append("</head>\n<body>\n");
+
+    // Header
+    sb.append("<header class=\"pd-header\">\n");
+    sb.append("  <a href=\"/\" class=\"pd-brand\">\n");
+    sb.append("    ").append(WAVE_LOGO_SVG_SMALL.replace("width=\"28\" height=\"28\"", "width=\"28\" height=\"28\""));
+    sb.append("    <span>SupaWave</span>\n");
+    sb.append("  </a>\n");
+    sb.append("  <div class=\"pd-header-actions\">\n");
+    sb.append("    <a href=\"/auth/signin\" class=\"pd-btn pd-btn-signin\">Sign In</a>\n");
+    sb.append("    <a href=\"/auth/register\" class=\"pd-btn pd-btn-register\">Register</a>\n");
+    sb.append("  </div>\n");
+    sb.append("</header>\n");
+
+    // Hero
+    sb.append("<section class=\"pd-hero\">\n");
+    sb.append("  <h1>Public Waves</h1>\n");
+    sb.append("  <p>Discover conversations shared by the SupaWave community</p>\n");
+    sb.append("</section>\n");
+
+    // Content
+    sb.append("<main class=\"pd-content\">\n");
+
+    if (digests.isEmpty()) {
+      sb.append("  <div class=\"pd-empty\">\n");
+      sb.append("    <h2>No public waves yet</h2>\n");
+      sb.append("    <p>Be the first to create a public wave! Sign in and toggle a wave to public.</p>\n");
+      sb.append("  </div>\n");
+    } else {
+      sb.append("  <div class=\"pd-grid\">\n");
+      for (SearchResult.Digest digest : digests) {
+        renderWaveCard(sb, digest, domain);
+      }
+      sb.append("  </div>\n");
+
+      // Pagination
+      sb.append("  <div class=\"pd-pagination\">\n");
+      if (hasPrevPage) {
+        sb.append("    <a href=\"/public?page=").append(page - 1)
+            .append("\" class=\"pd-page-btn\">Previous</a>\n");
+      } else {
+        sb.append("    <span class=\"pd-page-btn pd-page-btn-disabled\">Previous</span>\n");
+      }
+      sb.append("    <span class=\"pd-page-info\">Page ").append(page);
+      if (totalResults >= 0) {
+        int totalPages = Math.max(1, (totalResults + 19) / 20);
+        sb.append(" of ").append(totalPages);
+      }
+      sb.append("</span>\n");
+      if (hasNextPage) {
+        sb.append("    <a href=\"/public?page=").append(page + 1)
+            .append("\" class=\"pd-page-btn\">Next</a>\n");
+      } else {
+        sb.append("    <span class=\"pd-page-btn pd-page-btn-disabled\">Next</span>\n");
+      }
+      sb.append("  </div>\n");
+    }
+
+    sb.append("</main>\n");
+
+    // Footer
+    sb.append("<footer class=\"pd-footer\">\n");
+    sb.append("  <p>Powered by <a href=\"/\">SupaWave</a> &middot; ");
+    sb.append("<a href=\"/terms\">Terms</a> &middot; ");
+    sb.append("<a href=\"/privacy\">Privacy</a></p>\n");
+    sb.append("</footer>\n");
+
+    sb.append("</body>\n</html>\n");
+    return sb.toString();
+  }
+
+  /**
+   * Renders a single wave card for the public directory grid.
+   */
+  private static void renderWaveCard(StringBuilder sb, SearchResult.Digest digest, String domain) {
+    String title = digest.getTitle();
+    if (title == null || title.trim().isEmpty()) {
+      title = "Untitled Wave";
+    }
+    String snippet = digest.getSnippet();
+    if (snippet == null) {
+      snippet = "";
+    }
+    String waveId = digest.getWaveId();
+    String eTitle = escapeHtml(title);
+    String eSnippet = escapeHtml(snippet);
+    String eWaveId = escapeHtml(waveId);
+
+    // Get the author (first non-domain participant)
+    String author = "";
+    List<String> participants = digest.getParticipants();
+    String domainParticipant = "@" + domain;
+    for (String p : participants) {
+      if (!p.equals(domainParticipant)) {
+        author = p;
+        break;
+      }
+    }
+    String eAuthor = escapeHtml(author);
+
+    // Count non-domain participants
+    int participantCount = 0;
+    for (String p : participants) {
+      if (!p.equals(domainParticipant)) {
+        participantCount++;
+      }
+    }
+
+    // Format last modified
+    long lastModified = digest.getLastModified();
+    String timeAgo = formatTimeAgo(lastModified);
+
+    // Gravatar URL for author
+    String gravatarUrl = "";
+    if (!author.isEmpty()) {
+      String emailHash = md5Hex(author.trim().toLowerCase());
+      gravatarUrl = "https://www.gravatar.com/avatar/" + emailHash + "?d=identicon&s=56";
+    }
+
+    sb.append("    <article class=\"pd-card\">\n");
+    sb.append("      <h3 class=\"pd-card-title\"><a href=\"/wave/")
+        .append(eWaveId).append("\">").append(eTitle).append("</a></h3>\n");
+    if (!eSnippet.isEmpty()) {
+      sb.append("      <p class=\"pd-card-snippet\">").append(eSnippet).append("</p>\n");
+    }
+    sb.append("      <div class=\"pd-card-meta\">\n");
+    if (!gravatarUrl.isEmpty()) {
+      sb.append("        <img class=\"pd-avatar\" src=\"").append(escapeHtml(gravatarUrl))
+          .append("\" alt=\"\" loading=\"lazy\">\n");
+    }
+    sb.append("        <span class=\"pd-meta-text\">");
+    if (!eAuthor.isEmpty()) {
+      // Strip the domain part for display
+      String displayName = eAuthor;
+      int atIdx = displayName.indexOf('@');
+      if (atIdx > 0) {
+        displayName = displayName.substring(0, atIdx);
+      }
+      sb.append(displayName);
+    }
+    sb.append("</span>\n");
+    sb.append("        <span class=\"pd-participants\">\n");
+    sb.append("          <svg width='12' height='12' viewBox='0 0 24 24' fill='currentColor'>");
+    sb.append("<path d='M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 ");
+    sb.append("0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 ");
+    sb.append("3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 ");
+    sb.append("1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z'/>");
+    sb.append("</svg>\n");
+    sb.append("          ").append(participantCount);
+    sb.append("</span>\n");
+    sb.append("        <span>").append(escapeHtml(timeAgo)).append("</span>\n");
+    sb.append("      </div>\n");
+    sb.append("    </article>\n");
+  }
+
+  /**
+   * Formats a timestamp as a human-readable relative time string.
+   */
+  private static String formatTimeAgo(long timestampMs) {
+    if (timestampMs <= 0) return "";
+    long now = System.currentTimeMillis();
+    long diffMs = now - timestampMs;
+    if (diffMs < 0) return "just now";
+
+    long seconds = diffMs / 1000;
+    if (seconds < 60) return "just now";
+    long minutes = seconds / 60;
+    if (minutes < 60) return minutes + "m ago";
+    long hours = minutes / 60;
+    if (hours < 24) return hours + "h ago";
+    long days = hours / 24;
+    if (days < 30) return days + "d ago";
+    long months = days / 30;
+    if (months < 12) return months + "mo ago";
+    long years = days / 365;
+    return years + "y ago";
+  }
+
+  /**
+   * Computes a simple MD5 hex digest of the given string for Gravatar URLs.
+   * Falls back to "00000000000000000000000000000000" on error.
+   */
+  private static String md5Hex(String input) {
+    try {
+      java.security.MessageDigest md = java.security.MessageDigest.getInstance("MD5");
+      byte[] digest = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      StringBuilder hex = new StringBuilder(32);
+      for (byte b : digest) {
+        hex.append(String.format("%02x", b & 0xff));
+      }
+      return hex.toString();
+    } catch (java.security.NoSuchAlgorithmException e) {
+      return "00000000000000000000000000000000";
+    }
   }
 
   // =========================================================================

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicDirectoryServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicDirectoryServlet.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.wave.api.OperationQueue;
+import com.google.wave.api.OperationRequest;
+import com.google.wave.api.ProtocolVersion;
+import com.google.wave.api.JsonRpcConstant.ParamsProperty;
+import com.google.wave.api.JsonRpcResponse;
+import com.google.wave.api.SearchResult;
+import com.google.wave.api.data.converter.EventDataConverterManager;
+import com.typesafe.config.Config;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.waveprotocol.box.server.CoreSettingsNames;
+import org.waveprotocol.box.server.robots.OperationContextImpl;
+import org.waveprotocol.box.server.robots.OperationServiceRegistry;
+import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.box.server.robots.util.OperationUtil;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Server-rendered HTML directory of public waves at {@code /public}.
+ * No authentication required. Uses the search API internally with
+ * the shared domain participant to find public waves.
+ *
+ * <p>Supports server-side pagination via {@code ?page=N} (default 1),
+ * showing 20 waves per page.
+ */
+@Singleton
+public final class PublicDirectoryServlet extends HttpServlet {
+
+  private static final Log LOG = Log.get(PublicDirectoryServlet.class);
+  private static final int WAVES_PER_PAGE = 20;
+
+  private final String waveDomain;
+  private final String siteUrl;
+  private final WaveletProvider waveletProvider;
+  private final EventDataConverterManager converterManager;
+  private final OperationServiceRegistry operationRegistry;
+  private final ConversationUtil conversationUtil;
+  private final ParticipantId sharedDomainParticipant;
+
+  @Inject
+  public PublicDirectoryServlet(
+      Config config,
+      @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String waveDomain,
+      WaveletProvider waveletProvider,
+      EventDataConverterManager converterManager,
+      @Named("DataApiRegistry") OperationServiceRegistry operationRegistry,
+      ConversationUtil conversationUtil) {
+    this.waveDomain = waveDomain;
+    this.siteUrl = RobotsServlet.resolveSiteUrl(config);
+    this.waveletProvider = waveletProvider;
+    this.converterManager = converterManager;
+    this.operationRegistry = operationRegistry;
+    this.conversationUtil = conversationUtil;
+    this.sharedDomainParticipant =
+        ParticipantIdUtil.makeUnsafeSharedDomainParticipantId(waveDomain);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    int page = 1;
+    String pageParam = req.getParameter("page");
+    if (pageParam != null) {
+      try {
+        page = Math.max(1, Integer.parseInt(pageParam.trim()));
+      } catch (NumberFormatException ignored) {
+        // fall through to default
+      }
+    }
+
+    int startAt = (page - 1) * WAVES_PER_PAGE;
+
+    // Search for public waves using the domain participant query
+    String query = "with:@" + waveDomain;
+    SearchResult searchResult = performSearch(query, startAt, WAVES_PER_PAGE);
+
+    List<SearchResult.Digest> digests = searchResult.getDigests();
+    int totalResults = searchResult.getTotalResults();
+    boolean hasNextPage = digests.size() >= WAVES_PER_PAGE;
+    boolean hasPrevPage = page > 1;
+
+    String html = HtmlRenderer.renderPublicDirectoryPage(
+        waveDomain, digests, page, hasNextPage, hasPrevPage, totalResults);
+
+    resp.setStatus(HttpServletResponse.SC_OK);
+    resp.setContentType("text/html; charset=UTF-8");
+    resp.setHeader("Cache-Control", "public, max-age=120");
+    resp.getWriter().write(html);
+  }
+
+  /**
+   * Performs a search query as the shared domain participant.
+   */
+  private SearchResult performSearch(String query, int startAt, int numResults) {
+    OperationQueue opQueue = new OperationQueue();
+    opQueue.search(query, startAt, numResults);
+    OperationContextImpl context = new OperationContextImpl(
+        waveletProvider,
+        converterManager.getEventDataConverter(ProtocolVersion.DEFAULT),
+        conversationUtil);
+    OperationRequest operationRequest = opQueue.getPendingOperations().get(0);
+    String opId = operationRequest.getId();
+    OperationUtil.executeOperation(
+        operationRequest, operationRegistry, context, sharedDomainParticipant);
+    JsonRpcResponse jsonRpcResponse = context.getResponses().get(opId);
+    SearchResult result =
+        (SearchResult) jsonRpcResponse.getData().get(ParamsProperty.SEARCH_RESULTS);
+    return result != null ? result : new SearchResult(query);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
@@ -43,6 +43,7 @@ import org.waveprotocol.wave.client.wavepanel.view.dom.ModelAsViewProvider;
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.TypeCodes;
 import org.waveprotocol.wave.client.widget.popup.UniversalPopup;
 import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.util.Pair;
 import org.waveprotocol.wave.model.util.Preconditions;
 import org.waveprotocol.wave.model.wave.InvalidParticipantAddress;
@@ -137,6 +138,13 @@ public final class ParticipantController {
       @Override
       public boolean onClick(ClickEvent event, Element context) {
         handleTogglePublicClicked(context);
+        return true;
+      }
+    });
+    handlers.registerClickHandler(TypeCodes.kind(Type.SHARE_LINK), new WaveClickHandler() {
+      @Override
+      public boolean onClick(ClickEvent event, Element context) {
+        handleShareLinkClicked(context);
         return true;
       }
     });
@@ -260,6 +268,59 @@ public final class ParticipantController {
       buttonElement.setAttribute("aria-label", messages.waveIsPrivateClickToMakePublic());
     }
   }
+
+  /**
+   * Copies the public URL for this wave to the clipboard. The URL is
+   * constructed from the current origin and the wave ID extracted from
+   * the conversation model.
+   */
+  private void handleShareLinkClicked(Element context) {
+    ParticipantsView participantsUi = views.fromShareLinkButton(context);
+    Conversation conversation = models.getParticipants(participantsUi);
+
+    // Extract wave ID from the first blip's raw wavelet
+    WaveId waveId = null;
+    if (conversation.getRootThread() != null
+        && conversation.getRootThread().getFirstBlip() != null) {
+      waveId = conversation.getRootThread().getFirstBlip()
+          .hackGetRaw().getWavelet().getWaveId();
+    }
+
+    if (waveId == null) {
+      ToastNotification.showWarning("Unable to determine wave ID.");
+      return;
+    }
+
+    String publicUrl = nativeGetOrigin() + "/wave/" + waveId.serialise();
+    nativeCopyToClipboard(publicUrl);
+    ToastNotification.showSuccess("Public link copied!");
+  }
+
+  /**
+   * Returns the current page origin via native JS ({@code window.location.origin}).
+   */
+  private static native String nativeGetOrigin() /*-{
+    return $wnd.location.origin;
+  }-*/;
+
+  /**
+   * Copies the given text to the clipboard using the modern Clipboard API,
+   * falling back to a hidden textarea + execCommand approach.
+   */
+  private static native void nativeCopyToClipboard(String text) /*-{
+    if ($wnd.navigator && $wnd.navigator.clipboard && $wnd.navigator.clipboard.writeText) {
+      $wnd.navigator.clipboard.writeText(text);
+    } else {
+      var ta = $doc.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.left = '-9999px';
+      $doc.body.appendChild(ta);
+      ta.select();
+      try { $doc.execCommand('copy'); } catch (e) {}
+      $doc.body.removeChild(ta);
+    }
+  }-*/;
 
   /**
    * Creates a new wave with the participants of the current wave. Showing

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/View.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/View.java
@@ -71,6 +71,7 @@ public interface View {
     TAG,
     ADD_TAG,
     TOGGLE_PUBLIC,
+    SHARE_LINK,
   }
 
   Type getType();

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/DomAsViewProvider.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/DomAsViewProvider.java
@@ -81,6 +81,9 @@ public interface DomAsViewProvider {
   /** @return the participants view that surrounds the toggle-public button {@code source}. */
   ParticipantsView fromTogglePublicButton(Element source);
 
+  /** @return the participants view that surrounds the share-link button {@code source}. */
+  ParticipantsView fromShareLinkButton(Element source);
+
   /** @return {@code source} exposed as a top-conversation view. */
   TopConversationView asTopConversation(Element source);
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java
@@ -968,6 +968,15 @@ public class FullStructure implements UpgradeableDomAsViewProvider {
     return asParticipants(e);
   }
 
+  @Override
+  public ParticipantsView fromShareLinkButton(Element e) {
+    Preconditions.checkArgument(e == null || typeOf(e) == Type.SHARE_LINK);
+    while (e != null && !hasKnownType(e)) {
+      e = e.getParentElement();
+    }
+    return asParticipants(e);
+  }
+
 
   private AnchorView asAnchor(View v) {
     Preconditions.checkArgument(v == null || v.getType() == Type.ANCHOR);

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
@@ -77,6 +77,7 @@ public final class ParticipantsViewBuilder implements UiBuilder {
     String addButton();
     String newWaveWithParticipantsButton();
     String publicToggleButton();
+    String shareLinkButton();
     String dmLabel();
   }
 
@@ -199,6 +200,11 @@ public final class ParticipantsViewBuilder implements UiBuilder {
                   TypeCodes.kind(Type.TOGGLE_PUBLIC),
                   isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
                   isPublic);
+              if (isPublic) {
+                shareLinkIcon(output, css.shareLinkButton(),
+                    TypeCodes.kind(Type.SHARE_LINK),
+                    messages.sharePublicLink());
+              }
             }
             closeSpan(output);
 
@@ -215,6 +221,11 @@ public final class ParticipantsViewBuilder implements UiBuilder {
                   TypeCodes.kind(Type.TOGGLE_PUBLIC),
                   isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
                   isPublic);
+              if (isPublic) {
+                shareLinkIcon(output, css.shareLinkButton(),
+                    TypeCodes.kind(Type.SHARE_LINK),
+                    messages.sharePublicLink());
+              }
             }
             closeSpan(output);
           }
@@ -316,6 +327,36 @@ public final class ParticipantsViewBuilder implements UiBuilder {
           + "<path d='M7 11V7a5 5 0 0 1 10 0v4'/>"
           + "</svg>";
     }
+
+    output.appendHtmlConstant(
+        "<span"
+        + (escapedClazz != null ? " class='" + escapedClazz + "'" : "")
+        + (escapedKind != null ? " kind='" + escapedKind + "'" : "")
+        + (escapedTitle != null ? " title='" + escapedTitle + "'" : "")
+        + " role='button' tabindex='0'"
+        + (escapedTitle != null ? " aria-label='" + escapedTitle + "'" : "")
+        + ">"
+        + svgIcon
+        + "</span>");
+  }
+
+  /**
+   * Renders a compact circular icon button for sharing the public wave link.
+   * Uses a link/chain SVG icon with a green gradient background.
+   */
+  private static void shareLinkIcon(SafeHtmlBuilder output, String clazz, String kind,
+      String title) {
+    String escapedClazz = clazz != null ? EscapeUtils.htmlEscape(clazz) : null;
+    String escapedKind = kind != null ? EscapeUtils.htmlEscape(kind) : null;
+    String escapedTitle = title != null ? EscapeUtils.htmlEscape(title) : null;
+
+    // Link/chain icon for sharing
+    String svgIcon = "<svg width='14' height='14' viewBox='0 0 24 24' fill='none' "
+        + "stroke='currentColor' stroke-width='2' stroke-linecap='round' "
+        + "stroke-linejoin='round'>"
+        + "<path d='M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71'/>"
+        + "<path d='M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71'/>"
+        + "</svg>";
 
     output.appendHtmlConstant(
         "<span"

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TypeCodes.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TypeCodes.java
@@ -71,6 +71,7 @@ public final class TypeCodes {
     TYPES.put("tg", Type.TAG);
     TYPES.put("at", Type.ADD_TAG);
     TYPES.put("tp", Type.TOGGLE_PUBLIC);
+    TYPES.put("sl", Type.SHARE_LINK);
 
     TYPES.each(new ProcV<Type>() {
       @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/ParticipantMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/ParticipantMessages.java
@@ -49,4 +49,7 @@ public interface ParticipantMessages extends Messages {
 
   @DefaultMessage("Direct Message")
   String directMessage();
+
+  @DefaultMessage("Copy public link to clipboard")
+  String sharePublicLink();
  }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -51,7 +51,8 @@ public final class ToastNotification {
   /** Toast severity level, controlling background color. */
   public enum Level {
     INFO,
-    WARNING
+    WARNING,
+    SUCCESS
   }
 
   /** Default auto-dismiss duration in milliseconds. */
@@ -84,6 +85,11 @@ public final class ToastNotification {
   /** Shows a warning toast with the default duration. */
   public static void showWarning(String message) {
     show(message, Level.WARNING, DEFAULT_DURATION_MS);
+  }
+
+  /** Shows a success toast with the default duration. */
+  public static void showSuccess(String message) {
+    show(message, Level.SUCCESS, DEFAULT_DURATION_MS);
   }
 
   /**
@@ -218,6 +224,9 @@ public final class ToastNotification {
     // Theme
     if (level == Level.WARNING) {
       ts.setProperty("background", "linear-gradient(135deg, #f59e0b, #d97706)");
+      ts.setProperty("color", "#fff");
+    } else if (level == Level.SUCCESS) {
+      ts.setProperty("background", "linear-gradient(135deg, #10b981, #059669)");
       ts.setProperty("color", "#fff");
     } else {
       ts.setProperty("background", "linear-gradient(135deg, #0ea5e9, #0284c7)");

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Participants.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Participants.css
@@ -93,8 +93,8 @@
   overflow: hidden;
   /* Positioned container for add button. */
   position: relative;
-  /* Room for absolutely positioned action buttons (add + new-wave + public toggle). */
-  padding-right: 110px;
+  /* Room for absolutely positioned action buttons (add + new-wave + public toggle + share). */
+  padding-right: 140px;
 }
 
 .participant {
@@ -252,6 +252,27 @@ img.participant:hover {
   transform: scale(1.15);
   color: #005f8a;
   background: rgba(0, 119, 182, 0.1);
+}
+
+.shareLinkButton {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: white;
+  vertical-align: middle;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+.shareLinkButton:hover {
+  transform: scale(1.15);
+  box-shadow: 0 3px 8px rgba(16, 185, 129, 0.4);
+  background: linear-gradient(135deg, #059669, #047857);
 }
 
 .dmLabel {


### PR DESCRIPTION
## Summary
- **Share Button**: Adds a green share/link icon to the wave panel toolbar (visible only for public waves) that copies the public URL (`/wave/{waveId}`) to clipboard with a success toast notification
- **Public Directory (`/public`)**: New server-rendered HTML page listing all public waves in a responsive card grid with pagination, Gravatar avatars, relative timestamps, and participant counts -- no authentication required
- **Landing Page Link**: Adds "Explore Public Waves" button to the landing page hero section
- **Auto-Refresh**: Public wave pages (`/wave/{waveId}`) now auto-refresh content every 30 seconds via fetch + DOM update, with a "Last updated X seconds ago" indicator

Closes #356

## Files Changed
- `View.java` / `TypeCodes.java` -- new `SHARE_LINK` view type with `"sl"` code
- `ParticipantsViewBuilder.java` / `Participants.css` -- share link icon rendering and styling
- `ParticipantController.java` -- click handler with native clipboard API + fallback
- `DomAsViewProvider.java` / `FullStructure.java` -- DOM traversal for share button
- `ToastNotification.java` -- new `showSuccess()` method with green gradient
- `PublicDirectoryServlet.java` (new) -- serves `/public` directory page
- `HtmlRenderer.java` -- `renderPublicDirectoryPage()` + auto-refresh JS + landing page link
- `ServerMain.java` -- registers `/public` servlet

## Test plan
- [ ] Verify `sbt wave/compile` passes (confirmed)
- [ ] Verify `sbt compileGwt` passes (confirmed)
- [ ] Create a public wave and verify the share link button appears in the participant toolbar
- [ ] Click share button and verify URL is copied to clipboard with success toast
- [ ] Visit `/public` and verify public waves are listed in card grid
- [ ] Test pagination on `/public?page=2`
- [ ] Verify landing page shows "Explore Public Waves" button linking to `/public`
- [ ] Visit `/wave/{publicWaveId}` and wait 30s to verify auto-refresh updates content
- [ ] Verify "Last updated X seconds ago" indicator updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public waves directory with wave cards, metadata, and pagination
  * Added "Explore Public Waves" navigation link to the landing page
  * Added share button to copy public wave URLs to clipboard
  * Added auto-refresh capability for public wave pages
  * Added success-level toast notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->