### PR TITLE
[codex] Move tag creation into the tag bar

### DIFF
--- a/wave/config/changelog.d/2026-04-12-inline-tag-composer.json
+++ b/wave/config/changelog.d/2026-04-12-inline-tag-composer.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-inline-tag-composer",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Move tag creation into the tag bar",
+  "summary": "Adding tags now happens inline in the existing tag bar so mobile no longer opens a cramped modal popup for tag entry.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The tag add button now opens a compact inline composer directly in the tags bar instead of a centered popup dialog",
+        "Inline tag entry keeps comma-separated tag creation and keyboard shortcuts while fitting cleanly inside the mobile tags footer"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
@@ -20,8 +20,16 @@
 package org.waveprotocol.wave.client.wavepanel.impl.edit;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.TextBox;
 
 import org.waveprotocol.box.common.SearchQuerySyntax;
 import org.waveprotocol.wave.client.events.ClientEvents;
@@ -37,16 +45,21 @@ import org.waveprotocol.wave.client.wavepanel.view.TagsView;
 import org.waveprotocol.wave.client.wavepanel.view.View.Type;
 import org.waveprotocol.wave.client.wavepanel.view.dom.DomAsViewProvider;
 import org.waveprotocol.wave.client.wavepanel.view.dom.ModelAsViewProvider;
