### PR TITLE
Fix TOCTOU race in first-owner registration assignment

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
@@ -166,11 +166,8 @@ public final class UserRegistrationServlet extends HttpServlet {
         account.setEmail(normalizedEmail);
       }
       account.setRegistrationTime(System.currentTimeMillis());
-      assignOwnerIfFirst(account);
-      try {
-        accountStore.putAccount(account);
-      } catch (PersistenceException e) {
-        LOG.severe("Failed to create account for " + id, e);
+      boolean accountCreated = persistAccountWithOwnerAssignment(account);
+      if (!accountCreated) {
         return "An unexpected error occurred while trying to create the account";
       }
 
@@ -185,11 +182,8 @@ public final class UserRegistrationServlet extends HttpServlet {
         account.setEmail(normalizedEmail);
       }
       account.setRegistrationTime(System.currentTimeMillis());
-      assignOwnerIfFirst(account);
-      try {
-        accountStore.putAccount(account);
-      } catch (PersistenceException e) {
-        LOG.severe("Failed to create account for " + id, e);
+      boolean accountCreated = persistAccountWithOwnerAssignment(account);
+      if (!accountCreated) {
         return "An unexpected error occurred while trying to create the account";
       }
 
@@ -206,15 +200,24 @@ public final class UserRegistrationServlet extends HttpServlet {
   /**
    * If no other accounts exist yet, promote this account to "owner".
    */
-  private void assignOwnerIfFirst(HumanAccountDataImpl account) {
+  private boolean persistAccountWithOwnerAssignment(HumanAccountDataImpl account) {
     try {
-      long count = accountStore.getAccountCount();
-      if (count == 0) {
-        account.setRole(HumanAccountData.ROLE_OWNER);
-        LOG.info("First registration — assigning owner role to " + account.getId());
+      synchronized (accountStore) {
+        assignOwnerIfFirst(account);
+        accountStore.putAccount(account);
       }
+      return true;
     } catch (PersistenceException e) {
-      LOG.warning("Failed to check account count for owner assignment", e);
+      LOG.severe("Failed to create account for " + account.getId(), e);
+      return false;
+    }
+  }
+
+  private void assignOwnerIfFirst(HumanAccountDataImpl account) throws PersistenceException {
+    long count = accountStore.getAccountCount();
+    if (count == 0) {
+      account.setRole(HumanAccountData.ROLE_OWNER);
+      LOG.info("First registration — assigning owner role to " + account.getId());
     }
   }
 


### PR DESCRIPTION
### Motivation
- The servlet previously called `assignOwnerIfFirst()` before persisting the account, using a non-atomic `getAccountCount()` check that allowed two concurrent first registrations to both be promoted to `ROLE_OWNER`.
- The change aims to eliminate the time-of-check/time-of-use (TOCTOU) race while preserving existing registration flows and responses.

### Description
- Replaced the separate `assignOwnerIfFirst(...)` + `accountStore.putAccount(...)` calls with a single `persistAccountWithOwnerAssignment(...)` helper that synchronizes on `accountStore` and performs `assignOwnerIfFirst(...)` followed immediately by `putAccount(...)` inside the critical section.
- Converted `persistAccountWithOwnerAssignment(...)` to return a boolean success indicator and updated both the email-confirmation and non-confirmation registration paths to use it and preserve previous failure responses.
- Adjusted `assignOwnerIfFirst(...)` to be called from within the synchronized helper and to throw/propagate `PersistenceException` as appropriate so the count+write happen atomically in-process.
- File changed: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java`.

### Testing
- Attempted backend compilation with `sbt -no-colors 'project wave' 'compile'`, which failed in this environment because `sbt` is not installed (command not found).
- Attempted frontend/GWT compile with `sbt -no-colors 'compileGwt'`, which also failed due to the same environment limitation.
- Performed code review and local static validation of the modified servlet logic; no automated tests or builds succeeded in this environment due to missing `sbt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fea8908331b05aa6241d98a663)