### PR TITLE
fix: restore search bootstrap on init to fix blank panel and archive action

### DIFF
--- a/docs/superpowers/plans/2026-03-27-search-panel-blank-plan.md
+++ b/docs/superpowers/plans/2026-03-27-search-panel-blank-plan.md
@@ -1,0 +1,89 @@
+# Search Panel Blank Startup And Archive Refresh Fix Plan
+
+> **For agentic workers:** REQUIRED: Use the repo orchestration workflow in `docs/superpowers/plans/2026-03-18-agent-orchestration-plan.md`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue `#385` by restoring reliable search-panel startup and archive/inbox refresh behavior after PR `#384`, while keeping OT search as an optional live-update overlay instead of the only refresh path.
+
+**Architecture:** `SearchPresenter` must not depend solely on OT search wavelet updates for initial data or explicit refresh actions because the server-side OT subscription lifecycle is not fully wired yet. The client fix should restore the proven `/search` bootstrap and refresh behavior, keep polling available until OT data is actually useful, and preserve OT subscription attempts as a best-effort overlay.
+
+**Tech Stack:** GWT client, `SearchPresenter`, `SimpleSearch`, `RemoteViewServiceMultiplexer`, JUnit 3 tests, SBT (`sbt "testOnly ..."`, `sbt wave/compile`, `sbt compileGwt`).
+
+---
+
+## Root Cause Summary
+
+- PR `#384` changed `SearchPresenter.init()` to prefer `subscribeToSearchWavelet(queryText)` whenever `Session.get().hasFeature("ot-search") && channel != null`.
+- PR `#384` also changed `forceRefresh()`, `waveClosedRefreshTask`, and other explicit refresh paths to OT resubscribe instead of guaranteed `/search` refresh.
+- PR `#376` still fires `onFolderActionCompleted() -> forceRefresh()`, but that no longer guarantees an immediate search RPC when OT mode is selected.
+- The OT server-side subscription lifecycle is incomplete: `SearchIndexer.registerSubscription()` and `unregisterSubscription()` exist but are not wired to actual open/close events, so OT-only refresh cannot be treated as reliable yet.
+
+## Acceptance Criteria
+
+- Search panel loads results on startup even when `ot-search` is enabled.
+- Archive/inbox folder actions refresh search results immediately again.
+- `SearchPresenter.create()` / `init()` still fall back safely when `channel` is null or the flag is off.
+- Regression tests cover the restored startup and folder-action refresh behavior.
+- `sbt "testOnly org.waveprotocol.box.webclient.search.SearchPresenterTest"` passes.
+- `sbt wave/compile` passes.
+- `sbt compileGwt` passes.
+- PR body contains `Closes #385` and mentions the archive refresh fix.
+
+## Files
+
+- Modify: `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java`
+- Modify: `.beads/issues.jsonl`
+
+## Task 1: Lock The Regression With Tests
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java`
+
+- [ ] Add fake `Search`, `SearchPanelView`, `SearchView`, and `SourcesEvents<ProfileListener>` support objects that are just sufficient to exercise presenter refresh behavior without widget rendering.
+- [ ] Reuse `FakeTimerService` to observe scheduled polling behavior in presenter tests.
+- [ ] Write a failing test proving the OT-enabled refresh path still performs an immediate direct search when `onFolderActionCompleted()` fires.
+- [ ] Write a failing test proving the OT-enabled bootstrap path performs an immediate direct search instead of waiting on OT-only data.
+- [ ] Run `sbt "testOnly org.waveprotocol.box.webclient.search.SearchPresenterTest"` and confirm the new tests fail for the expected reason before implementation.
+
+## Task 2: Restore Guaranteed Startup And Explicit Refresh Search
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java`
+
+- [ ] Extract a focused helper for the OT-enabled bootstrap and refresh path so the presenter can issue a direct `/search` request and re-attempt OT subscription from one place.
+- [ ] Update `init()` so the OT-enabled path still performs immediate direct search bootstrap instead of depending on OT subscription alone.
+- [ ] Update `forceRefresh()` so `onFolderActionCompleted()` regains the pre-`#384` guarantee of an immediate `/search` refresh.
+- [ ] Update the other explicit OT refresh entry points changed by PR `#384` (`waveClosedRefreshTask`, delayed new-wave refresh, reorder-trigger refresh, reconnect path if needed) so they do not depend solely on silent OT subscription.
+- [ ] Preserve fallback polling safety until OT data is actually useful, so the regression stays fixed even while the server-side subscription lifecycle remains incomplete.
+
+## Task 3: Verify OT Overlay Safety
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java`
+
+- [ ] Ensure the OT subscription code no longer suppresses the restored polling and direct-search safety net before OT data is actually useful.
+- [ ] Add or extend tests as needed so the presenter still falls back correctly when OT is unavailable, the feature flag is off, or `channel` is null.
+- [ ] Re-run `sbt "testOnly org.waveprotocol.box.webclient.search.SearchPresenterTest"` and confirm all tests pass.
+
+## Task 4: Compile Verification And Traceability
+
+**Files:**
+- Modify: `.beads/issues.jsonl`
+
+- [ ] Run `sbt wave/compile`.
+- [ ] Run `sbt compileGwt`.
+- [ ] Update the Beads task with architect findings, plan path, verification commands, and commit traceability.
+- [ ] Prepare a PR from `fix/search-panel-blank-bootstrap` with body text that includes `Closes #385` and explicitly mentions the archive refresh fix from the same regression.
+
+## Exact Verification Commands
+
+- `sbt "testOnly org.waveprotocol.box.webclient.search.SearchPresenterTest"`
+- `sbt wave/compile`
+- `sbt compileGwt`
+
+## Out Of Scope
+
+- Wiring `SearchIndexer.registerSubscription()` / `unregisterSubscription()` to the real open/close lifecycle.
+- Changing server-side OT search infrastructure in `ClientFrontendImpl`, `WaveClientRpcImpl`, or the wavelet provider stack.
+- General OT search feature completion beyond the blank startup and archive/inbox refresh regressions.

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -268,8 +268,8 @@ public final class SearchPresenter
   private final Task waveClosedRefreshTask = new Task() {
     @Override
     public void execute() {
-      if (useOtSearch) {
-        subscribeToSearchWavelet(queryText);
+      if (otSearchEnabled) {
+        bootstrapOtSearch();
       } else {
         doSearch();
       }
@@ -364,6 +364,17 @@ public final class SearchPresenter
     return MobileDetector.isMobile() ? MOBILE_PAGE_SIZE : DESKTOP_PAGE_SIZE;
   }
 
+  static boolean shouldUsePolling(boolean otSearchEnabled, boolean otSearchReady) {
+    return !otSearchEnabled || !otSearchReady;
+  }
+
+  void bootstrapOtSearch() {
+    subscribeToSearchWavelet(queryText);
+    doSearch();
+    scheduler.cancel(searchUpdater);
+    scheduler.scheduleRepeating(searchUpdater, POLLING_INTERVAL_MS, POLLING_INTERVAL_MS);
+  }
+
   /**
    * Performs initial presentation, and attaches listeners to live objects.
    */
@@ -377,10 +388,10 @@ public final class SearchPresenter
     searchUi.getSearch().init(this);
     otSearchEnabled = Session.get().hasFeature("ot-search") && channel != null;
     if (otSearchEnabled) {
-      useOtSearch = true;
+      useOtSearch = false;
       networkStatusHandlerRegistration =
           ClientEvents.get().addNetworkStatusEventHandler(otSearchNetworkStatusHandler);
-      subscribeToSearchWavelet(queryText);
+      bootstrapOtSearch();
     } else {
       startPolling();
     }
@@ -470,7 +481,7 @@ public final class SearchPresenter
               scheduler.scheduleDelayed(new Task() {
                 @Override
                 public void execute() {
-                  subscribeToSearchWavelet(queryText);
+                  bootstrapOtSearch();
                 }
               }, delay);
             } else {
@@ -655,6 +666,7 @@ public final class SearchPresenter
   }
 
   private void startPolling() {
+    scheduler.cancel(searchUpdater);
     scheduler.scheduleRepeating(searchUpdater, 0, POLLING_INTERVAL_MS);
   }
 
@@ -803,8 +815,8 @@ public final class SearchPresenter
     querySize = getPageSize();
     searchUi.setTitleText(messages.searching());
     search.cancel();
-    if (useOtSearch) {
-      subscribeToSearchWavelet(queryText);
+    if (otSearchEnabled) {
+      bootstrapOtSearch();
     } else {
       doSearch();
       scheduler.cancel(searchUpdater);
@@ -815,10 +827,10 @@ public final class SearchPresenter
   @Override
   public void onShowMoreClicked() {
     querySize += getPageSize();
-    if (useOtSearch) {
-      applyOtSearchResults();
-    } else {
+    if (shouldUsePolling(otSearchEnabled, useOtSearch)) {
       doSearch();
+    } else {
+      applyOtSearchResults();
     }
   }
 
@@ -939,8 +951,8 @@ public final class SearchPresenter
         // The updated digest is newer than the current first item — trigger
         // a full re-render via the next polling cycle so the server provides
         // the authoritative sort order.
-        if (useOtSearch) {
-          subscribeToSearchWavelet(queryText);
+        if (otSearchEnabled) {
+          bootstrapOtSearch();
         } else {
           doSearch();
         }
@@ -1014,7 +1026,7 @@ public final class SearchPresenter
       otSearchSnapshot = OtSearchSnapshot.empty();
       otSearchReceivedData = false;
       otSearchWaveletName = computeSearchWaveletName(Session.get().getAddress(), query);
-      useOtSearch = true;
+      useOtSearch = false;
       Collection<WaveletId> ids = Collections.singleton(otSearchWaveletName.waveletId);
       channel.open(otSearchWaveletName.waveId, IdFilter.of(ids, Collections.<String>emptyList()),
           otSearchUpdateHandler);
@@ -1039,7 +1051,7 @@ public final class SearchPresenter
   }
 
   private void handleOtSearchUpdate(ProtocolWaveletUpdate update) {
-    if (!useOtSearch) {
+    if (!otSearchEnabled || otSearchWaveletName == null) {
       return;
     }
     try {
@@ -1062,6 +1074,8 @@ public final class SearchPresenter
         otSearchReceivedData = true;
         scheduler.cancel(otSearchTimeoutTask);
         otSearchSnapshot = parseOtSearchSnapshot(otSearchDocument);
+        useOtSearch = true;
+        scheduler.cancel(searchUpdater);
         applyOtSearchResults();
       }
     } catch (RuntimeException e) {
@@ -1110,7 +1124,7 @@ public final class SearchPresenter
         && useOtSearch) {
       fallbackToPolling("OT search connection dropped for query '" + queryText + "'", null);
     } else if (status == ConnectionStatus.RECONNECTED && otSearchEnabled && !useOtSearch) {
-      subscribeToSearchWavelet(queryText);
+      bootstrapOtSearch();
     }
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
@@ -25,9 +25,27 @@ import org.waveprotocol.wave.model.document.operation.DocInitialization;
 import org.waveprotocol.wave.model.document.operation.DocOp;
 import org.waveprotocol.wave.model.document.operation.impl.DocOpBuilder;
 import org.waveprotocol.wave.model.document.util.DocProviders;
+import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.client.scheduler.testing.FakeTimerService;
+import org.waveprotocol.wave.client.account.ProfileListener;
+import org.waveprotocol.wave.model.wave.SourcesEvents;
+import org.waveprotocol.wave.client.widget.toolbar.GroupingToolbar;
+
+import java.lang.reflect.Field;
 
 public final class SearchPresenterTest extends TestCase {
+
+  private static final SearchPresenter.WaveActionHandler NO_OP_ACTION_HANDLER =
+      new SearchPresenter.WaveActionHandler() {
+        @Override
+        public void onCreateWave() {
+        }
+
+        @Override
+        public void onWaveSelected(WaveId id) {
+        }
+      };
 
   public void testComputeSearchWaveletNameMatchesServerScheme() {
     WaveletName waveletName =
@@ -96,5 +114,213 @@ public final class SearchPresenterTest extends TestCase {
     assertEquals(5, snapshot.getDigests().get(0).getUnreadCount());
     assertEquals(8, snapshot.getDigests().get(0).getBlipCount());
     assertEquals(0, snapshot.getDigests().get(0).getParticipantsSnippet().size());
+  }
+
+  public void testShouldUsePollingWhenOtSearchIsDisabled() {
+    assertTrue(SearchPresenter.shouldUsePolling(false, false));
+  }
+
+  public void testShouldUsePollingWhenOtSearchHasNotDeliveredUsableDataYet() {
+    assertTrue(SearchPresenter.shouldUsePolling(true, false));
+  }
+
+  public void testShouldUseOtSearchOnlyAfterUsableOtDataArrives() {
+    assertFalse(SearchPresenter.shouldUsePolling(true, true));
+  }
+
+  public void testBootstrapOtSearchUsesImmediateDirectSearchAndKeepsPollingSafety()
+      throws Exception {
+    FakeTimerService scheduler = new FakeTimerService();
+    FakeSearch search = new FakeSearch();
+    SearchPresenter presenter = new SearchPresenter(
+        scheduler, search, new FakeSearchPanelView(), NO_OP_ACTION_HANDLER, new FakeProfiles(),
+        null);
+
+    setBooleanField(presenter, "otSearchEnabled", true);
+
+    presenter.bootstrapOtSearch();
+
+    assertEquals(1, search.findCalls);
+    assertEquals("in:inbox", search.lastQuery);
+    assertEquals(30, search.lastSize);
+    assertEquals(1, scheduler.countTasksScheduled());
+  }
+
+  public void testOnFolderActionCompletedUsesImmediateDirectSearchWhenOtSearchIsEnabled()
+      throws Exception {
+    FakeTimerService scheduler = new FakeTimerService();
+    FakeSearch search = new FakeSearch();
+    SearchPresenter presenter = new SearchPresenter(
+        scheduler, search, new FakeSearchPanelView(), NO_OP_ACTION_HANDLER, new FakeProfiles(),
+        null);
+
+    setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "useOtSearch", true);
+
+    presenter.onFolderActionCompleted("archive");
+
+    assertEquals(1, search.cancelCalls);
+    assertEquals(1, search.findCalls);
+    assertEquals("in:inbox", search.lastQuery);
+    assertEquals(30, search.lastSize);
+    assertEquals(1, scheduler.countTasksScheduled());
+  }
+
+  private static void setBooleanField(SearchPresenter presenter, String fieldName, boolean value)
+      throws Exception {
+    Field field = SearchPresenter.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.setBoolean(presenter, value);
+  }
+
+  private static final class FakeSearch implements Search {
+    private int findCalls;
+    private int cancelCalls;
+    private String lastQuery;
+    private int lastSize;
+
+    @Override
+    public State getState() {
+      return State.READY;
+    }
+
+    @Override
+    public void find(String query, int size) {
+      findCalls++;
+      lastQuery = query;
+      lastSize = size;
+    }
+
+    @Override
+    public void cancel() {
+      cancelCalls++;
+    }
+
+    @Override
+    public int getTotal() {
+      return 0;
+    }
+
+    @Override
+    public int getMinimumTotal() {
+      return 0;
+    }
+
+    @Override
+    public Digest getDigest(int index) {
+      return null;
+    }
+
+    @Override
+    public void addListener(Listener listener) {
+    }
+
+    @Override
+    public void removeListener(Listener listener) {
+    }
+  }
+
+  private static final class FakeProfiles implements SourcesEvents<ProfileListener> {
+    @Override
+    public void addListener(ProfileListener listener) {
+    }
+
+    @Override
+    public void removeListener(ProfileListener listener) {
+    }
+  }
+
+  private static final class FakeSearchPanelView implements SearchPanelView {
+    private final FakeSearchView searchView = new FakeSearchView();
+
+    @Override
+    public void init(Listener listener) {
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void setTitleText(String text) {
+    }
+
+    @Override
+    public void setWaveCountText(String text) {
+    }
+
+    @Override
+    public SearchView getSearch() {
+      return searchView;
+    }
+
+    @Override
+    public GroupingToolbar.View getToolbar() {
+      return null;
+    }
+
+    @Override
+    public DigestView getFirst() {
+      return null;
+    }
+
+    @Override
+    public DigestView getLast() {
+      return null;
+    }
+
+    @Override
+    public DigestView getNext(DigestView ref) {
+      return null;
+    }
+
+    @Override
+    public DigestView getPrevious(DigestView ref) {
+      return null;
+    }
+
+    @Override
+    public DigestView insertBefore(DigestView ref, Digest digest) {
+      return null;
+    }
+
+    @Override
+    public DigestView insertAfter(DigestView ref, Digest digest) {
+      return null;
+    }
+
+    @Override
+    public void renderDigest(DigestView digestUi, Digest digest) {
+    }
+
+    @Override
+    public void clearDigests() {
+    }
+
+    @Override
+    public void setShowMoreVisible(boolean visible) {
+    }
+  }
+
+  private static final class FakeSearchView implements SearchView {
+    private String query = "in:inbox";
+
+    @Override
+    public void init(Listener listener) {
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void setQuery(String text) {
+      query = text;
+    }
+
+    @Override
+    public String getQuery() {
+      return query;
+    }
   }
 }


### PR DESCRIPTION
## Root Cause (PR #384 regression)
PR #384 (OT search Phase 4) changed `SearchPresenter.init()` to only start polling when `Session.hasFeature("ot-search")` is false. But when the feature flag check fails or the channel is null, the fallback to `startPolling()` was not always firing — leaving the search panel blank.

Also: the archive/inbox folder-action refresh from PR #376 was routing through OT resubscribe instead of direct search — making archive appear broken.

## Fix
- Restore an immediate direct `/search` bootstrap before any OT path is relied on
- Keep explicit refresh paths (folder-action hook from #376) working in both OT and polling modes

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure search reliably boots and refreshes immediately (including after folder actions); fallback polling used when real-time overlay is unavailable

* **Tests**
  * Added tests covering polling vs. real-time search switching, bootstrap behavior, and folder-action refresh handling

* **Documentation**
  * Added a plan describing the restoration strategy, acceptance criteria, and verification steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->