### PR TITLE
fix: force-refresh search after archive/inbox action

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/SimpleWaveStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/SimpleWaveStore.java
@@ -93,4 +93,11 @@ public final class SimpleWaveStore implements WaveStore {
       listener.onClosed(wave);
     }
   }
+
+  @Override
+  public void notifyFolderAction(String folder) {
+    for (Listener listener : listeners) {
+      listener.onFolderActionCompleted(folder);
+    }
+  }
 }

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java
@@ -230,10 +230,13 @@ public class StagesProvider extends Stages {
   private void wireToolbarButtons(StageThree three) {
     ViewToolbar viewToolbar = three.getViewToolbar();
 
-    // --- Archive / Inbox buttons: navigate back to wave list on success ---
+    // --- Archive / Inbox buttons: refresh search and navigate back on success ---
     viewToolbar.setFolderActionListener(new ViewToolbar.FolderActionListener() {
       @Override
       public void onFolderActionCompleted(String folder) {
+        // Notify the wave store so listeners (SearchPresenter) can
+        // force-refresh the search results immediately.
+        waveStore.notifyFolderAction(folder);
         History.newItem("", true);
       }
     });

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -861,4 +861,15 @@ public final class SearchPresenter
     // after a short delay to allow the server to process the outstanding delta.
     scheduler.scheduleDelayed(waveClosedRefreshTask, WAVE_CLOSED_REFRESH_DELAY_MS);
   }
+
+  //
+  // WaveStore.Listener folder-action event. Fires when archive/inbox
+  // completes so the search panel refreshes immediately instead of
+  // waiting for the next 15-second polling cycle.
+  //
+
+  @Override
+  public void onFolderActionCompleted(String folder) {
+    forceRefresh();
+  }
 }

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/WaveStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/WaveStore.java
@@ -35,6 +35,16 @@ public interface WaveStore extends SourcesEvents<WaveStore.Listener> {
   interface Listener {
     void onOpened(WaveContext wave);
     void onClosed(WaveContext wave);
+
+    /**
+     * Called when a folder action (archive, inbox) completes for a wave.
+     * Listeners can use this to refresh search results immediately.
+     *
+     * @param folder the folder the wave was moved to (e.g. "archive", "inbox")
+     */
+    default void onFolderActionCompleted(String folder) {
+      // Default no-op so existing implementations are not forced to override.
+    }
   }
 
   /**
@@ -51,4 +61,11 @@ public interface WaveStore extends SourcesEvents<WaveStore.Listener> {
    * @return the collection of currently open waves.
    */
   Map<WaveId, WaveContext> getOpenWaves();
+
+  /**
+   * Notifies listeners that a folder action (archive, inbox) completed.
+   *
+   * @param folder the target folder name (e.g. "archive", "inbox")
+   */
+  void notifyFolderAction(String folder);
 }


### PR DESCRIPTION
## Summary
- After archiving a wave via the ViewToolbar, the wave continued to appear in the inbox for up to 15 seconds because the search panel only refreshed on its polling cycle.
- The server-side `FolderServlet` correctly persisted the archive state, but the client never notified `SearchPresenter` to re-query.
- Added a `onFolderActionCompleted` event to `WaveStore.Listener` (with a default no-op), fired from `StagesProvider` on successful archive/inbox POST. `SearchPresenter` handles this by calling `forceRefresh()`, which issues an immediate search query and resets the polling timer.

## Changed files
- `WaveStore.java` — new `onFolderActionCompleted` default method on `Listener`, new `notifyFolderAction` on the store interface
- `SimpleWaveStore.java` — implements `notifyFolderAction` to fire the event
- `StagesProvider.java` — calls `waveStore.notifyFolderAction(folder)` in the folder-action callback before navigating away
- `SearchPresenter.java` — overrides `onFolderActionCompleted` to call `forceRefresh()`

## Test plan
- [ ] Open a wave from the inbox
- [ ] Click the "Archive" button in the wave toolbar
- [ ] Verify the wave disappears from the inbox search results immediately (not after 15s)
- [ ] Click the "Archive" toolbar filter button to confirm the wave now appears in archive
- [ ] Open an archived wave, click "Inbox", verify it reappears in inbox immediately
- [ ] `sbt wave/compile` passes
- [ ] `sbt compileGwt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)