### PR TITLE
fix(search): stop redundant HTTP polling when OT-search is working

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -757,11 +757,16 @@ public final class SearchPresenter
     boolean totalKnown = total != Search.UNKNOWN_SIZE;
     int loaded = search.getMinimumTotal();
     int unread = 0;
-    for (int i = 0; i < loaded; i++) {
-      Digest digest = search.getDigest(i);
-      if (digest != null && digest.getUnreadCount() > 0) {
+    // Iterate via the view chain so that optimistic UI overrides stored in
+    // digestUis (e.g. the zeroUnread wrapper written by onOpened) are
+    // reflected immediately without waiting for the search model to update.
+    DigestView view = searchUi.getFirst();
+    while (view != null) {
+      Digest d = digestUis.get(view);
+      if (d != null && d.getUnreadCount() > 0) {
         unread++;
       }
+      view = searchUi.getNext(view);
     }
     String text;
     if (totalKnown && total <= 0) {
@@ -1057,8 +1062,8 @@ public final class SearchPresenter
   public void onOpened(WaveContext wave) {
     // Optimistically clear the unread badge for the opened wave so the search
     // panel does not flash "1 unread" while the OT read-mark is in flight.
-    // The correct unread count will be applied once the BlipReadStateMonitor
-    // fires (via WaveBasedDigest → onDigestReady) or the next poll cycle.
+    // The correct unread count is restored once the BlipReadStateMonitor
+    // fires (via WaveBasedDigest → onDigestReady) or the next OT/poll update.
     final WaveId openedWaveId = wave.getWave().getWaveId();
     DigestView targetView = searchUi.getFirst();
     while (targetView != null) {
@@ -1084,6 +1089,9 @@ public final class SearchPresenter
           @Override public boolean isPinned() { return digest.isPinned(); }
         };
         searchUi.renderDigest(targetView, zeroUnread);
+        // Also update the digestUis map so renderWaveCount()'s view-chain
+        // iteration sees the zero-unread wrapper instead of the original.
+        digestUis.put(targetView, zeroUnread);
         renderWaveCount();
         break;
       }

--- a/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
@@ -33,6 +33,8 @@ import org.waveprotocol.wave.model.document.util.DocProviders;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.client.scheduler.Scheduler.IncrementalTask;
+import org.waveprotocol.wave.client.scheduler.Scheduler.Task;
 import org.waveprotocol.wave.client.scheduler.testing.FakeTimerService;
 import org.waveprotocol.wave.client.account.ProfileListener;
 import org.waveprotocol.wave.client.events.NetworkStatusEvent;
@@ -311,8 +313,12 @@ public final class SearchPresenterTest extends TestCase {
 
     presenter.bootstrapOtSearch();
 
-    // Only the OT timeout task should be scheduled; the repeating 15-s poll must NOT be running.
-    assertEquals(1, scheduler.countTasksScheduled());
+    Task otSearchTimeoutTask = (Task) getObjectField(presenter, "otSearchTimeoutTask");
+    IncrementalTask searchUpdater = (IncrementalTask) getObjectField(presenter, "searchUpdater");
+    // The OT timeout task must be pending so it can start polling if OT never delivers.
+    assertTrue("otSearchTimeoutTask must be scheduled", scheduler.isScheduled(otSearchTimeoutTask));
+    // The repeating poll must NOT be running while OT subscription is active.
+    assertFalse("searchUpdater must not be scheduled", scheduler.isScheduled(searchUpdater));
   }
 
   /**
@@ -334,9 +340,15 @@ public final class SearchPresenterTest extends TestCase {
     // Advance past OT_SEARCH_TIMEOUT_MS (5000 ms) so the timeout task fires.
     scheduler.tick(6000);
 
-    assertTrue(getBooleanField(presenter, "otSearchTimedOut"));
-    // After timeout, the repeating poll must be running.
-    assertEquals(1, scheduler.countTasksScheduled());
+    Task otSearchTimeoutTask = (Task) getObjectField(presenter, "otSearchTimeoutTask");
+    IncrementalTask searchUpdater = (IncrementalTask) getObjectField(presenter, "searchUpdater");
+    assertTrue("otSearchTimedOut must be set", getBooleanField(presenter, "otSearchTimedOut"));
+    // The timeout task must have fired and be gone.
+    assertFalse("otSearchTimeoutTask must not be scheduled after firing",
+        scheduler.isScheduled(otSearchTimeoutTask));
+    // The repeating poll must now be running so results continue to refresh.
+    assertTrue("searchUpdater must be scheduled after OT timeout",
+        scheduler.isScheduled(searchUpdater));
   }
 
   public void testReconnectKeepsVisibleDigestsInsteadOfShowingSkeleton() throws Exception {
@@ -383,6 +395,13 @@ public final class SearchPresenterTest extends TestCase {
     Field field = SearchPresenter.class.getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(presenter, value);
+  }
+
+  private static Object getObjectField(SearchPresenter presenter, String fieldName)
+      throws Exception {
+    Field field = SearchPresenter.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(presenter);
   }
 
   private static void invokeNetworkStatus(


### PR DESCRIPTION
## Summary

- **Polling fix**: `bootstrapOtSearch()` was always scheduling a 15-second repeating HTTP poll even when subscribing to OT-search. This means every active user was making redundant `/search` requests every 15 s while the OT websocket subscription was delivering live updates. The poll now only starts when OT actually fails/times out.
- **Timeout fix**: `handleOtSearchTimeout()` now calls `startPolling()` explicitly — previously it relied on the poll that `bootstrapOtSearch()` had already (incorrectly) started.
- **Unread badge fix** (separate commit `e70cc95dd`): `onOpened()` now optimistically re-renders the digest with `unread=0` so the search panel doesn't flash "1 unread" for up to 15 s after a wave is opened.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| OT delivering updates | Poll + OT both firing | OT only |
| OT times out (5 s) | Poll was already running | Timeout handler starts poll |
| OT explicitly falls back | `fallbackToPolling()` starts poll | Same |
| Non-OT query (tag:) | Poll only | Poll only (unchanged) |

## Test plan

- [x] `SearchPresenterTest.testBootstrapOtSearchDoesNotStartRepeatingPollWhenOtSubscriptionSucceeds` — verifies only OT timeout task is pending after bootstrap
- [x] `SearchPresenterTest.testOtSearchTimeoutStartsPollingWhenOtDataNeverArrives` — verifies poll starts after timeout fires
- [x] `sbt wave/compile` passes
- [x] All sbt unit tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized search result updates to prioritize live subscriptions, with automatic fallback to polling only when necessary for better efficiency.
  * Enhanced wave opening behavior to properly refresh search result displays in real-time.

* **Tests**
  * Added tests validating search subscription initialization and automatic polling fallback mechanisms to ensure reliable updates across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->