### PR TITLE
fix: correct landing page capability copy

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-landing-page-accuracy",
+    "version": "PR #424",
+    "date": "2026-03-28",
+    "title": "Landing Page Accuracy",
+    "summary": "The landing page now reflects the product capabilities that are available today.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed the landing page federation claim until federation is actually supported",
+          "Added landing page messaging for Robot registration and Data API token support"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-direct-messages-stay-explicit",
     "version": "PR #422",
     "date": "2026-03-28",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -1995,8 +1995,8 @@ public final class HtmlRenderer {
     sb.append("          <path d=\"M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z\"/>\n");
     sb.append("        </svg>\n");
     sb.append("      </div>\n");
-    sb.append("      <h3>Open &amp; Federated</h3>\n");
-    sb.append("      <p>Built on an open protocol. Self-host your own server and communicate across federated SupaWave instances.</p>\n");
+    sb.append("      <h3>Robot &amp; Data API</h3>\n");
+    sb.append("      <p>Register robots and mint Data API tokens for integrations, bots, and scripted workflows on your SupaWave server.</p>\n");
     sb.append("    </div>\n");
 
     sb.append("  </div>\n");

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-landing-page-accuracy",
+    "version": "PR #424",
+    "date": "2026-03-28",
+    "title": "Landing Page Accuracy",
+    "summary": "The landing page now reflects the product capabilities that are available today.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed the landing page federation claim until federation is actually supported",
+          "Added landing page messaging for Robot registration and Data API token support"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-direct-messages-stay-explicit",
     "version": "PR #422",
     "date": "2026-03-28",

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
@@ -45,7 +45,7 @@ public final class HtmlRendererChangelogTest {
     assertTrue(html.contains("data.releaseNotesStatus"));
     assertTrue(html.contains("data.releaseNotes || []"));
     assertTrue(!html.contains("data.changelog || null"));
-    assertTrue(html.contains("'/changelog#' + encodeURIComponent(releaseNotes[0].releaseId)"));
+    assertTrue(html.contains("'/changelog#release-' + encodeURIComponent(releaseNotes[0].releaseId)"));
     assertTrue(html.contains("What's New"));
     assertTrue(
         html.contains(
@@ -106,5 +106,15 @@ public final class HtmlRendererChangelogTest {
     assertTrue(landing.contains(".nav-links {"));
     assertTrue(landing.contains("width: 100%;"));
     assertTrue(landing.contains("justify-content: flex-start;"));
+  }
+
+  @Test
+  public void landingPageAdvertisesCurrentApiSupportWithoutFederationClaim() {
+    String landing = HtmlRenderer.renderLandingPage("example.com", "");
+
+    assertTrue(landing.contains("Robot &amp; Data API"));
+    assertTrue(landing.contains("Register robots and mint Data API tokens"));
+    assertFalse(landing.contains("Open &amp; Federated"));
+    assertFalse(landing.contains("federated SupaWave instances"));
   }
 }


### PR DESCRIPTION
## Summary
- replace the landing page federation marketing claim with current Robot/Data API messaging
- add a renderer regression test that blocks federation copy from returning
- add a changelog entry for the user-facing landing page copy correction

## Verification
- `sbt 'testOnly org.waveprotocol.box.server.rpc.HtmlRendererChangelogTest'`\n- `sbt run` with a temporary local-only `config/application.conf` port override to `127.0.0.1:9899`, then:\n  - `curl -sS http://127.0.0.1:9899/ | rg -n "Robot &amp; Data API|Register robots and mint Data API tokens|Open &amp; Federated|federated SupaWave instances|What's New"`\n  - `curl -sS http://127.0.0.1:9899/changelog | rg -n "Landing Page Accuracy|Removed the landing page federation claim|Robot registration and Data API token support"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed federation-related messaging from the landing page pending full support availability.

* **New Features**
  * Updated landing page messaging to highlight Robot registration and Data API token capabilities for integrations and automated workflows.

* **Documentation**
  * Added changelog entry documenting landing page accuracy improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->