### PR TITLE
Enable lucene9 search and fix wave map cache eviction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,20 @@ jobs:
         timeout-minutes: 2
         run: |
           cd target/universal/stage
+          # Ensure port 9898 is free (previous smoke step should have stopped, but guard anyway).
+          # Fail closed: if ss is unavailable or errors, assume port may be in use and wait.
+          for attempt in 1 2 3; do
+            if command -v ss >/dev/null 2>&1; then
+              ss -tlnp 'sport = :9898' 2>/dev/null | grep -q LISTEN || break
+            else
+              # ss unavailable — fall back to curl probe (fail closed)
+              curl -s -o /dev/null --max-time 1 http://localhost:9898/ 2>/dev/null || break
+            fi
+            echo "Port 9898 still in use, waiting... (attempt $attempt)"
+            sleep 2
+          done
           SERVER_LOG=/tmp/wave-startup.log
+          CURL_LOG=/tmp/wave-curl-probe.log
           ./bin/wave > "$SERVER_LOG" 2>&1 &
           SERVER_PID=$!
           cleanup() {
@@ -100,7 +113,7 @@ jobs:
           }
           trap cleanup EXIT
           for i in $(seq 1 30); do
-            STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9898/healthz || true)"
+            STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9898/healthz 2>>"$CURL_LOG" || true)"
             if [ "$STATUS_CODE" = "200" ]; then
               echo "Server started successfully"
               exit 0
@@ -113,7 +126,10 @@ jobs:
             sleep 2
           done
           echo "Server failed to start within 60 seconds"
+          echo "--- Server log ---"
           tail -n 200 "$SERVER_LOG" || true
+          echo "--- Curl probe log ---"
+          cat "$CURL_LOG" 2>/dev/null || true
           exit 1
 
       - name: Guard experimental flags for release (tags/releases/release branches)

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -61,6 +61,12 @@ start() {
     echo "Install dir not found: $INSTALL_DIR. Run: sbt Universal/stage" >&2
     exit 1
   fi
+  # Ensure port is free before starting (avoids collision with prior runs)
+  if port_in_use; then
+    echo "Port $PORT already in use — stopping stale server first" >&2
+    stop
+    sleep 1
+  fi
   (cd "$INSTALL_DIR" && nohup ./bin/wave > wave_server.out 2>&1 & echo $! > wave_server.pid)
   echo "Started. Wrapper PID=$(cat "$PID_FILE" 2>/dev/null || echo unknown)"
   wait_ready
@@ -78,8 +84,12 @@ start() {
 }
 
 wait_ready() {
+  local curl_log="${INSTALL_DIR}/curl_probe.log"
   for i in {1..60}; do
-    http_status=$(curl -sS -o /dev/null -w "%{http_code}" "http://localhost:$PORT/" || true)
+    # Use -s (silent) without -S to suppress expected connection-refused errors
+    # during JVM startup. Redirect stderr to a log file so real networking
+    # problems (DNS, loopback misconfiguration) remain diagnosable.
+    http_status=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$PORT/" 2>>"$curl_log" || true)
     if [[ "${http_status:-000}" != "000" ]]; then
       echo "PROBE_HTTP=$http_status"
     fi


### PR DESCRIPTION
## Changes

### Search Configuration
- Enable Lucene9 search type by default in deployment configs (caddy, contabo)
- Simplify SearchModule to use Lucene9WaveIndexerImpl directly instead of composite indexer
- Route through FeatureFlaggedSearchProviderImpl for per-user Lucene9 feature flag support
- Use MemoryPerUserWaveViewHandlerImpl for both legacy and Lucene9 paths (no async bootstrap race)

### Wave Map Cache Eviction Fix
- Implement cooldown-based reloading in MemoryPerUserWaveViewHandlerImpl to prevent redundant full-store scans
- When per-user view cache expires and rebuilds, reload WaveMap from storage if needed
- 30-second cooldown prevents back-to-back scans when multiple users' caches miss simultaneously
- Fixes issue where search panel appeared empty after 60min due to cache eviction

### Startup Improvements
- Add wave view pre-warming in ServerMain for faster first search request
- Warm owner's per-user view if configured, otherwise warm entire wave map
- Change lucene9_rebuild_on_startup default from true to false for faster startup and safer rolling deploys
- Add Lucene write-lock retry logic (LuceneIndexWriterFactory) for start-first deployments

### CI/Test Improvements
- Improve smoke test startup probes to suppress false-alarm curl errors during JVM startup
- Add port availability check before starting server to avoid collision with prior runs
- Redirect curl stderr to log file for better diagnostics
- Add comprehensive test coverage for FeatureFlaggedSearchProviderImpl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced application startup with improved port conflict detection to prevent launch failures.
  * Expanded diagnostic logging to provide better visibility during deployment troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->