### PR TITLE
fix: enforce OT search updater queue backpressure accounting

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdater.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdater.java
@@ -169,7 +169,9 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
     // Check per-user rate limit
     UpdateCounter counter = userCounters.computeIfAbsent(
         key.getUser().getAddress(), k -> new UpdateCounter(MAX_UPDATES_PER_SEC));
-    if (counter.getQueueSize() >= MAX_QUEUE_PER_USER) {
+    ScheduledFuture<?> existing = pendingTasks.get(taskKey);
+    boolean hasPendingTask = existing != null && !existing.isDone();
+    if (!hasPendingTask && counter.getQueueSize() >= MAX_QUEUE_PER_USER) {
       LOG.warning("Dropping search update for " + key + " -- queue full");
       return;
     }
@@ -185,8 +187,7 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
     }
 
     // Cancel any existing pending task for this key
-    ScheduledFuture<?> existing = pendingTasks.get(taskKey);
-    if (existing != null && !existing.isDone()) {
+    if (hasPendingTask) {
       existing.cancel(false);
     }
 
@@ -194,6 +195,9 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
     ScheduledFuture<?> future = scheduler.schedule(
         () -> executeUpdate(key, taskKey), delay, TimeUnit.MILLISECONDS);
     pendingTasks.put(taskKey, future);
+    if (!hasPendingTask) {
+      counter.incrementQueue();
+    }
   }
 
   /**
@@ -202,16 +206,21 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
    */
   private void executeUpdate(SearchIndexer.SubscriptionKey key, String taskKey) {
     try {
-      // Clear batch tracking state
-      pendingTasks.remove(taskKey);
-      firstSeenTimestamps.remove(taskKey);
-
       // Rate-limit per user
       UpdateCounter counter = userCounters.get(key.getUser().getAddress());
       if (counter != null && !counter.tryAcquire()) {
         // Re-enqueue with a short delay
-        scheduler.schedule(() -> executeUpdate(key, taskKey), 100, TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> retryFuture = scheduler.schedule(
+            () -> executeUpdate(key, taskKey), 100, TimeUnit.MILLISECONDS);
+        pendingTasks.put(taskKey, retryFuture);
         return;
+      }
+
+      // Clear batch tracking state
+      ScheduledFuture<?> pendingTask = pendingTasks.remove(taskKey);
+      firstSeenTimestamps.remove(taskKey);
+      if (pendingTask != null && counter != null) {
+        counter.decrementQueue();
       }
 
       // Look up the raw query for this subscription
@@ -361,7 +370,9 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
     }
 
     synchronized void decrementQueue() {
-      if (queueSize > 0) queueSize--;
+      if (queueSize > 0) {
+        queueSize--;
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
- The updater checked a per-user queue size (`UpdateCounter.getQueueSize()`) but never updated it, making `MAX_QUEUE_PER_USER` ineffective and allowing unbounded scheduled retries under load.
- The intent is to reintroduce accurate per-user queue accounting so debounced and retried tasks are bounded and cannot cause an availability DoS when `ot_search` is enabled.

### Description
- Updated `wave/src/main/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdater.java` to increment per-user queue size only when a new task key is enqueued and to preserve queue size when replacing an already-pending (debounced) task.
- When rate limiting defers execution, the retry `ScheduledFuture` is now stored in `pendingTasks` so deferred tasks remain tracked instead of building untracked retries.
- When a queued task is actually consumed for execution, the code now removes the pending task, clears `firstSeenTimestamps`, and decrements the per-user queue counter.
- Minor formatting change in `decrementQueue()` to use a block form without altering semantics.

### Testing
- Attempted backend compile with `sbt compile` but `sbt` is not available in this environment (failed).
- Attempted fallback compile with `./gradlew :wave:compileJava` and `./gradlew :wave:compileGwt` but the Gradle wrapper is not present (failed).
- Performed static verification by reviewing the diff and tracing `enqueueUpdate`/`executeUpdate`/`UpdateCounter` paths to ensure queue increments/decrements and `pendingTasks` bookkeeping are consistent (succeeded).
- No automated build or unit tests were run due to missing build tooling in the runtime; change is localized and low-risk but please run the project build (`sbt compile` or your normal CI) and unit/integration tests before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82ff102c8331aaf96fbf67a73d88)