### PR TITLE
fix: preserve next unread after deleted blip

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-deleted-blip-next-unread",
+    "version": "PR #438",
+    "date": "2026-03-28",
+    "title": "Deleted Blip Focus Recovery",
+    "summary": "Deleting a reply now preserves unread navigation by moving focus to the next surviving blip or its containing parent.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a crashy unread-navigation case when deleting a blip that still contained the currently focused descendant.",
+          "When a deleted reply has no remaining siblings, focus now falls back to the containing parent blip instead of jumping unpredictably."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-reply-editor-stability",
     "version": "PR #437",
     "date": "2026-03-28",

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java
@@ -39,6 +39,7 @@ import org.waveprotocol.wave.client.wavepanel.view.dom.ModelAsViewProvider;
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.BlipQueueRenderer;
 import org.waveprotocol.wave.model.conversation.Conversation;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
+import org.waveprotocol.wave.model.conversation.ConversationBlipHierarchy;
 import org.waveprotocol.wave.model.conversation.ConversationThread;
 import org.waveprotocol.wave.model.conversation.WaveLockState;
 import org.waveprotocol.wave.model.id.DualIdSerialiser;
@@ -225,31 +226,8 @@ public final class ActionsImpl implements Actions {
 
   @Override
   public void delete(BlipView blipUi) {
-    // If focus is on the blip that is being deleted, move focus somewhere else.
-    // If focus is on a blip inside the blip being deleted, don't worry about it
-    // (checking could get too expensive).
-    BlipView currentlyFocused = (focus != null) ? focus.getFocusedBlip() : null;
-    boolean deletingFocused = (blipUi != null && currentlyFocused != null && blipUi.equals(currentlyFocused));
-    if (deletingFocused) {
-      // Move to next blip in thread if there is one, otherwise previous blip in
-      // thread, otherwise previous blip in traversal order.
-      ThreadView parentUi = (blipUi != null) ? blipUi.getParent() : null;
-      BlipView nextUi = null;
-      if (parentUi != null) {
-        nextUi = parentUi.getBlipAfter(blipUi);
-        if (nextUi == null) {
-          nextUi = parentUi.getBlipBefore(blipUi);
-        }
-      }
-      if (nextUi != null) {
-        if (focus != null) {
-          focus.focus(nextUi);
-        }
-      } else {
-        if (focus != null) {
-          focus.moveUp();
-        }
-      }
+    if (deletingFocusedSubtree(blipUi)) {
+      moveFocusAwayFromDeletedBlip(blipUi);
     }
 
     // When quasi-deletion UI is enabled, defer the actual delete and show an
@@ -258,6 +236,42 @@ public final class ActionsImpl implements Actions {
       UndoableDeleteHelper.softDelete(blipUi, views);
     } else {
       views.getBlip(blipUi).delete();
+    }
+  }
+
+  private boolean deletingFocusedSubtree(BlipView blipUi) {
+    ConversationBlip deletingBlip = blipUi != null ? views.getBlip(blipUi) : null;
+    BlipView focusedBlipUi = focus != null ? focus.getFocusedBlip() : null;
+    ConversationBlip focusedBlip = focusedBlipUi != null ? views.getBlip(focusedBlipUi) : null;
+    return ConversationBlipHierarchy.contains(deletingBlip, focusedBlip);
+  }
+
+  private void moveFocusAwayFromDeletedBlip(BlipView blipUi) {
+    ThreadView parentUi = blipUi != null ? blipUi.getParent() : null;
+    BlipView remainingBlip = null;
+    if (parentUi != null) {
+      remainingBlip = parentUi.getBlipAfter(blipUi);
+      if (remainingBlip == null) {
+        remainingBlip = parentUi.getBlipBefore(blipUi);
+      }
+    }
+    if (remainingBlip != null) {
+      if (focus != null) {
+        focus.focus(remainingBlip);
+      }
+    } else {
+      ConversationBlip deletedBlip = blipUi != null ? views.getBlip(blipUi) : null;
+      ConversationBlip containingBlip = ConversationBlipHierarchy.parentOutside(deletedBlip);
+      BlipView containingBlipUi = containingBlip != null ? views.getBlipView(containingBlip) : null;
+      if (containingBlipUi != null) {
+        if (focus != null) {
+          focus.focus(containingBlipUi);
+        }
+      } else {
+        if (focus != null) {
+          focus.moveUp();
+        }
+      }
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/ConversationBlipHierarchy.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/ConversationBlipHierarchy.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.wave.model.conversation;
+
+public final class ConversationBlipHierarchy {
+
+  private ConversationBlipHierarchy() {
+  }
+
+  public static boolean contains(ConversationBlip ancestor, ConversationBlip blip) {
+    boolean contains = false;
+    ConversationBlip current = blip;
+    while (!contains && current != null && ancestor != null) {
+      contains = ancestor.equals(current);
+      if (!contains) {
+        current = parentBlipOf(current);
+      }
+    }
+    return contains;
+  }
+
+  private static ConversationBlip parentBlipOf(ConversationBlip blip) {
+    ConversationThread thread = blip.getThread();
+    ConversationBlip parent = null;
+    if (thread != null) {
+      parent = thread.getParentBlip();
+    }
+    return parent;
+  }
+
+  public static ConversationBlip parentOutside(ConversationBlip blip) {
+    return blip != null ? parentBlipOf(blip) : null;
+  }
+}

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-03-28-deleted-blip-next-unread",
+    "version": "PR #438",
+    "date": "2026-03-28",
+    "title": "Deleted Blip Focus Recovery",
+    "summary": "Deleting a reply now preserves unread navigation by moving focus to the next surviving blip or its containing parent.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a crashy unread-navigation case when deleting a blip that still contained the currently focused descendant.",
+          "When a deleted reply has no remaining siblings, focus now falls back to the containing parent blip instead of jumping unpredictably."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-reply-editor-stability",
     "version": "PR #437",
     "date": "2026-03-28",

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/ConversationBlipHierarchyTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/ConversationBlipHierarchyTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.wave.model.conversation;
+
+import junit.framework.TestCase;
+
+import org.mockito.Mockito;
+
+public final class ConversationBlipHierarchyTest extends TestCase {
+
+  public void testContainsReturnsTrueForDescendantBlip() {
+    ConversationBlip ancestor = Mockito.mock(ConversationBlip.class);
+    ConversationBlip descendant = Mockito.mock(ConversationBlip.class);
+    ConversationBlip childBlip = Mockito.mock(ConversationBlip.class);
+    ConversationThread descendantThread = Mockito.mock(ConversationThread.class);
+    ConversationThread childThread = Mockito.mock(ConversationThread.class);
+
+    Mockito.when(descendant.getThread()).thenReturn(descendantThread);
+    Mockito.when(descendantThread.getParentBlip()).thenReturn(childBlip);
+    Mockito.when(childBlip.getThread()).thenReturn(childThread);
+    Mockito.when(childThread.getParentBlip()).thenReturn(ancestor);
+
+    assertTrue(ConversationBlipHierarchy.contains(ancestor, descendant));
+  }
+
+  public void testContainsReturnsTrueForSameBlip() {
+    ConversationBlip blip = Mockito.mock(ConversationBlip.class);
+
+    assertTrue(ConversationBlipHierarchy.contains(blip, blip));
+  }
+
+  public void testContainsReturnsFalseForNullBlip() {
+    ConversationBlip ancestor = Mockito.mock(ConversationBlip.class);
+
+    assertFalse(ConversationBlipHierarchy.contains(ancestor, null));
+  }
+
+  public void testContainsReturnsFalseForNullAncestor() {
+    ConversationBlip blip = Mockito.mock(ConversationBlip.class);
+
+    assertFalse(ConversationBlipHierarchy.contains(null, blip));
+  }
+
+  public void testContainsReturnsFalseForUnrelatedBlip() {
+    ConversationBlip ancestor = Mockito.mock(ConversationBlip.class);
+    ConversationBlip unrelated = Mockito.mock(ConversationBlip.class);
+    ConversationThread unrelatedThread = Mockito.mock(ConversationThread.class);
+
+    Mockito.when(unrelated.getThread()).thenReturn(unrelatedThread);
+    Mockito.when(unrelatedThread.getParentBlip()).thenReturn(null);
+
+    assertFalse(ConversationBlipHierarchy.contains(ancestor, unrelated));
+  }
+
+  public void testParentOutsideReturnsNullForNullInput() {
+    assertNull(ConversationBlipHierarchy.parentOutside(null));
+  }
+
+  public void testParentOutsideReturnsContainingBlip() {
+    ConversationBlip containingBlip = Mockito.mock(ConversationBlip.class);
+    ConversationBlip deletedReply = Mockito.mock(ConversationBlip.class);
+    ConversationThread deletedReplyThread = Mockito.mock(ConversationThread.class);
+
+    Mockito.when(deletedReply.getThread()).thenReturn(deletedReplyThread);
+    Mockito.when(deletedReplyThread.getParentBlip()).thenReturn(containingBlip);
+
+    assertSame(containingBlip, ConversationBlipHierarchy.parentOutside(deletedReply));
+  }
+}


### PR DESCRIPTION
## Summary
- move focus away when deleting a blip that contains the currently focused descendant
- fall back to the containing parent blip when the deleted reply has no surviving siblings
- add model-level regression tests for subtree detection and ancestor fallback

## Verification
- sbt "testOnly org.waveprotocol.wave.model.conversation.ConversationBlipHierarchyTest"
- sbt compileGwt
- sbt run
- local browser flow on http://127.0.0.1:9898/?enableNextUnreadBlipInToolbar=true&enableQuasiDeletionUi=true#local.net/w+16mi2rqpvk13fA: reproduced delete-subtree + Next Unread crash before the second fix, then reran after rebuilding and confirmed Next Unread advanced without the error overlay or console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus behavior when deleting a reply so focus moves to the next surviving sibling or falls back to the containing parent, preventing lost focus or crashy unread-navigation scenarios.

* **Tests**
  * Added tests covering blip-hierarchy traversal and the focus-selection logic used when deleting replies.

* **Documentation**
  * Added a release-note entry describing the deletion/unread-navigation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->