### PR TITLE
Remove redundant logging in RemoteWaveletContainerImpl

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/RemoteWaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/RemoteWaveletContainerImpl.java
@@ -259,15 +259,6 @@ class RemoteWaveletContainerImpl extends WaveletContainerImpl implements RemoteW
       for (ByteStringMessage<ProtocolAppliedWaveletDelta> appliedDelta : appliedDeltas) {
         LOG.info("Delta incoming: " + appliedDelta);
 
-        // Log any illformed signed original deltas. TODO: Check if this can be removed.
-        try {
-          ProtocolWaveletDelta actualDelta = ProtocolWaveletDelta.parseFrom(
-              appliedDelta.getMessage().getSignedOriginalDelta().getDelta());
-          LOG.info("actual delta: " + actualDelta);
-        } catch (InvalidProtocolBufferException e) {
-          e.printStackTrace();
-        }
-
         HashedVersion appliedAt;
         try {
           appliedAt = AppliedDeltaUtil.getHashedVersionAppliedAt(appliedDelta);


### PR DESCRIPTION
Removed redundant logging and parsing of ProtocolWaveletDelta in RemoteWaveletContainerImpl.java as suggested by the existing TODO. This simplifies the code and removes discouraged use of e.printStackTrace().

---
*PR created automatically by Jules for task [12154038753879282419](https://jules.google.com/task/12154038753879282419) started by @vega113*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed redundant internal code to improve maintainability; no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->