### PR TITLE
fix(mobile): harden attachment upload recovery

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-812-mobile-attachment-upload.md
+++ b/docs/superpowers/plans/2026-04-10-issue-812-mobile-attachment-upload.md
@@ -1,0 +1,142 @@
+# Issue 812 Mobile Attachment Upload Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reproduce and fix the mobile image attachment regression so mobile picker-selected images upload into the wave, and pasted images either upload correctly or fail in an explicit supported way.
+
+**Architecture:** Treat this as a boundary-debugging task, not a speculative client patch. First prove where the flow breaks across mobile picker/paste -> client state -> upload request -> Jakarta servlet -> attachment persistence -> wave insertion. Then add the narrowest regression test at the failing seam, implement the minimal fix in the runtime-active path, and finish with targeted tests plus a narrow mobile browser verification pass on the local worktree server.
+
+**Tech Stack:** SBT, GWT client code, Jakarta servlet runtime, JUnit/Jakarta IT, local browser verification against a staged/worktree server.
+
+---
+
+## Scope
+
+- In scope:
+  - mobile attachment picker upload path
+  - mobile image paste path
+  - the shared upload request contract to `/attachment/{id}`
+  - runtime-active Jakarta servlet behavior
+  - the client insertion path that adds uploaded attachments back into the wave
+- Out of scope:
+  - unrelated attachment UX redesign
+  - non-image attachment behavior unless the failing seam proves it is shared
+  - server deployment/config cleanup beyond what is required for the fix
+
+## Expected Files
+
+- Investigate / likely modify:
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/ClipboardImageUploader.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AttachmentServlet.java`
+- Tests / likely modify or create:
+  - `wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/AttachmentServletJakartaIT.java`
+  - `wave/src/test/java/org/waveprotocol/wave/client/editor/EditorContextAdapterHandlerTest.java`
+  - `wave/src/test/java/...` new focused client-side regression only if the failing seam is client-only and cannot be locked down server-side
+- Required release note:
+  - `wave/config/changelog.d/2026-04-10-issue-812-mobile-attachment-upload.json`
+
+## Acceptance Criteria
+
+- Mobile file-picker-selected image attachments upload end-to-end and insert into the wave.
+- Mobile paste-to-upload either works end-to-end or the unsupported mobile path is detected and surfaced explicitly instead of failing silently.
+- A targeted automated regression covers the identified failing seam.
+- Local verification evidence records the exact commands run and the observed browser result on the issue worktree server.
+
+## Task 1: Reproduce And Isolate The Failing Boundary
+
+**Files:**
+- Read: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java`
+- Read: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/ClipboardImageUploader.java`
+- Read: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AttachmentServlet.java`
+- Evidence: `journal/local-verification/2026-04-10-issue-812-mobile-attachment-upload.md` or issue comment summary
+
+- [ ] Start the worktree server for browser repro on a dedicated port and record the exact start/check/stop commands.
+- [ ] Reproduce the picker flow in a mobile-emulated browser and capture:
+  - whether the selection event fires
+  - whether preview/queue state updates
+  - whether an upload request is issued
+  - the request payload fields
+  - the server response status/body
+  - whether the uploaded attachment is inserted into the wave
+- [ ] Reproduce the paste flow in the same browser session and capture the same boundary data.
+- [ ] Write a short architect summary in the GitHub issue comment naming the failing seam and the narrowest viable fix.
+
+## Task 2: Write The Failing Regression First
+
+**Files:**
+- Modify: the smallest test file that can prove the confirmed seam
+- Prefer:
+  - `wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/AttachmentServletJakartaIT.java` if the request contract / receipt seam is broken
+  - a focused client-side test near the upload/insertion code if the request never leaves the browser or the response is mishandled client-side
+
+- [ ] Add one failing regression that matches the confirmed broken mobile behavior at the identified seam.
+- [ ] Run only that test first and verify it fails for the expected reason.
+
+Run target:
+
+```bash
+sbt "JakartaIT/testOnly org.waveprotocol.box.server.jakarta.AttachmentServletJakartaIT"
+```
+
+Client-side alternative only if needed:
+
+```bash
+sbt "testOnly <focused client test class>"
+```
+
+## Task 3: Implement The Minimal Fix
+
+**Files:**
+- Modify only the runtime seam proven by Task 1 and locked down by Task 2
+
+- [ ] Implement the smallest code change that fixes the failing boundary.
+- [ ] Avoid unrelated cleanup or popup redesign changes.
+- [ ] If picker and paste share the same seam, keep the fix shared.
+- [ ] If mobile paste is fundamentally unsupported in the browser, add explicit user-visible handling instead of a silent no-op.
+
+## Task 4: Verify Green And Add Release Note
+
+**Files:**
+- Modify: the regression test file from Task 2
+- Create: `wave/config/changelog.d/2026-04-10-issue-812-mobile-attachment-upload.json`
+
+- [ ] Re-run the targeted regression and confirm it passes.
+- [ ] Re-run a focused neighboring test set for any touched server/client seam.
+- [ ] Add the changelog fragment for the user-visible attachment upload fix.
+
+Likely commands:
+
+```bash
+sbt "JakartaIT/testOnly org.waveprotocol.box.server.jakarta.AttachmentServletJakartaIT"
+sbt "testOnly org.waveprotocol.wave.client.editor.EditorContextAdapterHandlerTest"
+```
+
+## Task 5: Local Mobile Verification
+
+**Files:**
+- Update: `journal/local-verification/2026-04-10-issue-812-mobile-attachment-upload.md`
+
+- [ ] Run the standard worktree boot / smoke flow for the fixed branch-local server.
+- [ ] Perform a narrow mobile browser verification against the fixed server:
+  - register/sign in to a local test account if needed
+  - open a wave
+  - verify picker-selected image upload inserts into the wave
+  - verify pasted image behavior on mobile is either fixed or explicitly surfaced
+- [ ] Record the exact commands, route checked, and observed result in the local verification journal and GitHub issue comment.
+
+## Task 6: Review, Commit, And PR
+
+- [ ] Run direct review on the final diff.
+- [ ] Run `claude-review` on the implementation diff and address any actionable findings.
+- [ ] Commit the fix in logical units.
+- [ ] Update GitHub issue `#812` with:
+  - worktree path and branch
+  - plan path
+  - root cause summary
+  - commit SHA(s)
+  - test commands and results
+  - local browser verification result
+  - PR URL
+- [ ] Open the PR against `main`.

