### PR TITLE
fix: prevent reply delete sink-null crash

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-reply-editor-stability",
+    "version": "PR #437",
+    "date": "2026-03-28",
+    "title": "Reply Editor Stability",
+    "summary": "Deleting all text in a new reply no longer crashes the editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Flushed pending editor typing state before detaching a blip editor during reply transitions"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-ai-robot-onboarding",
     "version": "PR #436",
     "date": "2026-03-28",

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
@@ -1573,6 +1573,7 @@ public class EditorImpl extends LogicalPanel.Impl implements
 
   @Override
   public ContentDocument removeContent() {
+    flushSynchronous();
     ContentDocument oldDoc = content;
 
     clearContent();
@@ -1590,6 +1591,7 @@ public class EditorImpl extends LogicalPanel.Impl implements
 
   @Override
   public ContentDocument removeContentAndUnrender() {
+    flushSynchronous();
     ContentDocument oldDoc = content;
 
     clearContent();

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-03-28-reply-editor-stability",
+    "version": "PR #437",
+    "date": "2026-03-28",
+    "title": "Reply Editor Stability",
+    "summary": "Deleting all text in a new reply no longer crashes the editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Flushed pending editor typing state before detaching a blip editor during reply transitions"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-ai-robot-onboarding",
     "version": "PR #436",
     "date": "2026-03-28",


### PR DESCRIPTION
## Summary
- flush pending editor typing before detaching a blip editor from its document
- prevent stale typing extraction from surviving the parent-blip -> reply-editor session switch
- add a changelog entry for the visible reply editor crash fix

## Verification
- `sbt compileGwt`
  - Passed
- `sbt prepareServerConfig run`
  - Local server started on `127.0.0.1:9898`
- Local browser verification against `http://127.0.0.1:9898`
  - signed in as `replydeletebug`
  - created a fresh wave
  - edited a blip, opened a reply, typed reply text, deleted the reply text back to empty
  - observed no page errors and no sink-null console exception

## Notes
- I was able to trace the failure to editor session teardown while pending typing extraction still existed.
- The legacy hosted GWT test surface is not runnable in this lane, so verification here is compile + local server/browser sanity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the reply editor when deleting all text in a new reply, improving editor stability.

* **Documentation**
  * Added a release entry describing the fix and noting that editor typing state is now flushed before reply transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->