### PR TITLE
[codex] fix GWT CssResource parser warnings

### DIFF
--- a/wave/config/changelog.d/2026-04-12-gwt-cssresource-warnings.json
+++ b/wave/config/changelog.d/2026-04-12-gwt-cssresource-warnings.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-gwt-cssresource-warnings",
+  "version": "PR #854",
+  "date": "2026-04-12",
+  "title": "Silence unsupported CssResource constructs in GWT wave panel CSS",
+  "summary": "Removes unsupported `@media` and `calc()` usage from legacy GWT CssResource inputs and adds a regression test so compileGwt stops emitting parser warnings for the affected wave panel resources.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed unsupported CssResource syntax from the affected wave panel CSS resources.",
+        "Added a regression test that fails if the blocked `@media` or `calc()` constructs return."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
@@ -167,10 +167,12 @@
   gap: 4px;
   margin: 5px 0 0 6px;
   min-height: 24px;
+  max-width: 100%;
   padding: 0 4px 0 8px;
   border: 1px solid #8bbbe5;
   border-radius: 999px;
   background: #ffffff;
+  box-sizing: border-box;
 }
 
 .inlineEditorVisible {
@@ -178,8 +180,9 @@
 }
 
 .inlineInput {
+  flex: 1 1 auto;
   width: 7em;
-  min-width: 5em;
+  min-width: 0;
   margin: 0;
   padding: 0;
   border: 0;

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css
@@ -167,7 +167,6 @@
   gap: 4px;
   margin: 5px 0 0 6px;
   min-height: 24px;
-  max-width: calc(100% - 5.5em);
   padding: 0 4px 0 8px;
   border: 1px solid #8bbbe5;
   border-radius: 999px;

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -397,12 +397,6 @@
   white-space: nowrap;
   font-style: italic;
 }
