### PR TITLE
Tasks UI: remove owner prefix from assignee label

### DIFF
--- a/wave/config/changelog.d/2026-04-10-task-assignee-label-prefix.json
+++ b/wave/config/changelog.d/2026-04-10-task-assignee-label-prefix.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-10-task-assignee-label-prefix",
+  "version": "PR #787",
+  "date": "2026-04-10",
+  "title": "Wave Tasks: cleaner assignee labels",
+  "summary": "Task assignee labels now show the selected participant identifier without the extra owner prefix.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Task assignee pills now display just the selected participant label instead of prefixing it with \"Owner\""
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/CheckBox.java
@@ -224,7 +224,7 @@ public final class CheckBox {
       boolean hasDetails = false;
 
       if (assignee != null) {
-        appendPill(metadata, TaskDocumentUtil.formatTaskOwnerLabel(assignee),
+        appendPill(metadata, TaskDocumentUtil.formatTaskAssigneeLabel(assignee),
             TASK_PILL_CLASS + " " + TASK_OWNER_PILL_CLASS);
         hasDetails = true;
       }

--- a/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/doodad/form/check/TaskDocumentUtil.java
@@ -123,8 +123,8 @@ public final class TaskDocumentUtil {
     doc.setAnnotation(start, end, AnnotationConstants.TASK_DUE_TS, null);
   }
 
-  public static String formatTaskOwnerLabel(String participantAddress) {
-    return TaskMetadataUtil.formatTaskOwnerLabel(participantAddress);
+  public static String formatTaskAssigneeLabel(String participantAddress) {
+    return TaskMetadataUtil.formatTaskAssigneeLabel(participantAddress);
   }
 
   public static String formatTaskDueLabel(long epochMillis) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
@@ -39,7 +39,7 @@ public final class TaskMetadataUtil {
   /**
    * Formats a task assignee pill label from a participant identifier.
    */
-  public static String formatTaskOwnerLabel(String assignee) {
+  public static String formatTaskAssigneeLabel(String assignee) {
     return formatParticipantDisplay(assignee);
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtil.java
@@ -37,14 +37,10 @@ public final class TaskMetadataUtil {
   }
 
   /**
-   * Formats an owner pill label from a participant identifier.
+   * Formats a task assignee pill label from a participant identifier.
    */
   public static String formatTaskOwnerLabel(String assignee) {
-    String display = formatParticipantDisplay(assignee);
-    if (display.isEmpty()) {
-      return "";
-    }
-    return "Owner " + display;
+    return formatParticipantDisplay(assignee);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
@@ -26,8 +26,8 @@ import junit.framework.TestCase;
  */
 public class TaskMetadataUtilTest extends TestCase {
 
-  public void testFormatTaskOwnerLabelStripsDomainForEmailAddress() {
-    assertEquals("Owner alice",
+  public void testFormatTaskOwnerLabelOmitsOwnerPrefixForEmailAddress() {
+    assertEquals("alice",
         TaskMetadataUtil.formatTaskOwnerLabel("alice@example.com"));
   }
 
@@ -36,9 +36,17 @@ public class TaskMetadataUtilTest extends TestCase {
         TaskMetadataUtil.formatParticipantDisplay("alice@example.com"));
   }
 
-  public void testFormatTaskOwnerLabelKeepsOpaqueIdentifier() {
-    assertEquals("Owner build-bot",
+  public void testFormatTaskOwnerLabelKeepsOpaqueIdentifierWithoutPrefix() {
+    assertEquals("build-bot",
         TaskMetadataUtil.formatTaskOwnerLabel("build-bot"));
+  }
+
+  public void testFormatTaskOwnerLabelReturnsEmptyForNull() {
+    assertEquals("", TaskMetadataUtil.formatTaskOwnerLabel(null));
+  }
+
+  public void testFormatTaskOwnerLabelReturnsEmptyForBlank() {
+    assertEquals("", TaskMetadataUtil.formatTaskOwnerLabel("   "));
   }
 
   public void testParseDateInputValueRoundTripsThroughFormatter() {

--- a/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/conversation/TaskMetadataUtilTest.java
@@ -26,9 +26,9 @@ import junit.framework.TestCase;
  */
 public class TaskMetadataUtilTest extends TestCase {
 
-  public void testFormatTaskOwnerLabelOmitsOwnerPrefixForEmailAddress() {
+  public void testFormatTaskAssigneeLabelOmitsOwnerPrefixForEmailAddress() {
     assertEquals("alice",
-        TaskMetadataUtil.formatTaskOwnerLabel("alice@example.com"));
+        TaskMetadataUtil.formatTaskAssigneeLabel("alice@example.com"));
   }
 
   public void testFormatParticipantDisplayStripsDomainForEmailAddress() {
@@ -36,17 +36,17 @@ public class TaskMetadataUtilTest extends TestCase {
         TaskMetadataUtil.formatParticipantDisplay("alice@example.com"));
   }
 
-  public void testFormatTaskOwnerLabelKeepsOpaqueIdentifierWithoutPrefix() {
+  public void testFormatTaskAssigneeLabelKeepsOpaqueIdentifierWithoutPrefix() {
     assertEquals("build-bot",
-        TaskMetadataUtil.formatTaskOwnerLabel("build-bot"));
+        TaskMetadataUtil.formatTaskAssigneeLabel("build-bot"));
   }
 
-  public void testFormatTaskOwnerLabelReturnsEmptyForNull() {
-    assertEquals("", TaskMetadataUtil.formatTaskOwnerLabel(null));
+  public void testFormatTaskAssigneeLabelReturnsEmptyForNull() {
+    assertEquals("", TaskMetadataUtil.formatTaskAssigneeLabel(null));
   }
 
-  public void testFormatTaskOwnerLabelReturnsEmptyForBlank() {
-    assertEquals("", TaskMetadataUtil.formatTaskOwnerLabel("   "));
+  public void testFormatTaskAssigneeLabelReturnsEmptyForBlank() {
+    assertEquals("", TaskMetadataUtil.formatTaskAssigneeLabel("   "));
   }
 
   public void testParseDateInputValueRoundTripsThroughFormatter() {


### PR DESCRIPTION
## Summary
- remove the `Owner ` prefix from task assignee pill formatting so the selected label shows only the participant identifier
- update the task metadata formatter tests to cover the no-prefix behavior plus null/blank inputs
- add a changelog fragment for the assignee-label wording fix

## Verification
- `sbt "testOnly org.waveprotocol.wave.model.conversation.TaskMetadataUtilTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `sbt wave/compile compileGwt`
- `bash scripts/worktree-boot.sh --port 9899`
- `PORT=9899 bash scripts/wave-smoke.sh check`
- manual browser sanity on `http://127.0.0.1:9899`:
  - registered `task787lane@local.net` and `task787peer@local.net`
  - created a wave, added the peer participant, inserted a task
  - verified the assignee pill showed `task787peer` with no `Owner` prefix and the popup reopened with `task787peer` selected

Closes #787