### PR TITLE
Fix default link affordance in wave content

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-link-affordance",
+    "version": "PR #433",
+    "date": "2026-03-28",
+    "title": "Clearer Link Styling",
+    "summary": "Links in wave content now look clickable before hover.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored visible underlines for links inside wave content while keeping the existing Supawave link colors"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-profile-last-seen",
     "version": "PR #423",
     "date": "2026-03-28",

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-link-affordance",
+    "version": "PR #433",
+    "date": "2026-03-28",
+    "title": "Clearer Link Styling",
+    "summary": "Links in wave content now look clickable before hover.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored visible underlines for links inside wave content while keeping the existing Supawave link colors"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-profile-last-seen",
     "version": "PR #423",
     "date": "2026-03-28",

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -253,44 +253,24 @@
 /* ---- Links inside blip content ---- */
 .contentContainer a {
   color: #0077b6;
-  text-decoration: none;
-  position: relative;
+  text-decoration: underline;
+  text-decoration-color: #0077b6;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 0.12em;
   cursor: pointer;
-  transition: color 0.2s ease;
-  -webkit-transition: color 0.2s ease;
-  -moz-transition: color 0.2s ease;
-}
-
-.contentContainer a::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 0;
-  height: 2px;
-  background: linear-gradient(90deg, #0077b6, #00b4d8);
-  transition: width 0.3s ease;
-  -webkit-transition: width 0.3s ease;
-  -moz-transition: width 0.3s ease;
-  border-radius: 1px;
-  -moz-border-radius: 1px;
-  -webkit-border-radius: 1px;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  -webkit-transition: color 0.2s ease, text-decoration-color 0.2s ease;
+  -moz-transition: color 0.2s ease, text-decoration-color 0.2s ease;
 }
 
 .contentContainer a:hover {
   color: #00b4d8;
-}
-
-.contentContainer a:hover::after {
-  width: 100%;
+  text-decoration-color: #00b4d8;
 }
 
 .contentContainer a:visited {
   color: #6b5b95;
-}
-
-.contentContainer a:visited::after {
-  background: linear-gradient(90deg, #6b5b95, #8b7db5);
+  text-decoration-color: #6b5b95;
 }
 
 /* Quasi-deleted / soft-delete state (client-side visual only).


### PR DESCRIPTION
## Summary
- restore visible default underlines for links inside blip content
- keep the existing Supawave link colors for default, hover, and visited states
- add a changelog entry for the user-facing styling fix

## Root cause
`Blip.css` explicitly removed link underlines in `.contentContainer a` and only surfaced a decorative underline via a hover-only `::after` effect. That made hyperlinks read like plain text until pointer hover.

## Verification
- `python3` CSS rule check against `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
- `sbt -Dsbt.global.base=/tmp/link-visibility-sbt-global -Dsbt.boot.directory=/tmp/link-visibility-sbt-boot -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch compileGwt`
- `./scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `sbt -Dsbt.global.base=/tmp/link-visibility-sbt-global -Dsbt.boot.directory=/tmp/link-visibility-sbt-boot -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch run` plus `curl http://127.0.0.1:9898/healthz`
- browser computed-style sanity check on a running local page: default link style resolved to `textDecorationLine: underline`, `cursor: pointer`, and the expected Supawave link color

## Review
- Direct review: no issues found
- External review via `claude-review`: Claude quota was exhausted locally; fallback Gemini review approved the change with no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Links in wave content now show visible underlines by default, making them clearly clickable before hover while keeping existing Supawave link colors intact.
  * Hover and visited states now primarily adjust color and underline color for simpler, more consistent behavior.

* **Chores**
  * Added a changelog entry documenting the clearer link styling update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->