-@media (max-width: 768px) {
-  .editHint {
-    display: none;
-  }
-}
-
 
 /* ---- Draft-mode active indicator ---- */
 

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -25,8 +25,18 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 public final class WavePanelCssCompatibilityTest extends TestCase {
+  private static final Pattern MEDIA_QUERY_PATTERN = Pattern.compile("(?i)@media\\b");
+  private static final Pattern CALC_FUNCTION_PATTERN = Pattern.compile("(?i)\\bcalc\\s*\\(");
+
+  public void testBlockedCssConstructMatchersCatchFormattingVariants() {
+    assertTrue(containsBlockedMediaQuery("@MEDIA(max-width:768px) { .editHint { display: none; } }"));
+    assertTrue(containsBlockedCalcFunction("width: CALC (100% - 5em);"));
+    assertFalse(containsBlockedMediaQuery(".editHint { display: inline; }"));
+    assertFalse(containsBlockedCalcFunction("width: 100%;"));
+  }
 
   public void testBlipCssUsesRuntimeMobileGuardInsteadOfMediaQuery() throws Exception {
     String css = read(
@@ -36,7 +46,7 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
 
     assertTrue(builder.contains("!MobileDetector.isMobile()"));
     assertTrue(css.contains(".editHint"));
-    assertFalse(css.contains("@media (max-width: 768px)"));
+    assertFalse(containsBlockedMediaQuery(css));
   }
 
   public void testTagsCssAvoidsCalcForInlineEditorWidth() throws Exception {
@@ -44,10 +54,18 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
         "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");
 
     assertTrue(css.contains(".inlineEditor"));
-    assertFalse(css.contains("calc("));
+    assertFalse(containsBlockedCalcFunction(css));
   }
 
   private String read(String relativePath) throws IOException {
     return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
+  }
+
+  private boolean containsBlockedMediaQuery(String css) {
+    return MEDIA_QUERY_PATTERN.matcher(css).find();
+  }
+
+  private boolean containsBlockedCalcFunction(String css) {
+    return CALC_FUNCTION_PATTERN.matcher(css).find();
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class WavePanelCssCompatibilityTest extends TestCase {
+
+  public void testBlipCssUsesRuntimeMobileGuardInsteadOfMediaQuery() throws Exception {
+    String css = read(
+        "wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css");
+    String builder = read(
+        "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java");
+
+    assertTrue(builder.contains("!MobileDetector.isMobile()"));
+    assertTrue(css.contains(".editHint"));
+    assertFalse(css.contains("@media (max-width: 768px)"));
+  }
+
+  public void testTagsCssAvoidsCalcForInlineEditorWidth() throws Exception {
+    String css = read(
+        "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");
+
+    assertTrue(css.contains(".inlineEditor"));
+    assertFalse(css.contains("calc("));
+  }
+
+  private String read(String relativePath) throws IOException {
+    return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 public final class WavePanelCssCompatibilityTest extends TestCase {
   private static final Pattern MEDIA_QUERY_PATTERN = Pattern.compile("(?i)@media\\b");
   private static final Pattern CALC_FUNCTION_PATTERN = Pattern.compile("(?i)\\bcalc\\s*\\(");
+  private static final Pattern CSS_COMMENT_PATTERN = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
 
   public void testBlockedCssConstructMatchersCatchFormattingVariants() {
     assertTrue(containsBlockedMediaQuery("@MEDIA(max-width:768px) { .editHint { display: none; } }"));
@@ -45,7 +46,7 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
         "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java");
 
     assertTrue(builder.contains("!MobileDetector.isMobile()"));
-    assertTrue(css.contains(".editHint"));
+    assertTrue(containsSelectorRule(css, ".editHint"));
     assertFalse(containsBlockedMediaQuery(css));
   }
 
@@ -53,8 +54,14 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
     String css = read(
         "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");
 
-    assertTrue(css.contains(".inlineEditor"));
+    assertTrue(containsSelectorRule(css, ".inlineEditor"));
     assertFalse(containsBlockedCalcFunction(css));
+  }
+
+  public void testSelectorRuleMatcherRejectsSubstringsAndComments() {
+    assertTrue(containsSelectorRule(".inlineEditor { display: inline-flex; }", ".inlineEditor"));
+    assertFalse(containsSelectorRule(".inlineEditorVisible { display: inline-flex; }", ".inlineEditor"));
+    assertFalse(containsSelectorRule("/* .editHint { display: none; } */", ".editHint"));
   }
 
   private String read(String relativePath) throws IOException {
@@ -67,5 +74,12 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
 
   private boolean containsBlockedCalcFunction(String css) {
     return CALC_FUNCTION_PATTERN.matcher(css).find();
+  }
+
+  private boolean containsSelectorRule(String css, String selector) {
+    String cssWithoutComments = CSS_COMMENT_PATTERN.matcher(css).replaceAll("");
+    Pattern selectorRulePattern = Pattern.compile(
+        "(?m)(^|,)\\s*" + Pattern.quote(selector) + "(?=\\s*(,|\\{))");
+    return selectorRulePattern.matcher(cssWithoutComments).find();
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -88,6 +88,20 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     assertFalse(controller.contains("new TagInputWidget("));
   }
 
+  public void testInlineComposerKeepsActionsInsideReservedRailWithoutCalc() throws Exception {
+    String css = read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");
+
+    assertTrue(css.contains(".flow"));
+    assertTrue(css.contains("padding-right: 4.5em;"));
+    assertTrue(css.contains(".inlineEditor"));
+    assertTrue(css.contains("max-width: 100%;"));
+    assertTrue(css.contains("box-sizing: border-box;"));
+    assertTrue(css.contains(".inlineInput"));
+    assertTrue(css.contains("flex: 1 1 auto;"));
+    assertTrue(css.contains("min-width: 0;"));
+    assertFalse(css.contains("max-width: calc("));
+  }
+
   public void testTagFilteringUsesClientSearchQueryEventSeam() throws Exception {
     String clientEvents =
         read("wave/src/main/java/org/waveprotocol/wave/client/events/ClientEvents.java");


### PR DESCRIPTION
## Summary
This removes two GWT `CssResource` parser warning sources that showed up during `sbt run` / `compileGwt`.

## What changed
- removed the redundant `@media (max-width: 768px)` block from the blip edit hint CSS
- removed the unsupported `calc(100% - 5.5em)` width rule from the inline tag editor CSS
- added a regression test that asserts these unsupported constructs do not return in the affected Wave panel CSS resources

## Root cause
The legacy GWT CSS parser used by `compileGwt` does not accept these modern CSS constructs in `CssResource` inputs, so it emitted warnings while compiling `BlipViewBuilder.Resources` and `TagsViewBuilder.Resources`.

The `@media` rule was already redundant because the edit hint is only rendered on desktop in `BlipMetaViewBuilder`. The inline tag editor width cap was not required for the control to render correctly.

## Validation
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `sbt "testOnly org.waveprotocol.box.server.util.WavePanelCssCompatibilityTest"`
- `sbt "compileGwtDev"`
- `sbt "compileGwt"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline editor sizing relaxed to avoid layout clipping.
  * Edit hint remains visible on small/mobile screens.
  * Removed unsupported CSS constructs that triggered build-time warnings.

* **Tests**
  * Added regression tests to ensure the CSS compatibility checks and layout rules don’t regress.

* **Chores**
  * Added a changelog entry documenting the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->