### PR TITLE
fix(robots): advertise rpcServerUrl by auth mode

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-720-rpcserverurl-authmode.md
+++ b/docs/superpowers/plans/2026-04-10-issue-720-rpcserverurl-authmode.md
@@ -1,0 +1,335 @@
+# Issue 720 RpcServerUrl Auth Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make passive robot event bundles advertise the JSON-RPC endpoint that matches the robot's configured OAuth mode: `/robot/rpc` for 2-legged robots and `/robot/dataapi/rpc` for 3-legged robots.
+
+**Architecture:** Keep the fix on the passive robot path only. Preserve the robot-advertised RPC endpoint when capabilities are fetched, then choose the bundle `rpcServerUrl` at event-generation time from the current robot account instead of freezing one URL at gateway construction. Treat the parsed endpoint as a runtime transport hint, not as part of the persisted capability identity, so the change stays narrow and restart-safe by forcing a capability refresh when the hint is missing.
+
+**Tech Stack:** Java, existing Wave robot capability parsing, JUnit 3 style unit tests, Mockito, SBT `wave/testOnly`.
+
+---
+
+### Task 1: Preserve The Robot-Advertised RPC Endpoint During Capability Fetch
+
+**Files:**
+- Modify: `wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/robots/RobotCapabilities.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java`
+- Test: `wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotConnectorTest.java`
+
+- [ ] **Step 1: Write the failing fetch-capabilities regression tests**
+
+```java
+public void testFetchCapabilitiesPrefersRobotRpcWhenCapabilitiesAdvertiseTwoLeggedOauth()
+    throws Exception {
+  String capabilitiesXml =
+      "<w:robot xmlns:w=\"http://wave.google.com/extensions/robots/1.0\">"
+          + "<w:version>hash</w:version>"
+          + "<w:protocolversion>0.22</w:protocolversion>"
+          + "<w:capabilities><w:capability name=\"WAVELET_SELF_ADDED\"/></w:capabilities>"
+          + "<w:consumer_keys>"
+          + "<w:consumer_key for=\"https://wave.example.com/robot/rpc\">robot@example.com</w:consumer_key>"
+          + "</w:consumer_keys>"
+          + "</w:robot>";
+  when(connection.get(TEST_CAPABILITIES_ENDPOINT)).thenReturn(capabilitiesXml);
+
+  RobotAccountData accountData =
+      connector.fetchCapabilities(ROBOT_ACCOUNT, "https://wave.example.com/robot/rpc");
+
+  assertEquals("https://wave.example.com/robot/rpc",
+      accountData.getCapabilities().getRpcServerUrl());
+}
+
+public void testFetchCapabilitiesFallsBackToDataApiRpcWhenOnlyThreeLeggedOauthIsAdvertised()
+    throws Exception {
+  String capabilitiesXml =
+      "<w:robot xmlns:w=\"http://wave.google.com/extensions/robots/1.0\">"
+          + "<w:version>hash</w:version>"
+          + "<w:protocolversion>0.22</w:protocolversion>"
+          + "<w:capabilities><w:capability name=\"WAVELET_SELF_ADDED\"/></w:capabilities>"
+          + "<w:consumer_keys>"
+          + "<w:consumer_key for=\"https://wave.example.com/robot/dataapi/rpc\">robot@example.com</w:consumer_key>"
+          + "</w:consumer_keys>"
+          + "</w:robot>";
+  when(connection.get(TEST_CAPABILITIES_ENDPOINT)).thenReturn(capabilitiesXml);
+
+  RobotAccountData accountData =
+      connector.fetchCapabilities(ROBOT_ACCOUNT, "https://wave.example.com/robot/rpc");
+
+  assertEquals("https://wave.example.com/robot/dataapi/rpc",
+      accountData.getCapabilities().getRpcServerUrl());
+}
+```
+
+- [ ] **Step 2: Run the focused connector test to verify red**
+
+Run: `sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest"`
+Expected: FAIL because `RobotCapabilities` does not yet expose a parsed `rpcServerUrl`.
+
+- [ ] **Step 3: Add the runtime transport hint to parsed capabilities**
+
+```java
+// RobotCapabilities.java
+private final String rpcServerUrl;
+
+public RobotCapabilities(Map<EventType, Capability> capabilitiesMap, String capabilitiesHash,
+    ProtocolVersion version) {
+  this(capabilitiesMap, capabilitiesHash, version, "");
+}
+
+public RobotCapabilities(Map<EventType, Capability> capabilitiesMap, String capabilitiesHash,
+    ProtocolVersion version, String rpcServerUrl) {
+  ...
+  this.rpcServerUrl = rpcServerUrl == null ? "" : rpcServerUrl;
+}
+
+public String getRpcServerUrl() {
+  return rpcServerUrl;
+}
+
+// RobotCapabilitiesParser.java
+private static final String ACTIVE_RPC_PATH = "/robot/rpc";
+private static final String DATA_API_RPC_PATH = "/robot/dataapi/rpc";
+private String rpcServerUrl = "";
+
+public String getRpcServerUrl() {
+  return rpcServerUrl;
+}
+
+for (Element consumerKeyElement : getElements(document, CONSUMER_KEYS_TAG, CONSUMER_KEY_TAG, XML_NS)) {
+  String forUrl = consumerKeyElement.getAttributeValue(CONSUMER_KEY_FOR_ATTRIBUTE);
+  if (forUrl == null || forUrl.isEmpty()) {
+    continue;
+  }
+  if (forUrl.equals(activeRobotApiUrl)) {
+    consumerKey = consumerKeyElement.getText();
+  }
+  if (forUrl.endsWith(ACTIVE_RPC_PATH)) {
+    rpcServerUrl = forUrl;
+  } else if (rpcServerUrl.isEmpty() && forUrl.endsWith(DATA_API_RPC_PATH)) {
+    rpcServerUrl = forUrl;
+  }
+}
+
+// RobotConnector.java
+RobotCapabilities capabilities = new RobotCapabilities(
+    parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion(),
+    parser.getRpcServerUrl());
+```
+
+- [ ] **Step 4: Re-run the focused connector test to verify green**
+
+Run: `sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest"`
+Expected: PASS, including the new 2-legged and 3-legged assertions.
+
+- [ ] **Step 5: Commit the capability-fetch seam**
+
+```bash
+git add \
+  wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java \
+  wave/src/main/java/org/waveprotocol/box/server/robots/RobotCapabilities.java \
+  wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java \
+  wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotConnectorTest.java
+git commit -m "fix(robots): retain advertised rpc endpoint from capabilities"
+```
+
+### Task 2: Choose RpcServerUrl Per Passive Robot Event Dispatch
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java`
+- Test: `wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java`
+- Test: `wave/src/test/java/org/waveprotocol/box/server/robots/passive/EventGeneratorTest.java`
+
+- [ ] **Step 1: Write the failing passive-dispatch regression tests**
+
+```java
+public void testProcessAdvertisesRobotRpcForTwoLeggedRobot() throws Exception {
+  RobotAccountData twoLeggedAccount =
+      new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
+          Maps.<EventType, Capability>newHashMap(), "fake", ProtocolVersion.DEFAULT,
+          "https://wave.example.com/robot/rpc"), true, 0L, null, "", 0L, 20L, false);
+  doAnswer(invocation -> {
+    robot.setAccount(twoLeggedAccount);
+    return null;
+  }).when(gateway).updateRobotAccount(robot);
+
+  EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
+  messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
+  when(eventGenerator.generateEvents(any(), anyMap(), any(), eq("https://wave.example.com/robot/rpc")))
+      .thenReturn(messages);
+  when(connector.sendMessageBundle(any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class)))
+      .thenReturn(Collections.<OperationRequest>emptyList());
+
+  enqueueEmptyWavelet();
+  robot.run();
+
+  verify(eventGenerator).generateEvents(any(), anyMap(), any(),
+      eq("https://wave.example.com/robot/rpc"));
+}
+
+public void testProcessAdvertisesDataApiRpcForThreeLeggedRobot() throws Exception {
+  RobotAccountData threeLeggedAccount =
+      new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
+          Maps.<EventType, Capability>newHashMap(), "fake", ProtocolVersion.DEFAULT,
+          "https://wave.example.com/robot/dataapi/rpc"), true, 0L, null, "", 0L, 20L, false);
+  doAnswer(invocation -> {
+    robot.setAccount(threeLeggedAccount);
+    return null;
+  }).when(gateway).updateRobotAccount(robot);
+
+  EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
+  messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
+  when(eventGenerator.generateEvents(any(), anyMap(), any(),
+      eq("https://wave.example.com/robot/dataapi/rpc"))).thenReturn(messages);
+  when(connector.sendMessageBundle(any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class)))
+      .thenReturn(Collections.<OperationRequest>emptyList());
+
+  enqueueEmptyWavelet();
+  robot.run();
+
+  verify(eventGenerator).generateEvents(any(), anyMap(), any(),
+      eq("https://wave.example.com/robot/dataapi/rpc"));
+}
+```
+
+- [ ] **Step 2: Run the passive robot tests to verify red**
+
+Run: `sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"`
+Expected: FAIL because the passive path still freezes a single `rpcServerUrl` before account capabilities are considered.
+
+- [ ] **Step 3: Move rpcServerUrl selection to event-generation time**
+
+```java
+// EventGenerator.java
+public EventMessageBundle generateEvents(WaveletAndDeltas waveletAndDeltas,
+    Map<EventType, Capability> capabilities, EventDataConverter converter,
+    String rpcServerUrl) {
+  EventMessageBundle messages = new EventMessageBundle(robotName.toEmailAddress(), rpcServerUrl);
+  ...
+}
+
+// Robot.java
+private static final String DEFAULT_DATA_API_RPC_PATH = "/robot/dataapi/rpc";
+
+private String resolveRpcServerUrl(RobotAccountData currentAccount) {
+  RobotCapabilities capabilities = currentAccount.getCapabilities();
+  if (capabilities != null && !capabilities.getRpcServerUrl().isEmpty()) {
+    return capabilities.getRpcServerUrl();
+  }
+  return gateway.getDefaultRpcServerUrl();
+}
+
+if (currentAccount.getCapabilities() == null
+    || currentAccount.getCapabilities().getRpcServerUrl().isEmpty()) {
+  gateway.updateRobotAccount(this);
+  currentAccount = account;
+}
+
+EventMessageBundle messages = eventGenerator.generateEvents(
+    wavelet, capabilities.getCapabilitiesMap(),
+    converterManager.getEventDataConverter(capabilities.getProtocolVersion()),
+    resolveRpcServerUrl(currentAccount));
+
+// RobotsGateway.java
+public static final String DATA_API_RPC_PATH = "/robot/dataapi/rpc";
+private final String defaultRpcServerUrl;
+
+this.defaultRpcServerUrl = PublicBaseUrlResolver.resolve(config) + DATA_API_RPC_PATH;
+
+String getDefaultRpcServerUrl() {
+  return defaultRpcServerUrl;
+}
+```
+
+- [ ] **Step 4: Re-run the passive robot tests to verify green**
+
+Run: `sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"`
+Expected: PASS, with passive dispatch verifying `/robot/rpc` for 2-legged and `/robot/dataapi/rpc` for 3-legged.
+
+- [ ] **Step 5: Commit the passive-dispatch fix**
+
+```bash
+git add \
+  wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java \
+  wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java \
+  wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java \
+  wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java \
+  wave/src/test/java/org/waveprotocol/box/server/robots/passive/EventGeneratorTest.java
+git commit -m "fix(robots): advertise rpc endpoint by oauth mode"
+```
+
+### Task 3: Verification, Review, And PR Evidence
+
+**Files:**
+- Modify: `journal/local-verification/2026-04-10-issue-720-rpcserverurl-authmode.md`
+- Modify: GitHub issue `#720` comments
+
+- [ ] **Step 1: Run the targeted verification suite**
+
+Run:
+
+```bash
+sbt \
+  "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest" \
+  "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" \
+  "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"
+```
+
+Expected: PASS for all targeted passive-robot regression tests.
+
+- [ ] **Step 2: Record the verification evidence locally**
+
+```md
+# Issue 720 Local Verification
+
+- Command: `sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"`
+- Result: PASS
+- Notes: Verified 2-legged robots advertise `/robot/rpc`; 3-legged robots advertise `/robot/dataapi/rpc`.
+```
+
+- [ ] **Step 3: Run direct review plus Claude review on the implementation diff**
+
+Run:
+
+```bash
+export REVIEW_TASK="issue-720 rpcServerUrl auth mode"
+export REVIEW_GOAL="Ensure passive robot event bundles advertise the JSON-RPC endpoint that matches 2-legged versus 3-legged OAuth configuration."
+export REVIEW_ACCEPTANCE=$'- 2-legged passive robots advertise /robot/rpc\n- 3-legged passive robots advertise /robot/dataapi/rpc\n- Fix stays on the passive robot path\n- Focused regression tests pass'
+export REVIEW_RUNTIME="Java + Wave robot server"
+export REVIEW_RISKY="Passive robot capability refresh, rpcServerUrl selection, event bundle generation"
+export REVIEW_TEST_COMMANDS='sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"'
+export REVIEW_TEST_RESULTS="pass"
+export REVIEW_DIFF_SPEC="origin/main...HEAD"
+/Users/vega/.codex/skills/public/claude-review/scripts/review_task.sh
+```
+
+Expected: review output in `/tmp/claude-review.out`; address any findings before PR.
+
+- [ ] **Step 4: Update issue evidence and open the PR**
+
+```bash
+git status --short
+git log --oneline --decorate origin/main..HEAD
+git push -u origin issue-720-rpcserverurl-authmode-20260410
+```
+
+Then add a GitHub issue comment containing:
+- worktree path `/Users/vega/devroot/worktrees/issue-720-rpcserverurl-authmode-20260410`
+- branch `issue-720-rpcserverurl-authmode-20260410`
+- this plan path
+- commit SHAs and one-line summaries
+- verification command/result
+- review summary and resolution notes
+
+- [ ] **Step 5: Create the PR**
+
+Create a PR against `main` titled:
+
+```text
+fix(robots): advertise rpcServerUrl by robot auth mode
+```
+
+PR body must link `#720` and include the same focused verification command/result.

