### PR TITLE
docs(harness): standardize browser verification on wave-smoke-ui baseline

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -1,6 +1,6 @@
 # Smoke Tests Summary
 
-Date: 2026-03-24
+Date: 2026-04-10
 Environment:
 - OS: macOS / Linux
 - Shell: zsh / bash
@@ -29,6 +29,22 @@ override into the smoke commands:
 2. `PORT=9899 bash scripts/wave-smoke.sh check`
 3. `curl -sS http://localhost:9899/healthz`
 4. `PORT=9899 bash scripts/wave-smoke.sh stop`
+
+## Browser verification baseline
+
+The standalone browser-smoke baseline remains:
+
+- `bash scripts/wave-smoke-ui.sh`
+- `sbt smokeUi`
+
+For issue worktrees, the port-aware equivalent is the worktree lifecycle above:
+`worktree-boot.sh` plus `wave-smoke.sh start|check|stop`.
+
+Use [docs/runbooks/browser-verification.md](runbooks/browser-verification.md)
+for the default UI-affecting verification flow, and use
+[docs/runbooks/change-type-verification-matrix.md](runbooks/change-type-verification-matrix.md)
+to decide whether the change also needs a real browser pass after the smoke
+checks succeed.
 
 ## SBT-level smoke
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,7 +1,7 @@
 # Runbooks Map
 
 Status: Canonical
-Updated: 2026-04-04
+Updated: 2026-04-10
 
 Use this map for procedures you are expected to follow step by step: local
 setup, smoke checks, deployment, and operational routines.
@@ -10,6 +10,10 @@ setup, smoke checks, deployment, and operational routines.
 
 - [`worktree-lane-lifecycle.md`](worktree-lane-lifecycle.md)
   - Existing-worktree boot lifecycle for GitHub-Issues lanes.
+- [`browser-verification.md`](browser-verification.md)
+  - Standard browser-verification path built on the existing smoke baseline.
+- [`change-type-verification-matrix.md`](change-type-verification-matrix.md)
+  - Quick reference for when smoke is enough versus when browser verification is required.
 - [`../DEV_SETUP.md`](../DEV_SETUP.md)
   - Local requirements and setup notes.
 - [`../BUILDING-sbt.md`](../BUILDING-sbt.md)

--- a/docs/runbooks/browser-verification.md
+++ b/docs/runbooks/browser-verification.md
@@ -30,7 +30,7 @@ When a change can affect browser-visible behavior, use this default path:
 5. Stop the server with `PORT=9900 bash scripts/wave-smoke.sh stop`.
 
 The smoke checks prove the server boots, health responds, and the compiled
-webclient asset is present. The browser pass is there to verify the specific
+web client asset is present. The browser pass verifies the specific
 auth, routing, or UI behavior that curl cannot prove.
 
 ## 3. When Curl Or Smoke Is Enough

