### PR TITLE
[codex] Add search metadata coverage for tag, mention, and task queries

### DIFF
--- a/wave/config/changelog.d/2026-04-12-search-metadata-coverage.json
+++ b/wave/config/changelog.d/2026-04-12-search-metadata-coverage.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-search-metadata-coverage",
+  "version": "PR #853",
+  "date": "2026-04-12",
+  "title": "Cover search metadata paths for tags, mentions, and tasks",
+  "summary": "Added regression coverage to ensure tag, mention, and task searches continue to route through the expected metadata and legacy-query paths.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added Lucene query-model and provider regression coverage so pure tag queries stay on the legacy metadata filter path",
+        "Added end-to-end coverage for mention and task metadata search lookups so assigned and mentioned waves remain discoverable"
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
+++ b/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -376,6 +380,85 @@ class WaveE2eTest {
                 + " not found in Alice's tag search within 20s");
     }
 
+    @Test @Order(21)
+    void test21_aliceMentionsBob() throws Exception {
+        JsonObject lv = E2eTestContext.lastVersion;
+        int version = lv.get("1").getAsInt();
+        String historyHash = lv.get("2").getAsString();
+
+        JsonObject delta = makeMentionDelta(
+                aliceAddr(),
+                "b+mention" + E2eTestContext.RUN_ID,
+                "@bob ping from e2e",
+                bobAddr(),
+                version,
+                historyHash);
+        JsonObject submitReq =
+                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
+        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
+
+        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
+        JsonObject msg = resp.get("message").getAsJsonObject();
+        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
+                "Expected operations_applied > 0 adding mention, got: " + resp);
+        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
+        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
+    }
+
+    @Test @Order(22)
+    void test22_bobMentionSearchFindsWave() throws Exception {
+        boolean found = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "mentions:me",
+                E2eTestContext.modernWaveId,
+                20_000,
+                500,
+                0);
+        assertTrue(found,
+                "Wave " + E2eTestContext.modernWaveId
+                + " not found in Bob's mentions:me search within 20s");
+    }
+
+    @Test @Order(23)
+    void test23_aliceAddsTaskForBob() throws Exception {
+        JsonObject lv = E2eTestContext.lastVersion;
+        int version = lv.get("1").getAsInt();
+        String historyHash = lv.get("2").getAsString();
+
+        JsonObject delta = makeTaskDelta(
+                aliceAddr(),
+                "b+task" + E2eTestContext.RUN_ID,
+                "Task assigned to Bob",
+                "task-" + E2eTestContext.RUN_ID,
+                bobAddr(),
+                version,
+                historyHash);
+        JsonObject submitReq =
+                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
+        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
+
+        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
+        JsonObject msg = resp.get("message").getAsJsonObject();
+        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
+                "Expected operations_applied > 0 adding task, got: " + resp);
+        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
+        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
+    }
+
+    @Test @Order(24)
+    void test24_bobTaskSearchFindsWave() throws Exception {
+        boolean found = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "tasks:me",
+                E2eTestContext.modernWaveId,
+                20_000,
+                500,
+                0);
+        assertTrue(found,
+                "Wave " + E2eTestContext.modernWaveId
+                + " not found in Bob's tasks:me search within 20s");
+    }
+
     // =========================================================================
     // Protocol message builders
     // =========================================================================
