### PR TITLE
fix(mobile): preserve new blip text after null composition end

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-835-mobile-edit-loss-regression.md
+++ b/docs/superpowers/plans/2026-04-12-issue-835-mobile-edit-loss-regression.md
@@ -1,0 +1,30 @@
+# Issue 835 Mobile Edit-Loss Regression Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the reopened Android/mobile regression where a newly created blip can show typed text locally but fail to persist it after Done.
+
+**Architecture:** Keep the fix inside the client editor event pipeline. The narrow seam is the delayed IME composition-end guard in `EditorEventHandler`: when `compositionEnd()` returns no selection, the trailing DOM mutation must still be allowed to reach the typing extractor so browser-owned text becomes a document operation instead of disappearing on teardown/reload.
+
+**Tech Stack:** GWT client editor event handling, browser DOM mutation fallback, existing local worktree verification, changelog fragments.
+
+---
+
+## File Map
+
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java`
+- Modify: `wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java`
+- Create: `wave/config/changelog.d/2026-04-12-mobile-edit-loss-regression.json`
+- Update: `journal/local-verification/2026-04-11-branch-android-edit-regression-20260411.md`
+
+## Acceptance
+
+- The null-selection delayed-composition path is covered by a focused regression in `EditorEventHandlerGwtTest`.
+- The editor only suppresses the trailing DOM mutation when `compositionEnd()` actually restored a selection.
+- Local browser verification covers the exact user path: mobile-emulated new blip edit, Done, reload/persist check.
+- Changelog and local verification evidence are recorded in-repo.
+
+## Notes
+
+- The current reconnect/save-state code already contains explicit fixes for stale socket callbacks and reconnect resubscribe; no reconnect patch should be added without a dedicated failing seam.
+- The existing uncommitted editor/test changes in this branch are in scope for this issue because they directly address the reported mobile non-persist path.

--- a/wave/config/changelog.d/2026-04-12-mobile-edit-loss-regression.json
+++ b/wave/config/changelog.d/2026-04-12-mobile-edit-loss-regression.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-12-mobile-edit-loss-regression",
-  "version": "Issue #835",
+  "version": "fix/mobile-edit-loss-regression",
   "date": "2026-04-12",
   "title": "Fix mobile new-blip edit loss after delayed composition teardown",
   "summary": "New blips on mobile no longer lose typed text when the browser finishes composition without restoring a selection before the trailing DOM mutation arrives.",

--- a/wave/config/changelog.d/2026-04-12-mobile-edit-loss-regression.json
+++ b/wave/config/changelog.d/2026-04-12-mobile-edit-loss-regression.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-mobile-edit-loss-regression",
+  "version": "Issue #835",
+  "date": "2026-04-12",
+  "title": "Fix mobile new-blip edit loss after delayed composition teardown",
+  "summary": "New blips on mobile no longer lose typed text when the browser finishes composition without restoring a selection before the trailing DOM mutation arrives.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Allowed the trailing DOM mutation fallback to materialize browser-owned text when delayed composition end returns no editor selection",
+        "Preserved the mobile new-blip flow where text previously appeared locally but disappeared after Done or reload"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -452,7 +452,13 @@ public final class EditorEventHandler {
     // into compositionStart()
     cachedSelection = editorInteractor.compositionEnd();
     state = State.NORMAL;
-    delayedCompositionMutationGuard.noteCompositionEnd();
+    // Only suppress the trailing DOM mutation when compositionEnd() produced a
+    // real editor selection. If compositionEnd() returns null, that same
+    // mutation is the fallback path that can still materialize browser-only
+    // text into a document operation.
+    if (cachedSelection != null) {
+      delayedCompositionMutationGuard.noteCompositionEnd();
+    }
   }
 
 

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -679,6 +679,8 @@ public class EditorEventHandlerGwtTest
    * never becomes a document operation.
    */
   public void testDomMutationAfterNullCompositionEndStillNotifiesTypingExtractor() {
+    assertTrue(QuirksConstants.MODIFIES_DOM_AND_FIRES_TEXTINPUT_AFTER_COMPOSITION);
+
     FakeEditorEvent[] composition = FakeEditorEvent.compositionSequence(0);
     FakeEditorEvent mutation = FakeEditorEvent.create(BrowserEvents.DOMCharacterDataModified);
 

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -674,6 +674,44 @@ public class EditorEventHandlerGwtTest
   }
 
   /**
+   * If delayed composition end produces no selection, the trailing DOM
+   * mutation still has to reach the typing extractor or the browser-only text
+   * never becomes a document operation.
+   */
+  public void testDomMutationAfterNullCompositionEndStillNotifiesTypingExtractor() {
+    FakeEditorEvent[] composition = FakeEditorEvent.compositionSequence(0);
+    FakeEditorEvent mutation = FakeEditorEvent.create(BrowserEvents.DOMCharacterDataModified);
+
+    final Point<ContentNode> caret = Point.inText(
+        new ContentTextNode(Document.get().createTextNode("tail"), null), 4);
+    FocusedContentRange collapsedSelection = new FocusedContentRange(caret);
+
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    subHandler.call(FakeEditorEventsSubHandler.HANDLE_DOM_MUTATION).anyOf();
+
+    FakeEditorInteractor interactor = setupFakeEditorInteractor(collapsedSelection);
+    interactor.call(FakeEditorInteractor.COMPOSITION_START).nOf(1).withArgs(caret);
+    interactor.call(FakeEditorInteractor.COMPOSITION_END).nOf(1).returns(null);
+    interactor.call(FakeEditorInteractor.NOTIFYING_TYPING_EXTRACTOR)
+        .nOf(1)
+        .withArgs(caret, false);
+
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(composition[0]));
+    assertEquals(EditorEventHandler.State.COMPOSITION, handler.getState());
+
+    assertFalse(handler.handleEvent(composition[1]));
+    assertEquals(EditorEventHandler.State.COMPOSITION, handler.getState());
+
+    assertFalse(handler.handleEvent(mutation));
+    assertEquals(EditorEventHandler.State.NORMAL, handler.getState());
+
+    interactor.checkExpectations();
+    subHandler.checkExpectations();
+  }
+
+  /**
    * Android/WebKit IME mutations can temporarily report the current composing
    * word as a range. That state belongs to the composition flow and must not be
    * passed to the typing extractor, which only understands stable collapsed


### PR DESCRIPTION
## Summary
- preserve the trailing DOM-mutation fallback when delayed `compositionEnd()` returns no selection
- add a focused `EditorEventHandlerGwtTest` regression for the null-selection composition-end path
- record the issue plan and changelog fragment for issue #835

## Why
Mobile-emulated new-blip text could appear locally but never become a document operation when delayed IME composition end restored no selection. In that case the trailing DOM mutation is the only remaining path that can materialize browser-owned text. Suppressing it unconditionally reintroduced the old "new blip created, text not persisted" failure mode.

## Verification
- `bash scripts/worktree-boot.sh --port 9903`
  - succeeded, including `compileGwt`
- Browser verification on `http://127.0.0.1:9903/` with mobile emulation
  - created a fresh local user
  - created a new reply blip, typed `new blip`, reloaded, and confirmed it persisted
  - forced a websocket drop with DevTools `Offline`, restored `Fast 4G`, created another reply blip, typed `rok`, reloaded, and confirmed the post-reconnect blip also persisted
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
  - succeeded

## Notes
- This PR intentionally does not add reconnect/transport code. I investigated the websocket-disconnect hypothesis separately, but the forced offline/online check on the patched branch did not reproduce a second save failure.
- Plan: `docs/superpowers/plans/2026-04-12-issue-835-mobile-edit-loss-regression.md`

Closes #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile regression fixed: text entered into new blips now persists after finishing an edit or reloading.

* **Tests**
  * Added a focused regression test to prevent recurrence of the mobile edit-to-loss scenario.

* **Documentation**
  * Added a release note entry and a planning doc describing verification steps and acceptance criteria for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->