### PR TITLE
🧪 Add tests for LogUtils.printObjectAsHtml

### DIFF
--- a/wave/src/test/java/org/waveprotocol/wave/common/logging/LogUtilsTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/common/logging/LogUtilsTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.common.logging;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link LogUtils}.
+ */
+public class LogUtilsTest extends TestCase {
+
+  public void testPrintObjectAsHtmlWithNull() {
+    assertEquals("<span class='object'>null</span>", LogUtils.printObjectAsHtml(null));
+  }
+
+  public void testPrintObjectAsHtmlWithSimpleString() {
+    assertEquals("<span class='object'>hello world</span>", LogUtils.printObjectAsHtml("hello world"));
+  }
+
+  public void testPrintObjectAsHtmlWithEscapedCharacters() {
+    String input = "A & B < C > D \" E ' F";
+    String expected = "<span class='object'>A &amp; B &lt; C &gt; D &quot; E &#39; F</span>";
+    assertEquals(expected, LogUtils.printObjectAsHtml(input));
+  }
+
+  public void testPrintObjectAsHtmlWithCustomObject() {
+    Object customObj = new Object() {
+      @Override
+      public String toString() {
+        return "custom <object>";
+      }
+    };
+    String expected = "<span class='object'>custom &lt;object&gt;</span>";
+    assertEquals(expected, LogUtils.printObjectAsHtml(customObj));
+  }
+}


### PR DESCRIPTION
🎯 **What:** The `LogUtils.printObjectAsHtml` method was missing test coverage. This is a pure function that converts objects to XML escaped strings wrapped in an HTML span, which makes it an ideal candidate for unit testing.
📊 **Coverage:** A new test class `LogUtilsTest` was added to test:
  *   Null inputs
  *   Standard string inputs
  *   String inputs with characters that need HTML escaping (`&`, `<`, `>`, `"`, `'`)
  *   Custom objects that rely on `toString()`
✨ **Result:** Test coverage improved for the `LogUtils` utility class, making future refactoring or changes safer and ensuring robust object-to-html conversion.

---
*PR created automatically by Jules for task [17768047036982297733](https://jules.google.com/task/17768047036982297733) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for HTML output formatting and character escaping functionality.
  * Tests validate proper handling of null inputs, plain text strings, and special characters requiring HTML escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->