### PR TITLE
fix: prevent private waves from appearing in public directory

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicDirectoryServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicDirectoryServlet.java
@@ -112,7 +112,10 @@ public final class PublicDirectoryServlet extends HttpServlet {
 
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("text/html; charset=UTF-8");
-    resp.setHeader("Cache-Control", "public, max-age=120");
+    // Use no-cache so browsers revalidate on every request. This ensures that
+    // waves toggled to private are immediately removed from the directory.
+    resp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    resp.setHeader("Pragma", "no-cache");
     resp.getWriter().write(html);
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServlet.java
@@ -190,8 +190,12 @@ public final class PublicWaveFetchServlet extends HttpServlet {
     } else {
       dest.setStatus(HttpServletResponse.SC_OK);
       dest.setContentType("application/json");
-      // Allow CDN/browser caching for public waves (short-lived)
-      dest.setHeader("Cache-Control", "public, max-age=60, s-maxage=120");
+      // Do not cache public wave data — when a wave is toggled to private the
+      // cached response would continue to serve the wave content. Use no-store
+      // to ensure every request hits the server and checks the current
+      // participant list.
+      dest.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+      dest.setHeader("Pragma", "no-cache");
       try (var w = dest.getWriter()) {
         w.append(serializer.toJson(message).toString());
         w.flush();

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveServlet.java
@@ -166,7 +166,11 @@ public final class PublicWaveServlet extends HttpServlet {
 
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("text/html; charset=UTF-8");
-    resp.setHeader("Cache-Control", "public, max-age=300");
+    // Use no-cache so browsers revalidate on every request. This ensures that
+    // waves toggled to private immediately return 404 instead of serving stale
+    // cached content for up to 5 minutes.
+    resp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    resp.setHeader("Pragma", "no-cache");
     resp.getWriter().write(html);
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SitemapServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SitemapServlet.java
@@ -54,8 +54,9 @@ import org.waveprotocol.wave.util.logging.Log;
 public final class SitemapServlet extends HttpServlet {
 
   private static final Log LOG = Log.get(SitemapServlet.class);
-  /** Cache the generated sitemap for 10 minutes to reduce load. */
-  private static final long CACHE_TTL_MS = 10 * 60 * 1000;
+  /** Cache the generated sitemap for 60 seconds to reduce load while keeping
+   *  it fresh enough that waves toggled to private disappear promptly. */
+  private static final long CACHE_TTL_MS = 60 * 1000;
 
   private final String siteUrl;
   private final String waveDomain;
@@ -86,7 +87,8 @@ public final class SitemapServlet extends HttpServlet {
     String sitemap = getCachedOrGenerate();
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("application/xml; charset=UTF-8");
-    resp.setHeader("Cache-Control", "public, max-age=600");
+    // Short cache TTL so that waves toggled to private are removed promptly.
+    resp.setHeader("Cache-Control", "public, max-age=60");
     resp.getWriter().write(sitemap);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServlet.java
@@ -192,8 +192,12 @@ public final class PublicWaveFetchServlet extends HttpServlet {
     } else {
       dest.setStatus(HttpServletResponse.SC_OK);
       dest.setContentType("application/json");
-      // Allow CDN/browser caching for public waves (short-lived)
-      dest.setHeader("Cache-Control", "public, max-age=60, s-maxage=120");
+      // Do not cache public wave data — when a wave is toggled to private the
+      // cached response would continue to serve the wave content. Use no-store
+      // to ensure every request hits the server and checks the current
+      // participant list.
+      dest.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+      dest.setHeader("Pragma", "no-cache");
       try {
         dest.getWriter().append(serializer.toJson(message).toString());
       } catch (SerializationException e) {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveFetchServletTest.java
@@ -191,9 +191,10 @@ public class PublicWaveFetchServletTest extends TestCase {
   }
 
   /**
-   * Test that a public wave returns proper cache headers for CDN caching.
+   * Test that a public wave returns no-cache headers to prevent stale content
+   * after a wave is toggled from public to private.
    */
-  public void testPublicWaveHasCacheHeaders() throws Exception {
+  public void testPublicWaveHasNoCacheHeaders() throws Exception {
     WaveletData wavelet = waveletProvider.getHostedWavelet();
     wavelet.addParticipant(DOMAIN_PARTICIPANT);
 
@@ -207,6 +208,7 @@ public class PublicWaveFetchServletTest extends TestCase {
 
     servlet.doGet(request, response);
 
-    verify(response).setHeader("Cache-Control", "public, max-age=60, s-maxage=120");
+    verify(response).setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    verify(response).setHeader("Pragma", "no-cache");
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveServletTest.java
@@ -180,7 +180,8 @@ public class PublicWaveServletTest extends TestCase {
     verify(response).setContentType("text/html");
     verify(response).setCharacterEncoding("UTF-8");
     verify(response).setStatus(HttpServletResponse.SC_OK);
-    verify(response).setHeader("Cache-Control", "public, max-age=60");
+    verify(response).setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    verify(response).setHeader("Pragma", "no-cache");
 
     // Verify the response contains expected HTML elements
     String html = writer.toString();


### PR DESCRIPTION
## Summary
- **Root cause**: When a wave was toggled from public to private (removing the `@domain` participant), the server-side access checks correctly rejected the wave, but HTTP `Cache-Control` headers allowed browsers and CDNs to serve stale cached content for 2-5 minutes.
- **Fix**: Replace `public, max-age=N` cache headers with `no-cache, no-store, must-revalidate` on all public wave servlets (`PublicDirectoryServlet`, `PublicWaveServlet`, `PublicWaveFetchServlet`). Reduce `SitemapServlet` in-memory cache from 10 minutes to 60 seconds.
- **Scope**: 5 servlet files (jakarta + javax variants of `PublicWaveFetchServlet`), 2 test files updated.

## Details

| Servlet | Endpoint | Old Cache | New Cache |
|---------|----------|-----------|-----------|
| `PublicDirectoryServlet` | `/public` | `public, max-age=120` | `no-cache, no-store, must-revalidate` |
| `PublicWaveServlet` | `/wave/{waveId}` | `public, max-age=300` | `no-cache, no-store, must-revalidate` |
| `PublicWaveFetchServlet` | `/wave/public/{waveRef}` | `public, max-age=60, s-maxage=120` | `no-cache, no-store, must-revalidate` |
| `SitemapServlet` | `/sitemap.xml` | `public, max-age=600` (10min memory) | `public, max-age=60` (60s memory) |

The server-side access checks (`WaveletDataUtil.checkAccessPermission`, `WaveletDataUtil.isPublicWavelet`) were already correct -- they read live participant data from the wavelet state. The bug was purely in the HTTP caching layer.

## Test plan
- [ ] Toggle a wave to public, verify it appears at `/public` and `/wave/{waveId}`
- [ ] Toggle the same wave back to private, immediately refresh `/public` -- wave should be gone
- [ ] Visit `/wave/{waveId}` for the now-private wave -- should return 404
- [ ] Verify `PublicWaveFetchServletTest` passes with `sbt 'wave/testOnly ...PublicWaveFetchServletTest'`
- [ ] Verify `sbt wave/compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled HTTP caching for public wave content and directories to ensure current data is always served.
  * Reduced sitemap cache refresh interval for more frequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->