### PR TITLE
[codex] Fix SupaWave Grafana log discovery

### DIFF
--- a/deploy/supawave-host/README.md
+++ b/deploy/supawave-host/README.md
@@ -81,7 +81,7 @@ sudo env \
 - Backups: `/var/backups/wave-supawave`
 - If PAM limits appear inactive, start a new login shell (`su - $USER`) or re-SSH into the host.
 - After rollback, run `sysctl --system` if custom sysctl files remain.
-- Confirm the live Alloy tail path and parser: `sudo grep -nE 'path\\s*=|job\\s*=|format\\s*=|level\\s*=|logger\\s*=|thread\\s*=' /etc/alloy/config.alloy`
+- Confirm the live Alloy tail path and parser: `sudo grep -nE '__path__\\s*=|job\\s*=|format\\s*=|level\\s*=|logger\\s*=|thread\\s*=' /etc/alloy/config.alloy`
 - Confirm Wave is still writing structured JSON: `tail -5 /home/ubuntu/supawave/shared/logs/wave-json.log | jq -c '{timestamp,level,logger_name,thread_name,message}'`
 - Check Alloy shipping errors: `sudo journalctl -u alloy --since "15 minutes ago" --no-pager | grep -iE 'error|401|invalid token|loki|prometheus'`
 - Check Alloy write counters: `curl -fsS http://127.0.0.1:12345/metrics | grep -E 'loki_write_sent_entries_total|loki_write_dropped_entries_total|prometheus_remote_storage_samples_failed_total'`

--- a/deploy/supawave-host/README.md
+++ b/deploy/supawave-host/README.md
@@ -70,7 +70,8 @@ sudo env \
 
 ### Loki Query Contract
 
-- Base selector: `{job="supawave/wave"}`
+- Recommended service selector: `{service_name="supawave"}`
+- Low-level fallback selector: `{job="supawave/wave"}`
 - Alloy promotes these labels from each JSON log line: `level`, `logger`, `thread`
 - Fields such as `participantId` and `waveId` remain in the JSON payload; inspect or filter them with `| json` in Grafana/Loki instead of expecting them as labels
 
@@ -84,6 +85,20 @@ sudo env \
 - Confirm Wave is still writing structured JSON: `tail -5 /home/ubuntu/supawave/shared/logs/wave-json.log | jq -c '{timestamp,level,logger_name,thread_name,message}'`
 - Check Alloy shipping errors: `sudo journalctl -u alloy --since "15 minutes ago" --no-pager | grep -iE 'error|401|invalid token|loki|prometheus'`
 - Check Alloy write counters: `curl -fsS http://127.0.0.1:12345/metrics | grep -E 'loki_write_sent_entries_total|loki_write_dropped_entries_total|prometheus_remote_storage_samples_failed_total'`
+- Check that the SupaWave file tailer is active: `curl -fsS http://127.0.0.1:12345/metrics | grep 'loki_source_file_files_active_total{component_id="loki.source.file.supawave_logs"'`
 - If Wave JSON logs exist, `/etc/alloy/config.alloy` still points at `wave-json*.log`, and Alloy logs show repeated `401 Unauthorized` / `authentication error: invalid token`, the remaining failure is Grafana Cloud authentication, not Wave log emission or Alloy file parsing.
 - Refresh and redeploy these values when that happens: `GRAFANA_ALLOY_ENABLE=true`, `GCLOUD_HOSTED_METRICS_URL`, `GCLOUD_HOSTED_METRICS_ID`, `GCLOUD_HOSTED_LOGS_URL`, `GCLOUD_HOSTED_LOGS_ID`, and `GCLOUD_RW_API_KEY`.
-- Healthy post-fix signals: `loki_write_sent_entries_total` rises above zero, `loki_write_dropped_entries_total{reason="ingester_error"}` stops increasing, `prometheus_remote_storage_samples_failed_total` stops increasing, and `{job="supawave/wave"}` starts returning log lines in Grafana.
+- Healthy post-fix signals: `loki_source_file_files_active_total{component_id="loki.source.file.supawave_logs"}` is `>= 1`, `loki_write_sent_entries_total` rises above zero, `loki_write_dropped_entries_total{reason="ingester_error"}` stops increasing, `prometheus_remote_storage_samples_failed_total` stays at zero, and `{service_name="supawave"}` starts returning log lines in Grafana.
+
+### Recommended Alerts
+
+Create these Grafana-managed alerts against the Alloy metrics stream and Loki logs after rollout:
+
+- SupaWave log tailer inactive:
+  `max_over_time(loki_source_file_files_active_total{component_id="loki.source.file.supawave_logs"}[10m]) < 1`
+- Loki write failures:
+  `increase(loki_write_dropped_entries_total{component_id="loki.write.grafana_cloud_loki",reason="ingester_error"}[10m]) > 0`
+- Prometheus remote-write failures:
+  `increase(prometheus_remote_storage_samples_failed_total{component_id="prometheus.remote_write.metrics_service"}[10m]) > 0`
+- SupaWave application error logs:
+  `sum(count_over_time({service_name="supawave",level="ERROR"}[5m])) > 0`

--- a/deploy/supawave-host/configure-grafana-alloy.sh
+++ b/deploy/supawave-host/configure-grafana-alloy.sh
@@ -169,8 +169,8 @@ loki.source.journal \"logs_integrations_integrations_node_exporter_journal_scrap
 
 local.file_match \"logs_integrations_integrations_node_exporter_direct_scrape\" {
   path_targets = [{
-    address = \"localhost\",
-    path    = \"/var/log/{syslog,messages,*.log}\",
+    __address__ = \"localhost\",
+    __path__    = \"/var/log/{syslog,messages,*.log}\",
     instance    = \"default\",
     job         = \"integrations/node_exporter\",
   }]
