### PR TITLE
fix: harden PR review monitoring

### DIFF
--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -63,6 +63,27 @@ const resolveCodeRabbitCompletedAt = (checkRuns, statusNodes = []) => {
   return latestCodeRabbitStatusCompletion(statusNodes);
 };
 
+const unresolvedReviewThreads = (reviewThreads = []) => {
+  return reviewThreads.filter((thread) => {
+    return thread != null &&
+      typeof thread === "object" &&
+      thread.isResolved !== true;
+  });
+};
+
+const summarizeUnresolvedReviewThreads = (reviewThreads = [], limit = 5) => {
+  return unresolvedReviewThreads(reviewThreads)
+    .slice(0, limit)
+    .map((thread) => {
+      const author = thread.comments?.nodes?.[0]?.author?.login ?? "unknown";
+      const path = thread.path ?? "general";
+      const line = thread.line == null ? "" : `:${thread.line}`;
+      const outdated = thread.isOutdated ? " (outdated)" : "";
+      return `${author} ${path}${line}${outdated}`;
+    })
+    .join("; ");
+};
+
 const publishCodexReviewGateHeadStatus = async (github, options) => {
   return github.rest.repos.createCommitStatus({
     owner: options.owner,
@@ -81,5 +102,7 @@ module.exports = {
   latestCodeRabbitCompletion,
   publishCodexReviewGateHeadStatus,
   resolveCodeRabbitCompletedAt,
+  summarizeUnresolvedReviewThreads,
+  unresolvedReviewThreads,
   reviewGracePeriodMs
 };

--- a/.github/scripts/codex-review-gate.test.js
+++ b/.github/scripts/codex-review-gate.test.js
@@ -22,6 +22,8 @@ const {
   latestCodeRabbitCompletion,
   publishCodexReviewGateHeadStatus,
   resolveCodeRabbitCompletedAt,
+  summarizeUnresolvedReviewThreads,
+  unresolvedReviewThreads,
 } = require('./codex-review-gate');
 
 test('latestCodeRabbitCompletion ignores nullish check runs', () => {
@@ -80,6 +82,64 @@ test('resolveCodeRabbitCompletedAt uses GraphQL check run timestamp when availab
   );
 
   assert.equal(result, Date.parse('2026-03-27T17:14:10Z'));
+});
+
+test('unresolvedReviewThreads keeps outdated unresolved threads and drops resolved threads', () => {
+  const result = unresolvedReviewThreads([
+    { isResolved: true, isOutdated: false },
+    { isResolved: false, isOutdated: false },
+    { isResolved: false, isOutdated: true }
+  ]);
+
+  assert.deepEqual(result, [
+    { isResolved: false, isOutdated: false },
+    { isResolved: false, isOutdated: true }
+  ]);
+});
+
+test('summarizeUnresolvedReviewThreads formats author, path, line, and outdated marker', () => {
+  const result = summarizeUnresolvedReviewThreads([
+    {
+      isResolved: false,
+      isOutdated: true,
+      path: '.github/workflows/codex-review-gate.yml',
+      line: 212,
+      comments: {
+        nodes: [
+          {
+            author: {
+              login: 'coderabbitai'
+            }
+          }
+        ]
+      }
+    },
+    {
+      isResolved: true,
+      path: 'ignored.md',
+      line: 99,
+      comments: {
+        nodes: [
+          {
+            author: {
+              login: 'ignored'
+            }
+          }
+        ]
+      }
+    },
+    {
+      isResolved: false,
+      comments: {
+        nodes: []
+      }
+    }
+  ]);
+
+  assert.equal(
+    result,
+    'coderabbitai .github/workflows/codex-review-gate.yml:212 (outdated); unknown general'
+  );
 });
 
 test('publishCodexReviewGateHeadStatus writes a success status on the PR head', async () => {

--- a/.github/workflows/codex-review-gate.yml
+++ b/.github/workflows/codex-review-gate.yml
@@ -49,6 +49,7 @@ jobs:
             const {
               isCodexReactionLogin,
               resolveCodeRabbitCompletedAt,
+              unresolvedReviewThreads,
               reviewGracePeriodMs
             } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/codex-review-gate`);
 
@@ -56,6 +57,11 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                      }
+                    }
                     commits(last: 1) {
                       nodes {
                         commit {
@@ -116,6 +122,13 @@ jobs:
                 repo,
                 number: pullRequest.number
               });
+              const unresolvedThreads = unresolvedReviewThreads(
+                statusResult.repository.pullRequest.reviewThreads.nodes
+              );
+              if (unresolvedThreads.length > 0) {
+                core.info(`Skipping PR #${pullRequest.number}; unresolved review threads remain`);
+                continue;
+              }
               const statusNodes =
                 statusResult.repository.pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? [];
 
@@ -215,6 +228,8 @@ jobs:
               isCodexReactionLogin,
               publishCodexReviewGateHeadStatus,
               resolveCodeRabbitCompletedAt,
+              summarizeUnresolvedReviewThreads,
+              unresolvedReviewThreads,
               reviewGracePeriodMs
             } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/codex-review-gate`);
 
@@ -224,6 +239,21 @@ jobs:
                   pullRequest(number: $number) {
                     isDraft
                     headRefOid
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        isOutdated
+                        path
+                        line
+                        comments(first: 1) {
+                          nodes {
+                            author {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
                     labels(first: 100) {
                       nodes { name }
                     }
@@ -269,6 +299,15 @@ jobs:
 
             if (pullRequest.isDraft) {
               core.setFailed("Draft PRs cannot pass Codex Review Gate");
+              return;
+            }
+
+            const unresolvedThreads = unresolvedReviewThreads(pullRequest.reviewThreads.nodes);
+            if (unresolvedThreads.length > 0) {
+              const unresolvedSummary = summarizeUnresolvedReviewThreads(unresolvedThreads);
+              core.setFailed(
+                "Unresolved review threads remain: " + unresolvedSummary
+              );
               return;
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,11 @@ git worktrees.
 - Keep that check narrow and relevant: boot the app and hit a local health or
   auth endpoint for server/runtime changes, or exercise the affected UI against
   the local server for client changes.
+- Before merge, clear review conversations by actually addressing them. Nitpicks
+  need an explicit fix or reply; they are not silently ignorable.
+- Do not resolve review threads just to bypass monitoring or branch protection.
+  If a thread is already addressed, reply with the fix commit or technical
+  reasoning before resolving it.
 - When implementation is complete and review is resolved, create a pull request
   from the reviewed worktree.
 - Keep Beads, commits, and PRs aligned so the task status is always traceable.

--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -1,7 +1,7 @@
 # Orchestrator Context — incubator-wave
 
 Status: Living document — updated by orchestrator thread
-Last updated: 2026-03-22
+Last updated: 2026-03-28
 
 Purpose:
 - preserve architecture, conventions, decisions, fragile areas, and current lane state across context compaction
@@ -240,6 +240,9 @@ sbt run                        # Run dev server on :9898
   - `codex-reviewed` label
   - Codex PR-level `+1` reaction after the latest successful current-head CodeRabbit completion
   - automatic pass 5 minutes after the latest successful current-head CodeRabbit completion if Codex stays silent and no newer commit exists
+- PR requires one valid bot-review signal and zero unresolved review threads
+- Nitpicks are not optional by default; they need a fix or a reply that explains why no change is needed
+- Do not resolve review threads just to satisfy the gate; leave an explicit reply before resolving an already-addressed thread
 - Commits reference Beads task IDs
 
 ## Critical Decisions Already Made
@@ -276,6 +279,9 @@ sbt run                        # Run dev server on :9898
   - `CodeRabbit`
   - resolved review conversations
 - The review gate auto-reevaluates on PR/review/comment events and on a 5-minute schedule fallback that posts the same `/codex-review-gate` trigger comment from the default-branch workflow
+- The review gate must fail while any review thread remains unresolved, including nitpicks and bot-authored comments
+- Monitor lanes must inspect thread state directly, not infer review cleanliness from labels, mergeability, or CI alone
+- A resolved thread still needs evidence of handling: either a fix commit or a reply explaining the disposition
 - For current policy, one valid review signal is enough, not both bots
 
 ## Known Fragile Areas

--- a/prompts/monitoring/pr-monitor.md
+++ b/prompts/monitoring/pr-monitor.md
@@ -23,12 +23,17 @@ Search for open PRs authored by me and PRs where review is requested, across all
 - Stuck/pending > 30min → re-run
 
 ### b. Review threads
-- Unresolved threads → fix code if valid, reply + resolve via GraphQL if already addressed
-- Resolve ALL threads: inline, out-of-diff, P1/P2, chatgpt-codex-connector, coderabbitai
+- Inspect thread-aware state with GraphQL, not flat PR comments
+- Unresolved threads → fix code if valid, or reply with technical reasoning if no code change is needed
+- Treat ALL threads as required work: inline, out-of-diff, P1/P2, nitpicks, chatgpt-codex-connector, coderabbitai
+- Never resolve a thread just to clear the gate
+- Only resolve after the fix is pushed or after posting the reply that explains why no code change is needed
+- If a thread was already addressed by a commit, reply with the commit SHA or exact explanation before resolving it
+- Before merge, inspect recently resolved threads too; a bare resolution with no reply or fix is not an acceptable disposition
 - GraphQL resolve: `mutation { resolveReviewThread(input: {threadId: "ID"}) { thread { isResolved } } }`
 
 ### c. Merge readiness
-- All checks pass + no conflicts + no unresolved threads + latest commit age > 5 min → merge
+- All checks pass + no conflicts + no unresolved threads + every nitpick has an explicit disposition + latest commit older than 5 minutes → merge
 - incubator-wave: `--merge`, tube2web/tubescribes/slides-lab: `--squash`
 - Enable auto-merge: `gh pr merge NUM -R repo --merge --auto`
 
@@ -47,6 +52,7 @@ Check all monitored repos for open issues. Spawn background agents to fix action
 ## 4. Codex Review Gate handling
 - Monitor PRs every ~3 minutes so review-state changes are noticed quickly even though the Actions schedule fallback only runs every 5 minutes.
 - Gate baseline is the latest qualifying **CodeRabbit completion on the current head**, not `prUpdatedAt` and not the latest commit timestamp alone.
+- Gate must stay red while any review thread is unresolved, including nitpicks.
 - After CodeRabbit completes on the current head:
   - if no further code changes are needed, add a PR-level `+1` reaction from Codex immediately
   - then re-run the gate via a PR comment containing `/codex-review-gate`
@@ -107,4 +113,3 @@ Check all monitored repos for open issues. Spawn background agents to fix action
 2. Keep the 5-minute Codex thumbs-up grace period aligned with the workflow
 3. TODO: Enable GitHub merge queue to eliminate BEHIND cascade
 4. TODO: Configure chatgpt-codex-connector to skip merge commits
-5. TODO: Auto-resolve P2/informational threads that don't need code changes


### PR DESCRIPTION
## Summary
- fail the Codex review gate while any review thread is still unresolved
- tighten monitor guidance so nitpicks need an explicit fix or reply
- document that threads must not be resolved just to bypass the gate

## Root cause
PR #419 merged with an unresolved Codex review thread. The existing gate only checked review labels, CodeRabbit state, and a grace-period timer; it did not inspect unresolved review threads, so a conversation-clean failure could still look green.

## Verification
- `git diff --check`
- YAML parse of `.github/workflows/codex-review-gate.yml` with `python3` + `yaml.safe_load(...)`
