### PR TITLE
Disable URL-based Jetty session IDs to prevent session fixation

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
@@ -123,6 +123,7 @@ public class ServerModule extends AbstractModule {
   @Provides @Singleton
   public SessionHandler provideSessionHandler(Config config) {
     SessionHandler sessionHandler = new SessionHandler();
+    sessionHandler.setSessionIdPathParameterName(null);
 
     // Configure cookie attributes to match the javax variant
     try {

--- a/wave/src/main/java/org/waveprotocol/box/server/ServerModule.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/ServerModule.java
@@ -149,6 +149,7 @@ public class ServerModule extends AbstractModule {
   @Singleton
   public SessionHandler provideSessionHandler(Config config) {
     SessionHandler sessionHandler = new SessionHandler();
+    sessionHandler.setSessionIdPathParameterName(null);
     // Configure cookie attributes
     try {
       sessionHandler.getSessionCookieConfig().setMaxAge(config.getInt("network.session_cookie_max_age"));


### PR DESCRIPTION
### Motivation
- Restore the pre-refactor hardening that disabled Jetty URL-based session IDs to prevent session fixation and leakage via `;jsessionid=...` after the move to `SessionHandler`.

### Description
- Add a single-line hardening by calling `SessionHandler#setSessionIdPathParameterName(null)` in both `wave/src/main/java/org/waveprotocol/box/server/ServerModule.java` and `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java` so the server rejects path-parameter session IDs while preserving existing cookie-based sessions.

### Testing
- Attempted automated checks: `sbt compile` (backend) could not be run because the `sbt` binary is not available in this environment and no separate frontend build tool was available for the GWT client (the docs note the GWT client is not compiled by SBT), so no automated compile or test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a3aeca908331a518f1129cae310d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session handler configuration for improved server stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->