### PR TITLE
fix: bound last-blip snippet extraction to prevent digest DoS

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/Snippets.java
@@ -84,6 +84,15 @@ public final class Snippets {
     return collateTextForOps(docOps);
   }
 
+  public static String collateTextForDocuments(Iterable<? extends ReadableBlipData> documents,
+      int maxLength) {
+    ArrayList<DocOp> docOps = new ArrayList<DocOp>();
+    for (ReadableBlipData blipData : documents) {
+      docOps.add(blipData.getContent().asOperation());
+    }
+    return collateTextForOps(docOps, DEFAULT_LINE_MODIFIER, maxLength);
+  }
+
   /**
    * Concatenates all of the text of the specified docops into a single String.
    *
@@ -94,53 +103,71 @@ public final class Snippets {
    */
   public static String collateTextForOps(Iterable<? extends DocOp> documentops,
       final Function<StringBuilder, Void> func) {
+    return collateTextForOps(documentops, func, Integer.MAX_VALUE);
+  }
+
+  private static String collateTextForOps(Iterable<? extends DocOp> documentops,
+      final Function<StringBuilder, Void> func, final int maxLength) {
     final StringBuilder resultBuilder = new StringBuilder();
-    for (DocOp docOp : documentops) {
-      docOp.apply(InitializationCursorAdapter.adapt(new DocOpCursor() {
-        @Override
-        public void characters(String s) {
-          resultBuilder.append(s);
-        }
-
-        @Override
-        public void annotationBoundary(AnnotationBoundaryMap map) {
-        }
-
-        @Override
-        public void elementStart(String type, Attributes attrs) {
-          if (type.equals(DocumentConstants.LINE)) {
-            func.apply(resultBuilder);
+    int safeMaxLength = Math.max(0, maxLength);
+    try {
+      for (DocOp docOp : documentops) {
+        docOp.apply(InitializationCursorAdapter.adapt(new DocOpCursor() {
+          @Override
+          public void characters(String s) {
+            if (resultBuilder.length() >= safeMaxLength) {
+              throw new SnippetLimitReachedException();
+            }
+            int remaining = safeMaxLength - resultBuilder.length();
+            if (s.length() <= remaining) {
+              resultBuilder.append(s);
+            } else {
+              resultBuilder.append(s.substring(0, remaining));
+              throw new SnippetLimitReachedException();
+            }
           }
-        }
 
-        @Override
-        public void elementEnd() {
-        }
+          @Override
+          public void annotationBoundary(AnnotationBoundaryMap map) {
+          }
 
-        @Override
-        public void retain(int itemCount) {
-        }
+          @Override
+          public void elementStart(String type, Attributes attrs) {
+            if (type.equals(DocumentConstants.LINE)) {
+              func.apply(resultBuilder);
+            }
+          }
 
-        @Override
-        public void deleteCharacters(String chars) {
-        }
+          @Override
+          public void elementEnd() {
+          }
 
-        @Override
-        public void deleteElementStart(String type, Attributes attrs) {
-        }
+          @Override
+          public void retain(int itemCount) {
+          }
 
-        @Override
-        public void deleteElementEnd() {
-        }
+          @Override
+          public void deleteCharacters(String chars) {
+          }
 
-        @Override
-        public void replaceAttributes(Attributes oldAttrs, Attributes newAttrs) {
-        }
+          @Override
+          public void deleteElementStart(String type, Attributes attrs) {
+          }
 
-        @Override
-        public void updateAttributes(AttributesUpdate attrUpdate) {
-        }
-      }));
+          @Override
+          public void deleteElementEnd() {
+          }
+
+          @Override
+          public void replaceAttributes(Attributes oldAttrs, Attributes newAttrs) {
+          }
+
+          @Override
+          public void updateAttributes(AttributesUpdate attrUpdate) {
+          }
+        }));
+      }
+    } catch (SnippetLimitReachedException ignored) {
     }
     return resultBuilder.toString().trim();
   }
@@ -284,11 +311,15 @@ public final class Snippets {
     if (document == null) {
       return "";
     }
-    String text = collateTextForDocuments(Arrays.asList(document)).trim();
+    String text = collateTextForDocuments(Arrays.asList(document), maxSnippetLength).trim();
     if (text.length() > maxSnippetLength) {
       return text.substring(0, maxSnippetLength);
     }
     return text;
+  }
+
+  private static final class SnippetLimitReachedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
   }
 
   private Snippets() {


### PR DESCRIPTION
### Motivation
- A denial-of-service risk was introduced because `renderSnippetFromLastBlip()` built the entire text of the latest reply via `collateTextForDocuments()` and only truncated afterward, allowing a huge reply to force large allocations and CPU work.  
- The change bounds text extraction during doc-op traversal so digest generation cannot materialize an unbounded `StringBuilder` from attacker-controlled content while preserving the existing snippet-length semantics.

### Description
- Added a bounded collation API `collateTextForDocuments(Iterable<? extends ReadableBlipData>, int maxLength)` that delegates into a new internal `collateTextForOps(..., int maxLength)` to enforce a hard character cap during traversal.  
- Implemented early-abort behavior in `collateTextForOps` by tracking the remaining budget and throwing an internal `SnippetLimitReachedException` to stop processing once the cap is reached.  
- Updated `renderSnippetFromLastBlip()` to call the bounded collation path (`collateTextForDocuments(Arrays.asList(document), maxSnippetLength)`) so the last-blip snippet cannot grow unbounded; existing unbounded APIs remain for callers that need full collation.

### Testing
- Attempted backend build with `sbt compile`, but the container lacks `sbt` so compilation could not be executed in this environment.  
- Attempted frontend/test compile with `sbt test:compile`, which also could not run due to missing `sbt`.  
- Verified local source edits and diff of `wave/src/main/java/org/waveprotocol/box/common/Snippets.java` to confirm the bounded path and `renderSnippetFromLastBlip` usage were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca82fe6e048331b1820a9175ad4e06)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for limiting snippet length with automatic text truncation when the maximum length is exceeded.
  * Improved snippet generation from documents with length-aware collation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->