### PR TITLE
docs: full J2CL migration plan — actionable phased roadmap

### DIFF
--- a/docs/superpowers/plans/j2cl-full-migration-plan.md
+++ b/docs/superpowers/plans/j2cl-full-migration-plan.md
@@ -170,7 +170,7 @@ Phase 0 must also enumerate and clean every gadget-coupled file outside the gadg
 | `wave/src/main/java/com/google/wave/api/BlipData.java` | Deserializes gadget elements into `com.google.wave.api.Gadget` | Remove gadget element deserialization or isolate it with the server-only compatibility module |
 | `wave/src/main/java/com/google/wave/api/data/ApiView.java` | Matches gadget element properties in the data API | Remove gadget element matching from the view serializer path or isolate it with the server-only compatibility module |
 | `wave/src/main/java/com/google/wave/api/data/ElementSerializer.java` | Serializes gadget elements in the data API | Remove gadget serialization support or isolate it with the server-only compatibility module |
-| `wave/src/main/java/com/google/wave/api/impl/ElementGsonAdaptor.java` | Gson adaptor reconstructs gadget elements | Remove gadget JSON adaptor support or isolate it with the server-only compatibility module |
+| `wave/src/main/java/com/google/wave/api/impl/ElementGsonAdaptor.java` | Gson adapter reconstructs gadget elements | Remove gadget JSON adapter support or isolate it with the server-only compatibility module |
 | `wave/src/main/java/com/google/wave/api/event/EventHandler.java` | Declares `onGadgetStateChanged(...)` | Delete the gadget-state callback from the robot event contract |
 | `wave/src/main/java/com/google/wave/api/event/EventType.java` | Defines `GADGET_STATE_CHANGED` event type | Delete the gadget-state event enum entry |
 | `wave/src/main/java/com/google/wave/api/event/GadgetStateChangedEvent.java` | Gadget-specific robot event payload | Delete the event type class |


### PR DESCRIPTION
## Summary

Actionable plan for migrating the full Supawave GWT client to J2CL (GWT 3 / Closure Compiler).

### Key decisions reflected
- Gadgets / OpenSocial code is **dropped entirely** (robot API will replace) — full coupling enumeration including `StageTwo`, `model/supplement/`, `doodad/suggestion`, and server-side
- Phased migration — app stays runnable at every phase boundary (6 phases)
- SBT build system: Maven J2CL sidecar invoked from SBT tasks
- Existing JSON-over-WebSocket wire format preserved — no protobuf-js needed
- OT/editor correctness called out as #1 risk with dedicated mitigation
- Estimated 29-43 person-weeks

### Verified inventory (2026-04-02)
- 139 `.gwt.xml` modules (113 production + 26 test)
- 97 JSNI/JavaScriptObject files, 297 native methods
- 94 `GWT.create()` callsites (24 binder, 17 resource bundle, remainder late-binding)
- 26 `.ui.xml` templates, 30 UiBinder Java files
- 27 GWTTestCase files
- 0 JsInterop/Elemental2 usage today

### Prior research synthesized
`docs/j2cl-gwt3-decision-memo.md`, `j2cl-gwt3-inventory.md`, `j2cl-preparatory-work.md`, `2026-03-18-j2cl-inventory-plan.md`

### Process
Written by Codex (gpt-5.4 high reasoning) with full codebase research. Reviewed by Opus (claude-opus-4-6) in 2 rounds — LGTM received after addressing: JSNI count correction, gadget coupling scope, model→client dependency, Closure Compiler configuration, PST codegen phase scoping, and supplement gadget state cleanup.

---

# Supawave J2CL Full Migration Plan

Status: Proposed  
Verified baseline: 2026-04-02  
Scope: migrate the Supawave browser client from GWT 2.10 to J2CL + Closure Compiler without a big-bang cutover  
Inputs absorbed: `docs/j2cl-gwt3-decision-memo.md`, `docs/j2cl-gwt3-inventory.md`, `docs/j2cl-preparatory-work.md`, `docs/superpowers/plans/2026-03-18-j2cl-inventory-plan.md`

## 1. Executive Summary

