### PR TITLE
fix(client): restore Android mobile editor selection

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
+++ b/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
@@ -1,0 +1,145 @@
+# Mobile Android Edit Loss Focus Selection Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore mobile blip persistence by ensuring Android/mobile edit sessions start with a valid editor focus/selection state before typing begins.
+
+**Architecture:** The failing boundary is before op generation. On Android mobile WebKit, edit sessions open with no active selection because two mobile-specific branches disable the normal setup path: `EditorImplWebkitMobile.focus()` is a no-op and `NativeSelectionUtil` routes mobile WebKit through `SelectionImplDisabled`. Typed text therefore lands only in browser DOM, while the editor model, websocket submit path, and server persistence remain unchanged. The minimal fix is to re-enable the normal focus/selection path for Android while keeping the older disabled behavior for non-Android mobile WebKit.
+
+**Tech Stack:** GWT editor, WavePanel edit session lifecycle, GWTTestCase, Playwright mobile emulation, SBT.
+
+---
+
+## File Map
+
+- Create: `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/selection/html/NativeSelectionUtil.java`
+- Create: `wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json`
+
+### Task 1: Lock the Focus Boundary with a Failing Test
+
+**Files:**
+- Create: `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java`
+
+- [ ] **Step 1: Write the mobile focus regression**
+
+```java
+public void testFocusRestoresSelectionForMobileEditor() throws Exception {
+  editor.setContent(DocProviders.POJO.parse("<body><line/>mobile</body>").asOperation(),
+      DocumentSchema.NO_SCHEMA_CONSTRAINTS);
+
+  assertNull("Precondition: mobile editor starts without a selection",
+      editor.getSelectionHelper().getSelectionRange());
+
+  editor.focus(false);
+
+  assertNotNull("Mobile focus must restore a caret/selection before typing",
+      editor.getSelectionHelper().getSelectionRange());
+}
+```
+
+- [ ] **Step 2: Run the focused regression and verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.editor.integration.MobileWebkitFocusGwtTest"`
+Expected: FAIL because `EditorImplWebkitMobile.focus()` is currently a no-op, leaving selection unset.
+
+### Task 2: Restore Android Mobile Focus And Selection Initialization
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/selection/html/NativeSelectionUtil.java`
+
+- [ ] **Step 1: Restore focus initialization for Android mobile editors**
+
+```java
+@Override
+public void focus(boolean collapsed) {
+  if (UserAgent.isAndroid()) {
+    super.focus(collapsed);
+  }
+}
+```
+
+- [ ] **Step 2: Re-enable W3C selection support on Android mobile WebKit**
+
+```java
+} else if (UserAgent.isMobileWebkit() && !UserAgent.isAndroid()) {
+  impl = new SelectionImplDisabled();
+  coordinateGetter = new SelectionCoordinatesHelperDisabled();
+} else {
+  SelectionImplW3C w3cImpl = new SelectionImplW3C();
+  impl = w3cImpl;
+  coordinateGetter = new SelectionCoordinatesHelperW3C(...);
+}
+```
+
+- [ ] **Step 3: Leave blur behavior unchanged in this slice**
+
+```java
+@Override
+public void blur() {
+  // unchanged in this slice; the reopened failure is before op generation
+}
+```
+
+- [ ] **Step 4: Re-run the regression and verify it passes**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.editor.integration.MobileWebkitFocusGwtTest"`
+Expected: PASS.
+
+### Task 3: Record the User-Facing Fix
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+```json
+{
+  "releaseId": "2026-04-10-mobile-edit-loss-focus",
+  "title": "Mobile edit persistence follow-up",
+  "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload.",
+  "date": "2026-04-10",
+  "type": "fix"
+}
+```
+
+- [ ] **Step 2: Assemble and validate changelog**
+
+Run: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+Expected: `assembled ...` then `changelog validation passed`.
+
+### Task 4: Verify the Reopened Reproduction Narrowly
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the focused regression**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.editor.integration.MobileWebkitFocusGwtTest"`
+Expected: PASS.
+
+- [ ] **Step 2: Run compile sanity**
+
+Run: `sbt "wave / compile"`
+Expected: PASS.
+
+- [ ] **Step 3: Re-run the live mobile trace**
+
+Run the local mobile-emulated Playwright reproduction used during investigation.
+Expected:
+- existing-blip edit: editor model changes and fetch/reload contain the typed marker
+- new reply blip: new blip still persists, and its typed marker also persists
+
+- [ ] **Step 4: Run local server sanity**
+
+Run: `bash scripts/wave-smoke.sh check`
+Expected: `ROOT_STATUS=200` or `302`, `HEALTH_STATUS=200`, `WEBCLIENT_STATUS=200`.
+
+## Out of Scope
+
+- IME composition teardown changes already landed in #764
+- Websocket transport or server persistence refactors
+- Mobile toolbar/navigation UX changes
+- General blur/save behavior outside the missing mobile focus/selection boundary

