### PR TITLE
docs: document supawave email deliverability fixes

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -10,5 +10,6 @@ Read in this order:
 3. `caddy.md` if you want the recommended reverse-proxy deployment
 4. `../../deploy/mongo/README.md` for Mongo auth, backup, restore, and durability guidance
 5. optional overlays such as `contabo.md` and `cloudflare-supawave.md` only after reading the generic docs
+6. `email-deliverability-supawave.md` if you are diagnosing Resend or DNS-related inbox-placement issues for `supawave.ai`
 
 Provider-specific notes are overlays, not the canonical deployment story.

--- a/docs/deployment/email-deliverability-supawave.md
+++ b/docs/deployment/email-deliverability-supawave.md
@@ -1,0 +1,194 @@
+# SupaWave Email Deliverability Checklist
+
+This note captures the current public DNS state for `supawave.ai` and the
+most likely reasons mail sent through Resend is reaching spam.
+
+Scope:
+- outbound mail from SupaWave application flows
+- public DNS records visible on 2026-03-28 UTC
+- operator actions that must happen outside this repo
+
+Non-goals:
+- changing Cloudflare DNS from this worktree
+- claiming mailbox-provider reputation results without mailbox-header samples
+
+## Current public DNS comparison
+
+Queried with:
+
+```bash
+for d in supawave.ai tube2web.ai; do
+  echo "=== $d ==="
+  for name in "$d" "_dmarc.$d" "resend._domainkey.$d" "send.$d"; do
+    echo "-- $name"
+    dig +short TXT "$name"
+    dig +short MX "$name"
+    dig +short CNAME "$name"
+  done
+done
+```
+
+Visible email-related records:
+
+| Record | `supawave.ai` | `tube2web.ai` | Notes |
+| --- | --- | --- | --- |
+| apex TXT | `v=spf1 include:_spf.mx.cloudflare.net ~all` | same | This is the Cloudflare Email Routing SPF record, not the Resend sending SPF. |
+| apex MX | `route1/2/3.mx.cloudflare.net` | same | Inbound mail is routed through Cloudflare on both domains. |
+| `resend._domainkey` TXT | present | present | Resend DKIM key exists on both domains. |
+| `send` TXT | `v=spf1 include:amazonses.com ~all` | same | Resend custom return-path SPF exists on both domains. |
+| `send` MX | `10 feedback-smtp.us-east-1.amazonses.com.` | same | Resend custom return-path MX exists on both domains. |
+| `_dmarc` TXT | missing | missing | Neither domain currently publishes DMARC. |
+
+Conclusion:
+- the visible Resend-related DNS on `supawave.ai` and `tube2web.ai` is effectively the same
+- the spam problem is not explained by an obvious SPF or DKIM mismatch in the public records above
+- the biggest visible authentication gap is the absence of DMARC
+
+## Repo-side configuration findings
+
+The deployment already sends application mail through Resend:
+
+- `deploy/caddy/application.conf` sets `core.mail_provider = "resend"`
+- `deploy/caddy/application.conf` reads `core.email_from_address = ${?WAVE_EMAIL_FROM}`
+- `wave/config/reference.conf` exposes the same `WAVE_EMAIL_FROM` override
+
+This means the sending address can be changed operationally without a code change once DNS is ready.
+
+## Likely spam causes
+
+### 1. No DMARC policy is published
+
+This is the clearest DNS weakness.
+
+Without DMARC:
+- mailbox providers lose an alignment policy signal for `From:` mail
+- domain owners receive no aggregate reports showing pass and fail behavior
+- Gmail explicitly recommends DMARC in addition to SPF and DKIM
+
+### 2. `supawave.ai` is an extremely new sending domain
+
+WHOIS on 2026-03-28 shows:
+- `supawave.ai` creation date: 2026-03-19
+- `tube2web.ai` creation date: 2025-11-22
+
+`supawave.ai` is still in the first days of sender reputation building. Even with correct SPF and DKIM, cold domains often hit spam until they accumulate positive engagement.
+
+### 3. Mail is likely being sent from the root domain instead of a dedicated sending subdomain
+
+Resend recommends a subdomain for sending so reputation is segmented by purpose.
+
+For SupaWave that means:
+- website reputation
+- future human mailbox reputation
+- automated auth-mail reputation
+
+are all currently tied too closely together if `WAVE_EMAIL_FROM` uses `@supawave.ai`.
+
+### 4. Auth-style traffic tends to look low-volume and low-engagement
+
+Password resets, confirmations, and magic links are legitimate, but they are also:
+- short-lived
+- link-heavy
+- often ignored by recipients who test the product once
+
+That makes warm-up and domain trust more important than usual.
+
+### 5. The sender presentation may be too bare
+
+If `WAVE_EMAIL_FROM` is only `noreply@supawave.ai`, the mail lacks a recognizable display name. That is not the primary cause, but it is a weak trust signal compared with `SupaWave <auth@notify.supawave.ai>`.
+
+## Recommended external DNS changes
+
+### Minimum improvement set for the current domain
+
+1. Publish DMARC at the apex:
+
+```txt
+Host: _dmarc
+Type: TXT
+Value: v=DMARC1; p=none; rua=mailto:dmarc@supawave.ai; adkim=r; aspf=r; pct=100
+```
+
+2. Make sure the reporting mailbox exists.
+
+Recommended:
+- create a Cloudflare Email Routing alias for `dmarc@supawave.ai`
+- forward it to a monitored mailbox
+
+3. After 1 to 2 weeks of clean aggregate reports, tighten the policy:
+
+Phase 2:
+
+```txt
+Host: _dmarc
+Type: TXT
+Value: v=DMARC1; p=quarantine; rua=mailto:dmarc@supawave.ai; adkim=r; aspf=r; pct=100
+```
+
+Phase 3:
+
+```txt
+Host: _dmarc
+Type: TXT
+Value: v=DMARC1; p=reject; rua=mailto:dmarc@supawave.ai; adkim=r; aspf=r; pct=100
+```
+
+### Preferred long-term setup
+
+Move automated application mail to a dedicated sending subdomain, for example `notify.supawave.ai`.
+
+Create and verify that subdomain in Resend, then add the records Resend provides for that exact subdomain. With the default Resend naming pattern, expect records shaped like:
+
+```txt
+Host: resend._domainkey.notify
+Type: TXT
+Value: <Resend-provided DKIM public key>
+```
+
+```txt
+Host: send.notify
+Type: TXT
+Value: v=spf1 include:amazonses.com ~all
+```
+
+```txt
+Host: send.notify
+Type: MX
+Priority: 10
+Value: feedback-smtp.us-east-1.amazonses.com.
+```
+
+Then update the runtime sender address to use that subdomain:
+
+```bash
+WAVE_EMAIL_FROM="SupaWave <auth@notify.supawave.ai>"
+```
+
+Why this is better:
+- sender reputation is isolated from the apex domain
+- future support or human mailboxes can stay on `supawave.ai`
+- application auth mail gets its own warm-up path
+
+## Recommended operational follow-up
+
+1. Keep the existing `send.supawave.ai` and `resend._domainkey.supawave.ai` records in place until the new subdomain is verified and live.
+2. Send only low-volume transactional mail first.
+3. Seed a few trusted inboxes across Gmail and Outlook, then open, star, reply, and move messages out of spam if they land there.
+4. Avoid batch sends from the new domain until engagement improves.
+5. Use a branded sender string such as `SupaWave <auth@notify.supawave.ai>`.
+
+## What does not currently look broken
+
+Based on the public DNS checks above:
+- Resend DKIM is present
+- the Resend return-path SPF and MX records are present
+- there is no visible MX conflict between Cloudflare inbound routing on the apex and Resend sending on the `send` subdomain
+
+So the highest-confidence conclusion is:
+- `supawave.ai` mail is probably hitting spam because the domain is brand new and lacks DMARC, not because the visible Resend DNS is missing
+
+## Sources used for the recommendations
+
+- Resend Cloudflare guide: https://resend.com/docs/knowledge-base/cloudflare
+- Resend authentication guide: https://resend.com/blog/email-authentication-a-developers-guide
+- Google authentication guidance: https://support.google.com/a/answer/10583557?hl=en

