### PR TITLE
Fix shared-wave pinning for non-owners

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-shared-wave-pinning",
+    "version": "PR #417",
+    "date": "2026-03-28",
+    "title": "Shared Wave Pinning",
+    "summary": "Pinning and unpinning now works for waves you can access even when you are not the wave owner.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed shared-wave pin and unpin requests so they update your per-user state without requiring wave ownership"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-search-bootstrap-loading-ux",
     "version": "PR #414",
     "date": "2026-03-28",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/FolderServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/FolderServlet.java
@@ -32,16 +32,21 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.robots.OperationContextImpl;
+import org.waveprotocol.box.server.robots.RobotWaveletData;
+import org.waveprotocol.box.server.robots.util.RobotsUtil;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.robots.util.LoggingRequestListener;
 import org.waveprotocol.box.server.robots.util.OperationUtil;
+import org.waveprotocol.box.server.waveserver.WaveServerException;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.wave.model.conversation.ConversationView;
 import org.waveprotocol.wave.model.id.IdConstants;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.operation.OperationException;
 import org.waveprotocol.wave.model.supplement.PrimitiveSupplement;
 import org.waveprotocol.wave.model.supplement.SupplementedWave;
@@ -152,7 +157,7 @@ public final class FolderServlet extends HttpServlet {
     WaveletId udwId =
         WaveletId.of(waveId.getDomain(),
             IdUtil.join(IdConstants.USER_DATA_WAVELET_PREFIX, participant.getAddress()));
-    OpBasedWavelet udw = context.openWavelet(waveId, udwId, participant);
+    OpBasedWavelet udw = openParticipantUserDataWavelet(context, waveId, participant);
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
 
@@ -173,14 +178,12 @@ public final class FolderServlet extends HttpServlet {
    */
   public void setPinState(WaveId waveId, boolean pin, ParticipantId participant)
       throws InvalidRequestException, OperationException, InterruptedException, ExecutionException {
+    verifyWaveVisibleToParticipant(waveId, participant);
 
     OperationContextImpl context = new OperationContextImpl(waveletProvider,
         converterManager.getEventDataConverter(ProtocolVersion.DEFAULT), conversationUtil);
 
-    WaveletId udwId =
-        WaveletId.of(waveId.getDomain(),
-            IdUtil.join(IdConstants.USER_DATA_WAVELET_PREFIX, participant.getAddress()));
-    OpBasedWavelet udw = context.openWavelet(waveId, udwId, participant);
+    OpBasedWavelet udw = openParticipantUserDataWavelet(context, waveId, participant);
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
     if (pin) {
@@ -193,5 +196,47 @@ public final class FolderServlet extends HttpServlet {
       }
     }
     OperationUtil.submitDeltas(context, waveletProvider, LOGGING_REQUEST_LISTENER);
+  }
+
+  private OpBasedWavelet openParticipantUserDataWavelet(
+      OperationContextImpl context, WaveId waveId, ParticipantId participant)
+      throws InvalidRequestException {
+    WaveletId userDataWaveletId = IdUtil.buildUserDataWaveletId(participant);
+    RobotWaveletData userDataWavelet = loadParticipantUserDataWavelet(waveId, participant);
+    context.putWavelet(waveId, userDataWaveletId, userDataWavelet);
+    return context.openWavelet(waveId, userDataWaveletId, participant);
+  }
+
+  private RobotWaveletData loadParticipantUserDataWavelet(WaveId waveId, ParticipantId participant)
+      throws InvalidRequestException {
+    WaveletName userDataWaveletName = WaveletName.of(waveId, IdUtil.buildUserDataWaveletId(participant));
+    try {
+      CommittedWaveletSnapshot snapshot = waveletProvider.getSnapshot(userDataWaveletName);
+      if (snapshot == null) {
+        return RobotsUtil.createEmptyRobotWavelet(participant, userDataWaveletName);
+      }
+      return new RobotWaveletData(snapshot.snapshot, snapshot.committedVersion);
+    } catch (WaveServerException e) {
+      throw new InvalidRequestException("Wavelet " + userDataWaveletName + " couldn't be retrieved");
+    }
+  }
+
+  private void verifyWaveVisibleToParticipant(WaveId waveId, ParticipantId participant)
+      throws InvalidRequestException {
+    try {
+      boolean hasAccessibleWavelet = false;
+      for (WaveletId waveletId : waveletProvider.getWaveletIds(waveId)) {
+        WaveletName waveletName = WaveletName.of(waveId, waveletId);
+        if (waveletProvider.checkAccessPermission(waveletName, participant)) {
+          hasAccessibleWavelet = true;
+          break;
+        }
+      }
+      if (!hasAccessibleWavelet) {
+        throw new InvalidRequestException("Access rejected");
+      }
+    } catch (WaveServerException e) {
+      throw new InvalidRequestException("Wave " + waveId + " couldn't be retrieved");
+    }
   }
 }

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-shared-wave-pinning",
+    "version": "PR #417",
+    "date": "2026-03-28",
+    "title": "Shared Wave Pinning",
+    "summary": "Pinning and unpinning now works for waves you can access even when you are not the wave owner.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed shared-wave pin and unpin requests so they update your per-user state without requiring wave ownership"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-search-bootstrap-loading-ux",
     "version": "PR #414",
     "date": "2026-03-28",

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/FolderServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/FolderServletTest.java
@@ -1,0 +1,82 @@
+package org.waveprotocol.box.server.rpc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.wave.api.InvalidRequestException;
+import com.google.wave.api.ProtocolVersion;
+import com.google.wave.api.data.converter.EventDataConverter;
+import com.google.wave.api.data.converter.EventDataConverterManager;
+import junit.framework.TestCase;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public class FolderServletTest extends TestCase {
+
+  private static final ParticipantId PARTICIPANT = ParticipantId.ofUnsafe("viewer@example.com");
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "waveid");
+  private static final WaveletId CONVERSATION_ROOT_ID =
+      WaveletId.of("example.com", "conv+root");
+  private static final WaveletName CONVERSATION_ROOT_WAVELET_NAME =
+      WaveletName.of(WAVE_ID, CONVERSATION_ROOT_ID);
+  private static final WaveletId USER_DATA_WAVELET_ID = IdUtil.buildUserDataWaveletId(PARTICIPANT);
+  private static final WaveletName USER_DATA_WAVELET_NAME =
+      WaveletName.of(WAVE_ID, USER_DATA_WAVELET_ID);
+
+  private SessionManager sessionManager;
+  private WaveletProvider waveletProvider;
+  private ConversationUtil conversationUtil;
+  private EventDataConverterManager converterManager;
+  private FolderServlet servlet;
+
+  @Override
+  protected void setUp() throws Exception {
+    sessionManager = mock(SessionManager.class);
+    waveletProvider = mock(WaveletProvider.class);
+    conversationUtil = mock(ConversationUtil.class);
+    converterManager = mock(EventDataConverterManager.class);
+    EventDataConverter converter = mock(EventDataConverter.class);
+
+    when(converterManager.getEventDataConverter(ProtocolVersion.DEFAULT)).thenReturn(converter);
+
+    servlet = new FolderServlet(
+        sessionManager, waveletProvider, conversationUtil, converterManager);
+  }
+
+  public void testSetPinStateAllowsAccessibleWaveWithoutExistingUserDataWavelet() throws Exception {
+    when(waveletProvider.getWaveletIds(WAVE_ID)).thenReturn(ImmutableSet.of(CONVERSATION_ROOT_ID));
+    when(waveletProvider.checkAccessPermission(CONVERSATION_ROOT_WAVELET_NAME, PARTICIPANT))
+        .thenReturn(true);
+    when(waveletProvider.getSnapshot(USER_DATA_WAVELET_NAME)).thenReturn(null);
+
+    servlet.setPinState(WAVE_ID, true, PARTICIPANT);
+
+    verify(waveletProvider).submitRequest(eq(USER_DATA_WAVELET_NAME), any(), any());
+  }
+
+  public void testSetPinStateRejectsInaccessibleWave() throws Exception {
+    when(waveletProvider.getWaveletIds(WAVE_ID)).thenReturn(ImmutableSet.of(CONVERSATION_ROOT_ID));
+    when(waveletProvider.checkAccessPermission(CONVERSATION_ROOT_WAVELET_NAME, PARTICIPANT))
+        .thenReturn(false);
+
+    try {
+      servlet.setPinState(WAVE_ID, true, PARTICIPANT);
+      fail("Expected InvalidRequestException");
+    } catch (InvalidRequestException expected) {
+      assertEquals("Access rejected", expected.getMessage());
+    }
+
+    verify(waveletProvider, never()).submitRequest(eq(USER_DATA_WAVELET_NAME), any(), any());
+  }
+}


### PR DESCRIPTION
## Summary
- authorize FolderServlet pinning against the per-user wave view instead of direct wavelet ownership
- load or synthesize the caller's own user-data wavelet directly for per-user folder state updates
- add a regression test for visible shared waves and update the changelog

## Verification
- sbt 'testOnly org.waveprotocol.box.server.rpc.FolderServletTest org.waveprotocol.box.server.robots.OperationContextImplTest org.waveprotocol.box.server.robots.operations.FetchWaveServiceTest'
- sbt compileGwt
- sbt prepareServerConfig run
- curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9898/healthz
- curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9898/auth/signin
- live browser verification as a non-owner viewer on a shared wave: POST /folder/ with operation=pin => 200, then operation=unpin => 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shared-wave pinning so users can pin/unpin waves they don't own, with correct per-user state updates.
* **Documentation**
  * Added a changelog entry for the "Shared Wave Pinning" release.
* **Tests**
  * Added tests to verify pin/unpin succeeds for accessible waves without existing user-data and is rejected for inaccessible waves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->