### PR TITLE
fix: wave sort uses max LMT across all conversational wavelets, not just root

### DIFF
--- a/docs/superpowers/plans/2026-03-27-wave-date-sort-plan.md
+++ b/docs/superpowers/plans/2026-03-27-wave-date-sort-plan.md
@@ -1,0 +1,77 @@
+# Wave Date Sort Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `orderby:datedesc` and `orderby:dateasc` order waves by the most recent blip edit time rather than an older wave/root creation timestamp.
+
+**Architecture:** The investigation already shows that `QueryHelper` sorts by conversational wavelet last-modified time, so the fix must be driven by a reproduction that proves whether the wrong timestamp comes from comparator input or from stale timestamp propagation. The implementation should add a focused regression test in the search provider harness, confirm which timestamp path is wrong, and then change the narrowest server-side code path that makes search ordering follow the latest blip edit time.
+
+**Tech Stack:** Java, Apache Wave server search, junit3, sbt
+
+---
+
+### Task 1: Reproduce the Ordering Bug in the Search Harness
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add a test that creates at least two waves in ascending time order, then performs a later blip edit on the older wave and asserts that `orderby:datedesc` returns the edited older wave first and `orderby:dateasc` returns it last.
+
+- [ ] **Step 2: Add the minimal test helpers needed for later edits**
+
+Add helper methods for submitting a delta to an existing wavelet and for creating or editing a blip with a later timestamp source from the local wavelet container.
+
+- [ ] **Step 3: Run the targeted test to verify it fails for the expected reason**
+
+Run: `sbt "testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest -- -Dtest.name=*Date*"`
+
+Expected: the new regression test fails because search ordering still follows the older timestamp path.
+
+### Task 2: Fix the Server-Side Timestamp Path
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java`
+- Modify if needed: timestamp propagation classes under `wave/src/main/java/org/waveprotocol/box/server/waveserver/` or `wave/src/main/java/org/waveprotocol/wave/model/`
+
+- [ ] **Step 1: Confirm the exact bad timestamp source from the failing test**
+
+Decide whether the wrong value comes from:
+- `WaveViewData` missing the wavelet that contains the newest edit
+- `ObservableWaveletData.getLastModifiedTime()` not reflecting the later blip edit
+- `QueryHelper` using the wrong field even when the correct data is present
+
+- [ ] **Step 2: Implement the narrowest fix**
+
+Change only the code path proven by the failing test. Prefer preserving the existing `orderby` API and result shape. Do not add unrelated search behavior changes.
+
+- [ ] **Step 3: Rerun the targeted test**
+
+Run: `sbt "testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest"`
+
+Expected: the new regression test passes and existing search-order tests stay green.
+
+### Task 3: Verify, Review, and Finalize the Branch
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-03-27-wave-date-sort-plan.md` only if plan-review feedback requires updates
+
+- [ ] **Step 1: Run compile verification**
+
+Run: `sbt wave/compile`
+
+Expected: success.
+
+- [ ] **Step 2: Run external code review on the implementation diff**
+
+Run the `claude-review` workflow against the task branch diff from `origin/main...HEAD` and capture findings.
+
+- [ ] **Step 3: Address findings and reverify if needed**
+
+Fix any important review findings, rerun the affected targeted test and `sbt wave/compile`, and record the review outcome in Beads.
+
+- [ ] **Step 4: Commit and push**
+
+Create a focused commit on the task branch and push `fix/wave-date-sort-lmt` to origin without opening a PR.

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/AbstractSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/AbstractSearchProviderImpl.java
@@ -54,7 +54,7 @@ public abstract class AbstractSearchProviderImpl implements SearchProvider {
 
   protected final WaveDigester digester;
   protected final ParticipantId sharedDomainParticipantId;
-  private final WaveMap waveMap;
+  protected final WaveMap waveMap;
 
   public AbstractSearchProviderImpl(final String waveDomain, WaveDigester digester, WaveMap waveMap) {
     this.digester = digester;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -31,6 +31,7 @@ import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.waveserver.QueryHelper.InvalidQueryException;
 import org.waveprotocol.wave.model.conversation.ObservableConversationView;
 import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
+import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
@@ -53,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Search provider that reads user specific info from user data wavelet.
@@ -240,6 +242,7 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     List<WaveViewData> results =
         Lists.newArrayList(filterWavesViewBySearchCriteria(filterWaveletsFunction,
             currentUserWavesView).values());
+    expandConversationalWavelets(results, filterWaveletsFunction);
 
     // Shared caches for supplement-building across all filter stages.
     // This prevents creating duplicate OpBasedWavelet adapters for the same
@@ -362,6 +365,52 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
       }
     };
     return matchesFunction;
