### PR TITLE
fix(robots): refresh legacy rpcServerUrl hints

### DIFF
--- a/wave/config/changelog.d/2026-04-10-robot-rpcserverurl-legacy-refresh.json
+++ b/wave/config/changelog.d/2026-04-10-robot-rpcserverurl-legacy-refresh.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-robot-rpcserverurl-legacy-refresh",
+  "version": "PR #720 follow-up",
+  "date": "2026-04-10",
+  "title": "Robots: Refresh Legacy Passive Capability RPC Hints",
+  "summary": "Passive robots with legacy stored capabilities now refresh before event delivery so rpcServerUrl matches the configured OAuth mode after restart.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Passive robots now refresh legacy capability snapshots that are missing rpcServerUrl before generating event bundles",
+        "Two-legged passive robots restored from older persisted records now recover /robot/rpc instead of falling back to the Data API endpoint"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/passive/Robot.java
@@ -325,7 +325,8 @@ public class Robot implements Runnable {
   }
 
   private boolean needsCapabilityRefresh(RobotAccountData currentAccount) {
-    return currentAccount.getCapabilities() == null;
+    RobotCapabilities capabilities = currentAccount.getCapabilities();
+    return capabilities == null || capabilities.getRpcServerUrl().isEmpty();
   }
 
   private String resolveRpcServerUrl(RobotAccountData currentAccount) {

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/passive/RobotTest.java
@@ -89,6 +89,10 @@ public class RobotTest extends TestCase {
   private static final RobotAccountData STALE_ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", null, true, 0L, null, "",
           0L, 10L, false);
+  private static final RobotAccountData LEGACY_TWO_LEGGED_ACCOUNT =
+      new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
+          Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT),
+          true, 0L, null, "", 0L, 15L, false);
   private static final RobotAccountData INITIALIZED_ACCOUNT =
       new RobotAccountDataImpl(ROBOT, "www.example.com", "secret", new RobotCapabilities(
           Maps.<EventType, Capability> newHashMap(), "fake", ProtocolVersion.DEFAULT,
@@ -297,6 +301,25 @@ public class RobotTest extends TestCase {
     enqueueEmptyWavelet();
     robot.run();
 
+    verify(eventGenerator).generateEvents(
+        any(), anyMap(), any(), eq(ACTIVE_RPC_SERVER_URL));
+  }
+
+  public void testProcessRefreshesLegacyCapabilitiesWhenRpcServerUrlMissing() throws Exception {
+    robot.setAccount(LEGACY_TWO_LEGGED_ACCOUNT);
+
+    EventMessageBundle messages = new EventMessageBundle(ROBOT_NAME.toEmailAddress(), "");
+    messages.addEvent(new DocumentChangedEvent(null, null, ALEX.getAddress(), 0L, "b+1234"));
+    when(eventGenerator.generateEvents(
+        any(), anyMap(), any(), eq(ACTIVE_RPC_SERVER_URL))).thenReturn(messages);
+    when(connector.sendMessageBundle(
+        any(EventMessageBundle.class), eq(robot), any(ProtocolVersion.class)))
+        .thenReturn(Collections.<OperationRequest>emptyList());
+
+    enqueueEmptyWavelet();
+    robot.run();
+
+    verify(gateway).updateRobotAccount(robot);
     verify(eventGenerator).generateEvents(
         any(), anyMap(), any(), eq(ACTIVE_RPC_SERVER_URL));
   }


### PR DESCRIPTION
## Summary

Follow-up for #720 and PR #794.

Passive robots restored from older persisted capability snapshots can still have an empty `rpcServerUrl` even after the auth-mode-aware advertisement fix landed. This branch refreshes those legacy snapshots before dispatch so passive event bundles continue to advertise the endpoint that matches the robot's configured OAuth mode after restart.

- refresh passive robot capabilities when the stored `rpcServerUrl` hint is missing
- add a regression test covering a legacy two-legged robot snapshot
- add a changelog fragment for the restart-safe follow-up behavior

## Root Cause

PR #794 fixed auth-mode-aware `rpcServerUrl` selection once capabilities were freshly fetched, but `Robot.process()` only refreshed passive robot capabilities when they were `null`. Older persisted accounts with non-null capabilities and an empty `rpcServerUrl` skipped refresh and fell back to the default Data API endpoint.

## Verification

```bash
python3 scripts/assemble-changelog.py
python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotConnectorTest"
sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.RobotTest"
sbt "wave/testOnly org.waveprotocol.box.server.robots.passive.EventGeneratorTest"
```

Results:
- changelog assembly passed
- changelog validation passed
- `RobotConnectorTest` passed
- `RobotTest` passed
- `EventGeneratorTest` resolved to `No tests to run for Test / testOnly` in this build, matching the earlier issue-720 verification path

## Review

- Direct diff review: no additional functional issues found
- External review: `/tmp/claude-review-issue-720-followup.out` returned `ship as-is`; one unused mock stub in the regression test was removed before push