### PR TITLE
[codex] Fix stale tag search after wave cache commit notifications

### DIFF
--- a/wave/config/changelog.d/2026-04-12-tag-search-stale-wave-cache.json
+++ b/wave/config/changelog.d/2026-04-12-tag-search-stale-wave-cache.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-12-tag-search-stale-wave-cache",
+  "version": "PR #855",
+  "date": "2026-04-12",
+  "title": "Keep tag search fresh after wave cache commit notifications",
+  "summary": "Fixes stale `tag:` results when a cached wave lags behind a newer committed wavelet version delivered through commit notifications.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Invalidate a cached wave only when a commit notification proves the cached wavelet version is older than the committed version",
+        "Preserve fresh local wave state so immediate metadata searches still reuse the in-memory cache when no newer committed data exists",
+        "Add regression coverage for existing tag documents, stale shared-store caches, and pure `tag:` queries that must stay on the legacy search path"
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
+++ b/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
@@ -6,6 +6,10 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -376,6 +380,85 @@ class WaveE2eTest {
                 + " not found in Alice's tag search within 20s");
     }
 
+    @Test @Order(21)
+    void test21_aliceMentionsBob() throws Exception {
+        JsonObject lv = E2eTestContext.lastVersion;
+        int version = lv.get("1").getAsInt();
+        String historyHash = lv.get("2").getAsString();
+
+        JsonObject delta = makeMentionDelta(
+                aliceAddr(),
+                "b+mention" + E2eTestContext.RUN_ID,
+                "@bob ping from e2e",
+                bobAddr(),
+                version,
+                historyHash);
+        JsonObject submitReq =
+                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
+        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
+
+        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
+        JsonObject msg = resp.get("message").getAsJsonObject();
+        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
+                "Expected operations_applied > 0 adding mention, got: " + resp);
+        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
+        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
+    }
+
+    @Test @Order(22)
+    void test22_bobMentionSearchFindsWave() throws Exception {
+        boolean found = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "mentions:me",
+                E2eTestContext.modernWaveId,
+                20_000,
+                500,
+                0);
+        assertTrue(found,
+                "Wave " + E2eTestContext.modernWaveId
+                + " not found in Bob's mentions:me search within 20s");
+    }
+
+    @Test @Order(23)
+    void test23_aliceAddsTaskForBob() throws Exception {
+        JsonObject lv = E2eTestContext.lastVersion;
+        int version = lv.get("1").getAsInt();
+        String historyHash = lv.get("2").getAsString();
+
+        JsonObject delta = makeTaskDelta(
+                aliceAddr(),
+                "b+task" + E2eTestContext.RUN_ID,
+                "Task assigned to Bob",
+                "task-" + E2eTestContext.RUN_ID,
+                bobAddr(),
+                version,
+                historyHash);
+        JsonObject submitReq =
+                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
+        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
+
+        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
+        JsonObject msg = resp.get("message").getAsJsonObject();
+        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
+                "Expected operations_applied > 0 adding task, got: " + resp);
+        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
+        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
+    }
+
+    @Test @Order(24)
+    void test24_bobTaskSearchFindsWave() throws Exception {
+        boolean found = pollSearchQueryForWave(
+                E2eTestContext.bobJsessionid,
+                "tasks:me",
+                E2eTestContext.modernWaveId,
+                20_000,
+                500,
+                0);
+        assertTrue(found,
+                "Wave " + E2eTestContext.modernWaveId
+                + " not found in Bob's tasks:me search within 20s");
+    }
+
     // =========================================================================
     // Protocol message builders
     // =========================================================================
@@ -508,6 +591,101 @@ class WaveE2eTest {
 
         JsonObject mutateDoc = new JsonObject();
         mutateDoc.addProperty("1", "tags");
+        mutateDoc.add("2", docOp);
+
+        JsonObject opWrapper = new JsonObject();
+        opWrapper.add("3", mutateDoc);
+
+        JsonArray ops = new JsonArray();
+        ops.add(opWrapper);
+
+        JsonObject delta = new JsonObject();
+        delta.add("1", makeHashedVersion(version, historyHash));
+        delta.addProperty("2", author);
+        delta.add("3", ops);
+        delta.add("4", new JsonArray());
+        return delta;
+    }
+
+    private static JsonObject makeMentionDelta(String author, String blipId, String text,
+                                               String mentionedAddress,
+                                               int version, String historyHash) {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("mention/user", mentionedAddress);
+        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
+    }
+
+    private static JsonObject makeTaskDelta(String author, String blipId, String text,
+                                            String taskId, String assigneeAddress,
+                                            int version, String historyHash) {
+        Map<String, String> annotations = new LinkedHashMap<>();
+        annotations.put("task/id", taskId);
+        annotations.put("task/assignee", assigneeAddress);
+        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
+    }
+
+    private static JsonObject makeAnnotatedTextDelta(String author, String blipId, String text,
+                                                     Map<String, String> annotations,
+                                                     int version, String historyHash) {
+        List<String> sortedKeys = new ArrayList<>(annotations.keySet());
+        sortedKeys.sort(String::compareTo);
+
+        JsonObject bodyStart = new JsonObject();
+        JsonObject bodyElem = new JsonObject();
+        bodyElem.addProperty("1", "body");
+        bodyElem.add("2", new JsonArray());
+        bodyStart.add("3", bodyElem);
+
+        JsonObject lineStart = new JsonObject();
+        JsonObject lineElem = new JsonObject();
+        lineElem.addProperty("1", "line");
+        lineElem.add("2", new JsonArray());
+        lineStart.add("3", lineElem);
+
+        JsonObject lineEnd = new JsonObject();
+        lineEnd.addProperty("4", true);
+
+        JsonObject annotationStart = new JsonObject();
+        JsonObject annotationStartPayload = new JsonObject();
+        JsonArray changeList = new JsonArray();
+        for (String key : sortedKeys) {
+            JsonObject change = new JsonObject();
+            change.addProperty("1", key);
+            change.addProperty("3", annotations.get(key));
+            changeList.add(change);
+        }
+        annotationStartPayload.add("3", changeList);
+        annotationStart.add("1", annotationStartPayload);
+
+        JsonObject chars = new JsonObject();
+        chars.addProperty("2", text);
+
+        JsonObject annotationEnd = new JsonObject();
+        JsonObject annotationEndPayload = new JsonObject();
+        JsonArray endList = new JsonArray();
+        for (String key : sortedKeys) {
+            endList.add(key);
+        }
+        annotationEndPayload.add("2", endList);
+        annotationEnd.add("1", annotationEndPayload);
+
+        JsonObject bodyEnd = new JsonObject();
+        bodyEnd.addProperty("4", true);
+
+        JsonArray components = new JsonArray();
+        components.add(bodyStart);
+        components.add(lineStart);
+        components.add(lineEnd);
+        components.add(annotationStart);
+        components.add(chars);
+        components.add(annotationEnd);
+        components.add(bodyEnd);
+
+        JsonObject docOp = new JsonObject();
+        docOp.add("1", components);
+
+        JsonObject mutateDoc = new JsonObject();
+        mutateDoc.addProperty("1", blipId);
         mutateDoc.add("2", docOp);
 
         JsonObject opWrapper = new JsonObject();

--- a/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
+++ b/wave/src/e2e-test/java/org/waveprotocol/wave/e2e/WaveE2eTest.java
@@ -6,10 +6,6 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -380,85 +376,6 @@ class WaveE2eTest {
                 + " not found in Alice's tag search within 20s");
     }
 
