### PR TITLE
fix: preserve deploy notification from address

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -304,11 +304,12 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
         run: |
+          WAVE_EMAIL_FROM_JSON=$(python3 -c 'import json, os; print(json.dumps(os.getenv("WAVE_EMAIL_FROM") or "noreply@supawave.ai"))')
           RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{
-              \"from\": \"${WAVE_EMAIL_FROM:-noreply@supawave.ai}\",
+              \"from\": ${WAVE_EMAIL_FROM_JSON},
               \"to\": [\"vega113@gmail.com\"],
               \"subject\": \"✅ Deploy succeeded: ${RELEASE_ID:0:8}\",
               \"html\": \"<h2>Deploy succeeded</h2><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Run</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View run</a></td></tr></table>\"
@@ -320,11 +321,12 @@ jobs:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
         run: |
+          WAVE_EMAIL_FROM_JSON=$(python3 -c 'import json, os; print(json.dumps(os.getenv("WAVE_EMAIL_FROM") or "noreply@supawave.ai"))')
           RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \
             -d "{
-              \"from\": \"${WAVE_EMAIL_FROM:-noreply@supawave.ai}\",
+              \"from\": ${WAVE_EMAIL_FROM_JSON},
               \"to\": [\"vega113@gmail.com\"],
               \"subject\": \"❌ Deploy FAILED: ${RELEASE_ID:0:8}\",
               \"html\": \"<h2>Deploy failed</h2><p>The production deploy failed and the previous version is still running.</p><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Logs</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View full logs</a></td></tr></table><p><strong>Next steps:</strong> Check the deploy logs linked above. Previous version is auto-preserved.</p>\"


### PR DESCRIPTION
Fixes #597

## Summary
- stop wrapping `WAVE_EMAIL_FROM` inside `Wave Deploy <...>` in deploy notification payloads
- pass through the configured sender directly so bare email and `Name <email>` formats both stay valid
- fall back to `noreply@supawave.ai` when the secret is empty

## Verification
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/deploy-contabo.yml\"); puts \"YAML_OK\"'` => `YAML_OK`
- sender expansion checks:
  - empty secret => `noreply@supawave.ai`
  - bare email => preserved as the bare email value
  - formatted `Name <email>` => preserved exactly without double wrapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deploy notification email configuration to improve sender value handling and ensure safe JSON formatting in notification payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->