### PR TITLE
fix(client): keep mobile search panel hidden during blip edit focus

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-810-mobile-search-panel-expand-plan.md
+++ b/docs/superpowers/plans/2026-04-10-issue-810-mobile-search-panel-expand-plan.md
@@ -1,0 +1,190 @@
+# Issue 810 Mobile Search Panel Expand Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the mobile search panel off-canvas while entering blip edit mode so the typing area stays visible on Android/mobile.
+
+**Architecture:** Investigation narrowed the regression to the Android focus path restored in `#796`, not the renderer's mobile drawer class toggles. `EditorImpl.focus()` already snapshots ancestor `scrollTop` to cancel WebKit auto-scroll, but it does not preserve `scrollLeft`; on mobile split-layout shells that leaves horizontal ancestor drift uncorrected and can reveal the sidebar while edit mode starts. The minimal fix is to preserve both axes in the editor focus helper, move the scroll capture/restore logic into a tiny testable helper with a normal JVM regression, and then re-run the live mobile browser path against the staged local server.
+
+**Tech Stack:** Java client code, `EditorImpl`, plain JVM `TestCase`, Playwright mobile verification, SBT, staged local Wave server.
+
+---
+
+## File Map
+
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java`
+- Create: `wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java`
+- Create: `wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java`
+- Create: `wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json`
+- Regenerate: `wave/config/changelog.json`
+
+### Task 1: Lock the Scroll-Restoration Boundary with a Failing JVM Test
+
+**Files:**
+- Create: `wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java`
+
+- [ ] **Step 1: Add a plain JVM regression for ancestor scroll restoration**
+
+Create `AncestorScrollPositionsTest` with a fake parent/child chain that:
+- captures scroll state from child through ancestors
+- mutates both `scrollTop` and `scrollLeft`
+- restores the captured state
+- asserts both axes are restored for every node
+
+Target assertion shape:
+
+```java
+assertEquals(120, parent.scrollLeft);
+assertEquals(40, parent.scrollTop);
+```
+
+- [ ] **Step 2: Run the focused compile/test harness and verify it fails before the helper exists**
+
+Run:
+
+```bash
+FULL_CP=$(cat target/streams/test/fullClasspath/_global/streams/export)
+OUT=/tmp/issue810-ancestor-scroll-test-red
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java
+```
+
+Expected:
+- FAIL because `AncestorScrollPositions` does not exist yet
+
+### Task 2: Preserve Both Scroll Axes During Mobile Focus
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java`
+- Create: `wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java`
+
+- [ ] **Step 1: Add a tiny helper that captures and restores both axes**
+
+Implement a small package-private helper that captures `{scrollTop, scrollLeft}` for a node and each ancestor through a narrow adapter interface, then restores those saved values later.
+
+- [ ] **Step 2: Wire `EditorImpl` through the helper**
+
+Replace the old single-axis `ancestorScrollTops` state so `maybeSaveAncestorScrollPositions(...)` / `maybeRestoreAncestorScrollPositions(...)` preserve both axes for real DOM `Element` ancestors.
+
+- [ ] **Step 3: Re-run the focused compile/test harness and verify it passes**
+
+Run:
+
+```bash
+FULL_CP=$(cat target/streams/test/fullClasspath/_global/streams/export)
+OUT=/tmp/issue810-ancestor-scroll-test-green
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java \
+  wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.editor.AncestorScrollPositionsTest
+```
+
+Expected:
+- `OK (1 test)`
+
+### Task 3: Record the User-Facing Fix
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json`
+- Regenerate: `wave/config/changelog.json`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+Create:
+
+```json
+{
+  "releaseId": "2026-04-10-mobile-search-panel-expand",
+  "version": "PR #810",
+  "title": "Mobile search panel no longer slides into blip edits",
+  "date": "2026-04-10",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Android/mobile blip edit sessions now preserve horizontal scroll state when the editor focuses, preventing the search panel from sliding over the typing area."
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Rebuild and validate the assembled changelog**
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Expected:
+- `assembled ... -> wave/config/changelog.json`
+- `changelog validation passed`
+
+### Task 4: Verify the Live Mobile Path Narrowly
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Re-run the focused regression**
+
+Run:
+
+```bash
+FULL_CP=$(cat target/streams/test/fullClasspath/_global/streams/export)
+OUT=/tmp/issue810-ancestor-scroll-test-green
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.editor.AncestorScrollPositionsTest
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 2: Rebuild the staged app**
+
+Run:
+
+```bash
+sbt -batch Universal/stage
+```
+
+Expected:
+- PASS
+
+- [ ] **Step 3: Start the local staged server on the lane port and run smoke**
+
+Run:
+
+```bash
+PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/mobile-search-panel-expand-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/mobile-search-panel-expand-20260410/wave/config/jaas.config' ./target/universal/stage/bin/wave
+PORT=9900 bash scripts/wave-smoke.sh check
+```
+
+Expected:
+- `ROOT_STATUS=200`
+- `HEALTH_STATUS=200`
+- `WEBCLIENT_STATUS=200`
+
+- [ ] **Step 4: Re-run the mobile browser edit flow**
+
+Use Playwright mobile emulation against `http://127.0.0.1:9900/`:
+- sign in as the local test user
+- open the welcome wave
+- enter root-blip edit mode
+- type a marker
+- confirm the search panel stays off-canvas and the typing area remains visible
+
+- [ ] **Step 5: Stop the local server after verification**
+
+Stop the foreground staged server session (or run `PORT=9900 bash scripts/wave-smoke.sh stop` if using the wrapper path).
+
+## Out of Scope
+
+- Changing the renderer’s mobile drawer state machine unless the focus-path fix fails to resolve the issue
+- Reworking SplitLayoutPanel mobile CSS
+- General editor focus/selection changes outside ancestor scroll restoration
+- Search result refresh behavior unrelated to mobile edit startup

--- a/wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json
+++ b/wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-mobile-search-panel-expand",
+  "version": "PR #810",
+  "date": "2026-04-10",
+  "title": "Mobile search panel stays hidden while editing",
+  "summary": "Android/mobile blip edit sessions now preserve horizontal focus scroll state so the search panel does not slide over the typing area.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Preserved both vertical and horizontal ancestor scroll positions when the mobile editor focuses",
+        "Prevented the off-canvas search panel from being revealed over the active blip editor during Android/mobile edit startup"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json
+++ b/wave/config/changelog.d/2026-04-10-mobile-search-panel-expand.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-10-mobile-search-panel-expand",
-  "version": "PR #810",
+  "version": "PR #818",
   "date": "2026-04-10",
   "title": "Mobile search panel stays hidden while editing",
   "summary": "Android/mobile blip edit sessions now preserve horizontal focus scroll state so the search panel does not slide over the typing area.",

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.editor;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+/** Captures and restores scroll positions for an element and all of its ancestors. */
+final class AncestorScrollPositions<T> {
+
+  interface Adapter<T> {
+    int getScrollTop(T element);
+
+    int getScrollLeft(T element);
+
+    void setScrollTop(T element, int scrollTop);
+
+    void setScrollLeft(T element, int scrollLeft);
+
+    T getParent(T element);
+  }
+
+  private static final class ScrollPosition {
+    private final int scrollTop;
+    private final int scrollLeft;
+
+    private ScrollPosition(int scrollTop, int scrollLeft) {
+      this.scrollTop = scrollTop;
+      this.scrollLeft = scrollLeft;
+    }
+  }
+
+  private final IdentityHashMap<T, ScrollPosition> positions;
+
+  private AncestorScrollPositions(IdentityHashMap<T, ScrollPosition> positions) {
+    this.positions = positions;
+  }
+
+  static <T> AncestorScrollPositions<T> capture(T start, Adapter<T> adapter) {
+    IdentityHashMap<T, ScrollPosition> positions = new IdentityHashMap<T, ScrollPosition>();
+    T current = start;
+    while (current != null) {
+      positions.put(current, new ScrollPosition(
+          adapter.getScrollTop(current), adapter.getScrollLeft(current)));
+      current = adapter.getParent(current);
+    }
+    return new AncestorScrollPositions<T>(positions);
+  }
+
+  void restore(Adapter<T> adapter) {
+    for (Map.Entry<T, ScrollPosition> entry : positions.entrySet()) {
+      T element = entry.getKey();
+      ScrollPosition position = entry.getValue();
+      adapter.setScrollTop(element, position.scrollTop);
+      adapter.setScrollLeft(element, position.scrollLeft);
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
@@ -638,8 +638,36 @@ public class EditorImpl extends LogicalPanel.Impl implements
 
   private final EditorUpdateEventImpl updateEvent = new EditorUpdateEventImpl(this);
 
-  /** stored scrollTops used by maybeSave/RestoreAncestorScrollPositions */
-  private IdentityMap<Element, Integer> ancestorScrollTops;
+  /** Stored ancestor scroll positions used by maybeSave/RestoreAncestorScrollPositions. */
+  private AncestorScrollPositions<Element> ancestorScrollPositions;
+
+  private static final AncestorScrollPositions.Adapter<Element> ELEMENT_SCROLL_ADAPTER =
+      new AncestorScrollPositions.Adapter<Element>() {
+        @Override
+        public int getScrollTop(Element element) {
+          return element.getScrollTop();
+        }
+
+        @Override
+        public int getScrollLeft(Element element) {
+          return element.getScrollLeft();
+        }
+
+        @Override
+        public void setScrollTop(Element element, int scrollTop) {
+          element.setScrollTop(scrollTop);
+        }
+
+        @Override
+        public void setScrollLeft(Element element, int scrollLeft) {
+          element.setScrollLeft(scrollLeft);
+        }
+
+        @Override
+        public Element getParent(Element element) {
+          return element.getParentElement();
+        }
+      };
 
   // TODO(user): This class can be broken down further. Things like paste/dom
   // mutation extraction are not really application specific and can be handled
@@ -1907,22 +1935,14 @@ public class EditorImpl extends LogicalPanel.Impl implements
 
   private void maybeSaveAncestorScrollPositions(Element e) {
     if (QuirksConstants.ADJUSTS_SCROLL_TOP_WHEN_FOCUSING) {
-      ancestorScrollTops = CollectionUtils.createIdentityMap();
-      while (e != null) {
-        ancestorScrollTops.put(e, e.getScrollTop());
-        e = e.getParentElement();
-      }
+      ancestorScrollPositions = AncestorScrollPositions.capture(e, ELEMENT_SCROLL_ADAPTER);
     }
   }
 
   private void maybeRestoreAncestorScrollPositions(Element e) {
-    if (QuirksConstants.ADJUSTS_SCROLL_TOP_WHEN_FOCUSING && ancestorScrollTops != null) {
-      ancestorScrollTops.each(new IdentityMap.ProcV<Element, Integer>() {
-        public void apply(Element e, Integer i) {
-          e.setScrollTop(i);
-        }
-      });
-      ancestorScrollTops = null;
+    if (QuirksConstants.ADJUSTS_SCROLL_TOP_WHEN_FOCUSING && ancestorScrollPositions != null) {
+      ancestorScrollPositions.restore(ELEMENT_SCROLL_ADAPTER);
+      ancestorScrollPositions = null;
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
@@ -1939,7 +1939,7 @@ public class EditorImpl extends LogicalPanel.Impl implements
     }
   }
 
-  private void maybeRestoreAncestorScrollPositions(Element e) {
+  private void maybeRestoreAncestorScrollPositions(@SuppressWarnings("unused") Element e) {
     if (QuirksConstants.ADJUSTS_SCROLL_TOP_WHEN_FOCUSING && ancestorScrollPositions != null) {
       ancestorScrollPositions.restore(ELEMENT_SCROLL_ADAPTER);
       ancestorScrollPositions = null;

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.editor;
+
+import junit.framework.TestCase;
+
+/** Regression coverage for preserving ancestor scroll positions during focus. */
+public final class AncestorScrollPositionsTest extends TestCase {
+
+  private static final class FakeElement {
+    private final FakeElement parent;
+    private int scrollTop;
+    private int scrollLeft;
+
+    private FakeElement(FakeElement parent, int scrollTop, int scrollLeft) {
+      this.parent = parent;
+      this.scrollTop = scrollTop;
+      this.scrollLeft = scrollLeft;
+    }
+  }
+
+  private static final AncestorScrollPositions.Adapter<FakeElement> ADAPTER =
+      new AncestorScrollPositions.Adapter<FakeElement>() {
+        @Override
+        public int getScrollTop(FakeElement element) {
+          return element.scrollTop;
+        }
+
+        @Override
+        public int getScrollLeft(FakeElement element) {
+          return element.scrollLeft;
+        }
+
+        @Override
+        public void setScrollTop(FakeElement element, int scrollTop) {
+          element.scrollTop = scrollTop;
+        }
+
+        @Override
+        public void setScrollLeft(FakeElement element, int scrollLeft) {
+          element.scrollLeft = scrollLeft;
+        }
+
+        @Override
+        public FakeElement getParent(FakeElement element) {
+          return element.parent;
+        }
+      };
+
+  public void testRestorePreservesHorizontalAndVerticalScroll() {
+    FakeElement root = new FakeElement(null, 5, 10);
+    FakeElement parent = new FakeElement(root, 40, 120);
+    FakeElement child = new FakeElement(parent, 80, 240);
+
+    AncestorScrollPositions<FakeElement> positions =
+        AncestorScrollPositions.capture(child, ADAPTER);
+
+    root.scrollTop = 0;
+    root.scrollLeft = 0;
+    parent.scrollTop = 0;
+    parent.scrollLeft = 0;
+    child.scrollTop = 0;
+    child.scrollLeft = 0;
+
+    positions.restore(ADAPTER);
+
+    assertEquals(5, root.scrollTop);
+    assertEquals(10, root.scrollLeft);
+    assertEquals(40, parent.scrollTop);
+    assertEquals(120, parent.scrollLeft);
+    assertEquals(80, child.scrollTop);
+    assertEquals(240, child.scrollLeft);
+  }
+}


### PR DESCRIPTION
## Summary
- preserve both horizontal and vertical ancestor scroll positions during editor focus
- route `EditorImpl` focus scroll preservation through a small testable helper
- add a focused JVM regression plus changelog fragment for the mobile edit/sidebar fix

## Root cause
`#796` restored the Android/mobile editor focus path. `EditorImpl.focus()` already snapshots ancestor `scrollTop` to cancel WebKit auto-scroll, but it did not preserve `scrollLeft`. In the mobile split layout that leaves horizontal drift uncorrected and can reveal the off-canvas search sidebar over the typing area during edit startup.

## Verification
- `FULL_CP=$(cat target/streams/test/fullClasspath/_global/streams/export); OUT=/tmp/issue810-ancestor-scroll-test-red; rm -rf "$OUT" && mkdir -p "$OUT"; javac --release 17 -cp "$FULL_CP" -d "$OUT" wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java`
  - red step failed before implementation because `AncestorScrollPositions` did not exist
- `FULL_CP=$(cat target/streams/test/fullClasspath/_global/streams/export); OUT=/tmp/issue810-ancestor-scroll-test-green; rm -rf "$OUT" && mkdir -p "$OUT"; javac --release 17 -cp "$FULL_CP" -d "$OUT" wave/src/main/java/org/waveprotocol/wave/client/editor/AncestorScrollPositions.java wave/src/test/java/org/waveprotocol/wave/client/editor/AncestorScrollPositionsTest.java && java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore org.waveprotocol.wave.client.editor.AncestorScrollPositionsTest`
  - `OK (1 test)`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `sbt -batch Universal/stage`
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- Playwright mobile verification against `http://127.0.0.1:9900/#local.net/w+1ce0wcur7d3ftM`
  - Android-style device metrics + touch + mobile UA
  - authenticated as local test user `issue810mobile@local.net`
  - existing blip edit flow kept the typing area visible
  - drawer state instrumentation stayed closed during the edit path (`mobile-panel-open=false`, `mobile-wave-open=true`)

## Review
- Direct in-lane review completed.
- External `claude-review` plan review hit Claude usage limits.
- External `claude-review` code review with Gemini fallback failed with `403 PERMISSION_DENIED` / `CONSUMER_INVALID` in this environment.

Closes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an implementation plan for Issue 810 detailing the rollout and validation steps.

* **Bug Fixes**
  * Preserve both vertical and horizontal ancestor scroll positions to prevent the mobile search panel from covering the active editor during mobile startup.

* **Tests**
  * Added a regression test validating restoration of horizontal and vertical scroll across ancestor chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->