### PR TITLE
fix(robots): null-guard blipId in OperationContextImpl.putBlip

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/robots/OperationContextImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/OperationContextImpl.java
@@ -296,6 +296,9 @@ public class OperationContextImpl implements OperationContext, OperationResults 
 
   @Override
   public void putBlip(String blipId, ConversationBlip newBlip) {
+    if (blipId == null) {
+      return;
+    }
     if (blipId.startsWith(TEMP_ID_MARKER)) {
       tempBlipIdMap.put(blipId, newBlip.getId());
     }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/OperationContextImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/OperationContextImplTest.java
@@ -202,6 +202,14 @@ public class OperationContextImplTest extends TestCase {
     }
   }
 
+  public void testPutNullBlipId() throws Exception {
+    // putBlip with null blipId should silently return without NPE
+    ConversationBlip blip = mock(ConversationBlip.class);
+    when(blip.getId()).thenReturn("b+1234");
+    // Should not throw NullPointerException
+    operationContext.putBlip(null, blip);
+  }
+
   public void testPutNonTemporaryBlip() throws Exception {
     // Non temporary blip is ignored
     Conversation conversation = mock(Conversation.class);


### PR DESCRIPTION
## Summary
- `OperationContextImpl.putBlip` called `blipId.startsWith()` without a null check, causing NPE when called from `BlipOperationServices` with `blipData.getBlipId()` returning null
- Added early return when `blipId` is null (6 call sites in `BlipOperationServices` are all affected)
- Added `testPutNullBlipId` regression test to `OperationContextImplTest`

## Test Plan
- [x] `testPutNullBlipId` verifies no NPE on null blipId
- [x] Existing 12 tests in `OperationContextImplTest` continue to pass (13 total)
- [x] Full test suite: 2024/2025 pass (1 pre-existing flaky timing test in `TokenGeneratorImplTest`)

Fixes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)