### PR TITLE
Security: Fix DNS rebinding TOCTOU gap in UrlPreviewServlet (#511)

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UrlPreviewServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UrlPreviewServlet.java
@@ -273,11 +273,12 @@ public class UrlPreviewServlet extends HttpServlet {
       HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
       httpsConn.setSSLSocketFactory(
           new SsrfSafeSSLSocketFactory(originalHost, effectivePort, validatedAddress));
-      // Verify the certificate against the original hostname, not the IP
-      httpsConn.setHostnameVerifier((hostname, session) -> {
-        // Delegate to the default verifier with the original hostname
-        return HttpsURLConnection.getDefaultHostnameVerifier().verify(originalHost, session);
-      });
+      // Certificate hostname verification is enforced at the TLS layer via
+      // SSLParameters.setEndpointIdentificationAlgorithm("HTTPS") in SsrfSafeSSLSocketFactory.
+      // This performs RFC 2818 hostname verification during handshake against the original hostname.
+      // The HostnameVerifier returns true because the IP-rewritten URL hostname won't match
+      // the cert, but the SSLSocket-level endpoint identification already verified it.
+      httpsConn.setHostnameVerifier((hostname, session) -> true);
     }
 
     conn.setRequestMethod("GET");
@@ -404,12 +405,14 @@ public class UrlPreviewServlet extends HttpServlet {
       }
       // Layer TLS over an existing socket, using original hostname for SNI
       SSLSocket sslSocket = (SSLSocket) delegate.createSocket(s, originalHost, port, autoClose);
+      SSLParameters params = sslSocket.getSSLParameters();
+      // Enforce RFC 2818 hostname verification at TLS level
+      params.setEndpointIdentificationAlgorithm("HTTPS");
       // Set SNI only if originalHost is not a numeric IP literal
       if (!isNumericIpLiteral(originalHost)) {
-        SSLParameters params = sslSocket.getSSLParameters();
         params.setServerNames(List.of(new SNIHostName(originalHost)));
-        sslSocket.setSSLParameters(params);
       }
+      sslSocket.setSSLParameters(params);
       return sslSocket;
     }
 
@@ -421,13 +424,15 @@ public class UrlPreviewServlet extends HttpServlet {
         // Layer TLS on top with original hostname for SNI and certificate verification
         SSLSocket sslSocket = (SSLSocket) delegate.createSocket(
             rawSocket, originalHost, port, true);
+        SSLParameters params = sslSocket.getSSLParameters();
+        // Enforce RFC 2818 hostname verification at TLS level
+        params.setEndpointIdentificationAlgorithm("HTTPS");
         // Set SNI only if originalHost is not a numeric IP literal
         if (!isNumericIpLiteral(originalHost)) {
-          SSLParameters params = sslSocket.getSSLParameters();
           params.setServerNames(
               List.of(new SNIHostName(originalHost)));
-          sslSocket.setSSLParameters(params);
         }
+        sslSocket.setSSLParameters(params);
         return sslSocket;
       } catch (Exception e) {
         // Catch Exception (not just IOException) to also handle IllegalArgumentException


### PR DESCRIPTION
Closes #511

## Changes
- Replaced HttpURLConnection with IP-pinning approach via custom SocketFactory
- DNS is resolved once and validated, preventing TOCTOU race
- HTTPS connections use SsrfSafeSSLSocketFactory to maintain TLS/SNI while connecting to validated IP
- validateUrlForPreview() kept as defense-in-depth check
- No new dependencies added

## Technical Details
The vulnerability was that HttpURLConnection.openConnection() performs its own independent DNS resolution after the initial validation check, allowing DNS rebinding attacks. The fix resolves and validates the hostname once, rewrites the URL to use the validated IP literal, and for HTTPS, layers TLS on top of the validated TCP connection with proper SNI and hostname verification.

## Testing
- sbt "wave/Test/compile" passes
- No logic changes to existing SSRF checks, only the connection mechanism

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL preview is more secure: connections now resolve and bind to a validated IP at connect time to prevent DNS-rebinding/SSRF and TOCTOU issues.
  * HTTPS previews preserve TLS hostname verification and SNI while attempting to send the original Host header so redirects and HTTPS hosts behave consistently.
  * Previewing avoids connecting to blocked/resolved addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->