+  }
+
+  private void expandConversationalWavelets(List<WaveViewData> results,
+      Function<ReadableWaveletData, Boolean> matchesFunction) {
+    Map<WaveId, Wave> loadedWaves = waveMap.getWaves();
+    for (WaveViewData wave : results) {
+      Set<WaveletId> visibleWaveletIds = new HashSet<WaveletId>();
+      for (ObservableWaveletData waveletData : wave.getWavelets()) {
+        visibleWaveletIds.add(waveletData.getWaveletId());
+      }
+
+      Set<WaveletId> conversationalWaveletIds = new HashSet<WaveletId>();
+      try {
+        Set<WaveletId> storedWaveletIds = waveMap.lookupWavelets(wave.getWaveId());
+        if (storedWaveletIds != null) {
+          conversationalWaveletIds.addAll(storedWaveletIds);
+        }
+      } catch (WaveletStateException e) {
+        LOG.warning("Failed to look up stored wavelets for " + wave.getWaveId(), e);
+      }
+
+      Wave loadedWave = loadedWaves.get(wave.getWaveId());
+      if (loadedWave != null) {
+        for (WaveletContainer container : loadedWave) {
+          conversationalWaveletIds.add(container.getWaveletName().waveletId);
+        }
+      }
+
+      for (WaveletId waveletId : conversationalWaveletIds) {
+        if (visibleWaveletIds.contains(waveletId) || !IdUtil.isConversationalId(waveletId)) {
+          continue;
+        }
+
+        WaveletName waveletName = WaveletName.of(wave.getWaveId(), waveletId);
+        try {
+          WaveletContainer container = waveMap.getWavelet(waveletName);
+          if (container == null || !container.applyFunction(matchesFunction)) {
+            continue;
+          }
+          wave.addWavelet(container.copyWaveletData());
+          visibleWaveletIds.add(waveletId);
+        } catch (WaveletStateException e) {
+          LOG.warning("Failed to expand wavelet " + waveletName, e);
+        }
+      }
+    }
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -42,13 +42,16 @@ import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.document.operation.impl.DocOpBuilder;
 import org.waveprotocol.wave.model.id.IdGenerator;
 import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.operation.wave.AddParticipant;
+import org.waveprotocol.wave.model.operation.wave.BlipContentOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletDelta;
+import org.waveprotocol.wave.model.operation.wave.WaveletBlipOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletOperationContext;
 import org.waveprotocol.wave.model.version.HashedVersion;
@@ -348,6 +351,58 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertTrue(descOrdering.isOrdered(results.getDigests()));
   }
 
