### PR TITLE
fix(reactions): use clearer add reaction icon

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-806-reaction-add-icon.md
+++ b/docs/superpowers/plans/2026-04-10-issue-806-reaction-add-icon.md
@@ -1,0 +1,211 @@
+# Issue 806 Reaction Add Icon Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic `+` add-reaction affordance with a clearer reaction-specific icon that matches Wave/SupaWave’s icon language and still reads cleanly in the live UI.
+
+**Architecture:** Keep the change narrow: `ReactionRowRenderer` remains the only source of add-button markup, while the existing `ReactionController` click handling and picker popup stay untouched. Swap the literal `+` for a compact inline SVG reaction icon, add explicit accessibility text, and make only the smallest CSS adjustment needed after real browser verification.
+
+**Tech Stack:** Java/GWT renderer code, CSS resource in `Blip.css`, JUnit/SBT, local Wave staged server/browser verification.
+
+---
+
+## Context Snapshot
+
+- Issue: `#806`
+- Existing reaction feature plan: `docs/superpowers/plans/2026-04-10-issue-798-reactions.md`
+- Narrow seam:
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java`
+  - `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java`
+  - `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+- Existing behavior:
+  - editable rows append `<button ...>+</button>`
+  - `ReactionController` already routes `data-reaction-add="true"` clicks to `ReactionPickerPopup`
+- Test harness note:
+  - the repo SBT test compile excludes `wave/client` tests from normal `testOnly` discovery, so the executable red/green seam for `ReactionRowRendererTest` is a manual `javac` + `org.junit.runner.JUnitCore` harness using `wave/Test/fullClasspath`
+- Non-goals:
+  - do not change picker behavior, reaction chip behavior, or reaction data semantics
+  - do not introduce a larger icon system or shared helper just for this issue
+
+## Acceptance Criteria
+
+- [ ] The add-reaction affordance is clearly reaction-related, not a generic plus.
+- [ ] The icon visually fits the existing toolbar/icon language through compact current-color SVG styling.
+- [ ] The button keeps the existing chip-shaped footprint and remains readable.
+- [ ] The live UI has been verified in a real browser against a local server.
+- [ ] App-affecting changes include a changelog fragment and regenerated `wave/config/changelog.json`.
+
+## Task 1: Lock The Renderer Contract First
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java`
+
+- [ ] **Step 1: Write the failing test for the new add button contract**
+
+```java
+public void testRenderUsesReactionSpecificAddIconWhenEditable() {
+  SafeHtml html = ReactionRowRenderer.render(
+      "b+blip1",
+      Collections.<ReactionDocument.Reaction>emptyList(),
+      "alice@example.com",
+      true);
+
+  String output = html.asString();
+  assertTrue(output.contains("data-reaction-add=\"true\""));
+  assertTrue(output.contains("aria-label=\"Add reaction\""));
+  assertTrue(output.contains("waveReactionAddIcon"));
+  assertFalse(output.contains(">+</button>"));
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify the failure is real**
+
+Run:
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | \
+  perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Expected:
+- FAIL because the current renderer still emits a literal `+` and no icon/accessibility markup
+
+## Task 2: Implement The Narrow Renderer/CSS Fix
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java`
+- Modify only if needed after browser check: `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+- Modify only if CSS changes: `wave/src/test/java/org/waveprotocol/box/server/rpc/BlipCssLinkStyleTest.java`
+
+- [ ] **Step 1: Replace the literal plus with a compact reaction SVG**
+
+```java
+private static final String ADD_ICON_HTML =
+    "<span class=\"waveReactionAddIcon\" aria-hidden=\"true\">"
+        + "<svg ...>"
+        + "...</svg>"
+        + "</span>";
+```
+
+```java
+html.appendHtmlConstant(
+    "<button type=\"button\" class=\"" + ADD_CLASS + "\" data-reaction-add=\"true\" "
+        + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
+        + "aria-label=\"Add reaction\" title=\"Add reaction\">");
+html.appendHtmlConstant(ADD_ICON_HTML);
+html.appendHtmlConstant("</button>");
+```
+
+- [ ] **Step 2: Keep CSS changes minimal and only for visual fit**
+
+If the browser pass shows the inline SVG is misaligned, add only a small selector such as:
+
+```css
+.reactions .waveReactionAddIcon,
+.reactions .waveReactionAddIcon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+```
+
+- [ ] **Step 3: Re-run the focused tests**
+
+Run:
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | \
+  perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Expected:
+- PASS with the new icon-specific markup
+
+If CSS changed, also run:
+```bash
+sbt "testOnly org.waveprotocol.box.server.rpc.BlipCssLinkStyleTest"
+```
+
+Expected:
+- PASS with the new CSS contract assertions
+
+## Task 3: Changelog And Real-UI Verification
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-10-issue-806-reaction-add-icon.json`
+- Regenerate: `wave/config/changelog.json`
+- Add: `journal/local-verification/2026-04-10-issue-806-reaction-add-icon.md`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+```json
+{
+  "releaseId": "2026-04-10-issue-806-reaction-add-icon",
+  "title": "Use a clearer add-reaction icon",
+  "summary": "Replaces the generic plus reaction button with a reaction-specific icon.",
+  "type": "fix"
+}
+```
+
+- [ ] **Step 2: Regenerate and validate changelog output**
+
+Run:
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+```
+
+Expected:
+- assemble completes and `wave/config/changelog.json` updates
+- validate exits 0
+
+- [ ] **Step 3: Run local server + browser verification**
+
+Run:
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+bash scripts/worktree-boot.sh --port 9900
+PORT=9900 JAVA_OPTS='-Dwave.config.name=wave -Djava.net.preferIPv4Stack=true' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+Browser flow:
+- open `http://localhost:9900/`
+- sign in with the shared local test account if needed
+- open a wave with reactions enabled
+- confirm the add button reads as a reaction action, not a generic plus
+- click it and confirm the picker still opens and the icon remains visually cohesive beside reaction chips
+
+- [ ] **Step 4: Record evidence and prepare PR**
+
+Record in:
+- `journal/local-verification/2026-04-10-issue-806-reaction-add-icon.md`
+- issue `#806`
+
+Include:
+- exact test commands and results
+- exact local server commands and result
+- browser URL and observed UI result
+- commit SHA(s)
+- review findings and resolutions

--- a/journal/local-verification/2026-04-10-issue-806-reaction-add-icon.md
+++ b/journal/local-verification/2026-04-10-issue-806-reaction-add-icon.md
@@ -1,0 +1,111 @@
+# Issue 806 Local Verification
+
+Date: 2026-04-10
+Issue: #806
+Branch: `reactions-add-icon-20260410`
+Worktree: `/Users/vega/devroot/worktrees/reactions-add-icon-20260410`
+
+## Test Harness Note
+
+The repo SBT test compile excludes `wave/client` tests from normal `testOnly` discovery, so the executable red/green seam for `ReactionRowRendererTest` used a manual `javac` + `org.junit.runner.JUnitCore` harness against `wave/Test/fullClasspath`.
+
+## Red Phase
+
+Command:
+
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Result:
+
+- `FAILURES!!!`
+- `testRenderUsesReactionSpecificAddIconWhenEditable` failed because the renderer still emitted the generic `+` button with no icon-specific/accessibility markup
+
+## Green Phase
+
+Command:
+
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Result:
+
+- `OK (4 tests)`
+
+## Changelog
+
+Commands:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Result:
+
+- `assembled 134 entries -> wave/config/changelog.json`
+- `changelog validation passed`
+
+## Local Server And Browser Verification
+
+Commands:
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+bash scripts/worktree-boot.sh --port 9900
+PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/reactions-add-icon-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/reactions-add-icon-20260410/wave/config/jaas.config' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+Results:
+
+- file-store links created for `_accounts`, `_attachments`, and `_deltas`
+- `worktree-boot.sh` completed successfully, including GWT compile and staged assets
+- smoke check passed:
+  - `ROOT_STATUS=200`
+  - `HEALTH_STATUS=200`
+  - `WEBCLIENT_STATUS=200`
+- shutdown completed cleanly:
+  - `Stopped server on port 9900`
+
+Browser flow:
+
+1. Opened `http://localhost:9900/auth/register`
+2. Registered throwaway local account `rx806lane@local.net`
+3. Signed in at `http://localhost:9900/auth/signin`
+4. Opened the welcome wave at `#local.net/w+uo4rne1ce8i4A`
+5. Located the updated `Add reaction` control beneath the blip
+6. Confirmed the affordance rendered as a reaction-specific icon, not a generic text plus
+7. Confirmed the button retained the existing reaction-chip footprint and styling
+8. Clicked the control and confirmed the emoji picker popup opened with the expected options
+
+Observed UI result:
+
+- the add-reaction button rendered as a compact blue `32x20` pill with inline SVG smile-plus iconography
+- the control read clearly as a reaction action in context
+- no additional CSS adjustment was needed after live inspection

--- a/wave/config/changelog.d/2026-04-10-issue-806-reaction-add-icon.json
+++ b/wave/config/changelog.d/2026-04-10-issue-806-reaction-add-icon.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-issue-806-reaction-add-icon",
+  "version": "PR #806",
+  "date": "2026-04-10",
+  "title": "Use a clearer add-reaction icon",
+  "summary": "Replaces the generic plus reaction affordance with a reaction-specific icon that reads more clearly in the wave UI.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The add-reaction control now uses a compact reaction icon instead of a bare plus",
+        "The reaction add button keeps the existing chip styling while reading more clearly as a reaction action"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -34,6 +34,22 @@ public final class ReactionRowRenderer {
   public static final String CHIP_CLASS = "waveReactionChip";
   public static final String CHIP_ACTIVE_CLASS = "waveReactionChipActive";
   public static final String ADD_CLASS = "waveReactionAdd";
+  private static final String ADD_ICON_CLASS = "waveReactionAddIcon";
+  private static final String ADD_BUTTON_LABEL = "Add reaction";
+  private static final String ADD_ICON_HTML =
+      "<span class=\"" + ADD_ICON_CLASS + "\" aria-hidden=\"true\">"
+          + "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" "
+          + "viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" "
+          + "stroke-width=\"1.75\" stroke-linecap=\"round\" stroke-linejoin=\"round\" "
+          + "style=\"display:block\">"
+          + "<circle cx=\"10\" cy=\"10\" r=\"6\"></circle>"
+          + "<circle cx=\"8\" cy=\"8.5\" r=\"0.75\" fill=\"currentColor\" stroke=\"none\"></circle>"
+          + "<circle cx=\"12\" cy=\"8.5\" r=\"0.75\" fill=\"currentColor\" stroke=\"none\"></circle>"
+          + "<path d=\"M7.5 11.5c0.7 1.1 1.7 1.7 2.5 1.7s1.8-0.6 2.5-1.7\"></path>"
+          + "<circle cx=\"17.5\" cy=\"16.5\" r=\"4.5\"></circle>"
+          + "<path d=\"M17.5 14.5v4\"></path>"
+          + "<path d=\"M15.5 16.5h4\"></path>"
+          + "</svg></span>";
 
   private ReactionRowRenderer() {
   }
@@ -56,7 +72,11 @@ public final class ReactionRowRenderer {
     if (editable) {
       html.appendHtmlConstant(
           "<button type=\"button\" class=\"" + ADD_CLASS + "\" data-reaction-add=\"true\" "
-              + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\">+</button>");
+              + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
+              + "aria-label=\"" + ADD_BUTTON_LABEL + "\" title=\"" + ADD_BUTTON_LABEL + "\" "
+              + "aria-haspopup=\"dialog\">");
+      html.appendHtmlConstant(ADD_ICON_HTML);
+      html.appendHtmlConstant("</button>");
     }
     return html.toSafeHtml();
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -73,8 +73,7 @@ public final class ReactionRowRenderer {
       html.appendHtmlConstant(
           "<button type=\"button\" class=\"" + ADD_CLASS + "\" data-reaction-add=\"true\" "
               + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
-              + "aria-label=\"" + ADD_BUTTON_LABEL + "\" title=\"" + ADD_BUTTON_LABEL + "\" "
-              + "aria-haspopup=\"dialog\">");
+              + "aria-label=\"" + ADD_BUTTON_LABEL + "\" title=\"" + ADD_BUTTON_LABEL + "\">");
       html.appendHtmlConstant(ADD_ICON_HTML);
       html.appendHtmlConstant("</button>");
     }

--- a/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
@@ -49,6 +49,20 @@ public final class ReactionRowRendererTest extends TestCase {
     assertTrue(output.contains("data-reaction-active=\"true\""));
   }
 
+  public void testRenderUsesReactionSpecificAddIconWhenEditable() {
+    SafeHtml html = ReactionRowRenderer.render(
+        "b+blip4",
+        Collections.<ReactionDocument.Reaction>emptyList(),
+        "alice@example.com",
+        true);
+
+    String output = html.asString();
+    assertTrue(output.contains("data-reaction-add=\"true\""));
+    assertTrue(output.contains("aria-label=\"Add reaction\""));
+    assertTrue(output.contains("waveReactionAddIcon"));
+    assertFalse(output.contains(">+</button>"));
+  }
+
   public void testRenderOmitsAddButtonWhenReadOnly() {
     SafeHtml html = ReactionRowRenderer.render(
         "b+blip2",


### PR DESCRIPTION
## Summary
- replace the generic `+` reaction affordance with a compact reaction-specific smile-plus icon
- add a renderer regression test covering the new icon markup and button accessibility text
- add the issue plan, changelog fragment, and local verification note for #806

## Verification
- manual `javac` + `org.junit.runner.JUnitCore` harness for `ReactionRowRendererTest` (red -> green)
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- browser verification on `http://localhost:9900/` against the signed-in wave UI

Closes #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The add-reaction control now shows a clearer, reaction-specific icon (with accessible label) instead of a generic plus, preserving existing styling and picker behavior.
* **Tests**
  * Added a unit test verifying the new add-reaction markup and accessibility attributes.
* **Documentation**
  * Added implementation plan, local verification journal, and changelog entry documenting the change and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->