### PR TITLE
feat(ui): show bot profile popup when clicking bot avatar

### DIFF
--- a/wave/config/changelog.d/2026-04-06-bot-profile-popup.json
+++ b/wave/config/changelog.d/2026-04-06-bot-profile-popup.json
@@ -1,6 +1,15 @@
 {
+  "releaseId": "2026-04-06-bot-profile-popup",
+  "version": "PR #674",
   "date": "2026-04-06",
-  "type": "feature",
-  "summary": "Show bot profile popup when clicking a bot avatar in a wave",
-  "details": "Clicking a bot's avatar or participant icon now opens a profile popup showing the bot's name, address, description, owner, and registration date. Bots display a robot icon avatar and have no Edit Profile or Send Message buttons."
+  "title": "Bot Profile Popup",
+  "summary": "Show a bot profile popup when clicking a bot avatar in a wave.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Clicking a bot's avatar or participant icon now opens a profile popup showing the bot's name, address, description, owner, and registration date. Bots display a robot icon avatar and have no Edit Profile or Send Message buttons."
+      ]
+    }
+  ]
 }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2909,14 +2909,14 @@ public final class HtmlRenderer {
     sb.append("    return 'Member since ' + months[d.getMonth()] + ' ' + d.getFullYear();\n");
     sb.append("  }\n\n");
 
-    // Bot avatar: inline SVG robot icon as a data URL
-    sb.append("  var BOT_AVATAR_URL = \"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 72 72'%3E\"\n");
-    sb.append("    + \"%3Ccircle cx='36' cy='36' r='36' fill='%23e2e8f0'/%3E\"\n");
-    sb.append("    + \"%3Crect x='18' y='22' width='36' height='28' rx='5' fill='%234a5568'/%3E\"\n");
-    sb.append("    + \"%3Ccircle cx='27' cy='33' r='5' fill='%2300b4d8'/%3E\"\n");
-    sb.append("    + \"%3Ccircle cx='45' cy='33' r='5' fill='%2300b4d8'/%3E\"\n");
-    sb.append("    + \"%3Crect x='23' y='42' width='26' height='4' rx='2' fill='%2300b4d8'/%3E\"\n");
-    sb.append("    + \"%3Crect x='32' y='14' width='8' height='10' rx='4' fill='%234a5568'/%3E\"\n");
+    // Bot avatar: inline SVG robot icon as a fully percent-encoded data URL
+    sb.append("  var BOT_AVATAR_URL = \"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2072%2072'%3E\"\n");
+    sb.append("    + \"%3Ccircle%20cx='36'%20cy='36'%20r='36'%20fill='%23e2e8f0'/%3E\"\n");
+    sb.append("    + \"%3Crect%20x='18'%20y='22'%20width='36'%20height='28'%20rx='5'%20fill='%234a5568'/%3E\"\n");
+    sb.append("    + \"%3Ccircle%20cx='27'%20cy='33'%20r='5'%20fill='%2300b4d8'/%3E\"\n");
+    sb.append("    + \"%3Ccircle%20cx='45'%20cy='33'%20r='5'%20fill='%2300b4d8'/%3E\"\n");
+    sb.append("    + \"%3Crect%20x='23'%20y='42'%20width='26'%20height='4'%20rx='2'%20fill='%2300b4d8'/%3E\"\n");
+    sb.append("    + \"%3Crect%20x='32'%20y='14'%20width='8'%20height='10'%20rx='4'%20fill='%234a5568'/%3E\"\n");
     sb.append("    + \"%3C/svg%3E\";\n\n");
 
     // Show bot profile card
@@ -2974,7 +2974,7 @@ public final class HtmlRenderer {
     sb.append("    fetch('/userprofile/card/' + encodeURIComponent(address))\n");
     sb.append("      .then(function(r) { return r.json(); })\n");
     sb.append("      .then(function(data) {\n");
-    sb.append("        if (data.error) return;\n");
+    sb.append("        if (currentAddress !== address || data.error) return;\n");
     sb.append("        if (data.isBot) {\n");
     sb.append("          showBotCard(data, address);\n");
     sb.append("        } else {\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ProfileServlet.java
@@ -477,8 +477,8 @@ public final class ProfileServlet extends HttpServlet {
     w.append("{\"isBot\":true");
     w.append(",\"address\":").append(jsonStr(address));
     w.append(",\"name\":").append(jsonStr(name));
-    w.append(",\"description\":").append(jsonStr(desc != null ? desc : ""));
-    w.append(",\"ownerAddress\":").append(jsonStr(owner != null ? owner : ""));
+    w.append(",\"description\":").append(jsonStr(desc));
+    w.append(",\"ownerAddress\":").append(jsonStr(owner));
     w.append(",\"registrationTime\":").append(String.valueOf(robot.getCreatedAtMillis()));
     w.append('}');
   }


### PR DESCRIPTION
## Summary
- Extends `GET /userprofile/card/{address}` to handle robot accounts — returns `{isBot:true, address, name, description, ownerAddress, registrationTime}` with no sensitive data exposed
- Adds `showBotCard` JS helper in `appendProfileCardFragment` that renders a robot SVG avatar, description, owner line, and member-since date; hides Edit Profile and Send Message buttons
- Existing user profile popup unchanged; `showProfileCard` now dispatches to `showBotCard` or `showUserCard` based on `data.isBot`

## Test plan
- [ ] Click a bot avatar (e.g. `gpt-bot`) in participant bar — popup appears with bot name, address, description, owner, registration date
- [ ] Verify no "Edit Profile" or "Send Message" buttons appear for bots
- [ ] Click a human participant avatar — existing user profile popup unchanged
- [ ] Verify `GET /userprofile/card/gpt-bot@supawave.ai` returns `{"isBot":true,...}` with no `consumerSecret` or `callbackUrl`
- [ ] Verify clicking outside the popup or × closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clicking a bot avatar or participant icon in a wave opens a bot profile popup showing the bot’s name, address, description, owner, and registration date with a robot-icon avatar.
  * Bot profile popups do not show "Edit Profile" or "Send Message" action buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->