### PR TITLE
fix: show share link button immediately after toggling wave to public

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ParticipantController.java
@@ -235,7 +235,11 @@ public final class ParticipantController {
     }
 
     // Update the toggle button icon and tooltip to reflect the new state.
-    updateTogglePublicIcon(context, !isCurrentlyPublic);
+    boolean isNowPublic = !isCurrentlyPublic;
+    updateTogglePublicIcon(context, isNowPublic);
+
+    // Show or hide all share-link buttons within the participants panel.
+    updateShareLinkVisibility(context, isNowPublic);
   }
 
   /**
@@ -269,6 +273,56 @@ public final class ParticipantController {
           + "</svg>");
       buttonElement.setTitle(messages.waveIsPrivateClickToMakePublic());
       buttonElement.setAttribute("aria-label", messages.waveIsPrivateClickToMakePublic());
+    }
+  }
+
+  /**
+   * Shows or hides all share-link buttons inside the participants panel that
+   * contains the given toggle button. Both the {@code .simple} and
+   * {@code .extra} panels contain a share-link button, so this method walks
+   * up to the {@code PARTICIPANTS} container and toggles every descendant
+   * share-link element it finds.
+   *
+   * @param toggleButton the toggle-public button that was clicked
+   * @param visible true to show, false to hide
+   */
+  private void updateShareLinkVisibility(Element toggleButton, boolean visible) {
+    // Walk up from the toggle button to the PARTICIPANTS container.
+    ParticipantsView participantsUi = views.fromTogglePublicButton(toggleButton);
+    if (participantsUi == null) {
+      return;
+    }
+    // The participants panel root element contains both .simple and .extra spans
+    // which each hold a share-link button identified by the SHARE_LINK kind attribute.
+    Element panelElement = toggleButton.getParentElement();
+    while (panelElement != null) {
+      String kind = panelElement.getAttribute("kind");
+      if (kind != null && kind.equals(TypeCodes.kind(Type.PARTICIPANTS))) {
+        break;
+      }
+      panelElement = panelElement.getParentElement();
+    }
+    if (panelElement == null) {
+      return;
+    }
+    String shareLinkKind = TypeCodes.kind(Type.SHARE_LINK);
+    setVisibilityByKind(panelElement, shareLinkKind, visible);
+  }
+
+  /**
+   * Recursively finds all descendant elements with the given {@code kind}
+   * attribute and sets their display style.
+   */
+  private static void setVisibilityByKind(Element root, String kind, boolean visible) {
+    Element child = root.getFirstChildElement();
+    while (child != null) {
+      String childKind = child.getAttribute("kind");
+      if (childKind != null && childKind.equals(kind)) {
+        child.getStyle().setProperty("display", visible ? "" : "none");
+      } else {
+        setVisibilityByKind(child, kind, visible);
+      }
+      child = child.getNextSiblingElement();
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/ParticipantsViewBuilder.java
@@ -200,11 +200,10 @@ public final class ParticipantsViewBuilder implements UiBuilder {
                   TypeCodes.kind(Type.TOGGLE_PUBLIC),
                   isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
                   isPublic);
-              if (isPublic) {
-                shareLinkIcon(output, css.shareLinkButton(),
-                    TypeCodes.kind(Type.SHARE_LINK),
-                    messages.sharePublicLink());
-              }
+              shareLinkIcon(output, css.shareLinkButton(),
+                  TypeCodes.kind(Type.SHARE_LINK),
+                  messages.sharePublicLink(),
+                  isPublic);
             }
             closeSpan(output);
 
@@ -221,11 +220,10 @@ public final class ParticipantsViewBuilder implements UiBuilder {
                   TypeCodes.kind(Type.TOGGLE_PUBLIC),
                   isPublic ? messages.makeWavePrivate() : messages.makeWavePublic(),
                   isPublic);
-              if (isPublic) {
-                shareLinkIcon(output, css.shareLinkButton(),
-                    TypeCodes.kind(Type.SHARE_LINK),
-                    messages.sharePublicLink());
-              }
+              shareLinkIcon(output, css.shareLinkButton(),
+                  TypeCodes.kind(Type.SHARE_LINK),
+                  messages.sharePublicLink(),
+                  isPublic);
             }
             closeSpan(output);
           }
@@ -345,7 +343,7 @@ public final class ParticipantsViewBuilder implements UiBuilder {
    * Uses a link/chain SVG icon with a green gradient background.
    */
   private static void shareLinkIcon(SafeHtmlBuilder output, String clazz, String kind,
-      String title) {
+      String title, boolean visible) {
     String escapedClazz = clazz != null ? EscapeUtils.htmlEscape(clazz) : null;
     String escapedKind = kind != null ? EscapeUtils.htmlEscape(kind) : null;
     String escapedTitle = title != null ? EscapeUtils.htmlEscape(title) : null;
@@ -365,6 +363,7 @@ public final class ParticipantsViewBuilder implements UiBuilder {
         + (escapedTitle != null ? " title='" + escapedTitle + "'" : "")
         + " role='button' tabindex='0'"
         + (escapedTitle != null ? " aria-label='" + escapedTitle + "'" : "")
+        + (visible ? "" : " style='display:none'")
         + ">"
         + svgIcon
         + "</span>");


### PR DESCRIPTION
## Summary
- The "Share Public Link" button (green chain icon) was only rendered in the initial HTML when the wave was already public. Toggling a private wave to public updated the lock/unlock icon but the share link button remained absent until a full page reload.
- **ParticipantsViewBuilder**: Always render the share link button in both `.extra` and `.simple` panels, but with `style='display:none'` when the wave is private.
- **ParticipantController**: After toggling public/private state, walk up to the PARTICIPANTS container and toggle visibility of all descendant share-link buttons (matching by `kind` attribute).

## Test plan
- [ ] Open a **private** wave, verify the share link button is hidden
- [ ] Click the lock icon to toggle the wave to **public** -- the share link button should appear immediately without page reload
- [ ] Click the share link button -- the public URL should be copied to clipboard
- [ ] Toggle back to **private** -- the share link button should disappear immediately
- [ ] Open a **public** wave -- the share link button should be visible on initial load
- [ ] `sbt wave/compile` passes
- [ ] `sbt compileGwt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility management of share-link UI elements in the participants panel. Share-link features now correctly display or hide based on whether a wave is set to public or private, providing users with a clearer interface that accurately reflects the wave's current sharing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->