### PR TITLE
fix: evict expired entries from TagsServlet per-user cache

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/TagsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/TagsServlet.java
@@ -176,6 +176,7 @@ public final class TagsServlet extends HttpServlet {
   private List<TagCount> getTagsForUser(ParticipantId user) {
     String key = user.getAddress();
     synchronized (cache) {
+      evictExpiredEntries();
       CacheEntry entry = cache.get(key);
       if (entry != null && !entry.isExpired()) {
         return entry.tags;
@@ -188,6 +189,10 @@ public final class TagsServlet extends HttpServlet {
       cache.put(key, new CacheEntry(tags));
     }
     return tags;
+  }
+
+  private void evictExpiredEntries() {
+    cache.entrySet().removeIf(entry -> entry.getValue().isExpired());
   }
 
   private List<TagCount> collectTagsFromWaves(ParticipantId user) {


### PR DESCRIPTION
### Motivation
- The `TagsServlet` used a singleton per-user `HashMap` cache with a TTL but never evicted expired entries globally, allowing unbounded growth when many distinct users access `/tags`.
- The intent is to prevent unbounded memory growth and availability degradation while preserving the existing per-user TTL caching behavior.
- This change implements a minimal, low-risk eviction strategy triggered on cache access to remove stale entries.

### Description
- Added a new helper `evictExpiredEntries()` that removes expired entries from the `cache` using `removeIf` on `entrySet()`.
- Call `evictExpiredEntries()` inside the `synchronized (cache)` section in `getTagsForUser()` before performing the per-user lookup.
- Preserves existing TTL semantics and the current cache update/refresh path while preventing stale-key accumulation.

### Testing
- Ran `sbt compile` to verify the build, which failed because `sbt` is not installed in the container (tooling unavailable).
- Ran `sbt compileGwt` which also failed due to missing `sbt` in the environment.
- Attempted `./gradlew :wave:compileJava` and `./gradlew :wave:compileGwt`, both failed because the Gradle wrapper is not present in this checkout.
- Attempted a standalone `javac` compile of the modified file, which failed due to missing classpath and external dependencies, so no successful compilation could be verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fdcd5883318b472e56a3133323)