### PR TITLE
docs: agents must read session memory at start of each session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,12 @@ git worktrees.
 - Favor tool use over guesswork. Keep calls minimal, scoped, and purposeful.
 
 ## Session Memory
-- At the start of every session, read all files in /Users/vega/.claude/projects/-Users-vega-devroot-incubator-wave/memory/
-- Start with MEMORY.md (the index), then read any relevant memory files for the current task
-- Memory contains: workflow rules, coding patterns, model selection, drill procedure, and project-specific lessons
-- This memory persists across sessions — always check it before starting work
+- At the start of every session, read `MEMORY.md` (the index) from the Claude
+  project memory directory (`.claude/projects/` under the repo or user config root).
+- After reading the index, read only the memory files that are relevant to the
+  current task — do not read every linked file unconditionally.
+- Memory contains: workflow rules, coding patterns, model selection, drill procedure, and project-specific lessons.
+- This memory persists across sessions — always check it before starting work.
 
 ## Agent Roles
 


### PR DESCRIPTION
Adds Session Memory section to AGENTS.md instructing all agents to read /Users/vega/.claude/projects/-Users-vega-devroot-incubator-wave/memory/ at session start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for session memory management, enabling agents to leverage persistent memory and carry over workflow rules and project-specific patterns across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->