### PR TITLE
Skip GWT compilation when output already exists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1182,11 +1182,12 @@ ThisBuild / compileGwt := {
   val webclientDir = base / "war" / "webclient"
   val mappingsFile = webclientDir / "compilation-mappings.txt"
   val hasCompleteOutput = nocacheJs.exists && mappingsFile.exists && {
-    val expectedHashes = IO.readLines(mappingsFile)
-      .map(_.trim).filter(_.matches("[0-9A-Fa-f]{32}"))
+    val cacheJsPattern = "([0-9A-Fa-f]{32})\\.cache\\.js".r
+    val expectedFiles = IO.readLines(mappingsFile)
+      .map(_.trim).collect { case cacheJsPattern(h) => h + ".cache.js" }
       .distinct
-    expectedHashes.nonEmpty &&
-      expectedHashes.forall(h => (webclientDir / (h + ".cache.js")).exists)
+    expectedFiles.nonEmpty &&
+      expectedFiles.forall(f => (webclientDir / f).exists)
   }
 
   val outputTs = if (hasCompleteOutput) nocacheJs.lastModified else 0L


### PR DESCRIPTION
### Changes

- Add check for existing `war/webclient/webclient.nocache.js` file before running GWT compilation
- Skip compilation if the output file already exists, avoiding unnecessary recompilation on `sbt run`
- Log informative message directing users to use `sbt clean run` if recompilation is needed

This optimization speeds up development workflows by skipping redundant GWT compilations when the output is already present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now uses timestamp-based incremental checks to detect when the web client output is up-to-date and skips unnecessary recompilation, improving incremental build times.
  * When skipped, a clear "Skipped — output is up-to-date ..." message is logged to indicate no work was performed.
  * Existing skip behavior and fallbacks to external/native compilation paths remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->