### PR TITLE
Upgrade robot dashboard management

### DIFF
--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "releaseId": "2026-03-29-robot-dashboard-upgrade",
+    "version": "PR #477",
+    "date": "2026-03-29",
+    "title": "Robot Dashboard Upgrade",
+    "summary": "Robot owners can now manage richer dashboard metadata, test callbacks, and pause delivery without leaving the server-rendered control room.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Expanded /account/robots with staged robot setup, description editing, one-time secret handoff pages, masked secret previews, callback testing, pause/unpause, delete, and created/updated timestamps"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Persisted robot descriptions, timestamps, and pause state across proto, file, memory, and Mongo account stores",
+          "Blocked paused robots from client-credentials token issuance and passive robot execution"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-robot-dashboard-management",
     "version": "PR #455",
     "date": "2026-03-28",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -21,16 +21,20 @@ import com.google.common.cache.CacheBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
+import com.google.wave.api.event.EventType;
+import com.google.wave.api.robot.CapabilityFetchException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
+import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
+import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
 import org.waveprotocol.box.server.robots.register.RobotRegistrar;
 import org.waveprotocol.box.server.robots.util.RobotsUtil.RobotRegistrationException;
 import org.waveprotocol.box.server.rpc.HtmlRenderer;
@@ -43,7 +47,11 @@ import org.waveprotocol.wave.util.logging.Log;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
@@ -54,23 +62,27 @@ import java.util.concurrent.TimeUnit;
 public final class RobotDashboardServlet extends HttpServlet {
   private static final int XSRF_TOKEN_LENGTH = 12;
   private static final int XSRF_TOKEN_TIMEOUT_HOURS = 12;
+  private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm 'UTC'").withZone(ZoneOffset.UTC);
   private static final Log LOG = Log.get(RobotDashboardServlet.class);
 
   private final String domain;
   private final SessionManager sessionManager;
   private final AccountStore accountStore;
   private final RobotRegistrar robotRegistrar;
+  private final RobotCapabilityFetcher capabilityFetcher;
   private final TokenGenerator tokenGenerator;
   private final ConcurrentMap<ParticipantId, String> xsrfTokens;
 
   @Inject
   public RobotDashboardServlet(@Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
       SessionManager sessionManager, AccountStore accountStore, RobotRegistrar robotRegistrar,
-      TokenGenerator tokenGenerator) {
+      RobotCapabilityFetcher capabilityFetcher, TokenGenerator tokenGenerator) {
     this.domain = domain;
     this.sessionManager = sessionManager;
     this.accountStore = accountStore;
     this.robotRegistrar = robotRegistrar;
+    this.capabilityFetcher = capabilityFetcher;
     this.tokenGenerator = tokenGenerator;
     this.xsrfTokens = CacheBuilder.newBuilder()
         .expireAfterWrite(XSRF_TOKEN_TIMEOUT_HOURS, TimeUnit.HOURS)
@@ -80,15 +92,8 @@ public final class RobotDashboardServlet extends HttpServlet {
 
   RobotDashboardServlet(String domain, SessionManager sessionManager, AccountStore accountStore,
       RobotRegistrar robotRegistrar) {
-    this.domain = domain;
-    this.sessionManager = sessionManager;
-    this.accountStore = accountStore;
-    this.robotRegistrar = robotRegistrar;
-    this.tokenGenerator = length -> "dashboard-xsrf";
-    this.xsrfTokens = CacheBuilder.newBuilder()
-        .expireAfterWrite(XSRF_TOKEN_TIMEOUT_HOURS, TimeUnit.HOURS)
-        .<ParticipantId, String>build()
-        .asMap();
+    this(domain, sessionManager, accountStore, robotRegistrar, (account, activeApiUrl) -> account,
+        length -> "dashboard-xsrf");
   }
 
   @Override
@@ -116,12 +121,32 @@ public final class RobotDashboardServlet extends HttpServlet {
       handleRegister(req, resp, user);
       return;
     }
+    if ("update-description".equals(action)) {
+      handleUpdateDescription(req, resp, user);
+      return;
+    }
     if ("update-url".equals(action)) {
       handleUpdateUrl(req, resp, user);
       return;
     }
     if ("rotate-secret".equals(action)) {
       handleRotateSecret(req, resp, user);
+      return;
+    }
+    if ("test-robot".equals(action)) {
+      handleTestRobot(req, resp, user);
+      return;
+    }
+    if ("pause-robot".equals(action)) {
+      handlePauseToggle(req, resp, user, true);
+      return;
+    }
+    if ("unpause-robot".equals(action)) {
+      handlePauseToggle(req, resp, user, false);
+      return;
+    }
+    if ("delete-robot".equals(action)) {
+      handleDeleteRobot(req, resp, user);
       return;
     }
 
@@ -148,6 +173,75 @@ public final class RobotDashboardServlet extends HttpServlet {
     return user;
   }
 
+  private void handleRegister(HttpServletRequest req, HttpServletResponse resp, ParticipantId user)
+      throws IOException {
+    String username = req.getParameter("username");
+    String description = Strings.nullToEmpty(req.getParameter("description")).trim();
+    String location = Strings.nullToEmpty(req.getParameter("location")).trim();
+    long tokenExpirySeconds = parseTokenExpiry(req.getParameter("token_expiry"));
+    if (Strings.isNullOrEmpty(username)) {
+      renderDashboard(req, resp, user, "Robot username is required.", null,
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    ParticipantId robotId;
+    try {
+      robotId = RegistrationSupport.checkNewRobotUsername(domain, username);
+    } catch (InvalidParticipantAddress e) {
+      renderDashboard(req, resp, user, e.getMessage(), null,
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    try {
+      RobotAccountData registeredRobot = robotRegistrar.registerNew(
+          robotId, location, user.getAddress(), tokenExpirySeconds, description);
+      renderSecretResponse(req, resp, user, registeredRobot,
+          "Robot ready: " + robotId.getAddress(),
+          location.isEmpty()
+              ? "Step 1 complete. Save this secret now, then come back to add the callback URL and test the bot."
+              : "Save this secret now. Your callback URL is already configured, so you can test the bot from the dashboard next.",
+          HttpServletResponse.SC_OK);
+    } catch (RobotRegistrationException e) {
+      renderDashboard(req, resp, user, e.getMessage(), null, HttpServletResponse.SC_BAD_REQUEST);
+    } catch (PersistenceException e) {
+      renderDashboard(req, resp, user, "Robot registration failed.", null,
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void handleUpdateDescription(HttpServletRequest req, HttpServletResponse resp,
+      ParticipantId user) throws IOException {
+    String robotIdValue = req.getParameter("robotId");
+    if (Strings.isNullOrEmpty(robotIdValue)) {
+      renderDashboard(req, resp, user, "Robot selection is required.", null,
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    RobotAccountData ownedRobot = findOwnedRobot(robotIdValue, user.getAddress());
+    if (ownedRobot == null) {
+      renderDashboard(req, resp, user, "You do not own this robot.", null,
+          HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    String description = Strings.nullToEmpty(req.getParameter("description")).trim();
+    try {
+      RobotAccountData updatedRobot = robotRegistrar.updateDescription(ownedRobot.getId(), description);
+      renderDashboard(req, resp, user,
+          "Description saved for " + ownedRobot.getId().getAddress(), updatedRobot,
+          HttpServletResponse.SC_OK);
+    } catch (RobotRegistrationException e) {
+      renderDashboard(req, resp, user, e.getMessage(), ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
+    } catch (PersistenceException e) {
+      renderDashboard(req, resp, user, "Description update failed.", ownedRobot,
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
   private void handleUpdateUrl(HttpServletRequest req, HttpServletResponse resp, ParticipantId user)
       throws IOException {
     String robotIdValue = req.getParameter("robotId");
@@ -168,12 +262,14 @@ public final class RobotDashboardServlet extends HttpServlet {
     try {
       RobotAccountData updatedRobot =
           robotRegistrar.registerOrUpdate(ownedRobot.getId(), location, user.getAddress());
-      renderDashboard(req, resp, user, "Callback URL updated for " + ownedRobot.getId().getAddress(),
+      renderDashboard(req, resp, user,
+          "Callback URL updated for " + ownedRobot.getId().getAddress(),
           updatedRobot, HttpServletResponse.SC_OK);
     } catch (RobotRegistrationException e) {
-      renderDashboard(req, resp, user, e.getMessage(), null, HttpServletResponse.SC_BAD_REQUEST);
+      renderDashboard(req, resp, user, e.getMessage(), ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
     } catch (PersistenceException e) {
-      renderDashboard(req, resp, user, "Callback URL update failed.", null,
+      renderDashboard(req, resp, user, "Callback URL update failed.", ownedRobot,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -196,50 +292,120 @@ public final class RobotDashboardServlet extends HttpServlet {
 
     try {
       RobotAccountData rotatedRobot = robotRegistrar.rotateSecret(ownedRobot.getId());
-      renderDashboard(
-          req,
-          resp,
-          user,
+      renderSecretResponse(req, resp, user, rotatedRobot,
           "Secret rotated for " + ownedRobot.getId().getAddress(),
-          rotatedRobot,
+          "The dashboard will only show a masked preview after you leave this page.",
           HttpServletResponse.SC_OK);
     } catch (RobotRegistrationException e) {
-      renderDashboard(req, resp, user, e.getMessage(), null, HttpServletResponse.SC_BAD_REQUEST);
+      renderDashboard(req, resp, user, e.getMessage(), ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
     } catch (PersistenceException e) {
-      renderDashboard(req, resp, user, "Secret rotation failed.", null,
+      renderDashboard(req, resp, user, "Secret rotation failed.", ownedRobot,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
 
-  private void handleRegister(HttpServletRequest req, HttpServletResponse resp, ParticipantId user)
+  private void handleTestRobot(HttpServletRequest req, HttpServletResponse resp, ParticipantId user)
       throws IOException {
-    String username = req.getParameter("username");
-    String location = Strings.nullToEmpty(req.getParameter("location")).trim();
-    long tokenExpirySeconds = parseTokenExpiry(req.getParameter("token_expiry"));
-    if (Strings.isNullOrEmpty(username)) {
-      renderDashboard(req, resp, user, "Robot username is required.", null,
+    String robotIdValue = req.getParameter("robotId");
+    if (Strings.isNullOrEmpty(robotIdValue)) {
+      renderDashboard(req, resp, user, "Robot selection is required.", null,
           HttpServletResponse.SC_BAD_REQUEST);
       return;
     }
 
-    ParticipantId robotId;
-    try {
-      robotId = RegistrationSupport.checkNewRobotUsername(domain, username);
-    } catch (InvalidParticipantAddress e) {
-      renderDashboard(req, resp, user, e.getMessage(), null,
+    RobotAccountData ownedRobot = findOwnedRobot(robotIdValue, user.getAddress());
+    if (ownedRobot == null) {
+      renderDashboard(req, resp, user, "You do not own this robot.", null,
+          HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+    if (Strings.isNullOrEmpty(ownedRobot.getUrl())) {
+      renderDashboard(req, resp, user,
+          "Add a callback URL before testing this robot.", ownedRobot,
           HttpServletResponse.SC_BAD_REQUEST);
       return;
     }
 
     try {
-      RobotAccountData registeredRobot =
-          robotRegistrar.registerNew(robotId, location, user.getAddress(), tokenExpirySeconds);
-      renderDashboard(req, resp, user, "Robot registered: " + robotId.getAddress(), registeredRobot,
-          HttpServletResponse.SC_OK);
-    } catch (RobotRegistrationException e) {
-      renderDashboard(req, resp, user, e.getMessage(), null, HttpServletResponse.SC_BAD_REQUEST);
+      RobotAccountData fetchedRobot = capabilityFetcher.fetchCapabilities(ownedRobot, "");
+      RobotAccountData testedRobot = stampRobotUpdate(fetchedRobot, System.currentTimeMillis());
+      accountStore.putAccount(testedRobot);
+      renderDashboard(req, resp, user,
+          "Robot verified: " + ownedRobot.getId().getAddress() + " • "
+              + capabilitySummary(testedRobot),
+          testedRobot, HttpServletResponse.SC_OK);
+    } catch (CapabilityFetchException e) {
+      String message = Strings.nullToEmpty(e.getMessage());
+      if (message.isEmpty()) {
+        message = "Robot test failed.";
+      }
+      renderDashboard(req, resp, user, message, ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
     } catch (PersistenceException e) {
-      renderDashboard(req, resp, user, "Robot registration failed.", null,
+      renderDashboard(req, resp, user, "Robot test failed.", ownedRobot,
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void handlePauseToggle(HttpServletRequest req, HttpServletResponse resp, ParticipantId user,
+      boolean paused) throws IOException {
+    String robotIdValue = req.getParameter("robotId");
+    if (Strings.isNullOrEmpty(robotIdValue)) {
+      renderDashboard(req, resp, user, "Robot selection is required.", null,
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    RobotAccountData ownedRobot = findOwnedRobot(robotIdValue, user.getAddress());
+    if (ownedRobot == null) {
+      renderDashboard(req, resp, user, "You do not own this robot.", null,
+          HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    try {
+      RobotAccountData updatedRobot = robotRegistrar.setPaused(ownedRobot.getId(), paused);
+      renderDashboard(req, resp, user,
+          paused
+              ? "Paused " + ownedRobot.getId().getAddress()
+              : "Unpaused " + ownedRobot.getId().getAddress(),
+          updatedRobot, HttpServletResponse.SC_OK);
+    } catch (RobotRegistrationException e) {
+      renderDashboard(req, resp, user, e.getMessage(), ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
+    } catch (PersistenceException e) {
+      renderDashboard(req, resp, user,
+          paused ? "Pause failed." : "Unpause failed.", ownedRobot,
+          HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void handleDeleteRobot(HttpServletRequest req, HttpServletResponse resp, ParticipantId user)
+      throws IOException {
+    String robotIdValue = req.getParameter("robotId");
+    if (Strings.isNullOrEmpty(robotIdValue)) {
+      renderDashboard(req, resp, user, "Robot selection is required.", null,
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    RobotAccountData ownedRobot = findOwnedRobot(robotIdValue, user.getAddress());
+    if (ownedRobot == null) {
+      renderDashboard(req, resp, user, "You do not own this robot.", null,
+          HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    try {
+      robotRegistrar.unregister(ownedRobot.getId());
+      renderDashboard(req, resp, user,
+          "Deleted " + ownedRobot.getId().getAddress(), null, HttpServletResponse.SC_OK);
+    } catch (RobotRegistrationException e) {
+      renderDashboard(req, resp, user, e.getMessage(), ownedRobot,
+          HttpServletResponse.SC_BAD_REQUEST);
+    } catch (PersistenceException e) {
+      renderDashboard(req, resp, user, "Robot deletion failed.", ownedRobot,
           HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -295,8 +461,7 @@ public final class RobotDashboardServlet extends HttpServlet {
   }
 
   private void renderDashboard(HttpServletRequest req, HttpServletResponse resp, ParticipantId user,
-      String message,
-      RobotAccountData highlightedRobot, int statusCode) throws IOException {
+      String message, RobotAccountData highlightedRobot, int statusCode) throws IOException {
     List<RobotAccountData> ownedRobots = loadOwnedRobots(user.getAddress());
     List<RobotAccountData> robotsToRender = mergeHighlightedRobot(ownedRobots, highlightedRobot);
     resp.setStatus(statusCode);
@@ -305,6 +470,17 @@ public final class RobotDashboardServlet extends HttpServlet {
     String baseUrl = derivePublicBaseUrl(req);
     resp.getWriter().write(renderDashboardPage(user.getAddress(), robotsToRender, message,
         getOrGenerateXsrfToken(user), baseUrl));
+  }
+
+  private void renderSecretResponse(HttpServletRequest req, HttpServletResponse resp, ParticipantId user,
+      RobotAccountData robot, String heading, String detail, int statusCode) throws IOException {
+    resp.setStatus(statusCode);
+    resp.setCharacterEncoding("UTF-8");
+    resp.setContentType("text/html; charset=UTF-8");
+    String baseUrl = derivePublicBaseUrl(req);
+    String dashboardPath = req.getRequestURI();
+    resp.getWriter().write(renderSecretResponsePage(user.getAddress(), robot, heading, detail,
+        baseUrl, dashboardPath));
   }
 
   private List<RobotAccountData> loadOwnedRobots(String ownerAddress) {
@@ -317,6 +493,10 @@ public final class RobotDashboardServlet extends HttpServlet {
     if (ownedRobots == null) {
       ownedRobots = new ArrayList<>();
     }
+    ownedRobots = new ArrayList<>(ownedRobots);
+    ownedRobots.sort(Comparator.comparingLong(RobotAccountData::getUpdatedAtMillis)
+        .reversed()
+        .thenComparing(robot -> robot.getId().getAddress(), String.CASE_INSENSITIVE_ORDER));
     return ownedRobots;
   }
 
@@ -335,120 +515,208 @@ public final class RobotDashboardServlet extends HttpServlet {
         robotsToRender.add(highlightedRobot);
       }
     }
+    robotsToRender.sort(Comparator.comparingLong(RobotAccountData::getUpdatedAtMillis)
+        .reversed()
+        .thenComparing(robot -> robot.getId().getAddress(), String.CASE_INSENSITIVE_ORDER));
     return robotsToRender;
   }
 
   private String renderDashboardPage(String userAddress, List<RobotAccountData> robots,
       String message, String xsrfToken, String baseUrl) {
-    RobotAccountData promptRobot = robots.isEmpty() ? null : robots.get(robots.size() - 1);
-    String promptRobotId = promptRobot == null ? "<robot@domain>" : promptRobot.getId().getAddress();
-    String promptRobotSecret =
-        promptRobot == null ? "<consumer secret>" : promptRobot.getConsumerSecret();
+    RobotAccountData promptRobot = robots.isEmpty() ? null : robots.get(0);
+    String promptRobotId = promptRobot == null ? "<robot@example.com>" : promptRobot.getId().getAddress();
+    String promptRobotSecret = promptRobot == null
+        ? "<replace with the secret you saved when you created or rotated this robot>"
+        : "<replace with the secret you saved; dashboard preview: " + maskSecret(promptRobot.getConsumerSecret()) + ">";
     String promptCallbackUrl = promptRobot == null || promptRobot.getUrl().isEmpty()
         ? "<deployment url>"
         : promptRobot.getUrl();
-    StringBuilder sb = new StringBuilder(8192);
+    StringBuilder sb = new StringBuilder(16384);
     sb.append("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">");
     sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
     sb.append("<title>Robot Control Room</title>");
     sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">");
     sb.append("<style>");
-    sb.append("body{margin:0;background:linear-gradient(180deg,#e8f8fc 0%,#ffffff 100%);");
-    sb.append("font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#123047;}");
-    sb.append(".shell{max-width:1100px;margin:0 auto;padding:40px 24px 64px;}");
-    sb.append(".hero,.panel{background:rgba(255,255,255,.94);border:1px solid rgba(0,119,182,.12);");
-    sb.append("border-radius:24px;box-shadow:0 22px 44px rgba(2,62,138,.08);}");
-    sb.append(".hero{padding:28px 30px;margin-bottom:20px;}");
+    sb.append("body{margin:0;background:linear-gradient(180deg,#e8f8fc 0%,#ffffff 100%);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#123047;}");
+    sb.append(".shell{max-width:1200px;margin:0 auto;padding:40px 24px 72px;}");
+    sb.append(".hero,.panel,.robot-card,.step-card,.credential-card{background:rgba(255,255,255,.96);border:1px solid rgba(0,119,182,.12);border-radius:24px;box-shadow:0 22px 44px rgba(2,62,138,.08);}");
+    sb.append(".hero{padding:28px 30px 24px;margin-bottom:20px;}");
     sb.append(".eyebrow{display:inline-block;padding:6px 12px;border-radius:999px;background:#023e8a;color:#fff;font-size:11px;letter-spacing:.12em;text-transform:uppercase;}");
-    sb.append("h1{margin:16px 0 10px;font-size:44px;line-height:1.04;}");
-    sb.append(".lede{margin:0;max-width:48rem;font-size:17px;line-height:1.7;color:#3d627a;}");
-    sb.append(".grid{display:grid;grid-template-columns:1.2fr .8fr;gap:20px;}");
-    sb.append(".panel{padding:24px 26px;}");
-    sb.append(".status{margin:0 0 18px;padding:12px 14px;border-radius:14px;background:#edf8fb;color:#124663;}");
-    sb.append(".robot-card{padding:16px 18px;border-radius:18px;background:#f7fcfd;border:1px solid rgba(0,119,182,.1);margin-bottom:14px;}");
-    sb.append(".robot-card h3{margin:0 0 8px;font-size:20px;}");
-    sb.append(".meta{font-size:13px;color:#56738a;line-height:1.6;}");
-    sb.append(".prompt{width:100%;min-height:220px;border-radius:16px;border:1px solid rgba(0,119,182,.16);padding:14px;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:13px;background:#f8fbfc;}");
+    sb.append("h1{margin:16px 0 10px;font-size:44px;line-height:1.04;}h2{margin:0 0 12px;font-size:24px;}h3{margin:0 0 8px;font-size:20px;}");
+    sb.append(".lede{margin:0;max-width:50rem;font-size:17px;line-height:1.7;color:#3d627a;}");
+    sb.append(".subtle{font-size:14px;color:#4d738a;line-height:1.6;}");
+    sb.append(".grid{display:grid;grid-template-columns:1.35fr .75fr;gap:20px;align-items:start;}");
+    sb.append(".stack{display:grid;gap:18px;}.panel{padding:24px 26px;}.step-card{padding:18px 20px;}");
+    sb.append(".status{margin:0 0 18px;padding:14px 16px;border-radius:16px;background:#edf8fb;color:#124663;line-height:1.5;}");
+    sb.append(".robot-card{padding:20px 22px;display:grid;gap:16px;}");
+    sb.append(".robot-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;}");
+    sb.append(".pill{display:inline-flex;align-items:center;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;background:#e9f7fb;color:#0c5f88;}");
+    sb.append(".pill.paused{background:#fef3c7;color:#92400e;}.pill.pending{background:#e0f2fe;color:#0f4c81;}");
+    sb.append(".pill.active{background:#dcfce7;color:#166534;}");
+    sb.append(".meta-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 18px;}");
+    sb.append(".meta-label{display:block;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#65839a;margin-bottom:4px;}");
+    sb.append(".meta-value{font-size:14px;line-height:1.6;color:#16364f;word-break:break-word;}");
     sb.append("label{display:block;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#4b6b81;margin:0 0 6px;}");
-    sb.append("input{width:100%;padding:12px 14px;border-radius:14px;border:1px solid rgba(0,119,182,.18);font:inherit;}");
-    sb.append("button{border:none;border-radius:999px;background:#0077b6;color:#fff;padding:12px 18px;font-weight:700;cursor:pointer;}");
-    sb.append(".tiny{font-size:12px;color:#5f8198;line-height:1.6;}");
+    sb.append("input,textarea,select{width:100%;padding:12px 14px;border-radius:14px;border:1px solid rgba(0,119,182,.18);font:inherit;background:#fff;color:#123047;box-sizing:border-box;}");
+    sb.append("textarea{min-height:108px;resize:vertical;}");
+    sb.append("button,.button-link{border:none;border-radius:999px;background:#0077b6;color:#fff;padding:12px 18px;font-weight:700;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;justify-content:center;}");
+    sb.append("button.secondary,.button-link.secondary{background:#dff3f8;color:#10526f;}button.danger{background:#d9534f;}button.ghost{background:#eef6f9;color:#13435b;}");
+    sb.append(".actions{display:flex;flex-wrap:wrap;gap:10px;}.form-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px;}.form-grid .full{grid-column:1 / -1;}");
+    sb.append(".tiny{font-size:12px;color:#5f8198;line-height:1.6;}.empty{padding:20px;border-radius:18px;background:#f7fcfd;border:1px dashed rgba(0,119,182,.18);}");
+    sb.append(".prompt{width:100%;min-height:280px;border-radius:18px;border:1px solid rgba(0,119,182,.16);padding:14px;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:13px;background:#f8fbfc;box-sizing:border-box;}");
+    sb.append(".owner-line{margin-top:16px;font-size:13px;color:#507089;}.section-divider{height:1px;background:rgba(0,119,182,.1);margin:4px 0;}");
+    sb.append("@media (max-width: 900px){.grid{grid-template-columns:1fr;}.meta-grid,.form-grid{grid-template-columns:1fr;}}");
     sb.append("</style></head><body><div class=\"shell\">");
     sb.append("<section class=\"hero\"><span class=\"eyebrow\">Automation</span>");
     sb.append("<h1>Robot Control Room</h1>");
-    sb.append("<p class=\"lede\">Create a robot, hand an external LLM a SupaWave-ready starter prompt, and come back later to activate the callback URL without rotating the secret.</p>");
+    sb.append("<p class=\"lede\">Reserve a robot identity, save its secret once, then come back later to wire the callback URL, test capabilities, and pause or resume delivery without leaving the server-rendered app.</p>");
+    sb.append("<div class=\"owner-line\">Signed in as <strong>").append(HtmlRenderer.escapeHtml(userAddress)).append("</strong></div>");
     sb.append("</section>");
-    sb.append("<div class=\"grid\"><section class=\"panel\">");
+    sb.append("<div class=\"grid\"><section class=\"stack\">");
     if (!Strings.isNullOrEmpty(message)) {
       sb.append("<div class=\"status\">").append(HtmlRenderer.escapeHtml(message)).append("</div>");
     }
-    for (RobotAccountData robot : robots) {
-      sb.append("<div class=\"robot-card\"><h3>")
-          .append(HtmlRenderer.escapeHtml(robot.getId().getAddress()))
-          .append("</h3><div class=\"meta\">");
-      sb.append("Callback URL: ")
-          .append(HtmlRenderer.escapeHtml(robot.getUrl().isEmpty() ? "Pending" : robot.getUrl()))
-          .append("<br>Secret: ")
-          .append(HtmlRenderer.escapeHtml(robot.getConsumerSecret()))
-          .append("</div>");
-      sb.append("<form method=\"post\" action=\"\">");
-      sb.append("<input type=\"hidden\" name=\"action\" value=\"update-url\">");
-      sb.append("<input type=\"hidden\" name=\"token\" value=\"")
-          .append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
-      sb.append("<input type=\"hidden\" name=\"robotId\" value=\"")
-          .append(HtmlRenderer.escapeHtml(robot.getId().getAddress())).append("\">");
-      sb.append("<label for=\"location-").append(HtmlRenderer.escapeHtml(robot.getId().getAddress()))
-          .append("\">Callback URL</label>");
-      sb.append("<input id=\"location-").append(HtmlRenderer.escapeHtml(robot.getId().getAddress()))
-          .append("\" name=\"location\" value=\"")
-          .append(HtmlRenderer.escapeHtml(robot.getUrl())).append("\">");
-      sb.append("<div style=\"margin-top:12px;\"><button type=\"submit\">Save Callback URL</button></div>");
-      sb.append("</form>");
-      sb.append("<form method=\"post\" action=\"\" style=\"margin-top:10px;\">");
-      sb.append("<input type=\"hidden\" name=\"action\" value=\"rotate-secret\">");
-      sb.append("<input type=\"hidden\" name=\"token\" value=\"")
-          .append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
-      sb.append("<input type=\"hidden\" name=\"robotId\" value=\"")
-          .append(HtmlRenderer.escapeHtml(robot.getId().getAddress())).append("\">");
-      sb.append("<div style=\"margin-top:12px;\"><button type=\"submit\">Rotate Secret</button></div>");
-      sb.append("</form></div>");
-    }
     if (robots.isEmpty()) {
-      sb.append("<div class=\"robot-card\"><h3>No robots yet</h3><div class=\"meta\">");
-      sb.append("Create a pending robot first, then come back here to activate its callback URL.");
-      sb.append("</div></div>");
+      sb.append("<div class=\"empty\"><h3>No robots yet</h3><p class=\"subtle\">Create a robot below to mint its identity first, then finish the callback setup when your deployment is ready.</p></div>");
     }
-    sb.append("<div class=\"robot-card\"><h3>Create a robot</h3>");
-    sb.append("<form method=\"post\" action=\"\">");
+    for (RobotAccountData robot : robots) {
+      String domId = toDomId(robot);
+      sb.append("<article class=\"robot-card\">");
+      sb.append("<div class=\"robot-header\"><div><h3>")
+          .append(HtmlRenderer.escapeHtml(robot.getId().getAddress()))
+          .append("</h3><div class=\"subtle\">")
+          .append(HtmlRenderer.escapeHtml(descriptionOrFallback(robot)))
+          .append("</div></div>");
+      sb.append("<span class=\"pill ").append(statusClass(robot)).append("\">")
+          .append(HtmlRenderer.escapeHtml(statusLabel(robot))).append("</span></div>");
+      sb.append("<div class=\"meta-grid\">");
+      appendMetaItem(sb, "Callback URL", robot.getUrl().isEmpty() ? "Not configured yet" : robot.getUrl());
+      appendMetaItem(sb, "Secret Preview", maskSecret(robot.getConsumerSecret()));
+      appendMetaItem(sb, "Created", formatTimestamp(robot.getCreatedAtMillis()));
+      appendMetaItem(sb, "Updated", formatTimestamp(robot.getUpdatedAtMillis()));
+      appendMetaItem(sb, "Capabilities", capabilitySummary(robot));
+      appendMetaItem(sb, "Token Expiry", formatTokenExpiry(robot.getTokenExpirySeconds()));
+      sb.append("</div>");
+      sb.append("<div class=\"section-divider\"></div>");
+      sb.append("<form method=\"post\" action=\"\" class=\"stack\">");
+      appendCommonHiddenFields(sb, xsrfToken, robot.getId().getAddress(), "update-description");
+      sb.append("<div><label for=\"description-").append(domId).append("\">Description</label>");
+      sb.append("<textarea id=\"description-").append(domId).append("\" name=\"description\">")
+          .append(HtmlRenderer.escapeHtml(robot.getDescription())).append("</textarea></div>");
+      sb.append("<div class=\"actions\"><button type=\"submit\">Save Description</button></div></form>");
+      sb.append("<form method=\"post\" action=\"\" class=\"stack\">");
+      appendCommonHiddenFields(sb, xsrfToken, robot.getId().getAddress(), "update-url");
+      sb.append("<div><label for=\"location-").append(domId).append("\">Callback URL</label>");
+      sb.append("<input id=\"location-").append(domId).append("\" name=\"location\" value=\"")
+          .append(HtmlRenderer.escapeHtml(robot.getUrl())).append("\" placeholder=\"https://example.com/robot\"></div>");
+      sb.append("<div class=\"actions\"><button type=\"submit\">Save Callback URL</button></div></form>");
+      sb.append("<div class=\"actions\">");
+      appendActionButton(sb, xsrfToken, robot.getId().getAddress(), "test-robot", "Test Bot", "secondary");
+      appendActionButton(sb, xsrfToken, robot.getId().getAddress(), "rotate-secret", "Rotate Secret", "ghost");
+      appendActionButton(sb, xsrfToken, robot.getId().getAddress(), robot.isPaused() ? "unpause-robot" : "pause-robot", robot.isPaused() ? "Unpause" : "Pause", "secondary");
+      appendActionButton(sb, xsrfToken, robot.getId().getAddress(), "delete-robot", "Delete", "danger");
+      sb.append("</div>");
+      sb.append("</article>");
+    }
+    sb.append("<section class=\"panel\"><h2>Step 1 · Create a robot</h2>");
+    sb.append("<p class=\"subtle\">Create the identity, add a short description for teammates, and optionally configure the callback URL now. If you leave the callback blank, you can finish activation later from the robot card.</p>");
+    sb.append("<form method=\"post\" action=\"\" class=\"stack\">");
     sb.append("<input type=\"hidden\" name=\"action\" value=\"register\">");
-    sb.append("<input type=\"hidden\" name=\"token\" value=\"")
-        .append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
-    sb.append("<label for=\"username\">Robot Username</label>");
-    sb.append("<input id=\"username\" name=\"username\" placeholder=\"helper-bot\">");
-    sb.append("<label for=\"create-location\" style=\"margin-top:12px;\">Callback URL</label>");
-    sb.append("<input id=\"create-location\" name=\"location\" placeholder=\"https://example.com/robot\">");
-    sb.append("<label for=\"token-expiry\" style=\"margin-top:12px;\">Robot Token Expiry</label>");
-    sb.append("<input id=\"token-expiry\" name=\"token_expiry\" value=\"3600\">");
-    sb.append("<div class=\"tiny\">Leave the callback URL empty to mint the secret first and activate the robot after deployment.</div>");
-    sb.append("<div style=\"margin-top:12px;\"><button type=\"submit\">Create Robot</button></div>");
-    sb.append("</form></div>");
-    sb.append("</section><aside class=\"panel\">");
-    sb.append("<h2>Build with AI</h2>");
-    sb.append("<p class=\"tiny\">Google AI Studio / Gemini starter prompt for ")
-        .append(HtmlRenderer.escapeHtml(userAddress)).append(".</p>");
+    sb.append("<input type=\"hidden\" name=\"token\" value=\"").append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
+    sb.append("<div class=\"form-grid\">");
+    sb.append("<div><label for=\"username\">Robot Username</label><input id=\"username\" name=\"username\" placeholder=\"helper-bot\"></div>");
+    sb.append("<div><label for=\"token-expiry\">Robot Token Expiry</label><input id=\"token-expiry\" name=\"token_expiry\" value=\"3600\"></div>");
+    sb.append("<div class=\"full\"><label for=\"create-description\">Description</label><textarea id=\"create-description\" name=\"description\" placeholder=\"What this robot does, who owns it, and when to use it.\"></textarea></div>");
+    sb.append("<div class=\"full\"><label for=\"create-location\">Callback URL</label><input id=\"create-location\" name=\"location\" placeholder=\"https://example.com/robot\"></div>");
+    sb.append("</div>");
+    sb.append("<div class=\"tiny\">The dashboard never re-renders full secrets after the one-time handoff page. Save the secret before you return here.</div>");
+    sb.append("<div class=\"actions\"><button type=\"submit\">Create Robot</button></div>");
+    sb.append("</form></section>");
+    sb.append("</section><aside class=\"stack\">");
+    sb.append("<section class=\"step-card\"><h2>Suggested flow</h2>");
+    sb.append("<ol class=\"subtle\" style=\"margin:0;padding-left:18px;display:grid;gap:10px;\">");
+    sb.append("<li>Create the robot and save the secret from the one-time handoff page.</li>");
+    sb.append("<li>Deploy your bot, then add the callback URL and use <strong>Test Bot</strong> to fetch capabilities.</li>");
+    sb.append("<li>Pause the robot anytime to block token issuance and passive delivery without deleting it.</li>");
+    sb.append("</ol></section>");
+    sb.append("<section class=\"panel\"><h2>Build with AI</h2>");
+    sb.append("<p class=\"tiny\">Use this starter prompt with the robot you are working on. The dashboard only shows a masked secret preview, so replace the secret placeholder with the value you saved earlier.</p>");
     sb.append("<textarea id=\"starter-prompt\" class=\"prompt\" readonly>");
-    sb.append("Build a SupaWave robot for me. Use these environment variables:\\n");
-    sb.append("SUPAWAVE_BASE_URL=").append(HtmlRenderer.escapeHtml(baseUrl)).append("\\n");
-    sb.append("SUPAWAVE_DATA_API_URL=").append(HtmlRenderer.escapeHtml(baseUrl)).append("/robot/dataapi/rpc\\n");
-    sb.append("SUPAWAVE_API_DOCS_URL=").append(HtmlRenderer.escapeHtml(baseUrl)).append("/api-docs\\n");
-    sb.append("SUPAWAVE_LLM_DOCS_URL=").append(HtmlRenderer.escapeHtml(baseUrl)).append("/api/llm.txt\\n");
-    sb.append("SUPAWAVE_DATA_API_TOKEN=<generating 1 hour JWT...>\\n");
-    sb.append("SUPAWAVE_ROBOT_ID=").append(HtmlRenderer.escapeHtml(promptRobotId)).append("\\n");
-    sb.append("SUPAWAVE_ROBOT_SECRET=").append(HtmlRenderer.escapeHtml(promptRobotSecret)).append("\\n");
-    sb.append("SUPAWAVE_ROBOT_CALLBACK_URL=").append(HtmlRenderer.escapeHtml(promptCallbackUrl)).append("\\n\\n");
-    sb.append("Use the docs to create or activate the robot, keep tokens short-lived, and explain any missing callback URL step clearly.");
+    sb.append(buildStarterPrompt(baseUrl, promptRobotId, promptRobotSecret, promptCallbackUrl));
     sb.append("</textarea>");
     sb.append("<div id=\"token-status\" class=\"tiny\" style=\"margin-top:10px;\">Generating a one-hour JWT for the starter prompt.</div>");
+    sb.append(renderDataApiTokenScript());
+    sb.append("</section></aside></div></div></body></html>");
+    return sb.toString();
+  }
+
+  private String renderSecretResponsePage(String userAddress, RobotAccountData robot, String heading,
+      String detail, String baseUrl, String dashboardPath) {
+    String callbackUrl = robot.getUrl().isEmpty() ? "<deployment url>" : robot.getUrl();
+    StringBuilder sb = new StringBuilder(12288);
+    sb.append("<!DOCTYPE html><html><head><meta charset=\"UTF-8\">");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">");
+    sb.append("<title>Robot Secret Handoff</title>");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">");
+    sb.append("<style>");
+    sb.append("body{margin:0;background:linear-gradient(180deg,#e8f8fc 0%,#ffffff 100%);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,sans-serif;color:#123047;}");
+    sb.append(".shell{max-width:1100px;margin:0 auto;padding:40px 24px 72px;}.grid{display:grid;grid-template-columns:1fr .85fr;gap:20px;align-items:start;}");
+    sb.append(".panel,.hero{background:rgba(255,255,255,.96);border:1px solid rgba(0,119,182,.12);border-radius:24px;box-shadow:0 22px 44px rgba(2,62,138,.08);}");
+    sb.append(".hero{padding:28px 30px 24px;margin-bottom:20px;}.panel{padding:24px 26px;}.eyebrow{display:inline-block;padding:6px 12px;border-radius:999px;background:#023e8a;color:#fff;font-size:11px;letter-spacing:.12em;text-transform:uppercase;}");
+    sb.append("h1{margin:16px 0 10px;font-size:40px;line-height:1.04;}h2{margin:0 0 12px;font-size:24px;}.subtle{font-size:14px;line-height:1.7;color:#45687f;}");
+    sb.append(".credential{padding:18px;border-radius:20px;background:#f7fcfd;border:1px solid rgba(0,119,182,.12);display:grid;gap:8px;margin-top:18px;}");
+    sb.append(".label{display:block;font-size:12px;letter-spacing:.08em;text-transform:uppercase;color:#4b6b81;}.secret-field,.prompt{width:100%;border-radius:16px;border:1px solid rgba(0,119,182,.18);padding:14px;font:inherit;box-sizing:border-box;background:#fff;color:#123047;}");
+    sb.append(".prompt{min-height:280px;font-family:'SFMono-Regular',Consolas,'Liberation Mono',Menlo,monospace;font-size:13px;background:#f8fbfc;}");
+    sb.append(".meta-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 16px;margin-top:18px;}.meta-value{font-size:14px;line-height:1.6;color:#16364f;word-break:break-word;}");
+    sb.append(".button-link{border:none;border-radius:999px;background:#0077b6;color:#fff;padding:12px 18px;font-weight:700;cursor:pointer;text-decoration:none;display:inline-flex;align-items:center;justify-content:center;margin-top:18px;}");
+    sb.append(".note{margin-top:18px;padding:14px 16px;border-radius:16px;background:#fff3cd;color:#7a5a00;line-height:1.6;}");
+    sb.append("@media (max-width: 900px){.grid,.meta-grid{grid-template-columns:1fr;}}");
+    sb.append("</style></head><body><div class=\"shell\">");
+    sb.append("<section class=\"hero\"><span class=\"eyebrow\">One-time Secret</span>");
+    sb.append("<h1>").append(HtmlRenderer.escapeHtml(heading)).append("</h1>");
+    sb.append("<p class=\"subtle\">You are signed in as <strong>").append(HtmlRenderer.escapeHtml(userAddress)).append("</strong>. ")
+        .append(HtmlRenderer.escapeHtml(detail)).append("</p></section>");
+    sb.append("<div class=\"grid\"><section class=\"panel\"><h2>Save this secret now</h2>");
+    sb.append("<div class=\"credential\"><span class=\"label\">Robot</span><div class=\"meta-value\">")
+        .append(HtmlRenderer.escapeHtml(robot.getId().getAddress())).append("</div></div>");
+    sb.append("<div class=\"credential\"><label class=\"label\" for=\"secret-field\">Client Secret</label>");
+    sb.append("<input id=\"secret-field\" class=\"secret-field\" readonly onclick=\"this.focus();this.select();\" value=\"")
+        .append(HtmlRenderer.escapeHtml(robot.getConsumerSecret())).append("\"></div>");
+    sb.append("<div class=\"meta-grid\">");
+    appendMetaItem(sb, "Callback URL", robot.getUrl().isEmpty() ? "Not configured yet" : robot.getUrl());
+    appendMetaItem(sb, "Dashboard Preview", maskSecret(robot.getConsumerSecret()));
+    appendMetaItem(sb, "Created", formatTimestamp(robot.getCreatedAtMillis()));
+    appendMetaItem(sb, "Updated", formatTimestamp(robot.getUpdatedAtMillis()));
+    sb.append("</div>");
+    sb.append("<div class=\"note\"><strong>Heads up:</strong> once you leave this page, the dashboard only shows a masked preview. Store the secret in your deployment or password manager now.</div>");
+    sb.append("<a class=\"button-link\" href=\"").append(HtmlRenderer.escapeHtml(dashboardPath)).append("\">Back to dashboard</a>");
+    sb.append("</section><aside class=\"panel\"><h2>Starter prompt</h2>");
+    sb.append("<p class=\"subtle\">This version includes the full secret once so you can hand it off to your deployment tooling immediately.</p>");
+    sb.append("<textarea id=\"starter-prompt\" class=\"prompt\" readonly>");
+    sb.append(buildStarterPrompt(baseUrl, robot.getId().getAddress(), robot.getConsumerSecret(), callbackUrl));
+    sb.append("</textarea>");
+    sb.append("<div id=\"token-status\" class=\"subtle\" style=\"margin-top:12px;\">Generating a one-hour JWT for the starter prompt.</div>");
+    sb.append(renderDataApiTokenScript());
+    sb.append("</aside></div></div></body></html>");
+    return sb.toString();
+  }
+
+  private String buildStarterPrompt(String baseUrl, String robotId, String robotSecret,
+      String callbackUrl) {
+    return "Build a SupaWave robot for me. Use these environment variables:\n"
+        + "SUPAWAVE_BASE_URL=" + HtmlRenderer.escapeHtml(baseUrl) + "\n"
+        + "SUPAWAVE_DATA_API_URL=" + HtmlRenderer.escapeHtml(baseUrl) + "/robot/dataapi/rpc\n"
+        + "SUPAWAVE_API_DOCS_URL=" + HtmlRenderer.escapeHtml(baseUrl) + "/api-docs\n"
+        + "SUPAWAVE_LLM_DOCS_URL=" + HtmlRenderer.escapeHtml(baseUrl) + "/api/llm.txt\n"
+        + "SUPAWAVE_DATA_API_TOKEN=<generating 1 hour JWT...>\n"
+        + "SUPAWAVE_ROBOT_ID=" + HtmlRenderer.escapeHtml(robotId) + "\n"
+        + "SUPAWAVE_ROBOT_SECRET=" + HtmlRenderer.escapeHtml(robotSecret) + "\n"
+        + "SUPAWAVE_ROBOT_CALLBACK_URL=" + HtmlRenderer.escapeHtml(callbackUrl) + "\n\n"
+        + "Use the docs to create or activate the robot, keep tokens short-lived, and explain any missing callback URL step clearly.";
+  }
+
+  private String renderDataApiTokenScript() {
+    StringBuilder sb = new StringBuilder(768);
     sb.append("<script>");
     sb.append("(() => {");
     sb.append("const prompt = document.getElementById('starter-prompt');");
@@ -462,8 +730,128 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append(".catch(() => { status.textContent = 'Sign in again if the one-hour JWT could not be generated automatically.'; });");
     sb.append("})();");
     sb.append("</script>");
-    sb.append("</aside></div></div></body></html>");
     return sb.toString();
+  }
+
+  private void appendMetaItem(StringBuilder sb, String label, String value) {
+    sb.append("<div><span class=\"meta-label\">").append(HtmlRenderer.escapeHtml(label)).append("</span>");
+    sb.append("<div class=\"meta-value\">").append(HtmlRenderer.escapeHtml(value)).append("</div></div>");
+  }
+
+  private void appendCommonHiddenFields(StringBuilder sb, String xsrfToken, String robotId,
+      String action) {
+    sb.append("<input type=\"hidden\" name=\"action\" value=\"")
+        .append(HtmlRenderer.escapeHtml(action)).append("\">");
+    sb.append("<input type=\"hidden\" name=\"token\" value=\"")
+        .append(HtmlRenderer.escapeHtml(xsrfToken)).append("\">");
+    sb.append("<input type=\"hidden\" name=\"robotId\" value=\"")
+        .append(HtmlRenderer.escapeHtml(robotId)).append("\">");
+  }
+
+  private void appendActionButton(StringBuilder sb, String xsrfToken, String robotId,
+      String action, String label, String buttonClass) {
+    sb.append("<form method=\"post\" action=\"\" style=\"margin:0;\">");
+    appendCommonHiddenFields(sb, xsrfToken, robotId, action);
+    sb.append("<button type=\"submit\" class=\"").append(HtmlRenderer.escapeHtml(buttonClass))
+        .append("\">").append(HtmlRenderer.escapeHtml(label)).append("</button></form>");
+  }
+
+  private RobotAccountData stampRobotUpdate(RobotAccountData robot, long updatedAtMillis) {
+    return new RobotAccountDataImpl(robot.getId(), robot.getUrl(), robot.getConsumerSecret(),
+        robot.getCapabilities(), robot.isVerified(), robot.getTokenExpirySeconds(),
+        robot.getOwnerAddress(), robot.getDescription(), robot.getCreatedAtMillis(),
+        updatedAtMillis, robot.isPaused());
+  }
+
+  private String maskSecret(String secret) {
+    if (Strings.isNullOrEmpty(secret)) {
+      return "Unavailable";
+    }
+    if (secret.length() <= 4) {
+      return "••••";
+    }
+    return "••••••" + secret.substring(secret.length() - 4);
+  }
+
+  private String descriptionOrFallback(RobotAccountData robot) {
+    if (robot.getDescription().isEmpty()) {
+      return "No description yet. Add a short summary so teammates know what this robot owns.";
+    }
+    return robot.getDescription();
+  }
+
+  private String capabilitySummary(RobotAccountData robot) {
+    if (robot.getCapabilities() == null || robot.getCapabilities().getCapabilitiesMap() == null
+        || robot.getCapabilities().getCapabilitiesMap().isEmpty()) {
+      return "Not checked yet";
+    }
+    List<String> eventNames = new ArrayList<>();
+    for (EventType eventType : robot.getCapabilities().getCapabilitiesMap().keySet()) {
+      eventNames.add(eventType.name());
+    }
+    eventNames.sort(String.CASE_INSENSITIVE_ORDER);
+    int maxNames = Math.min(3, eventNames.size());
+    StringBuilder summary = new StringBuilder();
+    summary.append(eventNames.size()).append(" events");
+    if (maxNames > 0) {
+      summary.append(" • ");
+      for (int i = 0; i < maxNames; i++) {
+        if (i > 0) {
+          summary.append(", ");
+        }
+        summary.append(eventNames.get(i));
+      }
+      if (eventNames.size() > maxNames) {
+        summary.append(", …");
+      }
+    }
+    return summary.toString();
+  }
+
+  private String formatTokenExpiry(long tokenExpirySeconds) {
+    if (tokenExpirySeconds <= 0L) {
+      return "No expiry";
+    }
+    if (tokenExpirySeconds % 86400L == 0L) {
+      long days = tokenExpirySeconds / 86400L;
+      return days == 1L ? "1 day" : days + " days";
+    }
+    if (tokenExpirySeconds % 3600L == 0L) {
+      long hours = tokenExpirySeconds / 3600L;
+      return hours == 1L ? "1 hour" : hours + " hours";
+    }
+    return tokenExpirySeconds + " seconds";
+  }
+
+  private String formatTimestamp(long millis) {
+    if (millis <= 0L) {
+      return "Unknown (legacy)";
+    }
+    return TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(millis));
+  }
+
+  private String statusClass(RobotAccountData robot) {
+    if (robot.isPaused()) {
+      return "paused";
+    }
+    if (robot.getUrl().isEmpty()) {
+      return "pending";
+    }
+    return "active";
+  }
+
+  private String statusLabel(RobotAccountData robot) {
+    if (robot.isPaused()) {
+      return "Paused";
+    }
+    if (robot.getUrl().isEmpty()) {
+      return "Pending callback";
+    }
+    return "Active";
+  }
+
+  private String toDomId(RobotAccountData robot) {
+    return robot.getId().getAddress().replace('@', '-').replace('.', '-');
   }
 
   private String derivePublicBaseUrl(HttpServletRequest req) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/DataApiTokenServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/DataApiTokenServlet.java
@@ -353,6 +353,12 @@ public final class DataApiTokenServlet extends HttpServlet {
       return;
     }
 
+    if (robotAccount.isPaused()) {
+      sendError(resp, HttpServletResponse.SC_UNAUTHORIZED, "invalid_client",
+          "Robot is paused");
+      return;
+    }
+
     String callbackUrl = robotAccount.getUrl();
     if (callbackUrl == null || callbackUrl.isEmpty()) {
       sendError(resp, HttpServletResponse.SC_UNAUTHORIZED, "invalid_client",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
@@ -58,6 +58,7 @@ public class RobotConnector implements RobotCapabilityFetcher {
         parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion());
     return new RobotAccountDataImpl(account.getId(), account.getUrl(), account.getConsumerSecret(),
         capabilities, account.isVerified(), account.getTokenExpirySeconds(),
-        account.getOwnerAddress());
+        account.getOwnerAddress(), account.getDescription(), account.getCreatedAtMillis(),
+        account.getUpdatedAtMillis(), account.isPaused());
   }
 }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/register/RobotRegistrar.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/register/RobotRegistrar.java
@@ -1,6 +1,22 @@
 /**
- * Jakarta build variant of {@link org.waveprotocol.box.server.robots.register.RobotRegistrar}.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.waveprotocol.box.server.robots.register;
 
 import org.waveprotocol.box.server.account.RobotAccountData;
@@ -8,40 +24,125 @@ import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.robots.util.RobotsUtil.RobotRegistrationException;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
+/**
+ * Provides robot un/registration services.
+ *
+ * @author yurize@apache.org (Yuri Zelikov)
+ */
 public interface RobotRegistrar {
-  interface Listener {
-    void onRegistrationSuccess(RobotAccountData account);
-    void onUnregistrationSuccess(RobotAccountData account);
+
+  /** Receives robot un/registration events. */
+  public interface Listener {
+
+    /** Invoked after the robot account was created and added to the account store. */
+    public void onRegistrationSuccess(RobotAccountData account);
+
+    /** Invoked after the robot account was removed from the account store. */
+    public void onUnregistrationSuccess(RobotAccountData account);
   }
 
-  RobotAccountData registerNew(ParticipantId robotId, String location)
+  /**
+   * Registers a new robot account.
+   *
+   * @param robotId the robotId to register.
+   * @param location the location of the robot (URI).
+   * @return the newly registered robot account.
+   * @throws RobotRegistrationException if account for this id already exist.
+   * @throws PersistenceException if the persistence layer reports an error.
+   */
+  public RobotAccountData registerNew(ParticipantId robotId, String location)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerNew(ParticipantId robotId, String location, long tokenExpirySeconds)
+  /**
+   * Registers a new robot account with configurable token expiry.
+   *
+   * @param robotId the robotId to register.
+   * @param location the location of the robot (URI).
+   * @param tokenExpirySeconds token expiry in seconds (0 = no expiry).
+   * @return the newly registered robot account.
+   * @throws RobotRegistrationException if account for this id already exist.
+   * @throws PersistenceException if the persistence layer reports an error.
+   */
+  public RobotAccountData registerNew(ParticipantId robotId, String location, long tokenExpirySeconds)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
+  /**
+   * Registers a new robot account with ownership metadata and configurable
+   * token expiry.
+   */
+  public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
       long tokenExpirySeconds) throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData unregister(ParticipantId robotId)
+  /**
+   * Registers a new robot account with ownership metadata, configurable token
+   * expiry, and an owner-managed description.
+   */
+  public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
+      long tokenExpirySeconds, String description)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerOrUpdate(ParticipantId robotId, String location)
+  /**
+   * Unregisters a robot by removing it from the account store.
+   *
+   * @param robotId the id to remove.
+   * @return the account data of the removed robot or
+   *         <code>null</null> if no such robot account exist.
+   * @throws RobotRegistrationException if the id to remove exist but is not a
+   *         robot.
+   * @throws PersistenceException if the persistence layer reports an error.
+   */
+  public RobotAccountData unregister(ParticipantId robotId) throws RobotRegistrationException,
+      PersistenceException;
+
+  /**
+   * Registers a new robot or re-registers an existing robot in order to update the robot location.
+   *
+   * @param robotId the robot id.
+   * @param location the new location of the robot (URI).
+   * @return the updated robot account.
+   * @throws RobotRegistrationException if the id to re-register exist but is not a robot.
+   * @throws PersistenceException if the persistence layer reports an error.
+   */
+  public RobotAccountData registerOrUpdate(ParticipantId robotId, String location)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerOrUpdate(ParticipantId robotId, String location, long tokenExpirySeconds)
+  /**
+   * Registers a new robot or updates an existing robot while preserving the
+   * owner that originally claimed it.
+   */
+  public RobotAccountData registerOrUpdate(ParticipantId robotId, String location,
+      String ownerAddress) throws RobotRegistrationException, PersistenceException;
+
+  /**
+   * Registers a new robot or updates an existing robot while preserving the
+   * owner that originally claimed it and applying the requested token expiry.
+   */
+  public RobotAccountData registerOrUpdate(ParticipantId robotId, String location,
+      String ownerAddress, long tokenExpirySeconds)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerOrUpdate(ParticipantId robotId, String location, String ownerAddress)
+  /**
+   * Rotates the shared secret for an existing robot while keeping its current
+   * callback URL, capabilities, expiry, and owner metadata.
+   */
+  public RobotAccountData rotateSecret(ParticipantId robotId)
       throws RobotRegistrationException, PersistenceException;
 
-  RobotAccountData registerOrUpdate(ParticipantId robotId, String location, String ownerAddress,
-      long tokenExpirySeconds) throws RobotRegistrationException, PersistenceException;
-
-  RobotAccountData rotateSecret(ParticipantId robotId)
+  /**
+   * Updates the owner-managed description for an existing robot.
+   */
+  public RobotAccountData updateDescription(ParticipantId robotId, String description)
       throws RobotRegistrationException, PersistenceException;
 
-  void addRegistrationListener(Listener listener);
+  /**
+   * Pauses or unpauses an existing robot.
+   */
+  public RobotAccountData setPaused(ParticipantId robotId, boolean paused)
+      throws RobotRegistrationException, PersistenceException;
 
-  void removeRegistrationListener(Listener listener);
+  /** Adds listener. */
+  public void addRegistrationListener(Listener listener);
+
+  /** Removes listener. */
+  public void removeRegistrationListener(Listener listener);
 }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImpl.java
@@ -1,8 +1,27 @@
-/** Jakarta variant of {@link RobotRegistrarImpl}. */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.waveprotocol.box.server.robots.register;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
@@ -17,8 +36,15 @@ import java.net.URI;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Logger;
 
-public final class RobotRegistrarImpl implements RobotRegistrar {
+/**
+ * Implements {@link RobotRegistrar}.
+ *
+ * @author yurize@apache.org (Yuri Zelikov)
+ */
+public class RobotRegistrarImpl implements RobotRegistrar {
+
   private static final Listener REGISTRATION_EVENTS_LOGGER = new Listener() {
+
     final Logger log = Logger.getLogger(RobotRegistrarImpl.class.getName());
 
     @Override
@@ -32,20 +58,35 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     }
   };
 
+  /** The length of the verification token (token secret). */
   private static final int TOKEN_LENGTH = 48;
 
+  /** The account store. */
   private final AccountStore accountStore;
-  private final TokenGenerator tokenGenerator;
-  private final CopyOnWriteArraySet<Listener> listeners = new CopyOnWriteArraySet<>();
 
+  /** The verification token generator. */
+  private final TokenGenerator tokenGenerator;
+
+  /** The list of listeners on robot un/registration events. */
+  private final CopyOnWriteArraySet<Listener> listeners = new CopyOnWriteArraySet<Listener>();
+
+  /**
+   * Computes and validates the robot URL.
+   *
+   * @param location the robot location.
+   * @return the validated robot URL in the form:
+   *         [http|https]://[domain]:[port]/[path], for example:
+   *         http://example.com:80/myrobot
+   * @throws RobotRegistrationException if the specified URI is invalid.
+   */
   private static String computeValidateRobotUrl(String location)
       throws RobotRegistrationException {
     URI uri;
     try {
       uri = URI.create(location);
     } catch (IllegalArgumentException e) {
-      throw new RobotRegistrationException(
-          "Invalid Location specified, please specify a location in URI format. " + e.getLocalizedMessage(), e);
+      String errorMessage = "Invalid Location specified, please specify a location in URI format.";
+      throw new RobotRegistrationException(errorMessage + " " + e.getLocalizedMessage(), e);
     }
     String scheme = uri.getScheme();
     if (scheme == null || (!scheme.equals("http") && !scheme.equals("https"))) {
@@ -57,6 +98,7 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     } else {
       robotLocation = scheme + "://" + uri.getHost() + uri.getPath();
     }
+
     if (robotLocation.endsWith("/")) {
       robotLocation = robotLocation.substring(0, robotLocation.length() - 1);
     }
@@ -86,6 +128,13 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
   public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
       long tokenExpirySeconds)
       throws RobotRegistrationException, PersistenceException {
+    return registerNew(robotId, location, ownerAddress, tokenExpirySeconds, "");
+  }
+
+  @Override
+  public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
+      long tokenExpirySeconds, String description)
+      throws RobotRegistrationException, PersistenceException {
     Preconditions.checkNotNull(robotId);
     Preconditions.checkNotNull(location);
 
@@ -94,12 +143,12 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
           + " is already in use, please choose another one.");
     }
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        tokenExpirySeconds, ownerAddress);
+        tokenExpirySeconds, ownerAddress, description);
   }
 
   @Override
-  public RobotAccountData unregister(ParticipantId robotId)
-      throws RobotRegistrationException, PersistenceException {
+  public RobotAccountData unregister(ParticipantId robotId) throws RobotRegistrationException,
+      PersistenceException {
     Preconditions.checkNotNull(robotId);
     AccountData accountData = accountStore.getAccount(robotId);
     if (accountData == null) {
@@ -114,14 +163,7 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
   @Override
   public RobotAccountData registerOrUpdate(ParticipantId robotId, String location)
       throws RobotRegistrationException, PersistenceException {
-    return registerOrUpdate(robotId, location, null, null);
-  }
-
-  @Override
-  public RobotAccountData registerOrUpdate(ParticipantId robotId, String location,
-      long tokenExpirySeconds)
-      throws RobotRegistrationException, PersistenceException {
-    return registerOrUpdate(robotId, location, null, Long.valueOf(tokenExpirySeconds));
+    return registerOrUpdate(robotId, location, null);
   }
 
   @Override
@@ -164,7 +206,7 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     }
     long resolvedTokenExpirySeconds = tokenExpirySeconds == null ? 0L : tokenExpirySeconds.longValue();
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        resolvedTokenExpirySeconds, ownerAddress);
+        resolvedTokenExpirySeconds, ownerAddress, "");
   }
 
   @Override
@@ -181,33 +223,87 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
   }
 
   @Override
-  public void addRegistrationListener(Listener listener) {
-    listeners.add(listener);
+  public RobotAccountData updateDescription(ParticipantId robotId, String description)
+      throws RobotRegistrationException, PersistenceException {
+    Preconditions.checkNotNull(robotId);
+    AccountData account = accountStore.getAccount(robotId);
+    if (account == null) {
+      return null;
+    }
+    throwExceptionIfNotRobot(account);
+    RobotAccountData robotAccount = account.asRobot();
+    String normalizedDescription = description == null ? "" : description;
+    if (robotAccount.getDescription().equals(normalizedDescription)) {
+      return robotAccount;
+    }
+    RobotAccountData updatedAccount = createRobotAccount(
+        robotAccount.getId(),
+        robotAccount.getUrl(),
+        robotAccount.getConsumerSecret(),
+        robotAccount.getCapabilities(),
+        robotAccount.isVerified(),
+        robotAccount.getTokenExpirySeconds(),
+        robotAccount.getOwnerAddress(),
+        normalizedDescription,
+        robotAccount.getCreatedAtMillis(),
+        System.currentTimeMillis(),
+        robotAccount.isPaused());
+    accountStore.putAccount(updatedAccount);
+    notifyRegistrationSuccess(updatedAccount);
+    return updatedAccount;
   }
 
   @Override
-  public void removeRegistrationListener(Listener listener) {
-    listeners.remove(listener);
+  public RobotAccountData setPaused(ParticipantId robotId, boolean paused)
+      throws RobotRegistrationException, PersistenceException {
+    Preconditions.checkNotNull(robotId);
+    AccountData account = accountStore.getAccount(robotId);
+    if (account == null) {
+      return null;
+    }
+    throwExceptionIfNotRobot(account);
+    RobotAccountData robotAccount = account.asRobot();
+    if (robotAccount.isPaused() == paused) {
+      return robotAccount;
+    }
+    RobotAccountData updatedAccount = createRobotAccount(
+        robotAccount.getId(),
+        robotAccount.getUrl(),
+        robotAccount.getConsumerSecret(),
+        robotAccount.getCapabilities(),
+        robotAccount.isVerified(),
+        robotAccount.getTokenExpirySeconds(),
+        robotAccount.getOwnerAddress(),
+        robotAccount.getDescription(),
+        robotAccount.getCreatedAtMillis(),
+        System.currentTimeMillis(),
+        paused);
+    accountStore.putAccount(updatedAccount);
+    notifyRegistrationSuccess(updatedAccount);
+    return updatedAccount;
   }
 
+  /**
+   *  Adds the robot to the account store and notifies the listeners.
+   */
   private RobotAccountData registerRobot(ParticipantId robotId, String location)
       throws RobotRegistrationException, PersistenceException {
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        0L, null);
+        0L, null, "");
   }
 
   private RobotAccountData registerRobot(ParticipantId robotId, String location, String consumerSecret,
       RobotCapabilities capabilities, boolean verified, long tokenExpirySeconds,
-      String ownerAddress)
+      String ownerAddress, String description)
       throws RobotRegistrationException, PersistenceException {
     String robotLocation = normalizeRobotLocation(location);
     boolean verifiedRobot = verified && !robotLocation.isEmpty();
-    RobotAccountData robotAccount = new RobotAccountDataImpl(robotId, robotLocation,
-        consumerSecret, capabilities, verifiedRobot, tokenExpirySeconds, ownerAddress);
+    long now = System.currentTimeMillis();
+    RobotAccountData robotAccount =
+        createRobotAccount(robotId, robotLocation, consumerSecret, capabilities, verifiedRobot,
+            tokenExpirySeconds, ownerAddress, description, now, now, false);
     accountStore.putAccount(robotAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(robotAccount);
-    }
+    notifyRegistrationSuccess(robotAccount);
     return robotAccount;
   }
 
@@ -216,18 +312,20 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     RobotCapabilities updatedCapabilities =
         existingAccount.getUrl().equals(location) ? existingAccount.getCapabilities() : null;
     RobotAccountData updatedAccount =
-        new RobotAccountDataImpl(
+        createRobotAccount(
             existingAccount.getId(),
             location,
             existingAccount.getConsumerSecret(),
             updatedCapabilities,
             !location.isEmpty(),
             tokenExpirySeconds,
-            ownerAddress);
+            ownerAddress,
+            existingAccount.getDescription(),
+            existingAccount.getCreatedAtMillis(),
+            System.currentTimeMillis(),
+            existingAccount.isPaused());
     accountStore.putAccount(updatedAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(updatedAccount);
-    }
+    notifyRegistrationSuccess(updatedAccount);
     return updatedAccount;
   }
 
@@ -235,18 +333,20 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
       throws RobotRegistrationException, PersistenceException {
     String normalizedLocation = normalizeRobotLocation(existingAccount.getUrl());
     RobotAccountData updatedAccount =
-        new RobotAccountDataImpl(
+        createRobotAccount(
             existingAccount.getId(),
             normalizedLocation,
             consumerSecret,
             existingAccount.getCapabilities(),
             existingAccount.isVerified(),
             existingAccount.getTokenExpirySeconds(),
-            existingAccount.getOwnerAddress());
+            existingAccount.getOwnerAddress(),
+            existingAccount.getDescription(),
+            existingAccount.getCreatedAtMillis(),
+            System.currentTimeMillis(),
+            existingAccount.isPaused());
     accountStore.putAccount(updatedAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(updatedAccount);
-    }
+    notifyRegistrationSuccess(updatedAccount);
     return updatedAccount;
   }
 
@@ -273,6 +373,11 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     return currentOwnerAddress.equals(resolvedOwnerAddress);
   }
 
+  /**
+   * Removes the robot account and notifies the listeners.
+   * @param existingAccount the account to remove
+   * @throws PersistenceException if the persistence layer reports an error.
+   */
   private void removeRobotAccount(RobotAccountData existingAccount)
       throws PersistenceException {
     accountStore.removeAccount(existingAccount.getId());
@@ -281,11 +386,44 @@ public final class RobotRegistrarImpl implements RobotRegistrar {
     }
   }
 
+  /**
+   * Ensures that the account belongs to a robot.
+   *
+   * @param existingAccount the account to check.
+   * @throws RobotRegistrationException if the account is not robot.
+   */
   private void throwExceptionIfNotRobot(AccountData existingAccount)
       throws RobotRegistrationException {
     if (!existingAccount.isRobot()) {
-      throw new RobotRegistrationException(
-          existingAccount.getId().getAddress() + " is not a robot.");
+      throw new RobotRegistrationException(existingAccount.getId().getAddress()
+          + " is not a robot account!");
+    }
+  }
+
+  // Handle listeners.
+  @Override
+  public void addRegistrationListener(Listener listener) {
+    Preconditions.checkNotNull(listener);
+    listeners.add(listener);
+  }
+
+  @Override
+  public void removeRegistrationListener(Listener listener) {
+    Preconditions.checkNotNull(listener);
+    listeners.remove(listener);
+  }
+
+  private RobotAccountData createRobotAccount(ParticipantId robotId, String robotLocation,
+      String consumerSecret, RobotCapabilities capabilities, boolean verified, long tokenExpirySeconds,
+      String ownerAddress, String description, long createdAtMillis, long updatedAtMillis,
+      boolean paused) {
+    return new RobotAccountDataImpl(robotId, robotLocation, consumerSecret, capabilities, verified,
+        tokenExpirySeconds, ownerAddress, description, createdAtMillis, updatedAtMillis, paused);
+  }
+
+  private void notifyRegistrationSuccess(RobotAccountData robotAccount) {
+    for (Listener listener : listeners) {
+      listener.onRegistrationSuccess(robotAccount);
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/account/RobotAccountData.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/RobotAccountData.java
@@ -64,4 +64,24 @@ public interface RobotAccountData extends AccountData {
    * robot predates ownership tracking.
    */
   String getOwnerAddress();
+
+  /**
+   * Returns the owner-managed description for this robot.
+   */
+  String getDescription();
+
+  /**
+   * Returns the persisted creation timestamp in epoch milliseconds.
+   */
+  long getCreatedAtMillis();
+
+  /**
+   * Returns the persisted last update timestamp in epoch milliseconds.
+   */
+  long getUpdatedAtMillis();
+
+  /**
+   * Returns true when this robot is paused and should not execute.
+   */
+  boolean isPaused();
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/account/RobotAccountDataImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/RobotAccountDataImpl.java
@@ -37,6 +37,10 @@ public final class RobotAccountDataImpl implements RobotAccountData {
   private final boolean isVerified;
   private final long tokenExpirySeconds;
   private final String ownerAddress;
+  private final String description;
+  private final long createdAtMillis;
+  private final long updatedAtMillis;
+  private final boolean paused;
 
   /**
    * Creates a new {@link RobotAccountData} with default token expiry (0 = no expiry).
@@ -54,7 +58,7 @@ public final class RobotAccountDataImpl implements RobotAccountData {
    */
   public RobotAccountDataImpl(ParticipantId id, String url, String consumerSecret,
       RobotCapabilities capabilities, boolean isVerified) {
-    this(id, url, consumerSecret, capabilities, isVerified, 0L, null);
+    this(id, url, consumerSecret, capabilities, isVerified, 0L, null, "", 0L, 0L, false);
   }
 
   /**
@@ -71,12 +75,21 @@ public final class RobotAccountDataImpl implements RobotAccountData {
    */
   public RobotAccountDataImpl(ParticipantId id, String url, String consumerSecret,
       RobotCapabilities capabilities, boolean isVerified, long tokenExpirySeconds) {
-    this(id, url, consumerSecret, capabilities, isVerified, tokenExpirySeconds, null);
+    this(id, url, consumerSecret, capabilities, isVerified, tokenExpirySeconds, null,
+        "", 0L, 0L, false);
   }
 
   public RobotAccountDataImpl(ParticipantId id, String url, String consumerSecret,
       RobotCapabilities capabilities, boolean isVerified, long tokenExpirySeconds,
       String ownerAddress) {
+    this(id, url, consumerSecret, capabilities, isVerified, tokenExpirySeconds, ownerAddress,
+        "", 0L, 0L, false);
+  }
+
+  public RobotAccountDataImpl(ParticipantId id, String url, String consumerSecret,
+      RobotCapabilities capabilities, boolean isVerified, long tokenExpirySeconds,
+      String ownerAddress, String description, long createdAtMillis, long updatedAtMillis,
+      boolean paused) {
     Preconditions.checkNotNull(id, "Id can not be null");
     Preconditions.checkNotNull(url, "Url can not be null");
     Preconditions.checkNotNull(consumerSecret, "Consumer secret can not be null");
@@ -89,6 +102,10 @@ public final class RobotAccountDataImpl implements RobotAccountData {
     this.isVerified = isVerified;
     this.tokenExpirySeconds = tokenExpirySeconds;
     this.ownerAddress = ownerAddress;
+    this.description = description == null ? "" : description;
+    this.createdAtMillis = Math.max(0L, createdAtMillis);
+    this.updatedAtMillis = Math.max(0L, updatedAtMillis);
+    this.paused = paused;
   }
 
   @Override
@@ -147,16 +164,40 @@ public final class RobotAccountDataImpl implements RobotAccountData {
   }
 
   @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public long getCreatedAtMillis() {
+    return createdAtMillis;
+  }
+
+  @Override
+  public long getUpdatedAtMillis() {
+    return updatedAtMillis;
+  }
+
+  @Override
+  public boolean isPaused() {
+    return paused;
+  }
+
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((capabilities == null) ? 0 : capabilities.hashCode());
     result = prime * result + ((consumerSecret == null) ? 0 : consumerSecret.hashCode());
+    result = prime * result + Long.hashCode(createdAtMillis);
+    result = prime * result + ((description == null) ? 0 : description.hashCode());
     result = prime * result + ((id == null) ? 0 : id.hashCode());
     result = prime * result + (isVerified ? 1231 : 1237);
     result = prime * result + ((ownerAddress == null) ? 0 : ownerAddress.hashCode());
+    result = prime * result + (paused ? 1231 : 1237);
     result = prime * result + ((url == null) ? 0 : url.hashCode());
     result = prime * result + Long.hashCode(tokenExpirySeconds);
+    result = prime * result + Long.hashCode(updatedAtMillis);
     return result;
   }
 
@@ -186,6 +227,16 @@ public final class RobotAccountDataImpl implements RobotAccountData {
     } else if (!consumerSecret.equals(other.consumerSecret)) {
       return false;
     }
+    if (createdAtMillis != other.createdAtMillis) {
+      return false;
+    }
+    if (description == null) {
+      if (other.description != null) {
+        return false;
+      }
+    } else if (!description.equals(other.description)) {
+      return false;
+    }
     if (id == null) {
       if (other.id != null) {
         return false;
@@ -203,6 +254,9 @@ public final class RobotAccountDataImpl implements RobotAccountData {
     } else if (!ownerAddress.equals(other.ownerAddress)) {
       return false;
     }
+    if (paused != other.paused) {
+      return false;
+    }
     if (url == null) {
       if (other.url != null) {
         return false;
@@ -213,6 +267,9 @@ public final class RobotAccountDataImpl implements RobotAccountData {
     if (tokenExpirySeconds != other.tokenExpirySeconds) {
       return false;
     }
+    if (updatedAtMillis != other.updatedAtMillis) {
+      return false;
+    }
     return true;
   }
 
@@ -220,11 +277,15 @@ public final class RobotAccountDataImpl implements RobotAccountData {
   public String toString() {
     return "RobotAccountDataImp" +
         "[id=" + id +
-	",url=" + url +
-	",consumerSecret=<redacted>" +
-	",capabilities=" + capabilities +
-	",isVerified=" + isVerified +
-	",ownerAddress=<redacted>" +
-	",tokenExpirySeconds=" + tokenExpirySeconds + "]";
+        ",url=" + url +
+        ",consumerSecret=<redacted>" +
+        ",capabilities=" + capabilities +
+        ",isVerified=" + isVerified +
+        ",ownerAddress=<redacted>" +
+        ",description=" + description +
+        ",createdAtMillis=" + createdAtMillis +
+        ",updatedAtMillis=" + updatedAtMillis +
+        ",paused=" + paused +
+        ",tokenExpirySeconds=" + tokenExpirySeconds + "]";
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
@@ -101,6 +101,11 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
   private static final String ROBOT_CAPABILITIES_FIELD = "capabilities";
   private static final String ROBOT_VERIFIED_FIELD = "verified";
   private static final String ROBOT_OWNER_FIELD = "ownerAddress";
+  private static final String ROBOT_TOKEN_EXPIRY_FIELD = "tokenExpirySeconds";
+  private static final String ROBOT_DESCRIPTION_FIELD = "description";
+  private static final String ROBOT_CREATED_AT_FIELD = "createdAtMillis";
+  private static final String ROBOT_UPDATED_AT_FIELD = "updatedAtMillis";
+  private static final String ROBOT_PAUSED_FIELD = "paused";
 
   private static final String CAPABILITIES_VERSION_FIELD = "version";
   private static final String CAPABILITIES_HASH_FIELD = "capabilitiesHash";
@@ -423,8 +428,12 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
         .append(ROBOT_SECRET_FIELD, account.getConsumerSecret())
         .append(ROBOT_CAPABILITIES_FIELD, capabilitiesToObject(account.getCapabilities()))
         .append(ROBOT_VERIFIED_FIELD, account.isVerified())
-        .append("tokenExpirySeconds", account.getTokenExpirySeconds())
-        .append(ROBOT_OWNER_FIELD, account.getOwnerAddress());
+        .append(ROBOT_TOKEN_EXPIRY_FIELD, account.getTokenExpirySeconds())
+        .append(ROBOT_OWNER_FIELD, account.getOwnerAddress())
+        .append(ROBOT_DESCRIPTION_FIELD, account.getDescription())
+        .append(ROBOT_CREATED_AT_FIELD, account.getCreatedAtMillis())
+        .append(ROBOT_UPDATED_AT_FIELD, account.getUpdatedAtMillis())
+        .append(ROBOT_PAUSED_FIELD, account.isPaused());
   }
 
   private DBObject capabilitiesToObject(RobotCapabilities capabilities) {
@@ -459,11 +468,18 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
     RobotCapabilities capabilities =
         objectToCapabilities((DBObject) robot.get(ROBOT_CAPABILITIES_FIELD));
     boolean verified = (Boolean) robot.get(ROBOT_VERIFIED_FIELD);
-    Object tokenExpiryObj = robot.get("tokenExpirySeconds");
+    Object tokenExpiryObj = robot.get(ROBOT_TOKEN_EXPIRY_FIELD);
     long tokenExpirySeconds = tokenExpiryObj instanceof Number ? ((Number) tokenExpiryObj).longValue() : 0L;
     String ownerAddress = (String) robot.get(ROBOT_OWNER_FIELD);
+    String description = (String) robot.get(ROBOT_DESCRIPTION_FIELD);
+    Object createdAtObj = robot.get(ROBOT_CREATED_AT_FIELD);
+    long createdAtMillis = createdAtObj instanceof Number ? ((Number) createdAtObj).longValue() : 0L;
+    Object updatedAtObj = robot.get(ROBOT_UPDATED_AT_FIELD);
+    long updatedAtMillis = updatedAtObj instanceof Number ? ((Number) updatedAtObj).longValue() : 0L;
+    Object pausedObj = robot.get(ROBOT_PAUSED_FIELD);
+    boolean paused = pausedObj instanceof Boolean && (Boolean) pausedObj;
     return new RobotAccountDataImpl(id, url, secret, capabilities, verified, tokenExpirySeconds,
-        ownerAddress);
+        ownerAddress, description, createdAtMillis, updatedAtMillis, paused);
   }
 
   @SuppressWarnings("unchecked")

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -62,6 +62,10 @@ final class Mongo4AccountStore implements AccountStore {
   private static final String ROBOT_VERIFIED_FIELD = "verified";
   private static final String ROBOT_TOKEN_EXPIRY_FIELD = "tokenExpirySeconds";
   private static final String ROBOT_OWNER_FIELD = "ownerAddress";
+  private static final String ROBOT_DESCRIPTION_FIELD = "description";
+  private static final String ROBOT_CREATED_AT_FIELD = "createdAtMillis";
+  private static final String ROBOT_UPDATED_AT_FIELD = "updatedAtMillis";
+  private static final String ROBOT_PAUSED_FIELD = "paused";
 
   private static final String CAPABILITIES_VERSION_FIELD = "version";
   private static final String CAPABILITIES_HASH_FIELD = "capabilitiesHash";
@@ -327,7 +331,11 @@ final class Mongo4AccountStore implements AccountStore {
         .append(ROBOT_CAPABILITIES_FIELD, capabilitiesToObject(account.getCapabilities()))
         .append(ROBOT_VERIFIED_FIELD, account.isVerified())
         .append(ROBOT_TOKEN_EXPIRY_FIELD, account.getTokenExpirySeconds())
-        .append(ROBOT_OWNER_FIELD, account.getOwnerAddress());
+        .append(ROBOT_OWNER_FIELD, account.getOwnerAddress())
+        .append(ROBOT_DESCRIPTION_FIELD, account.getDescription())
+        .append(ROBOT_CREATED_AT_FIELD, account.getCreatedAtMillis())
+        .append(ROBOT_UPDATED_AT_FIELD, account.getUpdatedAtMillis())
+        .append(ROBOT_PAUSED_FIELD, account.isPaused());
   }
 
   private static Document capabilitiesToObject(RobotCapabilities caps) {
@@ -354,8 +362,13 @@ final class Mongo4AccountStore implements AccountStore {
     Long tokenExpiry = robot.getLong(ROBOT_TOKEN_EXPIRY_FIELD);
     long tokenExpirySeconds = tokenExpiry != null ? tokenExpiry : 0L;
     String ownerAddress = robot.getString(ROBOT_OWNER_FIELD);
+    String description = robot.getString(ROBOT_DESCRIPTION_FIELD);
+    Long createdAt = robot.getLong(ROBOT_CREATED_AT_FIELD);
+    Long updatedAt = robot.getLong(ROBOT_UPDATED_AT_FIELD);
+    Boolean paused = robot.getBoolean(ROBOT_PAUSED_FIELD);
     return new RobotAccountDataImpl(id, url, secret, caps, verified, tokenExpirySeconds,
-        ownerAddress);
+        ownerAddress, description, createdAt != null ? createdAt : 0L,
+        updatedAt != null ? updatedAt : 0L, paused != null && paused);
   }
 
   private static RobotCapabilities objectToCapabilities(Document obj) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
@@ -129,6 +129,16 @@ public class ProtoAccountDataSerializer {
     if (account.getOwnerAddress() != null && !account.getOwnerAddress().isEmpty()) {
       builder.setOwnerAddress(account.getOwnerAddress());
     }
+    if (account.getDescription() != null && !account.getDescription().isEmpty()) {
+      builder.setDescription(account.getDescription());
+    }
+    if (account.getCreatedAtMillis() > 0L) {
+      builder.setCreatedAtMillis(account.getCreatedAtMillis());
+    }
+    if (account.getUpdatedAtMillis() > 0L) {
+      builder.setUpdatedAtMillis(account.getUpdatedAtMillis());
+    }
+    builder.setPaused(account.isPaused());
     if (account.getCapabilities() != null) {
       builder.setRobotCapabilities(serialize(account.getCapabilities()));
     }
@@ -232,8 +242,13 @@ public class ProtoAccountDataSerializer {
     }
     long tokenExpirySeconds = data.hasTokenExpirySeconds() ? data.getTokenExpirySeconds() : 0L;
     String ownerAddress = data.hasOwnerAddress() ? data.getOwnerAddress() : null;
+    String description = data.hasDescription() ? data.getDescription() : "";
+    long createdAtMillis = data.hasCreatedAtMillis() ? data.getCreatedAtMillis() : 0L;
+    long updatedAtMillis = data.hasUpdatedAtMillis() ? data.getUpdatedAtMillis() : 0L;
+    boolean paused = data.hasPaused() && data.getPaused();
     return new RobotAccountDataImpl(id, data.getUrl(), data.getConsumerSecret(),
-        capabilities, data.getIsVerified(), tokenExpirySeconds, ownerAddress);
+        capabilities, data.getIsVerified(), tokenExpirySeconds, ownerAddress, description,
+        createdAtMillis, updatedAtMillis, paused);
   }
 
   private static RobotCapabilities deserialize(ProtoRobotCapabilities data) {

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
@@ -67,7 +67,7 @@ public class Robot implements Runnable {
   // This is not final because it needs to be updated when the capabilities
   // change.
   // TODO(ljvderijk): Keep up to date with other updates to account?
-  private RobotAccountData account;
+  private volatile RobotAccountData account;
   private final RobotsGateway gateway;
   private final RobotConnector connector;
   private final EventDataConverterManager converterManager;
@@ -215,6 +215,17 @@ public class Robot implements Runnable {
   public void run() {
     try {
       LOG.fine(robotName + " called for processing");
+
+      if (!gateway.syncRobotAccount(this)) {
+        LOG.warning(robotName + ": skipped because the latest robot account could not be loaded");
+        gateway.doneRunning(this);
+        return;
+      }
+      if (account.isPaused()) {
+        LOG.info(robotName + ": skipped because the robot is paused");
+        gateway.doneRunning(this);
+        return;
+      }
 
       WaveletAndDeltas wavelet = dequeueWavelet();
       if (wavelet == null) {

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
@@ -109,6 +109,7 @@ public class RobotConnector implements RobotCapabilityFetcher {
 
     return new RobotAccountDataImpl(account.getId(), account.getUrl(), account.getConsumerSecret(),
         capabilities, account.isVerified(), account.getTokenExpirySeconds(),
-        account.getOwnerAddress());
+        account.getOwnerAddress(), account.getDescription(), account.getCreatedAtMillis(),
+        account.getUpdatedAtMillis(), account.isPaused());
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
@@ -125,7 +125,8 @@ public class RobotsGateway implements WaveBus.Subscriber {
 
       if (account != null && account.isRobot()) {
         RobotAccountData robotAccount = account.asRobot();
-        if (robotAccount.isVerified()) {
+        updateCachedRobotAccount(robotName, robotAccount);
+        if (robotAccount.isVerified() && !robotAccount.isPaused()) {
           Robot robot = getOrCreateRobot(robotName, robotAccount);
           updateRobot(robot, wavelet, deltas);
         }
@@ -146,6 +147,8 @@ public class RobotsGateway implements WaveBus.Subscriber {
     if (robot == null) {
       robot = createNewRobot(robotName, account);
       allRobots.put(robotName, robot);
+    } else {
+      robot.setAccount(account);
     }
     return robot;
   }
@@ -211,6 +214,20 @@ public class RobotsGateway implements WaveBus.Subscriber {
     runnableRobots.remove(robot.getRobotName());
   }
 
+  boolean syncRobotAccount(Robot robot) {
+    ParticipantId robotId = ParticipantId.ofUnsafe(robot.getRobotName().toEmailAddress());
+    try {
+      AccountData latestAccount = accountStore.getAccount(robotId);
+      if (latestAccount != null && latestAccount.isRobot()) {
+        robot.setAccount(latestAccount.asRobot());
+        return true;
+      }
+    } catch (PersistenceException e) {
+      LOG.severe("Failed to refresh robot account for " + robotId.getAddress(), e);
+    }
+    return false;
+  }
+
   /**
    * Updates the account for the given {@link Robot}.
    *
@@ -225,5 +242,12 @@ public class RobotsGateway implements WaveBus.Subscriber {
     RobotAccountData newAccount = connector.fetchCapabilities(robot.getAccount(), activeApiUrl);
     accountStore.putAccount(newAccount);
     robot.setAccount(newAccount);
+  }
+
+  private void updateCachedRobotAccount(RobotName robotName, RobotAccountData account) {
+    Robot robot = allRobots.get(robotName);
+    if (robot != null) {
+      robot.setAccount(account);
+    }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/register/RobotRegistrar.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/register/RobotRegistrar.java
@@ -74,6 +74,14 @@ public interface RobotRegistrar {
       long tokenExpirySeconds) throws RobotRegistrationException, PersistenceException;
 
   /**
+   * Registers a new robot account with ownership metadata, configurable token
+   * expiry, and an owner-managed description.
+   */
+  public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
+      long tokenExpirySeconds, String description)
+      throws RobotRegistrationException, PersistenceException;
+
+  /**
    * Unregisters a robot by removing it from the account store.
    *
    * @param robotId the id to remove.
@@ -118,6 +126,18 @@ public interface RobotRegistrar {
    * callback URL, capabilities, expiry, and owner metadata.
    */
   public RobotAccountData rotateSecret(ParticipantId robotId)
+      throws RobotRegistrationException, PersistenceException;
+
+  /**
+   * Updates the owner-managed description for an existing robot.
+   */
+  public RobotAccountData updateDescription(ParticipantId robotId, String description)
+      throws RobotRegistrationException, PersistenceException;
+
+  /**
+   * Pauses or unpauses an existing robot.
+   */
+  public RobotAccountData setPaused(ParticipantId robotId, boolean paused)
       throws RobotRegistrationException, PersistenceException;
 
   /** Adds listener. */

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImpl.java
@@ -128,6 +128,13 @@ public class RobotRegistrarImpl implements RobotRegistrar {
   public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
       long tokenExpirySeconds)
       throws RobotRegistrationException, PersistenceException {
+    return registerNew(robotId, location, ownerAddress, tokenExpirySeconds, "");
+  }
+
+  @Override
+  public RobotAccountData registerNew(ParticipantId robotId, String location, String ownerAddress,
+      long tokenExpirySeconds, String description)
+      throws RobotRegistrationException, PersistenceException {
     Preconditions.checkNotNull(robotId);
     Preconditions.checkNotNull(location);
 
@@ -136,7 +143,7 @@ public class RobotRegistrarImpl implements RobotRegistrar {
           + " is already in use, please choose another one.");
     }
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        tokenExpirySeconds, ownerAddress);
+        tokenExpirySeconds, ownerAddress, description);
   }
 
   @Override
@@ -199,7 +206,7 @@ public class RobotRegistrarImpl implements RobotRegistrar {
     }
     long resolvedTokenExpirySeconds = tokenExpirySeconds == null ? 0L : tokenExpirySeconds.longValue();
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        resolvedTokenExpirySeconds, ownerAddress);
+        resolvedTokenExpirySeconds, ownerAddress, "");
   }
 
   @Override
@@ -215,29 +222,88 @@ public class RobotRegistrarImpl implements RobotRegistrar {
     return updateRobotSecret(robotAccount, tokenGenerator.generateToken(TOKEN_LENGTH));
   }
 
+  @Override
+  public RobotAccountData updateDescription(ParticipantId robotId, String description)
+      throws RobotRegistrationException, PersistenceException {
+    Preconditions.checkNotNull(robotId);
+    AccountData account = accountStore.getAccount(robotId);
+    if (account == null) {
+      return null;
+    }
+    throwExceptionIfNotRobot(account);
+    RobotAccountData robotAccount = account.asRobot();
+    String normalizedDescription = description == null ? "" : description;
+    if (robotAccount.getDescription().equals(normalizedDescription)) {
+      return robotAccount;
+    }
+    RobotAccountData updatedAccount = createRobotAccount(
+        robotAccount.getId(),
+        robotAccount.getUrl(),
+        robotAccount.getConsumerSecret(),
+        robotAccount.getCapabilities(),
+        robotAccount.isVerified(),
+        robotAccount.getTokenExpirySeconds(),
+        robotAccount.getOwnerAddress(),
+        normalizedDescription,
+        robotAccount.getCreatedAtMillis(),
+        System.currentTimeMillis(),
+        robotAccount.isPaused());
+    accountStore.putAccount(updatedAccount);
+    notifyRegistrationSuccess(updatedAccount);
+    return updatedAccount;
+  }
+
+  @Override
+  public RobotAccountData setPaused(ParticipantId robotId, boolean paused)
+      throws RobotRegistrationException, PersistenceException {
+    Preconditions.checkNotNull(robotId);
+    AccountData account = accountStore.getAccount(robotId);
+    if (account == null) {
+      return null;
+    }
+    throwExceptionIfNotRobot(account);
+    RobotAccountData robotAccount = account.asRobot();
+    if (robotAccount.isPaused() == paused) {
+      return robotAccount;
+    }
+    RobotAccountData updatedAccount = createRobotAccount(
+        robotAccount.getId(),
+        robotAccount.getUrl(),
+        robotAccount.getConsumerSecret(),
+        robotAccount.getCapabilities(),
+        robotAccount.isVerified(),
+        robotAccount.getTokenExpirySeconds(),
+        robotAccount.getOwnerAddress(),
+        robotAccount.getDescription(),
+        robotAccount.getCreatedAtMillis(),
+        System.currentTimeMillis(),
+        paused);
+    accountStore.putAccount(updatedAccount);
+    notifyRegistrationSuccess(updatedAccount);
+    return updatedAccount;
+  }
+
   /**
    *  Adds the robot to the account store and notifies the listeners.
    */
   private RobotAccountData registerRobot(ParticipantId robotId, String location)
       throws RobotRegistrationException, PersistenceException {
     return registerRobot(robotId, location, tokenGenerator.generateToken(TOKEN_LENGTH), null, true,
-        0L, null);
+        0L, null, "");
   }
 
   private RobotAccountData registerRobot(ParticipantId robotId, String location, String consumerSecret,
       RobotCapabilities capabilities, boolean verified, long tokenExpirySeconds,
-      String ownerAddress)
+      String ownerAddress, String description)
       throws RobotRegistrationException, PersistenceException {
     String robotLocation = normalizeRobotLocation(location);
     boolean verifiedRobot = verified && !robotLocation.isEmpty();
-
+    long now = System.currentTimeMillis();
     RobotAccountData robotAccount =
-        new RobotAccountDataImpl(robotId, robotLocation,
-            consumerSecret, capabilities, verifiedRobot, tokenExpirySeconds, ownerAddress);
+        createRobotAccount(robotId, robotLocation, consumerSecret, capabilities, verifiedRobot,
+            tokenExpirySeconds, ownerAddress, description, now, now, false);
     accountStore.putAccount(robotAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(robotAccount);
-    }
+    notifyRegistrationSuccess(robotAccount);
     return robotAccount;
   }
 
@@ -246,18 +312,20 @@ public class RobotRegistrarImpl implements RobotRegistrar {
     RobotCapabilities updatedCapabilities =
         existingAccount.getUrl().equals(location) ? existingAccount.getCapabilities() : null;
     RobotAccountData updatedAccount =
-        new RobotAccountDataImpl(
+        createRobotAccount(
             existingAccount.getId(),
             location,
             existingAccount.getConsumerSecret(),
             updatedCapabilities,
             !location.isEmpty(),
             tokenExpirySeconds,
-            ownerAddress);
+            ownerAddress,
+            existingAccount.getDescription(),
+            existingAccount.getCreatedAtMillis(),
+            System.currentTimeMillis(),
+            existingAccount.isPaused());
     accountStore.putAccount(updatedAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(updatedAccount);
-    }
+    notifyRegistrationSuccess(updatedAccount);
     return updatedAccount;
   }
 
@@ -265,18 +333,20 @@ public class RobotRegistrarImpl implements RobotRegistrar {
       throws RobotRegistrationException, PersistenceException {
     String normalizedLocation = normalizeRobotLocation(existingAccount.getUrl());
     RobotAccountData updatedAccount =
-        new RobotAccountDataImpl(
+        createRobotAccount(
             existingAccount.getId(),
             normalizedLocation,
             consumerSecret,
             existingAccount.getCapabilities(),
             existingAccount.isVerified(),
             existingAccount.getTokenExpirySeconds(),
-            existingAccount.getOwnerAddress());
+            existingAccount.getOwnerAddress(),
+            existingAccount.getDescription(),
+            existingAccount.getCreatedAtMillis(),
+            System.currentTimeMillis(),
+            existingAccount.isPaused());
     accountStore.putAccount(updatedAccount);
-    for (Listener listener : listeners) {
-      listener.onRegistrationSuccess(updatedAccount);
-    }
+    notifyRegistrationSuccess(updatedAccount);
     return updatedAccount;
   }
 
@@ -341,5 +411,19 @@ public class RobotRegistrarImpl implements RobotRegistrar {
   public void removeRegistrationListener(Listener listener) {
     Preconditions.checkNotNull(listener);
     listeners.remove(listener);
+  }
+
+  private RobotAccountData createRobotAccount(ParticipantId robotId, String robotLocation,
+      String consumerSecret, RobotCapabilities capabilities, boolean verified, long tokenExpirySeconds,
+      String ownerAddress, String description, long createdAtMillis, long updatedAtMillis,
+      boolean paused) {
+    return new RobotAccountDataImpl(robotId, robotLocation, consumerSecret, capabilities, verified,
+        tokenExpirySeconds, ownerAddress, description, createdAtMillis, updatedAtMillis, paused);
+  }
+
+  private void notifyRegistrationSuccess(RobotAccountData robotAccount) {
+    for (Listener listener : listeners) {
+      listener.onRegistrationSuccess(robotAccount);
+    }
   }
 }

--- a/wave/src/main/resources/config/changelog.json
+++ b/wave/src/main/resources/config/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "releaseId": "2026-03-29-robot-dashboard-upgrade",
+    "version": "PR #477",
+    "date": "2026-03-29",
+    "title": "Robot Dashboard Upgrade",
+    "summary": "Robot owners can now manage richer dashboard metadata, test callbacks, and pause delivery without leaving the server-rendered control room.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Expanded /account/robots with staged robot setup, description editing, one-time secret handoff pages, masked secret previews, callback testing, pause/unpause, delete, and created/updated timestamps"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Persisted robot descriptions, timestamps, and pause state across proto, file, memory, and Mongo account stores",
+          "Blocked paused robots from client-credentials token issuance and passive robot execution"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-03-28-robot-dashboard-management",
     "version": "PR #455",
     "date": "2026-03-28",

--- a/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
+++ b/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
@@ -81,6 +81,10 @@ message ProtoRobotAccountData {
 	required bool is_verified = 4;
 	optional int64 token_expiry_seconds = 5 [default = 0];
 	optional string owner_address = 6;
+	optional string description = 7 [default = ""];
+	optional int64 created_at_millis = 8 [default = 0];
+	optional int64 updated_at_millis = 9 [default = 0];
+	optional bool paused = 10 [default = false];
 }
 
 // Data found in a RobotCapabilities instance

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
@@ -54,6 +54,8 @@ public abstract class AccountStoreTestBase extends TestCase {
 
   private RobotAccountData updatedRobotAccount;
 
+  private RobotAccountData robotAccountWithMetadata;
+
   private HumanAccountData convertedRobot;
 
   @Override
@@ -77,6 +79,9 @@ public abstract class AccountStoreTestBase extends TestCase {
     updatedRobotAccount =
         new RobotAccountDataImpl(ROBOT_ID, "example.com", "secret", new RobotCapabilities(
             capabilities, "FAKEHASH", ProtocolVersion.DEFAULT), true);
+    robotAccountWithMetadata =
+        new RobotAccountDataImpl(ROBOT_ID, "example.com", "secret", null, true, 3600L,
+            "owner@example.com", "Coordinates the daily digest", 1234L, 5678L, true);
     convertedRobot = new HumanAccountDataImpl(ROBOT_ID);
   }
 
@@ -109,6 +114,14 @@ public abstract class AccountStoreTestBase extends TestCase {
     accountStore.putAccount(robotAccount);
     AccountData retrievedAccount = accountStore.getAccount(ROBOT_ID);
     assertEquals(robotAccount, retrievedAccount);
+  }
+
+  public final void testRoundtripRobotAccountWithMetadata() throws Exception {
+    AccountStore accountStore = newAccountStore();
+
+    accountStore.putAccount(robotAccountWithMetadata);
+    AccountData retrievedAccount = accountStore.getAccount(ROBOT_ID);
+    assertEquals(robotAccountWithMetadata, retrievedAccount);
   }
 
   public final void testGetMissingAccountReturnsNull() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
@@ -56,6 +56,8 @@ public class ProtoAccountDataSerializerTest extends TestCase {
 
   private RobotAccountData robotAccountWithCapabilities;
 
+  private RobotAccountData robotAccountWithMetadata;
+
   private HumanAccountData humanAccount;
 
   private HumanAccountData humanAccountWithDigest;
@@ -81,6 +83,10 @@ public class ProtoAccountDataSerializerTest extends TestCase {
     robotAccountWithCapabilities =
         new RobotAccountDataImpl(ROBOT_ID, "example.com", "secret", new RobotCapabilities(
             capabilities, "FAKEHASH", ProtocolVersion.DEFAULT), true);
+
+    robotAccountWithMetadata =
+        new RobotAccountDataImpl(ROBOT_ID, "example.com", "secret", null, true, 3600L,
+            "owner@example.com", "Keeps the backlog tidy", 1000L, 2000L, true);
 
     humanAccount = new HumanAccountDataImpl(HUMAN_ID);
     humanAccountWithDigest = new HumanAccountDataImpl(HUMAN_ID,
@@ -168,5 +174,11 @@ public class ProtoAccountDataSerializerTest extends TestCase {
     ProtoAccountData data = ProtoAccountDataSerializer.serialize(robotAccountWithCapabilities);
     AccountData account = ProtoAccountDataSerializer.deserialize(data);
     assertEquals(robotAccountWithCapabilities, account);
+  }
+
+  public final void testRobotAccountWithMetadata() {
+    ProtoAccountData data = ProtoAccountDataSerializer.serialize(robotAccountWithMetadata);
+    AccountData account = ProtoAccountDataSerializer.deserialize(data);
+    assertEquals(robotAccountWithMetadata, account);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -22,20 +22,25 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.wave.api.ProtocolVersion;
+import com.google.wave.api.event.EventType;
+import com.google.wave.api.robot.Capability;
 import junit.framework.TestCase;
-
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
 import org.waveprotocol.box.server.robots.register.RobotRegistrar;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -49,6 +54,7 @@ public class RobotDashboardServletTest extends TestCase {
   private SessionManager sessionManager;
   private AccountStore accountStore;
   private RobotRegistrar robotRegistrar;
+  private RobotCapabilityFetcher capabilityFetcher;
   private HttpServletRequest req;
   private HttpServletResponse resp;
   private StringWriter outputWriter;
@@ -59,6 +65,7 @@ public class RobotDashboardServletTest extends TestCase {
     sessionManager = mock(SessionManager.class);
     accountStore = mock(AccountStore.class);
     robotRegistrar = mock(RobotRegistrar.class);
+    capabilityFetcher = mock(RobotCapabilityFetcher.class);
 
     req = mock(HttpServletRequest.class);
     resp = mock(HttpServletResponse.class);
@@ -66,9 +73,11 @@ public class RobotDashboardServletTest extends TestCase {
     outputWriter = new StringWriter();
     when(resp.getWriter()).thenReturn(new PrintWriter(outputWriter));
     when(req.getRequestURI()).thenReturn("/account/robots");
+    when(req.getContextPath()).thenReturn("");
     when(req.getSession(false)).thenReturn(session);
 
-    servlet = new RobotDashboardServlet("example.com", sessionManager, accountStore, robotRegistrar);
+    servlet = new RobotDashboardServlet("example.com", sessionManager, accountStore, robotRegistrar,
+        capabilityFetcher, length -> "dashboard-xsrf");
   }
 
   public void testDoGetRedirectsWhenLoggedOut() throws Exception {
@@ -91,30 +100,30 @@ public class RobotDashboardServletTest extends TestCase {
     verify(resp).sendRedirect("/wave/auth/signin?r=%2Faccount%2Frobots%3Fsource%3Dmenu");
   }
 
-  public void testDoGetRendersOwnedRobotsAndAiPrompt() throws Exception {
+  public void testDoGetRendersOwnedRobotsWithMaskedSecretsAndTimestamps() throws Exception {
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(
-        new RobotAccountDataImpl(ROBOT, "https://robot.example.com/callback", "secret", null,
-            true, 3600L, OWNER.getAddress())));
+        robot("https://robot.example.com/callback", "secret1234", "Summarises support load",
+            1700000000000L, 1700003600000L, false)));
 
     servlet.doGet(req, resp);
 
     assertTrue(outputWriter.toString().contains("Robot Control Room"));
     assertTrue(outputWriter.toString().contains("robot-bot@example.com"));
-    assertTrue(outputWriter.toString().contains("Google AI Studio / Gemini"));
-    assertTrue(outputWriter.toString().contains("SUPAWAVE_DATA_API_TOKEN"));
+    assertTrue(outputWriter.toString().contains("dashboard preview: ••••••1234"));
+    assertFalse(outputWriter.toString().contains("SUPAWAVE_ROBOT_SECRET=secret1234"));
+    assertTrue(outputWriter.toString().contains("2023-11-14 22:13 UTC"));
+    assertTrue(outputWriter.toString().contains("Google AI" ) || outputWriter.toString().contains("Build with AI"));
   }
 
-  public void testDoGetRendersRotateSecretControlForOwnedRobot() throws Exception {
+  public void testDoGetRendersUnknownTimestampForLegacyRobot() throws Exception {
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(
-        new RobotAccountDataImpl(ROBOT, "https://robot.example.com/callback", "secret", null,
-            true, 3600L, OWNER.getAddress())));
+        robot("", "secret1234", "", 0L, 0L, false)));
 
     servlet.doGet(req, resp);
 
-    assertTrue(outputWriter.toString().contains("action\" value=\"rotate-secret\""));
-    assertTrue(outputWriter.toString().contains("Rotate Secret"));
+    assertTrue(outputWriter.toString().contains("Unknown (legacy)"));
   }
 
   public void testDoGetUsesTrustedRequestOriginInAiPrompt() throws Exception {
@@ -192,11 +201,8 @@ public class RobotDashboardServletTest extends TestCase {
     when(req.getParameter("action")).thenReturn("rotate-secret");
     when(req.getParameter("token")).thenReturn("dashboard-xsrf");
     when(req.getParameter("robotId")).thenReturn(ROBOT.getAddress());
-    when(accountStore.getAccount(ROBOT))
-        .thenReturn(
-            (AccountData)
-                new RobotAccountDataImpl(
-                    ROBOT, "", "secret", null, false, 3600L, OTHER_OWNER.getAddress()));
+    when(accountStore.getAccount(ROBOT)).thenReturn((AccountData) new RobotAccountDataImpl(
+        ROBOT, "", "secret", null, false, 3600L, OTHER_OWNER.getAddress()));
 
     servlet.doPost(req, resp);
 
@@ -204,15 +210,34 @@ public class RobotDashboardServletTest extends TestCase {
     assertTrue(outputWriter.toString().contains("You do not own this robot"));
   }
 
-  public void testDoPostUpdatesCallbackForOwnedRobot() throws Exception {
-    RobotAccountData existingRobot = new RobotAccountDataImpl(ROBOT, "", "secret", null, false,
-        3600L, OWNER.getAddress());
-    RobotAccountData updatedRobot = new RobotAccountDataImpl(ROBOT,
-        "https://robot.example.com/callback", "secret", null, true, 3600L,
-        OWNER.getAddress());
+  public void testDoPostUpdatesDescriptionForOwnedRobot() throws Exception {
+    RobotAccountData existingRobot = robot("", "secret1234", "Old description", 1000L, 2000L, false);
+    RobotAccountData updatedRobot = robot("", "secret1234", "Fresh description", 1000L, 3000L, false);
 
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
-    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot));
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot), List.of(updatedRobot));
+    servlet.doGet(req, resp);
+    outputWriter.getBuffer().setLength(0);
+    when(req.getParameter("action")).thenReturn("update-description");
+    when(req.getParameter("token")).thenReturn("dashboard-xsrf");
+    when(req.getParameter("robotId")).thenReturn(ROBOT.getAddress());
+    when(req.getParameter("description")).thenReturn("Fresh description");
+    when(accountStore.getAccount(ROBOT)).thenReturn((AccountData) existingRobot);
+    when(robotRegistrar.updateDescription(ROBOT, "Fresh description")).thenReturn(updatedRobot);
+
+    servlet.doPost(req, resp);
+
+    verify(robotRegistrar).updateDescription(ROBOT, "Fresh description");
+    assertTrue(outputWriter.toString().contains("Fresh description"));
+  }
+
+  public void testDoPostUpdatesCallbackForOwnedRobot() throws Exception {
+    RobotAccountData existingRobot = robot("", "secret1234", "", 1000L, 2000L, false);
+    RobotAccountData updatedRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 3000L, false);
+
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot), List.of(updatedRobot));
     servlet.doGet(req, resp);
     outputWriter.getBuffer().setLength(0);
     when(req.getParameter("action")).thenReturn("update-url");
@@ -228,21 +253,86 @@ public class RobotDashboardServletTest extends TestCase {
     verify(robotRegistrar).registerOrUpdate(ROBOT, "https://robot.example.com/callback",
         OWNER.getAddress());
     assertTrue(outputWriter.toString().contains("https://robot.example.com/callback"));
-    assertTrue(outputWriter.toString().contains("secret"));
+    assertFalse(outputWriter.toString().contains("secret1234</div>"));
+  }
+
+  public void testDoPostTestsRobotAndStoresUpdatedCapabilities() throws Exception {
+    RobotAccountData existingRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 2000L, false);
+    RobotAccountData fetchedRobot = new RobotAccountDataImpl(ROBOT,
+        "https://robot.example.com/callback", "secret1234", new RobotCapabilities(
+            Map.of(EventType.BLIP_SUBMITTED, new Capability(EventType.BLIP_SUBMITTED)),
+            "hash", ProtocolVersion.DEFAULT), true, 3600L, OWNER.getAddress(), "", 1000L, 2000L,
+        false);
+    RobotAccountData renderedRobot = new RobotAccountDataImpl(ROBOT,
+        "https://robot.example.com/callback", "secret1234", fetchedRobot.getCapabilities(), true,
+        3600L, OWNER.getAddress(), "", 1000L, Instant.parse("2026-03-28T10:00:00Z").toEpochMilli(),
+        false);
+
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot), List.of(renderedRobot));
+    servlet.doGet(req, resp);
+    outputWriter.getBuffer().setLength(0);
+    when(req.getParameter("action")).thenReturn("test-robot");
+    when(req.getParameter("token")).thenReturn("dashboard-xsrf");
+    when(req.getParameter("robotId")).thenReturn(ROBOT.getAddress());
+    when(accountStore.getAccount(ROBOT)).thenReturn((AccountData) existingRobot);
+    when(capabilityFetcher.fetchCapabilities(existingRobot, "")).thenReturn(fetchedRobot);
+
+    servlet.doPost(req, resp);
+
+    verify(capabilityFetcher).fetchCapabilities(existingRobot, "");
+    verify(accountStore).putAccount(any(RobotAccountData.class));
+    assertTrue(outputWriter.toString().contains("Robot verified"));
+    assertTrue(outputWriter.toString().contains("BLIP_SUBMITTED"));
+  }
+
+  public void testDoPostPausesOwnedRobot() throws Exception {
+    RobotAccountData existingRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 2000L, false);
+    RobotAccountData pausedRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 3000L, true);
+
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot), List.of(pausedRobot));
+    servlet.doGet(req, resp);
+    outputWriter.getBuffer().setLength(0);
+    when(req.getParameter("action")).thenReturn("pause-robot");
+    when(req.getParameter("token")).thenReturn("dashboard-xsrf");
+    when(req.getParameter("robotId")).thenReturn(ROBOT.getAddress());
+    when(accountStore.getAccount(ROBOT)).thenReturn((AccountData) existingRobot);
+    when(robotRegistrar.setPaused(ROBOT, true)).thenReturn(pausedRobot);
+
+    servlet.doPost(req, resp);
+
+    verify(robotRegistrar).setPaused(ROBOT, true);
+    assertTrue(outputWriter.toString().contains("Paused"));
+  }
+
+  public void testDoPostDeletesOwnedRobot() throws Exception {
+    RobotAccountData existingRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 2000L, false);
+
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot), List.of());
+    servlet.doGet(req, resp);
+    outputWriter.getBuffer().setLength(0);
+    when(req.getParameter("action")).thenReturn("delete-robot");
+    when(req.getParameter("token")).thenReturn("dashboard-xsrf");
+    when(req.getParameter("robotId")).thenReturn(ROBOT.getAddress());
+    when(accountStore.getAccount(ROBOT)).thenReturn((AccountData) existingRobot);
+
+    servlet.doPost(req, resp);
+
+    verify(robotRegistrar).unregister(ROBOT);
+    assertTrue(outputWriter.toString().contains("No robots yet"));
   }
 
   public void testDoPostRotatesSecretForOwnedRobot() throws Exception {
-    RobotAccountData existingRobot =
-        new RobotAccountDataImpl(ROBOT, "", "secret", null, false, 3600L, OWNER.getAddress());
-    RobotAccountData rotatedRobot =
-        new RobotAccountDataImpl(
-            ROBOT,
-            "https://robot.example.com/callback",
-            "new-secret",
-            null,
-            true,
-            3600L,
-            OWNER.getAddress());
+    RobotAccountData existingRobot = robot("https://robot.example.com/callback", "secret1234", "",
+        1000L, 2000L, false);
+    RobotAccountData rotatedRobot = robot("https://robot.example.com/callback", "new-secret", "",
+        1000L, 3000L, false);
 
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(existingRobot));
@@ -258,28 +348,40 @@ public class RobotDashboardServletTest extends TestCase {
 
     verify(robotRegistrar).rotateSecret(ROBOT);
     assertTrue(outputWriter.toString().contains("new-secret"));
+    assertTrue(outputWriter.toString().contains("masked preview"));
   }
 
   public void testDoPostRegistersPendingRobotForCurrentOwner() throws Exception {
-    RobotAccountData registeredRobot = new RobotAccountDataImpl(ROBOT, "", "new-secret", null,
-        false, 3600L, OWNER.getAddress());
+    RobotAccountData registeredRobot = robot("", "new-secret", "Helper robot", 1000L, 1000L, false);
 
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
-    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of(), List.of(registeredRobot));
     servlet.doGet(req, resp);
     outputWriter.getBuffer().setLength(0);
     when(req.getParameter("action")).thenReturn("register");
     when(req.getParameter("token")).thenReturn("dashboard-xsrf");
     when(req.getParameter("username")).thenReturn("robot-bot");
+    when(req.getParameter("description")).thenReturn("Helper robot");
     when(req.getParameter("location")).thenReturn("");
     when(req.getParameter("token_expiry")).thenReturn("3600");
-    when(robotRegistrar.registerNew(ROBOT, "", OWNER.getAddress(), 3600L))
+    when(robotRegistrar.registerNew(ROBOT, "", OWNER.getAddress(), 3600L, "Helper robot"))
         .thenReturn(registeredRobot);
 
     servlet.doPost(req, resp);
 
-    verify(robotRegistrar).registerNew(ROBOT, "", OWNER.getAddress(), 3600L);
+    verify(robotRegistrar).registerNew(ROBOT, "", OWNER.getAddress(), 3600L, "Helper robot");
     assertTrue(outputWriter.toString().contains("new-secret"));
-    assertTrue(outputWriter.toString().contains("SUPAWAVE_ROBOT_SECRET=new-secret"));
+    assertTrue(outputWriter.toString().contains("one-time handoff" ) || outputWriter.toString().contains("dashboard only shows a masked preview"));
+
+    outputWriter.getBuffer().setLength(0);
+    servlet.doGet(req, resp);
+    assertTrue(outputWriter.toString().contains("dashboard preview: ••••••cret"));
+    assertFalse(outputWriter.toString().contains("SUPAWAVE_ROBOT_SECRET=new-secret"));
+  }
+
+  private RobotAccountData robot(String url, String secret, String description,
+      long createdAtMillis, long updatedAtMillis, boolean paused) {
+    return new RobotAccountDataImpl(ROBOT, url, secret, null, !url.isEmpty(), 3600L,
+        OWNER.getAddress(), description, createdAtMillis, updatedAtMillis, paused);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/DataApiTokenServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/DataApiTokenServletTest.java
@@ -72,4 +72,19 @@ public final class DataApiTokenServletTest {
     verify(resp).setStatus(HttpServletResponse.SC_OK);
     assertTrue(responseBody.toString().contains("access_token"));
   }
+
+  @Test
+  public void testClientCredentialsRejectsPausedRobot() throws Exception {
+    when(req.getParameter("grant_type")).thenReturn("client_credentials");
+    when(req.getParameter("client_id")).thenReturn(ROBOT_ID.getAddress());
+    when(req.getParameter("client_secret")).thenReturn("paused-secret");
+    when(accountStore.getAccount(ROBOT_ID)).thenReturn(
+        new RobotAccountDataImpl(ROBOT_ID, "https://example.com/robot", "paused-secret", null,
+            true, 0L, null, "", 0L, 0L, true));
+
+    servlet.doPost(req, resp);
+
+    verify(resp).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    assertTrue(responseBody.toString().contains("paused"));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
@@ -84,6 +84,9 @@ public class RobotTest extends TestCase {
   private static final ParticipantId ROBOT = ParticipantId.ofUnsafe(ROBOT_NAME.toEmailAddress());
   private static final RobotAccountData ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", null, true);
+  private static final RobotAccountData PAUSED_ACCOUNT =
+      new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", null, true, 0L, null, "",
+          0L, 0L, true);
   private static final RobotAccountData INITIALIZED_ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
           Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT), true);
@@ -105,10 +108,13 @@ public class RobotTest extends TestCase {
     waveletProvider = mock(WaveletProvider.class);
     eventGenerator = mock(EventGenerator.class);
     operationApplicator = mock(RobotOperationApplicator.class);
+    EventDataConverter converter = mock(EventDataConverter.class);
+    when(converterManager.getEventDataConverter(any(ProtocolVersion.class))).thenReturn(converter);
 
     robot =
         new Robot(ROBOT_NAME, ACCOUNT, gateway, connector, converterManager, waveletProvider,
             eventGenerator, operationApplicator);
+    when(gateway.syncRobotAccount(any(Robot.class))).thenReturn(true);
     // Set the initialized account when updateRobotAccount is called.
     doAnswer(new Answer<Object>() {
       @Override
@@ -180,6 +186,19 @@ public class RobotTest extends TestCase {
     robot.run();
     verify(gateway).doneRunning(robot);
     verify(gateway, never()).ensureScheduled(robot);
+  }
+
+  public void testRunSkipsPausedRobot() throws Exception {
+    robot.setAccount(PAUSED_ACCOUNT);
+    enqueueEmptyWavelet();
+
+    robot.run();
+
+    verify(gateway).syncRobotAccount(robot);
+    verify(gateway).doneRunning(robot);
+    verify(gateway, never()).ensureScheduled(robot);
+    verify(connector, never()).sendMessageBundle(
+        any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class));
   }
 
   public void testProcessUpdatesAccountIfNoCapabilities() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotsGatewayTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotsGatewayTest.java
@@ -32,10 +32,12 @@ import com.google.wave.api.robot.RobotName;
 import junit.framework.TestCase;
 
 import org.waveprotocol.box.server.account.RobotAccountData;
+import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.robots.operations.NotifyOperationService;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.testing.DeferredExecutor;
 
 /**
@@ -99,5 +101,19 @@ public class RobotsGatewayTest extends TestCase {
     gateway.updateRobotAccount(robot);
 
     verify(accountStore).putAccount(newAccount);
+  }
+
+  public void testSyncRobotAccountRefreshesPausedStateFromStore() throws Exception {
+    Robot robot = mock(Robot.class);
+    RobotName robotName = RobotName.fromAddress("robot@example.com");
+    RobotAccountData pausedAccount =
+        new RobotAccountDataImpl(ParticipantId.ofUnsafe("robot@example.com"),
+            "https://example.com/robot", "secret", null, true, 0L, null, "", 0L, 0L, true);
+    when(robot.getRobotName()).thenReturn(robotName);
+    when(accountStore.getAccount(ParticipantId.ofUnsafe("robot@example.com"))).thenReturn(pausedAccount);
+
+    gateway.syncRobotAccount(robot);
+
+    verify(robot).setAccount(pausedAccount);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/register/RobotRegistrarImplTest.java
@@ -73,6 +73,10 @@ public class RobotRegistrarImplTest extends TestCase {
     when(accountData.getConsumerSecret()).thenReturn(EXISTING_CONSUMER_TOKEN);
     when(accountData.isVerified()).thenReturn(true);
     when(accountData.getTokenExpirySeconds()).thenReturn(0L);
+    when(accountData.getDescription()).thenReturn("");
+    when(accountData.getCreatedAtMillis()).thenReturn(0L);
+    when(accountData.getUpdatedAtMillis()).thenReturn(0L);
+    when(accountData.isPaused()).thenReturn(false);
     when(tokenGenerator.generateToken(anyInt())).thenReturn(CONSUMER_TOKEN);
     registrar = new RobotRegistrarImpl(accountStore, tokenGenerator);
   }
@@ -97,6 +101,18 @@ public class RobotRegistrarImplTest extends TestCase {
 
     assertEquals(OWNER_ID.getAddress(), resultAccountData.getOwnerAddress());
     assertEquals(3600L, resultAccountData.getTokenExpirySeconds());
+  }
+
+  public void testRegisterNewStoresDescriptionAndTimestamps() throws PersistenceException,
+      RobotRegistrationException {
+    RobotAccountData resultAccountData =
+        registrar.registerNew(ROBOT_ID, LOCATION, OWNER_ID.getAddress(), 3600L,
+            "Summarises daily updates");
+
+    assertEquals("Summarises daily updates", resultAccountData.getDescription());
+    assertTrue(resultAccountData.getCreatedAtMillis() > 0L);
+    assertEquals(resultAccountData.getCreatedAtMillis(), resultAccountData.getUpdatedAtMillis());
+    assertFalse(resultAccountData.isPaused());
   }
 
   public void testRegisterNewFailsOnInvalidLocation() throws PersistenceException {
@@ -175,7 +191,8 @@ public class RobotRegistrarImplTest extends TestCase {
   public void testPendingRobotActivationPreservesExistingSecret() throws PersistenceException,
       RobotRegistrationException {
     RobotAccountData pendingAccount =
-        new RobotAccountDataImpl(ROBOT_ID, "", "pending-secret", null, false, 3600L, null);
+        new RobotAccountDataImpl(ROBOT_ID, "", "pending-secret", null, false, 3600L, null,
+            "Pending robot", 1000L, 2000L, false);
     when(accountStore.getAccount(ROBOT_ID)).thenReturn(pendingAccount);
 
     RobotAccountData updatedAccount =
@@ -186,6 +203,9 @@ public class RobotRegistrarImplTest extends TestCase {
     assertTrue(updatedAccount.isVerified());
     assertEquals(3600L, updatedAccount.getTokenExpirySeconds());
     assertEquals(OWNER_ID.getAddress(), updatedAccount.getOwnerAddress());
+    assertEquals("Pending robot", updatedAccount.getDescription());
+    assertEquals(1000L, updatedAccount.getCreatedAtMillis());
+    assertTrue(updatedAccount.getUpdatedAtMillis() >= 2000L);
   }
 
   public void testRegisterOrUpdateClaimsLegacyRobotWhenUrlIsUnchanged() throws PersistenceException,
@@ -250,5 +270,38 @@ public class RobotRegistrarImplTest extends TestCase {
     assertEquals(LOCATION.substring(0, LOCATION.length() - 1), rotatedAccountData.getUrl());
     assertEquals(CONSUMER_TOKEN, rotatedAccountData.getConsumerSecret());
     assertEquals(OWNER_ID.getAddress(), rotatedAccountData.getOwnerAddress());
+  }
+
+  public void testUpdateDescriptionPreservesExistingRobotSettings() throws PersistenceException,
+      RobotRegistrationException {
+    RobotAccountData existingAccount =
+        new RobotAccountDataImpl(ROBOT_ID, LOCATION.substring(0, LOCATION.length() - 1),
+            EXISTING_CONSUMER_TOKEN, null, true, 0L, OWNER_ID.getAddress(), "",
+            1111L, 2222L, false);
+    when(accountStore.getAccount(ROBOT_ID)).thenReturn(existingAccount);
+
+    RobotAccountData updatedAccount =
+        registrar.updateDescription(ROBOT_ID, "Handles after-hours triage");
+
+    assertEquals("Handles after-hours triage", updatedAccount.getDescription());
+    assertEquals(EXISTING_CONSUMER_TOKEN, updatedAccount.getConsumerSecret());
+    assertEquals(1111L, updatedAccount.getCreatedAtMillis());
+    assertTrue(updatedAccount.getUpdatedAtMillis() >= 2222L);
+  }
+
+  public void testSetPausedUpdatesPauseFlag() throws PersistenceException,
+      RobotRegistrationException {
+    RobotAccountData existingAccount =
+        new RobotAccountDataImpl(ROBOT_ID, LOCATION.substring(0, LOCATION.length() - 1),
+            EXISTING_CONSUMER_TOKEN, null, true, 0L, OWNER_ID.getAddress(),
+            "Owns the escalation queue", 1111L, 2222L, false);
+    when(accountStore.getAccount(ROBOT_ID)).thenReturn(existingAccount);
+
+    RobotAccountData pausedAccount = registrar.setPaused(ROBOT_ID, true);
+
+    assertTrue(pausedAccount.isPaused());
+    assertEquals("Owns the escalation queue", pausedAccount.getDescription());
+    assertEquals(1111L, pausedAccount.getCreatedAtMillis());
+    assertTrue(pausedAccount.getUpdatedAtMillis() >= 2222L);
   }
 }


### PR DESCRIPTION
## Summary
- persist robot descriptions, timestamps, and paused state across the robot account model and stores
- expand `/account/robots` with description editing, callback testing, masked secret previews, pause/unpause, delete, and one-time secret handoff pages
- block paused robots from client-credentials token issuance and passive robot execution

## Verification
- `sbt -Dsbt.log.noformat=true "testOnly org.waveprotocol.box.server.persistence.protos.ProtoAccountDataSerializerTest org.waveprotocol.box.server.persistence.memory.AccountStoreTest org.waveprotocol.box.server.persistence.file.AccountStoreTest org.waveprotocol.box.server.robots.register.RobotRegistrarImplTest org.waveprotocol.box.server.robots.RobotDashboardServletTest org.waveprotocol.box.server.robots.dataapi.DataApiTokenServletTest org.waveprotocol.box.server.robots.passive.RobotsGatewayTest org.waveprotocol.box.server.robots.passive.RobotTest"`
- local sanity: `cd target/universal/stage && ./bin/wave` with staged config adjusted to `127.0.0.1:9998`; `GET /healthz -> 200`, `HEAD /account/robots -> 302`, `GET /auth/signin -> 200`

## Tradeoff
- create/rotate now use a one-time secret handoff page so the dashboard itself only shows masked previews afterward. This keeps the server-rendered flow simple and avoids persisting any preview-only secret state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced robot management with description editing, callback testing, and pause/resume controls
  * One-time secret handoff pages with masked secret previews for improved security
  * Display robot creation and last-updated timestamps
  * Robot deletion capability

* **Bug Fixes**
  * Fixed persistence of robot descriptions, timestamps, and pause state across all storage backends
  * Prevented paused robots from issuing tokens and executing messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->