### PR TITLE
feat: allow admins to perform all owner-level wave actions

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionHistoryServlet.java
@@ -20,8 +20,11 @@ package org.waveprotocol.box.server.rpc;
 
 import com.google.inject.Inject;
 import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
 import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
@@ -82,11 +85,30 @@ public final class VersionHistoryServlet extends HttpServlet {
 
   private final WaveletProvider waveletProvider;
   private final SessionManager sessionManager;
+  private final AccountStore accountStore;
 
   @Inject
-  public VersionHistoryServlet(WaveletProvider waveletProvider, SessionManager sessionManager) {
+  public VersionHistoryServlet(WaveletProvider waveletProvider, SessionManager sessionManager,
+      AccountStore accountStore) {
     this.waveletProvider = waveletProvider;
     this.sessionManager = sessionManager;
+    this.accountStore = accountStore;
+  }
+
+  /**
+   * Returns true if the given user has the "admin" or "owner" account role.
+   */
+  private boolean isAdminUser(ParticipantId user) {
+    try {
+      AccountData acct = accountStore.getAccount(user);
+      if (acct != null && acct.isHuman()) {
+        String role = acct.asHuman().getRole();
+        return HumanAccountData.ROLE_ADMIN.equals(role) || HumanAccountData.ROLE_OWNER.equals(role);
+      }
+    } catch (Exception e) {
+      LOG.warning("Failed to look up admin role for " + user.getAddress(), e);
+    }
+    return false;
   }
 
   @Override
@@ -208,7 +230,7 @@ public final class VersionHistoryServlet extends HttpServlet {
       }
       ReadableWaveletData data = snapshot.snapshot;
       long version = data.getHashedVersion().getVersion();
-      boolean canRestore = user.equals(data.getCreator());
+      boolean canRestore = user.equals(data.getCreator()) || isAdminUser(user);
 
       setJsonUtf8(resp);
       try (PrintWriter w = resp.getWriter()) {
@@ -515,7 +537,7 @@ public final class VersionHistoryServlet extends HttpServlet {
    * extracting each document's content, and submitting document-replacement
    * deltas against the current version.
    *
-   * <p>Only the wave creator (owner) is allowed to restore.
+   * <p>Only the wave creator (owner) or a server admin is allowed to restore.
    */
   private void handleRestoreApi(String path, HttpServletRequest req,
       HttpServletResponse resp, ParticipantId user) throws IOException {
@@ -535,7 +557,7 @@ public final class VersionHistoryServlet extends HttpServlet {
       return;
     }
 
-    // Check that the requesting user is the wave creator
+    // Check that the requesting user is the wave creator or an admin
     CommittedWaveletSnapshot currentSnapshot;
     try {
       currentSnapshot = waveletProvider.getSnapshot(waveletName);
@@ -544,9 +566,9 @@ public final class VersionHistoryServlet extends HttpServlet {
         return;
       }
       ParticipantId creator = currentSnapshot.snapshot.getCreator();
-      if (!user.equals(creator)) {
+      if (!user.equals(creator) && !isAdminUser(user)) {
         resp.sendError(HttpServletResponse.SC_FORBIDDEN,
-            "Only the wave creator can restore versions");
+            "Only the wave creator or an admin can restore versions");
         return;
       }
     } catch (WaveServerException e) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -388,10 +388,25 @@ public class WaveClientServlet extends HttpServlet {
       ParticipantId user = sessionManager.getLoggedInUser(session);
       String address = (user != null) ? user.getAddress() : null;
       String sessionId = (new RandomBase64Generator()).next(10);
+
+      // Look up the user's role so the client knows if this is an admin
+      String userRole = HumanAccountData.ROLE_USER;
+      if (user != null) {
+        try {
+          AccountData acctData = accountStore.getAccount(user);
+          if (acctData != null && acctData.isHuman()) {
+            userRole = acctData.asHuman().getRole();
+          }
+        } catch (Exception e) {
+          LOG.warning("Failed to look up role for session JSON: " + address, e);
+        }
+      }
+
       return new JSONObject()
           .put(SessionConstants.DOMAIN, domain)
           .putOpt(SessionConstants.ADDRESS, address)
-          .putOpt(SessionConstants.ID_SEED, sessionId);
+          .putOpt(SessionConstants.ID_SEED, sessionId)
+          .put(SessionConstants.ROLE, userRole);
     } catch (JSONException e) {
       LOG.severe("Failed to create session JSON");
       return new JSONObject();

--- a/wave/src/main/java/org/waveprotocol/box/common/SessionConstants.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/SessionConstants.java
@@ -42,4 +42,9 @@ public interface SessionConstants {
    * is not guaranteed to be cryptographically strong.
    */
   public final static String ID_SEED = "id";
+
+  /**
+   * The user's role: "owner", "admin", or "user".
+   */
+  public final static String ROLE = "role";
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -385,7 +385,8 @@ public class WaveClientServlet extends HttpServlet {
       return new JSONObject()
           .put(SessionConstants.DOMAIN, domain)
           .putOpt(SessionConstants.ADDRESS, address)
-          .putOpt(SessionConstants.ID_SEED, sessionId);
+          .putOpt(SessionConstants.ID_SEED, sessionId)
+          .put(SessionConstants.ROLE, "user");
     } catch (JSONException e) {
       LOG.severe("Failed to create session JSON");
       return new JSONObject();

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/Session.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/Session.java
@@ -72,11 +72,24 @@ public abstract class Session implements SessionConstants {
   public boolean isLoggedIn() {
     return getAddress() != null;
   }
-  
+
   /**
    * @return the id seed that's going to be used for generating ids for the session
    */
   public abstract String getIdSeed();
+
+  /**
+   * @return the user's role: "owner", "admin", or "user". Defaults to "user".
+   */
+  public abstract String getRole();
+
+  /**
+   * @return true if the current user has admin or owner privileges.
+   */
+  public boolean isAdmin() {
+    String role = getRole();
+    return "admin".equals(role) || "owner".equals(role);
+  }
 
 
   /**
@@ -105,6 +118,12 @@ public abstract class Session implements SessionConstants {
       return getFieldAsString(ID_SEED);
     }
 
+    @Override
+    public String getRole() {
+      String role = getFieldAsString(ROLE);
+      return role != null ? role : "user";
+    }
+
     private native String getFieldAsString(String s) /*-{
       return $wnd.__session[s];
     }-*/;
@@ -127,6 +146,11 @@ public abstract class Session implements SessionConstants {
     @Override
     public String getIdSeed() {
       return ID_SEED;
+    }
+
+    @Override
+    public String getRole() {
+      return "user";
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -277,7 +277,7 @@ public class StagesProvider extends Stages {
 
   /**
    * Wires up the inline version history feature. Only shows the History
-   * button if the current user is the wave creator (owner).
+   * button if the current user is the wave creator (owner) or a server admin.
    */
   private void wireHistoryMode() {
     if (three == null || one == null || two == null) {
@@ -311,8 +311,9 @@ public class StagesProvider extends Stages {
       }
     }
 
-    if (!isCreator && !isDmParticipant) {
-      // Not the owner and not a DM participant -- hide the history button.
+    boolean isAdmin = Session.get().isAdmin();
+    if (!isCreator && !isDmParticipant && !isAdmin) {
+      // Not the owner, not a DM participant, and not an admin -- hide the history button.
       three.getViewToolbar().setHistoryButtonVisible(false);
       return;
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
@@ -49,6 +49,7 @@ import org.waveprotocol.wave.model.util.Preconditions;
 import org.waveprotocol.wave.model.wave.InvalidParticipantAddress;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+import org.waveprotocol.box.webclient.client.Session;
 
 import java.util.Set;
 
@@ -192,8 +193,9 @@ public final class ParticipantController {
 
   /**
    * Toggles a wave between public and private by adding or removing the shared
-   * domain participant. Only the wave creator (first participant) can perform
-   * this action. When public, the wave is visible to all users on the domain.
+   * domain participant. Only the wave creator (first participant) or a server
+   * admin can perform this action. When public, the wave is visible to all
+   * users on the domain.
    */
   private void handleTogglePublicClicked(Element context) {
     ParticipantsView participantsUi = views.fromTogglePublicButton(context);
@@ -208,8 +210,9 @@ public final class ParticipantController {
     Set<ParticipantId> participants = conversation.getParticipantIds();
 
     // The wave creator is the first participant in the ordered set.
+    // Both the creator and server admins may toggle public/private.
     ParticipantId creator = participants.iterator().next();
-    if (!user.equals(creator)) {
+    if (!user.equals(creator) && !Session.get().isAdmin()) {
       ToastNotification.showWarning(messages.onlyOwnerCanTogglePublic());
       return;
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ParticipantMessages.java
@@ -30,7 +30,7 @@ public interface ParticipantMessages extends Messages {
   @DefaultMessage("Remove")
   String remove();
 
-  @DefaultMessage("Only the wave creator can change public/private visibility.")
+  @DefaultMessage("Only the wave creator or an admin can change public/private visibility.")
   String onlyOwnerCanTogglePublic();
 
   @DefaultMessage("Public/private toggle is not available (no local domain configured).")


### PR DESCRIPTION
## Summary
- Admins (role=admin or role=owner) can now toggle wave public/private visibility, restore historical wave versions, and see the version history button -- all actions previously restricted to the wave creator only.
- The user's role is now included in the `__session` JSON (via `SessionConstants.ROLE`) so the GWT client can check admin status with `Session.get().isAdmin()`.
- Server-side: `VersionHistoryServlet` now injects `AccountStore` and checks admin role for both the `canRestore` info flag and the actual restore permission gate.

## Changed files
- `SessionConstants.java` -- added `ROLE` constant
- `Session.java` -- added `getRole()` and `isAdmin()` to both `JsSession` and `StubSession`
- `WaveClientServlet.java` (jakarta) -- role lookup added to `getSessionJson()`
- `WaveClientServlet.java` (main) -- passes default `"user"` role in session JSON
- `ParticipantController.java` -- toggle-public check now allows admins
- `StagesProvider.java` -- history button visibility now allows admins
- `VersionHistoryServlet.java` -- injected `AccountStore`, added `isAdminUser()` helper, updated `canRestore` and restore permission checks
- `ParticipantMessages.java` -- updated error message to mention admins

## Test plan
- [ ] Verify `sbt wave/compile` passes (confirmed)
- [ ] Verify `sbt compileGwt` passes (confirmed)
- [ ] Log in as admin user, open a wave created by another user, and confirm: toggle public/private works, version history button is visible, and restoring a version succeeds
- [ ] Log in as a regular user, open a wave created by another user, and confirm: toggle public/private is still blocked, version history button is hidden, and restore API returns 403
- [ ] Log in as the wave creator (non-admin) and confirm all owner actions still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server admins can now restore previous wave versions (previously creator-only).
  * Server admins can toggle wave privacy settings (previously creator-only).
  * Server admins can access wave history (previously limited to creators and participants).

* **Documentation**
  * Updated UI messaging to reflect expanded admin permissions for wave management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->