+import org.waveprotocol.wave.client.wavepanel.view.dom.full.TagsViewBuilder;
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.TypeCodes;
+import org.waveprotocol.wave.client.wavepanel.view.dom.full.WavePanelResourceLoader;
 import org.waveprotocol.wave.model.conversation.Conversation;
 import org.waveprotocol.wave.model.util.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Installs the add/filter/remove tag controls.
  *
  * Ported from Wiab.pro, adapted for Apache Wave (removed KeyComboManager
- * dependency). Uses a styled popup for adding tags and a dedicated inline
- * remove affordance for deletions.
+ * dependency). Uses an inline composer for adding tags and a dedicated
+ * inline remove affordance for deletions.
  */
 public final class TagController {
 
@@ -62,6 +75,9 @@ public final class TagController {
 
   private final DomAsViewProvider views;
   private final ModelAsViewProvider models;
+  private final TagsViewBuilder.Css tagsCss = WavePanelResourceLoader.getTags().css();
+  private final Map<String, InlineTagEditor> inlineEditors =
+      new HashMap<String, InlineTagEditor>();
 
   private TagController(DomAsViewProvider views, ModelAsViewProvider models) {
     this.views = views;
@@ -97,21 +113,14 @@ public final class TagController {
   }
 
   /**
-   * Shows an add-tag popup using {@link TagInputWidget}.
+   * Shows an inline add-tag editor in the tags bar.
    */
   private void handleAddButtonClicked(final Element addButton) {
-    TagInputWidget widget = new TagInputWidget(messages.addTagPrompt());
-    widget.showInPopup(new TagInputWidget.Listener() {
-      @Override
-      public void onSubmit(String tagValue) {
-        addTagsInner(addButton, tagValue);
-      }
-
-      @Override
-      public void onCancel() {
-        // no-op: user dismissed the dialog
-      }
-    });
+    TagsView tagUi = views.tagsFromAddButton(addButton);
+    if (tagUi == null) {
+      return;
+    }
+    showInlineEditor(tagUi);
   }
 
   /**
@@ -146,9 +155,56 @@ public final class TagController {
     }
   }
 
-  private void addTagsInner(Element addButton, String input) {
+  private void showInlineEditor(TagsView tagUi) {
+    String activeTagsViewId = tagUi.getId();
+    for (Map.Entry<String, InlineTagEditor> entry : inlineEditors.entrySet()) {
+      if (!entry.getKey().equals(activeTagsViewId)) {
+        entry.getValue().hide();
+      }
+    }
+    InlineTagEditor editor = getInlineEditor(tagUi);
+    if (editor != null) {
+      editor.show();
+    }
+  }
+
+  private InlineTagEditor getInlineEditor(TagsView tagUi) {
+    String tagsViewId = tagUi.getId();
+    InlineTagEditor editor = inlineEditors.get(tagsViewId);
+    if (editor != null && editor.isAttached()) {
+      return editor;
+    }
+    editor = createInlineEditor(tagsViewId);
+    if (editor != null) {
+      inlineEditors.put(tagsViewId, editor);
+    }
+    return editor;
+  }
+
+  private InlineTagEditor createInlineEditor(String tagsViewId) {
+    Element editorElement =
+        Document.get().getElementById(TagsViewBuilder.Components.INLINE_EDITOR.getDomId(tagsViewId));
+    Element inputElement =
+        Document.get().getElementById(TagsViewBuilder.Components.INLINE_INPUT.getDomId(tagsViewId));
+    Element submitElement =
+        Document.get().getElementById(TagsViewBuilder.Components.INLINE_SUBMIT.getDomId(tagsViewId));
+    Element cancelElement =
+        Document.get().getElementById(TagsViewBuilder.Components.INLINE_CANCEL.getDomId(tagsViewId));
+    if (editorElement == null || inputElement == null || submitElement == null || cancelElement == null) {
+      return null;
+    }
+    return new InlineTagEditor(
+        tagsViewId,
+        editorElement,
+        TextBox.wrap(inputElement),
+        Button.wrap(submitElement),
+        Button.wrap(cancelElement));
+  }
+
+  private void addTagsInner(String tagsViewId, String input) {
     String[] tags = input.split(",");
-    TagsView tagUi = views.tagsFromAddButton(addButton);
+    Element tagsRoot = Document.get().getElementById(tagsViewId);
+    TagsView tagUi = tagsRoot != null ? views.asTags(tagsRoot) : null;
     if (tagUi == null) {
       return;
     }
@@ -161,6 +217,75 @@ public final class TagController {
       if (!tag.isEmpty()) {
         conversation.addTag(tag);
       }
+    }
+  }
+
+  private final class InlineTagEditor {
+    private final String tagsViewId;
+    private final Element rootElement;
+    private final TextBox input;
+
+    private InlineTagEditor(
+        final String tagsViewId, Element rootElement, TextBox input, Button submitButton,
+        Button cancelButton) {
+      this.tagsViewId = tagsViewId;
+      this.rootElement = rootElement;
+      this.input = input;
+
+      submitButton.addClickHandler(new ClickHandler() {
+        @Override
+        public void onClick(ClickEvent event) {
+          submit();
+        }
+      });
+      cancelButton.addClickHandler(new ClickHandler() {
+        @Override
+        public void onClick(ClickEvent event) {
+          hide();
+        }
+      });
+      input.addKeyDownHandler(new KeyDownHandler() {
+        @Override
+        public void onKeyDown(KeyDownEvent event) {
+          if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER) {
+            event.preventDefault();
+            submit();
+          } else if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE) {
+            event.preventDefault();
+            hide();
+          }
+        }
+      });
+    }
+
+    private boolean isAttached() {
+      return rootElement.equals(Document.get().getElementById(rootElement.getId()));
+    }
+
+    private void show() {
+      rootElement.addClassName(tagsCss.inlineEditorVisible());
+      Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+        @Override
+        public void execute() {
+          input.setFocus(true);
+          input.selectAll();
+        }
+      });
+    }
+
+    private void hide() {
+      rootElement.removeClassName(tagsCss.inlineEditorVisible());
+      input.setValue("");
+    }
+
+    private void submit() {
+      String value = input.getValue();
+      if (value == null || value.trim().isEmpty()) {
+        input.setFocus(true);
+        return;
+      }
+      addTagsInner(tagsViewId, value.trim());
+      hide();
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
@@ -159,3 +159,67 @@
 .removed .removeButton {
   display: none;
 }
+
+.inlineEditor {
+  float: left;
+  display: none;
+  align-items: center;
+  gap: 4px;
+  margin: 5px 0 0 6px;
+  min-height: 24px;
+  max-width: calc(100% - 5.5em);
+  padding: 0 4px 0 8px;
+  border: 1px solid #8bbbe5;
+  border-radius: 999px;
+  background: #ffffff;
+}
+
+.inlineEditorVisible {
+  display: inline-flex;
+}
+
+.inlineInput {
+  width: 7em;
+  min-width: 5em;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #0c4e80;
+  font-size: 12px;
+  font-weight: 600;
+  outline: none;
+}
+
+.inlineInput::placeholder {
+  color: #6f9dc5;
+  font-weight: 500;
+}
+
+.inlineActionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+}
+
+.inlineActionButton:hover {
+  background-color: rgba(12, 78, 128, 0.1);
+}
+
+.inlineSubmitButton {
+  background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2012%2012%27%3E%3Cpath%20d%3D%27M2%206.3l2.1%202.1L10%202.5%27%20fill%3D%27none%27%20stroke%3D%27%230077b6%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27%2F%3E%3C%2Fsvg%3E);
+}
+
+.inlineCancelButton {
+  background-image: url(data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20width%3D%2712%27%20height%3D%2712%27%20viewBox%3D%270%200%2012%2012%27%3E%3Cpath%20d%3D%27M3%203l6%206M9%203L3%209%27%20fill%3D%27none%27%20stroke%3D%27%235a7088%27%20stroke-width%3D%271.8%27%20stroke-linecap%3D%27round%27%2F%3E%3C%2Fsvg%3E);
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TagsViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TagsViewBuilder.java
@@ -81,6 +81,12 @@ public final class TagsViewBuilder implements UiBuilder {
     String addButton();
     String addButtonPressed();
     String removeButton();
+    String inlineEditor();
+    String inlineEditorVisible();
+    String inlineInput();
+    String inlineActionButton();
+    String inlineSubmitButton();
+    String inlineCancelButton();
   }
 
   /** An enum for all the components of a tags view. */
@@ -89,7 +95,15 @@ public final class TagsViewBuilder implements UiBuilder {
     /** Element to which tag UIs are attached. */
     CONTAINER("C"),
     /** Add button. */
-    ADD("A");
+    ADD("A"),
+    /** Inline composer wrapper. */
+    INLINE_EDITOR("E"),
+    /** Inline composer input. */
+    INLINE_INPUT("I"),
+    /** Inline composer submit button. */
+    INLINE_SUBMIT("S"),
+    /** Inline composer cancel button. */
+    INLINE_CANCEL("X");
 
     private final String postfix;
 
@@ -140,6 +154,7 @@ public final class TagsViewBuilder implements UiBuilder {
           OutputHelper.close(output);
 
           tagUis.outputHtml(output);
+          appendInlineEditor(output);
 
           // Overflow-mode panel.
           OutputHelper.openSpan(output, null, css.extra(), null);
@@ -208,5 +223,47 @@ public final class TagsViewBuilder implements UiBuilder {
         .replace("'", "\\'")
         .replace("\r", "\\r")
         .replace("\n", "\\n");
+  }
+
+  private void appendInlineEditor(SafeHtmlBuilder output) {
+    OutputHelper.openSpan(output, Components.INLINE_EDITOR.getDomId(id), css.inlineEditor(), null);
+    {
+      output.appendHtmlConstant("<input"
+          + " type='text'"
+          + " id='" + escapeHtmlAttribute(Components.INLINE_INPUT.getDomId(id)) + "'"
+          + " class='" + escapeHtmlAttribute(css.inlineInput()) + "'"
+          + " placeholder='" + escapeHtmlAttribute(messages.tagInputPlaceholder()) + "'"
+          + " title='" + escapeHtmlAttribute(messages.tagInputHint()) + "'"
+          + " aria-label='" + escapeHtmlAttribute(messages.tagInputPlaceholder()) + "'"
+          + " autocomplete='off'"
+          + " spellcheck='false'"
+          + " />");
+      OutputHelper.button(
+          output,
+          Components.INLINE_SUBMIT.getDomId(id),
+          css.inlineActionButton() + " " + css.inlineSubmitButton(),
+          null,
+          messages.confirmAddTagHint(),
+          messages.confirmAddTagHint(),
+          "");
+      OutputHelper.button(
+          output,
+          Components.INLINE_CANCEL.getDomId(id),
+          css.inlineActionButton() + " " + css.inlineCancelButton(),
+          null,
+          messages.cancelAddTagHint(),
+          messages.cancelAddTagHint(),
+          "");
+    }
+    OutputHelper.closeSpan(output);
+  }
+
+  private static String escapeHtmlAttribute(String value) {
+    return value
+        .replace("&", "&amp;")
+        .replace("'", "&#39;")
+        .replace("\"", "&quot;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;");
   }
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/TagMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/TagMessages.java
@@ -40,4 +40,16 @@ public interface TagMessages extends Messages {
 
   @DefaultMessage("Add tag")
   String addTagHint();
+
+  @DefaultMessage("Enter tag name...")
+  String tagInputPlaceholder();
+
+  @DefaultMessage("Separate multiple tags with commas")
+  String tagInputHint();
+
+  @DefaultMessage("Add tags")
+  String confirmAddTagHint();
+
+  @DefaultMessage("Cancel tag entry")
+  String cancelAddTagHint();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/TagMessages_en.properties
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/i18n/TagMessages_en.properties
@@ -2,3 +2,7 @@ tags = Tags:
 less = less
 more = more
 addTagHint = Add tag
+tagInputPlaceholder = Enter tag name...
+tagInputHint = Separate multiple tags with commas
+confirmAddTagHint = Add tags
+cancelAddTagHint = Cancel tag entry

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -68,6 +68,26 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     assertTrue(css.contains("display: inline-flex"));
   }
 
+  public void testTagAddFlowUsesInlineComposerInsteadOfPopup() throws Exception {
+    String builder =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/TagsViewBuilder.java");
+    String css =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");
+    String controller =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java");
+
+    assertTrue(builder.contains("INLINE_EDITOR"));
+    assertTrue(builder.contains("INLINE_INPUT"));
+    assertTrue(builder.contains("INLINE_SUBMIT"));
+    assertTrue(builder.contains("INLINE_CANCEL"));
+    assertTrue(css.contains(".inlineEditor"));
+    assertTrue(css.contains(".inlineEditorVisible"));
+    assertTrue(css.contains(".inlineInput"));
+    assertTrue(css.contains(".inlineActionButton"));
+    assertTrue(controller.contains("showInlineEditor("));
+    assertFalse(controller.contains("new TagInputWidget("));
+  }
+
   public void testTagFilteringUsesClientSearchQueryEventSeam() throws Exception {
     String clientEvents =
         read("wave/src/main/java/org/waveprotocol/wave/client/events/ClientEvents.java");


### PR DESCRIPTION
## Summary
- replace the add-tag modal flow with an inline composer rendered inside the existing tags bar
- wire the add button to show the inline editor with add/cancel actions and Enter/Escape handling
- cover the new DOM/CSS/controller seam with a layout regression test and changelog fragment

## Root Cause
`TagController` always instantiated `TagInputWidget`, which opened a centered popup for tag creation. That interaction was especially cramped on mobile because the tag footer already lives at the bottom of the wave view, so adding a tag forced a separate modal overlay instead of letting the user type directly where tags live.

## User Impact
Adding tags now happens in place in the tags bar on both desktop and mobile, so the flow stays compact and the mobile footer no longer opens the ugly centered popup shown in issue #814.

## Validation
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `sbt "testOnly org.waveprotocol.box.server.util.WavePanelTagsLayoutTest"`
- `bash scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/.codex/worktrees/6687/incubator-wave/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/.codex/worktrees/6687/incubator-wave/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- Browser verification on `http://localhost:9900/`: registered `tag814pr@local.net`, signed in, opened the welcome wave, verified desktop inline tag entry, switched to a `430x932` mobile viewport, verified the inline editor stayed inside the tags bar, then removed the temporary `mobile-inline` tag
- `PORT=9900 bash scripts/wave-smoke.sh stop`

Refs #814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag creation and editing now occurs inline within the tags bar instead of a centered popup dialog. The compact inline composer improves the mobile experience in the tags footer while preserving comma-separated tag creation and keyboard shortcuts (Enter to submit, Escape to cancel).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->