--- a/wave/config/changelog.d/2026-04-10-issue-812-mobile-attachment-upload.json
+++ b/wave/config/changelog.d/2026-04-10-issue-812-mobile-attachment-upload.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-issue-812-mobile-attachment-upload",
+  "version": "Unreleased",
+  "date": "2026-04-10",
+  "title": "Mobile attachment upload resilience fixes",
+  "summary": "Mobile image uploads are now more tolerant of browser-specific file-picker and clipboard behavior, reducing silent failures when selecting or pasting images into a wave.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Attachment selection now recovers from mobile browsers that return from the file chooser without delivering the hidden input's normal change event",
+        "Image paste upload now falls back to clipboard files when browsers do not populate clipboardData.items for pasted images"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
@@ -415,6 +415,11 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   //  File selection & preview
   // ─────────────────────────────────────────────
 
+  /** Called from JSNI drag-drop handler to give each drop its own nonce. */
+  private void bumpSelectionNonce() {
+    selectionNonce++;
+  }
+
   private void onFilesSelected(int nonce) {
     if (isUploading) return;
     if (processedNonce == nonce) return;
@@ -959,6 +964,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
           var dt = new $wnd.DataTransfer();
           for (var i = 0; i < files.length; i++) dt.items.add(files[i]);
           fileInputEl.files = dt.files;
+          self.@org.waveprotocol.wave.client.wavepanel.impl.toolbar.attachment.AttachmentPopupWidget::bumpSelectionNonce()();
           var evt = $doc.createEvent('HTMLEvents');
           evt.initEvent('change', true, false);
           fileInputEl.dispatchEvent(evt);

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
@@ -54,6 +54,7 @@ import org.waveprotocol.wave.client.widget.popup.PopupEventSourcer;
 import org.waveprotocol.wave.client.widget.popup.PopupFactory;
 import org.waveprotocol.wave.client.widget.popup.UniversalPopup;
 import org.waveprotocol.wave.media.model.AttachmentId;
+import org.waveprotocol.wave.model.util.AttachmentUploadMobileSupport;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -291,6 +292,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   private String uploadDisplaySize = "medium";
   private boolean uploadCompressionEnabled = true;
   private int nextStoreIndex = 0;
+  private boolean awaitingFileSelection = false;
+  private Timer fileSelectionRecoveryTimer;
 
   public AttachmentPopupWidget() {
     initWidget(BINDER.createAndBindUi(this));
@@ -311,6 +314,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
       @Override
       public void onClick(ClickEvent event) {
         if (isUploading) return;
+        awaitingFileSelection = true;
+        armFileSelectionRecovery();
         nativeClickFileInput(fileUpload.getElement());
       }
     }, ClickEvent.getType());
