### PR TITLE
[codex] Fix inbox clear state and unread search

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-unread-search-read-state-fix",
+    "version": "PR #412",
+    "date": "2026-03-28",
+    "title": "Unread Search Read-State Fix",
+    "summary": "Unread-only searches now evaluate persisted read state so read waves stop leaking into unread results.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Unread-only searches now use wavelet read-state data instead of relying on the conversation-model supplement path",
+          "Read waves no longer remain in `unread:true` results when every matching wave has already been opened"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-search-panel-unread-accuracy",
     "version": "PR #411",
     "date": "2026-03-28",

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -610,7 +610,7 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
       WaveViewData wave = it.next();
       try {
         WaveSupplementContext ctx = getOrBuildContext(wave, user, supplementCache, waveletAdapters);
-        if (digester.getUnreadCount(ctx, waveletAdapters) <= 0) {
+        if (digester.countUnread(user, ctx, waveletAdapters) <= 0) {
           it.remove();
         }
       } catch (Exception e) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -25,6 +25,7 @@ import com.google.wave.api.ApiIdSerializer;
 import com.google.wave.api.SearchResult;
 import com.google.wave.api.SearchResult.Digest;
 
+import org.waveprotocol.box.common.DocumentConstants;
 import org.waveprotocol.box.common.Snippets;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl.WaveSupplementContext;
@@ -48,6 +49,7 @@ import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl.DefaultFollow
 import org.waveprotocol.wave.model.supplement.WaveletBasedSupplement;
 import org.waveprotocol.wave.model.util.CollectionUtils;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
 import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
 import org.waveprotocol.wave.model.wave.data.WaveletData;
@@ -120,11 +122,65 @@ public class WaveDigester {
 
   int getUnreadCount(WaveSupplementContext context,
       Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
-    if (context == null || context.supplement == null || context.conversations == null) {
+    return countUnread(null, context, waveletAdapters);
+  }
+
+  int countUnread(ParticipantId participant, WaveSupplementContext context,
+      Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
+    if (context == null) {
+      return 0;
+    }
+    PrimitiveSupplement readState = createReadState(participant, context, waveletAdapters);
+    if (readState != null) {
+      return countUnreadFromReadState(readState, context.conversationalWavelets);
+    }
+    if (context.supplement == null || context.conversations == null) {
       return 0;
     }
     return countUnread(context.convWavelet, context.conversationalWavelets, context.supplement,
         context.conversations, waveletAdapters);
+  }
+
+  private int countUnreadFromReadState(PrimitiveSupplement readState,
+      Iterable<? extends ObservableWaveletData> conversationalWavelets) {
+    int unreadCount = 0;
+    for (ObservableWaveletData conversationalWavelet : conversationalWavelets) {
+      WaveletId waveletId = conversationalWavelet.getWaveletId();
+      int lastReadWaveletVersion = readState.getLastReadWaveletVersion(waveletId);
+      for (String documentId : conversationalWavelet.getDocumentIds()) {
+        if (DocumentConstants.MANIFEST_DOCUMENT_ID.equals(documentId)) {
+          continue;
+        }
+        ReadableBlipData blip = conversationalWavelet.getDocument(documentId);
+        if (blip == null) {
+          continue;
+        }
+        long modifiedVersion = blip.getLastModifiedVersion();
+        boolean unreadByBlip = readState.getLastReadBlipVersion(waveletId, documentId)
+            == PrimitiveSupplement.NO_VERSION
+            || readState.getLastReadBlipVersion(waveletId, documentId) < modifiedVersion;
+        boolean unreadByWavelet = lastReadWaveletVersion == PrimitiveSupplement.NO_VERSION
+            || lastReadWaveletVersion < modifiedVersion;
+        if (unreadByBlip && unreadByWavelet) {
+          unreadCount++;
+        }
+      }
+    }
+    return unreadCount;
+  }
+
+  private PrimitiveSupplement createReadState(ParticipantId participant,
+      WaveSupplementContext context,
+      Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
+    if (context.udw != null) {
+      OpBasedWavelet userDataWavelet =
+          getOrCreateReadOnlyWavelet(context.udw, waveletAdapters);
+      return WaveletBasedSupplement.create(userDataWavelet);
+    }
+    if (isExplicitParticipant(participant, context.conversationalWavelets)) {
+      return new PrimitiveSupplementImpl();
+    }
+    return null;
   }
 
   public Digest build(ParticipantId participant, WaveViewData wave) {

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-unread-search-read-state-fix",
+    "version": "PR #412",
+    "date": "2026-03-28",
+    "title": "Unread Search Read-State Fix",
+    "summary": "Unread-only searches now evaluate persisted read state so read waves stop leaking into unread results.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Unread-only searches now use wavelet read-state data instead of relying on the conversation-model supplement path",
+          "Read waves no longer remain in `unread:true` results when every matching wave has already been opened"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-search-panel-unread-accuracy",
     "version": "PR #411",
     "date": "2026-03-28",

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -623,18 +623,52 @@ public class SimpleSearchProviderImplTest extends TestCase {
         WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
   }
 
+  public void testSearchUnreadTrueReturnsOnlyUnreadWaves() throws Exception {
+    WaveletName unreadWave = WaveletName.of(WaveId.of(DOMAIN, "unread"), WAVELET_ID);
+    WaveletName readWave = WaveletName.of(WaveId.of(DOMAIN, "read"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(unreadWave, USER1, addParticipantToWavelet(USER1, unreadWave));
+    appendBlipToWavelet(unreadWave, USER1, "b+unread", "project update");
+
+    submitDeltaToNewWavelet(readWave, USER1, addParticipantToWavelet(USER1, readWave));
+    appendBlipToWavelet(readWave, USER1, "b+read", "project update");
+
+    SearchProvider unreadFilterProvider =
+        newUnreadAwareSearchProvider(ImmutableMap.of("read", 0, "unread", 2));
+
+    SearchResult results = unreadFilterProvider.search(USER1, "unread:true", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("unread",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchUnreadTrueReturnsNothingWhenAllWavesAreRead() throws Exception {
+    WaveletName readWave = WaveletName.of(WaveId.of(DOMAIN, "read-only"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(readWave, USER1, addParticipantToWavelet(USER1, readWave));
+    appendBlipToWavelet(readWave, USER1, "b+read", "project update");
+
+    SearchProvider unreadFilterProvider =
+        newUnreadAwareSearchProvider(ImmutableMap.of("read-only", 0));
+
+    SearchResult results = unreadFilterProvider.search(USER1, "unread:true", 0, 10);
+
+    assertEquals(0, results.getNumResults());
+  }
+
   // *** Helpers
 
   private SearchProvider newUnreadAwareSearchProvider(final Map<String, Integer> unreadCounts) {
     ConversationUtil conversationUtil = new ConversationUtil(idGenerator);
     WaveDigester digester = new WaveDigester(conversationUtil) {
       @Override
-      int getUnreadCount(WaveSupplementContext context,
+      int countUnread(ParticipantId participant, WaveSupplementContext context,
           Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
         String waveId = context.convWavelet.getWaveId().getId();
         Integer unreadCount = unreadCounts.get(waveId);
         if (unreadCount == null) {
-          return super.getUnreadCount(context, waveletAdapters);
+          return super.countUnread(participant, context, waveletAdapters);
         }
         return unreadCount.intValue();
       }


### PR DESCRIPTION
## What changed
- normalize empty search submissions back to the default `in:inbox` query in the presenter so the visible search box and active filter stay aligned
- add explicit `unread:true` query parsing and unread-only filtering on the server
- count unread blips directly from wavelet read-state data so unopened/simple waves do not depend on the fragile conversation-model path
- document `unread:true` in search help and add a changelog entry for the user-facing fix

## Root cause
- the client only restored the default inbox query inside `SearchWidget` change handling, so empty submissions could leave the presenter using a reset filter while the input still appeared blank
- the server did not recognize `unread:true` as a structured query at all, and the missing unread-only filter stage let read waves leak through instead of producing an empty result set when everything was read

## Validation
- `sbt -Dsbt.global.base=/tmp/search-clear-unread-sbt-global -Dsbt.boot.directory=/tmp/search-clear-unread-sbt-boot -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch "project wave" "set Test / fork := true" "testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest"`
- `sbt -Dsbt.global.base=/tmp/search-clear-unread-sbt-global-7 -Dsbt.boot.directory=/tmp/search-clear-unread-sbt-boot-7 -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch wave/compile`
- `sbt -Dsbt.global.base=/tmp/search-clear-unread-sbt-global-9 -Dsbt.boot.directory=/tmp/search-clear-unread-sbt-boot-9 -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch compileGwt`
- local QA on `http://127.0.0.1:9898`: created a direct-message wave between fresh users, confirmed `unread:true` returned unread waves, opened both unread waves until `unread:true` returned `{"1":"unread:true","2":0,"3":[]}`, then cleared the search box to empty and confirmed the UI restored visible `in:inbox`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread-only search accuracy. Fixed an issue where some opened waves could incorrectly appear in unread search results. The search now uses more reliable state information to determine which waves are unread, ensuring that waves you've already read are properly excluded from unread-only searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->