### PR TITLE
fix(search): trigger mention subscriptions at waveletCommitted for non-participants

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -509,7 +509,8 @@ public class ServerMain {
     // ORDERING DEPENDENCY: SearchWaveletUpdater must be subscribed AFTER lucene9Indexer.
     // SearchWaveletUpdater.waveletCommitted() triggers mention-subscription recomputes only
     // after Lucene9 has committed its MENTIONED field update in its own waveletCommitted().
-    // WaveBus dispatches waveletCommitted to subscribers in registration order.
+    // WaveletNotificationDispatcher iterates subscribers via CopyOnWriteArraySet, which
+    // preserves insertion order; SearchWaveletUpdater is therefore notified after lucene9Indexer.
     FeatureFlagStore featureFlagStore = injector.getInstance(FeatureFlagStore.class);
     initializeSearchWaveletUpdater(injector, waveBus, featureFlagStore);
 

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdater.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdater.java
@@ -207,7 +207,7 @@ public class SearchWaveletUpdater implements WaveBus.Subscriber {
             String value = map.getNewValue(i);
             if (AnnotationConstants.isMentionKey(key) && value != null && !value.isEmpty()) {
               try {
-                mentioned.add(ParticipantId.ofUnsafe(value.toLowerCase(Locale.ROOT)));
+                mentioned.add(ParticipantId.ofUnsafe(value.trim().toLowerCase(Locale.ROOT)));
               } catch (IllegalArgumentException e) {
                 LOG.warning("Skipping malformed mention annotation value: " + value);
               }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdaterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/search/SearchWaveletUpdaterTest.java
@@ -24,7 +24,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,6 +44,7 @@ import org.waveprotocol.box.server.frontend.WaveletInfo;
 import org.waveprotocol.box.server.waveserver.SearchProvider;
 import org.waveprotocol.box.server.waveserver.WaveBus;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.model.conversation.AnnotationConstants;
 import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
 import org.waveprotocol.wave.model.document.operation.DocInitialization;
 import org.waveprotocol.wave.model.document.operation.DocInitializationCursor;
@@ -557,8 +557,8 @@ public final class SearchWaveletUpdaterTest extends TestCase {
     when(indexer.getAffectedSubscriptions(eq(waveId), eq(ImmutableSet.of(alice))))
         .thenReturn(Collections.emptySet());
 
-    // The wavelet doc mentions Bob
-    String mentionKey = "mention/" + bob.getAddress();
+    // The wavelet doc mentions Bob using the standard annotation key
+    String mentionKey = AnnotationConstants.MENTION_USER;
     DocInitialization docInit = mock(DocInitialization.class);
     doAnswer(invocation -> {
       DocInitializationCursor cursor = invocation.getArgument(0);


### PR DESCRIPTION
## Summary

- **Root cause**: `SearchWaveletUpdater.waveletCommitted()` was empty. Non-participant @mention users were never notified in real-time even though Lucene9 correctly updates its `MENTIONED` field at commit time.
- **Fix**: Cache mentioned non-participant users during `waveletUpdate()` (when wavelet data is available), then at `waveletCommitted()` (after Lucene9 is committed per WaveBus registration order) trigger `getAffectedSubscriptions()` for those users and enqueue low-latency search recomputes.
- **Also fixes**: `AdminServletTest` compile error (missing `Config` constructor arg added in d64c32830).

## What changed

**`SearchWaveletUpdater.java`**
- Add `pendingMentionedUsers: ConcurrentHashMap<WaveletName, Set<ParticipantId>>` field
- In `waveletUpdate()`: scan blip annotations for `mention/*` keys, filter out participants (already handled by existing path), cache non-participant mentioned users
- In `waveletCommitted()`: pop cached mentions, find affected subscriptions, enqueue recompute
- Guard malformed annotation values with try/catch
- Clear `pendingMentionedUsers` on `shutdown()`

**`ServerMain.java`**
- Add ordering-dependency comment explaining that `SearchWaveletUpdater` must be subscribed after `lucene9Indexer` for the `waveletCommitted` timing guarantee to hold

**`SearchWaveletUpdaterTest.java`**
- Add `testWaveletCommittedTriggersMentionSubscriptionForNonParticipant` verifying end-to-end: wavelet with Bob @mentioned (not a participant) → after `waveletUpdate` + `waveletCommitted`, Bob's `mentions:me` subscription is triggered

## Test plan
- [ ] `sbt wave/compile` — passes (no new errors)
- [ ] New unit test `testWaveletCommittedTriggersMentionSubscriptionForNonParticipant` covers the fix
- [ ] Existing `SearchWaveletUpdaterTest` tests pass unchanged (mock `getDocumentIds()` returns empty set → `extractMentionedUsers` returns empty → behavior unchanged)
- [ ] Manual: add @mention in a wave where the mentioned user is not a participant; verify their `mentions:me` search updates in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced search to track mentions in conversational waves and trigger search subscriptions for mentioned users, including those not yet participants.

* **Tests**
  * Added test coverage for mention-based search subscription processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->