### PR TITLE
fix(robots): show Admin link in Robot Control Center top bar for owner/admin users

### DIFF
--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.authentication.SessionManager;
@@ -510,14 +511,14 @@ public final class RobotDashboardServlet extends HttpServlet {
     String baseUrl = derivePublicBaseUrl(req);
     String contextPath = Strings.nullToEmpty(req.getContextPath());
     // Look up the user's role so the Admin link appears in the top bar for owners/admins.
-    String userRole = org.waveprotocol.box.server.account.HumanAccountData.ROLE_USER;
+    String userRole = HumanAccountData.ROLE_USER;
     try {
-      org.waveprotocol.box.server.account.AccountData acct = accountStore.getAccount(user);
+      AccountData acct = accountStore.getAccount(user);
       if (acct != null && acct.isHuman()) {
         userRole = acct.asHuman().getRole();
       }
-    } catch (org.waveprotocol.box.server.persistence.PersistenceException e) {
-      // fall back to ROLE_USER — Admin link won't appear but page still renders
+    } catch (PersistenceException e) {
+      LOG.warning("Failed to look up role for top bar in RobotDashboard: " + user.getAddress(), e);
     }
     resp.getWriter().write(renderDashboardPage(user.getAddress(), robotsToRender, message,
         getOrGenerateXsrfToken(user), baseUrl, revealedSecret, contextPath, userRole));

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 import junit.framework.TestCase;
 
 import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.authentication.SessionManager;
@@ -585,5 +587,29 @@ public class RobotDashboardServletTest extends TestCase {
     verify(robotRegistrar).registerNew(ROBOT, "", OWNER.getAddress(), 3600L);
     assertTrue(outputWriter.toString().contains("Copy this robot secret now: <strong>new-secret</strong>"));
     assertTrue(outputWriter.toString().contains("SUPAWAVE_ROBOT_SECRET=new-\u2026cret"));
+  }
+
+  public void testDoGetRendersAdminLinkForOwner() throws Exception {
+    HumanAccountDataImpl ownerAccount = new HumanAccountDataImpl(OWNER);
+    ownerAccount.setRole(HumanAccountData.ROLE_OWNER);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+    when(accountStore.getAccount(OWNER)).thenReturn(ownerAccount);
+
+    servlet.doGet(req, resp);
+
+    assertTrue(outputWriter.toString().contains("href=\"/admin\""));
+  }
+
+  public void testDoGetOmitsAdminLinkForUser() throws Exception {
+    HumanAccountDataImpl userAccount = new HumanAccountDataImpl(OWNER);
+    // role defaults to ROLE_USER — no setRole call needed
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+    when(accountStore.getAccount(OWNER)).thenReturn(userAccount);
+
+    servlet.doGet(req, resp);
+
+    assertFalse(outputWriter.toString().contains("href=\"/admin\""));
   }
 }


### PR DESCRIPTION
## Bug

The Admin link was missing from the user menu on the Robot Control Center page (\`/account/robots\`).

## Root cause

\`RobotDashboardServlet.renderDashboardPage()\` called \`HtmlRenderer.renderSharedTopBarHtml(userAddress, contextPath, **null**)\` — always passing \`null\` for \`userRole\`. The condition \`\"owner\".equals(null)\` is always \`false\`, so the Admin link was never rendered regardless of the user's actual role.

Other pages (e.g. the main Wave client via \`WaveClientServlet\`) correctly look up the role from the AccountStore before rendering the top bar.

## Fix

Look up the user's role from \`AccountStore\` in \`renderDashboard()\` and pass it through to \`renderSharedTopBarHtml()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays your actual user role information retrieved from the server and uses it in the shared top bar.
  * Admin UI link is shown conditionally for users with the owner/admin role.

* **Tests**
  * Added tests validating conditional rendering of the admin link based on user role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->