@@ -508,6 +591,101 @@ class WaveE2eTest {
 
         JsonObject mutateDoc = new JsonObject();
         mutateDoc.addProperty("1", "tags");
+        mutateDoc.add("2", docOp);
+
+        JsonObject opWrapper = new JsonObject();
+        opWrapper.add("3", mutateDoc);
+
+        JsonArray ops = new JsonArray();
+        ops.add(opWrapper);
+
+        JsonObject delta = new JsonObject();
+        delta.add("1", makeHashedVersion(version, historyHash));
+        delta.addProperty("2", author);
+        delta.add("3", ops);
+        delta.add("4", new JsonArray());
+        return delta;
+    }
+
+    private static JsonObject makeMentionDelta(String author, String blipId, String text,
+                                               String mentionedAddress,
+                                               int version, String historyHash) {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("mention/user", mentionedAddress);
+        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
+    }
+
+    private static JsonObject makeTaskDelta(String author, String blipId, String text,
+                                            String taskId, String assigneeAddress,
+                                            int version, String historyHash) {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("task/id", taskId);
+        annotations.put("task/assignee", assigneeAddress);
+        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
+    }
+
+    private static JsonObject makeAnnotatedTextDelta(String author, String blipId, String text,
+                                                     Map<String, String> annotations,
+                                                     int version, String historyHash) {
+        List<String> sortedKeys = new ArrayList<>(annotations.keySet());
+        sortedKeys.sort(String::compareTo);
+
+        JsonObject bodyStart = new JsonObject();
+        JsonObject bodyElem = new JsonObject();
+        bodyElem.addProperty("1", "body");
+        bodyElem.add("2", new JsonArray());
+        bodyStart.add("3", bodyElem);
+
+        JsonObject lineStart = new JsonObject();
+        JsonObject lineElem = new JsonObject();
+        lineElem.addProperty("1", "line");
+        lineElem.add("2", new JsonArray());
+        lineStart.add("3", lineElem);
+
+        JsonObject lineEnd = new JsonObject();
+        lineEnd.addProperty("4", true);
+
+        JsonObject annotationStart = new JsonObject();
+        JsonObject annotationStartPayload = new JsonObject();
+        JsonArray changeList = new JsonArray();
+        for (String key : sortedKeys) {
+            JsonObject change = new JsonObject();
+            change.addProperty("1", key);
+            change.addProperty("3", annotations.get(key));
+            changeList.add(change);
+        }
+        annotationStartPayload.add("3", changeList);
+        annotationStart.add("1", annotationStartPayload);
+
+        JsonObject chars = new JsonObject();
+        chars.addProperty("2", text);
+
+        JsonObject annotationEnd = new JsonObject();
+        JsonObject annotationEndPayload = new JsonObject();
+        JsonArray endList = new JsonArray();
+        for (String key : sortedKeys) {
+            endList.add(key);
+        }
+        annotationEndPayload.add("2", endList);
+        annotationEnd.add("1", annotationEndPayload);
+
+        JsonObject bodyEnd = new JsonObject();
+        bodyEnd.addProperty("4", true);
+
+        JsonArray components = new JsonArray();
+        components.add(bodyStart);
+        components.add(lineStart);
+        components.add(lineEnd);
+        components.add(annotationStart);
+        components.add(chars);
+        components.add(annotationEnd);
+        components.add(bodyEnd);
+
+        JsonObject docOp = new JsonObject();
+        docOp.add("1", components);
+
+        JsonObject mutateDoc = new JsonObject();
+        mutateDoc.addProperty("1", blipId);
         mutateDoc.add("2", docOp);
 
         JsonObject opWrapper = new JsonObject();

--- a/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
+++ b/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
@@ -382,6 +382,17 @@ class WaveE2eTest {
 
     @Test @Order(21)
     void test21_aliceMentionsBob() throws Exception {
+        boolean foundBeforeMention = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "mentions:me",
+                E2eTestContext.modernWaveId,
+                5_000,
+                500,
+                0);
+        assertFalse(foundBeforeMention,
+                "Wave " + E2eTestContext.modernWaveId
+                + " should not appear in Bob's mentions:me search before mention is added");
+
         JsonObject lv = E2eTestContext.lastVersion;
         int version = lv.get("1").getAsInt();
         String historyHash = lv.get("2").getAsString();
@@ -421,6 +432,17 @@ class WaveE2eTest {
 
     @Test @Order(23)
     void test23_aliceAddsTaskForBob() throws Exception {
+        boolean foundBeforeTask = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "tasks:me",
+                E2eTestContext.modernWaveId,
+                5_000,
+                500,
+                0);
+        assertFalse(foundBeforeTask,
+                "Wave " + E2eTestContext.modernWaveId
+                + " should not appear in Bob's tasks:me search before task assignment is added");
+
         JsonObject lv = E2eTestContext.lastVersion;
         int version = lv.get("1").getAsInt();
         String historyHash = lv.get("2").getAsString();

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
@@ -75,6 +75,16 @@ public class Lucene9QueryModelTest extends TestCase {
     assertEquals("in:inbox", model.toLegacyQuery());
   }
 
+  public void testTagQueryHasNoTextQuery() throws InvalidQueryException {
+    Lucene9QueryModel model = parser.parse("tag:project-x");
+    assertFalse("tag: queries should stay on the legacy filter path", model.hasTextQuery());
+  }
+
+  public void testTagQueryIsIncludedInLegacyQuery() throws InvalidQueryException {
+    Lucene9QueryModel model = parser.parse("tag:project-x");
+    assertEquals("tag:project-x", model.toLegacyQuery());
+  }
+
   public void testTitleIsExcludedFromLegacyQuery() throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("title:meeting");
     assertEquals("", model.toLegacyQuery());

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.wave.api.SearchResult;
+import java.util.Collections;
 import junit.framework.TestCase;
 import org.mockito.Mockito;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl;
@@ -51,6 +52,33 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
         "tasks:all", 0, 10);
 
     assertEquals(0, result.getTotalResults());
+    verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
+  }
+
+  public void testPureTagQueryReturnsLegacyResultsWithoutLuceneSearch() {
+    SimpleSearchProviderImpl legacySearchProvider = Mockito.mock(SimpleSearchProviderImpl.class);
+    Lucene9WaveIndexerImpl indexer = Mockito.mock(Lucene9WaveIndexerImpl.class);
+    SearchResult legacyResult = new SearchResult("tag:project-x");
+    legacyResult.addDigest(new SearchResult.Digest(
+        "Project X", "snippet", "example.com!w+project-x", Collections.singletonList(
+        "user@example.com"), 123L, 123L, 0, 1));
+    legacyResult.setTotalResults(1);
+
+    when(legacySearchProvider.search(ParticipantId.ofUnsafe("user@example.com"),
+        "tag:project-x", 0, 10000)).thenReturn(legacyResult);
+
+    Lucene9SearchProviderImpl provider = new Lucene9SearchProviderImpl(
+        legacySearchProvider,
+        new Lucene9QueryParser(),
+        new Lucene9QueryCompiler(),
+        indexer);
+
+    SearchResult result = provider.search(ParticipantId.ofUnsafe("user@example.com"),
+        "tag:project-x", 0, 10);
+
+    assertEquals(1, result.getTotalResults());
+    assertEquals(1, result.getNumResults());
+    assertEquals("example.com!w+project-x", result.getDigests().get(0).getWaveId());
     verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
   }
 }


### PR DESCRIPTION
## Summary
- add Lucene routing regression coverage proving pure `tag:` queries stay on the legacy/live search path
- extend the Java E2E search suite to cover `mentions:me` and `tasks:me` after adding those metadata to a wave
- keep the scope test-only; this PR does not change production search behavior

## Why
The original investigation did not reproduce a production failure on current `main`, but it exposed a coverage gap around metadata query routing and end-to-end verification. This PR closes that gap so future regressions in tag, mention, or task search behavior are caught earlier.

## Validation
- `sbt "testOnly org.waveprotocol.box.server.waveserver.lucene9.Lucene9QueryModelTest org.waveprotocol.box.server.waveserver.lucene9.Lucene9SearchProviderImplTest"`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9899 sbt "e2eTest:testOnly org.waveprotocol.wave.e2e.WaveE2eTest"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for mention and task metadata search to ensure assigned and mentioned waves remain discoverable.
  * Added unit tests to verify tag-based search queries use legacy routing and return expected results, preventing unintended index-based lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->