### PR TITLE
[codex] Render medium and large attachments inline

### DIFF
--- a/docs/superpowers/plans/2026-04-08-inline-wave-images.md
+++ b/docs/superpowers/plans/2026-04-08-inline-wave-images.md
@@ -1,0 +1,364 @@
+# Inline Wave Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make image attachments render as real inline wave content for medium and large display modes instead of only as scaled attachment thumbnails, while preserving attachment-id based document storage and existing attachment services.
+
+**Architecture:** Keep the current `<image attachment="...">` wave document model and extend the existing `ImageThumbnail` doodad so it can choose between thumbnail and full attachment media based on display mode and image metadata. Formalize the display-size attribute in the conversation schema, keep `style="full"` for backward compatibility, and avoid migrating to URL-only `<img>` nodes or reviving gadget-based rendering.
+
+**Tech Stack:** Java 17, GWT client editor/doodads, Wave conversation schema, SBT test runner, GitHub issue workflow, Claude review.
+
+---
+
+## Investigation Summary
+
+### Current upload and rendering path
+
+- Upload entrypoint: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`
+  - `createInsertAttachmentButton()` opens `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java`
+  - `onDoneWithSize()` always inserts `ImageThumbnail.constructXmlWithSize(...)` into the document.
+- Client attachment metadata fetch: `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/AttachmentManagerImpl.java`
+  - fetches `/attachmentsInfo?attachmentIds=...`
+  - hydrates `AttachmentImpl` with attachment URL, thumbnail URL, mime type, filename, and image metadata.
+- Server upload and metadata path:
+  - `wave/src/main/java/org/waveprotocol/box/server/rpc/AttachmentServlet.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/rpc/AttachmentInfoServlet.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/attachment/AttachmentService.java`
+  - originals are stored, thumbnails are generated, and both URLs plus dimensions are persisted in attachment metadata.
+
+### Why the current UX is still "thumbnail-first"
+
+- Document insertion uses the custom `<image attachment="...">` doodad, not a generic inline image node:
+  - `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/ImageThumbnail.java`
+- Rendering is owned by:
+  - `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailRenderer.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/ImageThumbnailAttachmentHandler.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java`
+- `ImageThumbnailWidget.setImageSize()` chooses `thumbnailUrl` unless `style="full"` is set. The newer `display-size=medium|large` code only changes CSS dimensions, so medium and large currently upscale the thumbnail card rather than switching to the attachment image.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java` resets the default selection to `small`, which further biases toward thumbnail-style insertion.
+
+### Wave document model support
+
+- Conversation schema already supports attachment-backed image content:
+  - `wave/src/main/java/org/waveprotocol/wave/model/schema/conversation/ConversationSchemas.java`
+  - permits `<image attachment="...">`, `<caption>`, and `style="full"`.
+- Attachment extraction/export logic relies on the `image@attachment` attribute:
+  - `wave/src/main/java/org/waveprotocol/box/expimp/DeltaParser.java`
+- API/serializer layers also distinguish:
+  - `ElementType.ATTACHMENT` -> `<image attachment="...">`
+  - `ElementType.IMAGE` -> `<img src="...">`
+  - files: `wave/src/main/java/com/google/wave/api/data/ElementSerializer.java`, `wave/src/main/java/com/google/wave/api/Image.java`
+- Gap: the schema does **not** currently permit `display-size`, even though the client now writes and reads it. That needs to be formalized if it remains the chosen encoding.
+
+### Doodad and gadget options
+
+- Active image rendering seam is the doodad path registered in `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java`.
+- The base editor also still knows how to render plain `<img>` through `wave/src/main/java/org/waveprotocol/wave/client/editor/content/img/ImgDoodad.java`, but that path is URL-based and explicitly described as legacy/undesirable.
+- Gadget path is not a good extension point:
+  - `Gadget` is deprecated for removal: `wave/src/main/java/com/google/wave/api/Gadget.java`
+  - repo design docs explicitly say not to extend OpenSocial gadgets.
+
+## Options
+
+### Option A: Native inline image element path
+
+Use a true inline image node as the stored/rendered representation, based on the existing `<img ...>` / `ElementType.IMAGE` path.
+
+UX fit:
+- Best match for a browser-native inline image experience.
+- Simplest long-term mental model for image-in-text rendering.
+
+Technical risk:
+- High. The current `<img>` path is URL-based, not attachment-id based.
+- Export/import and attachment-id discovery currently depend on `image@attachment`.
+- Caption handling, malware/file-card behavior, and attachment metadata fetch would need replacement or duplication.
+
+Migration effort:
+- High. Existing `<image attachment="...">` content would need migration or dual rendering forever.
+- Serializer, schema, robots/API compatibility, and downstream tools would need broader changes.
+
+Security implications:
+- Must avoid reviving arbitrary external image URLs as first-class content.
+- Internal attachment URLs are safer, but the native path does not currently encode attachment identity.
+
+Moderation implications:
+- Current attachment metadata and malware state are attachment-id centric. A URL-only content node weakens that coupling.
+
+Backward compatibility:
+- Weak unless both formats are supported indefinitely.
+
+### Option B: Doodad-based inline attachment path
+
+Keep storing `<image attachment="...">`, but make medium and large display modes render the original attachment image inline, preserve aspect ratio, and drop thumbnail chrome when appropriate.
+
+UX fit:
+- Delivers the desired Telegram-like inline image feel without changing the stored content primitive.
+- Keeps small mode as a compact thumbnail/card for non-inline cases.
+
+Technical risk:
+- Moderate and local. Most changes stay in the existing `ImageThumbnail` rendering seam.
+- Requires formalizing `display-size` in the schema and making the widget choose attachment media for medium/large.
+
+Migration effort:
+- Low. Existing content stays valid.
+- Old `style="full"` content continues to work.
+
+Security implications:
+- Best fit with current auth and download controls because images still resolve through attachment services.
+- No new external fetch surface.
+
+Moderation implications:
+- Preserves attachment metadata, MIME-type checks, malware flags, and export/import behavior.
+
+Backward compatibility:
+- Strong. Existing `<image attachment="...">` deltas, export/import, and robots keep working.
+
+## Recommendation
+
+Choose **Option B**.
+
+Reasoning:
+- It solves the actual product gap with the narrowest change set.
+- It preserves the attachment-id based document model that the rest of the repo already depends on.
+- It avoids a risky migration to URL-only `<img>` content and avoids extending deprecated gadget paths.
+
+Non-goals for this slice:
+- Gallery layouts
+- URL/video previews
+- Gadget-based media rendering
+- Migrating stored content from `<image>` to `<img>`
+- Broad SSR/public-wave rendering redesign
+
+## Design constants
+
+- Small mode remains thumbnail-first:
+  - source: thumbnail
+  - max box: `120x80`
+  - chrome: shown
+- Medium mode becomes inline-image preview for image attachments:
+  - source: original attachment image
+  - max box: `300x200`
+  - chrome: hidden for image attachments, shown for non-image attachments
+- Large mode becomes large inline image for image attachments:
+  - source: original attachment image
+  - max box: `600x400`
+  - chrome: hidden for image attachments, shown for non-image attachments
+- Full mode precedence:
+  - `style="full"` wins over `display-size`
+  - when `style="full"` is present and the attachment is an image, always use the original attachment image
+- Missing dimension fallback:
+  - if image metadata has not loaded yet, keep the current display box sizing for the selected mode and swap in aspect-ratio scaling once metadata arrives
+
+Implementation note:
+- `ImageThumbnailWidget` already has `isContentImage()`. Reuse that as the gate for inline-image behavior instead of inventing a second MIME check in the widget layer.
+
+## Phase 1 scope
+
+- Make medium and large modes load the original attachment image instead of the thumbnail.
+- Preserve aspect ratio for inline images.
+- Hide thumbnail chrome for inline image modes while keeping non-image attachments on the existing card path.
+- Make upload default to `medium` instead of `small`.
+- Add schema support for `display-size=small|medium|large`.
+- Preserve legacy `style="full"` behavior explicitly with regression coverage.
+
+## Task 1: Formalize the display-size document attribute
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/model/schema/conversation/ConversationSchemas.java`
+- Test: `wave/src/test/java/org/waveprotocol/wave/model/conversation/SchemaConstraintsTest.java`
+
+- [ ] **Step 1: Write the failing schema test**
+
+```java
+assertTrue(
+    BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "small"));
+assertTrue(
+    BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "medium"));
+assertTrue(
+    BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "large"));
+assertFalse(
+    BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "giant"));
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.wave.model.conversation.SchemaConstraintsTest"`
+Expected: FAIL because `display-size` is not currently permitted.
+
+- [ ] **Step 3: Add schema support**
+
+```java
+addAttrWithValues("image", "display-size", "small", "medium", "large");
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `sbt "testOnly org.waveprotocol.wave.model.conversation.SchemaConstraintsTest"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/wave/model/schema/conversation/ConversationSchemas.java \
+  wave/src/test/java/org/waveprotocol/wave/model/conversation/SchemaConstraintsTest.java
+git commit -m "fix(image): formalize display-size document attribute"
+```
+
+## Task 2: Move inline image rendering decisions into a testable seam
+
+**Files:**
+- Create: `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayout.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java`
+- Test: `wave/src/test/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayoutTest.java`
+
+- [ ] **Step 1: Write the failing layout tests**
+
+```java
+assertEquals(SourceKind.THUMBNAIL, layout("small", false, true).sourceKind());
+assertEquals(SourceKind.ATTACHMENT, layout("medium", false, true).sourceKind());
+assertEquals(SourceKind.ATTACHMENT, layout("large", false, true).sourceKind());
+assertEquals(SourceKind.ATTACHMENT, layout(null, true, true).sourceKind());
+assertTrue(layout("medium", false, true).hideChrome());
+assertFalse(layout("small", false, true).hideChrome());
+assertFalse(layout("medium", false, false).hideChrome());
+assertEquals(SourceKind.THUMBNAIL, layout("large", false, false).sourceKind());
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"`
+Expected: FAIL because the helper does not exist yet.
+
+- [ ] **Step 3: Implement the minimal layout helper**
+
+```java
+final class ImageThumbnailLayout {
+  enum SourceKind { THUMBNAIL, ATTACHMENT }
+
+  static Decision decide(String displaySize, boolean fullMode, boolean contentImage) {
+    boolean inlineImage = contentImage
+        && (fullMode || "medium".equals(displaySize) || "large".equals(displaySize));
+    return new Decision(
+        inlineImage ? SourceKind.ATTACHMENT : SourceKind.THUMBNAIL,
+        inlineImage);
+  }
+}
+```
+
+- [ ] **Step 4: Wire the widget to the helper**
+
+```java
+ImageThumbnailLayout.Decision decision =
+    ImageThumbnailLayout.decide(displaySize, isFullSize, isContentImage());
+String url = decision.sourceKind() == SourceKind.ATTACHMENT ? attachmentUrl : thumbnailUrl;
+boolean hideChrome = decision.hideChrome();
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayout.java \
+  wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java \
+  wave/src/test/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayoutTest.java
+git commit -m "feat(image): render medium and large attachments inline"
+```
+
+## Task 3: Preserve aspect ratio and default uploads to medium
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java`
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/doodad/attachment/render/Thumbnail.css`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java`
+- Test: `wave/src/test/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayoutTest.java`
+
+- [ ] **Step 1: Extend the failing test coverage**
+
+```java
+assertEquals(new Size(300, 200), scale(1200, 800, "medium"));
+assertEquals(new Size(600, 400), scale(1200, 800, "large"));
+assertEquals(new Size(120, 80), scale(1200, 800, "small"));
+assertEquals(new Size(300, 200), scale(0, 0, "medium"));
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"`
+Expected: FAIL because aspect-ratio scaling logic is not implemented yet.
+
+- [ ] **Step 3: Implement aspect-ratio scaling and chrome classes**
+
+```java
+ImageThumbnailLayout.Size scaled =
+    ImageThumbnailLayout.scale(sourceWidth, sourceHeight, displaySize, isFullSize);
+image.setPixelSize(scaled.width(), scaled.height());
+if (decision.hideChrome()) {
+  addStyleName("inline-image");
+} else {
+  removeStyleName("inline-image");
+}
+```
+
+- [ ] **Step 4: Change upload default to medium**
+
+```java
+selectedDisplaySize = "medium";
+selectDisplaySize("medium");
+```
+
+Update all current `small` defaults in:
+- field initialization
+- constructor/setup default state
+- `show()` reset path
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java \
+  wave/src/main/resources/org/waveprotocol/wave/client/doodad/attachment/render/Thumbnail.css \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java \
+  wave/src/test/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayoutTest.java
+git commit -m "feat(image): default uploads to inline preview"
+```
+
+## Task 4: Targeted verification
+
+**Files:**
+- Test: `wave/src/test/java/org/waveprotocol/wave/model/conversation/SchemaConstraintsTest.java`
+- Test: `wave/src/test/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailLayoutTest.java`
+
+- [ ] **Step 1: Run the targeted test set**
+
+Run: `sbt "testOnly org.waveprotocol.wave.model.conversation.SchemaConstraintsTest org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"`
+Expected: PASS
+
+- [ ] **Step 2: Run one narrow compile sanity check**
+
+Run: `sbt compile`
+Expected: PASS
+
+- [ ] **Step 3: Record verification in issue comment**
+
+```text
+Verification:
+- sbt "testOnly org.waveprotocol.wave.model.conversation.SchemaConstraintsTest org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailLayoutTest"
+- sbt compile
+```
+
+## Review checkpoints
+
+- Plan review: run `claude-review` against this plan before coding.
+- Implementation review: run `claude-review` against the final diff before the last commit or as an immediate follow-up fixup commit.
+
+## Open questions
+
+- None blocking for Phase 1. The path is clear enough to implement with the current attachment-backed document model.

--- a/wave/config/changelog.d/2026-04-08-inline-wave-images.json
+++ b/wave/config/changelog.d/2026-04-08-inline-wave-images.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-08-inline-wave-images",
+  "version": "Issue #185",
+  "date": "2026-04-08",
+  "title": "Render Medium And Large Attachments As Inline Images",
+  "summary": "Image attachments now use true inline rendering for medium and large display modes instead of just enlarging thumbnail cards.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Medium and large image attachments now render from the original attachment image for a more Telegram-like inline photo experience",
+        "Image attachments keep their attachment-backed document model while preserving thumbnail mode for compact displays",
+        "New image uploads now default to medium display size instead of small thumbnails"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java
@@ -67,6 +67,7 @@ import org.waveprotocol.wave.client.widget.button.ToggleButton.ToggleButtonListe
 import org.waveprotocol.wave.client.widget.button.ToggleButtonWidget;
 import org.waveprotocol.wave.client.widget.button.icon.IconButtonTemplate.IconButtonStyle;
 import org.waveprotocol.wave.client.widget.progress.ProgressWidget;
+import org.waveprotocol.wave.media.model.AttachmentDisplayLayout;
 
 /**
  * Widget that implements a thumbnail structure.
@@ -486,31 +487,20 @@ class ImageThumbnailWidget extends Composite implements ImageThumbnailView {
   public void setThumbnailSize(int width, int height) {
     this.thumbnailWidth = width;
     this.thumbnailHeight = height;
-
-    if (!isFullSize) {
-      setImageSize();
-    }
+    setImageSize();
   }
 
   @Override
   public void setAttachmentSize(int width, int height) {
     this.attachmentWidth = width;
     this.attachmentHeight = height;
-
-    if (isFullSize) {
-      setImageSize();
-    }
+    setImageSize();
   }
 
   @Override
   public void setFullSizeMode(boolean isOn) {
     isFullSize = isOn;
     button.setOn(isOn);
-    if (isOn) {
-      chromeContainer.getElement().getStyle().setDisplay(Display.NONE);
-    } else {
-      chromeContainer.getElement().getStyle().clearDisplay();
-    }
     setImageSize();
   }
 
@@ -544,8 +534,32 @@ class ImageThumbnailWidget extends Composite implements ImageThumbnailView {
   }
 
   private void setImageSize() {
-    int width = isFullSize?attachmentWidth:thumbnailWidth;
-    int height = isFullSize?attachmentHeight:thumbnailHeight;
+    AttachmentDisplayLayout.Decision decision =
+        AttachmentDisplayLayout.decide(displaySize, isFullSize, isContentImage());
+
+    int sourceWidth =
+        decision.getSourceKind() == AttachmentDisplayLayout.SourceKind.ATTACHMENT
+            ? attachmentWidth : thumbnailWidth;
+    int sourceHeight =
+        decision.getSourceKind() == AttachmentDisplayLayout.SourceKind.ATTACHMENT
+            ? attachmentHeight : thumbnailHeight;
+    AttachmentDisplayLayout.Size scaled =
+        AttachmentDisplayLayout.scaleToFit(
+            sourceWidth,
+            sourceHeight,
+            displaySize,
+            isFullSize && decision.getSourceKind() == AttachmentDisplayLayout.SourceKind.ATTACHMENT);
+    int width = scaled.getWidth();
+    int height = scaled.getHeight();
+
+    if (decision.hideChrome()) {
+      chromeContainer.getElement().getStyle().setDisplay(Display.NONE);
+      addStyleName("inline-image");
+    } else {
+      chromeContainer.getElement().getStyle().clearDisplay();
+      removeStyleName("inline-image");
+    }
+
     image.setPixelSize(width, height);
     //TODO(user,danilatos): Whinge about how declarative UI doesn't let us avoid this hack:
     Style pstyle = image.getElement().getParentElement().getParentElement().getStyle();
@@ -562,7 +576,9 @@ class ImageThumbnailWidget extends Composite implements ImageThumbnailView {
       pstyle.setHeight(height, Unit.PX);
     }
 
-    String url = isFullSize?attachmentUrl:thumbnailUrl;
+    String url =
+        decision.getSourceKind() == AttachmentDisplayLayout.SourceKind.ATTACHMENT
+            ? attachmentUrl : thumbnailUrl;
     if (url != null) {
       if (doubleBufferLoader == null) {
         doubleBufferLoader = new DoubleBufferImage(spin, errorLabel, image);
@@ -592,9 +608,7 @@ class ImageThumbnailWidget extends Composite implements ImageThumbnailView {
 
     // Apply new class
     getElement().addClassName("display-size-" + size);
-
-    // Adjust dimensions based on display size
-    applyDisplaySizeDimensions();
+    setImageSize();
   }
 
   @Override
@@ -711,31 +725,6 @@ class ImageThumbnailWidget extends Composite implements ImageThumbnailView {
         + "</svg>"
         + "<span class='file-type-label'>" + label + "</span>"
         + "</div>";
-  }
-
-  /**
-   * Applies dimensions based on the current display size setting.
-   */
-  private void applyDisplaySizeDimensions() {
-    int targetWidth;
-    int targetHeight;
-    switch (displaySize) {
-      case ImageThumbnail.DISPLAY_SIZE_MEDIUM:
-        targetWidth = 300;
-        targetHeight = 200;
-        break;
-      case ImageThumbnail.DISPLAY_SIZE_LARGE:
-        targetWidth = 600;
-        targetHeight = 400;
-        break;
-      default: // small
-        targetWidth = 120;
-        targetHeight = 80;
-        break;
-    }
-    if (!isFullSize) {
-      setThumbnailSize(targetWidth, targetHeight);
-    }
   }
 
   private boolean isContentImage() {

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
@@ -168,7 +168,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   private double simulatedProgress;
 
   /** Currently selected display size. */
-  private String selectedDisplaySize = "small";
+  private String selectedDisplaySize = "medium";
 
   /** Whether image compression is enabled. */
   private boolean compressionEnabled = true;
@@ -292,7 +292,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
       }
     });
     // Default selection
-    selectDisplaySize("small");
+    selectDisplaySize("medium");
 
     // Compression toggle
     compressToggleBtn.addClickHandler(new ClickHandler() {
@@ -597,7 +597,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
     status.setText("");
     status.removeStyleName("error");
     status.removeStyleName("success");
-    selectDisplaySize("small");
+    selectDisplaySize("medium");
     compressionEnabled = true;
     compressToggleBtn.setText("Compress: ON");
     popup.show();

--- a/wave/src/main/java/org/waveprotocol/wave/media/model/AttachmentDisplayLayout.java
+++ b/wave/src/main/java/org/waveprotocol/wave/media/model/AttachmentDisplayLayout.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.media.model;
+
+import java.util.Objects;
+
+/**
+ * Pure layout decisions for attachment-backed image rendering.
+ */
+public final class AttachmentDisplayLayout {
+  private static final String DISPLAY_SIZE_MEDIUM = "medium";
+  private static final String DISPLAY_SIZE_LARGE = "large";
+
+  private AttachmentDisplayLayout() {}
+
+  public enum SourceKind {
+    THUMBNAIL,
+    ATTACHMENT
+  }
+
+  public static final class Decision {
+    private final SourceKind sourceKind;
+    private final boolean hideChrome;
+
+    Decision(SourceKind sourceKind, boolean hideChrome) {
+      this.sourceKind = sourceKind;
+      this.hideChrome = hideChrome;
+    }
+
+    public SourceKind getSourceKind() {
+      return sourceKind;
+    }
+
+    public boolean hideChrome() {
+      return hideChrome;
+    }
+  }
+
+  public static final class Size {
+    private final int width;
+    private final int height;
+
+    public Size(int width, int height) {
+      this.width = width;
+      this.height = height;
+    }
+
+    public int getWidth() {
+      return width;
+    }
+
+    public int getHeight() {
+      return height;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (!(other instanceof Size)) {
+        return false;
+      }
+      Size that = (Size) other;
+      return width == that.width && height == that.height;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(width, height);
+    }
+
+    @Override
+    public String toString() {
+      return "Size{" + width + "x" + height + "}";
+    }
+  }
+
+  public static Decision decide(String displaySize, boolean fullMode, boolean contentImage) {
+    if (!contentImage) {
+      return new Decision(SourceKind.THUMBNAIL, false);
+    }
+    if (fullMode) {
+      return new Decision(SourceKind.ATTACHMENT, true);
+    }
+    String normalizedDisplaySize = normalizeDisplaySize(displaySize);
+    boolean inlineImage = DISPLAY_SIZE_MEDIUM.equals(normalizedDisplaySize)
+        || DISPLAY_SIZE_LARGE.equals(normalizedDisplaySize);
+    return new Decision(inlineImage ? SourceKind.ATTACHMENT : SourceKind.THUMBNAIL, inlineImage);
+  }
+
+  public static Size scaleToFit(int sourceWidth, int sourceHeight, String displaySize,
+      boolean fullMode) {
+    if (fullMode) {
+      if (sourceWidth > 0 && sourceHeight > 0) {
+        return new Size(sourceWidth, sourceHeight);
+      }
+      return getDisplayBox(DISPLAY_SIZE_LARGE);
+    }
+
+    Size box = getDisplayBox(displaySize);
+    if (sourceWidth <= 0 || sourceHeight <= 0) {
+      return box;
+    }
+
+    double widthScale = (double) box.getWidth() / sourceWidth;
+    double heightScale = (double) box.getHeight() / sourceHeight;
+    double scale = Math.min(widthScale, heightScale);
+    int scaledWidth = Math.max(1, (int) Math.round(sourceWidth * scale));
+    int scaledHeight = Math.max(1, (int) Math.round(sourceHeight * scale));
+    return new Size(scaledWidth, scaledHeight);
+  }
+
+  private static Size getDisplayBox(String displaySize) {
+    switch (normalizeDisplaySize(displaySize)) {
+      case DISPLAY_SIZE_MEDIUM:
+        return new Size(300, 200);
+      case DISPLAY_SIZE_LARGE:
+        return new Size(600, 400);
+      default:
+        return new Size(120, 80);
+    }
+  }
+
+  private static String normalizeDisplaySize(String displaySize) {
+    if (DISPLAY_SIZE_MEDIUM.equals(displaySize) || DISPLAY_SIZE_LARGE.equals(displaySize)) {
+      return displaySize;
+    }
+    return "small";
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/model/schema/conversation/ConversationSchemas.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/schema/conversation/ConversationSchemas.java
@@ -86,6 +86,7 @@ public final class ConversationSchemas implements SchemaProvider {
       addChildren("image", "caption");
       addAttrWithValues("image", "attachment");
       addAttrWithValues("image", "style", "full");
+      addAttrWithValues("image", "display-size", "small", "medium", "large");
       addChildren("image", "gadget");
 
       oneLiner("caption");

--- a/wave/src/main/resources/org/waveprotocol/wave/client/doodad/attachment/render/Thumbnail.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/doodad/attachment/render/Thumbnail.css
@@ -26,6 +26,11 @@
   display: inline-block;
 }
 
+.imageThumbnail.inline-image {
+  display: block;
+  margin: 8px 0;
+}
+
 
 .wave-editor-off .thumbSizeButton {
   display:none;
@@ -279,6 +284,16 @@
   padding: 4px;
   color: black;  /* Can't assume font color is not changed by the page theme. */
   background-color: white;
+}
+
+.imageThumbnail.inline-image .ittt {
+  margin: 0;
+}
+
+.imageThumbnail.inline-image .w-caption {
+  text-align: left;
+  padding: 8px 0 0;
+  background-color: transparent;
 }
 
 /* Rules for Table-based thumbnails. */

--- a/wave/src/test/java/org/waveprotocol/wave/media/model/AttachmentDisplayLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/media/model/AttachmentDisplayLayoutTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.media.model;
+
+import junit.framework.TestCase;
+
+public class AttachmentDisplayLayoutTest extends TestCase {
+
+  public void testDecideUsesThumbnailForSmallImages() {
+    AttachmentDisplayLayout.Decision decision =
+        AttachmentDisplayLayout.decide("small", false, true);
+
+    assertEquals(AttachmentDisplayLayout.SourceKind.THUMBNAIL, decision.getSourceKind());
+    assertFalse(decision.hideChrome());
+  }
+
+  public void testDecideUsesAttachmentForInlineImageModes() {
+    AttachmentDisplayLayout.Decision medium =
+        AttachmentDisplayLayout.decide("medium", false, true);
+    AttachmentDisplayLayout.Decision large =
+        AttachmentDisplayLayout.decide("large", false, true);
+    AttachmentDisplayLayout.Decision full =
+        AttachmentDisplayLayout.decide(null, true, true);
+
+    assertEquals(AttachmentDisplayLayout.SourceKind.ATTACHMENT, medium.getSourceKind());
+    assertEquals(AttachmentDisplayLayout.SourceKind.ATTACHMENT, large.getSourceKind());
+    assertEquals(AttachmentDisplayLayout.SourceKind.ATTACHMENT, full.getSourceKind());
+    assertTrue(medium.hideChrome());
+    assertTrue(large.hideChrome());
+    assertTrue(full.hideChrome());
+  }
+
+  public void testDecideKeepsNonImageAttachmentsOnCardPath() {
+    AttachmentDisplayLayout.Decision decision =
+        AttachmentDisplayLayout.decide("large", false, false);
+
+    assertEquals(AttachmentDisplayLayout.SourceKind.THUMBNAIL, decision.getSourceKind());
+    assertFalse(decision.hideChrome());
+  }
+
+  public void testScaleToFitPreservesAspectRatioForConfiguredSizes() {
+    assertEquals(new AttachmentDisplayLayout.Size(120, 80),
+        AttachmentDisplayLayout.scaleToFit(1200, 800, "small", false));
+    assertEquals(new AttachmentDisplayLayout.Size(300, 200),
+        AttachmentDisplayLayout.scaleToFit(1200, 800, "medium", false));
+    assertEquals(new AttachmentDisplayLayout.Size(600, 400),
+        AttachmentDisplayLayout.scaleToFit(1200, 800, "large", false));
+  }
+
+  public void testScaleToFitFallsBackToModeBoxWhenDimensionsUnknown() {
+    assertEquals(new AttachmentDisplayLayout.Size(300, 200),
+        AttachmentDisplayLayout.scaleToFit(0, 0, "medium", false));
+  }
+
+  public void testScaleToFitReturnsOriginalSizeForLegacyFullMode() {
+    assertEquals(new AttachmentDisplayLayout.Size(1200, 800),
+        AttachmentDisplayLayout.scaleToFit(1200, 800, "small", true));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/SchemaConstraintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/SchemaConstraintsTest.java
@@ -57,6 +57,14 @@ public class SchemaConstraintsTest extends TestCase {
         BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "attachment"));
     assertTrue(
         BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "attachment", "blahblah"));
+    assertTrue(
+        BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "small"));
+    assertTrue(
+        BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "medium"));
+    assertTrue(
+        BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "large"));
+    assertFalse(
+        BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "giant"));
     assertFalse(
         BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "something"));
     assertFalse(

--- a/wave/src/test/java/org/waveprotocol/wave/model/schema/conversation/ImageDisplaySizeSchemaTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/schema/conversation/ImageDisplaySizeSchemaTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.schema.conversation;
+
+import static org.waveprotocol.wave.model.schema.conversation.ConversationSchemas.BLIP_SCHEMA_CONSTRAINTS;
+
+import junit.framework.TestCase;
+
+public class ImageDisplaySizeSchemaTest extends TestCase {
+
+  public void testDisplaySizeValuesArePermittedForImageElements() {
+    assertTrue(BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "small"));
+    assertTrue(BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "medium"));
+    assertTrue(BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "large"));
+    assertFalse(BLIP_SCHEMA_CONSTRAINTS.permitsAttribute("image", "display-size", "giant"));
+  }
+}


### PR DESCRIPTION
## Summary
Implements Phase 1 of the inline image work for #185.

This keeps the existing attachment-backed `<image attachment="...">` document model, but changes medium and large image display modes to render from the original attachment image inline instead of just enlarging thumbnail cards.

## What Changed
- formalized `image@display-size` in the conversation schema
- added shared attachment display layout logic for source selection and aspect-ratio scaling
- updated the image thumbnail widget to use `attachmentUrl` for inline image modes and hide thumbnail chrome for those modes
- changed new upload default size from `small` to `medium`
- added a changelog fragment for the user-facing behavior

## Why
The existing upload/rendering path already stored full image attachments, but medium and large modes were still thumbnail-first in the client renderer. This closes that gap with the narrowest compatible change set.

## Verification
- `sbt -batch -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp "show Test / definedTests" | rg 'ImageDisplaySizeSchemaTest|AttachmentDisplayLayoutTest'`
- `sbt -batch -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp "testOnly org.waveprotocol.wave.model.schema.conversation.ImageDisplaySizeSchemaTest org.waveprotocol.wave.media.model.AttachmentDisplayLayoutTest"`
- `sbt -batch -Dsbt.ipcsocket.jni=false -Dsbt.ipcsocket.tmpdir=/tmp compileGwt`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

## Notes
- Claude Opus reviewed both the implementation plan and the implementation diff.
- This PR does not attempt galleries or URL/video previews; it is the inline-image rendering slice only.

Refs #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Images now display as full inline content in medium and large display modes
  * New image uploads automatically default to medium display size
  * Inline images render without chrome borders for a cleaner visual appearance

* **Documentation**
  * Added implementation plan for inline image rendering specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->