### PR TITLE
🧹 [code health] Make RobotName validation stricter

### DIFF
--- a/wave/src/main/java/com/google/wave/api/robot/RobotName.java
+++ b/wave/src/main/java/com/google/wave/api/robot/RobotName.java
@@ -64,10 +64,10 @@ public final class RobotName {
   /**
    * Regular expression for robot participant id. TLD is between 2 and 6
    * characters long to match the ascii IANA top level domains as of Sept 2010.
+   * The local part must start with an alphanumeric character.
    */
-  // TODO(user): Make this stricter.
   private static final Pattern ROBOT_ID_REGEX =
-      Pattern.compile("^[a-z0-9._%+#-]+?@[a-z0-9.-]+\\.[a-z]{2,6}$", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("^[a-z0-9][a-z0-9._%+#-]*@[a-z0-9.-]+\\.[a-z]{2,6}$", Pattern.CASE_INSENSITIVE);
 
   /**
    * Checks if the given address looks like a well-formed robot id.

--- a/wave/src/test/java/com/google/wave/api/robot/RobotNameTest.java
+++ b/wave/src/test/java/com/google/wave/api/robot/RobotNameTest.java
@@ -33,6 +33,10 @@ public class RobotNameTest extends TestCase {
     assertFalse(RobotName.isWellFormedAddress("bar.com"));
     assertFalse(RobotName.isWellFormedAddress("@bar.com"));
     assertFalse(RobotName.isWellFormedAddress("foo@"));
+    assertFalse(RobotName.isWellFormedAddress(".foo@bar.com"));
+    assertFalse(RobotName.isWellFormedAddress("+foo@bar.com"));
+    assertFalse(RobotName.isWellFormedAddress("#foo@bar.com"));
+    assertFalse(RobotName.isWellFormedAddress("_foo@bar.com"));
     assertTrue(RobotName.isWellFormedAddress("foo@bar.com"));
     assertTrue(RobotName.isWellFormedAddress("foo#1@bar.com"));
     assertTrue(RobotName.isWellFormedAddress("foo+wave#1@bar.com"));


### PR DESCRIPTION
🎯 **What:** Made the string validation check for a robot's ID stricter in `RobotName.java`, addressing an existing `TODO`.
💡 **Why:** This improves the maintainability and readability of the codebase by enforcing constraints on valid robot identifiers and explicitly defining expected patterns. The local part of the email address is now required to start with an alphanumeric character instead of allowing addresses starting with `.`, `_`, `%`, `+`, `#`, or `-`, which shouldn't be valid robot ids, while maintaining compatibility with internal structures like `+` for proxy and `#` for version further inside the ID.
✅ **Verification:** Verified that tests pass using `sbt "project wave" "testOnly com.google.wave.api.robot.RobotNameTest"` and the full suite.
✨ **Result:** A stricter and cleaner definition of valid robot IDs with updated test coverage to assert the new behaviors.

---
*PR created automatically by Jules for task [15055408336829430460](https://jules.google.com/task/15055408336829430460) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for robot IDs with stricter requirements. Robot identifiers must now begin with an alphanumeric character; identifiers starting with special characters (such as `.`, `+`, `#`, or `_`) will no longer be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->