+  public void testSearchOrderByDateUsesLatestBlipActivity() throws Exception {
+    WaveletName olderWave = WaveletName.of(WaveId.of(DOMAIN, "older"), WAVELET_ID);
+    WaveletName newerWave = WaveletName.of(WaveId.of(DOMAIN, "newer"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(olderWave, USER1, addParticipantToWavelet(USER1, olderWave));
+    appendBlipToWavelet(olderWave, USER1, "b+older-1", "older wave");
+
+    waitForDistinctTimestamp();
+
+    submitDeltaToNewWavelet(newerWave, USER1, addParticipantToWavelet(USER1, newerWave));
+    appendBlipToWavelet(newerWave, USER1, "b+newer-1", "newer wave");
+
+    waitForDistinctTimestamp();
+
+    appendBlipToWavelet(olderWave, USER1, "b+older-2", "latest activity on older wave");
+
+    SearchResult descResults = searchProvider.search(USER1, "in:inbox orderby:datedesc", 0, 10);
+    assertEquals("older",
+        WaveId.deserialise(descResults.getDigests().get(0).getWaveId()).getId());
+
+    SearchResult ascResults = searchProvider.search(USER1, "in:inbox orderby:dateasc", 0, 10);
+    assertEquals("newer", WaveId.deserialise(ascResults.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchOrderByDateUsesLatestConversationalWaveletActivity() throws Exception {
+    WaveletName olderRoot = WaveletName.of(WaveId.of(DOMAIN, "older-conv"), WAVELET_ID);
+    WaveletName newerRoot = WaveletName.of(WaveId.of(DOMAIN, "newer-conv"), WAVELET_ID);
+    WaveletName olderReply =
+        WaveletName.of(olderRoot.waveId, WaveletId.of(DOMAIN, "conv+reply"));
+
+    submitDeltaToNewWavelet(olderRoot, USER1, addParticipantToWavelet(USER1, olderRoot));
+    appendBlipToWavelet(olderRoot, USER1, "b+older-root", "older root");
+
+    waitForDistinctTimestamp();
+
+    submitDeltaToNewWavelet(newerRoot, USER1, addParticipantToWavelet(USER1, newerRoot));
+    appendBlipToWavelet(newerRoot, USER1, "b+newer-root", "newer root");
+
+    waitForDistinctTimestamp();
+
+    submitDeltaToNewWaveletWithoutView(olderReply, USER1, new AddParticipant(CONTEXT, USER1));
+    appendBlipToWavelet(olderReply, USER1, "b+older-reply", "latest reply activity");
+
+    SearchResult descResults = searchProvider.search(USER1, "in:inbox orderby:datedesc", 0, 10);
+    assertEquals("older-conv",
+        WaveId.deserialise(descResults.getDigests().get(0).getWaveId()).getId());
+
+    SearchResult ascResults = searchProvider.search(USER1, "in:inbox orderby:dateasc", 0, 10);
+    assertEquals("newer-conv",
+        WaveId.deserialise(ascResults.getDigests().get(0).getWaveId()).getId());
+  }
+
   public void testSearchOrderByCreatedAscWorks() throws Exception {
     for (int i = 0; i < 10; i++) {
       WaveletName name = WaveletName.of(WaveId.of(DOMAIN, String.valueOf(i)), WAVELET_ID);
@@ -483,9 +538,26 @@ public class SimpleSearchProviderImplTest extends TestCase {
       WaveletOperation... ops) throws Exception {
 
     HashedVersion version = V0_HASH_FACTORY.createVersionZero(name);
-    WaveletDelta delta = new WaveletDelta(user, version, Arrays.asList(ops));
     addWaveletToUserView(name, user);
+    submitDelta(name, user, version, ops);
+  }
 
+  private void submitDeltaToExistingWavelet(WaveletName name, ParticipantId user,
+      WaveletOperation... ops) throws Exception {
+    LocalWaveletContainer wavelet = waveMap.getOrCreateLocalWavelet(name);
+    HashedVersion version = wavelet.copyWaveletData().getHashedVersion();
+    submitDelta(name, user, version, ops);
+  }
+
+  private void submitDeltaToNewWaveletWithoutView(WaveletName name, ParticipantId user,
+      WaveletOperation... ops) throws Exception {
+    HashedVersion version = V0_HASH_FACTORY.createVersionZero(name);
+    submitDelta(name, user, version, ops);
+  }
+
+  private void submitDelta(WaveletName name, ParticipantId user, HashedVersion version,
+      WaveletOperation... ops) throws Exception {
+    WaveletDelta delta = new WaveletDelta(user, version, Arrays.asList(ops));
 
     ProtocolWaveletDelta protoDelta = CoreWaveletOperationSerializer.serialize(delta);
 
@@ -496,6 +568,19 @@ public class SimpleSearchProviderImplTest extends TestCase {
 
     LocalWaveletContainer wavelet = waveMap.getOrCreateLocalWavelet(name);
     wavelet.submitRequest(name, signedProtoDelta);
+  }
+
+  private void appendBlipToWavelet(WaveletName name, ParticipantId user, String blipId, String text)
+      throws Exception {
+    WaveletOperationContext context = new WaveletOperationContext(user, 0, 1);
+    WaveletOperation appendOp =
+        new WaveletBlipOperation(blipId, new BlipContentOperation(context,
+            new DocOpBuilder().characters(text).build()));
+    submitDeltaToExistingWavelet(name, user, appendOp);
+  }
+
+  private void waitForDistinctTimestamp() throws InterruptedException {
+    Thread.sleep(5L);
   }
 
   private void addWaveletToUserView(WaveletName name, ParticipantId user) {


### PR DESCRIPTION
## Root Cause
`SimpleSearchProviderImpl` built an incomplete `WaveViewData` — it only included wavelets from the per-user index entry, missing newer activity on additional conversational wavelets. Sort effectively fell back to the root wavelet timestamp.

## Fix
Expand each matched wave with all accessible conversational wavelets from `WaveMap` before sorting. This ensures `orderby:datedesc` reflects the most recently modified blip, not just the root.

## Tests
20 tests pass including new regressions for: later root-wavelet activity, later secondary conversational-wavelet activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed wave search ordering to correctly sort by the most recent blip activity when using date-based sorting
* Improved search results to include additional conversational wavelets in relevant searches

## Tests
* Added test coverage for date-based search ordering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->