### PR TITLE
🧪 Add test for AbstractLogger.log

### DIFF
--- a/wave/src/test/java/org/waveprotocol/wave/common/logging/AbstractLoggerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/common/logging/AbstractLoggerTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.common.logging;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.waveprotocol.wave.common.logging.AbstractLogger.Level;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link AbstractLogger}.
+ */
+public class AbstractLoggerTest extends TestCase {
+
+  private LogSink mockSink;
+  private TestLogger logger;
+  private boolean shouldLogResult;
+
+  private class TestLogger extends AbstractLogger {
+    boolean handleClientErrorsCalled = false;
+
+    public TestLogger(LogSink sink) {
+      super(sink);
+    }
+
+    @Override
+    protected boolean shouldLog(Level level) {
+      return shouldLogResult;
+    }
+
+    @Override
+    protected void handleClientErrors(Level level, Throwable t, Object... messages) {
+      handleClientErrorsCalled = true;
+    }
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    mockSink = mock(LogSink.class);
+    logger = new TestLogger(mockSink);
+  }
+
+  public void testLogWhenShouldLogIsTrue() {
+    shouldLogResult = true;
+    Object[] messages = new Object[]{"test", "message"};
+
+    logger.log(Level.ERROR, messages);
+
+    assertTrue(logger.handleClientErrorsCalled);
+    verify(mockSink).lazyLog(Level.ERROR, messages);
+    verifyNoMoreInteractions(mockSink);
+  }
+
+  public void testLogWhenShouldLogIsFalse() {
+    shouldLogResult = false;
+    Object[] messages = new Object[]{"test", "message"};
+
+    logger.log(Level.TRACE, messages);
+
+    assertTrue(logger.handleClientErrorsCalled);
+    verifyNoMoreInteractions(mockSink);
+  }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added a missing test for AbstractLogger.log in wave/src/main/java/org/waveprotocol/wave/common/logging/AbstractLogger.java.
📊 **Coverage:** What scenarios are now tested: created a concrete subclass TestLogger and mocked the LogSink. Verified that handleClientErrors and doLog are called when shouldLog returns true, and doLog is NOT called when shouldLog returns false.
✨ **Result:** The improvement in test coverage: AbstractLogger.log now has unit tests covering its primary execution paths.

---
*PR created automatically by Jules for task [10315864486828947274](https://jules.google.com/task/10315864486828947274) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for logging functionality, validating correct behavior when different logging conditions are met and ensuring system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->