### PR TITLE
fix: prevent crash when replying in empty wave with no blips

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
@@ -195,21 +195,32 @@ public final class ActionsImpl implements Actions {
   public void addContinuation(ThreadView threadUi) {
     ConversationThread thread = views.getThread(threadUi);
 
+    if (thread == null) {
+      EditorStaticDeps.logger.trace().log("addContinuation: thread is null, ignoring.");
+      ToastNotification.showWarning(messages.cannotReplyEmptyWave());
+      return;
+    }
+
     // Check if continuations are blocked by wave lock.
-    if (thread != null) {
-      ConversationBlip firstBlip = thread.getFirstBlip();
-      if (firstBlip != null) {
-        WaveLockState lockState = firstBlip.getConversation().getLockState();
-        if (lockState == WaveLockState.ALL_LOCKED) {
-          ToastNotification.showWarning(messages.waveIsLockedNoReply());
-          return;
-        }
+    ConversationBlip firstBlip = thread.getFirstBlip();
+    if (firstBlip != null) {
+      WaveLockState lockState = firstBlip.getConversation().getLockState();
+      if (lockState == WaveLockState.ALL_LOCKED) {
+        ToastNotification.showWarning(messages.waveIsLockedNoReply());
+        return;
       }
     }
 
     ConversationBlip continuation = thread.appendBlip();
     blipQueue.flush();
-    focusAndEdit(views.getBlipView(continuation));
+    BlipView continuationUi = views.getBlipView(continuation);
+    if (continuationUi == null) {
+      EditorStaticDeps.logger.trace().log(
+          "addContinuation: blip view not available after flush, ignoring.");
+      ToastNotification.showWarning(messages.cannotReplyEmptyWave());
+      return;
+    }
+    focusAndEdit(continuationUi);
   }
 
   @Override
@@ -286,6 +297,9 @@ public final class ActionsImpl implements Actions {
    * or document), the session is restarted.
    */
   private void focusAndEdit(BlipView blipUi) {
+    if (blipUi == null) {
+      return;
+    }
     boolean allowed = !BlipUiUtil.isQuasiDeleted(blipUi);
     if (allowed) {
       if (edit.isEditing() && blipUi.equals(edit.getBlip())

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ActionMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ActionMessages.java
@@ -44,4 +44,7 @@ public interface ActionMessages extends Messages {
 
   @DefaultMessage("The root blip is locked. Editing is not allowed here.")
   String rootBlipIsLocked();
+
+  @DefaultMessage("Cannot reply \u2014 this wave has no content.")
+  String cannotReplyEmptyWave();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reader/Reader.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reader/Reader.java
@@ -69,11 +69,13 @@ public final class Reader implements FocusFramePresenter.Listener, FocusOrder {
   public void onFocusMoved(BlipView oldUi, BlipView newUi) {
     if (oldUi != null) {
       ConversationBlip oldBlip = models.getBlip(oldUi);
-      InteractiveDocument document = documents.get(oldBlip);
       if (oldBlip != null) {
-        supplement.stopReading(oldBlip);
-        document.stopDiffRetention();
-        document.clearDiffs();
+        InteractiveDocument document = documents.get(oldBlip);
+        if (document != null) {
+          supplement.stopReading(oldBlip);
+          document.stopDiffRetention();
+          document.clearDiffs();
+        }
       }
     }
 
@@ -81,10 +83,12 @@ public final class Reader implements FocusFramePresenter.Listener, FocusOrder {
       // UI hack: normally, becoming read triggers diff clearing, except when
       // the cause of becoming read is focus-frame placement.
       ConversationBlip newBlip = models.getBlip(newUi);
-      InteractiveDocument document = documents.get(newBlip);
       if (newBlip != null) {
-        document.startDiffRetention();
-        supplement.startReading(newBlip);
+        InteractiveDocument document = documents.get(newBlip);
+        if (document != null) {
+          document.startDiffRetention();
+          supplement.startReading(newBlip);
+        }
       }
     }
   }

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ActionMessages_en.properties
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/ActionMessages_en.properties
@@ -25,3 +25,4 @@ maxReplyDepthContinueInThread = Maximum reply depth reached. Your reply will be 
 waveIsLocked = This wave is locked. Editing is not allowed.
 waveIsLockedNoReply = This wave is locked. Replies are not allowed.
 rootBlipIsLocked = The root blip is locked. Editing is not allowed here.
+cannotReplyEmptyWave = Cannot reply \u2014 this wave has no content.


### PR DESCRIPTION
## Summary
- Fixes a client crash (`TypeError: Cannot read properties of undefined (reading 'helper')`) when clicking the reply/continuation indicator in an empty wave where all blips have been deleted.
- Adds null guards in `ActionsImpl.addContinuation` (for null thread model and null blip view after flush), `ActionsImpl.focusAndEdit` (for null blipUi), and `Reader.onFocusMoved` (for null blip and null document from the registry -- a pre-existing latent bug).
- Shows a user-friendly toast ("Cannot reply -- this wave has no content") instead of crashing.

## Test plan
- [ ] Open a wave, delete all blips so the wave is empty
- [ ] Click the reply box / continuation indicator at the bottom of the empty thread
- [ ] Verify: no crash, a warning toast is shown instead
- [ ] Verify normal reply/continuation still works in waves with blips
- [ ] `sbt wave/compile` passes
- [ ] `sbt compileGwt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added user-facing message to indicate when replies cannot be sent to waves lacking content
  * Enhanced error handling and warning logging during reply creation when encountering missing or invalid application state
  * Improved overall application stability and reliability through defensive state validation checks throughout editing operations, focus management, and document reading processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->