### PR TITLE
feat(tasks): add assignee picker, due dates, and ownership pills (#779)

### DIFF
--- a/docs/superpowers/plans/2026-04-09-issue-779-task-metadata-ui.md
+++ b/docs/superpowers/plans/2026-04-09-issue-779-task-metadata-ui.md
@@ -1,0 +1,245 @@
+# Issue 779 Task Metadata UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the missing task metadata UX on top of the merged Wave Tasks base feature so users can assign a task to any current wave participant, set or edit a due date, and see task ownership clearly in the wave UI.
+
+**Architecture:** Keep the existing document model intact: tasks remain `<check name="task:<id>"/>` plus `task/*` annotations, with `task/assignee` and `task/dueTs` staying authoritative. Add a narrow client-side metadata layer: a styled task-details popup for editing assignee/due date, DOM-only ownership/due-date pills rendered next to task checkboxes, and an annotation refresh handler so the pills stay synced when task annotations change.
+
+**Tech Stack:** GWT client widgets, Wave editor doodads (`CheckBox`, annotation handlers, `EditToolbar`), existing `Conversation` participant model, existing popup infrastructure (`UniversalPopup`), targeted JUnit tests, GWT compile, local Wave server sanity verification.
+
+---
+
+## Context Snapshot
+
+- Base task support from issue `#737` / PR `#739` already shipped:
+  - `task/id`, `task/assignee`, `task/dueTs`, `task/reminders` annotations
+  - task insertion from the edit toolbar
+  - task search / unread badges / rendering
+- Current UX gaps in `main`:
+  - inserting a task hard-codes the signed-in user as assignee
+  - due date metadata is stored in the model but cannot be set from the UI
+  - task ownership is not rendered in-wave, so it is easy to confuse with normal text or mentions
+- Non-goals that stay unchanged:
+  - no background reminder delivery
+  - no new task document primitive
+  - no search redesign beyond what is needed for correctness
+
+## Acceptance Criteria
+
+- [ ] A user can assign a task to any participant currently in the root conversation, including robots.
+- [ ] A user can set or edit a due date on a task without changing the underlying annotation schema.
+- [ ] The wave UI shows task ownership in a way that is visually distinct from `@mentions`.
+- [ ] Existing tasks update their metadata pills when annotations change locally.
+- [ ] User-facing changes include a changelog fragment and regenerated `wave/config/changelog.json`.
+
+## File Ownership / Likely Touch Points
+
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java`
+  - render metadata pills next to task checkboxes
+  - attach chip click handling
+  - expose a narrow refresh hook for task metadata redraws
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/doodad/form/check/CheckBase.css`
+  - style owner / due-date pills distinctly from mention highlights
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java`
+  - centralize task annotation reads/writes plus date parsing/formatting helpers
+- Add: `wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java`
+  - shared owner-label / due-date parsing / formatting logic that both JVM tests and GWT client code can use
+- Add: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskAnnotationHandler.java`
+  - refresh task checkbox metadata UI when `task/*` annotations change
+- Add: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java`
+  - styled popup for assignee picker + due date editor
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`
+  - open task metadata popup immediately after inserting a task
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java`
+  - register the task annotation refresh handler
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java`
+  - configure popup context from the root conversation and signed-in user
+- Add: `wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java`
+  - cover shared owner-label / due-date helper logic in the normal JVM test runner
+- Add: `wave/src/test/java/org/waveprotocol/wave/client/doodad/form/check/TaskAnnotationHandlerTest.java`
+  - cover task-annotation-to-checkbox refresh behaviour if feasible without heavy GWT setup; otherwise keep this logic in `TaskDocumentUtilTest`
+- Add: `wave/config/changelog.d/2026-04-09-task-metadata-ui.json`
+  - user-facing summary for assignee picker / due date / ownership pills
+
+## Task 1: Lock The Metadata Contract Before UI Work
+
+**Files:**
+- Add: `wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java`
+- Test: `wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java`
+
+- [ ] Add shared helper methods in `TaskMetadataUtil` for:
+  - `formatTaskOwnerLabel(...)`
+  - `formatTaskDueLabel(...)`
+  - `parseDateInputValue(...)`
+  - `formatDateInputValue(...)`
+- [ ] Add client-side `TaskDocumentUtil` helpers that treat the checkbox element location as the single authoritative task metadata location:
+  - `getTaskAssignee(...)`
+  - `getTaskDueTimestamp(...)`
+  - `setTaskAssignee(...)`
+  - `setTaskDueTimestamp(...)`
+  - `clearTaskDueTimestamp(...)`
+- [ ] Write failing unit tests first for:
+  - owner label formatting from full participant addresses
+  - empty / invalid due-date annotation handling
+  - round-tripping `yyyy-MM-dd` input values to epoch millis and back
+  - clearing due-date metadata
+- [ ] Run the focused test command and verify the new assertions fail for the expected missing-helper reason.
+
+Run:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest"
+```
+
+Expected before implementation:
+- the new test methods fail because the helper methods / behaviours do not exist yet
+
+## Task 2: Build The Popup UI For Assignee + Due Date Editing
+
+**Files:**
+- Add: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java`
+
+- [ ] Implement a styled popup using existing `UniversalPopup` infrastructure, not browser prompts.
+- [ ] Configure it from `StageThree` with:
+  - root conversation participant set
+  - signed-in user
+- [ ] Popup requirements:
+  - assignee picker lists current participants plus an explicit unassigned option
+  - due date field uses a styled popup input with an explicit `yyyy-MM-dd` value contract
+  - implementation may use a DOM input with `type="date"` when available, but must still validate and round-trip plain `yyyy-MM-dd` values through `TaskDocumentUtil`
+  - save applies `task/assignee` and `task/dueTs` annotations on the clicked task element
+  - cancel makes no document change
+- [ ] Owner pill format is explicit, not mention-like:
+  - local-domain addresses render as `Owner alice`
+  - non-local or already-non-email identifiers may render the full identifier
+- [ ] Removed/stale assignees remain displayable:
+  - if an existing task annotation points at an address no longer in `Conversation.getParticipantIds()`, the popup still preserves and shows the current value until the user changes it
+- [ ] Keep popup state local to the selected task element; do not add new session-global task state.
+
+Run:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest"
+sbt wave/compile
+```
+
+Expected after popup helper integration:
+- contract/helper tests pass and no popup code regresses helper compilation
+
+## Task 3: Render Clear Ownership / Due-Date Pills Inline Next To Tasks
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java`
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/doodad/form/check/CheckBase.css`
+
+- [ ] Extend task checkbox rendering so every task checkbox wrapper owns a metadata container.
+- [ ] Render DOM-only pills for:
+  - owner: `Owner alice`
+  - due date: `Due Apr 12`
+  - empty state: `Add details`
+- [ ] Keep pill styling visually separate from mentions:
+  - no `@` prefix
+  - neutral/utility pill styles instead of mention-highlight background
+- [ ] Attach a click handler on the pill container that opens the popup without toggling the checkbox.
+- [ ] Keep existing checked-task strikethrough logic intact.
+
+Run:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest"
+```
+
+Expected:
+- focused helper tests still pass after rendering integration
+
+## Task 4: Keep Metadata UI Synced When Annotations Change
+
+**Files:**
+- Add: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskAnnotationHandler.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java`
+
+- [ ] Register a task annotation handler for the `task/` namespace during doodad installation.
+- [ ] Follow the existing annotation registration pattern:
+  - expose a static `TaskAnnotationHandler.register(Registries ...)`
+  - call that registration from the same doodad-install path used by `MentionAnnotationHandler`
+- [ ] On task annotation changes, traverse from the changed annotation offset back to the owning `<check>` `ContentElement` and refresh only that checkbox's metadata pills.
+- [ ] Treat the refresh path as DOM-specific, not painter-based:
+  - `MentionAnnotationHandler` uses `AnnotationPainter.scheduleRepaint()` for inline painted spans
+  - task pills are checkbox-owned DOM nodes, so the handler must call a narrow `CheckBox.refreshTaskMetadata(...)`-style hook instead
+- [ ] Make sure popup saves refresh the UI immediately without requiring checkbox toggles or full document rerender.
+- [ ] Explicitly verify popup save -> annotation write -> handler fire -> pill redraw in manual sanity, because this is the riskiest interaction path.
+- [ ] Keep the refresh path narrow; do not repaint unrelated annotation families.
+
+Run:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest"
+sbt wave/compile
+```
+
+Expected:
+- helper tests remain green; no compile/runtime regression from annotation refresh wiring
+
+## Task 5: Wire Popup Launch Into New Task Creation
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`
+
+- [ ] After inserting a new task, immediately open the task metadata popup for that inserted checkbox.
+- [ ] Preserve the existing checkbox insertion path and task ID generation.
+- [ ] Do not change search or reminder behaviour in this step.
+
+Run:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest" "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.EditSessionTest"
+```
+
+Expected:
+- targeted tests pass
+
+## Task 6: Verification, Changelog, And Local Sanity
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-09-task-metadata-ui.json`
+- Regenerate: `wave/config/changelog.json`
+
+- [ ] Add a changelog fragment covering:
+  - assignee picker from current wave participants
+  - due date editing UI
+  - inline ownership / due-date pills on task rows
+- [ ] Run changelog assembly / validation.
+- [ ] Run the focused client/server verification commands.
+- [ ] Run a local server sanity check that exercises task insertion and metadata editing in the browser.
+- [ ] Record exact commands and outcomes in issue `#779` and in `journal/local-verification/...`.
+
+Verification commands:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest" "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.EditSessionTest"
+sbt wave/compile
+sbt compileGwt
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+```
+
+Local sanity target:
+```bash
+sbt prepareServerConfig run
+```
+
+Manual/browser sanity checklist:
+- create a new local user if needed
+- open or create a wave with at least one additional participant/robot
+- insert a task
+- verify popup opens on insert
+- change assignee to another participant
+- set a due date
+- confirm owner / due pills update in-wave and remain distinct from mentions
+- reopen the popup from the task pill and edit values again
+
+## Out Of Scope / Guardrails
+
+- [ ] Do not add background reminder scheduling or delivery.
+- [ ] Do not change the server-side task annotation schema.
+- [ ] Do not widen search semantics beyond existing task metadata correctness.
+- [ ] Do not add mention-style profile popups for task owners in this issue.
+- [ ] Do not use browser-native `alert` / `confirm` / `prompt`.

--- a/journal/local-verification/2026-04-09-issue-779-task-metadata-ui.md
+++ b/journal/local-verification/2026-04-09-issue-779-task-metadata-ui.md
@@ -1,0 +1,83 @@
+# Issue 779 Local Verification
+
+Date: 2026-04-09 17:11:11 IDT
+Worktree: `/Users/vega/devroot/worktrees/tasks-v2-assignee-due-20260409`
+Branch: `tasks-v2-assignee-due-20260409`
+
+## Automated Verification
+
+Command:
+```bash
+sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest" wave/compile compileGwt
+```
+
+Result:
+- PASS
+- `TaskMetadataUtilTest`: 5 tests passed
+- `wave/compile`: passed
+- `compileGwt`: passed
+
+Command:
+```bash
+python3 scripts/assemble-changelog.py
+```
+
+Result:
+- PASS
+- assembled 119 entries into `wave/config/changelog.json`
+
+Command:
+```bash
+python3 scripts/validate-changelog.py
+```
+
+Result:
+- PASS
+- changelog validation passed
+
+## Local Server Sanity
+
+Command:
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Result:
+- PASS
+- linked `wave/_accounts`, `wave/_attachments`, and `wave/_deltas` from the main repo state into this worktree
+
+Command:
+```bash
+sbt prepareServerConfig run
+```
+
+Result:
+- PASS
+- server started on `http://127.0.0.1:9898`
+
+## Manual Browser Verification
+
+Environment:
+- Browser automation against `http://127.0.0.1:9898`
+- Fresh local users:
+  - `task779lane@local.net`
+  - `task779peer@local.net`
+
+Flow:
+1. Registered `task779lane@local.net` and signed in.
+2. Created a new wave.
+3. Added `task779peer@local.net` as a second participant.
+4. Entered edit mode on the root blip.
+5. Clicked `Insert task`.
+6. Verified the new `Task details` popup opened immediately.
+7. Set assignee to `task779peer@local.net` and due date to `2026-04-15`.
+8. Saved and verified the in-wave task row rendered pills for:
+   - `Owner task779peer`
+   - `Due Apr 15`
+9. Clicked the metadata pills and verified the popup reopened with the saved values prefilled.
+10. Changed assignee to `Unassigned`, cleared the due date, saved, and verified the row returned to the empty-state pill:
+    - `Add details`
+
+Notes:
+- An initial browser run exposed a task-insert race where task metadata refresh read annotations before the inserted checkbox had a valid annotation location. That was fixed by making task metadata reads fail closed on out-of-range offsets and re-running `compileGwt` plus the browser flow.
+- Post-fix browser console check reported `0` errors.

--- a/wave/config/changelog.d/2026-04-09-task-metadata-ui.json
+++ b/wave/config/changelog.d/2026-04-09-task-metadata-ui.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-09-task-metadata-ui",
-  "version": "PR #779",
+  "version": "PR #782",
   "date": "2026-04-09",
   "title": "Wave Tasks: assignee picker, due dates, and clearer ownership",
   "summary": "Tasks in the wave editor now open a metadata popup for assignee and due date, and the task row shows explicit owner and due-date pills so ownership is easier to understand at a glance.",

--- a/wave/config/changelog.d/2026-04-09-task-metadata-ui.json
+++ b/wave/config/changelog.d/2026-04-09-task-metadata-ui.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-09-task-metadata-ui",
+  "version": "PR #779",
+  "date": "2026-04-09",
+  "title": "Wave Tasks: assignee picker, due dates, and clearer ownership",
+  "summary": "Tasks in the wave editor now open a metadata popup for assignee and due date, and the task row shows explicit owner and due-date pills so ownership is easier to understand at a glance.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Insert Task now opens an in-wave task details popup where you can assign the task to any current wave participant and set or clear a due date",
+        "Task rows now render explicit owner and due-date pills beside the checkbox, using utility styling that stays visually distinct from @mentions",
+        "Clicking the task metadata pills reopens the same popup so assignee and due date can be edited after the task is created"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
@@ -183,9 +183,9 @@ public interface StageThree {
     }
 
     protected EditToolbar createEditToolbar() {
-      Conversation rootConversation = stageTwo.getConversations().getRoot();
-      if (rootConversation != null) {
-        TaskMetadataPopup.configure(rootConversation, getStageTwo().getSignedInUser());
+      Conversation root = stageTwo.getConversations().getRoot();
+      if (root != null) {
+        TaskMetadataPopup.configure(root, getStageTwo().getSignedInUser());
       }
       return EditToolbar.create(getStageTwo().getSignedInUser(), stageTwo.getIdGenerator(),
           stageTwo.getWave().getWaveId());

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
@@ -41,6 +41,7 @@ import org.waveprotocol.wave.client.wavepanel.impl.edit.EditSession;
 import org.waveprotocol.wave.client.wavepanel.impl.edit.KeepFocusInView;
 import org.waveprotocol.wave.client.wavepanel.impl.edit.ParticipantController;
 import org.waveprotocol.wave.client.wavepanel.impl.edit.TagController;
+import org.waveprotocol.wave.client.wavepanel.impl.edit.TaskMetadataPopup;
 import org.waveprotocol.wave.client.wavepanel.impl.edit.i18n.ParticipantMessages;
 import org.waveprotocol.wave.client.wavepanel.impl.focus.FocusFramePresenter;
 import org.waveprotocol.wave.client.wavepanel.render.TagUpdateRenderer;
@@ -182,6 +183,10 @@ public interface StageThree {
     }
 
     protected EditToolbar createEditToolbar() {
+      Conversation rootConversation = stageTwo.getConversations().getRoot();
+      if (rootConversation != null) {
+        TaskMetadataPopup.configure(rootConversation, getStageTwo().getSignedInUser());
+      }
       return EditToolbar.create(getStageTwo().getSignedInUser(), stageTwo.getIdGenerator(),
           stageTwo.getWave().getWaveId());
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java
@@ -47,6 +47,7 @@ import org.waveprotocol.wave.client.doodad.attachment.ImageThumbnail;
 import org.waveprotocol.wave.client.doodad.attachment.render.ImageThumbnailWrapper;
 import org.waveprotocol.wave.client.doodad.diff.DiffAnnotationHandler;
 import org.waveprotocol.wave.client.doodad.diff.DiffDeleteRenderer;
+import org.waveprotocol.wave.client.doodad.form.check.TaskAnnotationHandler;
 import org.waveprotocol.wave.client.doodad.link.LinkAnnotationHandler;
 import org.waveprotocol.wave.client.doodad.link.LinkAnnotationHandler.LinkAttributeAugmenter;
 import org.waveprotocol.wave.client.doodad.mention.MentionAnnotationHandler;
@@ -830,6 +831,7 @@ public interface StageTwo {
                     TitleAnnotationHandler.register(r);
                     LinkAnnotationHandler.register(r, createLinkAttributeAugmenter());
                     MentionAnnotationHandler.register(r, getProfileManager());
+                    TaskAnnotationHandler.register(r);
                     SelectionAnnotationHandler.register(r, getSessionId(), getProfileManager());
                     ImageThumbnail.register(r.getElementHandlerRegistry(),
                             AttachmentManagerProvider.get(),

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java
@@ -19,29 +19,52 @@
 
 package org.waveprotocol.wave.client.doodad.form.check;
 
-import org.waveprotocol.wave.model.util.Preconditions;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.event.dom.client.KeyCodes;
 
 import org.waveprotocol.wave.client.common.util.DomHelper;
 import org.waveprotocol.wave.client.editor.ElementHandlerRegistry;
 import org.waveprotocol.wave.client.editor.NodeEventHandler;
 import org.waveprotocol.wave.client.editor.NodeEventHandlerImpl;
+import org.waveprotocol.wave.client.editor.NodeEventHandlerImpl.Helper;
 import org.waveprotocol.wave.client.editor.RenderingMutationHandler;
 import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.event.EditorEvent;
+import org.waveprotocol.wave.client.wavepanel.impl.edit.TaskMetadataPopup;
 import org.waveprotocol.wave.model.document.util.XmlStringBuilder;
+import org.waveprotocol.wave.model.util.Preconditions;
 
 /** Doodad definition for a checkbox which stores its value in the doc. */
-public class CheckBox {
+public final class CheckBox {
   private static final String TAGNAME = "check";
 
-
   private static final NodeEventHandler CHECKBOX_NODE_EVENT_HANDLER = new NodeEventHandlerImpl() {
+    @Override
+    public void onActivated(final ContentElement element) {
+      if (!isTaskCheckBox(element)) {
+        return;
+      }
+      refreshTaskMetadata(element);
+      Element metadataNodelet = CheckBoxRenderingMutationHandler.getTaskMetadataNodelet(element);
+      if (metadataNodelet == null) {
+        return;
+      }
+      metadataNodelet.setTabIndex(0);
+      metadataNodelet.setAttribute("role", "button");
+      registerTaskMetadataPopupHandlers(element, metadataNodelet);
+    }
+
+    @Override
+    public void onDeactivated(ContentElement element) {
+      Helper.removeJsHandlers(element);
+    }
+
     @Override
     public boolean handleClick(ContentElement element, EditorEvent event) {
       setChecked(element, !getChecked(element));
@@ -55,7 +78,7 @@ public class CheckBox {
    */
   public static void register(ElementHandlerRegistry handlerRegistry) {
     RenderingMutationHandler renderingMutationHandler =
-        CheckBoxRendereringMutationHandler.getInstance();
+        CheckBoxRenderingMutationHandler.getInstance();
     handlerRegistry.registerRenderingMutationHandler(TAGNAME, renderingMutationHandler);
     handlerRegistry.registerEventHandler(TAGNAME, CHECKBOX_NODE_EVENT_HANDLER);
   }
@@ -80,11 +103,22 @@ public class CheckBox {
         submit, ContentElement.NAME, name, CheckConstants.VALUE, String.valueOf(value));
   }
 
-  private static class CheckBoxRendereringMutationHandler extends RenderingMutationHandler {
-    private static CheckBoxRendereringMutationHandler instance;
+  private static final class CheckBoxRenderingMutationHandler extends RenderingMutationHandler {
+    private static final String TASK_COMPLETED_CLASS = "task-completed";
+    private static final String TASK_SPAN_CLASS = "task-check-span";
+    private static final String TASK_METADATA_CLASS = "task-meta";
+    private static final String TASK_PILL_CLASS = "task-pill";
+    private static final String TASK_OWNER_PILL_CLASS = "task-owner-pill";
+    private static final String TASK_DUE_PILL_CLASS = "task-due-pill";
+    private static final String TASK_EMPTY_PILL_CLASS = "task-meta-empty";
+    private static final String PARAGRAPH_PROPERTY = "__waveTaskParagraph";
+    private static final String TASK_METADATA_PROPERTY = "__waveTaskMetadata";
+
+    private static CheckBoxRenderingMutationHandler instance;
+
     public static RenderingMutationHandler getInstance() {
       if (instance == null) {
-        instance = new CheckBoxRendereringMutationHandler();
+        instance = new CheckBoxRenderingMutationHandler();
       }
       return instance;
     }
@@ -106,19 +140,15 @@ public class CheckBox {
     @Override
     public void onActivationStart(ContentElement element) {
       fanoutAttrs(element);
+      refreshTaskMetadata(element);
     }
 
     @Override
     public void onActivatedSubtree(ContentElement element) {
-      // setupBehaviour calls triggerChildrenReady() (→ onActivatedSubtree) on each child
-      // BEFORE the parent's reInsertImpl() inserts that child's span into the parent's
-      // DOM container.  So implNodelet.getParentElement() is still null here during the
-      // initial bootstrap pass.  Defer to a scheduleFinally task that runs after the full
-      // setupBehaviour tree — and therefore all parent reInsertImpl() calls — completes.
-      String name = element.getAttribute(ContentElement.NAME);
-      if (name == null || !name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX)) {
+      if (!isTaskCheckBox(element)) {
         return;
       }
+      refreshTaskMetadata(element);
       if (!getChecked(element)) {
         return;
       }
@@ -126,20 +156,16 @@ public class CheckBox {
       if (implNodelet == null) {
         return;
       }
-      // PARAGRAPH_PROPERTY is set by updateCheckboxDom whenever paragraph != null.
-      // If already set, the initial pass succeeded; no deferred work needed.
       if (implNodelet.getPropertyObject(PARAGRAPH_PROPERTY) != null) {
         return;
       }
       Scheduler.get().scheduleFinally(new Scheduler.ScheduledCommand() {
         @Override
         public void execute() {
-          // Guard: user may have toggled the checkbox before the deferred task ran.
           Element firstChild = implNodelet.getFirstChildElement();
           if (firstChild == null || !InputElement.as(firstChild).isChecked()) {
             return;
           }
-          // Guard: a later updateCheckboxDom call may have already set this.
           if (implNodelet.getPropertyObject(PARAGRAPH_PROPERTY) != null) {
             return;
           }
@@ -160,32 +186,16 @@ public class CheckBox {
       }
     }
 
-    private static final String TASK_COMPLETED_CLASS = "task-completed";
-    /**
-     * Marker CSS class added to the span wrapper of every task checkbox.
-     * Not styled — used only to identify task checkbox spans in DOM queries.
-     */
-    private static final String TASK_SPAN_CLASS = "task-check-span";
-    /**
-     * Property key used to store the enclosing paragraph DOM element on the
-     * checkbox's span nodelet so it can be retrieved after DOM detachment.
-     */
-    private static final String PARAGRAPH_PROPERTY = "__waveTaskParagraph";
-
     private void updateCheckboxDom(ContentElement checkbox, boolean isChecked) {
       Element implNodelet = checkbox.getImplNodelet();
       InputElement checkboxElem = (InputElement) implNodelet.getFirstChild();
       checkboxElem.setChecked(isChecked);
+      refreshTaskMetadata(checkbox);
 
-      // Apply/remove strikethrough styling on the enclosing paragraph for task checkboxes.
-      String name = checkbox.getAttribute(ContentElement.NAME);
-      if (name != null && name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX)) {
-        // Mark the span so DOM-based sibling queries can identify task checkboxes.
+      if (isTaskCheckBox(checkbox)) {
         implNodelet.addClassName(TASK_SPAN_CLASS);
         Element paragraph = implNodelet.getParentElement();
         if (paragraph != null) {
-          // Cache the paragraph reference on the span: onDeactivated fires after the
-          // nodelet is detached from the DOM, so getParentElement() would return null there.
           implNodelet.setPropertyObject(PARAGRAPH_PROPERTY, paragraph);
           if (isChecked) {
             paragraph.addClassName(TASK_COMPLETED_CLASS);
@@ -196,25 +206,78 @@ public class CheckBox {
       }
     }
 
+    private static void refreshTaskMetadata(ContentElement checkbox) {
+      if (!isTaskCheckBox(checkbox)) {
+        return;
+      }
+      Element implNodelet = checkbox.getImplNodelet();
+      if (implNodelet == null) {
+        return;
+      }
+      implNodelet.addClassName(TASK_SPAN_CLASS);
+
+      Element metadata = getOrCreateTaskMetadataNodelet(implNodelet);
+      clearChildren(metadata);
+
+      String assignee = TaskDocumentUtil.getTaskAssignee(checkbox);
+      long dueTimestamp = TaskDocumentUtil.getTaskDueTimestamp(checkbox);
+      boolean hasDetails = false;
+
+      if (assignee != null) {
+        appendPill(metadata, TaskDocumentUtil.formatTaskOwnerLabel(assignee),
+            TASK_PILL_CLASS + " " + TASK_OWNER_PILL_CLASS);
+        hasDetails = true;
+      }
+      if (dueTimestamp > 0) {
+        appendPill(metadata, TaskDocumentUtil.formatTaskDueLabel(dueTimestamp),
+            TASK_PILL_CLASS + " " + TASK_DUE_PILL_CLASS);
+        hasDetails = true;
+      }
+      if (!hasDetails) {
+        appendPill(metadata, "Add details", TASK_PILL_CLASS + " " + TASK_EMPTY_PILL_CLASS);
+      }
+    }
+
+    private static Element getTaskMetadataNodelet(ContentElement checkbox) {
+      Element implNodelet = checkbox == null ? null : checkbox.getImplNodelet();
+      return implNodelet == null ? null
+          : (Element) implNodelet.getPropertyObject(TASK_METADATA_PROPERTY);
+    }
+
+    private static Element getOrCreateTaskMetadataNodelet(Element implNodelet) {
+      Element metadata = (Element) implNodelet.getPropertyObject(TASK_METADATA_PROPERTY);
+      if (metadata == null) {
+        SpanElement span = Document.get().createSpanElement();
+        span.setClassName(TASK_METADATA_CLASS);
+        implNodelet.appendChild(span);
+        implNodelet.setPropertyObject(TASK_METADATA_PROPERTY, span);
+        metadata = span;
+      }
+      return metadata;
+    }
+
+    private static void clearChildren(Element element) {
+      while (element.getFirstChild() != null) {
+        element.removeChild(element.getFirstChild());
+      }
+    }
+
+    private static void appendPill(Element metadata, String text, String classes) {
+      SpanElement pill = Document.get().createSpanElement();
+      pill.setClassName(classes);
+      pill.setInnerText(text);
+      metadata.appendChild(pill);
+    }
+
     @Override
     public void onRemovedFromParent(ContentElement element, ContentElement newParent) {
-      // newParent == null means deletion, which is handled by onDeactivated.
-      // newParent != null means a move (line merge/split): clean up the old paragraph.
-      if (newParent == null) {
-        return;
-      }
-      String name = element.getAttribute(ContentElement.NAME);
-      if (name == null || !name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX)) {
-        return;
-      }
-      if (!getChecked(element)) {
+      if (newParent == null || !isTaskCheckBox(element) || !getChecked(element)) {
         return;
       }
       Element implNodelet = element.getImplNodelet();
       if (implNodelet == null) {
         return;
       }
-      // The nodelet is detached from the DOM here; use the cached paragraph reference.
       Element oldParagraph = (Element) implNodelet.getPropertyObject(PARAGRAPH_PROPERTY);
       if (oldParagraph != null && !hasAnyOtherCheckedTaskSpan(oldParagraph, implNodelet)) {
         oldParagraph.removeClassName(TASK_COMPLETED_CLASS);
@@ -223,12 +286,7 @@ public class CheckBox {
 
     @Override
     public void onAddedToParent(ContentElement element, ContentElement oldParent) {
-      // When a checked task checkbox is moved into a new paragraph, style that paragraph.
-      String name = element.getAttribute(ContentElement.NAME);
-      if (name == null || !name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX)) {
-        return;
-      }
-      if (!getChecked(element)) {
+      if (!isTaskCheckBox(element) || !getChecked(element)) {
         return;
       }
       Element implNodelet = element.getImplNodelet();
@@ -244,16 +302,7 @@ public class CheckBox {
 
     @Override
     public void onDeactivated(ContentElement element) {
-      // When a checked task checkbox is removed from the document, clean up the
-      // task-completed class on its enclosing paragraph.
-      // NOTE: By the time onDeactivated fires the nodelet is already detached from
-      // the DOM, so we rely on the paragraph reference cached in PARAGRAPH_PROPERTY
-      // rather than on implNodelet.getParentElement() (which returns null here).
-      String name = element.getAttribute(ContentElement.NAME);
-      if (name == null || !name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX)) {
-        return;
-      }
-      if (!getChecked(element)) {
+      if (!isTaskCheckBox(element) || !getChecked(element)) {
         return;
       }
       Element implNodelet = element.getImplNodelet();
@@ -268,9 +317,7 @@ public class CheckBox {
 
     /**
      * Returns true if {@code paragraph} contains any task checkbox span other than
-     * {@code excludeSpan} whose input is currently checked. Uses DOM-based detection
-     * (via {@link #TASK_SPAN_CLASS}) so it works both during normal edits and inside
-     * {@link #onDeactivated} where the content model parent is no longer available.
+     * {@code excludeSpan} whose input is currently checked.
      */
     private boolean hasAnyOtherCheckedTaskSpan(Element paragraph, Element excludeSpan) {
       NodeList<Element> spans = DomHelper.getElementsByClassName(paragraph, TASK_SPAN_CLASS);
@@ -308,12 +355,49 @@ public class CheckBox {
         String.valueOf(checkValue));
   }
 
+  public static void refreshTaskMetadata(ContentElement checkbox) {
+    CheckBoxRenderingMutationHandler.refreshTaskMetadata(checkbox);
+  }
+
+  private static void registerTaskMetadataPopupHandlers(final ContentElement element,
+      Element metadataNodelet) {
+    Helper.registerJsHandler(element, metadataNodelet, "click",
+        new DomHelper.JavaScriptEventListener() {
+          @Override
+          public void onJavaScriptEvent(String name, Event event) {
+            event.preventDefault();
+            event.stopPropagation();
+            TaskMetadataPopup.show(element);
+          }
+        });
+    Helper.registerJsHandler(element, metadataNodelet, "keydown",
+        new DomHelper.JavaScriptEventListener() {
+          @Override
+          public void onJavaScriptEvent(String name, Event event) {
+            int keyCode = event.getKeyCode();
+            if (keyCode == KeyCodes.KEY_ENTER || keyCode == ' ') {
+              event.preventDefault();
+              event.stopPropagation();
+              TaskMetadataPopup.show(element);
+            }
+          }
+        });
+  }
+
   /**
    * @param element
    * @return true iff the element is a checkbox element
    */
   public static boolean isCheckBox(ContentElement element) {
     return TAGNAME.equalsIgnoreCase(element.getTagName());
+  }
+
+  private static boolean isTaskCheckBox(ContentElement element) {
+    if (!isCheckBox(element)) {
+      return false;
+    }
+    String name = element.getAttribute(ContentElement.NAME);
+    return name != null && name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX);
   }
 
   /** Utility class */

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskAnnotationHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskAnnotationHandler.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.doodad.form.check;
+
+import org.waveprotocol.wave.client.editor.content.ContentElement;
+import org.waveprotocol.wave.client.editor.content.Registries;
+import org.waveprotocol.wave.model.conversation.AnnotationConstants;
+import org.waveprotocol.wave.model.document.AnnotationMutationHandler;
+import org.waveprotocol.wave.model.document.util.DocumentContext;
+import org.waveprotocol.wave.model.document.util.Point;
+
+/**
+ * Refreshes task metadata pills when task annotations change.
+ */
+public final class TaskAnnotationHandler implements AnnotationMutationHandler {
+
+  public static void register(Registries registries) {
+    registries.getAnnotationHandlerRegistry().registerHandler(
+        AnnotationConstants.TASK_PREFIX, new TaskAnnotationHandler());
+  }
+
+  @Override
+  public <N, E extends N, T extends N> void handleAnnotationChange(
+      DocumentContext<N, E, T> bundle, int start, int end, String key, Object newValue) {
+    ContentElement taskElement = findTaskElement(bundle, start);
+    if (taskElement == null && end > start) {
+      taskElement = findTaskElement(bundle, end - 1);
+    }
+    if (taskElement != null) {
+      CheckBox.refreshTaskMetadata(taskElement);
+    }
+  }
+
+  private static <N, E extends N, T extends N> ContentElement findTaskElement(
+      DocumentContext<N, E, T> bundle, int location) {
+    Point<N> point = bundle.locationMapper().locate(location);
+    if (point == null) {
+      return null;
+    }
+    ContentElement after = asTaskCheckbox(Point.elementAfter(bundle.document(), point));
+    if (after != null) {
+      return after;
+    }
+    return asTaskCheckbox(point.getContainer());
+  }
+
+  private static ContentElement asTaskCheckbox(Object node) {
+    if (!(node instanceof ContentElement)) {
+      return null;
+    }
+    ContentElement element = (ContentElement) node;
+    if (!CheckBox.isCheckBox(element)) {
+      return null;
+    }
+    String name = element.getAttribute(ContentElement.NAME);
+    return name != null && name.startsWith(TaskDocumentUtil.TASK_NAME_PREFIX) ? element : null;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java
@@ -23,6 +23,9 @@ import org.waveprotocol.wave.client.editor.content.CMutableDocument;
 import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.content.ContentNode;
 import org.waveprotocol.wave.model.conversation.AnnotationConstants;
+import org.waveprotocol.wave.model.conversation.TaskMetadataUtil;
+import org.waveprotocol.wave.model.document.ReadableAnnotationSet;
+import org.waveprotocol.wave.model.document.ReadableDocument;
 import org.waveprotocol.wave.model.document.util.Point;
 import org.waveprotocol.wave.model.document.util.XmlStringBuilder;
 
@@ -35,7 +38,6 @@ import org.waveprotocol.wave.model.document.util.XmlStringBuilder;
  * text range.
  */
 public final class TaskDocumentUtil {
-
   /** Prefix applied to the check element name to mark it as a task checkbox. */
   public static final String TASK_NAME_PREFIX = "task:";
 
@@ -65,6 +67,116 @@ public final class TaskDocumentUtil {
     return CheckBox.constructXml(TASK_NAME_PREFIX + taskId, false);
   }
 
+  public static String getTaskAssignee(ReadableDocument<?, ?, ?> doc, int offset) {
+    if (doc == null || offset < 0) {
+      return null;
+    }
+    String assignee;
+    try {
+      assignee = getAnnotationValue(doc, offset, AnnotationConstants.TASK_ASSIGNEE);
+    } catch (RuntimeException e) {
+      return null;
+    }
+    if (assignee == null) {
+      return null;
+    }
+    String normalizedAssignee = assignee.trim();
+    return normalizedAssignee.isEmpty() ? null : normalizedAssignee;
+  }
+
+  public static long getTaskDueTimestamp(ReadableDocument<?, ?, ?> doc, int offset) {
+    if (doc == null || offset < 0) {
+      return -1L;
+    }
+    String dueTs;
+    try {
+      dueTs = getAnnotationValue(doc, offset, AnnotationConstants.TASK_DUE_TS);
+    } catch (RuntimeException e) {
+      return -1L;
+    }
+    if (dueTs == null) {
+      return -1L;
+    }
+    try {
+      long parsed = Long.parseLong(dueTs.trim());
+      return parsed > 0 ? parsed : -1L;
+    } catch (NumberFormatException e) {
+      return -1L;
+    }
+  }
+
+  public static void setTaskAssignee(CMutableDocument doc, int start, int end, String assignee) {
+    String normalizedAssignee = assignee == null ? null : assignee.trim();
+    doc.setAnnotation(start, end, AnnotationConstants.TASK_ASSIGNEE,
+        normalizedAssignee == null || normalizedAssignee.isEmpty() ? null : normalizedAssignee);
+  }
+
+  public static void setTaskDueTimestamp(CMutableDocument doc, int start, int end, long ts) {
+    if (ts <= 0) {
+      clearTaskDueTimestamp(doc, start, end);
+      return;
+    }
+    doc.setAnnotation(start, end, AnnotationConstants.TASK_DUE_TS, String.valueOf(ts));
+  }
+
+  public static void clearTaskDueTimestamp(CMutableDocument doc, int start, int end) {
+    doc.setAnnotation(start, end, AnnotationConstants.TASK_DUE_TS, null);
+  }
+
+  public static String formatTaskOwnerLabel(String participantAddress) {
+    return TaskMetadataUtil.formatTaskOwnerLabel(participantAddress);
+  }
+
+  public static String formatTaskDueLabel(long epochMillis) {
+    return TaskMetadataUtil.formatTaskDueLabel(epochMillis);
+  }
+
+  public static long parseDateInputValue(String yyyyMmDd) {
+    return TaskMetadataUtil.parseDateInputValue(yyyyMmDd);
+  }
+
+  public static String formatDateInputValue(long epochMillis) {
+    return TaskMetadataUtil.formatDateInputValue(epochMillis);
+  }
+
+  public static String getTaskAssignee(ContentElement taskElement) {
+    return taskElement == null ? null
+        : getTaskAssignee(taskElement.getMutableDoc(), taskElement.getMutableDoc().getLocation(taskElement));
+  }
+
+  public static long getTaskDueTimestamp(ContentElement taskElement) {
+    return taskElement == null ? -1L
+        : getTaskDueTimestamp(taskElement.getMutableDoc(),
+            taskElement.getMutableDoc().getLocation(taskElement));
+  }
+
+  public static void setTaskAssignee(ContentElement taskElement, String assignee) {
+    if (taskElement == null) {
+      return;
+    }
+    CMutableDocument doc = taskElement.getMutableDoc();
+    int start = doc.getLocation(taskElement);
+    setTaskAssignee(doc, start, start + 1, assignee);
+  }
+
+  public static void setTaskDueTimestamp(ContentElement taskElement, long ts) {
+    if (taskElement == null) {
+      return;
+    }
+    CMutableDocument doc = taskElement.getMutableDoc();
+    int start = doc.getLocation(taskElement);
+    setTaskDueTimestamp(doc, start, start + 1, ts);
+  }
+
+  public static void clearTaskDueTimestamp(ContentElement taskElement) {
+    if (taskElement == null) {
+      return;
+    }
+    CMutableDocument doc = taskElement.getMutableDoc();
+    int start = doc.getLocation(taskElement);
+    clearTaskDueTimestamp(doc, start, start + 1);
+  }
+
   /**
    * Inserts a task checkbox at the given point in the document and applies
    * task annotations to a small range covering the checkbox.
@@ -85,13 +197,16 @@ public final class TaskDocumentUtil {
     int end = start + 1;  // check element is a single node
 
     doc.setAnnotation(start, end, AnnotationConstants.TASK_ID, taskId);
-    if (assignee != null) {
-      String normalizedAssignee = assignee.trim();
-      if (!normalizedAssignee.isEmpty()) {
-        doc.setAnnotation(start, end, AnnotationConstants.TASK_ASSIGNEE, normalizedAssignee);
-      }
-    }
+    setTaskAssignee(doc, start, end, assignee);
 
     return inserted;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static String getAnnotationValue(ReadableDocument<?, ?, ?> doc, int offset, String key) {
+    if (!(doc instanceof ReadableAnnotationSet)) {
+      return null;
+    }
+    return ((ReadableAnnotationSet<String>) doc).getAnnotation(offset, key);
   }
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.css
@@ -1,0 +1,71 @@
+.self {
+  width: 320px;
+  padding: 18px;
+  background: #ffffff;
+  box-sizing: border-box;
+}
+
+.title {
+  display: block;
+  margin-bottom: 14px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #202124;
+}
+
+.fieldLabel {
+  display: block;
+  margin: 12px 0 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #5f6368;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.input,
+.select {
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  box-sizing: border-box;
+  background: #ffffff;
+  color: #202124;
+  font-size: 14px;
+}
+
+.inputFocused {
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, 0.15);
+}
+
+.buttonPanel {
+  margin-top: 18px;
+  text-align: right;
+}
+
+.cancelButton {
+  margin-right: 8px;
+  padding: 8px 12px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #3c4043;
+}
+
+.saveButton {
+  padding: 8px 12px;
+  border: 1px solid #1a73e8;
+  border-radius: 8px;
+  background: #1a73e8;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.errorLabel {
+  display: none;
+  margin-top: 8px;
+  font-size: 12px;
+  color: #b42318;
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
@@ -231,11 +231,8 @@ public final class TaskMetadataPopup extends Composite {
     assigneeList.addItem("Unassigned", "");
 
     List<ParticipantId> participants = new ArrayList<ParticipantId>();
-    Iterable<ParticipantId> participantIds = conversation.getParticipantIds();
-    if (participantIds != null) {
-      for (ParticipantId participant : participantIds) {
-        participants.add(participant);
-      }
+    if (conversation.getParticipantIds() != null) {
+      participants.addAll(conversation.getParticipantIds());
     }
     Collections.sort(participants, new Comparator<ParticipantId>() {
       @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
@@ -295,6 +295,7 @@ public final class TaskMetadataPopup extends Composite {
   }
 
   private void submit() {
+    clearError();
     String dueValue = dueDateInput.getText() == null ? "" : dueDateInput.getText().trim();
     long dueTs = dueValue.isEmpty() ? -1L : TaskDocumentUtil.parseDateInputValue(dueValue);
     if (!dueValue.isEmpty() && dueTs < 0) {
@@ -319,6 +320,11 @@ public final class TaskMetadataPopup extends Composite {
   private void showError(String message) {
     errorLabel.setText(message);
     errorLabel.getElement().getStyle().setProperty("display", "block");
+  }
+
+  private void clearError() {
+    errorLabel.setText("");
+    errorLabel.getElement().getStyle().setProperty("display", "none");
   }
 
   private static String displayParticipant(String address, boolean isSignedInUser) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.wavepanel.impl.edit;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.StyleInjector;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.ListBox;
+import com.google.gwt.user.client.ui.TextBox;
+
+import org.waveprotocol.wave.client.editor.content.ContentElement;
+import org.waveprotocol.wave.client.doodad.form.check.CheckBox;
+import org.waveprotocol.wave.client.doodad.form.check.TaskDocumentUtil;
+import org.waveprotocol.wave.client.widget.popup.CenterPopupPositioner;
+import org.waveprotocol.wave.client.widget.popup.PopupChrome;
+import org.waveprotocol.wave.client.widget.popup.PopupChromeFactory;
+import org.waveprotocol.wave.client.widget.popup.PopupFactory;
+import org.waveprotocol.wave.client.widget.popup.UniversalPopup;
+import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.wave.model.conversation.TaskMetadataUtil;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Styled popup for editing task assignee and due-date metadata.
+ */
+public final class TaskMetadataPopup extends Composite {
+
+  public interface Resources extends ClientBundle {
+    @Source("TaskMetadataPopup.css")
+    Style style();
+  }
+
+  interface Style extends CssResource {
+    String self();
+    String title();
+    String fieldLabel();
+    String input();
+    String inputFocused();
+    String select();
+    String buttonPanel();
+    String cancelButton();
+    String saveButton();
+    String errorLabel();
+  }
+
+  private static final Style style = GWT.<Resources>create(Resources.class).style();
+
+  private static Conversation configuredConversation;
+  private static ParticipantId configuredSignedInUser;
+
+  static {
+    if (style != null) {
+      StyleInjector.inject(style.getText(), true);
+    }
+  }
+
+  public static void configure(Conversation conversation, ParticipantId signedInUser) {
+    configuredConversation = conversation;
+    configuredSignedInUser = signedInUser;
+  }
+
+  public static boolean isConfigured() {
+    return configuredConversation != null && configuredSignedInUser != null;
+  }
+
+  public static void show(ContentElement taskElement) {
+    if (taskElement == null || !isConfigured()) {
+      return;
+    }
+    new TaskMetadataPopup(taskElement, configuredConversation, configuredSignedInUser).show();
+  }
+
+  private final ContentElement taskElement;
+  private final Conversation conversation;
+  private final ParticipantId signedInUser;
+  private final String initialAssignee;
+  private final long initialDueTimestamp;
+
+  private final Label titleLabel;
+  private final ListBox assigneeList;
+  private final TextBox dueDateInput;
+  private final Label errorLabel;
+  private final Button saveButton;
+  private final Button cancelButton;
+
+  private UniversalPopup popup;
+
+  private TaskMetadataPopup(ContentElement taskElement, Conversation conversation,
+      ParticipantId signedInUser) {
+    this.taskElement = taskElement;
+    this.conversation = conversation;
+    this.signedInUser = signedInUser;
+    this.initialAssignee = TaskDocumentUtil.getTaskAssignee(taskElement);
+    this.initialDueTimestamp = TaskDocumentUtil.getTaskDueTimestamp(taskElement);
+
+    FlowPanel panel = new FlowPanel();
+    panel.addStyleName(style.self());
+
+    titleLabel = new Label("Task details");
+    titleLabel.addStyleName(style.title());
+    panel.add(titleLabel);
+
+    Label assigneeLabel = new Label("Assignee");
+    assigneeLabel.addStyleName(style.fieldLabel());
+    panel.add(assigneeLabel);
+
+    assigneeList = new ListBox();
+    assigneeList.addStyleName(style.select());
+    panel.add(assigneeList);
+
+    Label dueDateLabel = new Label("Due date");
+    dueDateLabel.addStyleName(style.fieldLabel());
+    panel.add(dueDateLabel);
+
+    dueDateInput = new TextBox();
+    dueDateInput.addStyleName(style.input());
+    dueDateInput.getElement().setAttribute("type", "date");
+    dueDateInput.getElement().setAttribute("placeholder", "YYYY-MM-DD");
+    panel.add(dueDateInput);
+
+    errorLabel = new Label();
+    errorLabel.addStyleName(style.errorLabel());
+    panel.add(errorLabel);
+
+    FlowPanel buttonPanel = new FlowPanel();
+    buttonPanel.addStyleName(style.buttonPanel());
+
+    cancelButton = new Button("Cancel");
+    cancelButton.addStyleName(style.cancelButton());
+    buttonPanel.add(cancelButton);
+
+    saveButton = new Button("Save");
+    saveButton.addStyleName(style.saveButton());
+    buttonPanel.add(saveButton);
+
+    panel.add(buttonPanel);
+    initWidget(panel);
+
+    wireFocusStyles();
+    populateAssigneeOptions();
+    if (initialDueTimestamp > 0) {
+      dueDateInput.setText(TaskDocumentUtil.formatDateInputValue(initialDueTimestamp));
+    }
+    errorLabel.getElement().getStyle().setProperty("display", "none");
+  }
+
+  private void show() {
+    PopupChrome chrome = PopupChromeFactory.createPopupChrome();
+    popup = PopupFactory.createPopup(null, new CenterPopupPositioner(), chrome, true);
+    popup.add(this);
+    popup.setMaskEnabled(true);
+
+    saveButton.addClickHandler(new ClickHandler() {
+      @Override
+      public void onClick(ClickEvent event) {
+        submit();
+      }
+    });
+
+    cancelButton.addClickHandler(new ClickHandler() {
+      @Override
+      public void onClick(ClickEvent event) {
+        popup.hide();
+      }
+    });
+
+    KeyDownHandler keyHandler = new KeyDownHandler() {
+      @Override
+      public void onKeyDown(KeyDownEvent event) {
+        if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+          submit();
+        } else if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE) {
+          popup.hide();
+        }
+      }
+    };
+    assigneeList.addKeyDownHandler(keyHandler);
+    dueDateInput.addKeyDownHandler(keyHandler);
+
+    popup.show();
+
+    Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        assigneeList.setFocus(true);
+      }
+    });
+  }
+
+  private void populateAssigneeOptions() {
+    assigneeList.clear();
+    assigneeList.addItem("Unassigned", "");
+
+    List<ParticipantId> participants = new ArrayList<ParticipantId>();
+    Iterable<ParticipantId> participantIds = conversation.getParticipantIds();
+    if (participantIds != null) {
+      for (ParticipantId participant : participantIds) {
+        participants.add(participant);
+      }
+    }
+    Collections.sort(participants, new Comparator<ParticipantId>() {
+      @Override
+      public int compare(ParticipantId left, ParticipantId right) {
+        boolean leftIsMe = left.equals(signedInUser);
+        boolean rightIsMe = right.equals(signedInUser);
+        if (leftIsMe && !rightIsMe) {
+          return -1;
+        }
+        if (!leftIsMe && rightIsMe) {
+          return 1;
+        }
+        return left.getAddress().compareToIgnoreCase(right.getAddress());
+      }
+    });
+
+    Set<String> knownAddresses = new HashSet<String>();
+    for (ParticipantId participant : participants) {
+      String address = participant.getAddress();
+      knownAddresses.add(address);
+      assigneeList.addItem(displayParticipant(address, participant.equals(signedInUser)), address);
+    }
+
+    if (initialAssignee != null && !knownAddresses.contains(initialAssignee)) {
+      assigneeList.addItem(initialAssignee + " (not in wave)", initialAssignee);
+    }
+
+    selectAssignee(initialAssignee);
+  }
+
+  private void selectAssignee(String assignee) {
+    String normalized = assignee == null ? "" : assignee;
+    for (int i = 0; i < assigneeList.getItemCount(); i++) {
+      if (normalized.equals(assigneeList.getValue(i))) {
+        assigneeList.setSelectedIndex(i);
+        return;
+      }
+    }
+    assigneeList.setSelectedIndex(0);
+  }
+
+  private void wireFocusStyles() {
+    FocusHandler focusHandler = new FocusHandler() {
+      @Override
+      public void onFocus(FocusEvent event) {
+        dueDateInput.addStyleName(style.inputFocused());
+      }
+    };
+    BlurHandler blurHandler = new BlurHandler() {
+      @Override
+      public void onBlur(BlurEvent event) {
+        dueDateInput.removeStyleName(style.inputFocused());
+      }
+    };
+    dueDateInput.addFocusHandler(focusHandler);
+    dueDateInput.addBlurHandler(blurHandler);
+  }
+
+  private void submit() {
+    String dueValue = dueDateInput.getText() == null ? "" : dueDateInput.getText().trim();
+    long dueTs = dueValue.isEmpty() ? -1L : TaskDocumentUtil.parseDateInputValue(dueValue);
+    if (!dueValue.isEmpty() && dueTs < 0) {
+      showError("Use a valid date in YYYY-MM-DD format.");
+      dueDateInput.setFocus(true);
+      return;
+    }
+
+    String assignee = assigneeList.getSelectedIndex() >= 0
+        ? assigneeList.getValue(assigneeList.getSelectedIndex()) : "";
+    TaskDocumentUtil.setTaskAssignee(taskElement, assignee);
+    if (dueTs < 0) {
+      TaskDocumentUtil.clearTaskDueTimestamp(taskElement);
+    } else {
+      TaskDocumentUtil.setTaskDueTimestamp(taskElement, dueTs);
+    }
+
+    CheckBox.refreshTaskMetadata(taskElement);
+    popup.hide();
+  }
+
+  private void showError(String message) {
+    errorLabel.setText(message);
+    errorLabel.getElement().getStyle().setProperty("display", "block");
+  }
+
+  private static String displayParticipant(String address, boolean isSignedInUser) {
+    String display = TaskMetadataUtil.formatParticipantDisplay(address);
+    return isSignedInUser ? display + " (you)" : display;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java
@@ -43,6 +43,7 @@ import org.waveprotocol.wave.client.editor.util.EditorAnnotationUtil;
 import org.waveprotocol.wave.client.wavepanel.impl.toolbar.attachment.AttachmentPopupWidget;
 import org.waveprotocol.wave.client.wavepanel.impl.toolbar.attachment.ClipboardImageUploader;
 import org.waveprotocol.wave.client.wavepanel.impl.toolbar.color.ColorHelper;
+import org.waveprotocol.wave.client.wavepanel.impl.edit.TaskMetadataPopup;
 import org.waveprotocol.wave.client.wavepanel.view.AttachmentPopupView;
 import org.waveprotocol.wave.client.wavepanel.view.AttachmentPopupView.Listener;
 import org.waveprotocol.wave.client.widget.toolbar.SubmenuToolbarView;
@@ -628,7 +629,8 @@ public class EditToolbar {
               }
             }
             String taskId = TaskDocumentUtil.generateTaskId();
-            TaskDocumentUtil.insertTask(doc, point, taskId, user.getAddress());
+            ContentElement inserted = TaskDocumentUtil.insertTask(doc, point, taskId, user.getAddress());
+            TaskMetadataPopup.show(inserted);
           }
         });
     taskBtn.setVisualElement(createSvgIcon(ICON_TASK));

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
@@ -19,8 +19,6 @@
 
 package org.waveprotocol.wave.model.conversation;
 
-import java.util.Date;
-
 /**
  * Shared helpers for task ownership and due-date metadata.
  *
@@ -64,6 +62,9 @@ public final class TaskMetadataUtil {
   /**
    * Parses a {@code yyyy-MM-dd} date input into UTC-midnight epoch millis.
    *
+   * <p>Stores UTC midnight so the date is the same for all collaborators
+   * regardless of their local timezone.
+   *
    * @return epoch millis, or {@code -1} when the input is blank or invalid
    */
   public static long parseDateInputValue(String rawValue) {
@@ -84,40 +85,67 @@ public final class TaskMetadataUtil {
       return -1L;
     }
 
-    Date localMidnight = new Date(year - 1900, month - 1, day, 0, 0, 0);
-    return localMidnight.getTime() - localMidnight.getTimezoneOffset() * 60L * 1000L;
+    return toUtcMidnightMillis(year, month, day);
   }
 
   /**
-   * Formats epoch millis into a {@code yyyy-MM-dd} input value.
+   * Formats UTC-midnight epoch millis into a {@code yyyy-MM-dd} input value.
    */
   public static String formatDateInputValue(long dueTs) {
     if (dueTs < 0) {
       return "";
     }
-    Date utcDate = toUtcDate(dueTs);
-    return zeroPad(utcDate.getYear() + 1900, 4)
-        + "-"
-        + zeroPad(utcDate.getMonth() + 1, 2)
-        + "-"
-        + zeroPad(utcDate.getDate(), 2);
+    int[] ymd = fromUtcMidnightMillis(dueTs);
+    return zeroPad(ymd[0], 4) + "-" + zeroPad(ymd[1], 2) + "-" + zeroPad(ymd[2], 2);
   }
 
   /**
-   * Formats a due-date pill label.
+   * Formats a due-date pill label from UTC-midnight epoch millis.
    */
   public static String formatTaskDueLabel(long dueTs) {
     if (dueTs < 0) {
       return "";
     }
-    Date utcDate = toUtcDate(dueTs);
-    String month = MONTH_ABBREVIATIONS[utcDate.getMonth()];
-    return "Due " + month + " " + utcDate.getDate();
+    int[] ymd = fromUtcMidnightMillis(dueTs);
+    String month = MONTH_ABBREVIATIONS[ymd[1] - 1];
+    return "Due " + month + " " + ymd[2];
   }
 
-  private static Date toUtcDate(long epochMillis) {
-    Date localDate = new Date(epochMillis);
-    return new Date(epochMillis + localDate.getTimezoneOffset() * 60L * 1000L);
+  /**
+   * Converts a calendar date (year/month/day) to UTC-midnight epoch millis.
+   * Uses the Hinnant civil-from-days algorithm for timezone-independent arithmetic.
+   */
+  private static long toUtcMidnightMillis(int year, int month, int day) {
+    long y = month <= 2 ? year - 1 : year;
+    long m = month <= 2 ? month + 9 : month - 3;
+    long era = (y >= 0 ? y : y - 399) / 400;
+    long yoe = y - era * 400;
+    long doy = (153 * m + 2) / 5 + day - 1;
+    long doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    long days = era * 146097 + doe - 719468;
+    return days * 86400000L;
+  }
+
+  /**
+   * Converts UTC-midnight epoch millis to a [year, month, day] array.
+   * Uses the Hinnant days-from-civil algorithm for timezone-independent arithmetic.
+   */
+  private static int[] fromUtcMidnightMillis(long millis) {
+    long z = millis / 86400000L;
+    if (millis < 0 && millis % 86400000L != 0) {
+      z--;
+    }
+    z += 719468;
+    long era = (z >= 0 ? z : z - 146096) / 146097;
+    long doe = z - era * 146097;
+    long yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    long y = yoe + era * 400;
+    long doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    long mp = (5 * doy + 2) / 153;
+    long d = doy - (153 * mp + 2) / 5 + 1;
+    long m = mp + (mp < 10 ? 3 : -9);
+    y += (m <= 2 ? 1 : 0);
+    return new int[]{(int) y, (int) m, (int) d};
   }
 
   private static String normalize(String value) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.conversation;
+
+import java.util.Date;
+
+/**
+ * Shared helpers for task ownership and due-date metadata.
+ *
+ * <p>These helpers live in a non-client package so they can be exercised by the
+ * default JVM test runner and reused by the GWT client task UI code.
+ */
+@SuppressWarnings("deprecation")
+public final class TaskMetadataUtil {
+
+  private static final String[] MONTH_ABBREVIATIONS = {
+      "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  };
+
+  private TaskMetadataUtil() {
+  }
+
+  /**
+   * Formats an owner pill label from a participant identifier.
+   */
+  public static String formatTaskOwnerLabel(String assignee) {
+    String display = formatParticipantDisplay(assignee);
+    if (display.isEmpty()) {
+      return "";
+    }
+    return "Owner " + display;
+  }
+
+  /**
+   * Formats a participant identifier for compact UI display.
+   */
+  public static String formatParticipantDisplay(String participantAddress) {
+    String normalized = normalize(participantAddress);
+    if (normalized.isEmpty()) {
+      return "";
+    }
+    int at = normalized.indexOf('@');
+    return at > 0 ? normalized.substring(0, at) : normalized;
+  }
+
+  /**
+   * Parses a {@code yyyy-MM-dd} date input into UTC-midnight epoch millis.
+   *
+   * @return epoch millis, or {@code -1} when the input is blank or invalid
+   */
+  public static long parseDateInputValue(String rawValue) {
+    String value = normalize(rawValue);
+    if (value.isEmpty() || value.length() != 10
+        || value.charAt(4) != '-' || value.charAt(7) != '-') {
+      return -1L;
+    }
+
+    int year = parseInt(value.substring(0, 4));
+    int month = parseInt(value.substring(5, 7));
+    int day = parseInt(value.substring(8, 10));
+    if (year < 0 || month < 1 || month > 12) {
+      return -1L;
+    }
+    int maxDay = daysInMonth(year, month);
+    if (day < 1 || day > maxDay) {
+      return -1L;
+    }
+
+    Date localMidnight = new Date(year - 1900, month - 1, day, 0, 0, 0);
+    return localMidnight.getTime() - localMidnight.getTimezoneOffset() * 60L * 1000L;
+  }
+
+  /**
+   * Formats epoch millis into a {@code yyyy-MM-dd} input value.
+   */
+  public static String formatDateInputValue(long dueTs) {
+    if (dueTs < 0) {
+      return "";
+    }
+    Date utcDate = toUtcDate(dueTs);
+    return zeroPad(utcDate.getYear() + 1900, 4)
+        + "-"
+        + zeroPad(utcDate.getMonth() + 1, 2)
+        + "-"
+        + zeroPad(utcDate.getDate(), 2);
+  }
+
+  /**
+   * Formats a due-date pill label.
+   */
+  public static String formatTaskDueLabel(long dueTs) {
+    if (dueTs < 0) {
+      return "";
+    }
+    Date utcDate = toUtcDate(dueTs);
+    String month = MONTH_ABBREVIATIONS[utcDate.getMonth()];
+    return "Due " + month + " " + utcDate.getDate();
+  }
+
+  private static Date toUtcDate(long epochMillis) {
+    Date localDate = new Date(epochMillis);
+    return new Date(epochMillis + localDate.getTimezoneOffset() * 60L * 1000L);
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  private static int parseInt(String value) {
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  private static int daysInMonth(int year, int month) {
+    switch (month) {
+      case 1:
+      case 3:
+      case 5:
+      case 7:
+      case 8:
+      case 10:
+      case 12:
+        return 31;
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        return 30;
+      case 2:
+        return isLeapYear(year) ? 29 : 28;
+      default:
+        return 0;
+    }
+  }
+
+  private static boolean isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+  }
+
+  private static String zeroPad(int value, int width) {
+    String stringValue = String.valueOf(value);
+    if (stringValue.length() >= width) {
+      return stringValue;
+    }
+    StringBuilder builder = new StringBuilder(width);
+    for (int i = stringValue.length(); i < width; i++) {
+      builder.append('0');
+    }
+    builder.append(stringValue);
+    return builder.toString();
+  }
+}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/doodad/form/check/CheckBase.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/doodad/form/check/CheckBase.css
@@ -21,11 +21,53 @@
  * Author: lars@google.com (Lars Rasmussen)
  */
 
-@external task-completed;
+@external task-completed task-check-span task-meta task-pill task-owner-pill task-due-pill task-meta-empty;
 
 .check, .radio {
   padding:4px;
   cursor: pointer;
+}
+
+.task-check-span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.task-meta {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 6px;
+  cursor: pointer;
+}
+
+.task-meta:focus {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
+}
+
+.task-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+.task-owner-pill {
+  background: #e8f0fe;
+  color: #174ea6;
+}
+
+.task-due-pill {
+  background: #fff4e5;
+  color: #9a6700;
+}
+
+.task-meta-empty {
+  background: #f1f3f4;
+  color: #5f6368;
 }
 
 .task-completed {

--- a/wave/src/test/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtilTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtilTest.java
@@ -21,8 +21,16 @@ package org.waveprotocol.wave.client.doodad.form.check;
 
 import junit.framework.TestCase;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.HashSet;
 import java.util.Set;
+
+import org.waveprotocol.wave.client.editor.content.CMutableDocument;
+import org.waveprotocol.wave.model.conversation.AnnotationConstants;
+import org.waveprotocol.wave.model.document.ReadableAnnotationSet;
 
 /**
  * Tests for {@link TaskDocumentUtil}.
@@ -68,5 +76,49 @@ public class TaskDocumentUtilTest extends TestCase {
 
   public void testTaskNamePrefix() {
     assertEquals("task:", TaskDocumentUtil.TASK_NAME_PREFIX);
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testGetTaskAssigneeTrimsWhitespaceAndBlankValues() {
+    ReadableAnnotationSet<String> doc = mock(ReadableAnnotationSet.class);
+    when(doc.getAnnotation(7, AnnotationConstants.TASK_ASSIGNEE)).thenReturn("  alice@example.com  ");
+    assertEquals("alice@example.com", TaskDocumentUtil.getTaskAssignee(doc, 7));
+
+    when(doc.getAnnotation(8, AnnotationConstants.TASK_ASSIGNEE)).thenReturn("   ");
+    assertNull(TaskDocumentUtil.getTaskAssignee(doc, 8));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void testGetTaskDueTimestampParsesWhitespaceAndRejectsInvalidValues() {
+    ReadableAnnotationSet<String> doc = mock(ReadableAnnotationSet.class);
+    when(doc.getAnnotation(7, AnnotationConstants.TASK_DUE_TS)).thenReturn(" 12345 ");
+    assertEquals(12345L, TaskDocumentUtil.getTaskDueTimestamp(doc, 7));
+
+    when(doc.getAnnotation(8, AnnotationConstants.TASK_DUE_TS)).thenReturn("bogus");
+    assertEquals(-1L, TaskDocumentUtil.getTaskDueTimestamp(doc, 8));
+  }
+
+  public void testSetTaskAssigneeTrimsWhitespaceAndClearsBlankValues() {
+    CMutableDocument doc = mock(CMutableDocument.class);
+    TaskDocumentUtil.setTaskAssignee(doc, 2, 5, "  alice@example.com  ");
+    verify(doc).setAnnotation(2, 5, AnnotationConstants.TASK_ASSIGNEE, "alice@example.com");
+
+    TaskDocumentUtil.setTaskAssignee(doc, 2, 5, "   ");
+    verify(doc).setAnnotation(2, 5, AnnotationConstants.TASK_ASSIGNEE, null);
+  }
+
+  public void testSetTaskDueTimestampWritesAndClearsValues() {
+    CMutableDocument doc = mock(CMutableDocument.class);
+    TaskDocumentUtil.setTaskDueTimestamp(doc, 3, 6, 12345L);
+    verify(doc).setAnnotation(3, 6, AnnotationConstants.TASK_DUE_TS, "12345");
+
+    TaskDocumentUtil.setTaskDueTimestamp(doc, 3, 6, 0L);
+    verify(doc).setAnnotation(3, 6, AnnotationConstants.TASK_DUE_TS, null);
+  }
+
+  public void testClearTaskDueTimestampRemovesAnnotation() {
+    CMutableDocument doc = mock(CMutableDocument.class);
+    TaskDocumentUtil.clearTaskDueTimestamp(doc, 4, 9);
+    verify(doc).setAnnotation(4, 9, AnnotationConstants.TASK_DUE_TS, null);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.conversation;
+
+import junit.framework.TestCase;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Unit tests for shared task metadata formatting and parsing helpers.
+ */
+public class TaskMetadataUtilTest extends TestCase {
+
+  public void testFormatTaskOwnerLabelStripsDomainForEmailAddress() {
+    assertEquals("Owner alice",
+        TaskMetadataUtil.formatTaskOwnerLabel("alice@example.com"));
+  }
+
+  public void testFormatParticipantDisplayStripsDomainForEmailAddress() {
+    assertEquals("alice",
+        TaskMetadataUtil.formatParticipantDisplay("alice@example.com"));
+  }
+
+  public void testFormatTaskOwnerLabelKeepsOpaqueIdentifier() {
+    assertEquals("Owner build-bot",
+        TaskMetadataUtil.formatTaskOwnerLabel("build-bot"));
+  }
+
+  public void testParseDateInputValueRoundTripsThroughFormatter() {
+    long dueTs = TaskMetadataUtil.parseDateInputValue("2026-04-15");
+    assertEquals("2026-04-15", TaskMetadataUtil.formatDateInputValue(dueTs));
+  }
+
+  public void testParseDateInputValueRejectsInvalidDate() {
+    assertEquals(-1L, TaskMetadataUtil.parseDateInputValue("2026-13-40"));
+  }
+
+  public void testFormatTaskDueLabelUsesMonthDay() {
+    long dueTs = TaskMetadataUtil.parseDateInputValue("2026-04-15");
+    assertEquals("Due Apr 15", TaskMetadataUtil.formatTaskDueLabel(dueTs));
+  }
+
+  public void testDateParsingAndFormattingIgnoreDefaultTimezone() {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+      long expected = utcMillis(2026, Calendar.APRIL, 15);
+      long parsed = TaskMetadataUtil.parseDateInputValue("2026-04-15");
+      assertEquals(expected, parsed);
+      assertEquals("2026-04-15", TaskMetadataUtil.formatDateInputValue(parsed));
+      assertEquals("Due Apr 15", TaskMetadataUtil.formatTaskDueLabel(parsed));
+    } finally {
+      TimeZone.setDefault(original);
+    }
+  }
+
+  private static long utcMillis(int year, int month, int dayOfMonth) {
+    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+    calendar.clear();
+    calendar.set(year, month, dayOfMonth, 0, 0, 0);
+    return calendar.getTimeInMillis();
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
@@ -21,9 +21,6 @@ package org.waveprotocol.wave.model.conversation;
 
 import junit.framework.TestCase;
 
-import java.util.Calendar;
-import java.util.TimeZone;
-
 /**
  * Unit tests for shared task metadata formatting and parsing helpers.
  */
@@ -58,24 +55,27 @@ public class TaskMetadataUtilTest extends TestCase {
     assertEquals("Due Apr 15", TaskMetadataUtil.formatTaskDueLabel(dueTs));
   }
 
-  public void testDateParsingAndFormattingIgnoreDefaultTimezone() {
-    TimeZone original = TimeZone.getDefault();
-    try {
-      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
-      long expected = utcMillis(2026, Calendar.APRIL, 15);
-      long parsed = TaskMetadataUtil.parseDateInputValue("2026-04-15");
-      assertEquals(expected, parsed);
-      assertEquals("2026-04-15", TaskMetadataUtil.formatDateInputValue(parsed));
-      assertEquals("Due Apr 15", TaskMetadataUtil.formatTaskDueLabel(parsed));
-    } finally {
-      TimeZone.setDefault(original);
-    }
+  public void testParseDateInputValueIsUtcMidnight() {
+    // 2026-04-15T00:00:00Z = 1776211200000 ms since epoch
+    assertEquals(1776211200000L, TaskMetadataUtil.parseDateInputValue("2026-04-15"));
   }
 
-  private static long utcMillis(int year, int month, int dayOfMonth) {
-    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-    calendar.clear();
-    calendar.set(year, month, dayOfMonth, 0, 0, 0);
-    return calendar.getTimeInMillis();
+  public void testFormatDateInputValueHandlesUtcMidnight() {
+    // 1776211200000 ms = 2026-04-15T00:00:00Z
+    assertEquals("2026-04-15", TaskMetadataUtil.formatDateInputValue(1776211200000L));
+  }
+
+  public void testParseDateInputValueRejectsBlankInput() {
+    assertEquals(-1L, TaskMetadataUtil.parseDateInputValue(""));
+    assertEquals(-1L, TaskMetadataUtil.parseDateInputValue(null));
+    assertEquals(-1L, TaskMetadataUtil.parseDateInputValue("   "));
+  }
+
+  public void testFormatDateInputValueReturnsEmptyForNegative() {
+    assertEquals("", TaskMetadataUtil.formatDateInputValue(-1L));
+  }
+
+  public void testFormatTaskDueLabelReturnsEmptyForNegative() {
+    assertEquals("", TaskMetadataUtil.formatTaskDueLabel(-1L));
   }
 }


### PR DESCRIPTION
## Summary

Implements the deferred task metadata UX from #779 on top of the merged Wave Tasks base feature from #737 / PR #739.

This keeps the existing task document model intact (`<check name="task:<id>"/>` plus `task/assignee` and `task/dueTs`) and adds the missing client-side layer:

- `Insert task` now opens a `Task details` popup immediately after insertion
- the popup lets users assign the task to any current wave participant and set or clear a due date
- task rows now render explicit owner / due-date pills beside the checkbox so ownership is visually clear and distinct from `@mentions`
- clicking the pills reopens the popup for later edits
- task metadata pill refresh is wired to the `task/*` annotation change path so local edits update in place

## Why

PR #739 intentionally shipped the base task model/search/rendering path but deferred `TaskMetadataPopup` and the richer assignee / due-date UI. That left task ownership unclear in-wave and made due dates effectively write-only metadata. This PR closes that UX gap without changing the annotation schema or widening the scope into reminder delivery.

## Validation

- `sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest" wave/compile compileGwt`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `sbt prepareServerConfig run`
- Local browser sanity on `http://127.0.0.1:9898`
  - registered fresh users `task779lane@local.net` and `task779peer@local.net`
  - created a new wave and added the second participant
  - inserted a task, verified popup opened immediately
  - assigned the task to the second participant and set due date `2026-04-15`
  - verified in-wave pills updated to `Owner task779peer` and `Due Apr 15`
  - reopened the popup from the pills, cleared assignee + due date, and verified the row returned to `Add details`
  - browser console errors after the final fix: `0`

## Artifacts

- Plan: `docs/superpowers/plans/2026-04-09-issue-779-task-metadata-ui.md`
- Local verification note: `journal/local-verification/2026-04-09-issue-779-task-metadata-ui.md`
- Changelog fragment: `wave/config/changelog.d/2026-04-09-task-metadata-ui.json`

Closes #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task metadata popup for assignee and due-date when inserting or editing tasks
  * Inline owner and due-date “pills” rendered next to task checkboxes; click to reopen popup
  * Metadata refresh so checkbox UI updates when task annotations change

* **Bug Fixes**
  * Mitigated task-insert race condition with conservative offset handling

* **Tests**
  * Unit tests for metadata formatting/parsing and document read/write behavior

* **Documentation**
  * Implementation plan, verification journal, and changelog entry added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->