### PR TITLE
fix: sanitize link and image URI schemes in ServerHtmlRenderer

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
@@ -644,6 +644,12 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
 
     String scheme = parsedUri.getScheme();
     if (scheme == null) {
+      // Reject protocol-relative URLs like //evil.example/path, which have no scheme
+      // but do have an authority and are resolved by browsers using the current scheme.
+      if (parsedUri.getAuthority() != null || trimmedUri.startsWith("//")) {
+        return null;
+      }
+      // Allow true relative, query-only, or fragment-only URLs.
       return trimmedUri;
     }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRendererTest.java
@@ -66,6 +66,7 @@ public class ServerHtmlRendererTest extends TestCase {
     assertNull(ServerHtmlRenderer.sanitizeUri("data:text/html;base64,PHNjcmlwdA==", true));
     assertNull(ServerHtmlRenderer.sanitizeUri("vbscript:msgbox(1)", true));
     assertNull(ServerHtmlRenderer.sanitizeUri("mailto:user@example.com", false));
+    assertNull(ServerHtmlRenderer.sanitizeUri("//example.com/x", true));
   }
 
   // =========================================================================


### PR DESCRIPTION
### Motivation
- The server-side pre-renderer inlines HTML from wave content into the authenticated page and `ServerHtmlRenderer` previously wrote `href`/`src` attributes directly from stored content, allowing `javascript:`, `data:`, or other unsafe schemes that enable stored XSS when prerendering is enabled.
- The change aims to block unsafe URI schemes at render time while preserving valid/relative URLs and minimal visual behavior so prerendering remains useful and safe.

### Description
- Added `sanitizeUri(String uri, boolean allowMailtoAndTel)` which parses and normalizes URIs and permits only `http`/`https` for images and links, `mailto`/`tel` for links when allowed, and relative/fragment URLs without schemes.
- Updated link rendering to call `sanitizeUri(...)` and only emit `href="..."` when the URI is considered safe, otherwise render the anchor without an `href` (keeps text and structure but prevents unsafe navigation).
- Updated image rendering to include the `src` attribute only if the URI passes `sanitizeUri(...)`, dropping unsafe image sources entirely.
- Added unit tests in `ServerHtmlRendererTest` to assert acceptance of safe schemes and rejection of unsafe schemes, and added required imports (`java.net.URI`, `java.util.Locale`) to the renderer.
- Files changed: `wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java`, `wave/src/test/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRendererTest.java`.

### Testing
- Added unit tests (`ServerHtmlRendererTest`) covering `sanitizeUri` behavior, but tests were not executed in this environment.
- Attempted `sbt compile` to run a build in-repo but it failed here because `sbt` is not installed (`sbt: command not found`).
- Attempted `./gradlew :wave:compileJava :wave:compileGwt` but the Gradle wrapper is not available in this environment, so compile/test could not be run here; recommend CI or a developer machine run `sbt test` or the appropriate Gradle tasks to validate compilation and unit tests (they should pass once the build tool is run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c993bc57b483318863351b925d7166)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL sanitization for links and images: links with unsafe or disallowed schemes now render as anchors without href, and images with unsafe schemes render without src, reducing unsafe resource loading and click-to behavior.

* **Tests**
  * Added unit tests validating allowed and rejected URI schemes for link and image rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->