### PR TITLE
docs: narrow issue 724 to the stale ServerMain build reference

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-724-jakarta-cleanup-revalidation-plan.md
+++ b/docs/superpowers/plans/2026-04-10-issue-724-jakarta-cleanup-revalidation-plan.md
@@ -1,0 +1,65 @@
+# Issue 724 Jakarta Cleanup Revalidation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-check issue `#724` against the current repo state, keep the stale deletion/rename scope out of this branch, and fix only the one confirmed stale inline build-reference comment.
+
+**Architecture:** Treat the current dual-source Jakarta layout as authoritative. The implementation branch does not delete any duplicate main-tree classes or rename `wave/src/jakarta-overrides/`; it only corrects the main-tree `ServerMain` comment so it points readers to the active source-selection file (`build.sbt`) and leaves the runtime guidance intact.
+
+**Tech Stack:** Java source comments, Markdown issue evidence, `rg`, `git diff`
+
+---
+
+### Task 1: Fix The Only Confirmed Stale Inline Reference
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
+- Verify: `docs/architecture/jakarta-dual-source.md`
+- Verify: `build.sbt`
+
+- [ ] **Step 1: Confirm the stale reference is still present**
+
+Run: `rg -n "mainExactExcludes in build\\.gradle|jakarta-overrides variant of ServerMain" wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
+
+Expected: two matches: one line that still says `build.gradle` and one line that still explains the active `jakarta-overrides` variant.
+
+- [ ] **Step 2: Replace only the stale build-file reference**
+
+Update the adjacent inline comment block in `wave/src/main/java/org/waveprotocol/box/server/ServerMain.java` from:
+
+```java
+    // Note: this javax ServerMain is excluded from compilation (see mainExactExcludes in build.gradle).
+    // The active registration lives in the jakarta-overrides variant of ServerMain.
+```
+
+to:
+
+```java
+    // Note: this javax-era ServerMain is excluded from compilation (see mainExactExcludes in build.sbt).
+    // The active registration lives in the jakarta-overrides variant of ServerMain.
+```
+
+- [ ] **Step 3: Verify the targeted cleanup stayed narrow**
+
+Run: `rg -n "mainExactExcludes in build\\.sbt|mainExactExcludes in build\\.gradle" wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
+
+Expected: the `build.sbt` reference remains and the `build.gradle` reference no longer appears in that file.
+
+Run: `git diff -- wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
+
+Expected: only the two-line inline comment block is touched, with no runtime logic changes.
+
+- [ ] **Step 4: Record the stale-vs-current findings in the issue and PR summary**
+
+Capture:
+- the 48 duplicate paths still exist but are intentionally preserved by the current dual-source architecture
+- `build.sbt` still actively references `wave/src/jakarta-overrides/java/`
+- deleting the duplicate main-tree files and renaming `wave/src/jakarta-overrides/` are out of scope because those parts of the issue text are stale in the current repo
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-04-10-issue-724-jakarta-cleanup-revalidation-plan.md \
+  wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
+git commit -m "docs: revalidate issue 724 jakarta cleanup scope"
+```

