### PR TITLE
fix: handle deltas for wavelets with no active stacklet gracefully

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/OperationChannelMultiplexerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/OperationChannelMultiplexerImpl.java
@@ -507,8 +507,12 @@ public class OperationChannelMultiplexerImpl implements OperationChannelMultiple
           try {
             Stacklet stacklet = channels.get(waveletId);
             if (stacklet == null) {
-              //TODO(user): Figure out the right exception to throw here.
-              throw new IllegalStateException("Received deltas with no stacklet present!");
+              // A delta arrived for a wavelet that has no active operation channel.
+              // This can happen when the server sends deltas for wavelets the client
+              // hasn't fully opened yet (e.g. lock-state documents, public access
+              // participant changes). Log and drop rather than crashing the client.
+              logger.trace().log("Mux dropping delta for wavelet with no stacklet: " + waveletId);
+              return;
             }
             stacklet.onWaveletUpdate(deltas, lastCommittedVersion, currentVersion);
           } catch (ChannelException e) {


### PR DESCRIPTION
## Summary
- Replace `IllegalStateException("Received deltas with no stacklet present!")` crash with a defensive log-and-drop guard in `OperationChannelMultiplexerImpl.onUpdate`
- When the server sends deltas for a wavelet that has no active operation channel (stacklet), the client now logs a trace message and silently drops the delta instead of crashing the entire wave view
- This fixes a client error that occurs when interacting with public waves, where lock-state document changes or participant changes can generate deltas for wavelets the client hasn't fully opened yet

## Root Cause
In `OperationChannelMultiplexerImpl`, the `onSnapshot` handler already gracefully handles missing stacklets by creating them on demand. However, the `onUpdate` handler threw an unrecoverable `IllegalStateException` for the same condition. The original code even had a TODO comment acknowledging the issue: `//TODO(user): Figure out the right exception to throw here.`

## Test plan
- [x] `sbt wave/compile` passes
- [x] `sbt compileGwt` passes
- [ ] Manual: open a public wave and verify no client crash when other users edit or when lock state changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a client crash that occurred when processing certain server updates. The application now gracefully handles these updates by logging them instead of terminating unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->