### PR TITLE
fix(auth): use canonical public URL for auth email links to prevent host-header injection

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -31,6 +31,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.authentication.jwt.EmailTokenIssuer;
 import org.waveprotocol.box.server.mail.MailException;
 import org.waveprotocol.box.server.mail.MailProvider;
@@ -70,6 +71,7 @@ public final class AccountSettingsServlet extends HttpServlet {
   private final String fromAddress;
   private final boolean emailConfirmationEnabled;
   private final boolean passwordResetEnabled;
+  private final String publicBaseUrl;
 
   @Inject
   public AccountSettingsServlet(AccountStore accountStore,
@@ -89,6 +91,7 @@ public final class AccountSettingsServlet extends HttpServlet {
         && config.getBoolean("core.email_confirmation_enabled");
     this.passwordResetEnabled = !config.hasPath("core.password_reset_enabled")
         || config.getBoolean("core.password_reset_enabled");
+    this.publicBaseUrl = PublicBaseUrlResolver.resolve(config);
   }
 
   @Override
@@ -150,7 +153,7 @@ public final class AccountSettingsServlet extends HttpServlet {
         // Email changed and confirmation is enabled: mark as unconfirmed and send confirmation
         caller.setEmailConfirmed(false);
         accountStore.putAccount(caller);
-        sendConfirmationEmail(req, caller, newEmail);
+        sendConfirmationEmail(caller, newEmail);
         setJsonUtf8(resp);
         resp.getWriter().write("{\"ok\":true,\"message\":\"Email updated. A confirmation email has been sent to your new address.\"}");
       } else {
@@ -168,11 +171,10 @@ public final class AccountSettingsServlet extends HttpServlet {
     }
   }
 
-  private void sendConfirmationEmail(HttpServletRequest req, HumanAccountData caller,
-      String email) {
+  private void sendConfirmationEmail(HumanAccountData caller, String email) {
     try {
       String token = emailTokenIssuer.issueEmailConfirmToken(caller.getId());
-      String confirmUrl = buildUrl(req, "/auth/confirm-email?token=" + token);
+      String confirmUrl = buildUrl("/auth/confirm-email?token=" + token);
       String emailBody = "<html><body>"
           + "<h2>Confirm Your Email</h2>"
           + "<p>Your Wave account <b>" + HtmlRenderer.escapeHtml(caller.getId().getAddress())
@@ -217,7 +219,7 @@ public final class AccountSettingsServlet extends HttpServlet {
 
     try {
       String token = emailTokenIssuer.issuePasswordResetToken(caller.getId());
-      String resetUrl = buildUrl(req, "/auth/password-reset?token=" + token);
+      String resetUrl = buildUrl("/auth/password-reset?token=" + token);
       String emailBody = "<html><body>"
           + "<h2>Password Reset</h2>"
           + "<p>A password reset was requested for your Wave account: <b>"
@@ -273,18 +275,8 @@ public final class AccountSettingsServlet extends HttpServlet {
     }
   }
 
-  private String buildUrl(HttpServletRequest req, String path) {
-    String scheme = req.getScheme();
-    String serverName = req.getServerName();
-    int serverPort = req.getServerPort();
-    StringBuilder url = new StringBuilder();
-    url.append(scheme).append("://").append(serverName);
-    if (("http".equals(scheme) && serverPort != 80)
-        || ("https".equals(scheme) && serverPort != 443)) {
-      url.append(":").append(serverPort);
-    }
-    url.append(path);
-    return url.toString();
+  private String buildUrl(String path) {
+    return publicBaseUrl + path;
   }
 
   /** Masks an email address for display, e.g. "u***@example.com". */

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PasswordResetServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PasswordResetServlet.java
@@ -30,6 +30,7 @@ import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.authentication.jwt.EmailTokenIssuer;
 import org.waveprotocol.box.server.authentication.jwt.JwtClaims;
 import org.waveprotocol.box.server.authentication.jwt.JwtTokenType;
@@ -70,6 +71,7 @@ public final class PasswordResetServlet extends HttpServlet {
   private final String analyticsAccount;
   private final String fromAddress;
   private final boolean passwordResetEnabled;
+  private final String publicBaseUrl;
 
   @Inject
   public PasswordResetServlet(AccountStore accountStore,
@@ -87,6 +89,7 @@ public final class PasswordResetServlet extends HttpServlet {
         ? config.getString("core.email_from_address") : "noreply@wave.example.test";
     this.passwordResetEnabled = !config.hasPath("core.password_reset_enabled")
         || config.getBoolean("core.password_reset_enabled");
+    this.publicBaseUrl = PublicBaseUrlResolver.resolve(config);
   }
 
   @Override
@@ -172,7 +175,7 @@ public final class PasswordResetServlet extends HttpServlet {
           String sendTo = (human.getEmail() != null && !human.getEmail().isEmpty())
               ? human.getEmail() : account.getId().getAddress();
           String jwtToken = emailTokenIssuer.issuePasswordResetToken(account.getId());
-          String resetUrl = buildResetUrl(req, jwtToken);
+          String resetUrl = buildResetUrl(jwtToken);
           String emailBody = renderResetEmail(account.getId().getAddress(), resetUrl);
           mailProvider.sendEmail(sendTo, "Password Reset - Wave", emailBody);
           LOG.info("Password reset email sent for user " + account.getId().getAddress());
@@ -253,18 +256,8 @@ public final class PasswordResetServlet extends HttpServlet {
     }
   }
 
-  private String buildResetUrl(HttpServletRequest req, String token) {
-    String scheme = req.getScheme();
-    String serverName = req.getServerName();
-    int serverPort = req.getServerPort();
-    StringBuilder url = new StringBuilder();
-    url.append(scheme).append("://").append(serverName);
-    if (("http".equals(scheme) && serverPort != 80)
-        || ("https".equals(scheme) && serverPort != 443)) {
-      url.append(":").append(serverPort);
-    }
-    url.append("/auth/password-reset?token=").append(token);
-    return url.toString();
+  private String buildResetUrl(String token) {
+    return publicBaseUrl + "/auth/password-reset?token=" + token;
   }
 
   private String renderResetEmail(String address, String resetUrl) {

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/email/AuthEmailService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/email/AuthEmailService.java
@@ -61,7 +61,7 @@ public final class AuthEmailService {
     this.cooldownMillis = readCooldownMillis(config);
     this.maxPerAddressPerHour = readLimit(config, "core.auth_email_send_max_per_address_per_hour", 5);
     this.maxPerIpPerHour = readLimit(config, "core.auth_email_send_max_per_ip_per_hour", 20);
-    this.publicBaseUrl = readPublicBaseUrl(config);
+    this.publicBaseUrl = PublicBaseUrlResolver.resolve(config);
   }
 
   public DispatchResult sendConfirmationEmail(HttpServletRequest request, HumanAccountData account) {
@@ -234,45 +234,4 @@ public final class AuthEmailService {
     return Math.max(1, value);
   }
 
-  private String readPublicBaseUrl(Config config) {
-    if (config.hasPath("core.public_url")) {
-      String configuredUrl = stripTrailingSlash(config.getString("core.public_url").trim());
-      if (!configuredUrl.isEmpty()) {
-        return configuredUrl;
-      }
-    }
-
-    String configuredAddress = readFrontendAddress(config);
-    String scheme = readFrontendScheme(config);
-    return stripTrailingSlash(scheme + "://" + configuredAddress);
-  }
-
-  private String readFrontendAddress(Config config) {
-    if (config.hasPath("core.http_frontend_public_address")) {
-      String publicAddress = config.getString("core.http_frontend_public_address").trim();
-      if (!publicAddress.isEmpty()) {
-        return publicAddress;
-      }
-    }
-    if (config.hasPath("core.http_frontend_addresses")
-        && !config.getStringList("core.http_frontend_addresses").isEmpty()) {
-      return config.getStringList("core.http_frontend_addresses").get(0).trim();
-    }
-    if (config.hasPath("core.default_http_frontend_address")) {
-      return config.getString("core.default_http_frontend_address").trim();
-    }
-    return "wave.example.test";
-  }
-
-  private String readFrontendScheme(Config config) {
-    boolean sslEnabled = config.hasPath("security.enable_ssl") && config.getBoolean("security.enable_ssl");
-    return sslEnabled ? "https" : "http";
-  }
-
-  private String stripTrailingSlash(String value) {
-    if (value.endsWith("/")) {
-      return value.substring(0, value.length() - 1);
-    }
-    return value;
-  }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/email/PublicBaseUrlResolver.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/email/PublicBaseUrlResolver.java
@@ -1,0 +1,51 @@
+package org.waveprotocol.box.server.authentication.email;
+
+import com.typesafe.config.Config;
+
+public final class PublicBaseUrlResolver {
+
+  private PublicBaseUrlResolver() {
+  }
+
+  public static String resolve(Config config) {
+    if (config.hasPath("core.public_url")) {
+      String configuredUrl = stripTrailingSlash(config.getString("core.public_url").trim());
+      if (!configuredUrl.isEmpty()) {
+        return configuredUrl;
+      }
+    }
+
+    String configuredAddress = readFrontendAddress(config);
+    String scheme = readFrontendScheme(config);
+    return stripTrailingSlash(scheme + "://" + configuredAddress);
+  }
+
+  private static String readFrontendAddress(Config config) {
+    if (config.hasPath("core.http_frontend_public_address")) {
+      String publicAddress = config.getString("core.http_frontend_public_address").trim();
+      if (!publicAddress.isEmpty()) {
+        return publicAddress;
+      }
+    }
+    if (config.hasPath("core.http_frontend_addresses")
+        && !config.getStringList("core.http_frontend_addresses").isEmpty()) {
+      return config.getStringList("core.http_frontend_addresses").get(0).trim();
+    }
+    if (config.hasPath("core.default_http_frontend_address")) {
+      return config.getString("core.default_http_frontend_address").trim();
+    }
+    return "wave.example.test";
+  }
+
+  private static String readFrontendScheme(Config config) {
+    boolean sslEnabled = config.hasPath("security.enable_ssl") && config.getBoolean("security.enable_ssl");
+    return sslEnabled ? "https" : "http";
+  }
+
+  private static String stripTrailingSlash(String value) {
+    if (value.endsWith("/")) {
+      return value.substring(0, value.length() - 1);
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
### Motivation
- Email-based flows were enabled in production and constructed absolute links from `HttpServletRequest` values (`req.getScheme()` / `req.getServerName()`), creating a host-header injection vector that can exfiltrate JWT tokens in emails.
- The change centralizes link generation on a canonical, configuration-driven base URL to close that vector while preserving email flows.

### Description
- Add `PublicBaseUrlResolver` to compute a canonical public base URL from config, preferring `core.public_url` and falling back to frontend address/scheme settings.
- Switch `AuthEmailService` to use `PublicBaseUrlResolver` for building absolute URLs so all auth emails use a config-derived base URL via `buildAbsoluteUrl(...)`.
- Change `PasswordResetServlet` to construct reset links from the canonical `publicBaseUrl` (`buildResetUrl(String token)`) instead of using request-derived host/scheme.
- Change `AccountSettingsServlet` to use the canonical `publicBaseUrl` for confirmation and reset links and simplify the confirmation helper signature to remove dependence on the incoming request.

### Testing
- Attempted `sbt --batch "wave/compile"` but it failed in this environment with `sbt: command not found` so full compilation could not be performed.
- Attempted `sbt --batch "compileGwt"` but it also failed with `sbt: command not found` and client/GWT compile tests were not run.
- Ran repository searches (`rg`) to verify the modified servlets no longer build URLs from `req.getServerName()`/`req.getScheme()` and that auth email link construction now uses the canonical base URL, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82feca548331b57b4ca9f9dc4775)