Supawave is not in a state where a full GWT-to-J2CL switch can happen safely in one pass, but it is now in a state where a staged migration is realistic. The current branch still has a large GWT UI and JSNI surface, and the core is cleaner than the March inventory suggested but not fully pure yet: `wave/concurrencycontrol/**` is almost entirely pure Java except for two client-edge files in `channel/`, while `wave/model/**` still has one compile-time client dependency in `WaveContext.java` and still carries gadget-state supplement types that Phase 0 must remove. That changes the recommended path. The migration should start by shrinking and isolating the legacy surface, then compiling pure logic under J2CL, then replacing the transport seam, and only then moving UI slices.

The key architectural decision is to preserve the existing server JSON-over-WebSocket protocol and replace only the client-side GWT transport/runtime layers first. The server already serializes protobufs to JSON in `org.waveprotocol.box.server.rpc.WebSocketChannel` via `ProtoSerializer`; the browser client already consumes JSON envelopes in `WaveWebSocketClient`. That means Supawave does not need a protobuf-js toolchain to start J2CL migration. It should use the existing JSON wire format, replace the `JavaScriptObject`-based client DTO layer, and keep protobufs server-side until late in the program.

The build should remain SBT-first at the repo root. The practical bridge is an isolated Maven-based J2CL sidecar project invoked from SBT tasks, because upstream J2CL remains Bazel-centric and the root `build.sbt` is intentionally server-oriented. The current `build.sbt` already treats the browser client as a special path via `compileGwt`; J2CL should enter the repo the same way at first: as a dedicated external build that SBT orchestrates, not as a surprise dependency inside the server compile graph.

The recommended roadmap is six phases, numbered to match the detailed sections below:

0. drop gadget/OpenSocial code and remove remaining deferred-binding debt
1. stand up an isolated J2CL build scaffold
2. move `wave/model` and almost all of `wave/concurrencycontrol` as pure Java
3. replace the WebSocket and JSON/JSO transport layer
4. migrate UI slices, starting with the search panel and working inward
5. cut over `WebClient`, retire the GWT toolchain, and remove legacy modules

Estimated total effort is 29-43 person-weeks. The increase versus the March sizing comes from the corrected 97-file / 297-native-method JSNI surface, the wider PST transport/codegen scope, and the fact that gadget removal reaches into server and supplement code instead of stopping at the client widget tree. The wide range is still driven mostly by the editor and wavepanel DOM rewrite. Phases 0-2 are rollback-safe by staying off the production execution path. Phases 3-5 should ship behind a dual-bundle feature flag so Supawave can switch specific users or environments between the legacy GWT bundle and the J2CL bundle.

## 2. Current State

### 2.1 Inventory Snapshot

All numbers below were re-verified on 2026-04-02 in this worktree.

| Surface | Verified state | Notes |
|---|---:|---|
| Production `.gwt.xml` modules | 113 | `wave/src/main/resources/**` |
| Test `.gwt.xml` modules | 26 | `wave/src/test/resources/**`; `wave/src/test/java/**` has no duplicate module files now |
| Total `.gwt.xml` modules | 139 | Matches the user-provided April 2026 baseline |
| Java `EntryPoint` classes | 4 | `WebClient`, two editor harnesses, one editor example |
| `GWT.create(...)` callsites | 94 | Spread across 63 files |
| UiBinder Java files | 30 | Current branch still relies heavily on binders |
| `.ui.xml` templates | 26 | Mostly app shell, search, popup, gadget, attachment, and wavepanel widgets |
| JSNI / `JavaScriptObject` files | 97 | Runtime surface across `wave/src/main/java/**` plus PST-generated `gen/messages/**/jso/**`; the earlier figure counted only the hand-maintained runtime subset, not the generated JSO surface that Phases 3-4 must replace |
| JSNI native methods | 297 | Dominated by selection, DOM, gadget, generated JSON message accessors, and JSON helper code |
| JsInterop / Elemental2 usage | 0 | No `@JsType`, `@JsMethod`, `@JsProperty`, or `elemental2` imports found |
| `GWTTestCase` files | 27 | Includes model and concurrency-control wrappers plus editor/browser suites |

Important `GWT.create(...)` split:

- 24 binder instantiations (`Binder.class`)
- 17 resource bundle instantiations (`Resources.class`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive 680+ line migration plan describing a staged modernization to a J2CL+Closure-based client. It inventories current surface area, maps migration constraints and phased sequencing (Phases 0–5), specifies prerequisite refactors, transport and build-tool migration strategies, acceptance/rollback criteria, testing and rollout guidance, and a risk register with phase checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->