### PR TITLE
fix: admin page Users tab stuck on Loading

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4226,7 +4226,7 @@ public final class HtmlRenderer {
     // Send reply
     sb.append("  window.sendReply = function(id) {\n");
     sb.append("    var ta = document.getElementById('reply-' + id);\n");
-    sb.append("    if (!ta || !ta.value.trim()) { alert('Please enter a reply'); return; }\n");
+    sb.append("    if (!ta || !ta.value.trim()) { showToast('Please enter a reply', 'error'); return; }\n");
     sb.append("    fetch('/admin/api/contacts/' + id + '/reply', {\n");
     sb.append("      method: 'POST', headers: {'Content-Type':'application/json'},\n");
     sb.append("      body: JSON.stringify({body: ta.value.trim()})\n");
@@ -4289,7 +4289,7 @@ public final class HtmlRenderer {
     sb.append("        html += '<td>';\n");
     sb.append("        html += '<button class=\"action-btn\" onclick=\"editFlag(' + i + ')\">Edit</button>';\n");
     sb.append("        html += '<button class=\"action-btn\" onclick=\"toggleFlag(' + i + ')\">' + (f.enabled ? 'Disable' : 'Enable') + '</button>';\n");
-    sb.append("        html += '<button class=\"action-btn danger\" onclick=\"deleteFlag(\\'' + esc(f.name) + '\\')\"'>Delete</button>';\n");
+    sb.append("        html += '<button class=\"action-btn danger\" onclick=\"deleteFlag(\\'' + esc(f.name) + '\\')\">Delete</button>';\n");
     sb.append("        html += '</td></tr>';\n");
     sb.append("      }\n");
     sb.append("    }\n");


### PR DESCRIPTION
## Summary
- Fixed a JavaScript syntax error in the Feature Flags tab code (introduced in #378) that broke the entire admin page IIFE — a misplaced single quote in the `deleteFlag` button's `onclick` handler (`'\\')\"'` instead of `'\\')\"`) caused a JS parse error, preventing `fetchUsers()` from ever executing, leaving the Users tab permanently on "Loading..."
- Replaced a `Window.alert()` call in the contact reply handler with `showToast()` to comply with project conventions

## Test plan
- [ ] Open `/admin` as an admin user — Users tab should load and display user list
- [ ] Switch to Feature Flags tab — flags should load, Delete button should work
- [ ] Switch to Contacts tab, try sending an empty reply — should show toast instead of browser alert
- [ ] `sbt wave/compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect markup in Feature Flags deletion button

* **Refactor**
  * Updated validation feedback on admin pages to use toast notifications instead of alert dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->