--- a/docs/runbooks/browser-verification.md
+++ b/docs/runbooks/browser-verification.md
@@ -1,0 +1,92 @@
+# Browser Verification
+
+Use this runbook to decide when incubator-wave changes need real browser
+verification and how to run that verification without introducing a new
+browser framework.
+
+## 1. Baseline
+
+The existing shell baseline stays in place:
+
+- Standalone/source-tree UI smoke: `bash scripts/wave-smoke-ui.sh`
+- Worktree-lane equivalent: `bash scripts/worktree-boot.sh --port <port>`,
+  followed by the printed `wave-smoke.sh start|check|stop` commands
+
+The worktree-lane flow is the port-aware equivalent of `wave-smoke-ui.sh`.
+It uses the existing staged distribution and the existing smoke checks instead
+of inventing another wrapper around the same commands.
+
+## 2. Default Path For UI-Affecting Changes
+
+When a change can affect browser-visible behavior, use this default path:
+
+1. Run `bash scripts/worktree-boot.sh --port 9900` from the issue worktree.
+2. Start the staged server with the exact `PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start`
+   command printed by `worktree-boot.sh`.
+3. Run `PORT=9900 bash scripts/wave-smoke.sh check`.
+4. If the change-type matrix says browser verification is required, open
+   `http://localhost:9900/` and exercise only the narrow path affected by the
+   change.
+5. Stop the server with `PORT=9900 bash scripts/wave-smoke.sh stop`.
+
+The smoke checks prove the server boots, health responds, and the compiled
+webclient asset is present. The browser pass is there to verify the specific
+auth, routing, or UI behavior that curl cannot prove.
+
+## 3. When Curl Or Smoke Is Enough
+
+Smoke-only verification is usually enough when the change cannot alter rendered
+browser behavior. Typical examples:
+
+- backend-only logic with no auth, servlet, routing, or client-asset changes
+- search/indexing/storage changes that surface through existing server APIs but
+  do not alter the rendered page shell
+- deployment changes whose validation is already covered by deployment runbooks
+  and do not change client assets, headers, or auth/session behavior
+
+In those cases, record the exact smoke or curl commands you ran and note that
+the matrix did not require a browser pass.
+
+## 4. When Browser Verification Is Required
+
+Add a browser pass when the change can alter browser-visible behavior, even if
+the smoke checks are green. This includes:
+
+- auth and session transitions
+- servlet-rendered routes or redirects
+- GWT client/UI changes, including CSS, layout, editor behavior, and widgets
+- packaging/build changes that can change the served client assets
+- deployment changes that can change page delivery, auth headers, or static
+  asset serving
+
+Use the smallest possible manual or scripted browser flow that proves the
+affected behavior. This runbook standardizes the expectation, not the exact UI
+steps for every feature. Feature-specific plans should still describe the
+narrow browser flow they need.
+
+For change-type defaults, use
+[`change-type-verification-matrix.md`](change-type-verification-matrix.md).
+
+## 5. Evidence To Record
+
+Record the verification evidence in the issue comment and, for issue worktrees,
+in `journal/local-verification/<date>-issue-<number>-<slug>.md`.
+
+Minimum evidence:
+
+- exact startup, smoke, and shutdown commands
+- whether the matrix required browser verification
+- the URL or route checked in the browser
+- the narrow user-visible behavior that was confirmed
+- the observed result
+
+Example:
+
+```markdown
+- `bash scripts/worktree-boot.sh --port 9900`
+- `PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start`
+- `PORT=9900 bash scripts/wave-smoke.sh check`
+- Browser verification required by `docs/runbooks/change-type-verification-matrix.md` (`GWT client/UI` row)
+- Opened `http://localhost:9900/` and confirmed the affected toolbar/action/auth flow behaved as expected
+- `PORT=9900 bash scripts/wave-smoke.sh stop`
+```

--- a/docs/runbooks/change-type-verification-matrix.md
+++ b/docs/runbooks/change-type-verification-matrix.md
@@ -1,0 +1,21 @@
+# Change-Type Verification Matrix
+
+Use this matrix after the base worktree boot/smoke flow succeeds. It decides
+whether the change needs a real browser pass or whether curl/smoke evidence is
+enough.
+
+| Change type | Typical examples | Default scripted baseline | Browser verification | Browser focus | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| Server-only | backend services, storage, indexing, logging, internal RPC logic with no auth/page-shell/client-asset change | `bash scripts/worktree-boot.sh --port <port>` then `PORT=<port> ... bash scripts/wave-smoke.sh start`, `PORT=<port> bash scripts/wave-smoke.sh check`, `PORT=<port> bash scripts/wave-smoke.sh stop` | Usually unnecessary | None unless the server change leaks into rendered behavior | record the exact smoke/curl commands and note that the matrix did not require a browser pass |
+| Servlet/auth | signin/signout handlers, session filters, redirects, servlet-rendered pages, route guards | same worktree baseline as above | Required | sign-in/sign-out, redirect target, page shell, session restoration, route access | record the commands, route checked, credentials/test account if relevant, and observed auth result |
+| GWT client/UI | widgets, CSS, layout, editor behavior, topbar, client routing, browser-only regressions | same worktree baseline as above | Required | the narrow user-visible path touched by the change | record the commands, affected route, action performed, and browser-visible result |
+| Packaging/build/distribution | staged dist changes, asset packaging, cache-busting, static resource wiring | worktree baseline above and, when useful, standalone `bash scripts/wave-smoke-ui.sh` | Required when browser-visible assets/pages can change; otherwise optional | home page load, served `webclient.nocache.js`, signin page, affected asset path | record whether the change altered browser-visible packaging and which asset/page check was performed |
+| Deployment-only | compose/systemd/Caddy/deploy scripts with no app-code change | deployment/runbook verification plus smoke on the target environment or a local equivalent | Usually unnecessary; required if delivery/auth/static-asset behavior can change | root page, signin flow, or client asset delivery only when the deployment change can affect them | record deployment or smoke commands and explicitly note whether browser verification was or was not required |
+
+Rules of thumb:
+
+- If the change cannot alter rendered browser behavior, curl/smoke is enough.
+- If the change can affect auth, routing, GWT rendering, or served client
+  assets, add a browser pass.
+- Keep the browser pass narrow. The goal is not a full exploratory session; it
+  is proof that the affected path still behaves correctly.

--- a/docs/runbooks/worktree-lane-lifecycle.md
+++ b/docs/runbooks/worktree-lane-lifecycle.md
@@ -128,9 +128,13 @@ After `scripts/worktree-boot.sh` finishes, run the printed commands in order:
 
 1. Start the server with the printed `JAVA_OPTS` and `PORT`.
 2. Run `bash scripts/wave-smoke.sh check`.
-3. Run any task-specific manual verification.
+3. If the change can affect browser-visible behavior, use
+   [`browser-verification.md`](browser-verification.md) and
+   [`change-type-verification-matrix.md`](change-type-verification-matrix.md)
+   to decide whether a browser pass is required and what narrow path to check.
 4. Stop the server with `bash scripts/wave-smoke.sh stop`.
 
-This runbook standardizes only the base lifecycle. It does not standardize
-browser flows beyond whatever the task itself requires, and it does not require
-new browser automation or observability tooling.
+This runbook standardizes only the base lifecycle. Browser-verification
+expectations are standardized separately in
+[`browser-verification.md`](browser-verification.md), and they still do not
+require new browser automation or observability tooling.

--- a/docs/superpowers/plans/2026-04-10-issue-586-browser-verification.md
+++ b/docs/superpowers/plans/2026-04-10-issue-586-browser-verification.md
@@ -1,0 +1,141 @@
+# Issue 586 Browser Verification Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize the documented browser-verification path for incubator-wave issue lanes on top of the existing `scripts/wave-smoke-ui.sh` baseline.
+
+**Architecture:** Keep the current shell-based smoke baseline and worktree boot lifecycle. Add one browser-verification runbook that explains how the standalone `scripts/wave-smoke-ui.sh` baseline maps to worktree-lane verification, add one change-type matrix that defines when curl/smoke is enough versus when a real browser pass is required, and update adjacent docs so lanes discover the new guidance without introducing a new browser framework.
+
+**Tech Stack:** Bash smoke scripts, existing worktree-lane runbooks, Markdown docs, local staged server verification.
+
+---
+
+## Scope And Decisions
+
+- `scripts/wave-smoke-ui.sh` remains the standalone browser-smoke baseline.
+- Worktree lanes should not invent ad-hoc browser verification commands; the new runbook will map them to the existing `scripts/worktree-boot.sh` plus `scripts/wave-smoke.sh` flow.
+- The change-type matrix must distinguish at least server-only, servlet/auth, GWT client, packaging, and deployment-only changes.
+- The runbook must define the default UI-affecting verification path and the cases where a browser pass is mandatory.
+- A new wrapper script is only justified if the docs reveal a repeated command gap that cannot be explained cleanly with the current scripts. The implementation should default to no new wrapper.
+- No Playwright, Puppeteer, or other repo-wide browser framework will be introduced in this task.
+
+## Files
+
+- Create: `docs/runbooks/browser-verification.md`
+- Create: `docs/runbooks/change-type-verification-matrix.md`
+- Modify: `docs/runbooks/README.md`
+- Modify: `docs/runbooks/worktree-lane-lifecycle.md`
+- Modify: `docs/SMOKE_TESTS.md`
+
+## Risks And Non-Goals
+
+- The repo already has multiple verification entry points, so the new docs must clarify ownership instead of duplicating every existing command reference.
+- The runbook should standardize expectations, not over-specify feature-specific manual steps that belong in issue plans.
+- If the matrix is too broad, lanes will keep falling back to ad-hoc interpretations; if it is too rigid, it will encourage cargo-cult browser checks. The matrix should define defaults and escalation criteria, not every UI scenario.
+- This task does not add new browser automation, new smoke tasks in `build.sbt`, or diagnostic bundle collection.
+
+## Task 1: Define The Standard Baseline
+
+**Files:**
+- Modify: `docs/runbooks/worktree-lane-lifecycle.md`
+- Modify: `docs/SMOKE_TESTS.md`
+- Create: `docs/runbooks/browser-verification.md`
+
+- [ ] **Step 1: Capture the baseline decision in the runbook**
+
+Document that:
+- standalone validation can continue using `bash scripts/wave-smoke-ui.sh`
+- issue worktrees should first prepare the port-specific staged app with `bash scripts/worktree-boot.sh --port <port>`
+- issue worktrees should then use `PORT=<port> JAVA_OPTS='...' bash scripts/wave-smoke.sh start`, `PORT=<port> bash scripts/wave-smoke.sh check`, and `PORT=<port> bash scripts/wave-smoke.sh stop`
+- browser verification, when required by the matrix, runs against that started worktree server instead of inventing a separate framework
+
+- [ ] **Step 2: State the default browser-verification path for UI-affecting changes**
+
+In `docs/runbooks/browser-verification.md`, define this default path:
+1. prepare the worktree runtime with `bash scripts/worktree-boot.sh --port 9900`
+2. start the worktree server with the printed `PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start` command
+3. confirm the baseline checks with `PORT=9900 bash scripts/wave-smoke.sh check`
+4. open `http://localhost:9900/` and perform the narrow browser checks required by the change-type matrix
+5. stop the server with `PORT=9900 bash scripts/wave-smoke.sh stop`
+
+- [ ] **Step 3: Cross-link the new guidance from the existing smoke docs**
+
+Update `docs/SMOKE_TESTS.md` and `docs/runbooks/worktree-lane-lifecycle.md` so they point to `docs/runbooks/browser-verification.md` for the browser-verification decision after the base smoke/lifecycle commands succeed.
+
+## Task 2: Add The Change-Type Verification Matrix
+
+**Files:**
+- Create: `docs/runbooks/change-type-verification-matrix.md`
+- Create: `docs/runbooks/browser-verification.md`
+
+- [ ] **Step 1: Add the matrix rows for each required change type**
+
+Create a table covering:
+- server-only changes
+- servlet/auth changes
+- GWT client/UI changes
+- packaging/build/distribution changes
+- deployment-only changes
+
+For each row, define:
+- the default scripted baseline
+- whether browser verification is required, optional, or usually unnecessary
+- the narrow browser focus when it is required
+- the evidence that should be recorded in the issue comment or local-verification journal
+
+- [ ] **Step 2: Explain curl/smoke-only sufficiency versus browser-required cases**
+
+In `docs/runbooks/browser-verification.md`, summarize the matrix in prose:
+- curl/smoke is enough when the change cannot alter rendered browser behavior
+- browser verification is required when the change affects auth/session transitions, GWT client rendering, editor behavior, user-visible routing, or packaging that changes served client assets
+- deployment-only changes rely on deployment/runbook verification unless they also modify browser-visible assets or auth behavior
+
+## Task 3: Make The Runbooks Discoverable
+
+**Files:**
+- Modify: `docs/runbooks/README.md`
+
+- [ ] **Step 1: Add the new runbook and matrix to the runbooks map**
+
+Update `docs/runbooks/README.md` so lanes can find:
+- `browser-verification.md` as the browser-verification entry point
+- `change-type-verification-matrix.md` as the quick classification reference
+
+## Task 4: Verification And Evidence
+
+**Files:**
+- Modify: `journal/local-verification/2026-04-10-issue-586-wave-smoke-ui-20260410.md`
+
+- [ ] **Step 1: Run focused doc/script verification**
+
+Run:
+```bash
+bash scripts/wave-smoke-ui.sh
+```
+
+Expected:
+- the script exits `0`
+- output includes `ROOT=200|302`, `WEBCLIENT=200`, and `UI smoke OK`
+
+- [ ] **Step 2: Run the worktree-lane equivalent verification**
+
+Run:
+```bash
+bash scripts/worktree-boot.sh --port 9900
+PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-586-wave-smoke-ui-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-586-wave-smoke-ui-20260410/wave/config/jaas.config' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+Expected:
+- the helper prints a runtime config and evidence file for this branch
+- `wave-smoke.sh check` reports `ROOT_STATUS=200|302`, `HEALTH_STATUS=200`, and `WEBCLIENT_STATUS=200`
+- stop succeeds cleanly
+
+- [ ] **Step 3: Review the docs for consistency**
+
+Confirm the touched docs all agree on:
+- `scripts/wave-smoke-ui.sh` as the standalone baseline
+- `worktree-boot.sh` plus `wave-smoke.sh` as the worktree-lane equivalent
+- the matrix-driven rule for when browser verification is required
+- the evidence destination in issue comments and `journal/local-verification/...`

--- a/wave/config/changelog.d/2026-04-10-browser-verification-runbook.json
+++ b/wave/config/changelog.d/2026-04-10-browser-verification-runbook.json
@@ -6,7 +6,7 @@
   "summary": "Adds a browser-verification runbook and change-type matrix so agent lanes know when curl/smoke is enough and when a real browser pass is required, without introducing a new browser framework.",
   "sections": [
     {
-      "type": "chore",
+      "type": "feature",
       "items": [
         "Add docs/runbooks/browser-verification.md: defines the default UI-affecting verification path built on the existing wave-smoke-ui.sh and worktree-boot.sh + wave-smoke.sh baseline",
         "Add docs/runbooks/change-type-verification-matrix.md: decision matrix covering server-only, servlet/auth, GWT client/UI, packaging, and deployment-only change types",

--- a/wave/config/changelog.d/2026-04-10-browser-verification-runbook.json
+++ b/wave/config/changelog.d/2026-04-10-browser-verification-runbook.json
@@ -1,0 +1,19 @@
+{
+  "releaseId": "2026-04-10-browser-verification-runbook",
+  "version": "PR #586",
+  "date": "2026-04-10",
+  "title": "Standardized Browser Verification Runbooks",
+  "summary": "Adds a browser-verification runbook and change-type matrix so agent lanes know when curl/smoke is enough and when a real browser pass is required, without introducing a new browser framework.",
+  "sections": [
+    {
+      "type": "chore",
+      "items": [
+        "Add docs/runbooks/browser-verification.md: defines the default UI-affecting verification path built on the existing wave-smoke-ui.sh and worktree-boot.sh + wave-smoke.sh baseline",
+        "Add docs/runbooks/change-type-verification-matrix.md: decision matrix covering server-only, servlet/auth, GWT client/UI, packaging, and deployment-only change types",
+        "Update docs/runbooks/worktree-lane-lifecycle.md: step 7 cross-links to the new browser-verification and change-type matrix runbooks",
+        "Update docs/SMOKE_TESTS.md: adds browser-verification baseline section pointing to the new runbooks",
+        "Update docs/runbooks/README.md: indexes the two new runbooks under Local Development"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add `docs/runbooks/browser-verification.md` to define the default UI-affecting verification path on top of the existing `scripts/wave-smoke-ui.sh` baseline and the existing worktree `worktree-boot.sh` + `wave-smoke.sh` flow
- add `docs/runbooks/change-type-verification-matrix.md` covering server-only, servlet/auth, GWT client/UI, packaging/build/distribution, and deployment-only changes
- update `docs/runbooks/worktree-lane-lifecycle.md`, `docs/SMOKE_TESTS.md`, and `docs/runbooks/README.md` so issue lanes discover the new guidance from the existing runbook entry points

No new browser framework is introduced, and no redundant wrapper script is added.

## Plan

- `docs/superpowers/plans/2026-04-10-issue-586-browser-verification.md`

## Verification

- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-586-wave-smoke-ui-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-586-wave-smoke-ui-20260410/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- `PORT=9900 bash scripts/wave-smoke.sh stop`
- Result: `wave-smoke.sh check` returned `ROOT_STATUS=200`, `HEALTH_STATUS=200`, and `WEBCLIENT_STATUS=200`
- Note: standalone `bash scripts/wave-smoke-ui.sh` was not run unchanged because another worktree already had a Wave server listening on `127.0.0.1:9898`, and that script's broad `pkill -f org.waveprotocol.box.server.ServerMain` cleanup would have killed the unrelated lane
- Matrix decision: this is a docs-only standardization change, so a real browser pass was not required after the smoke baseline succeeded

## Review

- Direct review: no blockers found
- Claude plan review and implementation review were both attempted via `claude-review`, but the runner stalled after prompt generation and produced no issue-specific output/telemetry; that tooling blockage is recorded in issue `#586`

Closes #586


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a browser-verification runbook defining a standardized workflow for changes affecting user-visible behavior
* Added a change-type verification matrix to guide when smoke verification suffices versus browser verification is required
* Updated runbook discovery and smoke test documentation to reference new browser verification baseline guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->