### PR TITLE
[codex] docs: clarify robot Data API token lifecycle

### DIFF
--- a/docs/gpt-bot.md
+++ b/docs/gpt-bot.md
@@ -96,6 +96,26 @@ curl -sS -X POST "$SUPAWAVE_BASE_URL/api/robots/$GPTBOT_API_ROBOT_ID/verify" \
   -H "Authorization: Bearer $GPTBOT_MANAGEMENT_TOKEN"
 ```
 
+## Robot Token Handling
+
+`gpt-bot` does not require you to paste a static Data API token into `.env`.
+
+Instead, the example uses `GPTBOT_API_ROBOT_SECRET` to mint short-lived JWTs from `/robot/dataapi/token` at runtime:
+
+- Data API tokens are requested with `expiry=3600`
+- Active API tokens use the same endpoint with `token_type=robot`
+- the client refreshes each cached token approximately 30 seconds before expiry
+
+That logic lives in `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java`.
+
+Operator guidance:
+
+- keep the robot secret; the JWT is disposable
+- expect to mint a fresh token after any `401`
+- if secret rotation or another `tokenVersion` bump invalidates an older JWT early, clear the cached token and re-authenticate with the current secret
+
+For the full token lifecycle and passive bundle field rules, see [robot-data-api-authentication.md](robot-data-api-authentication.md).
+
 ## Passive And Active Modes
 
 `gpt-bot` supports both passive webhook replies and active API writes:

--- a/docs/robot-data-api-authentication.md
+++ b/docs/robot-data-api-authentication.md
@@ -1,0 +1,90 @@
+# Robot Data API Authentication
+
+This document explains the live robot token flow in SupaWave.
+
+## Permanent Secret vs Expiring JWT
+
+Each robot has two different credentials:
+
+- The robot `consumer secret` is the long-lived credential stored with the robot account.
+- The Data API token is a JWT Bearer token minted from that secret and sent on every RPC request.
+
+For Data API calls, send:
+
+```http
+Authorization: Bearer <jwt>
+```
+
+The robot secret stays valid until you rotate it. The JWT does not.
+
+## Requesting a Data API Token
+
+Robots mint JWTs from the token endpoint with `client_credentials`:
+
+```bash
+curl -sS -X POST "$SUPAWAVE_BASE_URL/robot/dataapi/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=client_credentials" \
+  --data-urlencode "client_id=$ROBOT_ID" \
+  --data-urlencode "client_secret=$ROBOT_SECRET" \
+  --data-urlencode "expiry=3600"
+```
+
+Current server behavior:
+
+- The robot must already have a configured callback URL.
+- The robot must already be in verified/active registration state.
+- If `expiry` is omitted, the server falls back to the robot account's `tokenExpirySeconds`.
+- `tokenExpirySeconds=0` preserves legacy no-expiry behavior. New integrations should prefer explicit short-lived tokens such as `3600`.
+
+Use `token_type=robot` when you need an Active API token for `/robot/rpc` rather than the Data API endpoint.
+
+## JWT Structure
+
+Data API JWTs are signed by the server's current JWT signing key.
+
+Important JWT header fields:
+
+- `typ`: `data-api-access`
+- `kid`: the signing key id used for verification/key rotation
+
+Important JWT payload claims:
+
+- `sub`: the robot participant address
+- `aud`: `["data-api"]`
+- `scope`: `["wave:data:read", "wave:data:write"]`
+- `exp`: expiry time
+- `ver`: the robot account's current `tokenVersion`
+
+## Refresh and Revocation Rules
+
+Robots should keep the secret and treat JWTs as disposable:
+
+- Store the permanent robot secret.
+- Cache the current JWT only as a convenience.
+- Renew before expiry by watching `expires_in` or decoding `exp`.
+- Refresh the JWT after any HTTP `401` and retry the RPC call once with the newly issued token.
+
+`tokenVersion` matters because the server checks it on every authenticated request:
+
+- rotating the consumer secret bumps `tokenVersion`
+- pausing a robot bumps `tokenVersion`
+- deleting a robot bumps `tokenVersion`
+
+When `tokenVersion` changes, older JWTs stop working immediately even if their `exp` is still in the future. Re-authenticate with the current secret.
+
+## Passive Event Bundle Notes
+
+Passive callback and fetch bundles use `EventMessageBundle` JSON.
+
+Important fields:
+
+- `robotAddress`: identifies the robot the bundle was built for
+- `rpcServerUrl`: current servers populate this with the Data API endpoint; prefer it over hardcoding `/robot/dataapi/rpc` when it is present
+- `threads`: older payloads may omit this field; treat missing `threads` as `{}`
+
+## Related Docs
+
+- Generated API docs: `/api-docs`
+- LLM-oriented API docs: `/api/llm.txt`
+- Example robot operator guide: [gpt-bot.md](gpt-bot.md)

--- a/docs/superpowers/plans/2026-04-10-issue-721-robot-token-docs.md
+++ b/docs/superpowers/plans/2026-04-10-issue-721-robot-token-docs.md
@@ -1,0 +1,91 @@
+# Issue #721 Robot Token Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining documentation gaps around robot Data API JWT issuance, refresh, revocation, and event-bundle callback fields without widening the scope beyond docs and doc-backed tests.
+
+**Architecture:** Keep the implementation doc-only. Update the generated API docs (`/api-docs` and `/api/llm.txt`) so they describe the live JWT contract and passive-event payload semantics, update the robot dashboard onboarding prompt so it stops teaching outdated token behavior, and add/update markdown docs so the same guidance exists outside servlet-rendered pages.
+
+**Tech Stack:** Jakarta servlet string-rendered docs, JUnit servlet tests, markdown docs under `docs/`.
+
+---
+
+## Audit Summary
+
+- Already covered by merged work:
+  - `#436` added the `Build with AI` section in `/api-docs` and `/api/llm.txt`.
+  - `#717` populated `rpcServerUrl` in live `EventMessageBundle` payloads.
+- Still missing or misleading:
+  - `/api-docs` and `/api/llm.txt` do not fully explain token claims, refresh-on-401 guidance, permanent secret vs expiring JWT, or token-version revocation.
+  - `RobotDashboardServlet` still teaches outdated token behavior (`never expire`, callback URL required for both token types) in its AI onboarding prompt.
+  - There is no durable markdown doc in `docs/` that explains robot token handling and passive bundle field expectations.
+
+## File Scope
+
+**Create:**
+- `docs/robot-data-api-authentication.md`
+
+**Modify:**
+- `docs/gpt-bot.md`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ApiDocsServlet.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java`
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/ApiDocsServletTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java`
+
+**Verification targets:**
+- `sbt "testOnly org.waveprotocol.box.server.rpc.ApiDocsServletTest org.waveprotocol.box.server.robots.RobotDashboardServletTest"`
+- `rg -n "tokenVersion|401|rpcServerUrl|robotAddress|threads" docs/robot-data-api-authentication.md docs/gpt-bot.md`
+
+### Task 1: Lock the missing generated-doc requirements with tests
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/rpc/ApiDocsServletTest.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java`
+
+- [ ] Add or update tests so `/api-docs` and `/api/llm.txt` must mention:
+  - permanent robot secret vs expiring JWT
+  - refresh after `401`
+  - `tokenVersion` / JWT version revocation
+  - `rpcServerUrl`, `robotAddress`, and nullable/optional `threads` guidance for fetch/event bundles
+- [ ] Add or update a dashboard test so the AI onboarding prompt must stop claiming Data API tokens default to never expire and instead mention refresh/re-auth guidance.
+- [ ] Run `sbt "testOnly org.waveprotocol.box.server.rpc.ApiDocsServletTest org.waveprotocol.box.server.robots.RobotDashboardServletTest"` and confirm the new assertions fail before production edits.
+
+### Task 2: Update generated API docs to match the live contract
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ApiDocsServlet.java`
+
+- [ ] Add a focused robot-auth section that documents the live client-credentials flow, JWT claims/audience/scopes, `tokenExpirySeconds`, `401` refresh expectations, and token-version invalidation.
+- [ ] Add passive-event/fetch bundle notes that call out `rpcServerUrl`, `robotAddress`, and that clients must tolerate missing or empty `threads`.
+- [ ] Keep the wording aligned with the actual code path (`POST /robot/dataapi/token` with `client_credentials`), not the stale issue phrasing.
+- [ ] Re-run `ApiDocsServletTest` and confirm it passes.
+
+### Task 3: Fix the robot dashboard onboarding prompt
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java`
+
+- [ ] Update the embedded AI onboarding prompt so it reflects short-lived Data API tokens, secret-based re-authentication, refresh after `401`, and `rpcServerUrl` bundle usage.
+- [ ] Remove or replace any prompt text that says Data API tokens default to never expire or that both token types require the same callback-URL assumptions.
+- [ ] Re-run `RobotDashboardServletTest` and confirm it passes.
+
+### Task 4: Add durable markdown docs
+
+**Files:**
+- Create: `docs/robot-data-api-authentication.md`
+- Modify: `docs/gpt-bot.md`
+
+- [ ] Add a standalone markdown doc covering robot Data API authentication, token refresh/revocation, and passive bundle field expectations.
+- [ ] Update `docs/gpt-bot.md` to point operators to the new auth doc and explain how the example robot actually gets and refreshes tokens.
+- [ ] Run the planned `rg` checks to confirm the expected guidance exists in markdown form.
+
+### Task 5: Final verification and issue/PR evidence
+
+**Files:**
+- No additional code changes unless verification finds a doc/test defect
+
+- [ ] Run `sbt "testOnly org.waveprotocol.box.server.rpc.ApiDocsServletTest org.waveprotocol.box.server.robots.RobotDashboardServletTest"`.
+- [ ] Run `rg -n "tokenVersion|401|rpcServerUrl|robotAddress|threads" docs/robot-data-api-authentication.md docs/gpt-bot.md`.
+- [ ] Review the diff for scope control (`git diff --stat`, `git diff`).
+- [ ] Record audit findings, plan path, verification commands, and final disposition on GitHub issue `#721`.
+- [ ] Open a PR only if tracked files changed.

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -790,12 +790,12 @@ public final class RobotDashboardServlet extends HttpServlet {
     // Section 1: Robot API Keys (long-lived)
     sb.append("<div style=\"margin-bottom:28px\">");
     sb.append("<div class=\"sec-title\">Robot API Keys</div>");
-    sb.append("<div class=\"sec-desc\">Each robot receives a <strong>consumer secret</strong> at creation time. Robots use this secret via the <code style=\"font-family:var(--mono);font-size:11px;background:var(--sf);padding:1px 5px;border-radius:3px\">client_credentials</code> grant to obtain long-lived API tokens. Since robots are persistent web services, tokens default to <strong>never expire</strong>. You can configure expiry per-robot in the registration modal.</div>");
+    sb.append("<div class=\"sec-desc\">Each robot receives a <strong>consumer secret</strong> at creation time. Use that long-lived secret via the <code style=\"font-family:var(--mono);font-size:11px;background:var(--sf);padding:1px 5px;border-radius:3px\">client_credentials</code> grant to mint JWT Bearer tokens for the Data API or Active API. Prefer short-lived tokens such as <strong>3600 seconds</strong>; if you omit expiry, the server falls back to the robot's configured default and a value of <code>0</code> preserves legacy no-expiry behavior.</div>");
     sb.append("<div class=\"refcard\" style=\"margin-top:12px\">");
     sb.append("<h4>Robot Authentication Flow</h4>");
     sb.append("<div class=\"hint\" style=\"margin-bottom:8px\">Robots get two types of Bearer tokens via <code style=\"font-family:var(--mono);font-size:10px\">client_credentials</code> grant:</div>");
     sb.append("<code style=\"font-family:var(--mono);font-size:11px;color:var(--p);background:var(--bg);padding:8px 10px;border-radius:3px;display:block;line-height:1.8;white-space:pre\">Data API token (search, create, read/write waves):\nPOST /robot/dataapi/token\ngrant_type=client_credentials&amp;client_id=bot@domain&amp;client_secret=...\n\nActive API token (respond to wave events):\nPOST /robot/dataapi/token\ngrant_type=client_credentials&amp;client_id=bot@domain&amp;client_secret=...&amp;token_type=robot</code>");
-    sb.append("<div class=\"hint\" style=\"margin-top:8px\">Both default to never expire. Active robots need both tokens.</div>");
+    sb.append("<div class=\"hint\" style=\"margin-top:8px\">Prefer <code>expiry=3600</code>, refresh after HTTP 401, and re-authenticate if secret rotation or <code>tokenVersion</code> invalidates an older JWT. Active robots need both token types.</div>");
     sb.append("</div></div>");
 
     // Section 2: Registration Management Token (short-lived)
@@ -845,7 +845,7 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("<code style=\"font-family:var(--mono);font-size:11px;color:var(--p);background:var(--bg);padding:6px 10px;border-radius:3px;display:block\">Authorization: Bearer eyJhbG...</code>");
     sb.append("<div class=\"hint\" style=\"margin-top:12px\"><strong>Two token types:</strong></div>");
     sb.append("<div class=\"hint\">1. <strong>Management token</strong> (short-lived) \u2014 for registration API, generated above</div>");
-    sb.append("<div class=\"hint\">2. <strong>Robot API key</strong> (long-lived) \u2014 for Data API, via client_credentials grant</div>");
+    sb.append("<div class=\"hint\">2. <strong>Robot consumer secret + JWTs</strong> \u2014 use client_credentials to mint short-lived Data API or Active API tokens</div>");
     sb.append("</div></div>");
     sb.append("</div>"); // end tp-api
 
@@ -871,7 +871,7 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("<li>Generate a <strong>Management Token</strong> on the \"API &amp; Tokens\" tab (expires in 1 hour)</li>");
     sb.append("<li>Copy the AI prompt above and paste into your LLM (Google AI Studio, ChatGPT, Claude, etc.)</li>");
     sb.append("<li>The LLM writes a robot, deploys it, and registers it via the Management API using your token</li>");
-    sb.append("<li>The robot receives a <strong>consumer secret</strong> at registration and uses <code style=\"font-family:var(--mono);font-size:11px;background:var(--sf);padding:1px 4px;border-radius:2px\">client_credentials</code> to get its own long-lived Data API token</li>");
+    sb.append("<li>The robot receives a <strong>consumer secret</strong> at registration and uses <code style=\"font-family:var(--mono);font-size:11px;background:var(--sf);padding:1px 4px;border-radius:2px\">client_credentials</code> to mint its own short-lived Data API and Active API JWTs</li>");
     sb.append("<li>Expand the robot on \"My Robots\" tab \u2014 click <strong>Test Robot</strong> to verify connectivity</li>");
     sb.append("</ol></div>");
     // Documentation links
@@ -912,7 +912,7 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("<div class=\"fg\">");
     sb.append("<label class=\"fl\">Robot API Key Expiry</label>");
     sb.append("<div class=\"fi-suffix\"><input class=\"fi\" type=\"number\" id=\"reg-expiry\" value=\"0\"/><span class=\"suffix\">seconds (0 = never)</span></div>");
-    sb.append("<div class=\"hint\">How long robot-issued API keys last. Default 0 = never expire (recommended for persistent services).</div></div>");
+    sb.append("<div class=\"hint\">How long robot-issued JWTs last when you omit an explicit expiry. Prefer 3600 for new robots; 0 preserves legacy no-expiry behavior.</div></div>");
     sb.append("</div>"); // end modal-body
     sb.append("<div class=\"modal-foot\">");
     sb.append("<button class=\"btn-o\" onclick=\"closeModal()\">Cancel</button>");
@@ -1169,26 +1169,30 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("+'Content-Type: application/json\\n'");
     sb.append("+'{\"username\":\"mybot-bot\",\"description\":\"My bot\",\"callbackUrl\":\"https://your-server/callback\"}\\n'");
     sb.append("+'Response: {id, secret, status, callbackUrl}\\n'");
-    sb.append("+'IMPORTANT: callbackUrl is required for both token types.\\n'");
+    sb.append("+'IMPORTANT: callbackUrl is currently required before the server will issue robot tokens.\\n'");
     sb.append("+'The callback URL is where SupaWave sends wave events to your robot.\\n\\n'");
-    sb.append("+'== Step 2: Get tokens ==\\n'");
-    sb.append("+'Robots need tokens to call SupaWave APIs. Get them via client_credentials:\\n\\n'");
+    sb.append("+'== Step 2: Get runtime tokens ==\\n'");
+    sb.append("+'Use the permanent robot secret to mint short-lived JWTs via client_credentials:\\n\\n'");
     sb.append("+'Data API token (for on-demand reads/writes):\\n'");
     sb.append("+'POST '+BASE+'/robot/dataapi/token\\n'");
     sb.append("+'Content-Type: application/x-www-form-urlencoded\\n'");
-    sb.append("+'grant_type=client_credentials&client_id=mybot-bot@'+DOMAIN+'&client_secret=SECRET\\n\\n'");
+    sb.append("+'grant_type=client_credentials&client_id=mybot-bot@'+DOMAIN+'&client_secret=SECRET&expiry=3600\\n\\n'");
     sb.append("+'Active API token (for responding to wave events):\\n'");
     sb.append("+'POST '+BASE+'/robot/dataapi/token\\n'");
     sb.append("+'Content-Type: application/x-www-form-urlencoded\\n'");
-    sb.append("+'grant_type=client_credentials&client_id=mybot-bot@'+DOMAIN+'&client_secret=SECRET&token_type=robot\\n\\n'");
+    sb.append("+'grant_type=client_credentials&client_id=mybot-bot@'+DOMAIN+'&client_secret=SECRET&expiry=3600&token_type=robot\\n\\n'");
     sb.append("+'Both return: {access_token, token_type:\"bearer\", expires_in}\\n'");
-    sb.append("+'Tokens default to never expire. Get both if building an active+data robot.\\n\\n'");
+    sb.append("+'Refresh the token after any HTTP 401 and retry once with a freshly issued JWT.\\n'");
+    sb.append("+'If tokenVersion changes because the secret was rotated or the robot was paused/deleted, the old JWT stops working immediately.\\n\\n'");
     sb.append("+'== Step 3: Build the robot web server ==\\n'");
     sb.append("+'Your robot is a web server that:\\n'");
     sb.append("+'a) Serves /_wave/capabilities.xml listing which events it handles\\n'");
     sb.append("+'b) Receives POST callbacks from SupaWave with wave events (JSON-RPC)\\n'");
     sb.append("+'c) Responds to events via POST to '+BASE+'/robot/rpc (Active API)\\n'");
-    sb.append("+'d) Proactively reads/writes via POST to '+BASE+'/robot/dataapi/rpc (Data API)\\n\\n'");
+    sb.append("+'d) Proactively reads/writes via POST to '+BASE+'/robot/dataapi/rpc (Data API)\\n'");
+    sb.append("+'When SupaWave POSTs an event bundle, read robotAddress from the payload so you know which robot identity handled the callback.\\n'");
+    sb.append("+'Use rpcServerUrl from the bundle instead of hardcoding the Data API endpoint when it is present.\\n'");
+    sb.append("+'For compatibility with older bundles, treat missing threads as {}.\\n\\n'");
     sb.append("+'== Capabilities XML (serve at https://your-server/_wave/capabilities.xml) ==\\n'");
     sb.append("+'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n'");
     sb.append("+'<w:robot xmlns:w=\"http://wave.google.com/extensions/robots/1.0\">\\n'");
@@ -1235,9 +1239,12 @@ public final class RobotDashboardServlet extends HttpServlet {
     sb.append("+'== Best practices ==\\n'");
     sb.append("+'- Read full docs at '+BASE+'/api/llm.txt before building\\n'");
     sb.append("+'- Build BOTH active + data mode for the most capable robot\\n'");
-    sb.append("+'- Robot tokens default to never expire (persistent web services)\\n'");
+    sb.append("+'- Prefer expiry=3600 for robot JWTs; 0 preserves legacy no-expiry behavior\\n'");
+    sb.append("+'- Refresh the token after any HTTP 401\\n'");
     sb.append("+'- Management tokens expire in 1 hour (registration only)\\n'");
     sb.append("+'- Callback URL must be set before requesting any robot tokens\\n'");
+    sb.append("+'- Use rpcServerUrl from the event bundle when it is present\\n'");
+    sb.append("+'- Read robotAddress from the bundle and treat missing threads as {}\\n'");
     sb.append("+'- Serve capabilities.xml so SupaWave knows which events to send\\n'");
     sb.append("+'- Rotate consumer secrets periodically\\n'");
     sb.append("+'- Data API supports batch requests (send array of operations)\\n'");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ApiDocsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ApiDocsServlet.java
@@ -548,6 +548,13 @@ public final class ApiDocsServlet extends HttpServlet {
         .append(escape(tokenCurlExample(baseUrl)))
         .append("</pre>\n");
     html.append("        <div class=\"warning\"><strong>Use short-lived tokens.</strong> The live token endpoint still supports effectively long-lived tokens when <code>expiry &lt;= 0</code> or when a robot account is configured with a zero lifetime. That behavior is high-risk and not shown in any example here.</div>\n");
+    html.append("        <div class=\"note\"><strong>Robot token lifecycle.</strong> A robot's consumer secret is long-lived until you rotate it, but the Data API JWT is not. Data API JWTs are signed by the server's current JWT signing key and include <code>sub</code> (robot address), <code>aud=[&quot;data-api&quot;]</code>, <code>scope=[&quot;wave:data:read&quot;,&quot;wave:data:write&quot;]</code>, <code>exp</code>, and <code>ver</code> (the current <code>tokenVersion</code> for that robot).</div>\n");
+    html.append("        <ul>\n");
+    html.append("          <li>The server only issues robot tokens once the robot has a configured callback URL and verified registration state.</li>\n");
+    html.append("          <li>If you omit <code>expiry</code>, the server falls back to the robot account's <code>tokenExpirySeconds</code>; prefer <code>expiry=3600</code> for new integrations.</li>\n");
+    html.append("          <li>Refresh the JWT after any HTTP 401 and retry the RPC call once with a newly issued token.</li>\n");
+    html.append("          <li>If <code>tokenVersion</code> changes because the secret was rotated or the robot was paused/deleted, older JWTs stop working even before <code>exp</code>.</li>\n");
+    html.append("        </ul>\n");
     html.append("      </section>\n");
     html.append("      <section id=\"build-with-ai\">\n");
     html.append("        <h2>Build with AI</h2>\n");
@@ -873,7 +880,7 @@ public final class ApiDocsServlet extends HttpServlet {
     post.put("summary", "Issue a Data API or Robot JWT");
     post.put(
         "description",
-        "Issue a JWT token for Data API or Robot API access. Use token_type=robot for Robot API tokens. Supports browser-session issuance and robot client_credentials issuance. Prefer expiry=3600 or another short-lived value.");
+        "Issue a JWT token for Data API or Robot API access. Use token_type=robot for Robot API tokens. Supports browser-session issuance and robot client_credentials issuance. Prefer expiry=3600 or another short-lived value, refresh after HTTP 401, and remember that tokenVersion changes revoke older JWTs immediately.");
     post.put(
         "requestBody",
         orderedMap(
@@ -1278,6 +1285,14 @@ public final class ApiDocsServlet extends HttpServlet {
     text.append("Token acquisition (client_credentials, short-lived example)\n");
     text.append(tokenCurlExample(baseUrl)).append("\n\n");
 
+    text.append("Robot token lifecycle\n");
+    text.append("- The robot consumer secret is long-lived until rotation; the JWT is not.\n");
+    text.append("- Data API JWTs are signed by the server's current JWT signing key and include typ=data-api-access, sub=<robotAddress>, aud=[data-api], scope=[wave:data:read,wave:data:write], exp, and ver=tokenVersion.\n");
+    text.append("- The server only issues robot tokens once the robot has a configured callback URL and verified registration state.\n");
+    text.append("- If you omit expiry, the server falls back to tokenExpirySeconds from the robot account; prefer expiry=3600 for new integrations.\n");
+    text.append("- Refresh the JWT after any HTTP 401 and retry once with a newly issued token.\n");
+    text.append("- If tokenVersion changes because the secret was rotated or the robot was paused/deleted, older JWTs stop working immediately.\n\n");
+
     text.append("Google AI Studio / Gemini starter prompt\n");
     text.append("Build a SupaWave robot for me.\n");
     text.append("Use these environment variables exactly:\n");
@@ -1373,6 +1388,9 @@ public final class ApiDocsServlet extends HttpServlet {
     text.append("- ").append(LLMS_FULL_PATH).append(" is the canonical LLM-friendly reference path.\n");
     text.append("- ").append(LLM_ALIAS_PATH).append(" remains live as a backward-compatible alias.\n");
     text.append("- Do not advertise wavelet.create as the current public API. All auth uses JWT Bearer tokens.\n");
+    text.append("- Fetch and callback bundles include robotAddress.\n");
+    text.append("- Current servers also include rpcServerUrl; use it instead of hardcoding /robot/dataapi/rpc when present.\n");
+    text.append("- Treat missing threads as {} when talking to older bundle payloads.\n");
     return text.toString();
   }
 
@@ -1560,6 +1578,8 @@ public final class ApiDocsServlet extends HttpServlet {
                 "returnWaveletIds", false,
                 "message", "optional fetch tag"),
             orderedMap(
+                "robotAddress", "helper-bot@example.com",
+                "rpcServerUrl", "https://wave.example.com/robot/dataapi/rpc",
                 "blipId", "b+root",
                 "message", "optional fetch tag",
                 "waveletData",
@@ -1576,7 +1596,7 @@ public final class ApiDocsServlet extends HttpServlet {
                                 "content", "\nWelcome to the wave",
                                 "contributors", list("alice@example.com"))),
                 "threads", orderedMap("thread+root", orderedMap("id", "thread+root", "blipIds", list("b+root")))),
-            "When returnWaveletIds=true the server returns waveletIds instead of the waveletData/blips/threads bundle."));
+            "When returnWaveletIds=true the server returns waveletIds instead of the waveletData/blips/threads bundle. Fetch bundles include robotAddress and, on current servers, rpcServerUrl. Treat missing threads as {} when reading older payloads."));
     operations.add(
         operation(
             "Wave and conversation",

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/RobotDashboardServletTest.java
@@ -219,6 +219,21 @@ public class RobotDashboardServletTest extends TestCase {
     assertTrue(outputWriter.toString().contains("SUPAWAVE_LLM_DOCS_URL="));
   }
 
+  public void testDoGetAiPromptDocumentsShortLivedRefreshAndBundleFields() throws Exception {
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
+    when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());
+
+    servlet.doGet(req, resp);
+
+    String output = outputWriter.toString();
+    assertTrue(output.contains("Refresh the token after any HTTP 401"));
+    assertTrue(output.contains("rpcServerUrl"));
+    assertTrue(output.contains("robotAddress"));
+    assertTrue(output.contains("treat missing threads as {}"));
+    assertFalse(output.contains("Tokens default to never expire. Get both if building an active+data robot."));
+    assertFalse(output.contains("- Robot tokens default to never expire (persistent web services)"));
+  }
+
   public void testDoPostRejectsMissingXsrfToken() throws Exception {
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(OWNER);
     when(accountStore.getRobotAccountsOwnedBy(OWNER.getAddress())).thenReturn(List.of());

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/ApiDocsServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/ApiDocsServletTest.java
@@ -47,6 +47,23 @@ public final class ApiDocsServletTest {
   }
 
   @Test
+  public void apiDocsHtmlDocumentsRobotTokenLifecycleAndBundleCompatibility() throws Exception {
+    ApiDocsServlet servlet = new ApiDocsServlet("docs.example.com");
+    StringWriter body = new StringWriter();
+    ResponseRecorder recorder = new ResponseRecorder();
+    HttpServletRequest request = request("/api-docs", "https", "docs.example.com");
+    HttpServletResponse response = response(recorder, body);
+
+    servlet.doGet(request, response);
+
+    assertTrue(recorder.status == HttpServletResponse.SC_OK);
+    assertTrue(body.toString().contains("Refresh the JWT after any HTTP 401"));
+    assertTrue(body.toString().contains("tokenVersion"));
+    assertTrue(body.toString().contains("robotAddress"));
+    assertTrue(body.toString().contains("Treat missing threads as {}"));
+  }
+
+  @Test
   public void apiDocsHtmlDocumentsAttachmentBackedInlineImageFlow() throws Exception {
     ApiDocsServlet servlet = new ApiDocsServlet("docs.example.com");
     StringWriter body = new StringWriter();
@@ -96,6 +113,10 @@ public final class ApiDocsServletTest {
     assertTrue(body.toString().contains("SupaWave Data API LLM Reference"));
     assertTrue(body.toString().contains("Canonical RPC path: /robot/dataapi/rpc"));
     assertTrue(body.toString().contains("https://docs.example.com/api/openapi.json"));
+    assertTrue(body.toString().contains("Refresh the JWT after any HTTP 401"));
+    assertTrue(body.toString().contains("tokenVersion"));
+    assertTrue(body.toString().contains("robotAddress"));
+    assertTrue(body.toString().contains("Treat missing threads as {}"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- document the live robot Data API JWT lifecycle in generated API docs and LLM docs
- update the robot dashboard onboarding prompt so it teaches short-lived token refresh/re-auth instead of never-expiring JWTs
- add durable markdown docs for operators and the `gpt-bot` example, plus focused servlet tests for the new guidance

## Why
Issue #721 was only partially covered by merged work. `#436` added the AI-friendly docs surfaces and `#717` populated `rpcServerUrl`, but the repo still lacked complete token refresh/version docs, the dashboard prompt still contained stale token guidance, and there was no durable markdown doc in `docs/` for the robot auth flow.

## Verification
- `cp /Users/vega/devroot/incubator-wave/wave/config/changelog.json wave/config/changelog.json && sbt "testOnly org.waveprotocol.box.server.rpc.ApiDocsServletTest org.waveprotocol.box.server.robots.RobotDashboardServletTest"`
- `rg -n "tokenVersion|401|rpcServerUrl|robotAddress|threads|consumer secret|expiry=3600|typ|kid" docs/robot-data-api-authentication.md docs/gpt-bot.md -S`

## Notes
- The local SBT compile path currently hard-requires `wave/config/changelog.json`, so the verification command restores the assembled changelog file into the worktree for the duration of the test run and then removes it afterward.
- Claude review flagged one markdown terminology issue (`typ`/`kid` header vs claim naming); that was corrected before push.

Closes #721.