### PR TITLE
fix: harden password reset link generation against Host header poisoning

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PasswordResetServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PasswordResetServlet.java
@@ -281,10 +281,18 @@ public final class PasswordResetServlet extends HttpServlet {
     }
     if (config.hasPath("core.http_frontend_addresses")
         && !config.getStringList("core.http_frontend_addresses").isEmpty()) {
-      return config.getStringList("core.http_frontend_addresses").get(0).trim();
+      for (String address : config.getStringList("core.http_frontend_addresses")) {
+        String trimmedAddress = address.trim();
+        if (!trimmedAddress.isEmpty()) {
+          return trimmedAddress;
+        }
+      }
     }
     if (config.hasPath("core.default_http_frontend_address")) {
-      return config.getString("core.default_http_frontend_address").trim();
+      String defaultAddress = config.getString("core.default_http_frontend_address").trim();
+      if (!defaultAddress.isEmpty()) {
+        return defaultAddress;
+      }
     }
     return "wave.example.test";
   }


### PR DESCRIPTION
### Motivation
- Password reset emails were constructing absolute links from `HttpServletRequest` values (`req.getScheme()`, `req.getServerName()`, `req.getServerPort()`), which trusts the Host header and enables link-poisoning/token exfiltration. 
- The goal is to remove attacker-controlled input from emailed links and use a configured public base URL instead.

### Description
- Stop deriving reset links from the incoming request in `PasswordResetServlet` and introduce a `publicBaseUrl` field initialized from configuration. 
- Replace the old `buildResetUrl(HttpServletRequest, String)` with `buildResetUrl(String)` that returns `publicBaseUrl + "/auth/password-reset?token=" + token`. 
- Add `readPublicBaseUrl`, `readFrontendAddress`, `readFrontendScheme`, and `stripTrailingSlash` helpers to mirror the existing `core.public_url` fallback behavior used elsewhere (so behavior matches `AuthEmailService`).

### Testing
- Attempted to run a backend/frontend compile with `sbt` to verify the change, but `sbt` is not available in the execution environment so the compile checks failed. 
- No repository unit tests were executed due to the missing `sbt` tool. 
- Static verification steps (diff/commit) were performed locally and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c99dd9502c83319fdcbc8a240c230d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password reset email links now use the configured public base URL, producing consistent, reliable reset links across deployments.
  * Link generation no longer depends on incoming request details (scheme/host/port), reducing broken or incorrect reset URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->