### PR TITLE
fix: trust IPv6 loopback in robot dashboard URLs

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -493,7 +493,9 @@ public final class RobotDashboardServlet extends HttpServlet {
     String normalizedHost = host;
     if (normalizedHost.startsWith("[")) {
       int closingBracket = normalizedHost.indexOf(']');
-      if (closingBracket > 0) {
+      if (closingBracket > 0
+          && (closingBracket == normalizedHost.length() - 1
+              || normalizedHost.charAt(closingBracket + 1) == ':')) {
         normalizedHost = normalizedHost.substring(1, closingBracket);
       }
     } else {

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -129,6 +129,18 @@ public class RobotDashboardServletTest extends TestCase {
     assertTrue(outputWriter.toString().contains("SUPAWAVE_API_DOCS_URL=http://[::1]:9898/api-docs"));
   }
 
+  public void testDoGetRejectsMalformedBracketedIpv6OriginInAiPrompt() throws Exception {
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+    when(req.getScheme()).thenReturn("http");
+    when(req.getHeader("X-Forwarded-Host")).thenReturn("[::1]evil.example");
+
+    servlet.doGet(req, resp);
+
+    assertTrue(outputWriter.toString().contains("SUPAWAVE_BASE_URL=https://example.com"));
+    assertTrue(outputWriter.toString().contains("SUPAWAVE_API_DOCS_URL=https://example.com/api-docs"));
+  }
+
   public void testDoPostRejectsCallbackUpdateFromDifferentOwner() throws Exception {
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());


### PR DESCRIPTION
## Summary
Audit follow-up for merged PR review gaps.

This fixes the still-live missed review finding from PR #436:
- unresolved comment: https://github.com/vega113/incubator-wave/pull/436#discussion_r3004742508
- finding: bracketed IPv6 loopback hosts such as `[::1]:9898` were treated as untrusted, so the dashboard prompt generated the wrong SupaWave URLs during local IPv6 onboarding

## Changes
- normalize bracketed IPv6 hostnames before the dashboard trust check
- keep loopback IPv6 (`::1`) in the trusted-host set
- add a servlet test covering the bracketed IPv6 prompt URL path

## Verification
- `sbt "testOnly org.waveprotocol.box.server.robots.RobotDashboardServletTest"`
- local server sanity: booted with `sbt run`, then verified `GET /healthz -> 200`, `HEAD /account/robots -> 302`, `GET /auth/signin -> 200`

## Review
- external review via Gemini completed; it suggested extra handling for unbracketed IPv6 literals, but that is outside this fix because valid HTTP `Host` IPv6 literals are bracketed and the current production bug was specific to the bracketed case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host normalization to correctly handle bracketed IPv6 loopback (::1) and ports, preserve original host format in generated URLs when appropriate, and gracefully reject malformed bracketed IPv6 hosts, falling back to the default base URL.

* **Tests**
  * Added tests confirming trusted IPv6 loopback is accepted for generated prompts and that malformed bracketed IPv6 origins are rejected and trigger fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->