### PR TITLE
Add deploy sanity check: login, search, fetch

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -149,7 +149,18 @@ jobs:
             mkdir -p '$release_dir'
             tar -xzf '$remote_root/incoming/$RELEASE_ID.tgz' -C '$release_dir'
             chmod +x '$release_dir/deploy.sh'
-            DEPLOY_ROOT='$remote_root' WAVE_IMAGE='$IMAGE_REF' CANONICAL_HOST='$CANONICAL_HOST' ROOT_HOST='$ROOT_HOST' WWW_HOST='$WWW_HOST' RESEND_API_KEY=$resend_api_key_q WAVE_EMAIL_FROM=$wave_email_from_q SANITY_ADDRESS=$sanity_address_q SANITY_PASSWORD=$sanity_password_q bash '$release_dir/deploy.sh' deploy
+            # Export secrets as environment variables (not argv) to avoid /proc/*/cmdline exposure
+            # The deploy script reads these via load_deploy_env() from shared/deploy.env or from the environment
+            export DEPLOY_ROOT='$remote_root'
+            export WAVE_IMAGE='$IMAGE_REF'
+            export CANONICAL_HOST='$CANONICAL_HOST'
+            export ROOT_HOST='$ROOT_HOST'
+            export WWW_HOST='$WWW_HOST'
+            export RESEND_API_KEY=$resend_api_key_q
+            export WAVE_EMAIL_FROM=$wave_email_from_q
+            export SANITY_ADDRESS=$sanity_address_q
+            export SANITY_PASSWORD=$sanity_password_q
+            bash '$release_dir/deploy.sh' deploy
           "
 
       - name: Close deploy-failure issues on success

--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -133,19 +133,23 @@ jobs:
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
+          SANITY_ADDRESS: ${{ secrets.SANITY_ADDRESS }}
+          SANITY_PASSWORD: ${{ secrets.SANITY_PASSWORD }}
         run: |
           set -euo pipefail
           remote_root="${{ secrets.CONTABO_DEPLOY_ROOT || format('/home/{0}/supawave', secrets.CONTABO_SSH_USER) }}"
           release_dir="$remote_root/releases/$RELEASE_ID"
           resend_api_key_q=$(printf '%q' "${RESEND_API_KEY:-}")
           wave_email_from_q=$(printf '%q' "${WAVE_EMAIL_FROM:-}")
+          sanity_address_q=$(printf '%q' "${SANITY_ADDRESS:-}")
+          sanity_password_q=$(printf '%q' "${SANITY_PASSWORD:-}")
           ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=20 -p "${{ secrets.CONTABO_SSH_PORT || '22' }}" "${{ secrets.CONTABO_SSH_USER }}@${{ secrets.CONTABO_SSH_HOST }}" "
             set -euo pipefail
             rm -rf '$release_dir'
             mkdir -p '$release_dir'
             tar -xzf '$remote_root/incoming/$RELEASE_ID.tgz' -C '$release_dir'
             chmod +x '$release_dir/deploy.sh'
-            DEPLOY_ROOT='$remote_root' WAVE_IMAGE='$IMAGE_REF' CANONICAL_HOST='$CANONICAL_HOST' ROOT_HOST='$ROOT_HOST' WWW_HOST='$WWW_HOST' RESEND_API_KEY=$resend_api_key_q WAVE_EMAIL_FROM=$wave_email_from_q bash '$release_dir/deploy.sh' deploy
+            DEPLOY_ROOT='$remote_root' WAVE_IMAGE='$IMAGE_REF' CANONICAL_HOST='$CANONICAL_HOST' ROOT_HOST='$ROOT_HOST' WWW_HOST='$WWW_HOST' RESEND_API_KEY=$resend_api_key_q WAVE_EMAIL_FROM=$wave_email_from_q SANITY_ADDRESS=$sanity_address_q SANITY_PASSWORD=$sanity_password_q bash '$release_dir/deploy.sh' deploy
           "
 
       - name: Close deploy-failure issues on success

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -202,7 +202,10 @@ sanity_check() {
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
       if command -v apk >/dev/null 2>&1; then
-        apk add --no-cache curl jq >/dev/null 2>&1
+        if ! apk add --no-cache curl jq >/dev/null; then
+          echo "[sanity] FAIL: unable to install curl/jq via apk" >&2
+          exit 1
+        fi
       else
         echo "[sanity] FAIL: curl/jq not found and apk unavailable in sanity image"
         exit 1
@@ -215,11 +218,14 @@ sanity_check() {
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
-    HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    if ! HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
       -c "$COOKIE" -L --max-time 10 \
       --data-urlencode "address=${ADDR}" \
       --data-urlencode "password=${PASS}" \
-      "$BASE/auth/signin")
+      "$BASE/auth/signin"); then
+      echo "[sanity] FAIL: login request failed" >&2
+      exit 1
+    fi
     if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
       echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"
       exit 1
