### PR TITLE
fix(editor): prevent character loss on Android mobile keyboards

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -413,6 +413,7 @@ public final class EditorEventHandler {
     // handler are not both active simultaneously — otherwise the typing
     // extractor's stale DOM tracking causes characters to be lost.
     editorInteractor.forceFlush();
+    cachedSelection = editorInteractor.getSelectionPoints();
 
     Point<ContentNode> caret;
     if (cachedSelection == null) {
@@ -420,8 +421,10 @@ public final class EditorEventHandler {
           "deep inside some doodad's html?");
       caret = null;
     } else if (cachedSelection.isCollapsed()) {
+      event.setCaret(ContentPoint.fromPoint(cachedSelection.getFocus()));
       caret = cachedSelection.getFocus();
     } else {
+      event.setCaret(ContentPoint.fromPoint(cachedSelection.getFocus()));
       caret = deleteCachedSelectionRangeAndInvalidate(true);
     }
 

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -631,6 +631,47 @@ public class EditorEventHandlerGwtTest
     interactor.checkExpectations();
   }
 
+  /**
+   * Composition start should use the refreshed selection after flushing the
+   * typing extractor, not the stale selection captured before the flush.
+   */
+  public void testCompositionStartRefreshesSelectionAfterFlush() {
+    FakeEditorEvent compositionStart = FakeEditorEvent.compositionSequence(0)[0];
+
+    final Point<ContentNode> staleCaret = Point.inText(
+        new ContentTextNode(Document.get().createTextNode("stale"), null), 1);
+    final Point<ContentNode> freshCaret = Point.inText(
+        new ContentTextNode(Document.get().createTextNode("fresh"), null), 3);
+
+    final FocusedContentRange staleSelection = new FocusedContentRange(staleCaret);
+    final FocusedContentRange freshSelection = new FocusedContentRange(freshCaret);
+    final Point<ContentNode>[] compositionCaret = new Point[1];
+
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    FakeEditorInteractor interactor = new FakeEditorInteractor() {
+      private int flushCount = 0;
+
+      @Override
+      public void forceFlush() {
+        flushCount++;
+      }
+
+      @Override
+      public FocusedContentRange getSelectionPoints() {
+        return flushCount >= 2 ? freshSelection : staleSelection;
+      }
+
+      @Override
+      public void compositionStart(Point<ContentNode> caret) {
+        compositionCaret[0] = caret;
+      }
+    };
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(compositionStart));
+    assertEquals(freshCaret, compositionCaret[0]);
+  }
+
   public void testIsAccelerator() {
     // Test alt+input and alt+shift+input keys - These are normal input on mac,
     // and accelerators on


### PR DESCRIPTION
## Changes

Prevents character loss on Android mobile keyboards by properly coordinating between the typing extractor and IME composition handler.

### Details

- Added `editorInteractor.forceFlush()` call in `onCompositionStart()` to ensure the typing extractor is flushed before IME composition begins
- Added check in keydown handler to skip typing extractor activation when composition events are enabled and the key is an IME key (keyCode 229)
- This prevents both handlers from being active simultaneously, which was causing stale DOM tracking and character loss on mobile browsers like Android Chrome

### Root Cause

On mobile browsers, keydown with keyCode 229 fires before compositionstart. Without these fixes, the typing extractor would be activated by the keydown, and then the IME composition handler would also become active, causing conflicts in DOM tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Automatically refreshes the page when reconnecting after extended network disconnections
  * Improved keyboard input handling for Input Method Editors (IME) during text composition
  * Enhanced offline-to-online reconnection state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review note

The reconnect reload work was rebased out because it already exists in `origin/main`, so this PR now only contains the Android IME editor fix.
