### PR TITLE
Improve registration success and activation UX

### DIFF
--- a/docs/superpowers/plans/2026-04-10-registration-success-ux.md
+++ b/docs/superpowers/plans/2026-04-10-registration-success-ux.md
@@ -1,0 +1,222 @@
+# Registration Success UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the confusing post-sign-up auth flow with dedicated registration success and activation-oriented states that match whether the account is immediately usable or still awaiting email confirmation.
+
+**Architecture:** Keep the existing `/auth/register`, `/auth/signin`, and `/auth/confirm-email` routes and move the UX improvement into the server-rendered auth HTML layer. Use PRG where it simplifies the flow: successful direct registrations redirect into a strong success state on sign-in, confirmation-required registrations redirect into a dedicated check-email page, and unconfirmed sign-ins render an action-required state without being treated as bad credentials.
+
+**Tech Stack:** Jakarta servlets, `HtmlRenderer`, JUnit 3 servlet tests, SBT, changelog fragment tooling.
+
+---
+
+### Task 1: Lock the expected auth states in renderer tests
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/rpc/EmailConfirmServletTest.java`
+- Create: `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java`
+
+Because the repo-wide SBT test path is currently blocked in this worktree by unrelated generated-source/runtime issues, the executable red-green seam for this task is a manual `javac`/JUnit harness around `HtmlRendererAuthStateTest`. Keep the legacy servlet tests unchanged unless their baseline harness is repaired separately.
+
+Before any SBT or manual classpath run in this plan, regenerate the assembled changelog file expected by the SBT resource pipeline:
+
+```bash
+python3 scripts/assemble-changelog.py
+```
+
+- [ ] **Step 1: Add a failing registration success test for direct sign-in mode**
+
+Add assertions to `HtmlRendererAuthStateTest` so the rendered auth pages prove the new states exist:
+
+```java
+assertTrue(HtmlRenderer.renderAuthenticationPage(...).contains("id=\"successBanner\""));
+assertTrue(HtmlRenderer.renderCheckEmailPage(...).contains("Activate your account"));
+assertTrue(HtmlRenderer.renderEmailConfirmationPage(...).contains("Ready to sign in"));
+```
+
+- [ ] **Step 2: Run the direct registration test and verify it fails for the old renderer**
+
+Run: `javac` the new test against `target/scala-3.3.4/classes` plus cached jars.
+
+Expected: FAIL because `renderActivationRequiredAuthenticationPage(...)` does not exist yet and the generic check-email / confirmation copy is still too weak.
+
+- [ ] **Step 3: Add a failing registration success test for email-confirmation mode**
+
+Extend `testRegisterNewUserWithEmailConfirmationEnabledDefersWelcomeWave` to assert the activation-oriented copy and CTA.
+
+```java
+assertTrue(responseBody.contains("Check your inbox"));
+assertTrue(responseBody.contains("pending@example.com"));
+assertTrue(responseBody.contains("Go to sign in"));
+assertFalse(responseBody.contains("id=\"regForm\""));
+```
+
+- [ ] **Step 4: Run the activation-pending registration test and verify it fails**
+
+Run: `sbt -Dsbt.supershell=false "testOnly org.waveprotocol.box.server.rpc.UserRegistrationServletTest -- -t testRegisterNewUserWithEmailConfirmationEnabledDefersWelcomeWave"`
+
+Expected: FAIL because the current renderer only prints the generic message above the form.
+
+- [ ] **Step 5: Add a failing sign-in test for unconfirmed accounts**
+
+In `AuthenticationServletTest.testValidLoginForUnconfirmedAccountResendsActivationEmail`, capture the written HTML and assert the pending-activation copy is rendered without the generic credential-failure wording.
+
+```java
+ArgumentCaptor<String> html = ArgumentCaptor.forClass(String.class);
+verify(writer).write(html.capture());
+assertTrue(html.getValue().contains("Check your inbox"));
+assertTrue(html.getValue().contains("activation email"));
+assertFalse(html.getValue().contains("incorrect"));
+```
+
+- [ ] **Step 6: Run the unconfirmed sign-in test and verify it fails**
+
+Run: `sbt -Dsbt.supershell=false "testOnly org.waveprotocol.box.server.rpc.AuthenticationServletTest -- -t testValidLoginForUnconfirmedAccountResendsActivationEmail"`
+
+Expected: FAIL because the current sign-in page still renders the pending state through the generic error message slot.
+
+- [ ] **Step 7: Add a failing confirmation-page test**
+
+Extend `EmailConfirmServletTest.testSuccessfulConfirmationCreatesWelcomeWave` to assert the confirmation result page contains upgraded ready-to-sign-in copy.
+
+```java
+assertTrue(body.toString().contains("Email confirmed"));
+assertTrue(body.toString().contains("Go to Sign In"));
+assertTrue(body.toString().contains("ready to sign in"));
+```
+
+- [ ] **Step 8: Run the confirmation-page test and verify it fails**
+
+Run: `sbt -Dsbt.supershell=false "testOnly org.waveprotocol.box.server.rpc.EmailConfirmServletTest -- -t testSuccessfulConfirmationCreatesWelcomeWave"`
+
+Expected: FAIL because the current confirmation page only shows a generic title and message slot.
+
+- [ ] **Step 9: Commit the red-phase tests**
+
+```bash
+git add wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java \
+        wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java \
+        wave/src/test/java/org/waveprotocol/box/server/rpc/EmailConfirmServletTest.java
+git commit -m "test: define registration success auth states"
+```
+
+### Task 2: Implement dedicated auth success and action-required states
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/EmailConfirmServlet.java`
+
+- [ ] **Step 1: Introduce explicit auth-page state helpers in `HtmlRenderer`**
+
+Add renderer-level helpers for:
+
+- registered sign-in success
+- registration-confirmation-pending
+- sign-in activation-required notice
+- email-confirmed result card
+
+Use a shared card layout based on `AUTH_CSS`, with dedicated hero, status pill, CTA row, and optional step list/email callout.
+
+- [ ] **Step 2: Update the registration servlet to return structured success context**
+
+Keep validation and persistence behavior unchanged. Only the rendering branch should change.
+
+- [ ] **Step 3: Redirect direct registrations into a sign-in success state**
+
+On successful registration without email confirmation:
+
+- redirect to `/auth/signin?registered=1`
+- render a prominent success state above the sign-in form
+
+- [ ] **Step 4: Redirect confirmation-required registrations into a check-email page**
+
+On successful registration with email confirmation enabled:
+
+- redirect to `/auth/register?check-email=1`
+- render the new check-inbox page
+- keep welcome-wave creation deferred until confirmation
+
+- [ ] **Step 5: Render pending activation on sign-in as action-required instead of failure**
+
+In `AuthenticationServlet`, keep the resend-email behavior and `403` status, but pass the new non-error action-required page state into `HtmlRenderer`.
+
+- [ ] **Step 6: Upgrade the email confirmation result page**
+
+In `HtmlRenderer.renderEmailConfirmationPage`, use the same polished auth-state presentation:
+
+- success and already-confirmed states look ready-to-proceed
+- invalid/expired links still look intentional, not broken
+
+- [ ] **Step 7: Run the focused auth tests and verify green**
+
+Run: manual `javac` compile of the touched auth classes, then `HtmlRendererAuthStateTest` via `org.junit.runner.JUnitCore`.
+
+Expected: PASS with the new auth-state copy and card structure.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java \
+        wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java \
+        wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java \
+        wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/EmailConfirmServlet.java
+git commit -m "feat: improve registration success auth ux"
+```
+
+### Task 3: Record product evidence and release metadata
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-10-registration-success-ux.json`
+- Modify: `wave/config/changelog.json`
+- Create or modify: `journal/local-verification/2026-04-10-issue-795-registration-success-ux.md`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+Create `wave/config/changelog.d/2026-04-10-registration-success-ux.json` with a concise user-facing summary of the new registration and activation guidance.
+
+- [ ] **Step 2: Regenerate and validate changelog output**
+
+Run: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+
+Expected: changelog generation succeeds and validation exits `0`.
+
+- [ ] **Step 3: Capture local verification evidence**
+
+Run a narrow local sanity check that exercises the affected auth flow, record the exact command and result in `journal/local-verification/2026-04-10-issue-795-registration-success-ux.md`, and mirror the same evidence into the GitHub issue and PR.
+
+Suggested command:
+
+```bash
+python3 scripts/assemble-changelog.py && \
+sbt -Dsbt.supershell=false "testOnly org.waveprotocol.box.server.rpc.UserRegistrationServletTest org.waveprotocol.box.server.rpc.AuthenticationServletTest org.waveprotocol.box.server.rpc.EmailConfirmServletTest"
+```
+
+If practical in the lane environment, also boot the app and manually hit `/auth/register`, `/auth/signin`, and `/auth/confirm-email`.
+
+- [ ] **Step 4: Commit the release metadata and verification note**
+
+```bash
+git add wave/config/changelog.d/2026-04-10-registration-success-ux.json \
+        wave/config/changelog.json \
+        journal/local-verification/2026-04-10-issue-795-registration-success-ux.md
+git commit -m "docs: record registration success ux release notes"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - direct sign-in success state: Task 1 + Task 2
+  - email-confirmation pending state: Task 1 + Task 2
+  - sign-in activation-required state: Task 1 + Task 2
+  - confirmation-page polish: Task 1 + Task 2
+  - changelog and verification evidence: Task 3
+- Placeholder scan:
+  - no `TODO`, `TBD`, or unnamed files remain
+  - commands and target files are explicit
+- Type consistency:
+  - the plan assumes renderer-level auth state helpers rather than new routes
+  - servlet ownership remains in the Jakarta override copies only

--- a/docs/superpowers/specs/2026-04-10-registration-success-ux-design.md
+++ b/docs/superpowers/specs/2026-04-10-registration-success-ux-design.md
@@ -1,0 +1,130 @@
+# Registration Success UX Design
+
+## Context
+
+Issue `#795` targets the server-rendered registration and activation journey:
+
+- `POST /auth/register` currently re-renders the registration form and only reveals a small `sign in` link on success.
+- `GET /auth/confirm-email` renders a minimal message-only confirmation page.
+- `POST /auth/signin` treats "valid credentials, but email still unconfirmed" as a failed login and shows the message in the generic error slot.
+
+This makes the next step unclear in both account modes:
+
+- direct sign-in mode: the account is ready immediately, but the page still looks like a form that needs more work
+- email-confirmation mode: the user needs to check email, but the page does not shift into an activation-oriented state
+
+## Goals
+
+- Replace the post-registration "message on top of the form" pattern with dedicated success and action-required states.
+- Make the primary action match the actual account state.
+- Keep the auth pages visually aligned with the current SupaWave auth shell and recent polished server-rendered pages.
+- Avoid widening scope into account model changes, redirects, or new backend flows.
+
+## Options Considered
+
+### 1. Bigger inline banner on the existing registration form
+
+Pros:
+- lowest implementation cost
+- minimal servlet change
+
+Cons:
+- still leaves the user on a form that no longer matches their state
+- does not solve the "pending activation is styled as login failure" problem
+
+### 2. PRG into dedicated auth-state surfaces inside the existing auth shell
+
+Pros:
+- clear state transition using the existing auth routes
+- keeps current SupaWave auth branding and renderer structure
+- lets direct sign-in, pending activation, and email-confirmed states each present the right CTA
+
+Cons:
+- requires some renderer branching and servlet response plumbing
+
+### 3. Redirect-based flash flow to `/auth/signin`
+
+Pros:
+- one canonical post-registration destination
+- conventional for direct-login products
+
+Cons:
+- requires redirect-state plumbing
+- harder to make email-confirmation mode feel first-class without adding more route/state handling
+
+## Recommendation
+
+Use option 2.
+
+The narrowest correct fix is to keep the existing auth shell and CSS foundation, then use PRG on top of the existing auth routes:
+
+- direct registration redirects to `/auth/signin?registered=1`
+- confirmation-required registration redirects to `/auth/register?check-email=1`
+- unconfirmed sign-in renders a dedicated action-required state on the sign-in surface
+
+This improves clarity without changing the account lifecycle or adding new standalone routes.
+
+## Proposed UX
+
+### Registration when email confirmation is disabled
+
+Redirect to sign-in and render a prominent success state above the form:
+
+- headline: account created
+- supporting copy: the user can now sign in with the new account
+- context chip: account ready / instant access
+- keep the sign-in form directly available so the next action is immediate
+
+### Registration when email confirmation is enabled
+
+Redirect to a dedicated check-email page:
+
+- headline: check your inbox
+- supporting copy: we sent an activation link and sign-in will work after confirmation
+- short next-step list:
+  - open the activation email
+  - click the confirmation link
+  - return to sign in
+- primary CTA: `Go to sign in`
+- secondary CTA: `Create another account`
+
+This keeps the user oriented even if they navigate to sign-in immediately afterward.
+
+### Sign-in attempt for an unconfirmed account
+
+Do not style this as a bad-credentials error.
+
+Keep the sign-in form available, but replace the generic error treatment with an action-required notice:
+
+- same authentication page shell
+- non-error visual treatment
+- copy based on resend result:
+  - resend sent
+  - resend throttled / failed
+- supporting line that the account will unlock after email confirmation
+
+This preserves the current resend behavior while making the state accurate.
+
+### Email confirmation page
+
+Upgrade the confirmation result page to match the new registration success language:
+
+- success: confirmed and ready to sign in
+- already confirmed: still ready to sign in
+- invalid or expired: link problem, return to sign in
+
+The CTA remains `Go to Sign In`, but the page should feel intentional rather than generic.
+
+## Implementation Notes
+
+- Keep logic in the Jakarta override copies only.
+- Prefer renderer-level composition over route additions.
+- Introduce a small auth-page state model rather than encoding more behavior in free-form strings.
+- Reuse the visual language already present in `AUTH_CSS` and the polished robot success card rather than inventing a second design system.
+
+## Non-Goals
+
+- no automatic sign-in after registration
+- no new resend endpoint
+- no localization overhaul
+- no session semantics changes