@@ -230,8 +236,11 @@ sanity_check() {
     DEADLINE=$(( $(date +%s) + 60 ))
     WAVE_ID=""
     while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      RESP=$(curl -s -b "$COOKIE" --max-time 10 \
-        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>/dev/null || true)
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time 10 \
+        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
+        sleep 2
+        continue
+      fi
       WAVE_ID=$(printf "%s" "$RESP" | jq -r ".[\"3\"][0][\"3\"] // empty" 2>/dev/null || true)
       if [ -n "$WAVE_ID" ]; then break; fi
       sleep 2
@@ -245,8 +254,11 @@ sanity_check() {
     # --- Step 3: Fetch top wave ------------------------------------------
     # Wave IDs use ! separator (e.g. domain!w+id) but fetch URL uses /
     FETCH_PATH=$(printf "%s" "$WAVE_ID" | sed "s|!|/|g")
-    FETCH_RESP=$(curl -s -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
-      "$BASE/fetch/$FETCH_PATH")
+    if ! FETCH_RESP=$(curl -sS -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
+      "$BASE/fetch/$FETCH_PATH"); then
+      echo "[sanity] FAIL: fetch request failed" >&2
+      exit 1
+    fi
     FETCH_CODE=$(printf "%s" "$FETCH_RESP" | tail -1)
     FETCH_BODY=$(printf "%s" "$FETCH_RESP" | sed "\$d")
     if [ "$FETCH_CODE" != "200" ]; then

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -174,16 +174,22 @@ sanity_check() {
   # If not configured, skip gracefully (opt-in gate).
   local addr="${SANITY_ADDRESS:-}"
   local pass="${SANITY_PASSWORD:-}"
-  if [[ -z "$addr" || -z "$pass" ]]; then
+  if [[ -z "$addr" && -z "$pass" ]]; then
     echo "[deploy] SANITY_ADDRESS/SANITY_PASSWORD not set, skipping sanity check"
     return 0
   fi
+  if [[ -z "$addr" || -z "$pass" ]]; then
+    echo "[deploy] SANITY_ADDRESS and SANITY_PASSWORD must both be set" >&2
+    return 1
+  fi
 
-  echo "[deploy] Running sanity check as ${addr%%@*}@*** ..."
+  echo "[deploy] Running sanity check ..."
 
   # Run all steps inside a single alpine container with curl+jq on the
   # compose network so we can reach the wave service by hostname.
   # Pass secrets via -e to avoid shell interpolation / injection risks.
+  # Override SANITY_IMAGE with a pre-built image containing curl+jq to
+  # avoid the runtime apk add dependency on Alpine repos.
   docker run --rm --network "${project_name}_default" \
     -e INTERNAL_PORT="${internal_port}" \
     -e SANITY_ADDR="${addr}" \
@@ -191,7 +197,12 @@ sanity_check() {
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-      apk add --no-cache curl jq >/dev/null 2>&1
+      if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl jq >/dev/null 2>&1
+      else
+        echo "[sanity] FAIL: curl/jq not found and apk unavailable in sanity image"
+        exit 1
+      fi
     fi
 
     BASE="http://wave:${INTERNAL_PORT}"

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -179,7 +179,7 @@ sanity_check() {
     return 0
   fi
 
-  echo "[deploy] Running sanity check as $addr ..."
+  echo "[deploy] Running sanity check as ${addr%%@*}@*** ..."
 
   # Run all steps inside a single alpine container with curl+jq on the
   # compose network so we can reach the wave service by hostname.

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -28,6 +28,7 @@ root_host=${ROOT_HOST:-wave.supawave.ai}
 www_host=${WWW_HOST:-www.supawave.ai}
 internal_port=${WAVE_INTERNAL_PORT:-9898}
 smoke_image=${SMOKE_IMAGE:-curlimages/curl:8.10.1}
+sanity_image=${SANITY_IMAGE:-alpine:3.20}
 registry_host=${GHCR_REGISTRY_HOST:-ghcr.io}
 deploy_env_file="$deploy_root/shared/deploy.env"
 lock_file="$deploy_root/deploy.lock"
@@ -167,6 +168,78 @@ wait_for_ready() {
   return 1
 }
 
+sanity_check() {
+  # Application-level sanity: login, search, fetch a wave.
+  # Credentials come from GitHub Secrets via environment variables.
+  # If not configured, skip gracefully (opt-in gate).
+  local addr="${SANITY_ADDRESS:-}"
+  local pass="${SANITY_PASSWORD:-}"
+  if [[ -z "$addr" || -z "$pass" ]]; then
+    echo "[deploy] SANITY_ADDRESS/SANITY_PASSWORD not set, skipping sanity check"
+    return 0
+  fi
+
+  echo "[deploy] Running sanity check as $addr ..."
+
+  # Run all steps inside a single alpine container with curl+jq on the
+  # compose network so we can reach the wave service by hostname.
+  docker run --rm --network "${project_name}_default" "$sanity_image" sh -c '
+    set -e
+    apk add --no-cache curl jq >/dev/null 2>&1
+
+    BASE="http://wave:'"${internal_port}"'"
+    ADDR="'"${addr}"'"
+    PASS="'"${pass}"'"
+    COOKIE=/tmp/c.txt
+
+    # --- Step 1: Login ---------------------------------------------------
+    HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -c "$COOKIE" -L --max-time 10 \
+      -d "address=${ADDR}&password=${PASS}" \
+      "$BASE/auth/signin")
+    if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
+      echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"
+      exit 1
+    fi
+    echo "[sanity] login OK"
+
+    # --- Step 2: Poll search (60 s) --------------------------------------
+    DEADLINE=$(( $(date +%s) + 60 ))
+    WAVE_ID=""
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+      RESP=$(curl -s -b "$COOKIE" --max-time 10 \
+        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>/dev/null || true)
+      WAVE_ID=$(printf "%s" "$RESP" | jq -r ".[\"3\"][0][\"3\"] // empty" 2>/dev/null || true)
+      if [ -n "$WAVE_ID" ]; then break; fi
+      sleep 2
+    done
+    if [ -z "$WAVE_ID" ]; then
+      echo "[sanity] FAIL: search returned no waves within 60 s"
+      exit 1
+    fi
+    echo "[sanity] search OK — found wave: $WAVE_ID"
+
+    # --- Step 3: Fetch top wave ------------------------------------------
+    # Wave IDs use ! separator (e.g. domain!w+id) but fetch URL uses /
+    FETCH_PATH=$(printf "%s" "$WAVE_ID" | sed "s|!|/|g")
+    FETCH_RESP=$(curl -s -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
+      "$BASE/fetch/$FETCH_PATH")
+    FETCH_CODE=$(printf "%s" "$FETCH_RESP" | tail -1)
+    FETCH_BODY=$(printf "%s" "$FETCH_RESP" | sed "\$d")
+    if [ "$FETCH_CODE" != "200" ]; then
+      echo "[sanity] FAIL: fetch returned HTTP $FETCH_CODE"
+      exit 1
+    fi
+    HAS_CONTENT=$(printf "%s" "$FETCH_BODY" | jq "has(\"1\")" 2>/dev/null || echo "false")
+    if [ "$HAS_CONTENT" != "true" ]; then
+      echo "[sanity] FAIL: fetch response missing wavelet content"
+      exit 1
+    fi
+    echo "[sanity] fetch OK — wave loaded with content"
+    echo "[sanity] ALL CHECKS PASSED"
+  '
+}
+
 _do_rollback_compose() {
   local rollback_image="$1"
   local previous_release="$2"
@@ -227,7 +300,7 @@ deploy_release() {
     exit 1
   fi
 
-  if wait_for_ready && check_proxy; then
+  if wait_for_ready && check_proxy && sanity_check; then
     echo "Deployed $(basename "$release_dir")"
     return 0
   fi

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -183,19 +183,27 @@ sanity_check() {
 
   # Run all steps inside a single alpine container with curl+jq on the
   # compose network so we can reach the wave service by hostname.
-  docker run --rm --network "${project_name}_default" "$sanity_image" sh -c '
+  # Pass secrets via -e to avoid shell interpolation / injection risks.
+  docker run --rm --network "${project_name}_default" \
+    -e INTERNAL_PORT="${internal_port}" \
+    -e SANITY_ADDR="${addr}" \
+    -e SANITY_PASS="${pass}" \
+    "$sanity_image" sh -c '
     set -e
-    apk add --no-cache curl jq >/dev/null 2>&1
+    if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+      apk add --no-cache curl jq >/dev/null 2>&1
+    fi
 
-    BASE="http://wave:'"${internal_port}"'"
-    ADDR="'"${addr}"'"
-    PASS="'"${pass}"'"
+    BASE="http://wave:${INTERNAL_PORT}"
+    ADDR="$SANITY_ADDR"
+    PASS="$SANITY_PASS"
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
     HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
       -c "$COOKIE" -L --max-time 10 \
-      -d "address=${ADDR}&password=${PASS}" \
+      --data-urlencode "address=${ADDR}" \
+      --data-urlencode "password=${PASS}" \
       "$BASE/auth/signin")
     if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
       echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -187,13 +187,17 @@ sanity_check() {
 
   # Run all steps inside a single alpine container with curl+jq on the
   # compose network so we can reach the wave service by hostname.
-  # Pass secrets via -e to avoid shell interpolation / injection risks.
+  # Export and pass variable names only so values are inherited from the
+  # environment and not embedded in the docker argv (visible via ps).
   # Override SANITY_IMAGE with a pre-built image containing curl+jq to
   # avoid the runtime apk add dependency on Alpine repos.
+  export INTERNAL_PORT="${internal_port}"
+  export SANITY_ADDR="${addr}"
+  export SANITY_PASS="${pass}"
   docker run --rm --network "${project_name}_default" \
-    -e INTERNAL_PORT="${internal_port}" \
-    -e SANITY_ADDR="${addr}" \
-    -e SANITY_PASS="${pass}" \
+    -e INTERNAL_PORT \
+    -e SANITY_ADDR \
+    -e SANITY_PASS \
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -28,6 +28,7 @@ root_host=${ROOT_HOST:-wave.supawave.ai}
 www_host=${WWW_HOST:-www.supawave.ai}
 internal_port=${WAVE_INTERNAL_PORT:-9898}
 smoke_image=${SMOKE_IMAGE:-curlimages/curl:8.10.1}
+sanity_image=${SANITY_IMAGE:-alpine:3.20}
 registry_host=${GHCR_REGISTRY_HOST:-ghcr.io}
 deploy_env_file="$deploy_root/shared/deploy.env"
 
@@ -115,6 +116,72 @@ wait_for_ready() {
   return 1
 }
 
+sanity_check() {
+  local addr="${SANITY_ADDRESS:-}"
+  local pass="${SANITY_PASSWORD:-}"
+  if [[ -z "$addr" || -z "$pass" ]]; then
+    echo "[deploy] SANITY_ADDRESS/SANITY_PASSWORD not set, skipping sanity check"
+    return 0
+  fi
+
+  echo "[deploy] Running sanity check as $addr ..."
+
+  docker run --rm --network host "$sanity_image" sh -c '
+    set -e
+    apk add --no-cache curl jq >/dev/null 2>&1
+
+    BASE="http://127.0.0.1:'"${internal_port}"'"
+    ADDR="'"${addr}"'"
+    PASS="'"${pass}"'"
+    COOKIE=/tmp/c.txt
+
+    # --- Step 1: Login ---------------------------------------------------
+    HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+      -c "$COOKIE" -L --max-time 10 \
+      -d "address=${ADDR}&password=${PASS}" \
+      "$BASE/auth/signin")
+    if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
+      echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"
+      exit 1
+    fi
+    echo "[sanity] login OK"
+
+    # --- Step 2: Poll search (60 s) --------------------------------------
+    DEADLINE=$(( $(date +%s) + 60 ))
+    WAVE_ID=""
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+      RESP=$(curl -s -b "$COOKIE" --max-time 10 \
+        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>/dev/null || true)
+      WAVE_ID=$(printf "%s" "$RESP" | jq -r ".[\"3\"][0][\"3\"] // empty" 2>/dev/null || true)
+      if [ -n "$WAVE_ID" ]; then break; fi
+      sleep 2
+    done
+    if [ -z "$WAVE_ID" ]; then
+      echo "[sanity] FAIL: search returned no waves within 60 s"
+      exit 1
+    fi
+    echo "[sanity] search OK — found wave: $WAVE_ID"
+
+    # --- Step 3: Fetch top wave ------------------------------------------
+    FETCH_PATH=$(printf "%s" "$WAVE_ID" | sed "s|!|/|g")
+    FETCH_RESP=$(curl -s -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
+      "$BASE/fetch/$FETCH_PATH")
+    FETCH_CODE=$(printf "%s" "$FETCH_RESP" | tail -1)
+    FETCH_BODY=$(printf "%s" "$FETCH_RESP" | sed "\$d")
+    if [ "$FETCH_CODE" != "200" ]; then
+      echo "[sanity] FAIL: fetch returned HTTP $FETCH_CODE"
+      exit 1
+    fi
+    HAS_CONTENT=$(printf "%s" "$FETCH_BODY" | jq "has(\"1\")" 2>/dev/null || echo "false")
+    if [ "$HAS_CONTENT" != "true" ]; then
+      echo "[sanity] FAIL: fetch response missing wavelet content"
+      exit 1
+    fi
+    echo "[sanity] fetch OK — wave loaded with content"
+    echo "[sanity] ALL CHECKS PASSED"
+  '
+}
+
 rollback_release() {
   if [[ ! -L "$deploy_root/previous" ]]; then
     echo "No previous release is available for rollback" >&2
@@ -154,7 +221,7 @@ deploy_release() {
   activate_release
   compose_up
 
-  if wait_for_ready && check_proxy; then
+  if wait_for_ready && check_proxy && sanity_check; then
     echo "Deployed $(basename "$release_dir")"
     return 0
   fi

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -124,7 +124,7 @@ sanity_check() {
     return 0
   fi
 
-  echo "[deploy] Running sanity check as $addr ..."
+  echo "[deploy] Running sanity check as ${addr%%@*}@*** ..."
 
   docker run --rm --network host \
     -e INTERNAL_PORT="${internal_port}" \

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -130,10 +130,13 @@ sanity_check() {
 
   echo "[deploy] Running sanity check ..."
 
+  export INTERNAL_PORT="${internal_port}"
+  export SANITY_ADDR="${addr}"
+  export SANITY_PASS="${pass}"
   docker run --rm --network host \
-    -e INTERNAL_PORT="${internal_port}" \
-    -e SANITY_ADDR="${addr}" \
-    -e SANITY_PASS="${pass}" \
+    -e INTERNAL_PORT \
+    -e SANITY_ADDR \
+    -e SANITY_PASS \
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -141,7 +141,10 @@ sanity_check() {
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
       if command -v apk >/dev/null 2>&1; then
-        apk add --no-cache curl jq >/dev/null 2>&1
+        if ! apk add --no-cache curl jq >/dev/null; then
+          echo "[sanity] FAIL: unable to install curl/jq via apk" >&2
+          exit 1
+        fi
       else
         echo "[sanity] FAIL: curl/jq not found and apk unavailable in sanity image"
         exit 1
@@ -154,11 +157,14 @@ sanity_check() {
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
-    HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+    if ! HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
       -c "$COOKIE" -L --max-time 10 \
       --data-urlencode "address=${ADDR}" \
       --data-urlencode "password=${PASS}" \
-      "$BASE/auth/signin")
+      "$BASE/auth/signin"); then
+      echo "[sanity] FAIL: login request failed" >&2
+      exit 1
+    fi
     if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
       echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"
       exit 1
@@ -169,8 +175,11 @@ sanity_check() {
     DEADLINE=$(( $(date +%s) + 60 ))
     WAVE_ID=""
     while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      RESP=$(curl -s -b "$COOKIE" --max-time 10 \
-        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>/dev/null || true)
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time 10 \
+        "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
+        sleep 2
+        continue
+      fi
       WAVE_ID=$(printf "%s" "$RESP" | jq -r ".[\"3\"][0][\"3\"] // empty" 2>/dev/null || true)
       if [ -n "$WAVE_ID" ]; then break; fi
       sleep 2
@@ -183,8 +192,11 @@ sanity_check() {
 
     # --- Step 3: Fetch top wave ------------------------------------------
     FETCH_PATH=$(printf "%s" "$WAVE_ID" | sed "s|!|/|g")
-    FETCH_RESP=$(curl -s -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
-      "$BASE/fetch/$FETCH_PATH")
+    if ! FETCH_RESP=$(curl -sS -b "$COOKIE" -w "\n%{http_code}" --max-time 10 \
+      "$BASE/fetch/$FETCH_PATH"); then
+      echo "[sanity] FAIL: fetch request failed" >&2
+      exit 1
+    fi
     FETCH_CODE=$(printf "%s" "$FETCH_RESP" | tail -1)
     FETCH_BODY=$(printf "%s" "$FETCH_RESP" | sed "\$d")
     if [ "$FETCH_CODE" != "200" ]; then

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -126,19 +126,26 @@ sanity_check() {
 
   echo "[deploy] Running sanity check as $addr ..."
 
-  docker run --rm --network host "$sanity_image" sh -c '
+  docker run --rm --network host \
+    -e INTERNAL_PORT="${internal_port}" \
+    -e SANITY_ADDR="${addr}" \
+    -e SANITY_PASS="${pass}" \
+    "$sanity_image" sh -c '
     set -e
-    apk add --no-cache curl jq >/dev/null 2>&1
+    if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+      apk add --no-cache curl jq >/dev/null 2>&1
+    fi
 
-    BASE="http://127.0.0.1:'"${internal_port}"'"
-    ADDR="'"${addr}"'"
-    PASS="'"${pass}"'"
+    BASE="http://127.0.0.1:${INTERNAL_PORT}"
+    ADDR="$SANITY_ADDR"
+    PASS="$SANITY_PASS"
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
     HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
       -c "$COOKIE" -L --max-time 10 \
-      -d "address=${ADDR}&password=${PASS}" \
+      --data-urlencode "address=${ADDR}" \
+      --data-urlencode "password=${PASS}" \
       "$BASE/auth/signin")
     if ! grep -q JSESSIONID "$COOKIE" 2>/dev/null; then
       echo "[sanity] FAIL: login did not set JSESSIONID (HTTP $HTTP)"

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -119,12 +119,16 @@ wait_for_ready() {
 sanity_check() {
   local addr="${SANITY_ADDRESS:-}"
   local pass="${SANITY_PASSWORD:-}"
-  if [[ -z "$addr" || -z "$pass" ]]; then
+  if [[ -z "$addr" && -z "$pass" ]]; then
     echo "[deploy] SANITY_ADDRESS/SANITY_PASSWORD not set, skipping sanity check"
     return 0
   fi
+  if [[ -z "$addr" || -z "$pass" ]]; then
+    echo "[deploy] SANITY_ADDRESS and SANITY_PASSWORD must both be set" >&2
+    return 1
+  fi
 
-  echo "[deploy] Running sanity check as ${addr%%@*}@*** ..."
+  echo "[deploy] Running sanity check ..."
 
   docker run --rm --network host \
     -e INTERNAL_PORT="${internal_port}" \
@@ -133,7 +137,12 @@ sanity_check() {
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-      apk add --no-cache curl jq >/dev/null 2>&1
+      if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache curl jq >/dev/null 2>&1
+      else
+        echo "[sanity] FAIL: curl/jq not found and apk unavailable in sanity image"
+        exit 1
+      fi
     fi
 
     BASE="http://127.0.0.1:${INTERNAL_PORT}"


### PR DESCRIPTION
## Changes

- **Workflow**: Add `SANITY_ADDRESS` and `SANITY_PASSWORD` secrets to deployment environment
- **Deploy scripts**: Add `sanity_check()` function to both Caddy and Contabo deployments
  - Validates login with test credentials
  - Polls search API (60s timeout) to verify data availability
  - Fetches a wave to confirm content loading
  - Gracefully skips if credentials not configured (opt-in)
- **Integration**: Include sanity check in deployment verification chain before considering cutover complete

## Details

The sanity check runs inside a containerized environment with curl+jq, using the compose network for Caddy and host network for Contabo. All three steps (login, search, fetch) must succeed for deployment to be marked as healthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an optional post-deploy health verification that performs an authenticated flow, checks search and fetch endpoints, and validates returned content; it polls up to 60 seconds and triggers automatic rollback on failure.
  * The verification can be enabled or skipped via provided credentials and allows overriding the container image used for the check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->