### PR TITLE
build: add dev GWT compile tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /_indexes/
 /gwt-unitCache/
 war/WEB-INF
+war-dev/
 *.old
 .DS_Store
 .helper

--- a/build.sbt
+++ b/build.sbt
@@ -1158,7 +1158,7 @@ ThisBuild / skipGwt := sys.props.get("skipGwt").exists(_.trim.toLowerCase == "tr
 
 lazy val devCompile = taskKey[Unit]("Run the lighter dev compile path: codegen plus Compile / compile, without GWT packaging tasks")
 lazy val compileGwt = taskKey[Unit]("Compile GWT client (delegates to Gradle when available, otherwise uses native Fork.java)")
-lazy val compileGwtDev = taskKey[Unit]("Compile a single GWT permutation in draft mode for faster local UI verification")
+lazy val compileGwtDev = taskKey[Unit]("Compile a single GWT permutation in draft mode into war-dev for faster compile feedback without touching production war assets")
 
 ThisBuild / compileGwt := {
   val log      = streams.value.log
@@ -1269,6 +1269,8 @@ ThisBuild / compileGwt := {
   }
 }
 
+// Keep the dev draft compile isolated from the runtime war/ tree.
+// `sbt run`, `stage`, and `packageBin` stay on the production compile path.
 ThisBuild / compileGwtDev := {
   val log       = streams.value.log
   val base      = baseDirectory.value
@@ -1300,7 +1302,7 @@ ThisBuild / compileGwtDev := {
     "org.waveprotocol.box.webclient.WebClientProd"
   )
 
-  log.info("[compileGwtDev] Native mode — one-permutation draft compile")
+  log.info("[compileGwtDev] Native mode — one-permutation draft compile (compile-only)")
   log.info("[compileGwtDev] Writing dev artifacts to " + devWarDir)
   log.info("[compileGwtDev] Classpath has " + fullCp.size + " entries")
   val cpStr = fullCp.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)

--- a/build.sbt
+++ b/build.sbt
@@ -1156,7 +1156,9 @@ libraryDependencies ++= Seq(
 lazy val skipGwt = settingKey[Boolean]("Skip GWT compilation (default: false, set -DskipGwt=true to skip)")
 ThisBuild / skipGwt := sys.props.get("skipGwt").exists(_.trim.toLowerCase == "true")
 
+lazy val devCompile = taskKey[Unit]("Run the lighter dev compile path: codegen plus Compile / compile, without GWT packaging tasks")
 lazy val compileGwt = taskKey[Unit]("Compile GWT client (delegates to Gradle when available, otherwise uses native Fork.java)")
+lazy val compileGwtDev = taskKey[Unit]("Compile a single GWT permutation in draft mode for faster local UI verification")
 
 ThisBuild / compileGwt := {
   val log      = streams.value.log
@@ -1267,6 +1269,48 @@ ThisBuild / compileGwt := {
   }
 }
 
+ThisBuild / compileGwtDev := {
+  val log       = streams.value.log
+  val base      = baseDirectory.value
+  val resolved  = update.value
+  val compileCp = (Compile / dependencyClasspath).value.map(_.data)
+
+  val javaSrcDirs = Seq(
+    base / "wave" / "src" / "main" / "java",
+    base / "wave" / "src" / "main" / "resources",
+    base / "wave" / "generated" / "src" / "main" / "java",
+    base / "proto_src",
+    base / "gen" / "messages",
+    base / "gen" / "flags"
+  ).filter(_.exists)
+
+  val gwtJars = resolved.select(configurationFilter(Gwt.name))
+  val fullCp = javaSrcDirs ++ gwtJars ++ compileCp
+
+  val forkOpts = ForkOptions()
+    .withRunJVMOptions(Vector("-Xmx1024M"))
+
+  val warDir = (base / "war").getAbsolutePath
+  val gwtArgs = Seq(
+    "-war", warDir,
+    "-draftCompile",
+    "-style", "PRETTY",
+    "-localWorkers", "2",
+    "-setProperty", "user.agent=safari",
+    "org.waveprotocol.box.webclient.WebClientProd"
+  )
+
+  log.info("[compileGwtDev] Native mode — one-permutation draft compile")
+  log.info("[compileGwtDev] Classpath has " + fullCp.size + " entries")
+  val cpStr = fullCp.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)
+
+  val exitCode = Fork.java(
+    forkOpts,
+    Seq("-cp", cpStr, "com.google.gwt.dev.Compiler") ++ gwtArgs
+  )
+  if (exitCode != 0) sys.error("[compileGwtDev] GWT Compiler failed (exit " + exitCode + ")")
+}
+
 // Prevent packaging distributions with missing GWT assets when -DskipGwt=true
 lazy val verifyGwtAssets = taskKey[Unit]("Fail when packaging would ship with missing GWT assets")
 
@@ -1282,6 +1326,8 @@ ThisBuild / verifyGwtAssets := {
 
 // Wire compileGwt to run after compileJava (GWT needs compiled classes)
 compileGwt := (compileGwt).dependsOn(Compile / compile).value
+devCompile := (Compile / compile).value
+compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 
 // ⚠️  DO NOT REMOVE these lines. They ensure GWT compilation runs before
 //     staging or packaging. Without them, distributions ship without the

--- a/build.sbt
+++ b/build.sbt
@@ -1290,9 +1290,9 @@ ThisBuild / compileGwtDev := {
   val forkOpts = ForkOptions()
     .withRunJVMOptions(Vector("-Xmx1024M"))
 
-  val warDir = (base / "war").getAbsolutePath
+  val devWarDir = (base / "war-dev").getAbsolutePath
   val gwtArgs = Seq(
-    "-war", warDir,
+    "-war", devWarDir,
     "-draftCompile",
     "-style", "PRETTY",
     "-localWorkers", "2",
@@ -1301,6 +1301,7 @@ ThisBuild / compileGwtDev := {
   )
 
   log.info("[compileGwtDev] Native mode — one-permutation draft compile")
+  log.info("[compileGwtDev] Writing dev artifacts to " + devWarDir)
   log.info("[compileGwtDev] Classpath has " + fullCp.size + " entries")
   val cpStr = fullCp.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)
 
@@ -1338,3 +1339,4 @@ Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyG
 cleanFiles += baseDirectory.value / "war" / "webclient"
 cleanFiles += baseDirectory.value / "war" / "org"
 cleanFiles += baseDirectory.value / "war" / "WEB-INF"
+cleanFiles += baseDirectory.value / "war-dev"

--- a/wave/config/changelog.d/2026-04-12-gwt-dev-compile-tasks.json
+++ b/wave/config/changelog.d/2026-04-12-gwt-dev-compile-tasks.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-gwt-dev-compile-tasks",
+  "version": "PR #844",
+  "date": "2026-04-12",
+  "title": "Keep draft GWT dev output out of the production war tree",
+  "summary": "Updated the new dev GWT compile task to emit draft artifacts into a separate directory so production packaging continues to rely on full compileGwt output.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "compileGwtDev now writes draft Safari-only GWT output into war-dev instead of war.",
+        "Added a changelog fragment for the new dev-only GWT compile task behavior."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -639,16 +639,17 @@ public class SimpleSearchProviderImplTest extends TestCase {
     SearchResult resultsAsc =
         searchProvider.search(USER2, "in:inbox orderby:creatorasc orderby:createddesc", 0, 10);
     assertEquals(10, resultsAsc.getNumResults());
+    List<SearchResult.Digest> digests = Lists.newArrayList(resultsAsc.getDigests());
     Ordering<SearchResult.Digest> ascAuthorOrdering = Ordering.from(ASC_CREATOR_COMPARATOR);
-    assertTrue(ascAuthorOrdering.isOrdered(resultsAsc.getDigests()));
+    assertTrue(ascAuthorOrdering.isOrdered(digests));
     Ordering<SearchResult.Digest> descCreatedOrdering = Ordering.from(DESC_CREATED_COMPARATOR);
-    // The whole list should not be ordered by creation time.
-    assertFalse(descCreatedOrdering.isOrdered(resultsAsc.getDigests()));
+    assertEquals(USER1, digestAuthor(digests.get(0)));
+    assertEquals(USER1, digestAuthor(digests.get(1)));
+    assertEquals(USER2, digestAuthor(digests.get(2)));
+    assertEquals(USER2, digestAuthor(digests.get(9)));
     // Each sublist should be ordered by creation time.
-    assertTrue(descCreatedOrdering.isOrdered(Lists.newArrayList(resultsAsc.getDigests()).subList(0,
-        2)));
-    assertTrue(descCreatedOrdering.isOrdered(Lists.newArrayList(resultsAsc.getDigests()).subList(2,
-        10)));
+    assertTrue(descCreatedOrdering.isOrdered(digests.subList(0, 2)));
+    assertTrue(descCreatedOrdering.isOrdered(digests.subList(2, 10)));
   }
 
   public void testSearchOrderByAuthorDescWorks() throws Exception {
@@ -1080,6 +1081,10 @@ public class SimpleSearchProviderImplTest extends TestCase {
 
   private WaveletOperation runtimeAddParticipant(ParticipantId user) {
     return new AddParticipant(CONTEXT, user);
+  }
+
+  private ParticipantId digestAuthor(SearchResult.Digest digest) {
+    return ParticipantId.ofUnsafe(digest.getParticipants().get(0));
   }
 
   private void submitDelta(WaveletName name, ParticipantId user, HashedVersion version,


### PR DESCRIPTION
## Summary
- add a lightweight `devCompile` SBT task that runs the standard compile path without GWT packaging
- add `compileGwtDev` for a single-permutation draft GWT compile into `war-dev` for faster compile feedback without touching production `war/`
- wire both tasks to depend on `Compile / compile`

## Verification
- `sbt --batch devCompile`
- `sbt --batch compileGwtDev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated development-mode GWT compilation with outputs written to a separate directory, isolating development from production build artifacts.

* **Chores**
  * Enhanced build infrastructure to support development compilation workflows.
  * Improved test coverage for search result ordering functionality with refined assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->