### PR TITLE
fix: clear stale save warning state

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-save-status-reliability",
+    "version": "PR #432",
+    "date": "2026-03-28",
+    "title": "Save Status Reliability",
+    "summary": "Save warnings now clear more reliably after reconnects and wavelet resets.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a case where the saving indicator could stay yellow and keep showing the slow-save warning after a disconnected wavelet was replaced."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-link-affordance",
     "version": "PR #433",
     "date": "2026-03-28",

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/webclient/client/WaveletSavingStateTrackerTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/webclient/client/WaveletSavingStateTrackerTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.webclient.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.waveprotocol.wave.concurrencycontrol.common.UnsavedDataListener;
+import org.waveprotocol.wave.concurrencycontrol.common.WaveletSavingStateTracker;
+import org.waveprotocol.wave.model.id.WaveletId;
+
+public final class WaveletSavingStateTrackerTest {
+
+  private static final WaveletId WAVELET_ID_1 = WaveletId.of("example.com", "conv+1");
+  private static final WaveletId WAVELET_ID_2 = WaveletId.of("example.com", "conv+2");
+
+  @Test
+  public void keepsUnsavedStateWhileAnotherWaveletIsStillDirty() {
+    RecordingStateListener stateListener = new RecordingStateListener();
+    WaveletSavingStateTracker tracker = new WaveletSavingStateTracker(stateListener);
+    UnsavedDataListener listener1 = tracker.create(WAVELET_ID_1);
+    UnsavedDataListener listener2 = tracker.create(WAVELET_ID_2);
+
+    listener1.onUpdate(new FakeUnsavedDataInfo(1));
+    listener2.onUpdate(new FakeUnsavedDataInfo(0));
+
+    assertTrue(tracker.hasUnsavedData());
+    assertEquals(Arrays.asList(Boolean.TRUE), stateListener.states);
+  }
+
+  @Test
+  public void clearsClosedDirtyWaveletImmediately() {
+    RecordingStateListener stateListener = new RecordingStateListener();
+    WaveletSavingStateTracker tracker = new WaveletSavingStateTracker(stateListener);
+    UnsavedDataListener listener = tracker.create(WAVELET_ID_1);
+
+    listener.onUpdate(new FakeUnsavedDataInfo(1));
+    listener.onClose(false);
+
+    assertFalse(tracker.hasUnsavedData());
+    assertEquals(Arrays.asList(Boolean.TRUE, Boolean.FALSE), stateListener.states);
+  }
+
+  private static final class RecordingStateListener
+      implements WaveletSavingStateTracker.OverallStateListener {
+
+    private final List<Boolean> states = new ArrayList<Boolean>();
+
+    @Override
+    public void onStateChanged(boolean hasUnsavedData) {
+      states.add(hasUnsavedData);
+    }
+  }
+
+  private static final class FakeUnsavedDataInfo implements UnsavedDataListener.UnsavedDataInfo {
+    private final int unacknowledgedSize;
+
+    private FakeUnsavedDataInfo(int unacknowledgedSize) {
+      this.unacknowledgedSize = unacknowledgedSize;
+    }
+
+    @Override
+    public int inFlightSize() {
+      return unacknowledgedSize;
+    }
+
+    @Override
+    public int estimateUnacknowledgedSize() {
+      return unacknowledgedSize;
+    }
+
+    @Override
+    public int estimateUncommittedSize() {
+      return unacknowledgedSize;
+    }
+
+    @Override
+    public long laskAckVersion() {
+      return 0L;
+    }
+
+    @Override
+    public long lastCommitVersion() {
+      return 0L;
+    }
+
+    @Override
+    public String getInfo() {
+      return "unacknowledged=" + unacknowledgedSize;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/SavedStateIndicator.java
@@ -28,6 +28,9 @@ import org.waveprotocol.wave.client.scheduler.SchedulerInstance;
 import org.waveprotocol.wave.client.scheduler.TimerService;
 import org.waveprotocol.wave.client.widget.toast.ToastNotification;
 import org.waveprotocol.wave.concurrencycontrol.common.UnsavedDataListener;
+import org.waveprotocol.wave.concurrencycontrol.common.UnsavedDataListenerFactory;
+import org.waveprotocol.wave.concurrencycontrol.common.WaveletSavingStateTracker;
+import org.waveprotocol.wave.model.id.WaveletId;
 
 import java.util.logging.Logger;
 
@@ -43,7 +46,7 @@ import java.util.logging.Logger;
  * @author danilatos@google.com (Daniel Danilatos)
  * @author yurize@apache.org (Yuri Zelikov)
  */
-public class SavedStateIndicator implements UnsavedDataListener {
+public class SavedStateIndicator implements UnsavedDataListener, UnsavedDataListenerFactory {
 
   private static final Logger LOG = Logger.getLogger(SavedStateIndicator.class.getName());
   private static final SavedStateMessages messages = GWT.create(SavedStateMessages.class);
@@ -66,6 +69,8 @@ public class SavedStateIndicator implements UnsavedDataListener {
 
   /** Persistent-toast id so we can dismiss the correct one. */
   private static final String UNSAVED_TOAST_ID = "unsaved-slow";
+  private static final WaveletId DEFAULT_WAVELET_ID =
+      WaveletId.of("example.com", "conv+saved-state");
 
   private final Scheduler.Task updateTask = new Scheduler.Task() {
     @Override
@@ -90,6 +95,8 @@ public class SavedStateIndicator implements UnsavedDataListener {
 
   private final Element element;
   private final TimerService scheduler;
+  private final WaveletSavingStateTracker stateTracker;
+  private final UnsavedDataListener defaultListener;
 
   private SavedState visibleSavedState = SavedState.SAVED;
   private SavedState currentSavedState = SavedState.SAVED;
@@ -126,6 +133,15 @@ public class SavedStateIndicator implements UnsavedDataListener {
       LOG.warning("SavedStateIndicator: element is null, indicator will not display");
     }
     this.scheduler = SchedulerInstance.getLowPriorityTimer();
+    this.stateTracker = new WaveletSavingStateTracker(
+        new WaveletSavingStateTracker.OverallStateListener() {
+          @Override
+          public void onStateChanged(boolean hasUnsavedData) {
+            setSavedState(hasUnsavedData ? SavedState.UNSAVED : SavedState.SAVED);
+            maybeUpdateDisplay();
+          }
+        });
+    this.defaultListener = stateTracker.create(DEFAULT_WAVELET_ID);
     // Initial display is already correct (SAVED), no need to schedule immediate update.
   }
 
@@ -171,22 +187,22 @@ public class SavedStateIndicator implements UnsavedDataListener {
 
   @Override
   public void onUpdate(UnsavedDataInfo unsavedDataInfo) {
-    if (unsavedDataInfo.estimateUnacknowledgedSize() != 0) {
-      setSavedState(SavedState.UNSAVED);
-    } else {
-      setSavedState(SavedState.SAVED);
-    }
-    maybeUpdateDisplay();
+    defaultListener.onUpdate(unsavedDataInfo);
   }
 
   @Override
   public void onClose(boolean everythingCommitted) {
-    if (everythingCommitted) {
-      setSavedState(SavedState.SAVED);
-    } else {
-      setSavedState(SavedState.UNSAVED);
-    }
-    maybeUpdateDisplay();
+    defaultListener.onClose(everythingCommitted);
+  }
+
+  @Override
+  public UnsavedDataListener create(WaveletId waveletId) {
+    return stateTracker.create(waveletId);
+  }
+
+  @Override
+  public void destroy(WaveletId waveletId) {
+    stateTracker.destroy(waveletId);
   }
 
   // ---- Unsaved-warning timer management ----

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
@@ -580,19 +580,22 @@ public interface StageTwo {
                     .build();
 
             ViewChannelFactory viewFactory = ViewChannelImpl.factory(createWaveViewService(), logger);
-            UnsavedDataListenerFactory unsyncedListeners = new UnsavedDataListenerFactory() {
+            UnsavedDataListenerFactory unsyncedListeners =
+                unsavedDataListener instanceof UnsavedDataListenerFactory
+                    ? (UnsavedDataListenerFactory) unsavedDataListener
+                    : new UnsavedDataListenerFactory() {
 
-                private final UnsavedDataListener listener = unsavedDataListener;
+                        private final UnsavedDataListener listener = unsavedDataListener;
 
-                @Override
-                public UnsavedDataListener create(WaveletId waveletId) {
-                    return listener;
-                }
+                        @Override
+                        public UnsavedDataListener create(WaveletId waveletId) {
+                            return listener;
+                        }
 
-                @Override
-                public void destroy(WaveletId waveletId) {
-                }
-            };
+                        @Override
+                        public void destroy(WaveletId waveletId) {
+                        }
+                    };
 
             WaveletId udwId = getIdGenerator().newUserDataWaveletId(getSignedInUser().getAddress());
             final IdFilter filter = IdFilter.of(Collections.singleton(udwId),

--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/common/WaveletSavingStateTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/common/WaveletSavingStateTracker.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.concurrencycontrol.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.waveprotocol.wave.model.id.WaveletId;
+
+public final class WaveletSavingStateTracker implements UnsavedDataListenerFactory {
+
+  public interface OverallStateListener {
+    void onStateChanged(boolean hasUnsavedData);
+  }
+
+  private final Map<WaveletId, Boolean> waveletStates = new HashMap<WaveletId, Boolean>();
+  private final OverallStateListener stateListener;
+
+  private boolean hasUnsavedData;
+
+  public WaveletSavingStateTracker(OverallStateListener stateListener) {
+    this.stateListener = stateListener;
+  }
+
+  @Override
+  public UnsavedDataListener create(final WaveletId waveletId) {
+    return new UnsavedDataListener() {
+      @Override
+      public void onUpdate(UnsavedDataInfo unsavedDataInfo) {
+        updateWaveletState(waveletId, unsavedDataInfo.estimateUnacknowledgedSize() != 0);
+      }
+
+      @Override
+      public void onClose(boolean everythingCommitted) {
+        clearWaveletState(waveletId);
+      }
+    };
+  }
+
+  @Override
+  public void destroy(WaveletId waveletId) {
+    clearWaveletState(waveletId);
+  }
+
+  public boolean hasUnsavedData() {
+    return hasUnsavedData;
+  }
+
+  private void updateWaveletState(WaveletId waveletId, boolean waveletHasUnsavedData) {
+    waveletStates.put(waveletId, waveletHasUnsavedData);
+    notifyIfChanged();
+  }
+
+  private void clearWaveletState(WaveletId waveletId) {
+    waveletStates.remove(waveletId);
+    notifyIfChanged();
+  }
+
+  private void notifyIfChanged() {
+    boolean nextHasUnsavedData = false;
+
+    for (Boolean waveletHasUnsavedData : waveletStates.values()) {
+      if (waveletHasUnsavedData.booleanValue()) {
+        nextHasUnsavedData = true;
+        break;
+      }
+    }
+
+    if (hasUnsavedData != nextHasUnsavedData) {
+      hasUnsavedData = nextHasUnsavedData;
+      stateListener.onStateChanged(hasUnsavedData);
+      return;
+    }
+
+    hasUnsavedData = nextHasUnsavedData;
+  }
+}

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-save-status-reliability",
+    "version": "PR #432",
+    "date": "2026-03-28",
+    "title": "Save Status Reliability",
+    "summary": "Save warnings now clear more reliably after reconnects and wavelet resets.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a case where the saving indicator could stay yellow and keep showing the slow-save warning after a disconnected wavelet was replaced."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-link-affordance",
     "version": "PR #433",
     "date": "2026-03-28",


### PR DESCRIPTION
## Summary
- aggregate save-state updates per wavelet instead of letting one shared listener overwrite global state
- clear stale disconnected wavelet state when the old wavelet listener is destroyed during replacement
- add a regression test for the stale close/destroy case and record the user-facing changelog entry

## Verification
- sbt 'JakartaTest / testOnly org.waveprotocol.box.webclient.client.WaveletSavingStateTrackerTest'\n- booted local server and verified `GET /`, `GET /healthz`, and `GET /auth/signin` all returned 200/302 as expected\n\n## Notes\n- `./scripts/wave-smoke-ui.sh` still reports `/webclient/webclient.nocache.js` as 404 in the current SBT dev layout, so it was not used as the gating sanity check for this lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save-status indicator reliability: fixed an issue where the saving indicator could remain yellow and continue showing the slow-save warning after a disconnected wavelet was replaced.

* **Documentation**
  * Added a release note entry titled "Save Status Reliability" describing the fix.

* **Tests**
  * Added unit tests covering aggregate and per-item save-state tracking and lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->