@@ -208,10 +208,11 @@ loki.source.file \"logs_integrations_integrations_node_exporter_direct_scrape\" 
 // ── SupaWave application logs ──────────────────────────────────────────
 local.file_match \"supawave_logs\" {
   path_targets = [{
-    address  = \"localhost\",
-    path     = \"$WAVE_LOG_PATH\",
-    job      = \"supawave/wave\",
-    instance = constants.hostname,
+    __address__  = \"localhost\",
+    __path__     = \"$WAVE_LOG_PATH\",
+    job          = \"supawave/wave\",
+    service_name = \"supawave\",
+    instance     = constants.hostname,
   }]
 }
 

--- a/scripts/tests/test_grafana_alloy_logging_config.py
+++ b/scripts/tests/test_grafana_alloy_logging_config.py
@@ -110,10 +110,10 @@ class GrafanaAlloyLoggingConfigTest(unittest.TestCase):
   def test_alloy_file_targets_use_internal_path_labels_and_service_name(self):
     script_text = ALLOY_CONFIG_SCRIPT.read_text(encoding="utf-8")
 
-    self.assertIn('__path__    = \\"/var/log/{syslog,messages,*.log}\\"', script_text)
-    self.assertIn('__path__     = \\"$WAVE_LOG_PATH\\"', script_text)
-    self.assertIn('service_name = \\"supawave\\"', script_text)
-    self.assertNotIn('path     = \\"$WAVE_LOG_PATH\\"', script_text)
+    self.assertRegex(script_text, r'__path__\s*=\s*\\"/var/log/\{syslog,messages,\*\.log\}\\"')
+    self.assertRegex(script_text, r'__path__\s*=\s*\\"\$WAVE_LOG_PATH\\"')
+    self.assertRegex(script_text, r'service_name\s*=\s*\\"supawave\\"')
+    self.assertNotRegex(script_text, r'(?m)^\s*path\s*=\s*\\"\$WAVE_LOG_PATH\\"')
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_grafana_alloy_logging_config.py
+++ b/scripts/tests/test_grafana_alloy_logging_config.py
@@ -107,6 +107,14 @@ class GrafanaAlloyLoggingConfigTest(unittest.TestCase):
     self.assertIn('WAVE_TIMESTAMP_FORMAT=${WAVE_TIMESTAMP_FORMAT:-RFC3339Nano}', script_text)
     self.assertIn('format = \\"$WAVE_TIMESTAMP_FORMAT\\"', script_text)
 
+  def test_alloy_file_targets_use_internal_path_labels_and_service_name(self):
+    script_text = ALLOY_CONFIG_SCRIPT.read_text(encoding="utf-8")
+
+    self.assertIn('__path__    = \\"/var/log/{syslog,messages,*.log}\\"', script_text)
+    self.assertIn('__path__     = \\"$WAVE_LOG_PATH\\"', script_text)
+    self.assertIn('service_name = \\"supawave\\"', script_text)
+    self.assertNotIn('path     = \\"$WAVE_LOG_PATH\\"', script_text)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/wave/config/changelog.d/2026-04-12-supawave-grafana-log-discovery.json
+++ b/wave/config/changelog.d/2026-04-12-supawave-grafana-log-discovery.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-supawave-grafana-log-discovery",
+  "version": "PR #852",
+  "date": "2026-04-12",
+  "title": "Fix SupaWave Grafana log discovery",
+  "summary": "Grafana Alloy now tails only SupaWave's structured JSON log files and the host docs call out the correct selectors for finding those logs in Grafana.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Updated the SupaWave Alloy file tailer to target the structured `wave-json*.log` files so Loki discovery stays aligned with the JSON parser pipeline",
+        "Documented the SupaWave Grafana selectors and troubleshooting steps needed to confirm Alloy is shipping the application logs correctly"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- fix the Alloy config generator to use `__path__` file-match labels so SupaWave JSON logs are actually tailed
- add a stable `service_name="supawave"` label so Grafana service-oriented log views can discover the stream
- document the Grafana/Loki selectors, troubleshooting checks, and recommended shipping/error alerts
- add regression coverage for the generated Alloy config

## Root Cause
The host was shipping journald logs to Loki, but the SupaWave file-log stream was not being tailed. `deploy/supawave-host/configure-grafana-alloy.sh` generated `local.file_match` targets with `path = ...` instead of `__path__ = ...`, so Alloy never activated `loki.source.file.supawave_logs`. That left Grafana without a discoverable SupaWave service stream even when Grafana Cloud authentication was healthy.

## Impact
This makes future deploys preserve the live fix so SupaWave server logs remain visible in Grafana under `{service_name="supawave"}` and operators have documented alert queries for both pipeline health and application errors.

## Verification
- `python3 -m unittest scripts.tests.test_grafana_alloy_logging_config`
- `bash -n deploy/supawave-host/configure-grafana-alloy.sh`
- applied the regenerated Alloy config on the `supawave` host and verified:
  - `loki_source_file_files_active_total{component_id="loki.source.file.supawave_logs"} = 1`
  - `loki_source_file_read_lines_total{component_id="loki.source.file.supawave_logs"} > 0`
  - `loki_write_dropped_entries_total{reason="ingester_error"} = 0`
  - `prometheus_remote_storage_samples_failed_total = 0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Grafana Loki query selectors and troubleshooting steps; added checks that the SupaWave file tailer is active and guidance for verifying log shipping.
  * Added recommended alert expressions for inactive tailers, ingester/write failures, remote-write failures, and SupaWave application ERROR logs.

* **Bug Fixes**
  * Improved Alloy log discovery configuration to target structured SupaWave logs with explicit scrape metadata.

* **Tests**
  * Added test coverage to validate the logging configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->