### PR TITLE
🧹 Refactor ContextProviders to use DocInitialization directly

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/model/document/util/ContextProviders.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/document/util/ContextProviders.java
@@ -32,6 +32,8 @@ import org.waveprotocol.wave.model.document.indexed.ObservableIndexedDocument;
 import org.waveprotocol.wave.model.document.operation.Attributes;
 import org.waveprotocol.wave.model.document.operation.DocInitialization;
 import org.waveprotocol.wave.model.document.operation.automaton.DocumentSchema;
+import org.waveprotocol.wave.model.document.operation.impl.DocOpUtil;
+import org.waveprotocol.wave.model.document.parser.XmlParseException;
 import org.waveprotocol.wave.model.document.raw.RawDocument;
 import org.waveprotocol.wave.model.document.raw.TextNodeOrganiser;
 import org.waveprotocol.wave.model.document.raw.impl.Element;
@@ -171,10 +173,15 @@ public class ContextProviders {
       final MiscListener miscListener,
       final DocumentSchema schemaConstraints) {
 
+    DocInitialization docInitialization;
+    try {
+      docInitialization = DocOpUtil.docInitializationFromXml(initialInnerXml);
+    } catch (XmlParseException e) {
+      throw new IllegalArgumentException(e);
+    }
+
     return createTestPojoContext(
-        // FIXME(ohler): it's a bit weird that we parse into an IndexedDocument just to
-        // get its asOperation().
-        DocProviders.POJO.parse(initialInnerXml).asOperation(),
+        docInitialization,
         docHandler, annotationSetListener, miscListener, schemaConstraints);
   }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `createTestPojoContext` method in `ContextProviders.java` was parsing an XML string into a full `IndexedDocument` using `DocProviders.POJO.parse`, just to immediately call `asOperation()` on it to extract the `DocInitialization`. This was inefficient and highlighted by a `FIXME` comment.

💡 **Why:** How this improves maintainability
This refactoring avoids the unnecessary creation of a complete POJO document in memory just to extract the operation payload. It uses `DocOpUtil.docInitializationFromXml(initialInnerXml)` directly, which is the exact utility method `IndexedDocProvider.parse` uses internally, resulting in cleaner and more performant code.

✅ **Verification:** How you confirmed the change is safe
Ran the SBT build and test suite (`sbt test`). Verified that the patch cleanly replaces the logic, correctly handles the `XmlParseException` by wrapping it in an `IllegalArgumentException` (preserving the original exception contract for invalid arguments), and compiles successfully. The code review confirmed that the change successfully resolves the technical debt safely without introducing regressions.

✨ **Result:** The improvement achieved
Resolved the `FIXME(ohler)` technical debt and streamlined the testing setup code in `ContextProviders`.

---
*PR created automatically by Jules for task [3617853595103734434](https://jules.google.com/task/3617853595103734434) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling for XML parsing with better exception reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->