### PR TITLE
fix: incremental Lucene9 index repair instead of skip on restart

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
@@ -121,8 +121,16 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
       } else {
         LOG.info("Lucene9 index is empty, performing initial build");
       }
-      boolean fullRebuild = existingDocs > 0 && rebuildOnStartup || existingDocs == 0;
-      waveMap.loadAllWavelets();
+      boolean fullRebuild = (existingDocs > 0 && rebuildOnStartup) || existingDocs == 0;
+      try {
+        waveMap.loadAllWavelets();
+      } catch (WaveletStateException e) {
+        if (fullRebuild) {
+          throw e;
+        }
+        LOG.log(Level.WARNING,
+            "loadAllWavelets failed during incremental repair, using cached waves", e);
+      }
       try {
         org.waveprotocol.box.common.ExceptionalIterator<WaveId, WaveServerException> waveIds =
             waveletProvider.getWaveIds();


### PR DESCRIPTION
## Summary
- When `lucene9_rebuild_on_startup=false` and the index has documents, run an incremental upsert instead of skipping entirely
- Repairs gaps from prior crashes — waves that were never indexed get added, already-indexed waves get a no-op update (`updateDocument` is idempotent)
- Full `deleteAll` + rebuild only happens when `lucene9_rebuild_on_startup=true`

## Context
This addresses a P1 review comment from PR #532 that landed after the squash merge. The previous behavior skipped rebuild entirely when the index had any documents, which meant a crash mid-indexing would leave permanent gaps — historical waves that were never indexed would remain missing since `waveletCommitted` only fires for new commits.

## Test plan
- [ ] Deploy with existing Lucene9 index — verify incremental repair logs and search results are complete
- [ ] Deploy with `lucene9_rebuild_on_startup=true` — verify full rebuild still works
- [ ] Deploy with empty index — verify initial build works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now always runs a rebuild/repair pass and clearly distinguishes full rebuilds from incremental repairs in logs.
  * Indexing is more resilient: per-item failures are isolated, failed items are skipped, errors are counted and logged, and processing continues.
  * Final logs/reporting reflect only successfully processed items and summarize any errors encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->