--- a/journal/local-verification/2026-04-10-issue-724-jakarta-cleanup.md
+++ b/journal/local-verification/2026-04-10-issue-724-jakarta-cleanup.md
@@ -1,0 +1,66 @@
+# Issue 724 Local Verification
+
+Date: 2026-04-10 02:41:57 IDT
+Worktree: `/Users/vega/devroot/worktrees/issue-724-jakarta-cleanup-20260410`
+Branch: `issue-724-jakarta-cleanup-20260410`
+Plan: `docs/superpowers/plans/2026-04-10-issue-724-jakarta-cleanup-revalidation-plan.md`
+
+## Investigation Evidence
+
+Command:
+```bash
+comm -12 /tmp/issue724-overrides.txt /tmp/issue724-main.txt | wc -l
+```
+
+Result:
+- PASS
+- confirmed `48` duplicate main/Jakarta paths still exist in the current tree
+
+Command:
+```bash
+rg -n "jakarta-overrides|mainExactExcludes|ServerMain\.java" build.sbt | sed -n '1,12p'
+```
+
+Result:
+- PASS
+- confirmed `build.sbt` still actively references `wave/src/jakarta-overrides/java/`
+- confirmed `mainExactExcludes` still includes `org/waveprotocol/box/server/ServerMain.java`
+- this invalidates the stale issue claim that build configs no longer reference `jakarta-overrides`
+
+## Automated Verification
+
+Command:
+```bash
+rg -n "mainExactExcludes in build\.sbt|mainExactExcludes in build\.gradle|jakarta-overrides variant of ServerMain" wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
+```
+
+Result:
+- PASS
+- line `498` now points to `build.sbt`
+- line `499` still documents that the active registration lives in the `jakarta-overrides` variant
+- no `build.gradle` reference remains in that file
+
+Command:
+```bash
+git diff --check
+```
+
+Result:
+- PASS
+- no whitespace or patch-application errors
+
+## Review
+
+Direct review:
+- PASS
+- no findings; the diff is limited to one inline Java comment plus the task plan file
+
+External Claude review:
+- PASS
+- plan review: pass; scope stays limited to the stale `build.gradle` comment and explicitly avoids file deletion or directory rename
+- implementation review: pass; no blockers or important concerns, only a minor note that `javax` -> `javax-era` is comment-only clarification
+
+## Local Server Sanity
+
+Not required:
+- the branch changes documentation/comment text only and does not affect runtime behavior

--- a/wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/ServerMain.java
@@ -495,7 +495,7 @@ public class ServerMain {
     server.addServlet("/iniavatars/*", InitialsAvatarsServlet.class);
     server.addServlet("/wave/public/*", PublicWaveFetchServlet.class);
     server.addServlet("/waveref/*", WaveRefServlet.class);
-    // Note: this javax ServerMain is excluded from compilation (see mainExactExcludes in build.gradle).
+    // Note: this javax-era ServerMain is excluded from compilation (see mainExactExcludes in build.sbt).
     // The active registration lives in the jakarta-overrides variant of ServerMain.
     server.addServlet("/folder/*", FolderServlet.class);
     server.addServlet("/searches", SearchesServlet.class);


### PR DESCRIPTION
Refs #724

## Summary
- revalidate issue `#724` against the current Jakarta dual-source repo state
- keep the stale deletion/rename proposals out of scope for this branch
- fix the one confirmed stale inline reference in `wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
- add the task plan and local verification record for traceability

## What Turned Out To Be Stale
- the 48 duplicate `src/main/java` / `src/jakarta-overrides/java` paths still exist, but the current repo now documents that layout as intentional dual-source architecture
- `build.sbt` still actively references `wave/src/jakarta-overrides/java/` and still excludes matching main-tree files through `mainExactExcludes`
- renaming `wave/src/jakarta-overrides/` or deleting the duplicate main-tree files would be broader work against the current architecture, not a scoped cleanup for this branch

## Actual Cleanup In This PR
- update the stale `build.gradle` reference in the main-tree `ServerMain` comment to `build.sbt`
- preserve the existing guidance that the active runtime copy lives in the `jakarta-overrides` variant

## Verification
- `comm -12 /tmp/issue724-overrides.txt /tmp/issue724-main.txt | wc -l`
  - confirmed `48` duplicate paths still exist
- `rg -n "jakarta-overrides|mainExactExcludes|ServerMain\.java" build.sbt | sed -n '1,12p'`
  - confirmed `build.sbt` still references `wave/src/jakarta-overrides/java/` and still excludes `ServerMain.java`
- `rg -n "mainExactExcludes in build\.sbt|mainExactExcludes in build\.gradle|jakarta-overrides variant of ServerMain" wave/src/main/java/org/waveprotocol/box/server/ServerMain.java`
  - confirmed the stale `build.gradle` string is gone and the runtime guidance remains
- `git diff --check`
  - passed

See also: `journal/local-verification/2026-04-10-issue-724-jakarta-cleanup.md`

## Review
- direct Codex diff review: no findings
- external Claude plan review: pass
- external Claude implementation review: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation plan for cleanup verification work.
  * Added local verification journal capturing verification results and findings.

* **Chores**
  * Updated an inline comment referencing the build configuration source to reflect current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->