### PR TITLE
fix: disable public robot registration endpoint in Jakarta server

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -32,7 +32,6 @@ import org.waveprotocol.box.server.rpc.*;
 import org.waveprotocol.box.server.robots.ProfileFetcherModule;
 import org.waveprotocol.box.server.robots.JakartaRobotApiBindingsModule;
 import org.waveprotocol.box.server.robots.RobotDashboardServlet;
-import org.waveprotocol.box.server.robots.RobotRegistrationServlet;
 import org.waveprotocol.box.server.robots.passive.RobotsGateway;
 import org.waveprotocol.box.server.robots.active.ActiveApiServlet;
 import org.waveprotocol.box.server.robots.agent.registration.RegistrationRobot;
@@ -285,7 +284,6 @@ public class ServerMain {
     server.addServlet("/folder/*", FolderServlet.class);
     server.addServlet("/searches", SearchesServlet.class);
     server.addServlet("/tags", TagsServlet.class);
-    server.addServlet("/robot/register/*", RobotRegistrationServlet.class);
     server.addServlet("/robot/rpc", ActiveApiServlet.class);
     server.addServlet("/robot/dataapi", DataApiServlet.class);
     server.addServlet("/robot/dataapi/rpc", DataApiServlet.class);


### PR DESCRIPTION
### Motivation
- Disable unauthenticated robot registration in the Jakarta server to prevent SSRF/outbound-request abuse by removing the publicly reachable `/robot/register/*` route now that passive robot delivery is wired up.

### Description
- Remove the public servlet mapping for `/robot/register/*` and the now-unused `RobotRegistrationServlet` import from `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`, while keeping the authenticated management endpoint ` /account/robots ` and robot API servlets intact.

### Testing
- Attempted to validate with `sbt compile` and `sbt compileGwt` in this environment, but both checks could not run because `sbt` is not available here (`sbt: command not found`), so no compile or automated test runs completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fe10cc8331a7aed069195b1fdc)