### PR TITLE
fix(reactions): polish chip alignment and add-button anchor

### DIFF
--- a/docs/superpowers/plans/2026-04-10-issue-822-reaction-chip-anchor.md
+++ b/docs/superpowers/plans/2026-04-10-issue-822-reaction-chip-anchor.md
@@ -1,0 +1,148 @@
+# Issue 822 Reaction Chip Anchor Polish Plan
+
+> **For agentic workers:** Keep this fix narrow. Use checkbox (`- [ ]`) steps for tracking and preserve the existing Wave reactions interaction model.
+
+**Goal:** Polish the reactions row so each chip reads as a compact, deliberate pill, with the emoji and count aligned on the same visual baseline and the add-reaction affordance staying anchored instead of jumping when reactions are added or removed.
+
+**Architecture:** Keep the fix inside the existing renderer/CSS seam. `ReactionRowRenderer` will emit explicit emoji/count spans and render the add button in a stable leading slot. `Blip.css` will convert the row to a compact flex layout and align chip internals intentionally, without changing reaction data semantics, picker behavior, or controller event handling.
+
+**Tech Stack:** Java/GWT renderer code, CSS resource in `Blip.css`, focused JUnit renderer tests via the local `javac` + `JUnitCore` harness, local Wave browser verification.
+
+---
+
+## Context Snapshot
+
+- Issue: `#822`
+- Existing reactions plans:
+  - `docs/superpowers/plans/2026-04-10-issue-798-reactions.md`
+  - `docs/superpowers/plans/2026-04-10-issue-806-reaction-add-icon.md`
+- Narrow seam:
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java`
+  - `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+  - `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java`
+- Root cause:
+  - the chip currently renders the emoji as a raw text node plus a count span, while CSS centers the whole button, so the emoji/counter pair lacks a reliable baseline contract
+  - the add button is rendered after the dynamic reaction chips, so its visual position changes whenever a chip appears or disappears
+- Constraints:
+  - preserve the current compact Wave pill styling
+  - keep reaction controller logic and picker behavior unchanged
+  - avoid widening the row into a toolbar-like full-width layout
+- Test harness note:
+  - `ReactionRowRendererTest` runs through the same focused `javac` + `JUnitCore` harness used for issue `#806`
+
+## Acceptance Criteria
+
+- [ ] Reaction chips render emoji and count in separate elements that CSS can baseline-align deliberately.
+- [ ] The add-reaction control stays visually anchored at the leading edge of the row instead of moving when a user toggles a unique reaction on/off.
+- [ ] The row remains compact and aligned with the existing Wave visual language.
+- [ ] The live UI is verified in a browser with real reactions on a local server.
+- [ ] App-affecting changes include a changelog fragment and regenerated `wave/config/changelog.json`.
+
+## Task 1: Lock The Renderer Contract First
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java`
+
+- [ ] Add a failing test that asserts editable rows render the add button before the first chip.
+- [ ] Add a failing test that asserts each reaction chip wraps the emoji in `waveReactionEmoji` and the count in `waveReactionCount`.
+- [ ] Verify the tests fail for the expected reason against the current renderer markup.
+
+Run:
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | \
+  perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Expected before implementation:
+- FAIL because the renderer still emits the add button after chips and does not emit a dedicated emoji span
+
+## Task 2: Implement The Narrow Layout Fix
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java`
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+- Modify only if CSS contract coverage needs it: `wave/src/test/java/org/waveprotocol/box/server/rpc/BlipCssLinkStyleTest.java`
+
+- [ ] Render the add button before the reaction chips so the control is anchored in a stable leading slot.
+- [ ] Wrap the emoji glyph in a dedicated `waveReactionEmoji` span.
+- [ ] Convert the row to a small flex layout with gap spacing instead of relying on trailing margins.
+- [ ] Align chip contents with explicit line-height/baseline rules so emoji and count sit cleanly together.
+- [ ] Keep the add button styling compact and visually consistent with the existing reaction chips.
+
+Expected implementation shape:
+```java
+appendAddButton(html, blipId);
+appendReactionChip(...);
+```
+
+```java
+html.appendHtmlConstant("<span class=\"waveReactionEmoji\">");
+html.appendEscaped(emoji);
+html.appendHtmlConstant("</span><span class=\"waveReactionCount\">");
+```
+
+```css
+.reactions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35em;
+}
+
+.reactions .waveReactionChip {
+  align-items: baseline;
+  line-height: 1;
+}
+```
+
+## Task 3: Verify, Changelog, And Issue Evidence
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-10-issue-822-reaction-chip-anchor.json`
+- Regenerate: `wave/config/changelog.json`
+- Add: `journal/local-verification/2026-04-10-issue-822-reaction-chip-anchor.md`
+
+- [ ] Re-run the focused renderer test harness and record the green result.
+- [ ] Run the CSS regression test if the CSS contract test needs updating.
+- [ ] Regenerate and validate changelog output.
+- [ ] Run the local server sanity path and verify the reactions row in a browser with real reactions.
+- [ ] Record commands, results, and browser observations in the journal file and issue `#822`.
+
+Verification commands:
+```bash
+FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | \
+  perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }')
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT" && mkdir -p "$OUT"
+javac --release 17 -cp "$FULL_CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+bash scripts/worktree-boot.sh --port 9902
+PORT=9902 bash scripts/wave-smoke.sh check
+```
+
+Browser flow:
+- open `http://127.0.0.1:9902/`
+- sign in with the shared local account if needed
+- open a wave with existing reactions or add reactions to a test blip
+- verify the add button stays visually fixed while toggling a unique user reaction on and off
+- verify emoji/count alignment reads as a single compact pill instead of a vertically misaligned pair