--- a/docs/superpowers/plans/2026-03-28-supawave-email-deliverability-plan.md
+++ b/docs/superpowers/plans/2026-03-28-supawave-email-deliverability-plan.md
@@ -1,0 +1,80 @@
+# SupaWave Email Deliverability Investigation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document why mail from `supawave.ai` sent through Resend is likely landing in spam and capture the exact repo-side and DNS-side follow-up.
+
+**Architecture:** Treat this as an evidence-first ops/documentation task, not a speculative code fix. Compare live DNS for `supawave.ai` and `tube2web.ai`, inspect the repo’s outbound-mail configuration, then publish a precise operator checklist for DNS and deliverability improvements.
+
+**Tech Stack:** Cloudflare DNS, Resend, Apache Wave deployment docs, shell verification
+
+---
+
+### Task 1: Capture Evidence
+
+**Files:**
+- Create: `docs/deployment/email-deliverability-supawave.md`
+- Modify: `docs/deployment/README.md`
+
+- [ ] **Step 1: Record the live DNS comparison**
+
+Run:
+
+```bash
+for d in supawave.ai tube2web.ai; do
+  echo "=== $d ==="
+  for name in "$d" "_dmarc.$d" "resend._domainkey.$d" "send.$d"; do
+    echo "-- $name"
+    dig +short TXT "$name"
+    dig +short MX "$name"
+    dig +short CNAME "$name"
+  done
+done
+```
+
+Expected: both domains expose the same visible Resend-related records and neither publishes `_dmarc`.
+
+- [ ] **Step 2: Confirm the repo’s outbound sender configuration**
+
+Run:
+
+```bash
+rg -n "WAVE_EMAIL_FROM|mail_provider|email_from_address" deploy wave/config wave/src
+```
+
+Expected: the deployment config uses `core.mail_provider = "resend"` and `core.email_from_address = ${?WAVE_EMAIL_FROM}`.
+
+- [ ] **Step 3: Write the operator-facing checklist**
+
+Document:
+- current public records
+- likely spam causes
+- exact DNS changes to make outside the repo
+- safe repo-side follow-up that is still configurable today
+
+### Task 2: Verify And Close Out
+
+**Files:**
+- Modify: `docs/deployment/README.md`
+- Create: `docs/deployment/email-deliverability-supawave.md`
+
+- [ ] **Step 1: Verify the doc edits**
+
+Run:
+
+```bash
+git diff --check
+rg -n "email-deliverability-supawave|_dmarc|WAVE_EMAIL_FROM|notify\\.supawave\\.ai" \
+  docs/deployment/README.md docs/deployment/email-deliverability-supawave.md
+```
+
+Expected: no diff-check errors and the new checklist/doc links are present.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-03-28-supawave-email-deliverability-plan.md \
+  docs/deployment/README.md \
+  docs/deployment/email-deliverability-supawave.md
+git commit -m "docs: add supawave email deliverability checklist"
+```


### PR DESCRIPTION
## Summary
- add a deliverability investigation note for `supawave.ai`
- record the live DNS comparison against `tube2web.ai`
- document likely spam causes and the exact external DNS changes to make
- add a task plan artifact and link the new note from the deployment docs

## Findings
- `supawave.ai` and `tube2web.ai` currently expose the same visible Resend-related records: `resend._domainkey` plus `send` SPF/MX
- neither domain currently publishes `_dmarc`
- `supawave.ai` is much newer (`2026-03-19`) than `tube2web.ai` (`2025-11-22`), which is a strong deliverability factor
- the highest-confidence explanation for spam placement is new-domain reputation plus missing DMARC, not an obvious missing Resend SPF or DKIM record

## Verification
- `git diff --check`
- `rg -n "email-deliverability-supawave|_dmarc|WAVE_EMAIL_FROM|notify\.supawave\.ai" docs/deployment/README.md docs/deployment/email-deliverability-supawave.md docs/superpowers/plans/2026-03-28-supawave-email-deliverability-plan.md`
- live `dig` queries for `supawave.ai` and `tube2web.ai`
- external review via `review_task.sh` with `REVIEW_PLATFORM=gemini` completed with `pass`

## External changes still required
- publish DMARC for `supawave.ai`
- ideally move auth mail to a dedicated sending subdomain such as `notify.supawave.ai`
- update `WAVE_EMAIL_FROM` after the subdomain is verified in Resend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive email deliverability troubleshooting guide for SupaWave.
  * Added an evidence-first investigational plan to diagnose why messages land in spam.
  * Updated deployment docs to reference the new deliverability resources.
  * Included actionable DNS/DMARC guidance and recommendations to use a dedicated sending subdomain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->