--- a/wave/config/changelog.d/2026-04-10-robot-rpcserverurl-auth-mode.json
+++ b/wave/config/changelog.d/2026-04-10-robot-rpcserverurl-auth-mode.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-robot-rpcserverurl-auth-mode",
+  "version": "PR #720",
+  "date": "2026-04-10",
+  "title": "Robots: Auth-Mode-Aware rpcServerUrl Advertisement",
+  "summary": "Passive robot event bundles now advertise the JSON-RPC endpoint that matches the robot's configured OAuth mode.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Passive robots using 2-legged OAuth now receive /robot/rpc in EventMessageBundle.rpcServerUrl",
+        "Passive robots using 3-legged OAuth now receive /robot/dataapi/rpc in EventMessageBundle.rpcServerUrl"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotApiServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotApiServlet.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.wave.api.robot.CapabilityFetchException;
+import com.typesafe.config.Config;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,9 +23,11 @@ import org.waveprotocol.box.server.authentication.jwt.JwtRequestAuthenticator;
 import org.waveprotocol.box.server.authentication.jwt.JwtScopes;
 import org.waveprotocol.box.server.authentication.jwt.JwtTokenType;
 import org.waveprotocol.box.server.authentication.jwt.JwtValidationException;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
+import org.waveprotocol.box.server.robots.passive.RobotsGateway;
 import org.waveprotocol.box.server.robots.register.RobotRegistrar;
 import org.waveprotocol.box.server.robots.util.RobotsUtil.RobotRegistrationException;
 import org.waveprotocol.box.server.util.RegistrationSupport;
