### PR TITLE
Suppress noisy Jakarta websocket close warnings

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/jakarta/WaveWebSocketEndpoint.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/jakarta/WaveWebSocketEndpoint.java
@@ -20,6 +20,7 @@ package org.waveprotocol.box.server.rpc.jakarta;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
 import jakarta.websocket.OnMessage;
 import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
@@ -29,6 +30,8 @@ import org.waveprotocol.box.server.rpc.ServerRpcProvider;
 import org.waveprotocol.box.server.rpc.ServerRpcProvider.WebSocketConnection;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
+
+import java.nio.channels.ClosedChannelException;
 
 /**
  * Jakarta EE WebSocket endpoint that bridges Jetty 12 websocket sessions to
@@ -89,14 +92,45 @@ public class WaveWebSocketEndpoint {
 
   @OnClose
   public void onClose(Session session) {
-    WebSocketConnection connection =
-        (WebSocketConnection) session.getUserProperties().remove(CONNECTION_KEY);
-    if (connection != null) {
-      connection.detachSession();
-    }
+    detachConnection(session);
     if (LOG.isFineLoggable()) {
       LOG.fine("WebSocket closed: id=" + (session != null ? session.getId() : "null"));
     }
+  }
+
+  @OnError
+  public void onError(Session session, Throwable error) {
+    detachConnection(session);
+    if (isClosedChannelError(error)) {
+      if (LOG.isFineLoggable()) {
+        LOG.fine("WebSocket closed during transport handling: id="
+            + (session != null ? session.getId() : "null"));
+      }
+    } else {
+      LOG.warning("WebSocket transport error", error);
+    }
+    closeQuietly(session);
+  }
+
+  private static void detachConnection(Session session) {
+    WebSocketConnection connection = null;
+    if (session != null) {
+      connection =
+          (WebSocketConnection) session.getUserProperties().remove(CONNECTION_KEY);
+    }
+    if (connection != null) {
+      connection.detachSession();
+    }
+  }
+
+  private static boolean isClosedChannelError(Throwable error) {
+    boolean closedChannelError = false;
+    Throwable current = error;
+    while (current != null && !closedChannelError) {
+      closedChannelError = current instanceof ClosedChannelException;
+      current = current.getCause();
+    }
+    return closedChannelError;
   }
 
   private static void closeQuietly(Session session) {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/jakarta/WaveWebSocketEndpointTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/jakarta/WaveWebSocketEndpointTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc.jakarta;
+
+import jakarta.websocket.Session;
+import org.junit.Test;
+import org.waveprotocol.box.server.rpc.ServerRpcProvider;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WaveWebSocketEndpointTest {
+  private static final String CONNECTION_KEY = "wave.websocket.connection";
+
+  @Test
+  public void closedChannelErrorDetachesConnectionWithoutWarning() {
+    WaveWebSocketEndpoint endpoint = new WaveWebSocketEndpoint();
+    Session session = mock(Session.class);
+    ServerRpcProvider.WebSocketConnection connection =
+        mock(ServerRpcProvider.WebSocketConnection.class);
+    Map<String, Object> userProperties = new HashMap<>();
+    userProperties.put(CONNECTION_KEY, connection);
+    when(session.getUserProperties()).thenReturn(userProperties);
+    when(session.getId()).thenReturn("closed-session");
+    when(session.isOpen()).thenReturn(false);
+
+    List<LogRecord> records =
+        captureEndpointLogs(() -> endpoint.onError(session, new ClosedChannelException()));
+
+    verify(connection).detachSession();
+    assertTrue(userProperties.isEmpty());
+    assertTrue(records.isEmpty());
+  }
+
+  @Test
+  public void unexpectedTransportErrorLogsWarningAndDetachesConnection() {
+    WaveWebSocketEndpoint endpoint = new WaveWebSocketEndpoint();
+    Session session = mock(Session.class);
+    ServerRpcProvider.WebSocketConnection connection =
+        mock(ServerRpcProvider.WebSocketConnection.class);
+    Map<String, Object> userProperties = new HashMap<>();
+    RuntimeException transportError = new RuntimeException("boom");
+    userProperties.put(CONNECTION_KEY, connection);
+    when(session.getUserProperties()).thenReturn(userProperties);
+    when(session.getId()).thenReturn("error-session");
+    when(session.isOpen()).thenReturn(false);
+
+    List<LogRecord> records =
+        captureEndpointLogs(() -> endpoint.onError(session, transportError));
+
+    verify(connection).detachSession();
+    assertEquals(1, records.size());
+    assertEquals(Level.WARNING, records.get(0).getLevel());
+    assertEquals("WebSocket transport error", records.get(0).getMessage());
+    assertSame(transportError, records.get(0).getThrown());
+  }
+
+  private List<LogRecord> captureEndpointLogs(Runnable action) {
+    Logger logger = Logger.getLogger(WaveWebSocketEndpoint.class.getName());
+    Level previousLevel = logger.getLevel();
+    boolean previousUseParentHandlers = logger.getUseParentHandlers();
+    RecordingHandler handler = new RecordingHandler();
+
+    logger.setLevel(Level.ALL);
+    logger.setUseParentHandlers(false);
+    logger.addHandler(handler);
+    try {
+      action.run();
+    } finally {
+      logger.removeHandler(handler);
+      logger.setUseParentHandlers(previousUseParentHandlers);
+      logger.setLevel(previousLevel);
+    }
+
+    return handler.warningRecords();
+  }
+
+  private static final class RecordingHandler extends Handler {
+    private final List<LogRecord> records = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    List<LogRecord> warningRecords() {
+      List<LogRecord> warningRecords = new ArrayList<>();
+      for (LogRecord record : records) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+          warningRecords.add(record);
+        }
+      }
+      return warningRecords;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Jakarta `@OnError` handler to `WaveWebSocketEndpoint`
- treat `ClosedChannelException` as an expected disconnect while still warning on real transport errors
- add focused Jakarta tests for closed-channel and unexpected transport error paths

## Root cause
Jetty 12/Jakarta delivers transport failures like `ClosedChannelException` through the endpoint error lifecycle. The Jakarta endpoint had `@OnOpen`, `@OnMessage`, and `@OnClose`, but no `@OnError`, so abrupt disconnects during the pre-auth/auth reconnect churn surfaced as generic `WaveWebSocketEndpoint` WARN `Unhandled Error` noise even though the client immediately reconnected successfully.

## Verification
- `sbt 'jakartaTest:testOnly org.waveprotocol.box.server.rpc.jakarta.WaveWebSocketEndpointTest'`
- `sbt 'jakartaTest:testOnly org.waveprotocol.box.server.rpc.WebSocketChannelImplTest'`
- `sbt prepareServerConfig run` then `curl -s -o /tmp/ws-health.out -w '%{http_code}\n' http://127.0.0.1:9898/healthz` -> `200` / `ok`
- local websocket sanity via Python `websockets.connect('ws://127.0.0.1:9898/socket')` with abrupt abort: reproduced Jetty closed-channel teardown without a `WaveWebSocketEndpoint` WARN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for WebSocket connections to properly manage cleanup during unexpected disconnections.

* **Tests**
  * Added comprehensive test coverage for WebSocket error scenarios and connection lifecycle events.

* **Refactor**
  * Streamlined internal connection management and lifecycle handling for improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->