### PR TITLE
Harden deploy workflow naming, branch guard, and emails

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -322,11 +322,38 @@ jobs:
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
+          NOTIFICATION_RECIPIENTS: ${{ vars.NOTIFICATION_RECIPIENTS || secrets.ON_CALL_EMAILS }}
         run: |
           CHANGELOG_HTML=$(cat /tmp/changelog_html.txt 2>/dev/null || true)
           EMAIL_SUBJECT="SupaWave deployed: ${RELEASE_ID:0:8}"
           EMAIL_HTML="<h2>Deploy succeeded</h2><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Branch</td><td><code>${GITHUB_REF_NAME}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Run</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View run</a></td></tr></table>${CHANGELOG_HTML}"
-          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": ["vega113@gmail.com"], "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
+          recipients_json=$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          raw = os.getenv("NOTIFICATION_RECIPIENTS", "").strip()
+          if not raw:
+              print("")
+              sys.exit(0)
+
+          if raw.startswith("["):
+              try:
+                  recipients = [item.strip() for item in json.loads(raw) if isinstance(item, str) and item.strip()]
+                  print(json.dumps(recipients))
+                  sys.exit(0)
+              except Exception:
+                  pass
+
+          recipients = [item.strip() for item in raw.split(",") if item.strip()]
+          print(json.dumps(recipients))
+          PY
+          )
+          if [ -z "$recipients_json" ] || [ "$recipients_json" = "[]" ]; then
+            echo "No deploy notification recipients configured; skipping email notification."
+            exit 0
+          fi
+          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" RECIPIENTS_JSON="$recipients_json" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": json.loads(os.environ["RECIPIENTS_JSON"]), "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
           RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \
@@ -337,10 +364,37 @@ jobs:
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
+          NOTIFICATION_RECIPIENTS: ${{ vars.NOTIFICATION_RECIPIENTS || secrets.ON_CALL_EMAILS }}
         run: |
           EMAIL_SUBJECT="SupaWave deploy FAILED: ${RELEASE_ID:0:8}"
           EMAIL_HTML="<h2>Deploy failed</h2><p>The production deploy failed and the previous version is still running.</p><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Branch</td><td><code>${GITHUB_REF_NAME}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Logs</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View full logs</a></td></tr></table><p><strong>Next steps:</strong> Check the deploy logs linked above. Previous version is auto-preserved.</p>"
-          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": ["vega113@gmail.com"], "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
+          recipients_json=$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          raw = os.getenv("NOTIFICATION_RECIPIENTS", "").strip()
+          if not raw:
+              print("")
+              sys.exit(0)
+
+          if raw.startswith("["):
+              try:
+                  recipients = [item.strip() for item in json.loads(raw) if isinstance(item, str) and item.strip()]
+                  print(json.dumps(recipients))
+                  sys.exit(0)
+              except Exception:
+                  pass
+
+          recipients = [item.strip() for item in raw.split(",") if item.strip()]
+          print(json.dumps(recipients))
+          PY
+          )
+          if [ -z "$recipients_json" ] || [ "$recipients_json" = "[]" ]; then
+            echo "No deploy notification recipients configured; skipping email notification."
+            exit 0
+          fi
+          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" RECIPIENTS_JSON="$recipients_json" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": json.loads(os.environ["RECIPIENTS_JSON"]), "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
           RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
             -H "Authorization: Bearer $RESEND_API_KEY" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
## Changes

- **Client reconnect handling**: Reloads the page only after a prolonged disconnect (5s+) so the browser picks up fresh JS and subscriptions after deploys or restarts, while short network blips keep the current session intact.

- **Workflow naming**: Improved run-name formatting for better clarity, especially for main branch deployments
- **Branch protection**: Added conditional guard to auto-deploy only on `main` branch and when `AUTO_DEPLOY_ENABLED` is not disabled; manual `workflow_dispatch` always runs for hotfixes
- **Job naming**: Simplified deploy job name from "Build and deploy Wave to Contabo" to "Deploy to Contabo"
- **Email notifications**: 
  - Added changelog extraction from `wave/config/changelog.json` for deploy success emails
  - Improved email formatting with proper JSON payload generation
  - Added branch information to email tables
  - Updated email subjects and sender formatting for consistency
  - Added fallback sender address (`noreply@supawave.ai`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment success notifications now include extracted changelog entries rendered as HTML.

* **Chores**
  * Improved deployment workflow naming and display formatting for push and manual runs.
  * Enhanced auto-deploy conditions to restrict automatic pushes to main when enabled.
  * Deployment success and failure emails now use an in-process payload generator, default the sender to noreply@supawave.ai, update subjects, and include branch info on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
