### PR TITLE
fix: block unsafe link schemes in public wave blip renderer

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveBlipRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/PublicWaveBlipRenderer.java
@@ -27,9 +27,12 @@ import org.waveprotocol.wave.model.document.operation.impl.InitializationCursorA
 import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -241,6 +244,7 @@ public final class PublicWaveBlipRenderer {
         } else if (activeAnnotations.containsKey("link/wave")) {
           newLink = activeAnnotations.get("link/wave");
         }
+        newLink = sanitizeLinkUrl(newLink);
 
         // Only emit close/open tags if formatting actually changed and we're in body.
         boolean boldChanged = inBold[0] != newBold;
@@ -427,5 +431,36 @@ public final class PublicWaveBlipRenderer {
     if (inBold[0]) {
       html.append("<strong>");
     }
+  }
+
+  private static String sanitizeLinkUrl(String rawUrl) {
+    if (rawUrl == null) {
+      return null;
+    }
+    String trimmedUrl = rawUrl.trim();
+    if (trimmedUrl.isEmpty()) {
+      return null;
+    }
+
+    URI parsedUri;
+    try {
+      parsedUri = new URI(trimmedUrl);
+    } catch (URISyntaxException e) {
+      return null;
+    }
+
+    String scheme = parsedUri.getScheme();
+    if (scheme == null) {
+      return trimmedUrl;
+    }
+
+    String normalizedScheme = scheme.toLowerCase(Locale.ROOT);
+    if ("http".equals(normalizedScheme)
+        || "https".equals(normalizedScheme)
+        || "mailto".equals(normalizedScheme)) {
+      return trimmedUrl;
+    }
+
+    return null;
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/PublicWaveServletTest.java
@@ -29,6 +29,7 @@ import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.wave.model.document.operation.impl.DocInitializationBuilder;
+import org.waveprotocol.wave.model.document.operation.impl.AnnotationBoundaryMapBuilder;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
@@ -94,6 +95,35 @@ public class PublicWaveServletTest extends TestCase {
             .characters("Hello public world")
             .elementEnd()
             .build(),
+        1234567890, 0);
+    return wavelet;
+  }
+
+  private WaveletData createWaveletWithLink(String linkUrl, ParticipantId... extraParticipants) {
+    WaveletName name = WaveletName.of(WAVE_ID, CONV_ROOT);
+    WaveletData wavelet = WaveletDataUtil.createEmptyWavelet(
+        name, CREATOR, HashedVersion.unsigned(0), 1234567890);
+    wavelet.addParticipant(CREATOR);
+    for (ParticipantId p : extraParticipants) {
+      wavelet.addParticipant(p);
+    }
+
+    DocInitializationBuilder contentBuilder = new DocInitializationBuilder()
+        .elementStart("body", org.waveprotocol.wave.model.document.operation.Attributes.EMPTY_MAP)
+        .elementStart("line", org.waveprotocol.wave.model.document.operation.Attributes.EMPTY_MAP)
+        .elementEnd()
+        .annotationBoundary(new AnnotationBoundaryMapBuilder()
+            .change("link/manual", null, linkUrl)
+            .build())
+        .characters("Danger link")
+        .annotationBoundary(new AnnotationBoundaryMapBuilder()
+            .end("link/manual")
+            .build())
+        .elementEnd();
+
+    wavelet.createDocument("b+first", CREATOR,
+        java.util.Collections.<ParticipantId>emptySet(),
+        contentBuilder.build(),
         1234567890, 0);
     return wavelet;
   }
@@ -231,5 +261,38 @@ public class PublicWaveServletTest extends TestCase {
     assertTrue("Expected robots meta", html.contains("robots"));
     assertTrue("Expected twitter:card meta", html.contains("twitter:card"));
     assertTrue("Expected og:type meta", html.contains("og:type"));
+  }
+
+  public void testPublicWaveBlocksJavascriptLinkAnnotations() throws Exception {
+    WaveletData wavelet = createWaveletWithLink("javascript:alert(1)", DOMAIN_PARTICIPANT);
+    setupWaveletProvider(wavelet);
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter writer = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(writer));
+    when(request.getPathInfo()).thenReturn("/" + WAVE_ID.serialise());
+
+    servlet.doGet(request, response);
+
+    String html = writer.toString();
+    assertFalse("Expected javascript URL to be removed", html.contains("href=\"javascript:alert(1)\""));
+    assertTrue("Expected link text to still render", html.contains("Danger link"));
+  }
+
+  public void testPublicWaveKeepsHttpsLinkAnnotations() throws Exception {
+    WaveletData wavelet = createWaveletWithLink("https://example.com/docs", DOMAIN_PARTICIPANT);
+    setupWaveletProvider(wavelet);
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter writer = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(writer));
+    when(request.getPathInfo()).thenReturn("/" + WAVE_ID.serialise());
+
+    servlet.doGet(request, response);
+
+    String html = writer.toString();
+    assertTrue("Expected https URL to be preserved", html.contains("href=\"https://example.com/docs\""));
   }
 }


### PR DESCRIPTION
### Motivation
- Public wave rendering emitted anchor `href` values directly from blip link annotations, allowing attacker-controlled schemes such as `javascript:` to create clickable links and enable stored XSS when visited.
- The change removes the exposure by validating and sanitizing annotation-supplied URLs before they are emitted into the public HTML.

### Description
- Added `sanitizeLinkUrl(String)` to `PublicWaveBlipRenderer` to parse and validate annotation URLs and return only safe values or `null` for unsafe/malformed inputs.
- Allowed schemes are limited to `http`, `https`, and `mailto`; scheme-less URLs are preserved and other schemes (e.g., `javascript:`) are dropped.
- Applied `sanitizeLinkUrl` to link annotation values (`link/manual`, `link/auto`, `link/wave`) before rendering anchors in `PublicWaveBlipRenderer`.
- Added unit tests to `PublicWaveServletTest`: `testPublicWaveBlocksJavascriptLinkAnnotations` and `testPublicWaveKeepsHttpsLinkAnnotations`, plus a helper `createWaveletWithLink` to construct annotated blips for regression testing.

### Testing
- Added two servlet-level unit tests in `PublicWaveServletTest` that assert `javascript:` links are not emitted and `https:` links are preserved; these tests must be run in the project's test harness (they were added but not executed here).
- Attempted to compile and run the targeted test via `sbt "compile" "compileGwt" "testOnly org.waveprotocol.box.server.rpc.PublicWaveServletTest"`, but the environment lacks `sbt` so the command failed with `sbt: command not found` and no automated tests were executed in this container.
- Local or CI validation should run the backend compile, GWT compile, and the new unit tests (`sbt compile`, `sbt compileGwt`, `sbt testOnly ...`) and will be expected to pass; no runtime regressions were exercised here due to the missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fdafc88331955299379775357c)