### PR TITLE
🧪 Add unit test for LogUtils.stringifyLogObject

### DIFF
--- a/wave/src/test/java/org/waveprotocol/wave/common/logging/LogUtilsTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/common/logging/LogUtilsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.common.logging;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LogUtils}.
+ */
+public class LogUtilsTest {
+
+  @Test
+  public void testStringifyLogObjectWithSingleObject() {
+    String singleObject = "single object";
+    assertEquals("single object", LogUtils.stringifyLogObject(singleObject));
+
+    Integer number = 42;
+    assertEquals("42", LogUtils.stringifyLogObject(number));
+  }
+
+  @Test
+  public void testStringifyLogObjectWithArray() {
+    Object[] array = new Object[]{"hello", " ", "world"};
+    assertEquals("hello world", LogUtils.stringifyLogObject(array));
+
+    Object[] emptyArray = new Object[]{};
+    assertEquals("", LogUtils.stringifyLogObject(emptyArray));
+
+    Object[] mixedArray = new Object[]{"Number: ", 42, ", Boolean: ", true};
+    assertEquals("Number: 42, Boolean: true", LogUtils.stringifyLogObject(mixedArray));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testStringifyLogObjectWithNullThrowsNPE() {
+    LogUtils.stringifyLogObject(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testStringifyLogObjectWithArrayContainingNullsThrowsNPE() {
+    Object[] arrayWithNull = new Object[]{"hello", null, "world"};
+    LogUtils.stringifyLogObject(arrayWithNull);
+  }
+}


### PR DESCRIPTION
🎯 **What:** Added unit test coverage for `LogUtils.stringifyLogObject`.
📊 **Coverage:** Covered all branching logic: single objects, arrays, and null/NPE edge cases.
✨ **Result:** Improved test reliability and caught edge cases where underlying `toString` is called directly.

---
*PR created automatically by Jules for task [2480773048059643231](https://jules.google.com/task/2480773048059643231) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for logging utilities to validate string conversion and array handling with proper null safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->