-    @Test @Order(21)
-    void test21_aliceMentionsBob() throws Exception {
-        JsonObject lv = E2eTestContext.lastVersion;
-        int version = lv.get("1").getAsInt();
-        String historyHash = lv.get("2").getAsString();
-
-        JsonObject delta = makeMentionDelta(
-                aliceAddr(),
-                "b+mention" + E2eTestContext.RUN_ID,
-                "@bob ping from e2e",
-                bobAddr(),
-                version,
-                historyHash);
-        JsonObject submitReq =
-                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
-        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
-
-        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
-        JsonObject msg = resp.get("message").getAsJsonObject();
-        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
-                "Expected operations_applied > 0 adding mention, got: " + resp);
-        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
-        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
-    }
-
-    @Test @Order(22)
-    void test22_bobMentionSearchFindsWave() throws Exception {
-        boolean found = pollSearchQueryForWave(
-                E2eTestContext.bobJsessionid,
-                "mentions:me",
-                E2eTestContext.modernWaveId,
-                20_000,
-                500,
-                0);
-        assertTrue(found,
-                "Wave " + E2eTestContext.modernWaveId
-                + " not found in Bob's mentions:me search within 20s");
-    }
-
-    @Test @Order(23)
-    void test23_aliceAddsTaskForBob() throws Exception {
-        JsonObject lv = E2eTestContext.lastVersion;
-        int version = lv.get("1").getAsInt();
-        String historyHash = lv.get("2").getAsString();
-
-        JsonObject delta = makeTaskDelta(
-                aliceAddr(),
-                "b+task" + E2eTestContext.RUN_ID,
-                "Task assigned to Bob",
-                "task-" + E2eTestContext.RUN_ID,
-                bobAddr(),
-                version,
-                historyHash);
-        JsonObject submitReq =
-                makeSubmitRequest(E2eTestContext.waveletName, delta, E2eTestContext.channelId);
-        E2eTestContext.aliceWs.send("ProtocolSubmitRequest", submitReq);
-
-        JsonObject resp = E2eTestContext.aliceWs.recvUntil("ProtocolSubmitResponse", 30_000);
-        JsonObject msg = resp.get("message").getAsJsonObject();
-        assertTrue(msg.has("1") && msg.get("1").getAsInt() > 0,
-                "Expected operations_applied > 0 adding task, got: " + resp);
-        assertTrue(msg.has("3"), "Submit response missing hashed_version_after_application");
-        E2eTestContext.lastVersion = msg.get("3").getAsJsonObject();
-    }
-
-    @Test @Order(24)
-    void test24_bobTaskSearchFindsWave() throws Exception {
-        boolean found = pollSearchQueryForWave(
-                E2eTestContext.bobJsessionid,
-                "tasks:me",
-                E2eTestContext.modernWaveId,
-                20_000,
-                500,
-                0);
-        assertTrue(found,
-                "Wave " + E2eTestContext.modernWaveId
-                + " not found in Bob's tasks:me search within 20s");
-    }
-
     // =========================================================================
     // Protocol message builders
     // =========================================================================
