### PR TITLE
[codex] Keep mobile blips visible beneath wrapped edit toolbar

### DIFF
--- a/wave/config/changelog.d/2026-04-12-mobile-toolbar-blip-visibility.json
+++ b/wave/config/changelog.d/2026-04-12-mobile-toolbar-blip-visibility.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-mobile-toolbar-blip-visibility",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Keep mobile blips visible beneath wrapped edit toolbars",
+  "summary": "The wave conversation scroller now follows the real rendered toolbar height on mobile, so wrapped edit toolbars no longer cover the first blip while you edit.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "When the mobile edit toolbar grows beyond a single row, the conversation pane now shifts down to keep the first blip fully visible",
+        "Toolbar height changes from reflow and viewport resizing now resync the wave panel instead of leaving blip content hidden under the toolbar"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/TopConversationDomImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/TopConversationDomImpl.java
@@ -19,8 +19,15 @@
 
 package org.waveprotocol.wave.client.wavepanel.view.dom;
 
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Window;
 
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.TopConversationViewBuilder.Components;
 
@@ -43,6 +50,9 @@ public final class TopConversationDomImpl implements DomView {
 
   private Element threadContainer;
   private Element toolbarContainer;
+  private HandlerRegistration resizeRegistration;
+  private JavaScriptObject toolbarResizeObserver;
+  private boolean threadTopSyncScheduled;
 
   TopConversationDomImpl(Element e, String id) {
     this.self = e;
@@ -98,11 +108,77 @@ public final class TopConversationDomImpl implements DomView {
     if (toolbar != null) {
       getToolbarContainer().appendChild(toolbar);
     }
+    ensureToolbarLayoutSync();
+    syncThreadTopToToolbar();
+    scheduleThreadTopSync();
   }
 
   public void remove() {
+    disconnectToolbarResizeObserver();
+    if (resizeRegistration != null) {
+      resizeRegistration.removeHandler();
+      resizeRegistration = null;
+    }
     getElement().removeFromParent();
   }
+
+  private void ensureToolbarLayoutSync() {
+    if (resizeRegistration == null) {
+      resizeRegistration = Window.addResizeHandler(new ResizeHandler() {
+        @Override
+        public void onResize(ResizeEvent event) {
+          scheduleThreadTopSync();
+        }
+      });
+    }
+    observeToolbarResize(getToolbarContainer());
+  }
+
+  private void scheduleThreadTopSync() {
+    if (threadTopSyncScheduled) {
+      return;
+    }
+    threadTopSyncScheduled = true;
+    Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        threadTopSyncScheduled = false;
+        syncThreadTopToToolbar();
+      }
+    });
+  }
+
+  private void syncThreadTopToToolbar() {
+    Element toolbar = getToolbarContainer();
+    Element thread = getThreadContainer();
+    if (toolbar == null || thread == null) {
+      return;
+    }
+    int topPx = toolbar.getOffsetTop() + toolbar.getOffsetHeight();
+    thread.getStyle().setTop(topPx, Unit.PX);
+  }
+
+  private native void observeToolbarResize(Element toolbar) /*-{
+    this.@org.waveprotocol.wave.client.wavepanel.view.dom.TopConversationDomImpl::disconnectToolbarResizeObserver()();
+    if (!$wnd.ResizeObserver || !toolbar) {
+      return;
+    }
+    var self = this;
+    var observer = new $wnd.ResizeObserver(function() {
+      self.@org.waveprotocol.wave.client.wavepanel.view.dom.TopConversationDomImpl::scheduleThreadTopSync()();
+    });
+    observer.observe(toolbar);
+    this.@org.waveprotocol.wave.client.wavepanel.view.dom.TopConversationDomImpl::toolbarResizeObserver = observer;
+  }-*/;
+
+  private native void disconnectToolbarResizeObserver() /*-{
+    var observer =
+        this.@org.waveprotocol.wave.client.wavepanel.view.dom.TopConversationDomImpl::toolbarResizeObserver;
+    if (observer && observer.disconnect) {
+      observer.disconnect();
+    }
+    this.@org.waveprotocol.wave.client.wavepanel.view.dom.TopConversationDomImpl::toolbarResizeObserver = null;
+  }-*/;
 
   //
   // Equality.

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -93,6 +93,15 @@ public final class ToolbarLayoutContractTest extends TestCase {
     assertTrue(css.contains("background-image: linear-gradient(180deg, #eef7ff 0%, #dcecff 100%);"));
   }
 
+  public void testTopConversationTracksActualToolbarHeightWhenLayoutChanges() throws Exception {
+    String javaSource = read(
+        "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/TopConversationDomImpl.java");
+
+    assertTrue(javaSource.contains("toolbar.getOffsetTop() + toolbar.getOffsetHeight()"));
+    assertTrue(javaSource.contains("setTop(topPx, Unit.PX);"));
+    assertTrue(javaSource.contains("Scheduler.get().scheduleDeferred"));
+  }
+
   public void testSearchToolbarSvgContractMatchesPolishedToolbarSizing() throws Exception {
     String javaSource = read(
         "wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java");


### PR DESCRIPTION
## Summary
- sync the top conversation scroll offset to the actual rendered toolbar height instead of assuming a single 36px toolbar row
- resync the thread container when the toolbar reflows or the viewport changes on mobile
- add a regression contract test and changelog fragment for the mobile visibility fix

## Root cause
The wave panel scroll area was still positioned using a fixed 36px toolbar offset. On mobile, the edit toolbar can wrap to multiple rows, so the thread container stayed too high and the first blip ended up hidden underneath the toolbar.

## Impact
When editing blips on mobile, wrapped edit toolbars no longer cover the first blip. The conversation pane follows the real toolbar height as layout changes.

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `sbt --batch "testOnly org.waveprotocol.box.server.util.ToolbarLayoutContractTest"`

## Notes
- I did not run a live browser sanity pass because no local Wave server was running on `127.0.0.1:9898` in this worktree session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mobile toolbar interaction: The conversation view now properly adjusts when the mobile toolbar reflows or grows in height, ensuring the first message remains fully visible and the view stays synchronized with toolbar changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->