### PR TITLE
🔒 Fix SHA-1 Vulnerability in WaveService OAuth body hashing

### DIFF
--- a/wave/src/main/java/com/google/wave/api/WaveService.java
+++ b/wave/src/main/java/com/google/wave/api/WaveService.java
@@ -289,7 +289,7 @@ public class WaveService {
   private static final String JSON_MIME_TYPE = "application/json; charset=utf-8";
   private static final String OAUTH_BODY_HASH = "oauth_body_hash";
   private static final String POST = "POST";
-  private static final String SHA_1 = "SHA-1";
+  private static final String SHA_256 = "SHA-256";
   private static final String UTF_8 = "UTF-8";
 
   /** Wave RPC URLs. */
@@ -435,7 +435,7 @@ public class WaveService {
 
     // Compute and check the hash of the body.
     try {
-      MessageDigest md = MessageDigest.getInstance(SHA_1);
+      MessageDigest md = MessageDigest.getInstance(SHA_256);
       byte[] hash = md.digest(jsonBody.getBytes(UTF_8));
       String encodedHash = new String(Base64.encodeBase64(hash, false), UTF_8);
       if (!encodedHash.equals(message.getParameter(OAUTH_BODY_HASH))) {
@@ -973,7 +973,7 @@ public class WaveService {
 
     // Compute the hash of the body.
     byte[] rawBody = jsonBody.getBytes(UTF_8);
-    byte[] hash = DigestUtils.sha1(rawBody);
+    byte[] hash = DigestUtils.sha256(rawBody);
     byte[] encodedHash = Base64.encodeBase64(hash);
     message.addParameter(OAUTH_BODY_HASH, new String(encodedHash, UTF_8));
 


### PR DESCRIPTION
🎯 **What:** The `oauth_body_hash` computation in `WaveService.java` used the SHA-1 hashing algorithm. This vulnerability has been fixed by upgrading the algorithm to SHA-256.

⚠️ **Risk:** While used here in an HMAC context (which is slightly less vulnerable), SHA-1 is no longer considered secure against collision attacks. If left unfixed, an attacker might be able to find a collision or exploit the algorithm's weaknesses to spoof OAuth requests or tamper with their bodies.

🛡️ **Solution:** The hardcoded algorithm name "SHA-1" and the corresponding `DigestUtils.sha1()` calls were replaced with "SHA-256" and `DigestUtils.sha256()`. This upgrades the hashing function for generating and validating the OAuth body hash to a secure standard. This is a moderate confidence fix as it may require coordinating changes with clients or servers expecting SHA-1 in the OAuth flow.

---
*PR created automatically by Jules for task [15616759240996898710](https://jules.google.com/task/15616759240996898710) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Updated OAuth body-hash computation to use SHA-256 algorithm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->