--- a/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
+++ b/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
@@ -98,10 +98,16 @@ Expected: PASS.
 ```json
 {
   "releaseId": "2026-04-10-mobile-edit-loss-focus",
+  "version": "PR #796",
   "title": "Mobile edit persistence follow-up",
   "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload.",
   "date": "2026-04-10",
-  "type": "fix"
+  "sections": [
+    {
+      "type": "fix",
+      "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload."
+    }
+  ]
 }
 ```
 

--- a/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
+++ b/docs/superpowers/plans/2026-04-10-issue-759-mobile-focus-selection-plan.md
@@ -105,7 +105,9 @@ Expected: PASS.
   "sections": [
     {
       "type": "fix",
-      "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload."
+      "items": [
+        "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload."
+      ]
     }
   ]
 }

--- a/wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json
+++ b/wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-mobile-edit-loss-focus",
+  "version": "Unreleased",
+  "date": "2026-04-10",
+  "title": "Mobile edit persistence follow-up",
+  "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Restored mobile editor focus initialization so edit sessions start with a valid caret instead of a DOM-only typing surface",
+        "Fixed both existing-blip edits and brand-new reply blips losing typed text after reload because no document ops were generated"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json
+++ b/wave/config/changelog.d/2026-04-10-mobile-edit-loss-focus.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-10-mobile-edit-loss-focus",
-  "version": "Unreleased",
+  "version": "PR #796",
   "date": "2026-04-10",
   "title": "Mobile edit persistence follow-up",
   "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload.",

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java
@@ -20,9 +20,10 @@
 package org.waveprotocol.wave.client.editor;
 
 import com.google.gwt.dom.client.Element;