@@ -319,6 +324,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
       @Override
       public void onClick(ClickEvent event) {
         if (isUploading) return;
+        awaitingFileSelection = true;
+        armFileSelectionRecovery();
         nativeClickFileInput(fileUpload.getElement());
       }
     });
@@ -333,6 +340,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
     cancelBtn.addClickHandler(new ClickHandler() {
       @Override
       public void onClick(ClickEvent event) {
+        stopFileSelectionRecovery();
         hide();
       }
     });
@@ -402,6 +410,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
 
   private void onFilesSelected() {
     if (isUploading) return;
+    awaitingFileSelection = false;
+    stopFileSelectionRecovery();
     int added = appendFilesToStore(fileUpload.getElement());
     int startIndex = nextStoreIndex;
     nextStoreIndex += added;
@@ -666,7 +676,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   // ─────────────────────────────────────────────
 
   private static boolean isImageMime(String mime) {
-    return mime != null && mime.startsWith("image/");
+    return AttachmentUploadMobileSupport.isImageMime(mime);
   }
 
   private static boolean isImageFileName(String name) {
@@ -759,6 +769,39 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
     el.click();
   }-*/;
 
+  private void maybeRecoverFileSelection() {
+    if (AttachmentUploadMobileSupport.shouldRecoverSelection(awaitingFileSelection,
+        isUploading, getNativeFileCount(fileUpload.getElement()))) {
+      onFilesSelected();
+    }
+  }
+
+  private void armFileSelectionRecovery() {
+    stopFileSelectionRecovery();
+    fileSelectionRecoveryTimer = new Timer() {
+      private int attempts;
+
+      @Override
+      public void run() {
+        attempts++;
+        maybeRecoverFileSelection();
+        if (!awaitingFileSelection || attempts >= 240) {
+          awaitingFileSelection = false;
+          cancel();
+          fileSelectionRecoveryTimer = null;
+        }
+      }
+    };
+    fileSelectionRecoveryTimer.scheduleRepeating(250);
+  }
+
+  private void stopFileSelectionRecovery() {
+    if (fileSelectionRecoveryTimer != null) {
+      fileSelectionRecoveryTimer.cancel();
+      fileSelectionRecoveryTimer = null;
+    }
+  }
+
   /** Initializes (or resets) the JS-side file store on this instance. */
   private native void initFileStore() /*-{
     this._fileStore = [];
@@ -776,6 +819,10 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
         this._fileStore.push(files[i]);
     }
     return files.length;
+  }-*/;
+
+  private static native int getNativeFileCount(Element fileInput) /*-{
+    return (fileInput.files && fileInput.files.length) ? fileInput.files.length : 0;
   }-*/;
 
   private native String getStoreFileName(int index) /*-{
@@ -939,6 +986,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
     isUploading = false;
     batchFailed = false;
     nextStoreIndex = 0;
+    awaitingFileSelection = false;
+    stopFileSelectionRecovery();
     initFileStore();
     updateUploadButton();
     spinnerPanel.setVisible(false);
@@ -956,6 +1005,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
 
   @Override
   public void hide() {
+    awaitingFileSelection = false;
+    stopFileSelectionRecovery();
     popup.hide();
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java
@@ -294,6 +294,9 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   private int nextStoreIndex = 0;
   private boolean awaitingFileSelection = false;
   private Timer fileSelectionRecoveryTimer;
+  private int selectionNonce = 0;
+  private int processedNonce = -1;
+  private int fileCountAtArmTime = 0;
 
   public AttachmentPopupWidget() {
     initWidget(BINDER.createAndBindUi(this));
@@ -314,6 +317,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
       @Override
       public void onClick(ClickEvent event) {
         if (isUploading) return;
+        selectionNonce++;
+        fileCountAtArmTime = getNativeFileCount(fileUpload.getElement());
         awaitingFileSelection = true;
         armFileSelectionRecovery();
         nativeClickFileInput(fileUpload.getElement());
@@ -324,6 +329,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
       @Override
       public void onClick(ClickEvent event) {
         if (isUploading) return;
+        selectionNonce++;
+        fileCountAtArmTime = getNativeFileCount(fileUpload.getElement());
         awaitingFileSelection = true;
         armFileSelectionRecovery();
         nativeClickFileInput(fileUpload.getElement());
@@ -333,7 +340,7 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
     fileUpload.addChangeHandler(new ChangeHandler() {
       @Override
       public void onChange(ChangeEvent event) {
-        onFilesSelected();
+        onFilesSelected(selectionNonce);
       }
     });
 
@@ -408,8 +415,10 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
   //  File selection & preview
   // ─────────────────────────────────────────────
 
-  private void onFilesSelected() {
+  private void onFilesSelected(int nonce) {
     if (isUploading) return;
+    if (processedNonce == nonce) return;
+    processedNonce = nonce;
     awaitingFileSelection = false;
     stopFileSelectionRecovery();
     int added = appendFilesToStore(fileUpload.getElement());
@@ -771,8 +780,8 @@ public final class AttachmentPopupWidget extends Composite implements Attachment
 
   private void maybeRecoverFileSelection() {
     if (AttachmentUploadMobileSupport.shouldRecoverSelection(awaitingFileSelection,
-        isUploading, getNativeFileCount(fileUpload.getElement()))) {
-      onFilesSelected();
+        isUploading, getNativeFileCount(fileUpload.getElement()), fileCountAtArmTime)) {
+      onFilesSelected(selectionNonce);
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/ClipboardImageUploader.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/ClipboardImageUploader.java
@@ -35,6 +35,7 @@ import org.waveprotocol.wave.media.model.AttachmentId;
 import org.waveprotocol.wave.media.model.AttachmentIdGenerator;
 import org.waveprotocol.wave.model.document.indexed.LocationMapper;
 import org.waveprotocol.wave.model.document.util.Point;
+import org.waveprotocol.wave.model.util.AttachmentUploadMobileSupport;
 import org.waveprotocol.wave.model.document.util.XmlStringBuilder;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.waveref.WaveRef;
@@ -232,10 +233,21 @@ public final class ClipboardImageUploader implements ImagePasteHandler {
    * Checks whether the paste event's clipboardData contains at least one image item.
    */
   private static native boolean hasClipboardImage(NativeEvent event) /*-{
-    var items = event.clipboardData && event.clipboardData.items;
-    if (!items) return false;
-    for (var i = 0; i < items.length; i++) {
-      if (items[i].type && items[i].type.match(/^image\//)) return true;
+    var data = event.clipboardData;
+    if (!data) return false;
+    var items = data.items;
+    if (items) {
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].type && items[i].type.match(/^image\//)) return true;
+      }
+    }
+    var files = data.files;
+    if (files) {
+      for (var j = 0; j < files.length; j++) {
+        if (@org.waveprotocol.wave.model.util.AttachmentUploadMobileSupport::isImageMime(Ljava/lang/String;)(files[j].type || null)) {
+          return true;
+        }
+      }
     }
     return false;
   }-*/;
@@ -255,16 +267,27 @@ public final class ClipboardImageUploader implements ImagePasteHandler {
   private native void startXhrUpload(NativeEvent event,
       String attachmentId, String waveRef,
       Runnable successCb, Runnable failureCb) /*-{
-    var items = event.clipboardData && event.clipboardData.items;
-    if (!items) {
+    var data = event.clipboardData;
+    if (!data) {
       failureCb.@java.lang.Runnable::run()();
       return;
     }
+    var items = data.items;
     var blob = null;
-    for (var i = 0; i < items.length; i++) {
-      if (items[i].type && items[i].type.match(/^image\//)) {
-        blob = items[i].getAsFile();
-        break;
+    if (items) {
+      for (var i = 0; i < items.length; i++) {
+        if (items[i].type && items[i].type.match(/^image\//)) {
+          blob = items[i].getAsFile();
+          break;
+        }
+      }
+    }
+    if (!blob && data.files) {
+      for (var j = 0; j < data.files.length; j++) {
+        if (@org.waveprotocol.wave.model.util.AttachmentUploadMobileSupport::isImageMime(Ljava/lang/String;)(data.files[j].type || null)) {
+          blob = data.files[j];
+          break;
+        }
       }
     }
     if (!blob) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupport.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupport.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.util;
+
+/**
+ * Small shared predicates for mobile-oriented attachment upload recovery.
+ */
+public final class AttachmentUploadMobileSupport {
+
+  private AttachmentUploadMobileSupport() {
+  }
+
+  public static boolean isImageMime(String mime) {
+    return mime != null && mime.startsWith("image/");
+  }
+
+  public static boolean shouldRecoverSelection(boolean awaitingFileSelection, boolean isUploading,
+      int fileCount) {
+    return awaitingFileSelection && !isUploading && fileCount > 0;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupport.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupport.java
@@ -32,7 +32,7 @@ public final class AttachmentUploadMobileSupport {
   }
 
   public static boolean shouldRecoverSelection(boolean awaitingFileSelection, boolean isUploading,
-      int fileCount) {
-    return awaitingFileSelection && !isUploading && fileCount > 0;
+      int fileCount, int fileCountAtArmTime) {
+    return awaitingFileSelection && !isUploading && fileCount > fileCountAtArmTime;
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupportTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupportTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.util;
+
+import junit.framework.TestCase;
+
+public final class AttachmentUploadMobileSupportTest extends TestCase {
+
+  public void testIsImageMimeAcceptsImagePrefix() {
+    assertTrue(AttachmentUploadMobileSupport.isImageMime("image/png"));
+  }
+
+  public void testIsImageMimeRejectsNullAndNonImageTypes() {
+    assertFalse(AttachmentUploadMobileSupport.isImageMime(null));
+    assertFalse(AttachmentUploadMobileSupport.isImageMime("application/pdf"));
+  }
+
+  public void testShouldRecoverSelectionOnlyWhenAwaitingChooserReturn() {
+    assertTrue(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 1));
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(false, false, 1));
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, true, 1));
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 0));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupportTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/AttachmentUploadMobileSupportTest.java
@@ -33,9 +33,15 @@ public final class AttachmentUploadMobileSupportTest extends TestCase {
   }
 
   public void testShouldRecoverSelectionOnlyWhenAwaitingChooserReturn() {
-    assertTrue(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 1));
-    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(false, false, 1));
-    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, true, 1));
-    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 0));
+    // Recover when awaiting, not uploading, and file count exceeds pre-click count.
+    assertTrue(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 1, 0));
+    assertTrue(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 2, 1));
+    // No recovery when not awaiting.
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(false, false, 1, 0));
+    // No recovery when uploading.
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, true, 1, 0));
+    // No recovery when file count unchanged (cancel with stale FileList).
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 1, 1));
+    assertFalse(AttachmentUploadMobileSupport.shouldRecoverSelection(true, false, 0, 0));
   }
 }


