### PR TITLE
[codex] Fix save indicator for uncommitted edits

### DIFF
--- a/wave/config/changelog.d/2026-04-12-save-indicator-uncommitted.json
+++ b/wave/config/changelog.d/2026-04-12-save-indicator-uncommitted.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-12-save-indicator-uncommitted",
+  "version": "Unreleased",
+  "title": "Fix stale saved indicator during local edits",
+  "summary": "The topbar save state now treats locally uncommitted wave changes as unsaved instead of waiting only for server acknowledgements.",
+  "date": "2026-04-12",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The topbar save state now treats locally uncommitted wave changes as unsaved instead of waiting only for server acknowledgements."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/webclient/client/WaveletSavingStateTrackerTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/webclient/client/WaveletSavingStateTrackerTest.java
@@ -52,6 +52,18 @@ public final class WaveletSavingStateTrackerTest {
   }
 
   @Test
+  public void marksWaveletUnsavedWhenChangesAreLocalButNotYetAcknowledged() {
+    RecordingStateListener stateListener = new RecordingStateListener();
+    WaveletSavingStateTracker tracker = new WaveletSavingStateTracker(stateListener);
+    UnsavedDataListener listener = tracker.create(WAVELET_ID_1);
+
+    listener.onUpdate(new FakeUnsavedDataInfo(0, 2));
+
+    assertTrue(tracker.hasUnsavedData());
+    assertEquals(Arrays.asList(Boolean.TRUE), stateListener.states);
+  }
+
+  @Test
   public void clearsClosedDirtyWaveletImmediately() {
     RecordingStateListener stateListener = new RecordingStateListener();
     WaveletSavingStateTracker tracker = new WaveletSavingStateTracker(stateListener);
@@ -77,9 +89,15 @@ public final class WaveletSavingStateTrackerTest {
 
   private static final class FakeUnsavedDataInfo implements UnsavedDataListener.UnsavedDataInfo {
     private final int unacknowledgedSize;
+    private final int uncommittedSize;
 
     private FakeUnsavedDataInfo(int unacknowledgedSize) {
+      this(unacknowledgedSize, unacknowledgedSize);
+    }
+
+    private FakeUnsavedDataInfo(int unacknowledgedSize, int uncommittedSize) {
       this.unacknowledgedSize = unacknowledgedSize;
+      this.uncommittedSize = uncommittedSize;
     }
 
     @Override
@@ -94,7 +112,7 @@ public final class WaveletSavingStateTrackerTest {
 
     @Override
     public int estimateUncommittedSize() {
-      return unacknowledgedSize;
+      return uncommittedSize;
     }
 
     @Override

--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/common/WaveletSavingStateTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/common/WaveletSavingStateTracker.java
@@ -44,7 +44,7 @@ public final class WaveletSavingStateTracker implements UnsavedDataListenerFacto
     return new UnsavedDataListener() {
       @Override
       public void onUpdate(UnsavedDataInfo unsavedDataInfo) {
-        updateWaveletState(waveletId, unsavedDataInfo.estimateUnacknowledgedSize() != 0);
+        updateWaveletState(waveletId, unsavedDataInfo.estimateUncommittedSize() != 0);
       }
 
       @Override


### PR DESCRIPTION
## What changed
- treat locally uncommitted wavelet changes as unsaved in `WaveletSavingStateTracker`
- add a regression test proving a wavelet stays dirty even before the server has acknowledged the local ops
- add a changelog fragment for the topbar save-state fix

## Why
The topbar save indicator was only watching `estimateUnacknowledgedSize()`. That left a gap where locally dirty edits could still render as `Saved` until the server ack arrived, which matches the observed green indicator staying green during active edits.

## Impact
- the save indicator now flips out of `Saved` as soon as a wavelet has local uncommitted edits
- users get accurate feedback instead of a false green/saved state while edits are still pending locally

## Validation
- `sbt -batch 'jakartaTest:testOnly org.waveprotocol.box.webclient.client.WaveletSavingStateTrackerTest'`
- `sbt -batch 'wave / compile'`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- browser verification on `http://127.0.0.1:9900/#local.net/w+q2jxmmy8laf5A`

## Note
This PR covers the save-indicator bug that I could reproduce and verify locally. I did not reproduce the full mobile-only IME data-loss path end to end in local emulation, so this PR does not claim to fix that broader issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the save indicator to properly identify locally uncommitted changes as "unsaved," ensuring users have accurate visibility into the save state regardless of server acknowledgement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->