### PR TITLE
🧹 Remove stale TODO to combine ParamsProperty and OperationType Enums

### DIFF
--- a/wave/src/main/java/com/google/wave/api/JsonRpcConstant.java
+++ b/wave/src/main/java/com/google/wave/api/JsonRpcConstant.java
@@ -94,8 +94,6 @@ public class JsonRpcConstant {
    * @author mprasetya@google.com (Marcel Prasetya)
    */
   public enum ParamsProperty {
-    // TODO(mprasetya): Consider combining this with OperationType, or at least
-    // each OperationType should have a list of ParamsProperty.
 
     // Commonly used parameters.
     WAVE_ID("waveId", String.class),


### PR DESCRIPTION
🎯 **What:** Removed a stale `TODO` comment from `JsonRpcConstant.java` which suggested combining `ParamsProperty` with `OperationType`.
💡 **Why:** Refactoring these Enums to combine them would require significant cascading changes throughout the API, making it extremely involved and risking API breakages. Therefore, it's better to remove the comment to prevent developers from attempting a risky, unnecessary refactoring.
✅ **Verification:** Ran `sbt test` to ensure that this purely textual change does not introduce any regressions or break the build.
✨ **Result:** Improved codebase readability by removing a stale, un-actionable comment.

---
*PR created automatically by Jules for task [2360284419036448235](https://jules.google.com/task/2360284419036448235) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal code comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->