@@ -73,6 +76,7 @@ public final class RobotApiServlet extends HttpServlet {
   private final AccountStore accountStore;
   private final RobotRegistrar robotRegistrar;
   private final RobotCapabilityFetcher capabilityFetcher;
+  private final String activeRobotApiUrl;
 
   @Inject
   public RobotApiServlet(
@@ -80,12 +84,14 @@ public final class RobotApiServlet extends HttpServlet {
       JwtRequestAuthenticator jwtAuthenticator,
       AccountStore accountStore,
       RobotRegistrar robotRegistrar,
-      RobotCapabilityFetcher capabilityFetcher) {
+      RobotCapabilityFetcher capabilityFetcher,
+      Config config) {
     this.domain = domain;
     this.jwtAuthenticator = jwtAuthenticator;
     this.accountStore = accountStore;
     this.robotRegistrar = robotRegistrar;
     this.capabilityFetcher = capabilityFetcher;
+    this.activeRobotApiUrl = PublicBaseUrlResolver.resolve(config) + RobotsGateway.DATA_API_RPC_PATH;
   }
 
   // ── Authentication ──────────────────────────────────────────────────
@@ -452,7 +458,7 @@ public final class RobotApiServlet extends HttpServlet {
     try {
       // Fetch capabilities via network call, then atomically apply to a fresh store read
       // to avoid overwriting concurrent changes (secret rotation, description edits, etc.)
-      RobotAccountData refreshed = capabilityFetcher.fetchCapabilities(robot, "");
+      RobotAccountData refreshed = capabilityFetcher.fetchCapabilities(robot, activeRobotApiUrl);
       RobotAccountData verified = robotRegistrar.markVerified(robot.getId(), refreshed.getCapabilities());
       if (verified == null) {
         sendError(resp, 404, "Robot not found", "NOT_FOUND");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/RobotDashboardServlet.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.wave.api.robot.CapabilityFetchException;
 import com.google.inject.name.Named;
+import com.typesafe.config.Config;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -35,9 +36,11 @@ import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
+import org.waveprotocol.box.server.robots.passive.RobotsGateway;
 import org.waveprotocol.box.server.robots.register.RobotRegistrar;
 import org.waveprotocol.box.server.robots.util.RobotsUtil.RobotRegistrationException;
 import org.waveprotocol.box.server.rpc.HtmlRenderer;
@@ -72,10 +75,29 @@ public final class RobotDashboardServlet extends HttpServlet {
   private final RobotCapabilityFetcher capabilityFetcher;
   private final TokenGenerator tokenGenerator;
   private final Clock clock;
+  private final String activeRobotApiUrl;
   private final ConcurrentMap<ParticipantId, String> xsrfTokens;
 
   @Inject
   public RobotDashboardServlet(@Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
+      SessionManager sessionManager, AccountStore accountStore, RobotRegistrar robotRegistrar,
+      RobotCapabilityFetcher capabilityFetcher, TokenGenerator tokenGenerator, Clock clock,
+      Config config) {
+    this.domain = domain;
+    this.sessionManager = sessionManager;
+    this.accountStore = accountStore;
+    this.robotRegistrar = robotRegistrar;
+    this.capabilityFetcher = capabilityFetcher;
+    this.tokenGenerator = tokenGenerator;
+    this.clock = clock;
+    this.activeRobotApiUrl = PublicBaseUrlResolver.resolve(config) + RobotsGateway.DATA_API_RPC_PATH;
+    this.xsrfTokens = CacheBuilder.newBuilder()
+        .expireAfterWrite(XSRF_TOKEN_TIMEOUT_HOURS, TimeUnit.HOURS)
+        .<ParticipantId, String>build()
+        .asMap();
+  }
+
+  RobotDashboardServlet(@Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
       SessionManager sessionManager, AccountStore accountStore, RobotRegistrar robotRegistrar,
       RobotCapabilityFetcher capabilityFetcher, TokenGenerator tokenGenerator, Clock clock) {
     this.domain = domain;
@@ -85,6 +107,7 @@ public final class RobotDashboardServlet extends HttpServlet {
     this.capabilityFetcher = capabilityFetcher;
     this.tokenGenerator = tokenGenerator;
     this.clock = clock;
+    this.activeRobotApiUrl = "";
     this.xsrfTokens = CacheBuilder.newBuilder()
         .expireAfterWrite(XSRF_TOKEN_TIMEOUT_HOURS, TimeUnit.HOURS)
         .<ParticipantId, String>build()
@@ -444,7 +467,7 @@ public final class RobotDashboardServlet extends HttpServlet {
 
   private RobotAccountData verifyRobot(RobotAccountData ownedRobot)
       throws CapabilityFetchException, PersistenceException {
-    RobotAccountData refreshedRobot = capabilityFetcher.fetchCapabilities(ownedRobot, "");
+    RobotAccountData refreshedRobot = capabilityFetcher.fetchCapabilities(ownedRobot, activeRobotApiUrl);
     RobotAccountData verifiedRobot = new RobotAccountDataImpl(
         refreshedRobot.getId(),
         refreshedRobot.getUrl(),

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/operations/NotifyOperationService.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/operations/NotifyOperationService.java
@@ -8,13 +8,16 @@ import com.google.wave.api.OperationRequest;
 import com.google.wave.api.JsonRpcConstant.ParamsProperty;
 import com.google.wave.api.robot.CapabilityFetchException;
 import com.google.wave.api.robot.RobotName;
+import com.typesafe.config.Config;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.robots.OperationContext;
 import org.waveprotocol.box.server.robots.RobotCapabilities;
 import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
+import org.waveprotocol.box.server.robots.passive.RobotsGateway;
 import org.waveprotocol.box.server.robots.util.OperationUtil;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
@@ -24,11 +27,14 @@ public class NotifyOperationService implements OperationService {
 
   private final AccountStore accountStore;
   private final RobotCapabilityFetcher capabilityFetcher;
+  private final String activeRobotApiUrl;
 
   @Inject
-  public NotifyOperationService(AccountStore accountStore, RobotCapabilityFetcher capabilityFetcher) {
+  public NotifyOperationService(AccountStore accountStore, RobotCapabilityFetcher capabilityFetcher,
+      Config config) {
     this.accountStore = accountStore;
     this.capabilityFetcher = capabilityFetcher;
+    this.activeRobotApiUrl = PublicBaseUrlResolver.resolve(config) + RobotsGateway.DATA_API_RPC_PATH;
   }
 
   @Override
@@ -61,7 +67,7 @@ public class NotifyOperationService implements OperationService {
     }
 
     try {
-      robotAccountData = capabilityFetcher.fetchCapabilities(robotAccountData, "");
+      robotAccountData = capabilityFetcher.fetchCapabilities(robotAccountData, activeRobotApiUrl);
     } catch (CapabilityFetchException e) {
       LOG.fine("Unable to retrieve capabilities for " + account.getId(), e);
       context.constructErrorResponse(operation, "Unable to retrieve new capabilities");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
@@ -57,7 +57,8 @@ public class RobotConnector implements RobotCapabilityFetcher {
     RobotCapabilitiesParser parser = new RobotCapabilitiesParser(
         robotBaseUrl(account.getUrl()) + Robot.CAPABILITIES_URL, connection, activeApiUrl);
     RobotCapabilities capabilities = new RobotCapabilities(
-        parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion());
+        parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion(),
+        parser.getRpcServerUrl());
     long updatedAtMillis = Math.max(account.getUpdatedAtMillis() + 1L,
         System.currentTimeMillis());
     return new RobotAccountDataImpl(account.getId(), account.getUrl(), account.getConsumerSecret(),

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/NotifyOperationServiceJakartaIT.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/NotifyOperationServiceJakartaIT.java
@@ -37,6 +37,7 @@ import org.waveprotocol.box.server.robots.RobotCapabilities;
 import org.waveprotocol.box.server.robots.operations.NotifyOperationService;
 import org.waveprotocol.box.server.robots.passive.RobotConnector;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import com.typesafe.config.ConfigFactory;
 
 import java.util.Map;
 import java.util.NavigableMap;
@@ -64,7 +65,7 @@ public final class NotifyOperationServiceJakartaIT {
     connection = new ConfigurableRobotConnection("hash-new");
     RobotSerializer serializer = createSerializer();
     RobotConnector connector = new RobotConnector(connection, serializer);
-    service = new NotifyOperationService(accountStore, connector);
+    service = new NotifyOperationService(accountStore, connector, ConfigFactory.empty());
   }
 
   @Test

--- a/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
+++ b/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
@@ -216,10 +216,19 @@ public class RobotCapabilitiesParser {
       URI ref = new URI(referenceUrl);
       return u.getScheme() != null && u.getScheme().equals(ref.getScheme())
           && u.getHost() != null && u.getHost().equals(ref.getHost())
-          && u.getPort() == ref.getPort();
+          && effectivePort(u) == effectivePort(ref);
     } catch (URISyntaxException e) {
       return false;
     }
+  }
+
+  private static int effectivePort(URI uri) {
+    int port = uri.getPort();
+    if (port != -1) return port;
+    String scheme = uri.getScheme();
+    if ("https".equalsIgnoreCase(scheme)) return 443;
+    if ("http".equalsIgnoreCase(scheme)) return 80;
+    return -1;
   }
 
   @SuppressWarnings({"cast", "unchecked"})

--- a/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
+++ b/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
@@ -57,6 +57,8 @@ public class RobotCapabilitiesParser {
   private static final String CONSUMER_KEYS_TAG = "consumer_keys";
   private static final String CONSUMER_KEY_TAG = "consumer_key";
   private static final String CONSUMER_KEY_FOR_ATTRIBUTE = "for";
+  private static final String ACTIVE_RPC_PATH = "/robot/rpc";
+  private static final String DATA_API_RPC_PATH = "/robot/dataapi/rpc";
 
   private final String capabilitiesXmlUrl;
 
@@ -69,6 +71,7 @@ public class RobotCapabilitiesParser {
   private ProtocolVersion protocolVersion;
 
   private String consumerKey;  // null if no consumer key
+  private String rpcServerUrl = "";
 
   private final String activeRobotApiUrl;
 
@@ -96,6 +99,10 @@ public class RobotCapabilitiesParser {
 
   public String getConsumerKey() {
     return consumerKey;
+  }
+
+  public String getRpcServerUrl() {
+    return rpcServerUrl;
   }
 
   private void parseRobotDescriptionXmlFile() throws CapabilityFetchException {
@@ -144,6 +151,15 @@ public class RobotCapabilitiesParser {
         String forUrl = consumerKeyElement.getAttributeValue(CONSUMER_KEY_FOR_ATTRIBUTE);
         if (forUrl != null && forUrl.equals(activeRobotApiUrl)) {
           consumerKey = consumerKeyElement.getText();
+        }
+        if (forUrl == null || forUrl.isEmpty()) {
+          continue;
+        }
+        // Prefer the 2-legged active endpoint when both are advertised.
+        if (forUrl.endsWith(ACTIVE_RPC_PATH)) {
+          rpcServerUrl = forUrl;
+        } else if (rpcServerUrl.isEmpty() && forUrl.endsWith(DATA_API_RPC_PATH)) {
+          rpcServerUrl = forUrl;
         }
       }
     } catch (IOException iox) {

--- a/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
+++ b/wave/src/main/java/com/google/wave/api/robot/RobotCapabilitiesParser.java
@@ -33,6 +33,8 @@ import org.jdom.input.SAXBuilder;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -156,10 +158,13 @@ public class RobotCapabilitiesParser {
           continue;
         }
         // Prefer the 2-legged active endpoint when both are advertised.
-        if (forUrl.endsWith(ACTIVE_RPC_PATH)) {
-          rpcServerUrl = forUrl;
-        } else if (rpcServerUrl.isEmpty() && forUrl.endsWith(DATA_API_RPC_PATH)) {
-          rpcServerUrl = forUrl;
+        // Only accept endpoints on the same host as this server.
+        if (isSameHost(forUrl, activeRobotApiUrl)) {
+          if (forUrl.endsWith(ACTIVE_RPC_PATH)) {
+            rpcServerUrl = forUrl;
+          } else if (rpcServerUrl.isEmpty() && forUrl.endsWith(DATA_API_RPC_PATH)) {
+            rpcServerUrl = forUrl;
+          }
         }
       }
     } catch (IOException iox) {
@@ -203,6 +208,18 @@ public class RobotCapabilitiesParser {
     }
 
     this.capabilities.put(eventType, new Capability(eventType, contexts, filter));
+  }
+
+  private static boolean isSameHost(String url, String referenceUrl) {
+    try {
+      URI u = new URI(url);
+      URI ref = new URI(referenceUrl);
+      return u.getScheme() != null && u.getScheme().equals(ref.getScheme())
+          && u.getHost() != null && u.getHost().equals(ref.getHost())
+          && u.getPort() == ref.getPort();
+    } catch (URISyntaxException e) {
+      return false;
+    }
   }
 
   @SuppressWarnings({"cast", "unchecked"})

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
@@ -111,6 +111,7 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
   private static final String CAPABILITIES_VERSION_FIELD = "version";
   private static final String CAPABILITIES_HASH_FIELD = "capabilitiesHash";
   private static final String CAPABILITIES_CAPABILITIES_FIELD = "capabilities";
+  private static final String CAPABILITIES_RPC_SERVER_URL_FIELD = "rpcServerUrl";
   private static final String CAPABILITY_CONTEXTS_FIELD = "contexts";
   private static final String CAPABILITY_FILTER_FIELD = "filter";
 
@@ -476,7 +477,8 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
         new BasicDBObject()
             .append(CAPABILITIES_CAPABILITIES_FIELD, capabilitiesObj)
             .append(CAPABILITIES_HASH_FIELD, capabilities.getCapabilitiesHash())
-            .append(CAPABILITIES_VERSION_FIELD, capabilities.getProtocolVersion().name());
+            .append(CAPABILITIES_VERSION_FIELD, capabilities.getProtocolVersion().name())
+            .append(CAPABILITIES_RPC_SERVER_URL_FIELD, capabilities.getRpcServerUrl());
 
     return object;
   }
@@ -532,7 +534,9 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
     String capabilitiesHash = (String) object.get(CAPABILITIES_HASH_FIELD);
     ProtocolVersion version =
         ProtocolVersion.valueOf((String) object.get(CAPABILITIES_VERSION_FIELD));
+    String rpcServerUrl = (String) object.get(CAPABILITIES_RPC_SERVER_URL_FIELD);
 
-    return new RobotCapabilities(capabilities, capabilitiesHash, version);
+    return new RobotCapabilities(capabilities, capabilitiesHash, version,
+        rpcServerUrl != null ? rpcServerUrl : "");
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -75,6 +75,7 @@ final class Mongo4AccountStore implements AccountStore {
   private static final String CAPABILITIES_VERSION_FIELD = "version";
   private static final String CAPABILITIES_HASH_FIELD = "capabilitiesHash";
   private static final String CAPABILITIES_CAPABILITIES_FIELD = "capabilities";
+  private static final String CAPABILITIES_RPC_SERVER_URL_FIELD = "rpcServerUrl";
   private static final String CAPABILITY_CONTEXTS_FIELD = "contexts";
   private static final String CAPABILITY_FILTER_FIELD = "filter";
 
@@ -379,7 +380,8 @@ final class Mongo4AccountStore implements AccountStore {
     return new Document()
         .append(CAPABILITIES_CAPABILITIES_FIELD, capsMap)
         .append(CAPABILITIES_HASH_FIELD, caps.getCapabilitiesHash())
-        .append(CAPABILITIES_VERSION_FIELD, caps.getProtocolVersion().name());
+        .append(CAPABILITIES_VERSION_FIELD, caps.getProtocolVersion().name())
+        .append(CAPABILITIES_RPC_SERVER_URL_FIELD, caps.getRpcServerUrl());
   }
 
   private static AccountData objectToRobot(ParticipantId id, Document robot) {
@@ -419,6 +421,7 @@ final class Mongo4AccountStore implements AccountStore {
     }
     String hash = (String) obj.get(CAPABILITIES_HASH_FIELD);
     ProtocolVersion ver = ProtocolVersion.valueOf((String) obj.get(CAPABILITIES_VERSION_FIELD));
-    return new RobotCapabilities(map, hash, ver);
+    String rpcServerUrl = (String) obj.get(CAPABILITIES_RPC_SERVER_URL_FIELD);
+    return new RobotCapabilities(map, hash, ver, rpcServerUrl != null ? rpcServerUrl : "");
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/RobotCapabilities.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/RobotCapabilities.java
@@ -38,6 +38,7 @@ public class RobotCapabilities {
   private final Map<EventType, Capability> capabilities;
   private final String capabilitiesHash;
   private final ProtocolVersion version;
+  private final String rpcServerUrl;
 
   /**
    * Constructs a new {@link RobotCapabilities} object with the given data.
@@ -48,6 +49,17 @@ public class RobotCapabilities {
    */
   public RobotCapabilities(Map<EventType, Capability> capabilitiesMap, String capabilitiesHash,
       ProtocolVersion version) {
+    this(capabilitiesMap, capabilitiesHash, version, "");
+  }
+
+  /**
+   * Constructs a new {@link RobotCapabilities} object with the given data and
+   * the preferred server RPC endpoint advertised by the robot. The RPC URL is a
+   * runtime transport hint and is intentionally excluded from equality so older
+   * persisted capability records remain comparable.
+   */
+  public RobotCapabilities(Map<EventType, Capability> capabilitiesMap, String capabilitiesHash,
+      ProtocolVersion version, String rpcServerUrl) {
     Preconditions.checkNotNull(capabilitiesMap, "Capabilities map may not be null");
     Preconditions.checkNotNull(capabilitiesHash, "Capabilities hash may not be null");
     Preconditions.checkNotNull(version, "Version may not be null");
@@ -55,6 +67,7 @@ public class RobotCapabilities {
     this.capabilities = ImmutableMap.copyOf(capabilitiesMap);
     this.capabilitiesHash = capabilitiesHash;
     this.version = version;
+    this.rpcServerUrl = rpcServerUrl == null ? "" : rpcServerUrl;
   }
 
   /**
@@ -76,6 +89,14 @@ public class RobotCapabilities {
    */
   public ProtocolVersion getProtocolVersion() {
     return version;
+  }
+
+  /**
+   * Returns the preferred server RPC endpoint advertised in capabilities.xml.
+   * Empty means the robot did not advertise one.
+   */
+  public String getRpcServerUrl() {
+    return rpcServerUrl;
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/operations/NotifyOperationService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/operations/NotifyOperationService.java
@@ -26,14 +26,17 @@ import com.google.wave.api.OperationRequest;
 import com.google.wave.api.JsonRpcConstant.ParamsProperty;
 import com.google.wave.api.robot.CapabilityFetchException;
 import com.google.wave.api.robot.RobotName;
+import com.typesafe.config.Config;
 
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.robots.OperationContext;
 import org.waveprotocol.box.server.robots.RobotCapabilities;
 import org.waveprotocol.box.server.robots.passive.RobotCapabilityFetcher;
+import org.waveprotocol.box.server.robots.passive.RobotsGateway;
 import org.waveprotocol.box.server.robots.util.OperationUtil;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
@@ -50,11 +53,14 @@ public class NotifyOperationService implements OperationService {
 
   private final AccountStore accountStore;
   private final RobotCapabilityFetcher capabilityFetcher;
+  private final String activeRobotApiUrl;
 
   @Inject
-  public NotifyOperationService(AccountStore accountStore, RobotCapabilityFetcher capabilityFetcher) {
+  public NotifyOperationService(AccountStore accountStore, RobotCapabilityFetcher capabilityFetcher,
+      Config config) {
     this.accountStore = accountStore;
     this.capabilityFetcher = capabilityFetcher;
+    this.activeRobotApiUrl = PublicBaseUrlResolver.resolve(config) + RobotsGateway.DATA_API_RPC_PATH;
   }
 
   @Override
@@ -89,7 +95,7 @@ public class NotifyOperationService implements OperationService {
     }
 
     try {
-      robotAccountData = capabilityFetcher.fetchCapabilities(robotAccountData, "");
+      robotAccountData = capabilityFetcher.fetchCapabilities(robotAccountData, activeRobotApiUrl);
     } catch (CapabilityFetchException e) {
       LOG.fine("Unable to retrieve capabilities for " + account.getId(), e);
       context.constructErrorResponse(operation, "Unable to retrieve new capabilities");

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java
@@ -493,22 +493,16 @@ public class EventGenerator {
 
   private final ParticipantId robotId;
 
-  /** The server's Data API RPC endpoint URL sent to robots so they know where to call back. */
-  private final String rpcServerUrl;
-
   /**
    * Constructs a new {@link EventGenerator} for the robot with the given name.
    *
    * @param robotName the name of the robot.
    * @param conversationUtil used to create conversations.
-   * @param rpcServerUrl the server's Data API RPC endpoint URL.
    */
-  public EventGenerator(RobotName robotName, ConversationUtil conversationUtil,
-      String rpcServerUrl) {
+  public EventGenerator(RobotName robotName, ConversationUtil conversationUtil) {
     this.robotName = robotName;
     this.conversationUtil = conversationUtil;
     this.robotId = ParticipantId.ofUnsafe(robotName.toParticipantAddress());
-    this.rpcServerUrl = rpcServerUrl;
   }
 
   /**
@@ -518,10 +512,13 @@ public class EventGenerator {
    * @param capabilities the capabilities to filter events on
    * @param converter converter for generating the API implementations of
    *        WaveletData and BlipData.
+   * @param rpcServerUrl the server RPC endpoint the robot should use for
+   *        follow-up JSON-RPC calls.
    * @returns true if an event was generated, false otherwise
    */
   public EventMessageBundle generateEvents(WaveletAndDeltas waveletAndDeltas,
-      Map<EventType, Capability> capabilities, EventDataConverter converter) {
+      Map<EventType, Capability> capabilities, EventDataConverter converter,
+      String rpcServerUrl) {
     EventMessageBundle messages = new EventMessageBundle(robotName.toEmailAddress(), rpcServerUrl);
     ObservableWaveletData snapshot =
         WaveletDataUtil.copyWavelet(waveletAndDeltas.getSnapshotBeforeDeltas());

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/EventGenerator.java
@@ -514,7 +514,7 @@ public class EventGenerator {
    *        WaveletData and BlipData.
    * @param rpcServerUrl the server RPC endpoint the robot should use for
    *        follow-up JSON-RPC calls.
-   * @returns true if an event was generated, false otherwise
+   * @return the event message bundle containing all generated events
    */
   public EventMessageBundle generateEvents(WaveletAndDeltas waveletAndDeltas,
       Map<EventType, Capability> capabilities, EventDataConverter converter,

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
@@ -325,8 +325,7 @@ public class Robot implements Runnable {
   }
 
   private boolean needsCapabilityRefresh(RobotAccountData currentAccount) {
-    return currentAccount.getCapabilities() == null
-        || currentAccount.getCapabilities().getRpcServerUrl().isEmpty();
+    return currentAccount.getCapabilities() == null;
   }
 
   private String resolveRpcServerUrl(RobotAccountData currentAccount) {

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
@@ -267,7 +267,7 @@ public class Robot implements Runnable {
    */
   private void process(WaveletAndDeltas wavelet) {
     RobotAccountData currentAccount = account;
-    if (currentAccount.getCapabilities() == null) {
+    if (needsCapabilityRefresh(currentAccount)) {
       try {
         LOG.info(robotName + ": Initializing capabilities");
         gateway.updateRobotAccount(this);
@@ -301,7 +301,8 @@ public class Robot implements Runnable {
     RobotCapabilities capabilities = currentAccount.getCapabilities();
     EventMessageBundle messages =
         eventGenerator.generateEvents(wavelet, capabilities.getCapabilitiesMap(),
-            converterManager.getEventDataConverter(capabilities.getProtocolVersion()));
+            converterManager.getEventDataConverter(capabilities.getProtocolVersion()),
+            resolveRpcServerUrl(currentAccount));
 
     if (messages.getEvents().isEmpty()) {
       // No events were generated, we are done
@@ -321,5 +322,18 @@ public class Robot implements Runnable {
 
     operationApplicator.applyOperations(
         response, wavelet.getSnapshotAfterDeltas(), wavelet.getVersionAfterDeltas(), currentAccount);
+  }
+
+  private boolean needsCapabilityRefresh(RobotAccountData currentAccount) {
+    return currentAccount.getCapabilities() == null
+        || currentAccount.getCapabilities().getRpcServerUrl().isEmpty();
+  }
+
+  private String resolveRpcServerUrl(RobotAccountData currentAccount) {
+    RobotCapabilities capabilities = currentAccount.getCapabilities();
+    if (capabilities != null && !capabilities.getRpcServerUrl().isEmpty()) {
+      return capabilities.getRpcServerUrl();
+    }
+    return gateway.getDefaultRpcServerUrl();
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotConnector.java
@@ -107,7 +107,8 @@ public class RobotConnector implements RobotCapabilityFetcher {
     RobotCapabilitiesParser parser = new RobotCapabilitiesParser(
         robotBaseUrl(account.getUrl()) + Robot.CAPABILITIES_URL, connection, activeApiUrl);
     RobotCapabilities capabilities = new RobotCapabilities(
-        parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion());
+        parser.getCapabilities(), parser.getCapabilitiesHash(), parser.getProtocolVersion(),
+        parser.getRpcServerUrl());
     long updatedAtMillis = Math.max(account.getUpdatedAtMillis() + 1L,
         System.currentTimeMillis());
 

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
@@ -250,9 +250,7 @@ public class RobotsGateway implements WaveBus.Subscriber {
    */
   public void updateRobotAccount(Robot robot) throws CapabilityFetchException,
       PersistenceException {
-    // TODO: Pass in activeAPIUrl
-    String activeApiUrl = "";
-    RobotAccountData newAccount = connector.fetchCapabilities(robot.getAccount(), activeApiUrl);
+    RobotAccountData newAccount = connector.fetchCapabilities(robot.getAccount(), defaultRpcServerUrl);
     accountStore.putAccount(newAccount);
     robot.setAccount(newAccount);
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/RobotsGateway.java
@@ -76,7 +76,7 @@ public class RobotsGateway implements WaveBus.Subscriber {
   private final Executor executor;
   private final ConversationUtil conversationUtil;
   private final NotifyOperationService notifyOpService;
-  private final String rpcServerUrl;
+  private final String defaultRpcServerUrl;
 
   @Inject
   @VisibleForTesting
@@ -91,7 +91,7 @@ public class RobotsGateway implements WaveBus.Subscriber {
     this.executor = executor;
     this.conversationUtil = conversationUtil;
     this.notifyOpService = notifyOpService;
-    this.rpcServerUrl = PublicBaseUrlResolver.resolve(config) + DATA_API_RPC_PATH;
+    this.defaultRpcServerUrl = PublicBaseUrlResolver.resolve(config) + DATA_API_RPC_PATH;
   }
 
   @Override
@@ -184,12 +184,16 @@ public class RobotsGateway implements WaveBus.Subscriber {
    *        {@link RobotName}.
    */
   private Robot createNewRobot(RobotName robotName, RobotAccountData account) {
-    EventGenerator eventGenerator = new EventGenerator(robotName, conversationUtil, rpcServerUrl);
+    EventGenerator eventGenerator = new EventGenerator(robotName, conversationUtil);
     RobotOperationApplicator operationApplicator =
         new RobotOperationApplicator(converterManager, waveletProvider,
             new OperationServiceRegistryImpl(notifyOpService), conversationUtil);
     return new Robot(robotName, account, this, connector, converterManager, waveletProvider,
         eventGenerator, operationApplicator);
+  }
+
+  String getDefaultRpcServerUrl() {
+    return defaultRpcServerUrl;
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/operations/NotifyOperationServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/operations/NotifyOperationServiceTest.java
@@ -35,6 +35,7 @@ import com.google.wave.api.ProtocolVersion;
 import com.google.wave.api.event.EventType;
 import com.google.wave.api.robot.Capability;
 import com.google.wave.api.robot.CapabilityFetchException;
+import com.typesafe.config.Config;
 import junit.framework.TestCase;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
@@ -75,7 +76,9 @@ public class NotifyOperationServiceTest extends TestCase {
     accountStore = mock(AccountStore.class);
     context = mock(OperationContext.class);
     capabilityFetcher = new RecordingRobotCapabilityFetcher();
-    operationService = new NotifyOperationService(accountStore, capabilityFetcher);
+    Config config = mock(Config.class);
+    when(config.hasPath(anyString())).thenReturn(false);
+    operationService = new NotifyOperationService(accountStore, capabilityFetcher, config);
 
     when(accountStore.getAccount(ROBOT)).thenReturn(ROBOT_ACCOUNT);
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/EventGeneratorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/EventGeneratorTest.java
@@ -133,7 +133,7 @@ public class EventGeneratorTest extends RobotsTestBase {
   @Override
   protected void setUp() throws Exception {
     conversationUtil = new ConversationUtil(FakeIdGenerator.create());
-    eventGenerator = new EventGenerator(ROBOT_NAME, conversationUtil, TEST_RPC_SERVER_URL);
+    eventGenerator = new EventGenerator(ROBOT_NAME, conversationUtil);
 
     waveletData = WaveletDataImpl.Factory.create(DOCUMENT_FACTORY).create(
         new EmptyWaveletSnapshot(WAVELET_NAME.waveId, WAVELET_NAME.waveletId, ALEX,
@@ -167,7 +167,7 @@ public class EventGeneratorTest extends RobotsTestBase {
         WaveletAndDeltas.create(waveletData, DeltaSequence.of(delta));
 
     EventMessageBundle bundle =
-        eventGenerator.generateEvents(waveletAndDeltas, ALL_CAPABILITIES, CONVERTER);
+        generateEvents(waveletAndDeltas, ALL_CAPABILITIES);
 
     assertEquals("rpcServerUrl must be populated in the event bundle",
         TEST_RPC_SERVER_URL, bundle.getRpcServerUrl());
@@ -390,7 +390,7 @@ public class EventGeneratorTest extends RobotsTestBase {
     capabilities.put(EventType.BLIP_EDITING_DONE, new Capability(EventType.BLIP_EDITING_DONE));
 
     EventMessageBundle messages =
-        eventGenerator.generateEvents(waveletAndDeltas, capabilities, CONVERTER);
+        generateEvents(waveletAndDeltas, capabilities);
 
     for (Event event : messages.getEvents()) {
       assertFalse("BLIP_EDITING_DONE must not fire while editing is in progress",
@@ -435,7 +435,7 @@ public class EventGeneratorTest extends RobotsTestBase {
     capabilities.put(EventType.BLIP_EDITING_DONE, new Capability(EventType.BLIP_EDITING_DONE));
 
     EventMessageBundle messages =
-        eventGenerator.generateEvents(waveletAndDeltas, capabilities, CONVERTER);
+        generateEvents(waveletAndDeltas, capabilities);
 
     for (Event event : messages.getEvents()) {
       assertFalse("BLIP_EDITING_DONE must not fire when any session is still active",
@@ -480,7 +480,7 @@ public class EventGeneratorTest extends RobotsTestBase {
     capabilities.put(EventType.BLIP_EDITING_DONE, new Capability(EventType.BLIP_EDITING_DONE));
 
     EventMessageBundle messages =
-        eventGenerator.generateEvents(waveletAndDeltas, capabilities, CONVERTER);
+        generateEvents(waveletAndDeltas, capabilities);
 
     boolean found = false;
     for (Event event : messages.getEvents()) {
@@ -689,14 +689,14 @@ public class EventGeneratorTest extends RobotsTestBase {
 
     // Generate the events
     EventMessageBundle messages =
-        eventGenerator.generateEvents(waveletAndDeltas, capabilities, CONVERTER);
+        generateEvents(waveletAndDeltas, capabilities);
 
     // Check that the event was generated and that no other types were generated
     checkEventTypeWasGenerated(messages, eventType);
     checkAllEventsAreInCapabilites(messages, capabilities);
 
     // Generate events with all capabilities
-    messages = eventGenerator.generateEvents(waveletAndDeltas, ALL_CAPABILITIES, CONVERTER);
+    messages = generateEvents(waveletAndDeltas, ALL_CAPABILITIES);
     checkEventTypeWasGenerated(messages, eventType);
 
     return messages;
@@ -742,8 +742,14 @@ public class EventGeneratorTest extends RobotsTestBase {
     Map<EventType, Capability> capabilities = ALL_CAPABILITIES;
     // Generate the events
     EventMessageBundle messages =
-        eventGenerator.generateEvents(waveletAndDeltas, capabilities, CONVERTER);
+        generateEvents(waveletAndDeltas, capabilities);
     return messages;
+  }
+
+  private EventMessageBundle generateEvents(WaveletAndDeltas waveletAndDeltas,
+      Map<EventType, Capability> capabilities) {
+    return eventGenerator.generateEvents(
+        waveletAndDeltas, capabilities, CONVERTER, TEST_RPC_SERVER_URL);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotConnectorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotConnectorTest.java
@@ -59,6 +59,24 @@ public class RobotConnectorTest extends TestCase {
           + CAPABILITIES_HASH + "</w:version> " + "<w:protocolversion>0.22</w:protocolversion> "
           + "<w:capabilities> " + "<w:capability name=\"OPERATION_ERROR\"/> "
           + "<w:capability name=\"WAVELET_SELF_ADDED\"/> " + "</w:capabilities>" + "</w:robot> ";
+  private static final String TWO_LEGGED_CAPABILITIES_XML =
+      "<w:robot xmlns:w=\"http://wave.google.com/extensions/robots/1.0\">"
+          + "<w:version>" + CAPABILITIES_HASH + "</w:version>"
+          + "<w:protocolversion>0.22</w:protocolversion>"
+          + "<w:capabilities><w:capability name=\"WAVELET_SELF_ADDED\"/></w:capabilities>"
+          + "<w:consumer_keys>"
+          + "<w:consumer_key for=\"https://wave.example.com/robot/rpc\">test@example.com</w:consumer_key>"
+          + "</w:consumer_keys>"
+          + "</w:robot>";
+  private static final String THREE_LEGGED_CAPABILITIES_XML =
+      "<w:robot xmlns:w=\"http://wave.google.com/extensions/robots/1.0\">"
+          + "<w:version>" + CAPABILITIES_HASH + "</w:version>"
+          + "<w:protocolversion>0.22</w:protocolversion>"
+          + "<w:capabilities><w:capability name=\"WAVELET_SELF_ADDED\"/></w:capabilities>"
+          + "<w:consumer_keys>"
+          + "<w:consumer_key for=\"https://wave.example.com/robot/dataapi/rpc\">test@example.com</w:consumer_key>"
+          + "</w:consumer_keys>"
+          + "</w:robot>";
   private static final ProtocolVersion PROTOCOL_VERSION = ProtocolVersion.DEFAULT;
   private static final String ROBOT_ACCOUNT_NAME = "test@example.com";
   private static final String TEST_URL = "www.example.com/robot";
@@ -222,6 +240,29 @@ public class RobotConnectorTest extends TestCase {
     assertEquals("Expected protocol version as specified in the xml", ProtocolVersion.V2_2,
         capabilities.getProtocolVersion());
     verify(connection).get(ABSOLUTE_CAPABILITIES_ENDPOINT);
+  }
+
+  public void testFetchCapabilitiesPrefersRobotRpcWhenCapabilitiesAdvertiseTwoLeggedOauth()
+      throws Exception {
+    when(connection.get(TEST_CAPABILITIES_ENDPOINT)).thenReturn(TWO_LEGGED_CAPABILITIES_XML);
+
+    RobotAccountData accountData =
+        connector.fetchCapabilities(ROBOT_ACCOUNT, "https://wave.example.com/robot/rpc");
+
+    assertEquals("Expected two-legged passive robots to advertise the active RPC endpoint",
+        "https://wave.example.com/robot/rpc", accountData.getCapabilities().getRpcServerUrl());
+  }
+
+  public void testFetchCapabilitiesFallsBackToDataApiRpcWhenOnlyThreeLeggedOauthIsAdvertised()
+      throws Exception {
+    when(connection.get(TEST_CAPABILITIES_ENDPOINT)).thenReturn(THREE_LEGGED_CAPABILITIES_XML);
+
+    RobotAccountData accountData =
+        connector.fetchCapabilities(ROBOT_ACCOUNT, "https://wave.example.com/robot/rpc");
+
+    assertEquals("Expected three-legged passive robots to advertise the Data API RPC endpoint",
+        "https://wave.example.com/robot/dataapi/rpc",
+        accountData.getCapabilities().getRpcServerUrl());
   }
 
   public void testFetchCapabilitiesPreservesAbsoluteBasePathWithoutRpcEndpoint()

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
@@ -82,6 +82,8 @@ public class RobotTest extends TestCase {
   private static final ParticipantId ALEX = ParticipantId.ofUnsafe("alex@example.com");
   private static final RobotName ROBOT_NAME = RobotName.fromAddress("robot@example.com");
   private static final ParticipantId ROBOT = ParticipantId.ofUnsafe(ROBOT_NAME.toEmailAddress());
+  private static final String ACTIVE_RPC_SERVER_URL = "https://wave.example.com/robot/rpc";
+  private static final String DATA_API_RPC_SERVER_URL = "https://wave.example.com/robot/dataapi/rpc";
   private static final RobotAccountData ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", null, true);
   private static final RobotAccountData STALE_ACCOUNT =
@@ -89,8 +91,12 @@ public class RobotTest extends TestCase {
           0L, 10L, false);
   private static final RobotAccountData INITIALIZED_ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
-          Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT), true, 0L,
-          null, "", 0L, 20L, false);
+          Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT,
+          ACTIVE_RPC_SERVER_URL), true, 0L, null, "", 0L, 20L, false);
+  private static final RobotAccountData THREE_LEGGED_ACCOUNT =
+      new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
+          Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT,
+          DATA_API_RPC_SERVER_URL), true, 0L, null, "", 0L, 30L, false);
 
   private RobotsGateway gateway;
   private RobotConnector connector;
@@ -127,7 +133,8 @@ public class RobotTest extends TestCase {
     // Generate no events on default
     EventMessageBundle emptyMessageBundle = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
     when(eventGenerator.generateEvents(
-        any(WaveletAndDeltas.class), anyMap(), any(EventDataConverter.class))).thenReturn(
+        any(WaveletAndDeltas.class), anyMap(), any(EventDataConverter.class), any(String.class)))
+        .thenReturn(
         emptyMessageBundle);
   }
 
@@ -237,7 +244,7 @@ public class RobotTest extends TestCase {
     EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
     messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
     when(eventGenerator.generateEvents(
-        any(), anyMap(), any())).thenReturn(messages);
+        any(), anyMap(), any(), any(String.class))).thenReturn(messages);
 
     OperationRequest op = new OperationRequest("wavelet.fetch", "op1");
     List<OperationRequest> ops = Collections.singletonList(op);
@@ -258,7 +265,7 @@ public class RobotTest extends TestCase {
     EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
     messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
     when(eventGenerator.generateEvents(
-        any(), anyMap(), any())).thenReturn(messages);
+        any(), anyMap(), any(), any(String.class))).thenReturn(messages);
 
     OperationRequest op = new OperationRequest("wavelet.fetch", "op1");
     List<OperationRequest> ops = Collections.singletonList(op);
@@ -276,6 +283,46 @@ public class RobotTest extends TestCase {
 
     verify(operationApplicator).applyOperations(
         eq(ops), any(ReadableWaveletData.class), any(HashedVersion.class), eq(INITIALIZED_ACCOUNT));
+  }
+
+  public void testProcessAdvertisesRobotRpcForTwoLeggedRobot() throws Exception {
+    EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
+    messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
+    when(eventGenerator.generateEvents(
+        any(), anyMap(), any(), eq(ACTIVE_RPC_SERVER_URL))).thenReturn(messages);
+    when(connector.sendMessageBundle(
+        any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class)))
+        .thenReturn(Collections.<OperationRequest>emptyList());
+
+    enqueueEmptyWavelet();
+    robot.run();
+
+    verify(eventGenerator).generateEvents(
+        any(), anyMap(), any(), eq(ACTIVE_RPC_SERVER_URL));
+  }
+
+  public void testProcessAdvertisesDataApiRpcForThreeLeggedRobot() throws Exception {
+    doAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        robot.setAccount(THREE_LEGGED_ACCOUNT);
+        return null;
+      }
+    }).when(gateway).updateRobotAccount(robot);
+
+    EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
+    messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
+    when(eventGenerator.generateEvents(
+        any(), anyMap(), any(), eq(DATA_API_RPC_SERVER_URL))).thenReturn(messages);
+    when(connector.sendMessageBundle(
+        any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class)))
+        .thenReturn(Collections.<OperationRequest>emptyList());
+
+    enqueueEmptyWavelet();
+    robot.run();
+
+    verify(eventGenerator).generateEvents(
+        any(), anyMap(), any(), eq(DATA_API_RPC_SERVER_URL));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #720.

Passive robot event bundles now advertise the JSON-RPC endpoint that matches the robot's configured OAuth mode instead of always hardcoding the Data API URL.

- retain the robot-advertised endpoint from `capabilities.xml` during capability fetch
- choose `rpcServerUrl` per passive dispatch so 2-legged robots get `/robot/rpc` and 3-legged robots get `/robot/dataapi/rpc`
- keep the change scoped to the passive robot path and cover it with focused regression tests
- add a changelog fragment for the robot API behavior fix

## Verification

```bash
python3 scripts/assemble-changelog.py
python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest" \
    "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest" \
    "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"
```

Results:
- changelog assembly passed
- changelog validation passed
- `RobotConnectorTest` passed
- `RobotTest` passed
- `EventGeneratorTest` target resolved to `No tests to run for Test / testOnly`; compile/signature coverage still exercised by the suite

## Plan

- `docs/superpowers/plans/2026-04-10-issue-720-rpcserverurl-authmode.md`