--- a/journal/local-verification/2026-04-10-issue-822-reaction-chip-anchor.md
+++ b/journal/local-verification/2026-04-10-issue-822-reaction-chip-anchor.md
@@ -1,0 +1,141 @@
+# Issue 822 Local Verification
+
+Date: 2026-04-10
+Issue: #822
+Branch: `reaction-chip-anchor-20260410`
+Worktree: `/Users/vega/devroot/worktrees/reaction-chip-anchor-20260410`
+
+## Setup Notes
+
+- Freshly rebased worktree did not yet have generated `wave/config/changelog.json`, so `python3 scripts/assemble-changelog.py` was run once before SBT tasks that require the generated resource.
+- The repo SBT test compile still excludes `wave/client` tests from normal `testOnly` discovery, so the executable red/green seam for `ReactionRowRendererTest` used a manual `javac` + `org.junit.runner.JUnitCore` harness against the already-compiled target classes and cached JUnit jars.
+
+## Discovery Check
+
+Command:
+
+```bash
+sbt -Dsbt.supershell=false 'testOnly org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest'
+```
+
+Result:
+
+- `No tests to run for Test / testOnly`
+
+## Red Phase
+
+Command:
+
+```bash
+CP=target/scala-3.3.4/classes:.coursier-cache/https/repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar:.coursier-cache/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT"
+mkdir -p "$OUT"
+javac --release 17 -cp "$CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Result:
+
+- `FAILURES!!!`
+- `testRenderWrapsEmojiAndCountForBaselineStyling` failed because the renderer still emitted a raw emoji text node instead of a dedicated emoji span
+- `testRenderPlacesAddButtonBeforeReactionChipsWhenEditable` failed because the add button still rendered after the dynamic chips
+
+## Green Phase
+
+Command:
+
+```bash
+CP=target/scala-3.3.4/classes:.coursier-cache/https/repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar:.coursier-cache/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+OUT=/tmp/reaction-row-renderer-test
+rm -rf "$OUT"
+mkdir -p "$OUT"
+javac --release 17 -cp "$CP" -d "$OUT" \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java \
+  wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+java -cp "$OUT:$CP" org.junit.runner.JUnitCore \
+  org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest
+```
+
+Result:
+
+- `OK (6 tests)`
+
+## CSS Regression
+
+Command:
+
+```bash
+sbt -Dsbt.supershell=false 'testOnly org.waveprotocol.box.server.rpc.BlipCssLinkStyleTest'
+```
+
+Result:
+
+- `Passed: Total 2, Failed 0, Errors 0, Passed 2`
+
+## Changelog
+
+Commands:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Result:
+
+- `assembled 138 entries -> wave/config/changelog.json`
+- `changelog validation passed`
+
+## Local Server And Browser Verification
+
+Commands:
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+bash scripts/worktree-boot.sh --port 9902
+PORT=9902 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/reaction-chip-anchor-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/reaction-chip-anchor-20260410/wave/config/jaas.config' bash scripts/wave-smoke.sh start
+PORT=9902 bash scripts/wave-smoke.sh check
+PORT=9902 bash scripts/wave-smoke.sh stop
+```
+
+Results:
+
+- file-store links created for `_accounts`, `_attachments`, and `_deltas`
+- `worktree-boot.sh` completed successfully, including GWT compile and staged assets
+- smoke check passed:
+  - `ROOT_STATUS=200`
+  - `HEALTH_STATUS=200`
+  - `WEBCLIENT_STATUS=200`
+- shutdown completed cleanly:
+  - `Stopped server on port 9902`
+
+Browser flow:
+
+1. Opened `http://127.0.0.1:9902/auth/register`
+2. Registered throwaway local account `rx822lane@local.net`
+3. Signed in at `http://127.0.0.1:9902/auth/signin`
+4. Opened the welcome wave at `#local.net/w+1i46c7czxlxuzA`
+5. Clicked the root-blip `Add reaction` control and selected `👍`
+6. Confirmed the row HTML rendered the add button first and the chip as `<span class="waveReactionEmoji">👍</span><span class="waveReactionCount">1</span>`
+7. Captured the add-button box before and after toggling the unique reaction off:
+   - before removal: `x=413`, `y=1357.484375`, `width=32`, `height=20`
+   - after removal: `x=413`, `y=1357.484375`, `width=32`, `height=20`
+8. Added `😂` again and captured the final row screenshot
+
+Observed UI result:
+
+- the add-reaction control remained visually anchored at the leading edge while a unique reaction was added and removed
+- the compact row rendered as a stable `32x20` add pill followed by a `44x19` reaction chip
+- the emoji/count pair in the chip read as a single aligned pill in the live UI screenshot (`reaction-row-after-laugh.png`)

