### PR TITLE
🔒 Fix insecure random number generation in OperationQueue

### DIFF
--- a/wave/config/changelog.d/2026-04-11-fix-operationqueue-random.json
+++ b/wave/config/changelog.d/2026-04-11-fix-operationqueue-random.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-11-fix-operationqueue-random",
+  "version": "PR #842",
+  "date": "2026-04-11",
+  "title": "Fix insecure random number generation in OperationQueue",
+  "summary": "Replaced java.util.Random with java.security.SecureRandom for the ID_GENERATOR field in OperationQueue.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Replaced java.util.Random with java.security.SecureRandom for generating temporary IDs in OperationQueue to fix a security vulnerability."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/com/google/wave/api/OperationQueue.java
+++ b/wave/src/main/java/com/google/wave/api/OperationQueue.java
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class OperationQueue implements Serializable {
 
   /** A random number generator for the temporary ids. */
-  private static final Random ID_GENERATOR = new Random();
+  private static final SecureRandom ID_GENERATOR = new SecureRandom();
 
   /** The format of temporary blip ids. */
   private static final String TEMP_BLIP_ID_FORMAT = "TBD_%s_%s";


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of an insecure, predictable pseudorandom number generator (`java.util.Random`) for generating temporary blip IDs and wave IDs in `OperationQueue`.
⚠️ **Risk:** Predictable temporary IDs can make those IDs easier to guess before they are persisted.
🛡️ **Solution:** The fix replaces `java.util.Random` with `java.security.SecureRandom` for temporary ID generation. The `OperationQueue` operation-id counter remains unchanged.

---
*PR created automatically by Jules for task [12884189841912420055](https://jules.google.com/task/12884189841912420055) started by @vega113*
