### PR TITLE
Gate full storage warmup to prevent repeated full scans on per-user cache miss

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -37,6 +37,7 @@ import org.waveprotocol.wave.util.logging.Log;
 
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -61,6 +62,8 @@ public class MemoryPerUserWaveViewHandlerImpl implements PerUserWaveViewHandler 
   /** The loading cache that holds wave viev per each online user.*/
   public LoadingCache<ParticipantId, Multimap<WaveId, WaveletId>> explicitPerUserWaveViews;
 
+  private final AtomicBoolean storageWarmupCompleted = new AtomicBoolean(false);
+
   @Inject
   public MemoryPerUserWaveViewHandlerImpl(final WaveMap waveMap) {
     // Let the view expire if it not accessed for some time.
@@ -73,11 +76,7 @@ public class MemoryPerUserWaveViewHandlerImpl implements PerUserWaveViewHandler 
           public Multimap<WaveId, WaveletId> load(final ParticipantId user) {
             long startMs = System.currentTimeMillis();
             Multimap<WaveId, WaveletId> userView = HashMultimap.create();
-            try {
-              waveMap.loadAllWavelets();
-            } catch (WaveletStateException e) {
-              throw new RuntimeException("Failed to load waves for " + user.getAddress(), e);
-            }
+            ensureWaveMapLoaded(waveMap, user);
 
             Map<WaveId, Wave> waves = waveMap.getWaves();
             for (Map.Entry<WaveId, Wave> entry : waves.entrySet()) {
@@ -119,6 +118,21 @@ public class MemoryPerUserWaveViewHandlerImpl implements PerUserWaveViewHandler 
             return userView;
           }
         });
+  }
+
+  private void ensureWaveMapLoaded(WaveMap waveMap, ParticipantId user) {
+    if (!storageWarmupCompleted.get()) {
+      synchronized (storageWarmupCompleted) {
+        if (!storageWarmupCompleted.get()) {
+          try {
+            waveMap.loadAllWavelets();
+            storageWarmupCompleted.set(true);
+          } catch (WaveletStateException e) {
+            throw new RuntimeException("Failed to load waves for " + user.getAddress(), e);
+          }
+        }
+      }
+    }
   }
 
   @Override

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -59,6 +59,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
   private static final WaveletId WAVELET_ID = WaveletId.of(DOMAIN, "conv+root");
   private static final WaveletName WAVELET_NAME = WaveletName.of(WAVE_ID, WAVELET_ID);
   private static final ParticipantId PARTICIPANT = ParticipantId.ofUnsafe("user1@" + DOMAIN);
+  private static final ParticipantId SECOND_PARTICIPANT = ParticipantId.ofUnsafe("user2@" + DOMAIN);
   private static final Config CONFIG = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
       "core.wave_cache_size", 1000,
       "core.wave_cache_expire", "60m"));
@@ -115,9 +116,20 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     assertTrue(waveView.containsEntry(WAVE_ID, WAVELET_ID));
   }
 
+  public void testRetrievePerUserWaveViewLoadsStorageOnlyOnce() {
+    ReloadingWaveMap reloadingWaveMap = (ReloadingWaveMap) waveMap;
+    MemoryPerUserWaveViewHandlerImpl handler = new MemoryPerUserWaveViewHandlerImpl(reloadingWaveMap);
+
+    handler.retrievePerUserWaveView(PARTICIPANT);
+    handler.retrievePerUserWaveView(SECOND_PARTICIPANT);
+
+    assertEquals(1, reloadingWaveMap.loadAllWaveletsCallCount);
+  }
+
   private static final class ReloadingWaveMap extends WaveMap {
     private final ImmutableMap<WaveId, Wave> loadedWaves;
     private boolean loaded;
+    private int loadAllWaveletsCallCount;
 
     private ReloadingWaveMap(DeltaAndSnapshotStore store,
         LocalWaveletContainer.Factory localFactory, RemoteWaveletContainer.Factory remoteFactory,
@@ -130,6 +142,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     @Override
     public void loadAllWavelets() {
       loaded = true;
+      loadAllWaveletsCallCount++;
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- A per-user view cache loader called `waveMap.loadAllWavelets()` on every cache miss, which iterates all stored wave IDs and can cause expensive full storage scans and availability degradation when triggered repeatedly.  
- The intent is to avoid re-running that expensive full-scan on each per-user cache miss while preserving correct per-user view construction after a single storage warmup.

### Description
- Added a one-time warmup gate using `AtomicBoolean storageWarmupCompleted` and a synchronized helper `ensureWaveMapLoaded(WaveMap, ParticipantId)` so `waveMap.loadAllWavelets()` runs at most once per handler lifecycle.  
- Replaced the direct `waveMap.loadAllWavelets()` call in the per-user cache `load` method with a call to `ensureWaveMapLoaded(...)`.  
- Added a regression unit test `testRetrievePerUserWaveViewLoadsStorageOnlyOnce` to `MemoryPerUserWaveViewHandlerImplTest` that asserts `loadAllWavelets()` is invoked exactly once when retrieving views for multiple users.  
- Files changed: `wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java` and `wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java`.

### Testing
- Added the unit test `testRetrievePerUserWaveViewLoadsStorageOnlyOnce` which verifies the warmup gate prevents repeated `loadAllWavelets()` calls; the test was added but not executed in this environment.  
- Attempted to compile/run tests via `sbt wave/compile` and `sbt pst/compile` but those commands could not run here because `sbt` is not installed in the execution environment, so compilation and test execution were not completed.  
- Manual inspection and targeted test coverage were used to validate the change logic and ensure existing per-user view construction behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fecd8883318084e3f4a13b4e05)