### PR TITLE
fix: recover cleanly from deploy-time reconnects

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java
@@ -20,6 +20,10 @@
 package org.waveprotocol.box.webclient.client;
 
 import org.waveprotocol.box.common.comms.ProtocolWaveletUpdate;
+import org.waveprotocol.wave.client.events.ClientEvents;
+import org.waveprotocol.wave.client.events.NetworkStatusEvent;
+import org.waveprotocol.wave.client.events.NetworkStatusEvent.ConnectionStatus;
+import org.waveprotocol.wave.client.events.NetworkStatusEventHandler;
 import org.waveprotocol.box.common.comms.jso.ProtocolOpenRequestJsoImpl;
 import org.waveprotocol.box.common.comms.jso.ProtocolSubmitRequestJsoImpl;
 import org.waveprotocol.wave.model.id.IdFilter;
@@ -70,12 +74,29 @@ public final class RemoteViewServiceMultiplexer implements WaveWebSocketCallback
   public RemoteViewServiceMultiplexer(WaveWebSocketClient socket, String userId) {
     this.socket = socket;
     this.userId = userId;
+    ClientEvents.get().addNetworkStatusEventHandler(new NetworkStatusEventHandler() {
+      @Override
+      public void onNetworkStatus(NetworkStatusEvent event) {
+        handleConnectionStatus(event.getStatus());
+      }
+    });
 
     // Note: Currently, the client's communication stack (websocket) is opened
     // too early, before an identity is established. Once that is fixed, this
     // object will be registered as a callback when the websocket is opened,
     // rather than afterwards here.
     socket.attachHandler(this);
+  }
+
+  void handleConnectionStatus(ConnectionStatus status) {
+    if (status == ConnectionStatus.DISCONNECTED
+        || status == ConnectionStatus.NEVER_CONNECTED) {
+      resetKnownChannels();
+    }
+  }
+
+  void resetKnownChannels() {
+    channelTracker.clear();
   }
 
   /** Dispatches an update to the appropriate wave stream. */

--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/WaveStreamChannelTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/WaveStreamChannelTracker.java
@@ -28,6 +28,10 @@ public final class WaveStreamChannelTracker {
 
   private final Map<WaveId, String> knownChannels = CollectionUtils.newHashMap();
 
+  public void clear() {
+    knownChannels.clear();
+  }
+
   public void onStreamOpened(WaveId waveId) {
     knownChannels.remove(waveId);
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveStreamChannelTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveStreamChannelTrackerTest.java
@@ -52,4 +52,17 @@ public final class WaveStreamChannelTrackerTest {
     assertFalse(tracker.shouldDropUpdate(waveId, null));
     assertFalse(tracker.shouldDropUpdate(waveId, "channel-2"));
   }
+
+  @Test
+  public void acceptsNewChannelIdAfterTrackerClearsAllKnownChannels() {
+    WaveStreamChannelTracker tracker = new WaveStreamChannelTracker();
+    WaveId waveId = WaveId.of("example.com", "w+saved-state");
+
+    assertFalse(tracker.shouldDropUpdate(waveId, "channel-1"));
+    assertTrue(tracker.shouldDropUpdate(waveId, "channel-2"));
+
+    tracker.clear();
+
+    assertFalse(tracker.shouldDropUpdate(waveId, "channel-2"));
+  }
 }


### PR DESCRIPTION
## Summary
- clear stale client channel ids when the websocket disconnects so reconnect can accept the next server channel assignment
- keep the fix scoped to the client transport seam and add a changelog entry for deploy-time recovery behavior
- record the investigation plan plus Beads traceability for this reconnect regression lane

## Root cause
Deploy restarts create a short real availability gap: websocket failures and transient `/search` 503 responses are expected during the restart window. The recovery bug was client-side: `RemoteViewServiceMultiplexer` kept `knownChannels` across websocket disconnects, so the first post-reconnect update could be treated as stale and dropped.

## Verification
- `sbt compileGwt`
- `git diff --check`
- `sbt run` then `curl http://127.0.0.1:9898/healthz`
- `sbt run` then `curl -I http://127.0.0.1:9898/`
- Playwright load of `http://127.0.0.1:9898/` confirmed the landing page title `SupaWave - Real-time Collaborative Communication`

## Notes
- The current SBT test graph excludes `org.waveprotocol.box.webclient` sources from normal/Jakarta test compilation, so this lane used `compileGwt` plus local runtime sanity instead of a non-runnable unit test stub.
- External implementation review passed; the follow-up is to add a real automated reconnect regression lane for webclient transport behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset stale websocket channel routing on disconnect so clients resume receiving updates after reconnect.

* **Tests**
  * Added a focused regression test to validate post-reconnect delivery of channel-bearing updates.

* **Documentation**
  * Added a deploy-time plan documenting the reconnect regression, test commands, and follow-up checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->