--- a/wave/config/changelog.d/2026-04-10-registration-success-ux.json
+++ b/wave/config/changelog.d/2026-04-10-registration-success-ux.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-10-registration-success-ux",
+  "version": "PR #795",
+  "date": "2026-04-10",
+  "title": "Registration Success Guidance",
+  "summary": "Registration now guides you into sign-in or email activation with clearer next steps instead of leaving you on the signup form.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Successful direct registrations now send you to sign-in with a clear account-created state",
+        "Email-confirmation registrations now open a dedicated check-your-inbox page with the activation steps",
+        "Trying to sign in before activation now shows an action-required state instead of looking like bad credentials"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -418,16 +418,19 @@ public class AuthenticationServlet extends HttpServlet {
         }
       }
 
-      if (!isLoginPageDisabled) {
+      resp.setContentType("text/html;charset=utf-8");
+      String registeredParam = req.getParameter("registered");
+      boolean isRegistrationSuccess = "1".equals(registeredParam);
+      // Return 200 even when login is disabled if arriving via registration success redirect,
+      // so a successful registration does not land on a 403 page.
+      if (!isLoginPageDisabled || isRegistrationSuccess) {
         resp.setStatus(HttpServletResponse.SC_OK);
       } else {
         resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
       }
-      resp.setContentType("text/html;charset=utf-8");
-      String registeredParam = req.getParameter("registered");
       String initMessage = "";
       String initResponseType = RESPONSE_STATUS_NONE;
-      if ("1".equals(registeredParam)) {
+      if (isRegistrationSuccess) {
         initMessage = "Account created! Sign in to get started.";
         initResponseType = RESPONSE_STATUS_SUCCESS;
       }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -421,9 +421,7 @@ public class AuthenticationServlet extends HttpServlet {
       resp.setContentType("text/html;charset=utf-8");
       String registeredParam = req.getParameter("registered");
       boolean isRegistrationSuccess = "1".equals(registeredParam);
-      // Return 200 even when login is disabled if arriving via registration success redirect,
-      // so a successful registration does not land on a 403 page.
-      if (!isLoginPageDisabled || isRegistrationSuccess) {
+      if (!isLoginPageDisabled) {
         resp.setStatus(HttpServletResponse.SC_OK);
       } else {
         resp.setStatus(HttpServletResponse.SC_FORBIDDEN);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -269,7 +269,7 @@ public class AuthenticationServlet extends HttpServlet {
             resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
             resp.setContentType("text/html;charset=utf-8");
             resp.getWriter().write(HtmlRenderer.renderActivationRequiredAuthenticationPage(
-                domain, message, analyticsAccount,
+                domain, message, analyticsAccount, isLoginPageDisabled,
                 passwordResetEnabled, magicLinkEnabled));
             return;
           }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -268,8 +268,8 @@ public class AuthenticationServlet extends HttpServlet {
                 authEmailService.sendConfirmationEmail(req, human));
             resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
             resp.setContentType("text/html;charset=utf-8");
-            resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, message,
-                RESPONSE_STATUS_FAILED, isLoginPageDisabled, analyticsAccount,
+            resp.getWriter().write(HtmlRenderer.renderActivationRequiredAuthenticationPage(
+                domain, message, analyticsAccount,
                 passwordResetEnabled, magicLinkEnabled));
             return;
           }
@@ -424,8 +424,15 @@ public class AuthenticationServlet extends HttpServlet {
         resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
       }
       resp.setContentType("text/html;charset=utf-8");
-      resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, "",
-          RESPONSE_STATUS_NONE, isLoginPageDisabled, analyticsAccount,
+      String registeredParam = req.getParameter("registered");
+      String initMessage = "";
+      String initResponseType = RESPONSE_STATUS_NONE;
+      if ("1".equals(registeredParam)) {
+        initMessage = "Account created! Sign in to get started.";
+        initResponseType = RESPONSE_STATUS_SUCCESS;
+      }
+      resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, initMessage,
+          initResponseType, isLoginPageDisabled, analyticsAccount,
           passwordResetEnabled, magicLinkEnabled));
     }
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2018,7 +2018,9 @@ public final class HtmlRenderer {
     sb.append("    if (banner) banner.style.display = \"none\";\n");
     sb.append("  } else if (rt == RESPONSE_STATUS_FAILED) {\n");
     sb.append("    if (lbl) { lbl.style.display = \"block\"; lbl.className = \"msg error\"; lbl.textContent = msg; }\n");
+    sb.append("    if (banner) banner.style.display = \"none\";\n");
     sb.append("  } else if (rt == RESPONSE_STATUS_SUCCESS) {\n");
+    sb.append("    if (lbl) { lbl.style.display = \"none\"; lbl.textContent = \"\"; }\n");
     sb.append("    if (banner) {\n");
     sb.append("      banner.style.display = \"block\";\n");
     sb.append("      var copy = banner.querySelector('p');\n");
@@ -4432,7 +4434,7 @@ public final class HtmlRenderer {
     sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
     sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
     sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
-    sb.append("<title>Check Your Inbox - SupaWave</title>\n");
+    sb.append("<title>Activation required - SupaWave</title>\n");
     sb.append(AUTH_CSS);
     appendAnalyticsFragment(sb, analyticsAccount, null);
     sb.append("</head>\n<body>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -1960,7 +1960,7 @@ public final class HtmlRenderer {
     sb.append("  <div class=\"card\">\n");
     sb.append("    <h1>Sign In</h1>\n");
     sb.append("    <div class=\"subtitle\">@").append(escapeHtml(domain)).append("</div>\n");
-    sb.append("    <div class=\"auth-state-inline success\" id=\"successBanner\" style=\"display:none;\">");
+    sb.append("    <div class=\"auth-state-inline success\" id=\"successBanner\" role=\"status\" aria-live=\"polite\" aria-atomic=\"true\" style=\"display:none;\">");
     sb.append("<div class=\"auth-state-inline-pill\">Account ready</div>");
     sb.append("<h2>Account created</h2>");
     sb.append("<p></p></div>\n");
@@ -4427,7 +4427,8 @@ public final class HtmlRenderer {
    * the normal sign-in affordances available.
    */
   public static String renderActivationRequiredAuthenticationPage(String domain, String message,
-      String analyticsAccount, boolean passwordResetEnabled, boolean magicLinkEnabled) {
+      String analyticsAccount, boolean disableLoginPage,
+      boolean passwordResetEnabled, boolean magicLinkEnabled) {
     StringBuilder sb = new StringBuilder(8192);
     sb.append("<!DOCTYPE html>\n<html dir=\"ltr\">\n<head>\n");
     sb.append("<meta charset=\"UTF-8\">\n");
@@ -4454,29 +4455,34 @@ public final class HtmlRenderer {
     sb.append("      <p>").append(escapeHtml(message))
         .append(" Activate your account first, then return here to sign in.</p>\n");
     sb.append("    </div>\n");
-    sb.append("    <form id=\"wiab_loginform\" action=\"\" method=\"post\">\n");
-    sb.append("      <label for=\"address\">Username</label>\n");
-    sb.append("      <div class=\"input-group\">\n");
-    sb.append("        <input type=\"text\" name=\"address\" id=\"address\" autocomplete=\"username\" placeholder=\"your.name\">\n");
-    sb.append("        <span class=\"domain-suffix\">@").append(escapeHtml(domain)).append("</span>\n");
-    sb.append("      </div>\n");
-    sb.append("      <label for=\"password\">Password</label>\n");
-    sb.append("      <input type=\"password\" name=\"password\" id=\"password\" autocomplete=\"current-password\" placeholder=\"Enter your password\">\n");
-    sb.append("      <input type=\"submit\" class=\"btn-primary\" name=\"signIn\" id=\"signIn\" value=\"Sign in\" style=\"width:100%;\">\n");
-    sb.append("    </form>\n");
-    if (passwordResetEnabled) {
+    if (disableLoginPage) {
+      sb.append("    <p>HTTP authentication disabled by administrator. "
+          + "Install and use your certificate instead.</p>\n");
+    } else {
+      sb.append("    <form id=\"wiab_loginform\" action=\"\" method=\"post\">\n");
+      sb.append("      <label for=\"address\">Username</label>\n");
+      sb.append("      <div class=\"input-group\">\n");
+      sb.append("        <input type=\"text\" name=\"address\" id=\"address\" autocomplete=\"username\" placeholder=\"your.name\">\n");
+      sb.append("        <span class=\"domain-suffix\">@").append(escapeHtml(domain)).append("</span>\n");
+      sb.append("      </div>\n");
+      sb.append("      <label for=\"password\">Password</label>\n");
+      sb.append("      <input type=\"password\" name=\"password\" id=\"password\" autocomplete=\"current-password\" placeholder=\"Enter your password\">\n");
+      sb.append("      <input type=\"submit\" class=\"btn-primary\" name=\"signIn\" id=\"signIn\" value=\"Sign in\" style=\"width:100%;\">\n");
+      sb.append("    </form>\n");
+      if (passwordResetEnabled) {
+        sb.append("    <div class=\"footer-link\">\n");
+        sb.append("      <a href=\"/auth/password-reset\">Forgot password?</a>\n");
+        sb.append("    </div>\n");
+      }
+      if (magicLinkEnabled) {
+        sb.append("    <div class=\"footer-link\">\n");
+        sb.append("      <a href=\"/auth/magic-link\">Login with email link</a>\n");
+        sb.append("    </div>\n");
+      }
       sb.append("    <div class=\"footer-link\">\n");
-      sb.append("      <a href=\"/auth/password-reset\">Forgot password?</a>\n");
+      sb.append("      Need a different account? <a href=\"/auth/register\">Register</a>\n");
       sb.append("    </div>\n");
     }
-    if (magicLinkEnabled) {
-      sb.append("    <div class=\"footer-link\">\n");
-      sb.append("      <a href=\"/auth/magic-link\">Login with email link</a>\n");
-      sb.append("    </div>\n");
-    }
-    sb.append("    <div class=\"footer-link\">\n");
-    sb.append("      Need a different account? <a href=\"/auth/register\">Register</a>\n");
-    sb.append("    </div>\n");
     sb.append("  </div>\n");
     sb.append("</div>\n");
     sb.append("</body>\n</html>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -1534,6 +1534,218 @@ public final class HtmlRenderer {
       + ".footer-link a { color: " + WAVE_PRIMARY + "; text-decoration: none; font-weight: 500; }\n"
       + ".footer-link a:hover { text-decoration: underline; }\n"
       + ".buttons { display: flex; gap: 8px; margin-top: 8px; }\n"
+      + ".auth-state-card {\n"
+      + "  padding: 0;\n"
+      + "  overflow: hidden;\n"
+      + "  background: linear-gradient(180deg, rgba(255,255,255,0.99) 0%, rgba(245,250,255,0.96) 100%);\n"
+      + "}\n"
+      + ".auth-state-hero {\n"
+      + "  position: relative;\n"
+      + "  overflow: hidden;\n"
+      + "  padding: 28px 28px 24px;\n"
+      + "  color: #fff;\n"
+      + "}\n"
+      + ".auth-state-hero::after {\n"
+      + "  content: '';\n"
+      + "  position: absolute;\n"
+      + "  right: -10%;\n"
+      + "  bottom: -72px;\n"
+      + "  width: 320px;\n"
+      + "  height: 160px;\n"
+      + "  border-radius: 50%;\n"
+      + "  background: radial-gradient(circle, rgba(255,255,255,0.28) 0%, rgba(255,255,255,0) 72%);\n"
+      + "  transform: rotate(-10deg);\n"
+      + "}\n"
+      + ".auth-state-hero.success {\n"
+      + "  background: radial-gradient(circle at top right, rgba(144,224,239,0.72) 0%, rgba(144,224,239,0) 44%), linear-gradient(140deg, #023e8a 0%, #0077b6 44%, #00b4d8 100%);\n"
+      + "}\n"
+      + ".auth-state-hero.pending {\n"
+      + "  background: radial-gradient(circle at top right, rgba(255,255,255,0.22) 0%, rgba(255,255,255,0) 42%), linear-gradient(140deg, #0f766e 0%, #0f9d90 48%, #34d399 100%);\n"
+      + "}\n"
+      + ".auth-state-hero.action {\n"
+      + "  background: radial-gradient(circle at top right, rgba(255,255,255,0.22) 0%, rgba(255,255,255,0) 42%), linear-gradient(140deg, #92400e 0%, #b45309 48%, #f59e0b 100%);\n"
+      + "}\n"
+      + ".auth-state-hero.problem {\n"
+      + "  background: radial-gradient(circle at top right, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0) 42%), linear-gradient(140deg, #7f1d1d 0%, #b91c1c 48%, #ef4444 100%);\n"
+      + "}\n"
+      + ".auth-state-pill {\n"
+      + "  position: relative;\n"
+      + "  z-index: 1;\n"
+      + "  display: inline-flex;\n"
+      + "  align-items: center;\n"
+      + "  gap: 8px;\n"
+      + "  padding: 7px 12px;\n"
+      + "  border: 1px solid rgba(255,255,255,0.22);\n"
+      + "  border-radius: 999px;\n"
+      + "  background: rgba(255,255,255,0.14);\n"
+      + "  font-size: 12px;\n"
+      + "  font-weight: 700;\n"
+      + "  letter-spacing: 0.08em;\n"
+      + "  text-transform: uppercase;\n"
+      + "  backdrop-filter: blur(10px);\n"
+      + "}\n"
+      + ".auth-state-pill::before {\n"
+      + "  content: '';\n"
+      + "  width: 8px;\n"
+      + "  height: 8px;\n"
+      + "  border-radius: 50%;\n"
+      + "  background: rgba(255,255,255,0.9);\n"
+      + "  box-shadow: 0 0 0 5px rgba(255,255,255,0.18);\n"
+      + "}\n"
+      + ".auth-state-hero h1 {\n"
+      + "  position: relative;\n"
+      + "  z-index: 1;\n"
+      + "  margin: 16px 0 10px;\n"
+      + "  color: #fff;\n"
+      + "  font-size: 32px;\n"
+      + "  letter-spacing: -0.04em;\n"
+      + "}\n"
+      + ".auth-state-subtitle {\n"
+      + "  position: relative;\n"
+      + "  z-index: 1;\n"
+      + "  margin: 0;\n"
+      + "  max-width: 36rem;\n"
+      + "  color: rgba(255,255,255,0.9);\n"
+      + "  font-size: 15px;\n"
+      + "  line-height: 1.6;\n"
+      + "}\n"
+      + ".auth-state-body {\n"
+      + "  padding: 24px 28px 28px;\n"
+      + "}\n"
+      + ".auth-state-copy {\n"
+      + "  margin: 0;\n"
+      + "  color: #334155;\n"
+      + "  font-size: 14px;\n"
+      + "  line-height: 1.7;\n"
+      + "}\n"
+      + ".auth-state-account {\n"
+      + "  margin-top: 16px;\n"
+      + "  padding: 14px 16px;\n"
+      + "  border-radius: 16px;\n"
+      + "  border: 1px solid rgba(0,119,182,0.14);\n"
+      + "  background: rgba(232,244,248,0.9);\n"
+      + "}\n"
+      + ".auth-state-account-label {\n"
+      + "  display: block;\n"
+      + "  margin-bottom: 6px;\n"
+      + "  color: #475569;\n"
+      + "  font-size: 12px;\n"
+      + "  font-weight: 700;\n"
+      + "  letter-spacing: 0.08em;\n"
+      + "  text-transform: uppercase;\n"
+      + "}\n"
+      + ".auth-state-account-value {\n"
+      + "  color: #0f172a;\n"
+      + "  font-size: 15px;\n"
+      + "  font-weight: 600;\n"
+      + "  overflow-wrap: anywhere;\n"
+      + "}\n"
+      + ".auth-state-steps {\n"
+      + "  list-style: none;\n"
+      + "  margin: 18px 0 0;\n"
+      + "  padding: 0;\n"
+      + "  display: grid;\n"
+      + "  gap: 12px;\n"
+      + "  counter-reset: auth-step;\n"
+      + "}\n"
+      + ".auth-state-steps li {\n"
+      + "  position: relative;\n"
+      + "  min-height: 40px;\n"
+      + "  padding: 8px 0 8px 54px;\n"
+      + "  color: #334155;\n"
+      + "  font-size: 14px;\n"
+      + "  line-height: 1.6;\n"
+      + "}\n"
+      + ".auth-state-steps li::before {\n"
+      + "  counter-increment: auth-step;\n"
+      + "  content: counter(auth-step);\n"
+      + "  position: absolute;\n"
+      + "  left: 0;\n"
+      + "  top: 2px;\n"
+      + "  width: 34px;\n"
+      + "  height: 34px;\n"
+      + "  border-radius: 50%;\n"
+      + "  display: inline-flex;\n"
+      + "  align-items: center;\n"
+      + "  justify-content: center;\n"
+      + "  background: rgba(0,119,182,0.12);\n"
+      + "  color: " + WAVE_PRIMARY + ";\n"
+      + "  font-weight: 700;\n"
+      + "}\n"
+      + ".auth-state-actions {\n"
+      + "  display: flex;\n"
+      + "  flex-wrap: wrap;\n"
+      + "  gap: 12px;\n"
+      + "  margin-top: 24px;\n"
+      + "}\n"
+      + ".auth-state-link {\n"
+      + "  display: inline-flex;\n"
+      + "  align-items: center;\n"
+      + "  justify-content: center;\n"
+      + "  min-height: 44px;\n"
+      + "  padding: 11px 18px;\n"
+      + "  border-radius: 12px;\n"
+      + "  font-size: 14px;\n"
+      + "  font-weight: 600;\n"
+      + "  text-decoration: none;\n"
+      + "  transition: transform 0.12s ease, box-shadow 0.2s ease, background 0.2s ease;\n"
+      + "}\n"
+      + ".auth-state-link:hover { transform: translateY(-1px); }\n"
+      + ".auth-state-link.primary {\n"
+      + "  background: " + WAVE_PRIMARY + ";\n"
+      + "  color: #fff;\n"
+      + "  box-shadow: 0 12px 24px rgba(0,119,182,0.18);\n"
+      + "}\n"
+      + ".auth-state-link.primary:hover {\n"
+      + "  background: #005f8f;\n"
+      + "  text-decoration: none;\n"
+      + "}\n"
+      + ".auth-state-link.secondary {\n"
+      + "  background: #fff;\n"
+      + "  color: " + WAVE_PRIMARY + ";\n"
+      + "  border: 1.5px solid rgba(0,119,182,0.22);\n"
+      + "}\n"
+      + ".auth-state-link.secondary:hover {\n"
+      + "  background: #f0f8ff;\n"
+      + "  text-decoration: none;\n"
+      + "}\n"
+      + ".auth-state-inline {\n"
+      + "  margin-bottom: 18px;\n"
+      + "  padding: 18px 18px 16px;\n"
+      + "  border-radius: 16px;\n"
+      + "  border: 1px solid rgba(0,119,182,0.14);\n"
+      + "  background: rgba(232,244,248,0.94);\n"
+      + "}\n"
+      + ".auth-state-inline.success {\n"
+      + "  background: rgba(232,244,248,0.96);\n"
+      + "}\n"
+      + ".auth-state-inline.pending {\n"
+      + "  background: rgba(255,247,237,0.98);\n"
+      + "  border-color: rgba(180,83,9,0.16);\n"
+      + "}\n"
+      + ".auth-state-inline h2 {\n"
+      + "  margin: 10px 0 8px;\n"
+      + "  color: #0f172a;\n"
+      + "  font-size: 18px;\n"
+      + "}\n"
+      + ".auth-state-inline p {\n"
+      + "  margin: 0;\n"
+      + "  color: #475569;\n"
+      + "  font-size: 14px;\n"
+      + "  line-height: 1.6;\n"
+      + "}\n"
+      + ".auth-state-inline-pill {\n"
+      + "  display: inline-flex;\n"
+      + "  align-items: center;\n"
+      + "  padding: 6px 10px;\n"
+      + "  border-radius: 999px;\n"
+      + "  background: rgba(0,119,182,0.12);\n"
+      + "  color: " + WAVE_PRIMARY + ";\n"
+      + "  font-size: 11px;\n"
+      + "  font-weight: 700;\n"
+      + "  letter-spacing: 0.08em;\n"
+      + "  text-transform: uppercase;\n"
+      + "}\n"
       + ".robot-success-card {\n"
       + "  padding: 0;\n"
       + "  overflow: hidden;\n"
@@ -1681,6 +1893,11 @@ public final class HtmlRenderer {
       + "  .robot-success-hero { padding: 24px 20px 20px; }\n"
       + "  .robot-success-hero h1 { font-size: 28px; }\n"
       + "  .robot-success-body { padding: 20px; }\n"
+      + "  .auth-state-hero { padding: 24px 20px 20px; }\n"
+      + "  .auth-state-hero h1 { font-size: 28px; }\n"
+      + "  .auth-state-body { padding: 20px; }\n"
+      + "  .auth-state-actions { flex-direction: column; }\n"
+      + "  .auth-state-link { width: 100%; }\n"
       + "  .robot-credential-card { padding: 16px; }\n"
       + "  .robot-credential-value {\n"
       + "    padding: 13px 14px;\n"
@@ -1743,6 +1960,10 @@ public final class HtmlRenderer {
     sb.append("  <div class=\"card\">\n");
     sb.append("    <h1>Sign In</h1>\n");
     sb.append("    <div class=\"subtitle\">@").append(escapeHtml(domain)).append("</div>\n");
+    sb.append("    <div class=\"auth-state-inline success\" id=\"successBanner\" style=\"display:none;\">");
+    sb.append("<div class=\"auth-state-inline-pill\">Account ready</div>");
+    sb.append("<h2>Account created</h2>");
+    sb.append("<p></p></div>\n");
 
     if (disableLoginPage) {
       sb.append("    <p>HTTP authentication disabled by administrator. "
@@ -1791,10 +2012,18 @@ public final class HtmlRenderer {
     sb.append("function setFocus() { var el = document.getElementById(\"address\"); if (el) el.focus(); }\n");
     sb.append("function handleResponse(rt, msg) {\n");
     sb.append("  var lbl = document.getElementById(\"messageLbl\");\n");
-    sb.append("  if (!lbl) return;\n");
-    sb.append("  if (rt == RESPONSE_STATUS_NONE) { lbl.style.display = \"none\"; }\n");
-    sb.append("  else if (rt == RESPONSE_STATUS_FAILED) {\n");
-    sb.append("    lbl.style.display = \"block\"; lbl.className = \"msg error\"; lbl.textContent = msg;\n");
+    sb.append("  var banner = document.getElementById(\"successBanner\");\n");
+    sb.append("  if (rt == RESPONSE_STATUS_NONE) {\n");
+    sb.append("    if (lbl) lbl.style.display = \"none\";\n");
+    sb.append("    if (banner) banner.style.display = \"none\";\n");
+    sb.append("  } else if (rt == RESPONSE_STATUS_FAILED) {\n");
+    sb.append("    if (lbl) { lbl.style.display = \"block\"; lbl.className = \"msg error\"; lbl.textContent = msg; }\n");
+    sb.append("  } else if (rt == RESPONSE_STATUS_SUCCESS) {\n");
+    sb.append("    if (banner) {\n");
+    sb.append("      banner.style.display = \"block\";\n");
+    sb.append("      var copy = banner.querySelector('p');\n");
+    sb.append("      if (copy) copy.textContent = msg;\n");
+    sb.append("    }\n");
     sb.append("  }\n");
     sb.append("}\n");
     sb.append("</script>\n");
@@ -4137,6 +4366,122 @@ public final class HtmlRenderer {
   // =========================================================================
 
   /**
+   * Renders the "Check your inbox" page shown after registration when email
+   * confirmation is required. The user is redirected here via PRG so refreshing
+   * this page is safe.
+   *
+   * @param domain           the wave server domain
+   * @param analyticsAccount Google Analytics account ID (may be null/empty)
+   */
+  public static String renderCheckEmailPage(String domain, String analyticsAccount) {
+    StringBuilder sb = new StringBuilder(4096);
+    sb.append("<!DOCTYPE html>\n<html dir=\"ltr\">\n<head>\n");
+    sb.append("<meta charset=\"UTF-8\">\n");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
+    sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
+    sb.append("<title>Check Your Inbox - SupaWave</title>\n");
+    sb.append(AUTH_CSS);
+    appendAnalyticsFragment(sb, analyticsAccount, null);
+    sb.append("</head>\n<body>\n");
+
+    sb.append(WAVE_SVG);
+    sb.append("<div class=\"page-wrapper\">\n");
+    sb.append("  <div class=\"brand\">\n");
+    sb.append("    ").append(WAVE_LOGO_SVG);
+    sb.append("    <div class=\"brand-name\">SupaWave</div>\n");
+    sb.append("  </div>\n");
+
+    sb.append("  <div class=\"card auth-state-card\">\n");
+    sb.append("    <div class=\"auth-state-hero pending\">\n");
+    sb.append("      <div class=\"auth-state-pill\">Activation pending</div>\n");
+    sb.append("      <h1>Check your inbox</h1>\n");
+    sb.append("      <p class=\"auth-state-subtitle\">Activate your account to finish setting up SupaWave.</p>\n");
+    sb.append("    </div>\n");
+    sb.append("    <div class=\"auth-state-body\">\n");
+    sb.append("      <p class=\"auth-state-copy\">We sent a confirmation email with an activation link. Once you open it, your account will be ready for SupaWave @");
+    sb.append(escapeHtml(domain)).append(".</p>\n");
+    sb.append("      <ol class=\"auth-state-steps\">\n");
+    sb.append("        <li>Open the confirmation email from SupaWave.</li>\n");
+    sb.append("        <li>Activate your account by clicking the link inside.</li>\n");
+    sb.append("        <li>Return here and sign in once activation is complete.</li>\n");
+    sb.append("      </ol>\n");
+    sb.append("      <div class=\"auth-state-actions\">\n");
+    sb.append("        <a href=\"/auth/signin\" class=\"auth-state-link primary\">Go to sign in</a>\n");
+    sb.append("        <a href=\"/auth/register\" class=\"auth-state-link secondary\">Create another account</a>\n");
+    sb.append("      </div>\n");
+    sb.append("      <div class=\"footer-link\">\n");
+    sb.append("        Already confirmed? <a href=\"/auth/signin\">Sign in</a>\n");
+    sb.append("      </div>\n");
+    sb.append("    </div>\n");
+    sb.append("  </div>\n"); // .card
+    sb.append("</div>\n"); // .page-wrapper
+    sb.append("</body>\n</html>\n");
+    return sb.toString();
+  }
+
+  /**
+   * Renders the sign-in page with an activation-required callout while keeping
+   * the normal sign-in affordances available.
+   */
+  public static String renderActivationRequiredAuthenticationPage(String domain, String message,
+      String analyticsAccount, boolean passwordResetEnabled, boolean magicLinkEnabled) {
+    StringBuilder sb = new StringBuilder(8192);
+    sb.append("<!DOCTYPE html>\n<html dir=\"ltr\">\n<head>\n");
+    sb.append("<meta charset=\"UTF-8\">\n");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
+    sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
+    sb.append("<title>Check Your Inbox - SupaWave</title>\n");
+    sb.append(AUTH_CSS);
+    appendAnalyticsFragment(sb, analyticsAccount, null);
+    sb.append("</head>\n<body>\n");
+
+    sb.append(WAVE_SVG);
+    sb.append("<div class=\"page-wrapper\">\n");
+    sb.append("  <div class=\"brand\">\n");
+    sb.append("    ").append(WAVE_LOGO_SVG);
+    sb.append("    <div class=\"brand-name\">SupaWave</div>\n");
+    sb.append("  </div>\n");
+    sb.append("  <div class=\"card\">\n");
+    sb.append("    <h1>Sign In</h1>\n");
+    sb.append("    <div class=\"subtitle\">@").append(escapeHtml(domain)).append("</div>\n");
+    sb.append("    <div class=\"auth-state-inline pending\">\n");
+    sb.append("      <div class=\"auth-state-inline-pill\">Action required</div>\n");
+    sb.append("      <h2>Check your inbox</h2>\n");
+    sb.append("      <p>").append(escapeHtml(message))
+        .append(" Activate your account first, then return here to sign in.</p>\n");
+    sb.append("    </div>\n");
+    sb.append("    <form id=\"wiab_loginform\" action=\"\" method=\"post\">\n");
+    sb.append("      <label for=\"address\">Username</label>\n");
+    sb.append("      <div class=\"input-group\">\n");
+    sb.append("        <input type=\"text\" name=\"address\" id=\"address\" autocomplete=\"username\" placeholder=\"your.name\">\n");
+    sb.append("        <span class=\"domain-suffix\">@").append(escapeHtml(domain)).append("</span>\n");
+    sb.append("      </div>\n");
+    sb.append("      <label for=\"password\">Password</label>\n");
+    sb.append("      <input type=\"password\" name=\"password\" id=\"password\" autocomplete=\"current-password\" placeholder=\"Enter your password\">\n");
+    sb.append("      <input type=\"submit\" class=\"btn-primary\" name=\"signIn\" id=\"signIn\" value=\"Sign in\" style=\"width:100%;\">\n");
+    sb.append("    </form>\n");
+    if (passwordResetEnabled) {
+      sb.append("    <div class=\"footer-link\">\n");
+      sb.append("      <a href=\"/auth/password-reset\">Forgot password?</a>\n");
+      sb.append("    </div>\n");
+    }
+    if (magicLinkEnabled) {
+      sb.append("    <div class=\"footer-link\">\n");
+      sb.append("      <a href=\"/auth/magic-link\">Login with email link</a>\n");
+      sb.append("    </div>\n");
+    }
+    sb.append("    <div class=\"footer-link\">\n");
+    sb.append("      Need a different account? <a href=\"/auth/register\">Register</a>\n");
+    sb.append("    </div>\n");
+    sb.append("  </div>\n");
+    sb.append("</div>\n");
+    sb.append("</body>\n</html>\n");
+    return sb.toString();
+  }
+
+  /**
    * Renders the email confirmation result page.
    */
   public static String renderEmailConfirmationPage(String domain, String message,
@@ -4150,7 +4495,7 @@ public final class HtmlRenderer {
     sb.append("<title>Email Confirmation - SupaWave</title>\n");
     sb.append(AUTH_CSS);
     appendAnalyticsFragment(sb, analyticsAccount, null);
-    sb.append("</head>\n<body onload=\"init()\">\n");
+    sb.append("</head>\n<body>\n");
 
     sb.append(WAVE_SVG);
     sb.append("<div class=\"page-wrapper\">\n");
@@ -4159,35 +4504,30 @@ public final class HtmlRenderer {
     sb.append("    <div class=\"brand-name\">SupaWave</div>\n");
     sb.append("  </div>\n");
 
-    sb.append("  <div class=\"card\">\n");
-    sb.append("    <h1>Email Confirmation</h1>\n");
+    String heroClass = AuthenticationServlet.RESPONSE_STATUS_SUCCESS.equals(responseType)
+        ? "success" : "problem";
+    String pill = AuthenticationServlet.RESPONSE_STATUS_SUCCESS.equals(responseType)
+        ? "Activation complete" : "Action required";
+    String headline = AuthenticationServlet.RESPONSE_STATUS_SUCCESS.equals(responseType)
+        ? "Ready to sign in" : "This confirmation link needs attention";
+    String subtitle = AuthenticationServlet.RESPONSE_STATUS_SUCCESS.equals(responseType)
+        ? "Your account is active and ready for SupaWave."
+        : "Use a fresh confirmation link, then come back to sign in.";
 
-    sb.append("    <div class=\"msg\" id=\"messageLbl\"></div>\n");
-
-    sb.append("    <div class=\"footer-link\">\n");
-    sb.append("      <a href=\"/auth/signin\">Go to Sign In</a>\n");
+    sb.append("  <div class=\"card auth-state-card\">\n");
+    sb.append("    <div class=\"auth-state-hero ").append(heroClass).append("\">\n");
+    sb.append("      <div class=\"auth-state-pill\">").append(escapeHtml(pill)).append("</div>\n");
+    sb.append("      <h1>").append(escapeHtml(headline)).append("</h1>\n");
+    sb.append("      <p class=\"auth-state-subtitle\">").append(escapeHtml(subtitle)).append("</p>\n");
+    sb.append("    </div>\n");
+    sb.append("    <div class=\"auth-state-body\">\n");
+    sb.append("      <p class=\"auth-state-copy\">").append(escapeHtml(message)).append("</p>\n");
+    sb.append("      <div class=\"auth-state-actions\">\n");
+    sb.append("        <a href=\"/auth/signin\" class=\"auth-state-link primary\">Go to Sign In</a>\n");
+    sb.append("      </div>\n");
     sb.append("    </div>\n");
     sb.append("  </div>\n"); // .card
     sb.append("</div>\n"); // .page-wrapper
-
-    sb.append("<script>\n");
-    sb.append("var RESPONSE_STATUS_NONE = \"NONE\";\n");
-    sb.append("var RESPONSE_STATUS_FAILED = \"FAILED\";\n");
-    sb.append("var RESPONSE_STATUS_SUCCESS = \"SUCCESS\";\n");
-    sb.append("var message = ").append(escapeJsonString(message)).append(";\n");
-    sb.append("var responseType = ").append(escapeJsonString(responseType)).append(";\n");
-    sb.append("function init() { handleResponse(responseType, message); }\n");
-    sb.append("function handleResponse(rt, msg) {\n");
-    sb.append("  var lbl = document.getElementById(\"messageLbl\");\n");
-    sb.append("  if (!lbl) return;\n");
-    sb.append("  if (rt == RESPONSE_STATUS_NONE) { lbl.style.display = \"none\"; }\n");
-    sb.append("  else if (rt == RESPONSE_STATUS_FAILED) {\n");
-    sb.append("    lbl.style.display = \"block\"; lbl.className = \"msg error\"; lbl.innerHTML = msg;\n");
-    sb.append("  } else if (rt == RESPONSE_STATUS_SUCCESS) {\n");
-    sb.append("    lbl.style.display = \"block\"; lbl.className = \"msg success\"; lbl.innerHTML = msg;\n");
-    sb.append("  }\n");
-    sb.append("}\n");
-    sb.append("</script>\n");
     sb.append("</body>\n</html>\n");
     return sb.toString();
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
@@ -94,6 +94,10 @@ public final class UserRegistrationServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    if ("1".equals(req.getParameter("check-email"))) {
+      writeCheckEmailPage(resp);
+      return;
+    }
     writeRegistrationPage("", AuthenticationServlet.RESPONSE_STATUS_NONE, resp);
   }
 
@@ -101,33 +105,40 @@ public final class UserRegistrationServlet extends HttpServlet {
   protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     req.setCharacterEncoding("UTF-8");
 
-    String message = null;
-    String responseType;
-    if (!registrationDisabled) {
-      message = tryCreateUser(
-          req.getParameter(HttpRequestBasedCallbackHandler.ADDRESS_FIELD),
-          req.getParameter(HttpRequestBasedCallbackHandler.PASSWORD_FIELD),
-          req.getParameter("email"),
-          req);
+    if (registrationDisabled) {
+      // Template renders its own "Registration disabled by administrator." paragraph.
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      writeRegistrationPage("", AuthenticationServlet.RESPONSE_STATUS_NONE, resp);
+      return;
     }
 
-    if (message != null || registrationDisabled) {
-      // Check if the message is actually a confirmation-pending success
-      if (message != null && message.startsWith("CONFIRM_PENDING:")) {
-        message = message.substring("CONFIRM_PENDING:".length());
-        resp.setStatus(HttpServletResponse.SC_OK);
-        responseType = AuthenticationServlet.RESPONSE_STATUS_SUCCESS;
-      } else {
-        resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        responseType = AuthenticationServlet.RESPONSE_STATUS_FAILED;
-      }
-    } else {
-      message = "Registration complete.";
-      resp.setStatus(HttpServletResponse.SC_OK);
-      responseType = AuthenticationServlet.RESPONSE_STATUS_SUCCESS;
+    String message = tryCreateUser(
+        req.getParameter(HttpRequestBasedCallbackHandler.ADDRESS_FIELD),
+        req.getParameter(HttpRequestBasedCallbackHandler.PASSWORD_FIELD),
+        req.getParameter("email"),
+        req);
+
+    if (message != null && message.startsWith("CONFIRM_PENDING:")) {
+      // Email confirmation required — PRG to check-email page
+      resp.sendRedirect("/auth/register?check-email=1");
+      return;
     }
 
-    writeRegistrationPage(message, responseType, resp);
+    if (message != null) {
+      // Validation or server error — re-render form with error
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      writeRegistrationPage(message, AuthenticationServlet.RESPONSE_STATUS_FAILED, resp);
+      return;
+    }
+
+    // Direct registration success — PRG to sign-in with success banner
+    resp.sendRedirect("/auth/signin?registered=1");
+  }
+
+  private void writeCheckEmailPage(HttpServletResponse dest) throws IOException {
+    dest.setCharacterEncoding("UTF-8");
+    dest.setContentType("text/html;charset=utf-8");
+    dest.getWriter().write(HtmlRenderer.renderCheckEmailPage(domain, analyticsAccount));
   }
 
   private String tryCreateUser(String username, String password, String email,

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
@@ -55,6 +55,7 @@ import org.waveprotocol.wave.util.escapers.PercentEscaper;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.Reader;
 import java.io.StringReader;
 import java.time.Clock;
@@ -237,12 +238,15 @@ public class AuthenticationServletTest extends TestCase {
     when(req.getServerName()).thenReturn("wave.example.com");
     when(req.getServerPort()).thenReturn(443);
     when(req.getRemoteAddr()).thenReturn("198.51.100.7");
-    PrintWriter writer = mock(PrintWriter.class);
-    when(resp.getWriter()).thenReturn(writer);
+    StringWriter body = new StringWriter();
+    when(resp.getWriter()).thenReturn(new PrintWriter(body));
 
     servlet.doPost(req, resp);
 
     verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    assertTrue(body.toString().contains("Check your inbox"));
+    assertTrue(body.toString().contains("activation email"));
+    assertFalse(body.toString().contains("incorrect"));
     verify(mailProvider).sendEmail(eq("frodo@example.com"),
         eq("Confirm your Wave account"), contains("confirm-token"));
     verify(manager, never()).setLoggedInUser(Mockito.any(), Mockito.any());

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/EmailConfirmServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/EmailConfirmServletTest.java
@@ -63,6 +63,8 @@ public class EmailConfirmServletTest extends TestCase {
 
     verify(resp).setStatus(HttpServletResponse.SC_OK);
     assertTrue(accountStore.getAccount(USER).asHuman().isEmailConfirmed());
+    assertTrue(body.toString().contains("Ready to sign in"));
+    assertTrue(body.toString().contains("Go to Sign In"));
     verify(welcomeWaveCreator).createWelcomeWave(USER);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -39,6 +39,7 @@ public final class HtmlRendererAuthStateTest {
         "example.com",
         "We sent a fresh activation email.",
         "",
+        false,
         true,
         true);
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -1,6 +1,5 @@
 package org.waveprotocol.box.server.rpc;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.server.rpc;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -18,6 +19,8 @@ public final class HtmlRendererAuthStateTest {
 
     assertTrue(html.contains("Account created"));
     assertTrue(html.contains("id=\"successBanner\""));
+    assertTrue(html.contains("role=\"status\""));
+    assertTrue(html.contains("aria-live=\"polite\""));
     assertTrue(html.contains("Forgot password?"));
     assertTrue(html.contains("Login with email link"));
   }
@@ -47,6 +50,22 @@ public final class HtmlRendererAuthStateTest {
     assertTrue(html.contains("We sent a fresh activation email."));
     assertTrue(html.contains("Forgot password?"));
     assertTrue(html.contains("Login with email link"));
+  }
+
+  @Test
+  public void activationRequiredSignInPageHidesLoginFormWhenDisabled() {
+    String html = HtmlRenderer.renderActivationRequiredAuthenticationPage(
+        "example.com",
+        "We sent a fresh activation email.",
+        "",
+        true,
+        true,
+        true);
+
+    assertTrue(html.contains("HTTP authentication disabled by administrator."));
+    assertFalse(html.contains("id=\"wiab_loginform\""));
+    assertFalse(html.contains("Forgot password?"));
+    assertFalse(html.contains("Login with email link"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -1,0 +1,63 @@
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public final class HtmlRendererAuthStateTest {
+  @Test
+  public void registeredSignInPageShowsSuccessBanner() {
+    String html = HtmlRenderer.renderAuthenticationPage(
+        "example.com",
+        "Account created! Sign in to get started.",
+        AuthenticationServlet.RESPONSE_STATUS_SUCCESS,
+        false,
+        "",
+        true,
+        true);
+
+    assertTrue(html.contains("Account created"));
+    assertTrue(html.contains("id=\"successBanner\""));
+    assertTrue(html.contains("Forgot password?"));
+    assertTrue(html.contains("Login with email link"));
+  }
+
+  @Test
+  public void checkEmailPageShowsInboxGuidance() {
+    String html = HtmlRenderer.renderCheckEmailPage(
+        "example.com",
+        "");
+
+    assertTrue(html.contains("Check your inbox"));
+    assertTrue(html.contains("Activate your account"));
+    assertTrue(html.contains("Already confirmed?"));
+  }
+
+  @Test
+  public void activationRequiredSignInPageShowsActionRequiredMessage() {
+    String html = HtmlRenderer.renderActivationRequiredAuthenticationPage(
+        "example.com",
+        "We sent a fresh activation email.",
+        "",
+        true,
+        true);
+
+    assertTrue(html.contains("Check your inbox"));
+    assertTrue(html.contains("We sent a fresh activation email."));
+    assertTrue(html.contains("Forgot password?"));
+    assertTrue(html.contains("Login with email link"));
+  }
+
+  @Test
+  public void emailConfirmationPageSuccessFeelsReadyToProceed() {
+    String html = HtmlRenderer.renderEmailConfirmationPage(
+        "example.com",
+        "Email confirmed successfully! You can now sign in.",
+        AuthenticationServlet.RESPONSE_STATUS_SUCCESS,
+        "");
+
+    assertTrue(html.contains("Ready to sign in"));
+    assertTrue(html.contains("Go to Sign In"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
@@ -80,7 +80,7 @@ public class UserRegistrationServletTest extends TestCase {
   public void testRegisterNewUserEnabled() throws Exception {
     attemptToRegister(req, resp, "foo@example.com", "internet", false);
 
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/auth/signin?registered=1");
     ParticipantId participantId = ParticipantId.ofUnsafe("foo@example.com");
     AccountData account = store.getAccount(participantId);
     assertNotNull(account);
@@ -89,15 +89,14 @@ public class UserRegistrationServletTest extends TestCase {
   }
 
   public void testRegisterNewUserWithEmailConfirmationEnabledDefersWelcomeWave() throws Exception {
-    String responseBody = attemptToRegister(
+    attemptToRegister(
         req, resp, "pending@example.com", "internet", "pending@example.com", false, true);
 
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/auth/register?check-email=1");
     ParticipantId participantId = ParticipantId.ofUnsafe("pending@example.com");
     AccountData pendingAccount = store.getAccount(participantId);
     assertNotNull(pendingAccount);
     assertFalse(pendingAccount.asHuman().isEmailConfirmed());
-    assertTrue(responseBody.contains("Please check your email to confirm your account."));
     verify(welcomeWaveCreator, never()).createWelcomeWave(participantId);
   }
 
@@ -113,7 +112,7 @@ public class UserRegistrationServletTest extends TestCase {
   public void testDomainInsertedAutomatically() throws Exception {
     attemptToRegister(req, resp, "sam", "fdsa", false);
 
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/auth/signin?registered=1");
     assertNotNull(store.getAccount(ParticipantId.ofUnsafe("sam@example.com")));
   }
 
@@ -136,14 +135,14 @@ public class UserRegistrationServletTest extends TestCase {
   public void testUsernameTrimmed() throws Exception {
     attemptToRegister(req, resp, " ben@example.com ", "beetleguice", false);
 
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/auth/signin?registered=1");
     assertNotNull(store.getAccount(ParticipantId.ofUnsafe("ben@example.com")));
   }
 
   public void testNullPasswordWorks() throws Exception {
     attemptToRegister(req, resp, "zd@example.com", null, false);
 
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/auth/signin?registered=1");
     AccountData account = store.getAccount(ParticipantId.ofUnsafe("zd@example.com"));
     assertNotNull(account);
     assertTrue(account.asHuman().getPasswordDigest().verify("".toCharArray()));
@@ -228,7 +227,6 @@ public class UserRegistrationServletTest extends TestCase {
     }
 
     writer.flush();
-    assertFalse(responseBody.toString().isEmpty());
     return responseBody.toString();
   }
 }


### PR DESCRIPTION
## Summary
- redirect successful direct registrations into sign-in with a prominent account-created state
- add a dedicated check-email page for confirmation-required registrations and an action-required sign-in state for unconfirmed accounts
- polish the email-confirmed page, add focused auth renderer coverage, and record the issue #795 design/plan docs plus changelog fragment

Closes #795.

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `CP="target/scala-3.3.4/classes:$(find .coursier-cache -name '*.jar' | paste -sd: -)" && javac -cp "$CP" -d target/scala-3.3.4/classes wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/EmailConfirmServlet.java && rm -rf /tmp/issue795-test-classes && mkdir -p /tmp/issue795-test-classes && javac -cp "$CP" -d /tmp/issue795-test-classes wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java && java -cp "/tmp/issue795-test-classes:$CP" org.junit.runner.JUnitCore org.waveprotocol.box.server.rpc.HtmlRendererAuthStateTest`
- `CP="/tmp/issue795-test-classes:target/scala-3.3.4/test-classes:target/scala-3.3.4/classes:$(find .coursier-cache -name '*.jar' | paste -sd: -)" && java --add-opens java.base/java.lang=ALL-UNNAMED -cp "$CP" junit.textui.TestRunner org.waveprotocol.box.server.rpc.UserRegistrationServletTest && java --add-opens java.base/java.lang=ALL-UNNAMED -cp "$CP" junit.textui.TestRunner org.waveprotocol.box.server.rpc.AuthenticationServletTest && java --add-opens java.base/java.lang=ALL-UNNAMED -cp "$CP" junit.textui.TestRunner org.waveprotocol.box.server.rpc.EmailConfirmServletTest`
- rendered the four auth states to `/tmp/issue795-pages` and inspected them via Playwright over a local HTTP server

## Notes
- the repo-wide SBT `testOnly` path in this worktree was blocked by unrelated generated-source/runtime issues, so the auth verification used the scoped manual `javac`/JUnit harness recorded in `journal/local-verification/2026-04-10-issue-795-registration-success-ux.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated post-registration success page with "Account created" confirmation and sign-in CTA.
  * "Check your inbox" activation page for email-confirmation flows.
  * Sign-in now shows an action-required notice for unconfirmed accounts instead of generic credential errors; auth-state visuals and small-screen layout improved.

* **Bug Fixes**
  * Clarified email-confirmation messaging for confirmed, already-confirmed, and expired/invalid outcomes.

* **Documentation**
  * Added UX design spec and implementation plan for registration/activation flows.

* **Tests**
  * New renderer auth-state tests and updated servlet tests to verify pages, content, and redirects.

* **Chores**
  * Added changelog entry and release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->