### PR TITLE
🧪 Add test for BlipContentRefs.all with restriction map

### DIFF
--- a/wave/src/test/java/com/google/wave/api/BlipRobotTest.java
+++ b/wave/src/test/java/com/google/wave/api/BlipRobotTest.java
@@ -127,6 +127,25 @@ public class BlipRobotTest extends TestCase {
     assertEquals("\nHello 5 world!", blip.getContent());
   }
 
+  public void testAllWithRestrictionMap() throws Exception {
+    Blip blip = newBlip(ROOT_BLIP_ID, Arrays.asList(CHILD_BLIP_ID), null);
+    String url1 = "http://www.test.com/image1.png";
+    String url2 = "http://www.test.com/image2.png";
+
+    blip.append(new Image(url1, 100, 100, "Image 1"));
+    blip.append(new Image(url2, 100, 100, "Image 2"));
+
+    Map<String, String> restrictions = new HashMap<String, String>();
+    restrictions.put("url", url2);
+
+    List<BlipContent> result = BlipContentRefs.all(blip, ElementType.IMAGE, -1, restrictions).values();
+    assertEquals(1, result.size());
+
+    Element element = result.get(0).asElement();
+    assertTrue(element instanceof Image);
+    assertEquals(url2, ((Image) element).getUrl());
+  }
+
   public void testElementHandling() throws Exception {
     Blip blip = newBlip(ROOT_BLIP_ID, Arrays.asList(CHILD_BLIP_ID), null);
     int originalLength = blip.getContent().length();


### PR DESCRIPTION
This PR adds a missing test case for `BlipContentRefs.all(Blip blip, ElementType target, int maxResult, Map<String, String> restrictions)` in `wave/src/test/java/com/google/wave/api/BlipRobotTest.java`.

🎯 **What:** The testing gap addressed is the lack of test coverage for the `BlipContentRefs.all` method that takes a `Map<String, String>` of restrictions.
📊 **Coverage:** The new test `testAllWithRestrictionMap` covers creating a `Blip` with multiple elements, applying a restriction map to filter them, and verifying that only the matching element is returned by the `BlipContentRefs.all` method.
✨ **Result:** Improved test coverage and reliability for the `BlipContentRefs` utility methods.

---
*PR created automatically by Jules for task [2469918407354680339](https://jules.google.com/task/2469918407354680339) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for restriction filtering functionality on image elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->