### PR TITLE
fix(client): reload page after prolonged WebSocket disconnect (deploy)

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
@@ -262,6 +262,12 @@ public class WebClient implements EntryPoint {
   /** Persistent-toast id for the offline-while-editing warning. */
   private static final String OFFLINE_EDITING_TOAST_ID = "offline-editing";
 
+  /**
+   * If the WebSocket was disconnected for longer than this, assume a server
+   * restart (deploy) and force a full page reload on reconnect.
+   */
+  private static final double DEPLOY_DISCONNECT_THRESHOLD_MS = 5000;
+
   /** Show the turbulence banner (called after the delay). */
   private void showTurbulenceBanner() {
     injectTurbulenceCss();
@@ -294,6 +300,7 @@ public class WebClient implements EntryPoint {
   /** Hide the turbulence banner and optionally show a success flash. */
   private void hideTurbulenceBanner(boolean showSuccess) {
     turbulencePending = false;
+    turbulenceStartTime = 0;
 
     // Cancel the delay timer if the banner hasn't appeared yet
     if (turbulenceDelayTimer != null) {
@@ -650,7 +657,9 @@ public class WebClient implements EntryPoint {
         if (event.getStatus() == ConnectionStatus.RECONNECTED
             && turbulenceStartTime > 0) {
           double disconnectMs = new Date().getTime() - turbulenceStartTime;
-          if (disconnectMs > 5000) {
+          if (disconnectMs > DEPLOY_DISCONNECT_THRESHOLD_MS) {
+            LOG.info("Prolonged disconnect (" + (int) disconnectMs
+                + "ms), reloading page to resync with server");
             hideTurbulenceBanner(false);
             Window.Location.replace(Window.Location.getHref());
             return;


### PR DESCRIPTION
## Summary

- After a server restart during deployment, the client's WebSocket reconnects but internal channel state machines (ViewChannelImpl, OperationChannelMultiplexerImpl) retain stale state, causing `IllegalStateException` during wavelet update deserialization
- When the disconnect lasts more than 5 seconds (indicating server restart rather than brief network hiccup), force a full page reload on reconnect
- This ensures the client fetches the latest GWT JS and establishes fresh server-side subscriptions

## Test plan
- [ ] Deploy to prod and verify the client reloads cleanly instead of showing the `Token: ... null IllegalStateException` error
- [ ] Verify brief network hiccups (< 5s) do NOT trigger a reload — only prolonged disconnects
- [ ] Check browser console for the new log message: `"Prolonged disconnect (Xms), reloading page to resync with server"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network recovery: The app now automatically reloads when reconnecting after extended offline periods (exceeding 5 seconds) to ensure data consistency and application integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->