### PR TITLE
feat: bare words in search query treated as implicit content: filter

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java
@@ -320,13 +320,21 @@ public class QueryHelper {
     String[] tokens = query.split("\\s+");
     Map<TokenQueryType, Set<String>> tokensMap = Maps.newEnumMap(TokenQueryType.class);
     for (String token : tokens) {
-      String[] pair = token.split(":");
-      if (pair.length != 2 || !TokenQueryType.hasToken(pair[0])) {
-        String msg = "Invalid query param: " + token;
-        throw new InvalidQueryException(msg);
+      int separatorIndex = token.indexOf(':');
+      TokenQueryType tokenType;
+      String tokenValue;
+      String tokenName = separatorIndex < 0 ? null : token.substring(0, separatorIndex);
+      if (separatorIndex < 0 || separatorIndex == 0 || !TokenQueryType.hasToken(tokenName)) {
+        tokenType = TokenQueryType.CONTENT;
+        tokenValue = token;
+      } else {
+        if (separatorIndex == token.length() - 1) {
+          String msg = "Invalid query param: " + token;
+          throw new InvalidQueryException(msg);
+        }
+        tokenType = TokenQueryType.fromToken(tokenName);
+        tokenValue = token.substring(separatorIndex + 1);
       }
-      String tokenValue = pair[1];
-      TokenQueryType tokenType = TokenQueryType.fromToken(pair[0]);
       // Verify the orderby param.
       if (tokenType.equals(TokenQueryType.ORDERBY)) {
         try {

--- a/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml
+++ b/wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml
@@ -88,7 +88,7 @@
            </tr>
            <tr>
              <td><em>free text</em></td>
-             <td>Search in wave content</td>
+             <td>Implicit <code>content:</code> search in wave content</td>
            </tr>
          </table>
        </div>
@@ -126,7 +126,7 @@
          </table>
          <div class='{css.helpSectionTitle}' style='margin-top:10px'>Combining</div>
          <div class='{css.helpCombiningText}'>
-           Filters can be combined freely. The default sort is <code>orderby:datedesc</code> (newest first).
+           Filters can be combined freely. Plain text searches content: <code>hello world</code> finds waves containing those words. The default sort is <code>orderby:datedesc</code> (newest first).
          </div>
        </div>
      </div>

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import com.google.common.collect.ImmutableSet;
+
+import junit.framework.TestCase;
+
+import java.util.Map;
+import java.util.Set;
+
+public class QueryHelperTest extends TestCase {
+
+  public void testParseQueryTreatsBareWordsAsContentFilters() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams = QueryHelper.parseQuery("hello world");
+
+    assertEquals(ImmutableSet.of("hello", "world"), queryParams.get(TokenQueryType.CONTENT));
+  }
+
+  public void testParseQueryCombinesExplicitFiltersWithBareWords() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams =
+        QueryHelper.parseQuery("tag:work meeting notes");
+
+    assertEquals(ImmutableSet.of("work"), queryParams.get(TokenQueryType.TAG));
+    assertEquals(ImmutableSet.of("meeting", "notes"), queryParams.get(TokenQueryType.CONTENT));
+  }
+
+  public void testParseQueryTreatsUnknownPrefixesAsContentFilters() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams =
+        QueryHelper.parseQuery("meeting 10:30 https://example foo:bar:baz");
+
+    assertEquals(ImmutableSet.of("meeting", "10:30", "https://example", "foo:bar:baz"),
+        queryParams.get(TokenQueryType.CONTENT));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -532,6 +532,23 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(0, results.getNumResults());
   }
 
+  public void testSearchFilterByImplicitContentWorks() throws Exception {
+    WaveletName matchingWave = WaveletName.of(WaveId.of(DOMAIN, "matching"), WAVELET_ID);
+    WaveletName partialWave = WaveletName.of(WaveId.of(DOMAIN, "partial"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(matchingWave, USER1, addParticipantToWavelet(USER1, matchingWave));
+    appendBlipToWavelet(matchingWave, USER1, "b+matching", "meeting notes and action items");
+
+    submitDeltaToNewWavelet(partialWave, USER1, addParticipantToWavelet(USER1, partialWave));
+    appendBlipToWavelet(partialWave, USER1, "b+partial", "meeting recap only");
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox meeting notes", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("matching",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
   // *** Helpers
 
   private void submitDeltaToNewWavelet(WaveletName name, ParticipantId user,


### PR DESCRIPTION
## Summary
Typing plain text in the search box now searches wave content automatically.

## Examples
- `hello` → finds waves containing "hello"
- `in:inbox hello world` → inbox filtered by content with both words
- `tag:work meeting notes` → tag:work + content contains "meeting" + "notes"
- Edge cases: `10:30` and `https://example.com` handled correctly (colons in plain text are not treated as operators)

## Changes
- `QueryHelper.parseQuery()` — bare tokens without recognized prefix populate `TokenQueryType.CONTENT`
- `SearchWidget.ui.xml` — search help updated with free-text example
- 24 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated search help text to clearly explain that free-text queries perform implicit content searches, with examples showing how plain text matches waves containing those words.

* **Bug Fixes**
  * Improved query parsing to more robustly handle edge cases including bare words, unknown prefixes, and malformed token syntax.

* **Tests**
  * Added comprehensive test coverage validating query parsing behavior and search filtering with implicit content queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->