+import org.waveprotocol.wave.client.common.util.UserAgent;
 
 /**
- * Disable certain features for mobile clients
+ * Disable selected legacy mobile behaviors while preserving Android edit focus.
  *
  * @author danilatos@google.com (Daniel Danilatos)
  *
@@ -35,7 +36,10 @@ public class EditorImplWebkitMobile extends EditorImpl {
 
   @Override
   public void focus(boolean collapsed) {
-    // do nothing
+    // Android needs the standard focus path so edit sessions start with a real caret.
+    if (UserAgent.isAndroid()) {
+      super.focus(collapsed);
+    }
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImplWebkitMobile.java
@@ -37,9 +37,14 @@ public class EditorImplWebkitMobile extends EditorImpl {
   @Override
   public void focus(boolean collapsed) {
     // Android needs the standard focus path so edit sessions start with a real caret.
-    if (UserAgent.isAndroid()) {
+    if (isAndroid()) {
       super.focus(collapsed);
     }
+  }
+
+  /** Returns true if the current environment is Android. Overridable for testing. */
+  protected boolean isAndroid() {
+    return UserAgent.isAndroid();
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/selection/html/NativeSelectionUtil.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/selection/html/NativeSelectionUtil.java
@@ -74,7 +74,7 @@ public class NativeSelectionUtil {
     if (UserAgent.isIE()) {
       impl = new SelectionImplIE();
       coordinateGetter = new SelectionCoordinatesHelperIEImpl();
-    } else if (UserAgent.isMobileWebkit()) {
+    } else if (UserAgent.isMobileWebkit() && !UserAgent.isAndroid()) {
       // TODO(patcoleman/mtsui/macpherson): adapt to perform as desired on browsers:
       impl = new SelectionImplDisabled();
       coordinateGetter = new SelectionCoordinatesHelperDisabled();

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.editor.integration;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.RootPanel;
+
+import org.waveprotocol.wave.client.editor.Editor;
+import org.waveprotocol.wave.client.editor.EditorImplWebkitMobile;
+import org.waveprotocol.wave.client.editor.EditorSettings;
+import org.waveprotocol.wave.client.editor.EditorStaticDeps;
+import org.waveprotocol.wave.client.common.util.UserAgent;
+import org.waveprotocol.wave.client.editor.keys.KeyBindingRegistry;
+import org.waveprotocol.wave.client.editor.content.misc.StyleAnnotationHandler;
+import org.waveprotocol.wave.client.editor.content.paragraph.LineRendering;
+import org.waveprotocol.wave.client.editor.testing.TestInlineDoodad;
+import org.waveprotocol.wave.client.widget.popup.simple.Popup;
+import org.waveprotocol.wave.model.conversation.Blips;
+import org.waveprotocol.wave.model.document.operation.automaton.DocumentSchema;
+import org.waveprotocol.wave.model.document.util.DocProviders;
+import org.waveprotocol.wave.model.document.util.LineContainers;
+
+/**
+ * Regression coverage for mobile editor sessions that must restore a valid
+ * caret when focus begins.
+ */
+public class MobileWebkitFocusGwtTest extends TestBase {
+
+  private static boolean handlersRegistered;
+
+  private TestMobileEditor mobileEditor;
+
+  private static final class TestMobileEditor extends EditorImplWebkitMobile {
+    private TestMobileEditor(Element e) {
+      super(true, e);
+    }
+  }
+
+  @Override
+  protected Editor createEditor() {
+    ensureHandlersRegistered();
+    EditorStaticDeps.setPopupProvider(Popup.LIGHTWEIGHT_POPUP_PROVIDER);
+    mobileEditor = new TestMobileEditor(Document.get().createDivElement());
+    RootPanel.get().add(mobileEditor);
+    mobileEditor.init(Editor.ROOT_REGISTRIES, KeyBindingRegistry.NONE, EditorSettings.DEFAULT);
+    mobileEditor.setEditing(true);
+    return mobileEditor;
+  }
+
+  public void testFocusRestoresSelectionForMobileEditor() throws Exception {
+    if (!UserAgent.isAndroid()) {
+      // The production fix is Android-specific; desktop GWT runners should skip rather than
+      // report a false failure for the preserved legacy mobile-Safari path.
+      return;
+    }
+
+    editor.setContent(DocProviders.POJO.parse("<body><line/>mobile</body>").asOperation(),
+        DocumentSchema.NO_SCHEMA_CONSTRAINTS);
+
+    assertNull("Precondition: mobile editor starts without a selection",
+        editor.getSelectionHelper().getSelectionRange());
+
+    editor.focus(false);
+
+    assertNotNull("Mobile focus must restore a caret/selection before typing",
+        editor.getSelectionHelper().getSelectionRange());
+  }
+
+  @Override
+  protected void gwtTearDown() throws Exception {
+    if (mobileEditor != null && mobileEditor.getParent() != null) {
+      RootPanel.get().remove(mobileEditor);
+      mobileEditor = null;
+    }
+    super.gwtTearDown();
+  }
+
+  private static void ensureHandlersRegistered() {
+    if (handlersRegistered) {
+      return;
+    }
+    handlersRegistered = true;
+    LineContainers.setTopLevelContainerTagname(Blips.BODY_TAGNAME);
+    LineRendering.registerContainer(Blips.BODY_TAGNAME, Editor.ROOT_HANDLER_REGISTRY);
+    StyleAnnotationHandler.register(Editor.ROOT_REGISTRIES);
+    TestInlineDoodad.register(Editor.ROOT_HANDLER_REGISTRY);
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java
@@ -27,7 +27,6 @@ import org.waveprotocol.wave.client.editor.Editor;
 import org.waveprotocol.wave.client.editor.EditorImplWebkitMobile;
 import org.waveprotocol.wave.client.editor.EditorSettings;
 import org.waveprotocol.wave.client.editor.EditorStaticDeps;
-import org.waveprotocol.wave.client.common.util.UserAgent;
 import org.waveprotocol.wave.client.editor.keys.KeyBindingRegistry;
 import org.waveprotocol.wave.client.editor.content.misc.StyleAnnotationHandler;
 import org.waveprotocol.wave.client.editor.content.paragraph.LineRendering;
@@ -52,6 +51,11 @@ public class MobileWebkitFocusGwtTest extends TestBase {
     private TestMobileEditor(Element e) {
       super(true, e);
     }
+
+    @Override
+    protected boolean isAndroid() {
+      return true; // Force Android code path so CI exercises the actual fix.
+    }
   }
 
   @Override
@@ -66,12 +70,6 @@ public class MobileWebkitFocusGwtTest extends TestBase {
   }
 
   public void testFocusRestoresSelectionForMobileEditor() throws Exception {
-    if (!UserAgent.isAndroid()) {
-      // The production fix is Android-specific; desktop GWT runners should skip rather than
-      // report a false failure for the preserved legacy mobile-Safari path.
-      return;
-    }
-
     editor.setContent(DocProviders.POJO.parse("<body><line/>mobile</body>").asOperation(),
         DocumentSchema.NO_SCHEMA_CONSTRAINTS);
 


### PR DESCRIPTION
## Summary
- fix the Android mobile edit-loss bug at the pre-op-generation boundary by restoring the normal editor focus path for Android mobile sessions
- enable W3C selection handling for Android mobile WebKit so mobile editors can read/write a real caret instead of using the fully disabled selection path
- add a focused mobile regression source, updated issue plan, and changelog fragment for the reopened #759 investigation

## Root cause
Android mobile edit sessions were opening with no active editor selection because two mobile-specific branches stacked together:
- `EditorImplWebkitMobile.focus()` was a no-op
- `NativeSelectionUtil` used `SelectionImplDisabled` for all mobile WebKit

That left `startSelection = endSelection = -1`, so typed text appeared only in browser DOM. The editor model did not change, no persisted content was produced, and reload lost the text.

## Verification
- `sbt "wave / compile"`
- `sbt "Test / compile"`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/wave-smoke.sh check`
- live Playwright mobile reproduction on `http://127.0.0.1:9898`
  - before fix: existing-blip edit changed DOM only; model/fetch/reload unchanged
  - before fix: new reply blip persisted as a blank blip while typed DOM text was lost
  - after fix: existing-blip edit updated model and persisted through fetch/reload
  - after fix: new reply blip persisted both the new blip and its typed content

Closes #759.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile Android editor persistence issue where typed text would be lost after application reload. The text cursor and selection state are now properly restored when opening a blip editor, ensuring all typed content is saved and persists correctly for both new reply blips and edits to existing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->