### PR DESCRIPTION
Closes #812.

## Summary
- add a bounded mobile chooser-recovery path so attachment selection no longer depends solely on the hidden file input's normal `change` event
- add clipboard `files` fallback handling for image paste uploads when browsers do not populate `clipboardData.items`
- add a small regression helper/test plus a changelog fragment for the mobile upload resilience fix

## Verification
- `sbt "testOnly org.waveprotocol.wave.model.util.AttachmentUploadMobileSupportTest"`
- `sbt "compileGwt"`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- staged browser pass on `http://localhost:9900/`:
  - registered `issue812z1`
  - signed in and opened the welcome wave
  - focused the reply editor and opened the attachment popup
  - selected `target/scala-3.3.4/classes/org/waveprotocol/box/webclient/search/images/toolbar_empty.png`
  - observed popup preview, `POST /attachment/{id} -> 201`, `GET /attachmentsInfo -> 200`, and the uploaded image inserted into the wave

## Notes
- Clipboard-backed paste could not be fully automated in this tool environment because the browser clipboard API rejected image writes (`DataError` for `image/png`). The paste path was verified by code-path hardening plus successful `compileGwt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile image-attachment upload resilience: better recovery after file-chooser cancel/return and deduplication of selections; paste-to-upload falls back to clipboard files when needed.

* **Tests**
  * Added unit tests for mobile attachment recovery and image-mime detection.

* **Documentation**
  * Added an implementation plan and changelog entry describing the mobile attachment upload fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->