### PR TITLE
fix: account for 4KB kernel swap header in swap validation

### DIFF
--- a/deploy/supawave-host/setup-swap.sh
+++ b/deploy/supawave-host/setup-swap.sh
@@ -76,7 +76,7 @@ validate_swap() {
     log "FAIL: $swap_path not active"
     exit 1
   fi
-  if (( size < expected_bytes )); then
+  if (( size < expected_bytes - 4096 )); then
     log "FAIL: $swap_path size ${size}B below expected ${expected_bytes}B"
     exit 1
   fi
@@ -99,7 +99,7 @@ main() {
   if swapon --show=NAME --noheadings 2>/dev/null | grep -q "^$swap_path$"; then
     local current_bytes
     current_bytes=$(swapon --show=NAME,SIZE --bytes --noheadings 2>/dev/null | awk '$1 == "'"$swap_path"'" {print $2}')
-    if [[ -n "$current_bytes" ]] && (( current_bytes >= swap_bytes )); then
+    if [[ -n "$current_bytes" ]] && (( current_bytes >= swap_bytes - 4096 )); then
       log "$swap_path already active (${current_bytes} bytes)"
     else
       swapoff "$swap_path"

--- a/deploy/supawave-host/validate.sh
+++ b/deploy/supawave-host/validate.sh
@@ -93,7 +93,7 @@ check_swap() {
     log "FAIL: swapfile not active"
     return 1
   fi
-  if (( size < expected_bytes )); then
+  if (( size < expected_bytes - 4096 )); then
     log "FAIL: swapfile size ${size} below expected ${expected_bytes}"
     return 1
   fi


### PR DESCRIPTION
This fixes the incomplete swap validation fix from PR #569.

**Issue with PR #569:**
The previous fix changed operator syntax but didn't account for kernel swap header overhead. The validation compared usable swap capacity (from swapon) against full file size, which is always 4KB short due to the unavoidable kernel swap header.

**Correct Root Cause:**
- swapon --show=SIZE reports USABLE swap capacity (file minus 4KB header)
- Validation was comparing: usable_bytes < expected_file_size
- This always fails because: expected_file_size - usable_bytes = 4096 (kernel header)

**Correct Fix:**
Compare against expected_bytes - 4096 to account for the kernel header:

- setup-swap.sh:79: if (( size < expected_bytes - 4096 ))
- setup-swap.sh:102: if (( current_bytes >= swap_bytes - 4096 ))
- validate.sh:96: if (( size < expected_bytes - 4096 ))

**Testing:**
- 34359734272 (usable) < 34359738368 - 4096 = 34359734272 ✓ PASS (correct)
- 34359734272 (usable) < 34359738368 = ✗ FAIL (wrong - old behavior)

This fixes the production deploy failure that blocks all new deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced swap file validation with increased tolerance for minor size variations, reducing false validation failures during deployment and improving system configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->