### PR TITLE
Block unsafe profile image MIME types in ProfileServlet

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
@@ -40,6 +40,7 @@ import org.waveprotocol.wave.util.logging.Log;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 /**
  * Profile servlet for editing the current user's profile and serving
@@ -62,6 +63,11 @@ public final class ProfileServlet extends HttpServlet {
   private static final Log LOG = Log.get(ProfileServlet.class);
   private static final int MAX_BIO_LENGTH = 200;
   private static final int MAX_NAME_LENGTH = 50;
+  private static final Set<String> ALLOWED_PROFILE_IMAGE_MIME_TYPES = Set.of(
+      "image/png",
+      "image/jpeg",
+      "image/gif",
+      "image/webp");
 
   private final AccountStore accountStore;
   private final SessionManager sessionManager;
@@ -225,9 +231,9 @@ public final class ProfileServlet extends HttpServlet {
       return;
     }
 
-    String mimeType = filePart.getContentType();
-    if (mimeType == null || !mimeType.startsWith("image/")) {
-      sendJsonError(resp, HttpServletResponse.SC_BAD_REQUEST, "Only image files are allowed");
+    String mimeType = normalizeMimeType(filePart.getContentType());
+    if (!isAllowedProfileImageMimeType(mimeType)) {
+      sendJsonError(resp, HttpServletResponse.SC_BAD_REQUEST, "Only PNG, JPEG, GIF, and WEBP images are allowed");
       return;
     }
 
@@ -323,11 +329,16 @@ public final class ProfileServlet extends HttpServlet {
         resp.sendRedirect(profilesFetcher.fetchProfile(address).getImageUrl());
         return;
       }
-      String header = imageData.substring(5, commaIdx); // after "data:"
-      String mimeType = header.split(";")[0];
+      String header = imageData.substring(5, commaIdx);
+      String mimeType = normalizeMimeType(header.split(";")[0]);
+      if (!isAllowedProfileImageMimeType(mimeType)) {
+        resp.sendRedirect(profilesFetcher.fetchProfile(address).getImageUrl());
+        return;
+      }
       byte[] bytes = java.util.Base64.getDecoder().decode(imageData.substring(commaIdx + 1));
 
       resp.setContentType(mimeType);
+      resp.setHeader("X-Content-Type-Options", "nosniff");
       resp.setContentLength(bytes.length);
       resp.setHeader("Cache-Control", "public, max-age=3600");
       resp.getOutputStream().write(bytes);
@@ -410,9 +421,13 @@ public final class ProfileServlet extends HttpServlet {
     String profileImageId = account.getProfileImageAttachmentId();
     if (profileImageId != null && !profileImageId.isEmpty()) {
       if (profileImageId.startsWith("data:")) {
-        return profileImageId;
+        String mimeType = extractMimeTypeFromDataUrl(profileImageId);
+        if (isAllowedProfileImageMimeType(mimeType)) {
+          return profileImageId;
+        }
+      } else {
+        return "/userprofile/image/" + profileImageId;
       }
-      return "/userprofile/image/" + profileImageId;
     }
     // Use the profile fetcher to get the default image URL
     return profilesFetcher.fetchProfile(account.getId().getAddress()).getImageUrl();
@@ -435,6 +450,28 @@ public final class ProfileServlet extends HttpServlet {
     // Registration time is always public
     w.append(",\"registrationTime\":").append(String.valueOf(h.getRegistrationTime()));
     w.append('}');
+  }
+
+  private static String extractMimeTypeFromDataUrl(String dataUrl) {
+    if (dataUrl == null || !dataUrl.startsWith("data:")) return null;
+    int commaIdx = dataUrl.indexOf(',');
+    if (commaIdx <= 5) return null;
+    String header = dataUrl.substring(5, commaIdx);
+    return normalizeMimeType(header.split(";")[0]);
+  }
+
+  private static boolean isAllowedProfileImageMimeType(String mimeType) {
+    return mimeType != null && ALLOWED_PROFILE_IMAGE_MIME_TYPES.contains(mimeType);
+  }
+
+  private static String normalizeMimeType(String mimeType) {
+    if (mimeType == null) return null;
+    String normalized = mimeType.trim().toLowerCase();
+    int separator = normalized.indexOf(';');
+    if (separator >= 0) {
+      normalized = normalized.substring(0, separator).trim();
+    }
+    return normalized;
   }
 
   private static String readBody(HttpServletRequest req) throws IOException {


### PR DESCRIPTION
### Motivation
- A stored-XSS vector was introduced by storing and later serving client-supplied `data:` image URLs with attacker-controlled MIME types (e.g. `image/svg+xml`), allowing active SVG payloads to execute in the Wave origin.
- The intent of this change is to close that vector by preventing SVG (and other unsafe image types) from being uploaded or served from stored `data:` URLs while preserving normal raster image behavior.

### Description
- Added a strict allowlist `ALLOWED_PROFILE_IMAGE_MIME_TYPES` (`image/png`, `image/jpeg`, `image/gif`, `image/webp`) and helper functions `normalizeMimeType`, `isAllowedProfileImageMimeType`, and `extractMimeTypeFromDataUrl` to `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java`.
- Enforced allowlist validation during upload in `handleUploadImage` by normalizing the incoming MIME type and rejecting non-allowed types with a clear JSON error.
- Hardened serving in `handleGetProfileImage` to parse and normalize the stored `data:` MIME type, redirect to the default image if the stored MIME type is not allowed, and set `X-Content-Type-Options: nosniff` on responses.
- Prevented unsafe `data:` URLs from being emitted in profile JSON by validating the embedded MIME type in `resolveImageUrl` and falling back to the default image when the stored data URL is not allowed.

### Testing
- Attempted backend compilation with `sbt -batch compile`, but the command could not be executed in this environment because `sbt` is not installed (failed: `sbt: command not found`).
- Attempted frontend/GWT build with `sbt -batch gwtBuild`, but the command could not be executed in this environment because `sbt` is not installed (failed: `sbt: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca830060bc8331a68dec60ea7b6039)