### PR TITLE
[codex] Fix PR #440 robot dashboard review follow-up

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -41,6 +41,8 @@ import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -131,7 +133,17 @@ public final class RobotDashboardServlet extends HttpServlet {
       throws IOException {
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
     if (user == null) {
-      resp.sendRedirect("/auth/signin?r=" + req.getRequestURI());
+      String requestUri = req.getRequestURI();
+      String contextPath = Strings.nullToEmpty(req.getContextPath());
+      String returnTo = requestUri.startsWith(contextPath)
+          ? requestUri.substring(contextPath.length())
+          : requestUri;
+      String queryString = req.getQueryString();
+      if (!Strings.isNullOrEmpty(queryString)) {
+        returnTo = returnTo + "?" + queryString;
+      }
+      resp.sendRedirect(contextPath + "/auth/signin?r="
+          + URLEncoder.encode(returnTo, StandardCharsets.UTF_8.name()));
     }
     return user;
   }
@@ -459,14 +471,26 @@ public final class RobotDashboardServlet extends HttpServlet {
     if (Strings.isNullOrEmpty(host)) {
       host = firstHeaderValue(req.getHeader("Host"));
     }
-    String scheme = firstHeaderValue(req.getHeader("X-Forwarded-Proto"));
-    if (Strings.isNullOrEmpty(scheme)) {
-      scheme = req.getScheme();
-    }
+    String scheme = derivePublicScheme(req, host);
     if (isTrustedPublicHost(host)) {
       return scheme + "://" + host;
     }
     return "https://" + domain;
+  }
+
+  private String derivePublicScheme(HttpServletRequest req, String host) {
+    String forwardedScheme = normalizeScheme(firstHeaderValue(req.getHeader("X-Forwarded-Proto")));
+    if (!Strings.isNullOrEmpty(forwardedScheme)) {
+      return forwardedScheme;
+    }
+    if (!isLocalHost(host)) {
+      return "https";
+    }
+    String requestScheme = normalizeScheme(req.getScheme());
+    if (!Strings.isNullOrEmpty(requestScheme)) {
+      return requestScheme;
+    }
+    return "http";
   }
 
   private String firstHeaderValue(String headerValue) {
@@ -483,10 +507,17 @@ public final class RobotDashboardServlet extends HttpServlet {
       return false;
     }
     String normalizedHost = normalizeHostName(host);
-    return normalizedHost.equalsIgnoreCase(domain)
-        || normalizedHost.equalsIgnoreCase("localhost")
-        || normalizedHost.equals("127.0.0.1")
-        || normalizedHost.equals("::1");
+    return normalizedHost.equalsIgnoreCase(domain) || isLocalHost(normalizedHost);
+  }
+
+  private boolean isLocalHost(String host) {
+    if (Strings.isNullOrEmpty(host)) {
+      return false;
+    }
+    String normalizedHost = normalizeHostName(host);
+    return "localhost".equalsIgnoreCase(normalizedHost)
+        || "127.0.0.1".equals(normalizedHost)
+        || "::1".equals(normalizedHost);
   }
 
   private String normalizeHostName(String host) {
@@ -500,10 +531,20 @@ public final class RobotDashboardServlet extends HttpServlet {
       }
     } else {
       int portSeparator = normalizedHost.indexOf(':');
-      if (portSeparator >= 0) {
+      if (portSeparator >= 0 && normalizedHost.indexOf(':', portSeparator + 1) < 0) {
         normalizedHost = normalizedHost.substring(0, portSeparator);
       }
     }
     return normalizedHost;
+  }
+
+  private String normalizeScheme(String scheme) {
+    if ("http".equalsIgnoreCase(scheme)) {
+      return "http";
+    }
+    if ("https".equalsIgnoreCase(scheme)) {
+      return "https";
+    }
+    return "";
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -76,7 +76,19 @@ public class RobotDashboardServletTest extends TestCase {
 
     servlet.doGet(req, resp);
 
-    verify(resp).sendRedirect("/auth/signin?r=/account/robots");
+    verify(resp).sendRedirect("/auth/signin?r=%2Faccount%2Frobots");
+  }
+
+  public void testDoGetRedirectsLoggedOutUsersBackToCurrentRequestWithinContextPath()
+      throws Exception {
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(null);
+    when(req.getContextPath()).thenReturn("/wave");
+    when(req.getRequestURI()).thenReturn("/wave/account/robots");
+    when(req.getQueryString()).thenReturn("source=menu");
+
+    servlet.doGet(req, resp);
+
+    verify(resp).sendRedirect("/wave/auth/signin?r=%2Faccount%2Frobots%3Fsource%3Dmenu");
   }
 
   public void testDoGetRendersOwnedRobotsAndAiPrompt() throws Exception {
@@ -134,6 +146,19 @@ public class RobotDashboardServletTest extends TestCase {
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
     when(req.getScheme()).thenReturn("http");
     when(req.getHeader("X-Forwarded-Host")).thenReturn("[::1]evil.example");
+
+    servlet.doGet(req, resp);
+
+    assertTrue(outputWriter.toString().contains("SUPAWAVE_BASE_URL=https://example.com"));
+    assertTrue(outputWriter.toString().contains("SUPAWAVE_API_DOCS_URL=https://example.com/api-docs"));
+  }
+
+  public void testDoGetDefaultsPublicPromptUrlsToHttpsWithoutForwardedProto() throws Exception {
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+    when(req.getScheme()).thenReturn("http");
+    when(req.getHeader("Host")).thenReturn("example.com");
+    when(req.getHeader("X-Forwarded-Proto")).thenReturn(null);
 
     servlet.doGet(req, resp);
 


### PR DESCRIPTION
## Summary
- fix the unresolved PR #440 robot dashboard signin redirect follow-up by preserving the context-relative return path and query string
- harden robot dashboard onboarding prompt URL generation so public hosts stay on HTTPS when proxy proto headers are missing
- add focused regression coverage for both missed review seams in `RobotDashboardServletTest`

## Why
PR #440 merged with two unresolved review threads that still warranted follow-up:
- `3004830856` https://github.com/vega113/incubator-wave/pull/440#discussion_r3004830856
  Current `main` still redirected logged-out dashboard requests to a root-relative `/auth/signin` and dropped the query string. Under a non-root context path like `/wave`, that breaks the return flow.
- `3004830857` https://github.com/vega113/incubator-wave/pull/440#discussion_r3004830857
  Current `main` still used the servlet request scheme for trusted public hosts when `X-Forwarded-Proto` was absent, so reverse-proxy HTTP-to-JVM traffic could render `http://<public-host>` onboarding URLs for JWT-bearing docs/prompts.

## Root Cause
- `RobotDashboardServlet.requireUser()` had not adopted the context-path-aware, query-preserving signin redirect logic already used by `RobotRegistrationServlet`.
- `RobotDashboardServlet.derivePublicBaseUrl()` trusted `req.getScheme()` for all trusted hosts instead of defaulting non-local public hosts back to HTTPS unless an explicit normalized forwarded proto was present.

## Validation
- `sbt wave/compile "testOnly org.waveprotocol.box.server.robots.RobotDashboardServletTest"`
- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `sbt prepareServerConfig run`
- `curl -sSI "http://127.0.0.1:9898/account/robots?source=menu"`
  Returned `Location: /auth/signin?r=%2Faccount%2Frobots%3Fsource%3Dmenu`

## Notes
- This follow-up intentionally does not start a PR monitor automatically, per the audit-gap cleanup instruction for this lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unauthenticated user redirect flow with proper URL encoding and context path handling
  * Enhanced public URL scheme derivation to consistently use HTTPS when appropriate
  * Better hostname normalization and local network detection
  * Fixed IPv6-aware port handling

* **Tests**
  * Added test coverage for redirects within custom context paths
  * Added test coverage for HTTPS scheme defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->