### PR TITLE
Restore local webclient GWT wiring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1039,7 +1039,7 @@ Compile / compile := (Compile / compile)
   .value
 
 // Ensure `run` has a config in place
-Compile / run := (Compile / run).dependsOn(prepareServerConfig).evaluated
+Compile / run := (Compile / run).dependsOn(prepareServerConfig, compileGwt).evaluated
 
 // =============================================================================
 // Phase 6: GWT Compilation Bridge
@@ -1147,3 +1147,6 @@ ThisBuild / compileGwt := {
 
 // Wire compileGwt to run after compileJava (GWT needs compiled classes)
 compileGwt := (compileGwt).dependsOn(Compile / compile).value
+Universal / mappings := (Universal / mappings).dependsOn(compileGwt).value
+Universal / stage := (Universal / stage).dependsOn(compileGwt).value
+Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt).value


### PR DESCRIPTION
Summary:\nRestore the missing GWT wiring on main so local startup and packaging regenerate the webclient bundle. This also wires Universal / mappings to compileGwt so stage and package paths cannot scan wave/war before the bundle exists.\n\nValidation:\n- git diff --check\n- sbt -Dsbt.supershell=false "Universal/stage"\n- sbt -Dsbt.supershell=false "Universal/packageBin"\n- rm -rf wave/war/webclient && sbt -Dsbt.supershell=false run, then verified wave/war/webclient/ was regenerated\n\nNotes:\nEvidence supports this as the missing main regression: current main had compileGwt defined but not wired into local run or package and stage task paths, while the PR 475 behavior is now restored and strengthened for Universal / mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved build process to ensure GWT client compilation occurs before server operations and packaging tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->