### PR TITLE
fix: prevent quadratic indirect contact updates in ContactsRecorder

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/contact/ContactsRecorder.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/contact/ContactsRecorder.java
@@ -118,21 +118,6 @@ public class ContactsRecorder implements WaveBus.Subscriber {
                   ex);
             }
           }
-          // Indirect call: every existing participant -> receptor
-          for (ParticipantId participant : participants) {
-            if (!participant.equals(sharedParticipant)
-                && !participant.equals(caller)
-                && !participant.equals(receptor)) {
-              try {
-                contactManager.newCall(
-                    participant, receptor, delta.getApplicationTimestamp(), false);
-              } catch (PersistenceException ex) {
-                LOG.severe(
-                    "Update contact " + participant.getAddress() + "->" + receptor.getAddress(),
-                    ex);
-              }
-            }
-          }
           participants.add(receptor);
         }
       } else if (op instanceof RemoveParticipant) {


### PR DESCRIPTION
### Motivation
- The recorder processed each `AddParticipant` by iterating over the entire existing participant set and calling `ContactManager.newCall` for every pair, producing O(n²) CPU and unbounded per-user contact growth that enables resource exhaustion (DoS).

### Description
- Remove the indirect fan-out loop from `ContactsRecorder.updateContacts` so only the direct caller->receptor `contactManager.newCall(...)` is recorded.  
- Keep the existing behavior of updating the local `participants` set so later operations in the same delta stream see the updated membership.  
- Change is localized to `wave/src/main/java/org/waveprotocol/box/server/contact/ContactsRecorder.java` and does not modify `ContactManagerImpl` behavior or contact storage semantics.

### Testing
- Attempted backend compilation with `sbt "compile"`, but the environment lacks SBT and the command failed (`sbt: command not found`).  
- Attempted frontend/GWT compilation with `sbt "compileGwt"`, but the environment lacks SBT and the command failed (`sbt: command not found`).  
- No automated unit test runs were performed in this environment due to the missing SBT toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fe48f883319ae607587dd72fc8)