### PR TITLE
fix: expose robot secret rotation in dashboard

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -391,6 +391,14 @@ public final class RobotDashboardServlet extends HttpServlet {
           .append("\" name=\"location\" value=\"")
           .append(HtmlRenderer.escapeHtml(robot.getUrl())).append("\">");
       sb.append("<div style=\"margin-top:12px;\"><button type=\"submit\">Save Callback URL</button></div>");
+      sb.append("</form>");
+      sb.append("<form method=\"post\" action=\"\" style=\"margin-top:10px;\">");
+      sb.append("<input type=\"hidden\" name=\"action\" value=\"rotate-secret\">");
+      sb.append("<input type=\"hidden\" name=\"token\" value=\"")
+          .append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
+      sb.append("<input type=\"hidden\" name=\"robotId\" value=\"")
+          .append(HtmlRenderer.escapeHtml(robot.getId().getAddress())).append("\">");
+      sb.append("<div style=\"margin-top:12px;\"><button type=\"submit\">Rotate Secret</button></div>");
       sb.append("</form></div>");
     }
     if (robots.isEmpty()) {

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -93,6 +93,18 @@ public class RobotDashboardServletTest extends TestCase {
     assertTrue(outputWriter.toString().contains("SUPAWAVE_DATA_API_TOKEN"));
   }
 
+  public void testDoGetRendersRotateSecretControlForOwnedRobot() throws Exception {
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(
+        new RobotAccountDataImpl(ROBOT, "https://robot.example.com/callback", "secret", null,
+            true, 3600L, OWNER.getAddress())));
+
+    servlet.doGet(req, resp);
+
+    assertTrue(outputWriter.toString().contains("action\" value=\"rotate-secret\""));
+    assertTrue(outputWriter.toString().contains("Rotate Secret"));
+  }
+
   public void testDoGetUsesTrustedRequestOriginInAiPrompt() throws Exception {
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());


### PR DESCRIPTION
## Summary
Audit follow-up for merged PR review gaps.

This fixes the still-live missed review finding from PR #431:
- unresolved comment: https://github.com/vega113/incubator-wave/pull/431#discussion_r3004799253
- finding: the dashboard implemented `action=rotate-secret` server-side but rendered no UI control to trigger it

## Changes
- add a visible `Rotate Secret` form/button for each owned robot in `RobotDashboardServlet`
- add a servlet test proving the control is rendered for owned robots

## Verification
- `sbt "testOnly org.waveprotocol.box.server.robots.RobotDashboardServletTest"`
- local server sanity: booted with `sbt run`, then verified `GET /healthz -> 200`, `HEAD /account/robots -> 302`, `GET /auth/signin -> 200`

## Review
- external review via Gemini completed with no blockers
- note: a confirmation-dialog suggestion was not applied because this repo explicitly forbids `alert`/`confirm`/`prompt` browser popups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Rotate Secret" button to the robot dashboard, allowing users to rotate their robot credentials directly from the dashboard interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->