@@ -591,101 +508,6 @@ class WaveE2eTest {
 
         JsonObject mutateDoc = new JsonObject();
         mutateDoc.addProperty("1", "tags");
-        mutateDoc.add("2", docOp);
-
-        JsonObject opWrapper = new JsonObject();
-        opWrapper.add("3", mutateDoc);
-
-        JsonArray ops = new JsonArray();
-        ops.add(opWrapper);
-
-        JsonObject delta = new JsonObject();
-        delta.add("1", makeHashedVersion(version, historyHash));
-        delta.addProperty("2", author);
-        delta.add("3", ops);
-        delta.add("4", new JsonArray());
-        return delta;
-    }
-
-    private static JsonObject makeMentionDelta(String author, String blipId, String text,
-                                               String mentionedAddress,
-                                               int version, String historyHash) {
-        Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("mention/user", mentionedAddress);
-        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
-    }
-
-    private static JsonObject makeTaskDelta(String author, String blipId, String text,
-                                            String taskId, String assigneeAddress,
-                                            int version, String historyHash) {
-        Map<String, String> annotations = new LinkedHashMap<>();
-        annotations.put("task/id", taskId);
-        annotations.put("task/assignee", assigneeAddress);
-        return makeAnnotatedTextDelta(author, blipId, text, annotations, version, historyHash);
-    }
-
-    private static JsonObject makeAnnotatedTextDelta(String author, String blipId, String text,
-                                                     Map<String, String> annotations,
-                                                     int version, String historyHash) {
-        List<String> sortedKeys = new ArrayList<>(annotations.keySet());
-        sortedKeys.sort(String::compareTo);
-
-        JsonObject bodyStart = new JsonObject();
-        JsonObject bodyElem = new JsonObject();
-        bodyElem.addProperty("1", "body");
-        bodyElem.add("2", new JsonArray());
-        bodyStart.add("3", bodyElem);
-
-        JsonObject lineStart = new JsonObject();
-        JsonObject lineElem = new JsonObject();
-        lineElem.addProperty("1", "line");
-        lineElem.add("2", new JsonArray());
-        lineStart.add("3", lineElem);
-
-        JsonObject lineEnd = new JsonObject();
-        lineEnd.addProperty("4", true);
-
-        JsonObject annotationStart = new JsonObject();
-        JsonObject annotationStartPayload = new JsonObject();
-        JsonArray changeList = new JsonArray();
-        for (String key : sortedKeys) {
-            JsonObject change = new JsonObject();
-            change.addProperty("1", key);
-            change.addProperty("3", annotations.get(key));
-            changeList.add(change);
-        }
-        annotationStartPayload.add("3", changeList);
-        annotationStart.add("1", annotationStartPayload);
-
-        JsonObject chars = new JsonObject();
-        chars.addProperty("2", text);
-
-        JsonObject annotationEnd = new JsonObject();
-        JsonObject annotationEndPayload = new JsonObject();
-        JsonArray endList = new JsonArray();
-        for (String key : sortedKeys) {
-            endList.add(key);
-        }
-        annotationEndPayload.add("2", endList);
-        annotationEnd.add("1", annotationEndPayload);
-
-        JsonObject bodyEnd = new JsonObject();
-        bodyEnd.addProperty("4", true);
-
-        JsonArray components = new JsonArray();
-        components.add(bodyStart);
-        components.add(lineStart);
-        components.add(lineEnd);
-        components.add(annotationStart);
-        components.add(chars);
-        components.add(annotationEnd);
-        components.add(bodyEnd);
-
-        JsonObject docOp = new JsonObject();
-        docOp.add("1", components);
-
-        JsonObject mutateDoc = new JsonObject();
-        mutateDoc.addProperty("1", blipId);
         mutateDoc.add("2", docOp);
 
         JsonObject opWrapper = new JsonObject();

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -90,9 +90,11 @@ public class MemoryPerUserWaveViewHandlerImpl
    * Monotonic epoch for the last non-search wavelet mutation observed on the wave bus.
    */
   private final AtomicLong waveMutationEpoch = new AtomicLong(0);
+  private final WaveMap waveMap;
 
   @Inject
   public MemoryPerUserWaveViewHandlerImpl(final WaveMap waveMap) {
+    this.waveMap = waveMap;
     // Let the view expire if it not accessed for some time.
     explicitPerUserWaveViews =
         CacheBuilder.newBuilder().expireAfterAccess(PER_USER_WAVES_VIEW_CACHE_MINUTES,
@@ -239,7 +241,27 @@ public class MemoryPerUserWaveViewHandlerImpl
 
   @Override
   public void waveletCommitted(WaveletName waveletName, HashedVersion version) {
+    invalidateWaveCacheIfStale(waveletName, version);
     markWaveMapDirty(waveletName);
+  }
+
+  private void invalidateWaveCacheIfStale(WaveletName waveletName, HashedVersion version) {
+    if (waveletName == null || version == null || isSearchWavelet(waveletName)) {
+      return;
+    }
+    try {
+      WaveletContainer container = waveMap.getWavelet(waveletName);
+      if (container == null) {
+        return;
+      }
+      HashedVersion cachedVersion = container.getLastCommittedVersion();
+      if (cachedVersion == null || cachedVersion.getVersion() < version.getVersion()) {
+        waveMap.invalidateWave(waveletName.waveId);
+      }
+    } catch (WaveletStateException e) {
+      LOG.warning("Failed to compare cached version for " + waveletName, e);
+      waveMap.invalidateWave(waveletName.waveId);
+    }
   }
 
   private void markWaveMapDirty(WaveletName waveletName) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -241,8 +241,11 @@ public class MemoryPerUserWaveViewHandlerImpl
 
   @Override
   public void waveletCommitted(WaveletName waveletName, HashedVersion version) {
-    invalidateWaveCacheIfStale(waveletName, version);
-    markWaveMapDirty(waveletName);
+    try {
+      invalidateWaveCacheIfStale(waveletName, version);
+    } finally {
+      markWaveMapDirty(waveletName);
+    }
   }
 
   private void invalidateWaveCacheIfStale(WaveletName waveletName, HashedVersion version) {
@@ -250,7 +253,7 @@ public class MemoryPerUserWaveViewHandlerImpl
       return;
     }
     try {
-      WaveletContainer container = waveMap.getWavelet(waveletName);
+      WaveletContainer container = waveMap.getCachedWavelet(waveletName);
       if (container == null) {
         return;
       }
@@ -258,7 +261,7 @@ public class MemoryPerUserWaveViewHandlerImpl
       if (cachedVersion == null || cachedVersion.getVersion() < version.getVersion()) {
         waveMap.invalidateWave(waveletName.waveId);
       }
-    } catch (WaveletStateException e) {
+    } catch (WaveletStateException | RuntimeException e) {
       LOG.warning("Failed to compare cached version for " + waveletName, e);
       waveMap.invalidateWave(waveletName.waveId);
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -259,12 +259,32 @@ public class MemoryPerUserWaveViewHandlerImpl
       }
       HashedVersion cachedVersion = container.getLastCommittedVersion();
       if (cachedVersion == null || cachedVersion.getVersion() < version.getVersion()) {
-        waveMap.invalidateWave(waveletName.waveId);
+        invalidateWaveBestEffort(waveletName.waveId);
       }
+    } catch (IllegalStateException e) {
+      if (isCommitCallbackWriteLockPrecondition(e)) {
+        LOG.fine("Skipping cached version check while commit callback still holds write lock for "
+            + waveletName);
+        return;
+      }
+      LOG.warning("Failed to compare cached version for " + waveletName, e);
+      invalidateWaveBestEffort(waveletName.waveId);
     } catch (WaveletStateException | RuntimeException e) {
       LOG.warning("Failed to compare cached version for " + waveletName, e);
-      waveMap.invalidateWave(waveletName.waveId);
+      invalidateWaveBestEffort(waveletName.waveId);
     }
+  }
+
+  private void invalidateWaveBestEffort(WaveId waveId) {
+    try {
+      waveMap.invalidateWave(waveId);
+    } catch (RuntimeException e) {
+      LOG.warning("Failed to invalidate cached wave " + waveId, e);
+    }
+  }
+
+  private boolean isCommitCallbackWriteLockPrecondition(IllegalStateException e) {
+    return e.getMessage() != null && e.getMessage().contains("should not hold write lock");
   }
 
   private void markWaveMapDirty(WaveletName waveletName) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/Wave.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/Wave.java
@@ -103,6 +103,14 @@ final class Wave implements Iterable<WaveletContainer> {
     return getWavelet(waveletId, remoteWavelets);
   }
 
+  WaveletContainer getCachedWavelet(WaveletId waveletId) {
+    WaveletContainer wavelet = remoteWavelets.getIfPresent(waveletId);
+    if (wavelet != null) {
+      return wavelet;
+    }
+    return localWavelets.getIfPresent(waveletId);
+  }
+
   LocalWaveletContainer getOrCreateLocalWavelet(WaveletId waveletId) {
     try {
       return localWavelets.get(waveletId);

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
@@ -121,6 +121,12 @@ public class WaveMap {
     waves.asMap().clear();
   }
 
+  public void invalidateWave(WaveId waveId) {
+    if (waveId != null) {
+      waves.invalidate(waveId);
+    }
+  }
+
   /**
    * Returns defensive copy of the map that holds waves.
    */

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
@@ -127,6 +127,14 @@ public class WaveMap {
     }
   }
 
+  public WaveletContainer getCachedWavelet(WaveletName waveletName) {
+    Wave wave = waves.getIfPresent(waveletName.waveId);
+    if (wave == null) {
+      return null;
+    }
+    return wave.getCachedWavelet(waveletName.waveletId);
+  }
+
   /**
    * Returns defensive copy of the map that holds waves.
    */

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -123,7 +123,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     handler.retrievePerUserWaveView(PARTICIPANT);
     handler.retrievePerUserWaveView(SECOND_PARTICIPANT);
 
-    assertEquals(1, reloadingWaveMap.loadAllWaveletsCallCount);
+    assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
   }
 
   public void testRetrievePerUserWaveViewCacheHitSkipsReload() {
@@ -133,10 +133,55 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     handler.retrievePerUserWaveView(PARTICIPANT);
     handler.retrievePerUserWaveView(PARTICIPANT);
 
-    assertEquals(1, reloadingWaveMap.loadAllWaveletsCallCount);
+    assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
   }
 
-  private static final class ReloadingWaveMap extends WaveMap {
+  public void testWaveletCommittedMarksWaveMapDirtyWhenInvalidateThrowsRuntimeException()
+      throws Exception {
+    ExplodingInvalidateWaveMap reloadingWaveMap =
+        new ExplodingInvalidateWaveMap(createLoadedWaves(new FakeLocalWavelet(
+            WAVELET_NAME, PARTICIPANT, HashedVersion.unsigned(1L))));
+    MemoryPerUserWaveViewHandlerImpl handler =
+        new MemoryPerUserWaveViewHandlerImpl(reloadingWaveMap);
+
+    handler.retrievePerUserWaveView(PARTICIPANT);
+    assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
+
+    handler.explicitPerUserWaveViews.invalidate(PARTICIPANT);
+
+    handler.waveletCommitted(WAVELET_NAME, HashedVersion.unsigned(2L));
+
+    handler.retrievePerUserWaveView(PARTICIPANT);
+    assertEquals(2, reloadingWaveMap.getLoadAllWaveletsCallCount());
+  }
+
+  private static ImmutableMap<WaveId, Wave> createLoadedWaves(LocalWaveletContainer container)
+      throws Exception {
+    SettableFuture<ImmutableSet<WaveletId>> lookedupWavelets = SettableFuture.create();
+    lookedupWavelets.set(ImmutableSet.of(WAVELET_ID));
+
+    LocalWaveletContainer.Factory localFactory = new LocalWaveletContainer.Factory() {
+      @Override
+      public LocalWaveletContainer create(WaveletNotificationSubscriber notifiee,
+          WaveletName waveletName, String domain) {
+        return container;
+      }
+    };
+    RemoteWaveletContainer.Factory remoteFactory = new RemoteWaveletContainer.Factory() {
+      @Override
+      public RemoteWaveletContainer create(WaveletNotificationSubscriber notifiee,
+          WaveletName waveletName, String domain) {
+        throw new UnsupportedOperationException();
+      }
+    };
+
+    Wave wave = new Wave(
+        WAVE_ID, lookedupWavelets, NO_OP_NOTIFIEE, localFactory, remoteFactory, DOMAIN);
+    wave.getOrCreateLocalWavelet(WAVELET_ID);
+    return ImmutableMap.of(WAVE_ID, wave);
+  }
+
+  private static class ReloadingWaveMap extends WaveMap {
     private final ImmutableMap<WaveId, Wave> loadedWaves;
     private boolean loaded;
     private int loadAllWaveletsCallCount;
@@ -153,6 +198,10 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     public void loadAllWavelets() {
       loaded = true;
       loadAllWaveletsCallCount++;
+    }
+
+    int getLoadAllWaveletsCallCount() {
+      return loadAllWaveletsCallCount;
     }
 
     @Override
@@ -189,11 +238,52 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     }
   }
 
+  private static final class ExplodingInvalidateWaveMap extends ReloadingWaveMap {
+    private ExplodingInvalidateWaveMap(ImmutableMap<WaveId, Wave> loadedWaves) {
+      super(
+          new DeltaStoreBasedSnapshotStore(
+              new org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore(), null),
+          new LocalWaveletContainer.Factory() {
+            @Override
+            public LocalWaveletContainer create(
+                WaveletNotificationSubscriber notifiee,
+                WaveletName waveletName,
+                String domain) {
+              throw new UnsupportedOperationException();
+            }
+          },
+          new RemoteWaveletContainer.Factory() {
+            @Override
+            public RemoteWaveletContainer create(
+                WaveletNotificationSubscriber notifiee,
+                WaveletName waveletName,
+                String domain) {
+              throw new UnsupportedOperationException();
+            }
+          },
+          loadedWaves);
+    }
+
+    @Override
+    public void invalidateWave(WaveId waveId) {
+      throw new RuntimeException("boom");
+    }
+  }
+
   private static final class FakeLocalWavelet implements LocalWaveletContainer {
     private final WaveletName waveletName;
+    private final ParticipantId participant;
+    private final HashedVersion lastCommittedVersion;
 
     private FakeLocalWavelet(WaveletName waveletName) {
+      this(waveletName, PARTICIPANT, null);
+    }
+
+    private FakeLocalWavelet(
+        WaveletName waveletName, ParticipantId participant, HashedVersion lastCommittedVersion) {
       this.waveletName = waveletName;
+      this.participant = participant;
+      this.lastCommittedVersion = lastCommittedVersion;
     }
 
     @Override
@@ -235,12 +325,12 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
 
     @Override
     public HashedVersion getLastCommittedVersion() {
-      throw new UnsupportedOperationException();
+      return lastCommittedVersion;
     }
 
     @Override
     public boolean hasParticipant(ParticipantId participant) {
-      return PARTICIPANT.equals(participant);
+      return this.participant.equals(participant);
     }
 
     @Override

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -136,6 +136,47 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
   }
 
+  public void testWaveletCommittedSkipsInvalidateWhenCommittedVersionCheckRequiresWriteLock()
+      throws Exception {
+    ReloadingWaveMap reloadingWaveMap =
+        new ReloadingWaveMap(
+            new DeltaStoreBasedSnapshotStore(
+                new org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore(), null),
+            new LocalWaveletContainer.Factory() {
+              @Override
+              public LocalWaveletContainer create(
+                  WaveletNotificationSubscriber notifiee,
+                  WaveletName waveletName,
+                  String domain) {
+                throw new UnsupportedOperationException();
+              }
+            },
+            new RemoteWaveletContainer.Factory() {
+              @Override
+              public RemoteWaveletContainer create(
+                  WaveletNotificationSubscriber notifiee,
+                  WaveletName waveletName,
+                  String domain) {
+                throw new UnsupportedOperationException();
+              }
+            },
+            createLoadedWaves(
+                new FakeLocalWavelet(
+                    WAVELET_NAME,
+                    PARTICIPANT,
+                    null,
+                    new IllegalStateException("should not hold write lock"))));
+    MemoryPerUserWaveViewHandlerImpl handler =
+        new MemoryPerUserWaveViewHandlerImpl(reloadingWaveMap);
+
+    handler.retrievePerUserWaveView(PARTICIPANT);
+    assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
+
+    handler.waveletCommitted(WAVELET_NAME, HashedVersion.unsigned(2L));
+
+    assertEquals(0, reloadingWaveMap.getInvalidateWaveCallCount());
+  }
+
   public void testWaveletCommittedMarksWaveMapDirtyWhenInvalidateThrowsRuntimeException()
       throws Exception {
     ExplodingInvalidateWaveMap reloadingWaveMap =
@@ -150,6 +191,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     handler.explicitPerUserWaveViews.invalidate(PARTICIPANT);
 
     handler.waveletCommitted(WAVELET_NAME, HashedVersion.unsigned(2L));
+    assertEquals(1, reloadingWaveMap.getInvalidateWaveCallCount());
 
     handler.retrievePerUserWaveView(PARTICIPANT);
     assertEquals(2, reloadingWaveMap.getLoadAllWaveletsCallCount());
@@ -185,6 +227,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     private final ImmutableMap<WaveId, Wave> loadedWaves;
     private boolean loaded;
     private int loadAllWaveletsCallCount;
+    private int invalidateWaveCallCount;
 
     private ReloadingWaveMap(DeltaAndSnapshotStore store,
         LocalWaveletContainer.Factory localFactory, RemoteWaveletContainer.Factory remoteFactory,
@@ -204,9 +247,35 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
       return loadAllWaveletsCallCount;
     }
 
+    int getInvalidateWaveCallCount() {
+      return invalidateWaveCallCount;
+    }
+
     @Override
     Map<WaveId, Wave> getWaves() {
       return loaded ? loadedWaves : ImmutableMap.of();
+    }
+
+    protected void recordInvalidateWaveCall() {
+      invalidateWaveCallCount++;
+    }
+
+    @Override
+    public void invalidateWave(WaveId waveId) {
+      recordInvalidateWaveCall();
+      super.invalidateWave(waveId);
+    }
+
+    @Override
+    public WaveletContainer getCachedWavelet(WaveletName waveletName) {
+      if (!loaded) {
+        return null;
+      }
+      Wave wave = loadedWaves.get(waveletName.waveId);
+      if (wave == null) {
+        return null;
+      }
+      return wave.getCachedWavelet(waveletName.waveletId);
     }
 
     @Override
@@ -266,6 +335,7 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
 
     @Override
     public void invalidateWave(WaveId waveId) {
+      recordInvalidateWaveCall();
       throw new RuntimeException("boom");
     }
   }
@@ -274,16 +344,26 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     private final WaveletName waveletName;
     private final ParticipantId participant;
     private final HashedVersion lastCommittedVersion;
+    private final RuntimeException lastCommittedVersionException;
 
     private FakeLocalWavelet(WaveletName waveletName) {
-      this(waveletName, PARTICIPANT, null);
+      this(waveletName, PARTICIPANT, null, null);
     }
 
     private FakeLocalWavelet(
         WaveletName waveletName, ParticipantId participant, HashedVersion lastCommittedVersion) {
+      this(waveletName, participant, lastCommittedVersion, null);
+    }
+
+    private FakeLocalWavelet(
+        WaveletName waveletName,
+        ParticipantId participant,
+        HashedVersion lastCommittedVersion,
+        RuntimeException lastCommittedVersionException) {
       this.waveletName = waveletName;
       this.participant = participant;
       this.lastCommittedVersion = lastCommittedVersion;
+      this.lastCommittedVersionException = lastCommittedVersionException;
     }
 
     @Override
@@ -325,6 +405,9 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
 
     @Override
     public HashedVersion getLastCommittedVersion() {
+      if (lastCommittedVersionException != null) {
+        throw lastCommittedVersionException;
+      }
       return lastCommittedVersion;
     }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -46,6 +46,9 @@ import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl.WaveSupplementContext;
 import org.waveprotocol.wave.model.conversation.AnnotationConstants;
 import org.waveprotocol.wave.model.document.operation.Attributes;
+import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
+import org.waveprotocol.wave.model.document.operation.DocInitialization;
+import org.waveprotocol.wave.model.document.operation.DocInitializationCursor;
 import org.waveprotocol.wave.model.document.operation.impl.AnnotationBoundaryMapImpl;
 import org.waveprotocol.wave.model.document.operation.impl.AttributesImpl;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
@@ -75,6 +78,7 @@ import org.waveprotocol.box.server.robots.RobotWaveletData;
 import org.waveprotocol.box.server.robots.util.RobotsUtil;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
 import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
@@ -195,6 +199,7 @@ public class SimpleSearchProviderImplTest extends TestCase {
   @Mock private RemoteWaveletContainer.Factory remoteWaveletContainerFactory;
   @Mock private PerUserWaveViewProvider waveViewProvider;
 
+  private MemoryDeltaStore deltaStore;
   private SearchProvider searchProvider;
   private MemoryPerUserWaveViewHandlerImpl runtimeWaveViewProvider;
   private SearchProvider runtimeSearchProvider;
@@ -215,7 +220,7 @@ public class SimpleSearchProviderImplTest extends TestCase {
     ConversationUtil conversationUtil = new ConversationUtil(idGenerator);
     WaveDigester digester = new WaveDigester(conversationUtil);
 
-    final MemoryDeltaStore deltaStore = new MemoryDeltaStore();
+    deltaStore = new MemoryDeltaStore();
     final DeltaAndSnapshotStore inMemoryWaveletStore =
         new DeltaStoreBasedSnapshotStore(deltaStore, null);
     final Executor persistExecutor = MoreExecutors.directExecutor();
@@ -917,6 +922,65 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(wave.waveId.serialise(), tagResults.getDigests().get(0).getWaveId());
   }
 
+  public void testRuntimeTagSearchSeesNewTagWhenTagsDocumentAlreadyExists()
+      throws Exception {
+    WaveletName wave = WaveletName.of(WaveId.of(DOMAIN, "freshness-existing-tags"), WAVELET_ID);
+
+    submitDeltaToNewWaveletWithoutView(wave, USER1, runtimeAddParticipant(USER1));
+    runtimeWaveViewProvider.onParticipantAdded(wave, USER1).get();
+    addTagToWavelet(wave, USER1, "existing-tag");
+    runtimeWaveViewProvider.waveletCommitted(wave, null);
+
+    SearchResult existingTagResults =
+        runtimeSearchProvider.search(USER1, "tag:existing-tag", 0, 20);
+    assertEquals(1, existingTagResults.getNumResults());
+    assertEquals(wave.waveId.serialise(), existingTagResults.getDigests().get(0).getWaveId());
+
+    addTagToWavelet(wave, USER1, "new-tag");
+    runtimeWaveViewProvider.waveletCommitted(wave, null);
+
+    waveMap.unloadAllWavelets();
+    runtimeWaveViewProvider.explicitPerUserWaveViews.invalidate(USER1);
+    runtimeWaveViewProvider.waveletCommitted(wave, null);
+
+    SearchResult newTagResults = runtimeSearchProvider.search(USER1, "tag:new-tag", 0, 20);
+    assertEquals(1, newTagResults.getNumResults());
+    assertEquals(wave.waveId.serialise(), newTagResults.getDigests().get(0).getWaveId());
+  }
+
+  public void testRuntimeTagSearchRefreshesCachedWaveAfterExternalTagMutation()
+      throws Exception {
+    WaveletName wave = WaveletName.of(WaveId.of(DOMAIN, "freshness-external-tag"), WAVELET_ID);
+
+    submitDeltaToNewWaveletWithoutView(wave, USER1, runtimeAddParticipant(USER1));
+    runtimeWaveViewProvider.onParticipantAdded(wave, USER1).get();
+    addTagToWavelet(wave, USER1, "existing-tag");
+    runtimeWaveViewProvider.waveletCommitted(wave, null);
+
+    WaveMap staleWaveMap = createWaveMap(deltaStore);
+    MemoryPerUserWaveViewHandlerImpl staleWaveViewProvider =
+        new MemoryPerUserWaveViewHandlerImpl(staleWaveMap);
+    SearchProvider staleSearchProvider =
+        new SimpleSearchProviderImpl(
+            DOMAIN,
+            new WaveDigester(new ConversationUtil(idGenerator)),
+            staleWaveMap,
+            staleWaveViewProvider);
+
+    SearchResult warmResults = staleSearchProvider.search(USER1, "tag:existing-tag", 0, 20);
+    assertEquals(1, warmResults.getNumResults());
+
+    addTagToWavelet(wave, USER1, "new-tag");
+    staleWaveViewProvider.explicitPerUserWaveViews.invalidate(USER1);
+    staleWaveViewProvider.waveletCommitted(
+        wave,
+        waveMap.getWavelet(wave).getLastCommittedVersion());
+
+    SearchResult newTagResults = staleSearchProvider.search(USER1, "tag:new-tag", 0, 20);
+    assertEquals(1, newTagResults.getNumResults());
+    assertEquals(wave.waveId.serialise(), newTagResults.getDigests().get(0).getWaveId());
+  }
+
   public void testSearchFilterByMentionsReturnsOnlyMentionedWaves() throws Exception {
     WaveletName mentionedWave = WaveletName.of(WaveId.of(DOMAIN, "mentioned"), WAVELET_ID);
     WaveletName unmentionedWave = WaveletName.of(WaveId.of(DOMAIN, "unmentioned"), WAVELET_ID);
@@ -1083,6 +1147,49 @@ public class SimpleSearchProviderImplTest extends TestCase {
     return new AddParticipant(CONTEXT, user);
   }
 
+  private WaveMap createWaveMap(MemoryDeltaStore store) {
+    final DeltaAndSnapshotStore snapshotStore =
+        new DeltaStoreBasedSnapshotStore(store, null);
+    final Executor persistExecutor = MoreExecutors.directExecutor();
+    final Executor storageContinuationExecutor = MoreExecutors.directExecutor();
+    final Executor lookupExecutor = MoreExecutors.directExecutor();
+
+    LocalWaveletContainer.Factory localWaveletContainerFactory =
+        new LocalWaveletContainer.Factory() {
+          @Override
+          public LocalWaveletContainer create(WaveletNotificationSubscriber notifiee,
+              WaveletName waveletName, String domain) {
+            WaveletState waveletState;
+            try {
+              waveletState =
+                  DeltaStoreBasedWaveletState.create(store.open(waveletName), persistExecutor);
+            } catch (PersistenceException e) {
+              throw new RuntimeException(e);
+            }
+            return new LocalWaveletContainerImpl(
+                waveletName,
+                notifiee,
+                Futures.immediateFuture(waveletState),
+                DOMAIN,
+                storageContinuationExecutor);
+          }
+        };
+
+    Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
+        "core.wave_cache_size", 1000,
+        "core.wave_cache_expire", "60m")
+    );
+
+    return new WaveMap(
+        snapshotStore,
+        notifiee,
+        localWaveletContainerFactory,
+        remoteWaveletContainerFactory,
+        DOMAIN,
+        config,
+        lookupExecutor);
+  }
+
   private ParticipantId digestAuthor(SearchResult.Digest digest) {
     return ParticipantId.ofUnsafe(digest.getParticipants().get(0));
   }
@@ -1113,14 +1220,56 @@ public class SimpleSearchProviderImplTest extends TestCase {
 
   private void addTagToWavelet(WaveletName name, ParticipantId user, String tag) throws Exception {
     WaveletOperationContext context = new WaveletOperationContext(user, 0, 1);
+    final int[] existingDocSize = {0};
+    waveMap.getWavelet(name).applyFunction(new Function<ReadableWaveletData, Void>() {
+      @Override
+      public Void apply(ReadableWaveletData waveletData) {
+        ReadableBlipData tagsBlip = waveletData.getDocument(IdConstants.TAGS_DOC_ID);
+        if (tagsBlip != null) {
+          existingDocSize[0] = documentLength(tagsBlip.getContent().asOperation());
+        }
+        return null;
+      }
+    });
+    DocOpBuilder builder = new DocOpBuilder();
+    if (existingDocSize[0] > 0) {
+      builder.retain(existingDocSize[0]);
+    }
     WaveletOperation addTagOp =
         new WaveletBlipOperation(IdConstants.TAGS_DOC_ID, new BlipContentOperation(context,
-            new DocOpBuilder()
+            builder
                 .elementStart("tag", Attributes.EMPTY_MAP)
                 .characters(tag)
                 .elementEnd()
                 .build()));
     submitDeltaToExistingWavelet(name, user, addTagOp);
+  }
+
+  private int documentLength(DocInitialization docOp) {
+    final int[] length = {0};
+    docOp.apply(new DocInitializationCursor() {
+      @Override
+      public void annotationBoundary(AnnotationBoundaryMap map) {
+      }
+
+      @Override
+      public void characters(String chars) {
+        if (chars != null) {
+          length[0] += chars.length();
+        }
+      }
+
+      @Override
+      public void elementStart(String type, Attributes attrs) {
+        length[0] += 1;
+      }
+
+      @Override
+      public void elementEnd() {
+        length[0] += 1;
+      }
+    });
+    return length[0];
   }
 
   private void waitForDistinctTimestamp() throws InterruptedException {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -981,6 +981,20 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(wave.waveId.serialise(), newTagResults.getDigests().get(0).getWaveId());
   }
 
+  public void testWaveletCommittedDoesNotWarmColdWaveCache() throws Exception {
+    WaveletName wave = WaveletName.of(WaveId.of(DOMAIN, "cold-commit-cache"), WAVELET_ID);
+
+    submitDeltaToNewWaveletWithoutView(wave, USER1, runtimeAddParticipant(USER1));
+    HashedVersion committedVersion = waveMap.getWavelet(wave).getLastCommittedVersion();
+
+    waveMap.unloadAllWavelets();
+    assertTrue(waveMap.getWaves().isEmpty());
+
+    runtimeWaveViewProvider.waveletCommitted(wave, committedVersion);
+
+    assertTrue(waveMap.getWaves().isEmpty());
+  }
+
   public void testSearchFilterByMentionsReturnsOnlyMentionedWaves() throws Exception {
     WaveletName mentionedWave = WaveletName.of(WaveId.of(DOMAIN, "mentioned"), WAVELET_ID);
     WaveletName unmentionedWave = WaveletName.of(WaveId.of(DOMAIN, "unmentioned"), WAVELET_ID);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
@@ -75,6 +75,16 @@ public class Lucene9QueryModelTest extends TestCase {
     assertEquals("in:inbox", model.toLegacyQuery());
   }
 
+  public void testTagQueryHasNoTextQuery() throws InvalidQueryException {
+    Lucene9QueryModel model = parser.parse("tag:project-x");
+    assertFalse("tag: queries should stay on the legacy filter path", model.hasTextQuery());
+  }
+
+  public void testTagQueryIsIncludedInLegacyQuery() throws InvalidQueryException {
+    Lucene9QueryModel model = parser.parse("tag:project-x");
+    assertEquals("tag:project-x", model.toLegacyQuery());
+  }
+
   public void testTitleIsExcludedFromLegacyQuery() throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("title:meeting");
     assertEquals("", model.toLegacyQuery());

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.wave.api.SearchResult;
+import java.util.Collections;
 import junit.framework.TestCase;
 import org.mockito.Mockito;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl;
@@ -51,6 +52,33 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
         "tasks:all", 0, 10);
 
     assertEquals(0, result.getTotalResults());
+    verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
+  }
+
+  public void testPureTagQueryReturnsLegacyResultsWithoutLuceneSearch() {
+    SimpleSearchProviderImpl legacySearchProvider = Mockito.mock(SimpleSearchProviderImpl.class);
+    Lucene9WaveIndexerImpl indexer = Mockito.mock(Lucene9WaveIndexerImpl.class);
+    SearchResult legacyResult = new SearchResult("tag:project-x");
+    legacyResult.addDigest(new SearchResult.Digest(
+        "Project X", "snippet", "example.com!w+project-x", Collections.singletonList(
+        "user@example.com"), 123L, 123L, 0, 1));
+    legacyResult.setTotalResults(1);
+
+    when(legacySearchProvider.search(ParticipantId.ofUnsafe("user@example.com"),
+        "tag:project-x", 0, 10000)).thenReturn(legacyResult);
+
+    Lucene9SearchProviderImpl provider = new Lucene9SearchProviderImpl(
+        legacySearchProvider,
+        new Lucene9QueryParser(),
+        new Lucene9QueryCompiler(),
+        indexer);
+
+    SearchResult result = provider.search(ParticipantId.ofUnsafe("user@example.com"),
+        "tag:project-x", 0, 10);
+
+    assertEquals(1, result.getTotalResults());
+    assertEquals(1, result.getNumResults());
+    assertEquals("example.com!w+project-x", result.getDigests().get(0).getWaveId());
     verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
   }
 }