--- a/wave/config/changelog.d/2026-04-10-issue-822-reaction-chip-anchor.json
+++ b/wave/config/changelog.d/2026-04-10-issue-822-reaction-chip-anchor.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-10-issue-822-reaction-chip-anchor",
+  "version": "PR #822",
+  "date": "2026-04-10",
+  "title": "Polish reaction chip alignment",
+  "summary": "Keeps the add-reaction affordance anchored and aligns reaction emoji/counts more cleanly within the existing Wave pill styling.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Reaction rows now keep the add-reaction control anchored at the leading edge instead of shifting when reactions are toggled",
+        "Reaction chips now render explicit emoji and count spans so the pill content aligns more cleanly on a shared visual baseline"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -98,7 +98,7 @@ public final class ReactionRowRenderer {
         + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\">");
     html.appendHtmlConstant("<span class=\"" + EMOJI_CLASS + "\">");
     html.appendEscaped(emoji);
-    html.appendHtmlConstant("</span><span class=\"" + COUNT_CLASS + "\">");
+    html.appendHtmlConstant("</span> <span class=\"" + COUNT_CLASS + "\">");
     html.append(count);
     html.appendHtmlConstant("</span></button>");
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -34,6 +34,8 @@ public final class ReactionRowRenderer {
   public static final String CHIP_CLASS = "waveReactionChip";
   public static final String CHIP_ACTIVE_CLASS = "waveReactionChipActive";
   public static final String ADD_CLASS = "waveReactionAdd";
+  private static final String EMOJI_CLASS = "waveReactionEmoji";
+  private static final String COUNT_CLASS = "waveReactionCount";
   private static final String ADD_ICON_CLASS = "waveReactionAddIcon";
   private static final String ADD_BUTTON_LABEL = "Add reaction";
   private static final String ADD_ICON_HTML =
@@ -57,6 +59,9 @@ public final class ReactionRowRenderer {
   public static SafeHtml render(String blipId, List<ReactionDocument.Reaction> reactions,
       String currentUserAddress, boolean editable) {
     SafeHtmlBuilder html = new SafeHtmlBuilder();
+    if (editable) {
+      appendAddButton(html, blipId);
+    }
     if (reactions != null) {
       for (ReactionDocument.Reaction reaction : reactions) {
         if (reaction == null) {
@@ -69,15 +74,16 @@ public final class ReactionRowRenderer {
         appendReactionChip(html, blipId, reaction, active);
       }
     }
-    if (editable) {
-      html.appendHtmlConstant(
-          "<button type=\"button\" class=\"" + ADD_CLASS + "\" data-reaction-add=\"true\" "
-              + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
-              + "aria-label=\"" + ADD_BUTTON_LABEL + "\" title=\"" + ADD_BUTTON_LABEL + "\">");
-      html.appendHtmlConstant(ADD_ICON_HTML);
-      html.appendHtmlConstant("</button>");
-    }
     return html.toSafeHtml();
+  }
+
+  private static void appendAddButton(SafeHtmlBuilder html, String blipId) {
+    html.appendHtmlConstant(
+        "<button type=\"button\" class=\"" + ADD_CLASS + "\" data-reaction-add=\"true\" "
+            + "data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
+            + "aria-label=\"" + ADD_BUTTON_LABEL + "\" title=\"" + ADD_BUTTON_LABEL + "\">");
+    html.appendHtmlConstant(ADD_ICON_HTML);
+    html.appendHtmlConstant("</button>");
   }
 
   private static void appendReactionChip(SafeHtmlBuilder html, String blipId,
@@ -90,8 +96,9 @@ public final class ReactionRowRenderer {
     html.appendHtmlConstant("<button type=\"button\" class=\"" + classes
         + "\" data-reaction-emoji=\"" + safeEmoji + "\" data-reaction-active=\""
         + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\">");
+    html.appendHtmlConstant("<span class=\"" + EMOJI_CLASS + "\">");
     html.appendEscaped(emoji);
-    html.appendHtmlConstant(" <span class=\"waveReactionCount\">");
+    html.appendHtmlConstant("</span><span class=\"" + COUNT_CLASS + "\">");
     html.append(count);
     html.appendHtmlConstant("</span></button>");
   }

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -239,28 +239,37 @@
 .reactions {
   margin: 0.35em 0 0.15em 0;
   min-height: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35em;
 }
 
 @external .waveReactionChip;
 @external .waveReactionChipActive;
+@external .waveReactionEmoji;
 @external .waveReactionCount;
 @external .waveReactionAdd;
+@external .waveReactionAddIcon;
 
 .reactions .waveReactionChip,
 .reactions .waveReactionAdd {
   display: inline-flex;
-  align-items: center;
   justify-content: center;
-  gap: 0.25em;
-  margin-right: 0.35em;
   padding: 2px 8px;
   border: 1px solid #d6dee8;
   border-radius: 999px;
   background: #ffffff;
   color: #4a5568;
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1;
+  white-space: nowrap;
   cursor: pointer;
+}
+
+.reactions .waveReactionChip {
+  align-items: baseline;
+  gap: 0.28em;
 }
 
 .reactions .waveReactionChipActive {
@@ -269,12 +278,29 @@
   color: #1a365d;
 }
 
+.reactions .waveReactionEmoji {
+  display: block;
+  font-size: 13px;
+  line-height: 1;
+}
+
 .reactions .waveReactionCount {
+  display: block;
   font-weight: 600;
+  line-height: 1;
 }
 
 .reactions .waveReactionAdd {
+  align-items: center;
+  flex: 0 0 auto;
   color: #2b6cb0;
+}
+
+.reactions .waveReactionAddIcon,
+.reactions .waveReactionAddIcon svg {
+  display: block;
+  width: 14px;
+  height: 14px;
 }
 
 .replies {

--- a/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
@@ -90,7 +90,7 @@ public final class ReactionRowRendererTest extends TestCase {
 
     String output = html.asString();
     assertTrue(output.contains("<span class=\"waveReactionEmoji\">thumbs_up</span>"));
-    assertTrue(output.contains("<span class=\"waveReactionCount\">2</span>"));
+    assertTrue(output.contains("</span> <span class=\"waveReactionCount\">2</span>"));
   }
 
   public void testRenderOmitsAddButtonWhenReadOnly() {

--- a/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
@@ -63,6 +63,36 @@ public final class ReactionRowRendererTest extends TestCase {
     assertFalse(output.contains(">+</button>"));
   }
 
+  public void testRenderPlacesAddButtonBeforeReactionChipsWhenEditable() {
+    SafeHtml html = ReactionRowRenderer.render(
+        "b+blip5",
+        Collections.singletonList(
+            new ReactionDocument.Reaction("thumbs_up", Collections.singletonList("alice@example.com"))),
+        "alice@example.com",
+        true);
+
+    String output = html.asString();
+    int addIndex = output.indexOf("data-reaction-add=\"true\"");
+    int chipIndex = output.indexOf("data-reaction-emoji=\"thumbs_up\"");
+    assertTrue(addIndex >= 0);
+    assertTrue(chipIndex >= 0);
+    assertTrue(addIndex < chipIndex);
+  }
+
+  public void testRenderWrapsEmojiAndCountForBaselineStyling() {
+    SafeHtml html = ReactionRowRenderer.render(
+        "b+blip6",
+        Collections.singletonList(
+            new ReactionDocument.Reaction("thumbs_up",
+                Arrays.asList("alice@example.com", "bob@example.com"))),
+        "alice@example.com",
+        true);
+
+    String output = html.asString();
+    assertTrue(output.contains("<span class=\"waveReactionEmoji\">thumbs_up</span>"));
+    assertTrue(output.contains("<span class=\"waveReactionCount\">2</span>"));
+  }
+
   public void testRenderOmitsAddButtonWhenReadOnly() {
     SafeHtml html = ReactionRowRenderer.render(
         "b+blip2",


### PR DESCRIPTION
## Summary
- move the add-reaction control into a stable leading slot so it no longer shifts when a unique reaction is toggled on or off
- render reaction chips with explicit emoji/count spans and tighten the reactions-row flex styling for a more deliberate baseline-aligned pill layout
- add an issue-specific plan, changelog fragment, and local verification record for issue `#822`

## Verification
- `sbt -Dsbt.supershell=false 'testOnly org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest'` (`No tests to run for Test / testOnly`; expected discovery gap for `wave/client` tests)
- Manual red harness using `javac` + `org.junit.runner.JUnitCore` against `ReactionRowRendererTest` (`FAILURES!!!` before the fix on add-button order + emoji wrapper contract)
- Manual green harness using the same `javac` + `org.junit.runner.JUnitCore` flow (`OK (6 tests)`)
- `sbt -Dsbt.supershell=false 'testOnly org.waveprotocol.box.server.rpc.BlipCssLinkStyleTest'`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `bash scripts/worktree-boot.sh --port 9902`
- `PORT=9902 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/reaction-chip-anchor-20260410/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/reaction-chip-anchor-20260410/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9902 bash scripts/wave-smoke.sh check`
- Browser verification on `http://127.0.0.1:9902/`: registered `rx822lane@local.net`, signed in, opened the welcome wave, verified the add button stayed at `x=413` before/after a unique reaction toggle, and confirmed the updated reaction chip rendered as a compact aligned pill in the live UI
- `PORT=9902 bash scripts/wave-smoke.sh stop`

Closes #822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Add-reaction control now remains anchored at the leading edge when toggling reactions
  * Reaction chips display more consistent alignment and spacing for stable layout

* **Tests**
  * New tests covering add-reaction positioning and reaction chip emoji/count structure

* **Documentation**
  * Added polish plan, local verification notes, and a changelog entry describing the UI alignment improvements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->