### PR TITLE
Fix muted waves disappearing from archive search

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -486,7 +486,7 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
         FolderState folderState = readFolderState(wave, user);
         if (wantInbox && folderState != FolderState.INBOX) {
           it.remove();
-        } else if (!wantInbox && folderState != FolderState.ARCHIVE) {
+        } else if (!wantInbox && folderState == FolderState.INBOX) {
           it.remove();
         }
       } catch (Exception e) {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -264,6 +264,19 @@ public class SimpleSearchProviderImplTest extends TestCase {
         WAVELET_NAME.waveId.serialise(), archiveResults.getDigests().get(0).getWaveId());
   }
 
+  public void testSearchArchiveKeepsMutedWave() throws Exception {
+    submitDeltaToNewWavelet(WAVELET_NAME, USER1, addParticipantToWavelet(USER1, WAVELET_NAME));
+    muteWaveForUser(WAVELET_NAME, USER1);
+
+    SearchResult inboxResults = searchProvider.search(USER1, "in:inbox", 0, 20);
+    SearchResult archiveResults = searchProvider.search(USER1, "in:archive", 0, 20);
+
+    assertEquals(0, inboxResults.getNumResults());
+    assertEquals(1, archiveResults.getNumResults());
+    assertEquals(
+        WAVELET_NAME.waveId.serialise(), archiveResults.getDigests().get(0).getWaveId());
+  }
+
   public void testSearchInboxIncludesWaveAfterArchiveStateCleared() throws Exception {
     submitDeltaToNewWavelet(WAVELET_NAME, USER1, addParticipantToWavelet(USER1, WAVELET_NAME));
     archiveWaveForUser(WAVELET_NAME, USER1);
@@ -788,6 +801,24 @@ public class SimpleSearchProviderImplTest extends TestCase {
   private void archiveWaveForUser(WaveletName name, ParticipantId user) throws Exception {
     long version = waveMap.getOrCreateLocalWavelet(name).copyWaveletData().getVersion();
     archiveWaveForUserWithVersions(name, user, version);
+  }
+
+  private void muteWaveForUser(WaveletName name, ParticipantId user) throws Exception {
+    WaveletOperation muteOperation =
+        new WaveletBlipOperation(
+            WaveletBasedSupplement.MUTED_DOCUMENT,
+            new BlipContentOperation(
+                new WaveletOperationContext(user, 0, 1),
+                new DocOpBuilder()
+                    .elementStart(
+                        WaveletBasedSupplement.MUTED_TAG,
+                        new AttributesImpl(
+                            WaveletBasedSupplement.MUTED_ATTR,
+                            String.valueOf(true)))
+                    .elementEnd()
+                    .build()));
+    submitDeltaToNewWaveletWithoutView(
+        userDataWaveletName(name.waveId, user), user, muteOperation);
   }
 
   private void archiveWaveForUserWithVersions(WaveletName name, ParticipantId user,


### PR DESCRIPTION
Fixes #427.

Muted waves were being filtered out of archive search because the archive branch only kept waves whose folder state was exactly ARCHIVE. That excluded muted waves, even though they should still appear in archive search.

Change:
- Treat archive search as "not inbox" instead of "exactly archive".
- Add a regression test that mutes a wave and confirms it appears in in:archive but not in in:inbox.

Verification:
- sbt -Dsbt.global.base=/tmp/issue-427-sbt-global -Dsbt.boot.directory=/tmp/issue-427-sbt-boot -Dsbt.ivy.home=/Users/vega/.ivy2 -Dcoursier.cache=/Users/vega/devroot/incubator-wave/.coursier-cache -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp -batch "set Test / fork := true" "testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest"
- Result: passed (31 tests, 0 failed)

Commit: 0289e63c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search filtering refined so archive queries retain muted and other non-inbox waves while inbox queries still show only inbox items.

* **Tests**
  * Added a test confirming muted waves are excluded from inbox searches but included in archive searches, validating the corrected filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->