### PR TITLE
feat: redesign Robot Control Room — mobile-first, dark theme, ⓘ tooltips on all fields

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -926,9 +926,11 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("<div id=\"token-status\" class=\"prompt-status\">Generating a one-hour JWT for the starter prompt\u2026</div>");
     sb.append("<button id=\"copy-prompt-btn\" class=\"btn-primary\" style=\"margin-top:12px;\" disabled onclick=\"");
     sb.append("var btn=this;btn.disabled=true;btn.textContent='Copying\u2026';");
+    sb.append("generateStarterJWT().then(function(){");
     sb.append("var ta=document.getElementById('starter-prompt');");
-    sb.append("navigator.clipboard.writeText(ta.value).then(function(){");
-    sb.append("btn.textContent='Copied!';btn.disabled=false;setTimeout(function(){btn.textContent='Copy Prompt';btn.disabled=false;},1500);");
+    sb.append("return navigator.clipboard.writeText(ta.value);");
+    sb.append("}).then(function(){");
+    sb.append("btn.textContent='Copied!';setTimeout(function(){btn.textContent='Copy Prompt';btn.disabled=false;},1500);");
     sb.append("}).catch(function(){btn.textContent='Copy Prompt';btn.disabled=false;});");
     sb.append("\">Copy Prompt</button>");
     sb.append("</div></div>");


### PR DESCRIPTION
## Summary
- Complete UI redesign of `/account/robots` based on Stitch mockup
- Dark space theme with starfield gradient background (`#0d0d1a`)
- Mobile-first single-column card layout with tab navigation (Robots / Create / Build AI)
- Robot cards with avatar icon, animated status dot (green pulse = online, grey = paused), collapse chevron
- ⓘ info tooltips on every field (Callback URL, Description, Consumer Secret, Token Expiry, etc.) with plain-English explanations
- Golden/amber gradient CTA buttons (`#f59e0b → #d97706`), pill-shaped, full-width
- Floating "+ Create Robot" FAB button
- Styled delete confirmation modal (replaces `window.confirm`)
- Danger zone section with red accent for destructive actions
- Copy Prompt button on Build AI tab
- CSS custom properties for full theme control
- All 7 server-side actions preserved: register, update-url, update-description, rotate-secret, verify, set-paused, delete
- XSRF token forms intact — **zero Java logic changes**, only HTML/CSS/JS output modified

## Test plan
- [ ] Compile: `sbt wave/compile` passes cleanly
- [ ] Visual: Load `/account/robots` — verify dark space theme, starfield background, tab navigation
- [ ] Functionality: Create a robot, update callback URL, update description, rotate secret, test bot, pause/unpause, delete
- [ ] Tooltips: Hover/tap ⓘ icons — verify tooltip appears with correct explanation text
- [ ] Mobile: Resize browser to 375px width — verify single-column layout, bottom tab bar
- [ ] Delete modal: Click delete — verify styled modal appears (no browser `confirm()` dialog)
- [ ] Build AI tab: Verify starter prompt textarea, JWT auto-generation, Copy Prompt button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed interface for Robots / Create / Build AI; Build AI JWT generated only when its tab opens
  * "Copy Prompt" button updates its label on success
  * Modal-based delete confirmation requiring explicit confirm

* **UI/Design**
  * Mobile-first single-column dashboard with top tab bar and floating "+ Create Robot"
  * Collapsible robot cards, toast-style notifications, masked read-only secret display
  * Reorganized form fields and consolidated action-row buttons

* **Bug Fixes**
  * JWT token endpoint requests use the app context path for correct routing
  * Token expiry handling now clamps negative values to zero

* **Chores**
  * E2E test invocation updated to a different sbt subcommand form
<!-- end of auto-generated comment: release notes by coderabbit.ai -->