### PR TITLE
fix: enforce same-origin CSRF checks on account settings POST endpoints

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -107,6 +107,10 @@ public final class AccountSettingsServlet extends HttpServlet {
     req.setCharacterEncoding("UTF-8");
     HumanAccountData caller = getAuthenticatedUser(req, resp);
     if (caller == null) return;
+    if (!isTrustedSameOriginRequest(req)) {
+      sendJsonError(resp, HttpServletResponse.SC_FORBIDDEN, "CSRF validation failed");
+      return;
+    }
 
     String pathInfo = req.getPathInfo();
     if (pathInfo == null) pathInfo = "";
@@ -343,5 +347,31 @@ public final class AccountSettingsServlet extends HttpServlet {
     resp.setStatus(status);
     setJsonUtf8(resp);
     resp.getWriter().write("{\"error\":\"" + message.replace("\"", "\\\"") + "\"}");
+  }
+
+  private static boolean isTrustedSameOriginRequest(HttpServletRequest req) {
+    String expectedOrigin = getExpectedOrigin(req);
+    String origin = req.getHeader("Origin");
+    if (origin != null && !origin.isEmpty()) {
+      return expectedOrigin.equals(origin);
+    }
+    String referer = req.getHeader("Referer");
+    if (referer == null || referer.isEmpty()) {
+      return false;
+    }
+    return referer.startsWith(expectedOrigin + "/");
+  }
+
+  private static String getExpectedOrigin(HttpServletRequest req) {
+    String scheme = req.getScheme();
+    String serverName = req.getServerName();
+    int serverPort = req.getServerPort();
+    StringBuilder origin = new StringBuilder();
+    origin.append(scheme).append("://").append(serverName);
+    if (("http".equals(scheme) && serverPort != 80)
+        || ("https".equals(scheme) && serverPort != 443)) {
+      origin.append(":").append(serverPort);
+    }
+    return origin.toString();
   }
 }


### PR DESCRIPTION
### Motivation
- The account settings endpoints (`POST /account/settings/email` and `/account/settings/request-password-reset`) accepted state-changing requests with only session authentication, enabling CSRF-based email takeover and password reset abuse.
- Add a minimal, backward-compatible server-side validation to block cross-site POSTs when `SameSite` cookie protections are not sufficient or unavailable.

### Description
- Enforce same-origin validation at the start of `doPost` in `AccountSettingsServlet` and return a JSON `403` when validation fails.
- Validate the request `Origin` header when present and fall back to `Referer` when `Origin` is absent, rejecting requests when neither header matches the server origin.
- Implemented helpers `isTrustedSameOriginRequest(HttpServletRequest)` and `getExpectedOrigin(HttpServletRequest)` in `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java`.
- The change is a minimal server-side gate that preserves existing in-app fetches while blocking cross-site submissions.

### Testing
- Attempted to compile the backend with `sbt -batch "wave/compile"`, but the environment lacks `sbt` and the command failed (exit: `sbt: command not found`).
- Attempted to run the client GWT compile with `sbt -batch "wave/gwtCompile"`, but the environment lacks `sbt` and the command failed (exit: `sbt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82ffd534833185d66e98c04141af)