### PR DESCRIPTION
## Summary
- invalidate a cached wave only when a `waveletCommitted` notification proves the local cached version is older than the committed version
- keep local fresh wave state intact while forcing stale nodes to reload the updated wave from store on the next metadata search
- add regression coverage for existing-tag documents and for a stale cached wave backed by the same shared store

## Root Cause
`MemoryPerUserWaveViewHandlerImpl` could receive a freshness signal for a wave while `WaveMap` still held an older cached `Wave` instance for that wave. The subsequent `tag:` search reused the stale cached wavelet snapshot, so new tags were invisible until process restart cleared the cache.

The initial blunt cache-clear approach fixed the stale-cache regression but regressed immediate local metadata searches. This PR uses version-aware invalidation instead: only evict the wave when the notified committed version is newer than the cached wavelet version.

## Validation
- `sbt "testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest org.waveprotocol.box.server.waveserver.MemoryPerUserWaveViewHandlerImplTest"`
- `sbt "testOnly org.waveprotocol.box.server.waveserver.lucene9.Lucene9QueryModelTest org.waveprotocol.box.server.waveserver.lucene9.Lucene9SearchProviderImplTest"`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9899 sbt "e2eTest:testOnly org.waveprotocol.wave.e2e.WaveE2eTest"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect and invalidate stale cached wave data on commit so tag searches reflect recent external updates; ensures cache is marked dirty even if invalidation errors occur.
  * Prevents unintentionally warming a cold cache after unloading wavelets.

* **Tests**
  * Added unit and integration tests for tag-query parsing, pure tag-query routing, tag-document appends, and cache-refresh behavior.

* **Documentation**
  * Added a changelog entry describing the fix and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->