### PR TITLE
fix: cap groups history scan and remove synchronous boundary precache to mitigate DoS

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionedFetchServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/VersionedFetchServlet.java
@@ -28,7 +28,6 @@ import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
 import org.waveprotocol.box.server.common.SnapshotSerializer;
 import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
-import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.SnapshotStore;
 import org.waveprotocol.box.server.rpc.ProtoSerializer.SerializationException;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
@@ -74,6 +73,7 @@ import java.util.List;
 @SuppressWarnings("serial")
 public final class VersionedFetchServlet extends HttpServlet {
   private static final Log LOG = Log.get(VersionedFetchServlet.class);
+  private static final long MAX_GROUPS_HISTORY_VERSION_SPAN = 10000L;
 
   private final WaveletProvider waveletProvider;
   private final ProtoSerializer serializer;
@@ -512,6 +512,12 @@ public final class VersionedFetchServlet extends HttpServlet {
       return;
     }
 
+    if (currentVersion > MAX_GROUPS_HISTORY_VERSION_SPAN) {
+      response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+          "Wavelet history is too large for grouped fetch");
+      return;
+    }
+
     // Fetch all deltas
     try {
       HashedVersion startVersion = waveletProvider.getHashedVersion(waveletName, 0);
@@ -579,55 +585,9 @@ public final class VersionedFetchServlet extends HttpServlet {
 
       writeJsonResponse(response, result);
 
-      // Pre-cache snapshots at group boundary versions (async, best-effort)
-      preCacheGroupBoundarySnapshots(waveletName, allGroups, startIdx, endIdx);
-
     } catch (WaveServerException e) {
       LOG.warning("Failed to compute groups for " + waveletName, e);
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  /**
-   * Pre-caches snapshots at group boundary versions (endVersion of each group)
-   * in the SnapshotStore so that scrubbing between groups in the UI is fast.
-   * This is best-effort; failures are logged but do not affect the API response.
-   */
-  private void preCacheGroupBoundarySnapshots(WaveletName waveletName,
-      List<ChangeGroup> groups, int startIdx, int endIdx) {
-    for (int i = startIdx; i < endIdx; i++) {
-      long boundaryVersion = groups.get(i).getEndVersion();
-      if (boundaryVersion <= 0) {
-        continue;
-      }
-      try {
-        // Build snapshot at this version by replaying deltas
-        HashedVersion start = waveletProvider.getHashedVersion(waveletName, 0);
-        HashedVersion end = waveletProvider.getHashedVersion(waveletName, boundaryVersion);
-        if (start == null || end == null) {
-          continue;
-        }
-        ListReceiver<TransformedWaveletDelta> receiver = new ListReceiver<>();
-        waveletProvider.getHistory(waveletName, start, end, receiver);
-        List<TransformedWaveletDelta> filteredDeltas = new ArrayList<>();
-        for (TransformedWaveletDelta delta : receiver) {
-          if (delta.getResultingVersion().getVersion() <= boundaryVersion) {
-            filteredDeltas.add(delta);
-          }
-        }
-        if (filteredDeltas.isEmpty()) {
-          continue;
-        }
-        ObservableWaveletData wavelet = WaveletDataUtil.buildWaveletFromDeltas(
-            waveletName, filteredDeltas.iterator());
-        Message message = SnapshotSerializer.serializeWavelet(
-            wavelet, wavelet.getHashedVersion());
-        byte[] serialized = message.toByteArray();
-        snapshotStore.storeSnapshot(waveletName, serialized, boundaryVersion);
-      } catch (WaveServerException | OperationException | PersistenceException e) {
-        LOG.warning("Failed to pre-cache snapshot at version " + boundaryVersion
-            + " for " + waveletName + ": " + e.getMessage());
-      }
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/VersionedFetchServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/VersionedFetchServlet.java
@@ -27,7 +27,6 @@ import org.waveprotocol.box.common.ListReceiver;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.common.SnapshotSerializer;
 import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
-import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.SnapshotStore;
 import org.waveprotocol.box.server.rpc.ProtoSerializer.SerializationException;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
@@ -74,6 +73,7 @@ import java.util.List;
 @Singleton
 public final class VersionedFetchServlet extends HttpServlet {
   private static final Log LOG = Log.get(VersionedFetchServlet.class);
+  private static final long MAX_GROUPS_HISTORY_VERSION_SPAN = 10000L;
 
   private final WaveletProvider waveletProvider;
   private final ProtoSerializer serializer;
@@ -502,6 +502,12 @@ public final class VersionedFetchServlet extends HttpServlet {
       return;
     }
 
+    if (currentVersion > MAX_GROUPS_HISTORY_VERSION_SPAN) {
+      response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+          "Wavelet history is too large for grouped fetch");
+      return;
+    }
+
     // Fetch all deltas
     try {
       HashedVersion startVersion = HashedVersion.unsigned(0);
@@ -563,52 +569,9 @@ public final class VersionedFetchServlet extends HttpServlet {
 
       writeJsonResponse(response, result);
 
-      // Pre-cache snapshots at group boundary versions (async, best-effort)
-      preCacheGroupBoundarySnapshots(waveletName, allGroups, startIdx, endIdx);
-
     } catch (WaveServerException e) {
       LOG.warning("Failed to compute groups for " + waveletName, e);
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  /**
-   * Pre-caches snapshots at group boundary versions (endVersion of each group)
-   * in the SnapshotStore so that scrubbing between groups in the UI is fast.
-   * This is best-effort; failures are logged but do not affect the API response.
-   */
-  private void preCacheGroupBoundarySnapshots(WaveletName waveletName,
-      List<ChangeGroup> groups, int startIdx, int endIdx) {
-    for (int i = startIdx; i < endIdx; i++) {
-      long boundaryVersion = groups.get(i).getEndVersion();
-      if (boundaryVersion <= 0) {
-        continue;
-      }
-      try {
-        // Build snapshot at this version by replaying deltas
-        HashedVersion start = HashedVersion.unsigned(0);
-        HashedVersion end = HashedVersion.unsigned(boundaryVersion);
-        ListReceiver<TransformedWaveletDelta> receiver = new ListReceiver<>();
-        waveletProvider.getHistory(waveletName, start, end, receiver);
-        List<TransformedWaveletDelta> filteredDeltas = new ArrayList<>();
-        for (TransformedWaveletDelta delta : receiver) {
-          if (delta.getResultingVersion().getVersion() <= boundaryVersion) {
-            filteredDeltas.add(delta);
-          }
-        }
-        if (filteredDeltas.isEmpty()) {
-          continue;
-        }
-        ObservableWaveletData wavelet = WaveletDataUtil.buildWaveletFromDeltas(
-            waveletName, filteredDeltas.iterator());
-        Message message = SnapshotSerializer.serializeWavelet(
-            wavelet, wavelet.getHashedVersion());
-        byte[] serialized = message.toByteArray();
-        snapshotStore.storeSnapshot(waveletName, serialized, boundaryVersion);
-      } catch (WaveServerException | OperationException | PersistenceException e) {
-        LOG.warning("Failed to pre-cache snapshot at version " + boundaryVersion
-            + " for " + waveletName + ": " + e.getMessage());
-      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- The `/fetch/version/.../groups` handler loaded the full wavelet history into memory and grouped it before applying pagination, and then synchronously replayed history per-group to pre-cache snapshots, creating an easy CPU/memory amplification vector for DoS. 
- The change prevents unbounded work in that request path by limiting how much history a single request will process and by removing the repeated replay step.

### Description
- Add a hard upper bound `MAX_GROUPS_HISTORY_VERSION_SPAN = 10000L` and return HTTP `413` when the wavelet's current version exceeds this span, avoiding unbounded grouping work in `handleGroups`.
- Remove the synchronous group-boundary snapshot pre-caching from the `/groups` handler so requests no longer trigger repeated full-history replays; the precache helper and its invocation were removed from both servlet implementations. 
- Apply the same fixes to both servlet sources to keep `src/main` and `src/jakarta-overrides` aligned (`VersionedFetchServlet.java` in both locations). 
- Preserve existing pagination, `blipId` filtering, and grouping semantics when the history is within the allowed span.

### Testing
- Attempted `sbt -no-colors compile` but the environment lacks SBT so the command failed with `sbt: command not found`. 
- Attempted `sbt -no-colors compileGwt` but the environment lacks SBT so the command failed with `sbt: command not found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca81776e1c8331a99f2ee7df4148de)