### PR TITLE
🧪 Add test coverage for BlipContentRefs.insert(BlipContent...)

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveletstate/segment/SegmentWaveletStateRegistry.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveletstate/segment/SegmentWaveletStateRegistry.java
@@ -74,7 +74,7 @@ public final class SegmentWaveletStateRegistry {
   private static final Map<WaveletName, Entry> LRU =
       new LinkedHashMap<WaveletName, Entry>(16, 0.75f, true) {
         @Override
-        protected boolean removeEldestEntry(Map.Entry<WaveletName, Entry> eldest) {
+        protected boolean removeEldestEntry(Map.Entry<WaveletName, SegmentWaveletStateRegistry.Entry> eldest) {
           if (size() > maxEntries) {
             evictions.incrementAndGet();
             return true;

--- a/wave/src/test/java/com/google/wave/api/BlipContentRefsTest.java
+++ b/wave/src/test/java/com/google/wave/api/BlipContentRefsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.google.wave.api;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.wave.api.impl.DocumentModifyAction.BundledAnnotation;
+
+import junit.framework.TestCase;
+
+import java.util.List;
+
+/**
+ * Tests for {@link BlipContentRefs}.
+ */
+public class BlipContentRefsTest extends TestCase {
+
+  public void testInsertBlipContentDelegatesToNullAnnotations() {
+    Blip blip = mock(Blip.class);
+    when(blip.length()).thenReturn(10);
+    when(blip.getContent()).thenReturn("1234567890");
+
+    BlipContentRefs refs = BlipContentRefs.range(blip, 1, 2);
+    BlipContentRefs spiedRefs = spy(refs);
+
+    BlipContent arg1 = Plaintext.of("hello");
+    BlipContent arg2 = Plaintext.of("world");
+    BlipContent[] args = new BlipContent[]{arg1, arg2};
+
+    // Prevent actual execution on the deeper `insert` method by mocking the delegation target
+    doReturn(spiedRefs).when(spiedRefs).insert((List<BundledAnnotation>) null, args);
+
+    // This is the target method we are testing
+    spiedRefs.insert(args);
+
+    // Verify it delegates correctly to the method taking a List<BundledAnnotation>
+    verify(spiedRefs).insert((List<BundledAnnotation>) null, args);
+  }
+}


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for `BlipContentRefs.insert(BlipContent... arguments)`.
📊 **Coverage:** The test explicitly verifies that the 1-argument `insert()` method properly delegates to the underlying `insert(List<BundledAnnotation>, BlipContent...)` method, passing `null` as the first argument, using Mockito spies.
✨ **Result:** Improved test coverage for `BlipContentRefs`, ensuring modifications directly delegating to internal mutation strategies are safeguarded against future regressions.

---
*PR created automatically by Jules for task [12147093572908741758](https://jules.google.com/task/12147093572908741758) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for blip content reference insertion behavior.

* **Chores**
  * Internal code quality improvements.

---

**Note:** This release contains primarily internal improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->