### PR TITLE
[codex] Update repo references after SupaWave rename

### DIFF
--- a/.github/scripts/codex-review-gate.test.js
+++ b/.github/scripts/codex-review-gate.test.js
@@ -235,7 +235,7 @@ test("publishes success status on the PR head", async () => {
   await publishCodexReviewGateHeadStatus(github, {
     description: "Review gate passed: 10-minute window elapsed and no unresolved threads",
     owner: "vega113",
-    repo: "incubator-wave",
+    repo: "supawave",
     sha: "head-oid",
   });
 
@@ -244,7 +244,7 @@ test("publishes success status on the PR head", async () => {
       context: "Codex Review Gate",
       description: "Review gate passed: 10-minute window elapsed and no unresolved threads",
       owner: "vega113",
-      repo: "incubator-wave",
+      repo: "supawave",
       sha: "head-oid",
       state: "success",
     },
@@ -267,7 +267,7 @@ test("publishes failure status on the PR head", async () => {
   await publishCodexReviewGateHeadStatus(github, {
     description: "Pull request has 1 unresolved review thread(s)",
     owner: "vega113",
-    repo: "incubator-wave",
+    repo: "supawave",
     sha: "head-oid",
     state: "failure",
   });
@@ -277,7 +277,7 @@ test("publishes failure status on the PR head", async () => {
       context: "Codex Review Gate",
       description: "Pull request has 1 unresolved review thread(s)",
       owner: "vega113",
-      repo: "incubator-wave",
+      repo: "supawave",
       sha: "head-oid",
       state: "failure",
     },

--- a/ORCHESTRATOR.md
+++ b/ORCHESTRATOR.md
@@ -246,9 +246,9 @@ Practical note:
 2. If orchestration-plan work applies, follow
    `docs/superpowers/plans/2026-03-18-agent-orchestration-plan.md`.
 3. Check open PRs:
-   - `gh pr list --repo vega113/incubator-wave --state open`
+   - `gh pr list --repo vega113/supawave --state open`
 4. Check live deploy status:
-   - `gh run list --repo vega113/incubator-wave --workflow deploy-contabo.yml --limit 5`
+   - `gh run list --repo vega113/supawave --workflow deploy-contabo.yml --limit 5`
 5. If touching production deploy behavior, verify live endpoints first:
    - `https://supawave.ai/`
    - `https://supawave.ai/webclient/webclient.nocache.js`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This repository now tracks its active roadmap in GitHub Issues:
 
 - Human-readable overview: `docs/current-state.md`
 - Live issue workflow and label conventions: `docs/github-issues.md`
-- Repository issue list: `https://github.com/vega113/incubator-wave/issues`
+- Repository issue list: `https://github.com/vega113/supawave/issues`
 - Historical Beads archive: `.beads/README.md`, `docs/epics/README.md`
 
 The `.beads/` directory remains in the repo as a read-only historical archive.

--- a/docs/E2E/sanity-check-loop.md
+++ b/docs/E2E/sanity-check-loop.md
@@ -109,9 +109,9 @@ ssh supawave "docker logs supawave-mongo-1 --since 1h 2>&1 | tail -300 | grep -i
 
 PHASE 3 — TRIAGE (if NEW errors found):
 
-1. Check recent commits: `git log --oneline -20` and `gh pr list --repo vega113/incubator-wave --state all --limit 10`
+1. Check recent commits: `git log --oneline -20` and `gh pr list --repo vega113/supawave --state all --limit 10`
 2. If confirmed NEW bug (not already tracked):
-   a. Create GitHub issue: `gh issue create --repo vega113/incubator-wave --title "..." --body "..."`
+   a. Create GitHub issue: `gh issue create --repo vega113/supawave --title "..." --body "..."`
    b. If fix is straightforward, create a PR
 3. Known issues to IGNORE (already tracked):
    - Caddy 502s during deploy restart windows (transient)

--- a/docs/epics/README.md
+++ b/docs/epics/README.md
@@ -9,7 +9,7 @@ live tracker.
 
 For current work:
 - use `docs/github-issues.md` for the live issue workflow
-- use the GitHub Issues filter `is:issue repo:vega113/incubator-wave label:agent-task`
+- use the GitHub Issues filter `is:issue repo:vega113/supawave label:agent-task`
 - treat `.beads/` as read-only archive material
 
 ## Closed documentation epic

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -19,11 +19,11 @@ This document defines the live planning and execution tracker for
 ## Core Filters
 
 - Live implementation slices:
-  - `is:issue repo:vega113/incubator-wave label:agent-task`
+  - `is:issue repo:vega113/supawave label:agent-task`
 - Active in-flight issue work:
-  - `is:issue repo:vega113/incubator-wave label:agent-task label:in-progress`
+  - `is:issue repo:vega113/supawave label:agent-task label:in-progress`
 - Harness migration slices:
-  - `is:issue repo:vega113/incubator-wave label:harness-engineering`
+  - `is:issue repo:vega113/supawave label:harness-engineering`
 
 ## Label Conventions
 

--- a/prompts/monitoring/pr-monitor.md
+++ b/prompts/monitoring/pr-monitor.md
@@ -8,7 +8,7 @@ Before doing anything, check if there's any work:
 ```
 count=$(gh search prs --author=@me --state=open --json number --jq length 2>/dev/null)
 reviews=$(gh search prs --review-requested=@me --state=open --json number --jq length 2>/dev/null)
-issues=$(for repo in vega113/incubator-wave vega113/tube2web vega113/tubescribes vega113/slides-lab; do gh issue list -R "$repo" --state open --json number --jq length 2>/dev/null; done | paste -sd+ | bc)
+issues=$(for repo in vega113/supawave vega113/tube2web vega113/tubescribes vega113/slides-lab; do gh issue list -R "$repo" --state open --json number --jq length 2>/dev/null; done | paste -sd+ | bc)
 if [ "${count:-0}" -eq 0 ] && [ "${reviews:-0}" -eq 0 ] && [ "${issues:-0}" -eq 0 ]; then echo "All clean"; exit 0; fi
 ```
 
@@ -35,7 +35,7 @@ Search for open PRs authored by me and PRs where review is requested, across all
 ### c. Merge readiness
 - All checks pass + no conflicts + no unresolved threads + every nitpick has an explicit disposition + latest commit older than 10 minutes → merge
 - For stacked PRs targeting a non-default branch, also verify explicit Codex coverage on the current `headRefOid` before merge
-- incubator-wave: `--merge`, tube2web/tubescribes/slides-lab: `--squash`
+- supawave: `--merge`, tube2web/tubescribes/slides-lab: `--squash`
 - Enable auto-merge: `gh pr merge NUM -R repo --merge --auto`
 
 ### d. Immediate cascade on merge
@@ -67,7 +67,7 @@ Check all monitored repos for open issues. Spawn background agents to fix action
 - After any late-arriving bot review, re-check unresolved threads before merging
 
 ## Monitored repos
-- vega113/incubator-wave
+- vega113/supawave
 - vega113/tube2web
 - vega113/tubescribes
 - vega113/slides-lab
@@ -75,7 +75,7 @@ Check all monitored repos for open issues. Spawn background agents to fix action
 ## Merge strategy
 | Repo | Strategy |
 |------|----------|
-| incubator-wave | `--merge` |
+| supawave | `--merge` |
 | tube2web | `--squash` |
 | tubescribes | `--squash` |
 | slides-lab | `--squash` |

--- a/scripts/pr-monitor/wave-lanes-monitor-prompt.md
+++ b/scripts/pr-monitor/wave-lanes-monitor-prompt.md
@@ -20,11 +20,11 @@ tmux list-panes -t vibe-code:wave-lanes -F "#{pane_index}"$'\t'"#{pane_title}"$'
 For EACH pane, extract the PR number using THREE methods:
 1. **From title:** If title contains `PR#NNN`, extract the number
 2. **From path:** If path contains `pr-NNN-lane` (e.g. `/Users/vega/devroot/worktrees/pr-700-lane`), extract NNN
-3. **From branch:** `git -C <PATH> branch --show-current` then `gh pr list --repo vega113/incubator-wave --state all --head <BRANCH> --json number,state -q '.[0]'`
+3. **From branch:** `git -C <PATH> branch --show-current` then `gh pr list --repo vega113/supawave --state all --head <BRANCH> --json number,state -q '.[0]'`
 
 IMPORTANT: Many panes have generic titles like "Claude Code" — you MUST check the path, not just the title.
 
-Once you have the PR number, check: `gh pr view NNN --repo vega113/incubator-wave --json state -q .state`
+Once you have the PR number, check: `gh pr view NNN --repo vega113/supawave --json state -q .state`
 
 If state is MERGED or CLOSED → kill the pane completely:
    ```bash
@@ -50,7 +50,7 @@ If state is MERGED or CLOSED → kill the pane completely:
 ### Step A: Get open PRs and current panes
 
 ```bash
-gh pr list --repo vega113/incubator-wave --state open --json number,title,headRefName,mergeable --limit 50 2>/dev/null
+gh pr list --repo vega113/supawave --state open --json number,title,headRefName,mergeable --limit 50 2>/dev/null
 tmux list-panes -t vibe-code:wave-lanes -F "#{pane_index}"$'\t'"#{pane_title}"$'\t'"#{pane_current_path}" 2>/dev/null
 ```
 
@@ -59,11 +59,11 @@ tmux list-panes -t vibe-code:wave-lanes -F "#{pane_index}"$'\t'"#{pane_title}"$'
 For each open PR, gather status:
 ```bash
 # Get review threads — count unresolved
-gh api graphql -f query='{ repository(owner:"vega113", name:"incubator-wave") { pullRequest(number:NNN) { reviewThreads(first:100) { nodes { isResolved } } } } }' -q '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
+gh api graphql -f query='{ repository(owner:"vega113", name:"supawave") { pullRequest(number:NNN) { reviewThreads(first:100) { nodes { isResolved } } } } }' -q '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length'
 
 # Get mergeable status (from the PR list output above)
 # Get CI checks
-gh pr checks NNN --repo vega113/incubator-wave 2>/dev/null | head -10
+gh pr checks NNN --repo vega113/supawave 2>/dev/null | head -10
 ```
 
 ### Step C: For each open PR — create lane if missing, send instructions if issues exist
@@ -109,7 +109,7 @@ The instructions should be specific based on what you found in Step B:
 **If there are unresolved review threads (count > 0):**
 ```text
 PRIORITY: PR #NNN has <COUNT> unresolved review threads. For each thread:
-1. Read the review comment with: gh api repos/vega113/incubator-wave/pulls/NNN/comments
+1. Read the review comment with: gh api repos/vega113/supawave/pulls/NNN/comments
 2. Fix the code issue or reply explaining why no change is needed
 3. After fixing, RESOLVE the thread: gh api graphql -f query='mutation { resolveReviewThread(input:{threadId:"THREAD_ID"}) { thread { isResolved } } }'
 All threads must be resolved for CI to pass.
@@ -126,7 +126,7 @@ PRIORITY: PR #NNN has merge conflicts. Rebase onto main:
 
 **If CI checks are failing:**
 ```text
-PRIORITY: PR #NNN has failing CI checks. Run: gh pr checks NNN --repo vega113/incubator-wave
+PRIORITY: PR #NNN has failing CI checks. Run: gh pr checks NNN --repo vega113/supawave
 Then: cd wave && sbt compile 2>&1 | tail -30
 If build fails, fix the errors. Do NOT comment out code or skip tests.
 Then: cd wave && sbt test 2>&1 | tail -50

--- a/scripts/pr-monitor/wave-lanes-monitor.sh
+++ b/scripts/pr-monitor/wave-lanes-monitor.sh
@@ -17,11 +17,14 @@
 # (network blips, missing panes) must not abort the monitoring loop.
 set -uo pipefail
 
-REPO="vega113/incubator-wave"
+DEFAULT_REPO="vega113/supawave"
+REPO="${GITHUB_REPO:-$DEFAULT_REPO}"
 WAVE_SESSION="vibe-code:wave-lanes"
 WORKTREE_BASE="/Users/vega/devroot/worktrees"
 REPO_PATH="/Users/vega/devroot/incubator-wave"
 CYCLE_INTERVAL=300
+REPO_OWNER="${REPO%%/*}"
+REPO_NAME="${REPO#*/}"
 
 extract_pr_number() {
   local text="$1"
@@ -44,7 +47,7 @@ is_pane_idle() {
 
 get_unresolved_threads() {
   local pr=$1
-  gh api graphql -f query="{ repository(owner:\"vega113\", name:\"incubator-wave\") { pullRequest(number:${pr}) { reviewThreads(first:100) { nodes { isResolved } } } } }" \
+  gh api graphql -f query="{ repository(owner:\"${REPO_OWNER}\", name:\"${REPO_NAME}\") { pullRequest(number:${pr}) { reviewThreads(first:100) { nodes { isResolved } } } } }" \
     -q '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length' 2>/dev/null || echo "0"
 }
 

--- a/scripts/pr_monitor.py
+++ b/scripts/pr_monitor.py
@@ -427,7 +427,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     start_parser = subparsers.add_parser("start")
-    start_parser.add_argument("--repo", default="vega113/incubator-wave")
+    start_parser.add_argument("--repo", default="vega113/supawave")
     start_parser.add_argument("--pr-number", type=positive_int, required=True)
     start_parser.add_argument("--pr-title")
     start_parser.add_argument("--worktree", required=True)

--- a/scripts/tests/test_pr_monitor.py
+++ b/scripts/tests/test_pr_monitor.py
@@ -18,7 +18,7 @@ from scripts.pr_monitor import render_prompt
 class PrMonitorTest(unittest.TestCase):
     def test_render_prompt_requires_actual_merge_or_real_blocker(self) -> None:
         prompt = render_prompt(
-            repo="vega113/incubator-wave",
+            repo="vega113/supawave",
             pr_number=405,
             pr_title="Fix monitor reliability",
             worktree_path="/tmp/worktree",
@@ -59,7 +59,7 @@ class PrMonitorTest(unittest.TestCase):
 
     def test_build_runner_script_restarts_when_pr_stays_open(self) -> None:
         config = LauncherConfig(
-            repo="vega113/incubator-wave",
+            repo="vega113/supawave",
             pr_number=405,
             pr_title="Fix monitor reliability",
             worktree_path=pathlib.Path("/tmp/worktree"),
@@ -82,7 +82,7 @@ class PrMonitorTest(unittest.TestCase):
 
     def test_build_runner_script_fails_fast_if_worktree_cd_fails(self) -> None:
         config = LauncherConfig(
-            repo="vega113/incubator-wave",
+            repo="vega113/supawave",
             pr_number=405,
             pr_title="Fix monitor reliability",
             worktree_path=pathlib.Path("/tmp/worktree"),
@@ -168,6 +168,19 @@ class PrMonitorTest(unittest.TestCase):
                     "0",
                 ]
             )
+
+    def test_parse_args_defaults_repo_to_supawave(self) -> None:
+        args = parse_args(
+            [
+                "start",
+                "--pr-number",
+                "405",
+                "--worktree",
+                "/tmp/pr405-live-head",
+            ]
+        )
+
+        self.assertEqual("vega113/supawave", args.repo)
 
     def test_build_pane_title_includes_pr_number_and_title(self) -> None:
         self.assertEqual(

--- a/wave/config/changelog.d/2026-04-12-supawave-repo-rename.json
+++ b/wave/config/changelog.d/2026-04-12-supawave-repo-rename.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-supawave-repo-rename",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Update SupaWave repository references after GitHub rename",
+  "summary": "The app welcome wave and the repo’s operational tooling now point at the renamed SupaWave GitHub repository instead of the legacy incubator-wave slug.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Updated the in-app welcome wave repository link and label to point at the renamed `vega113/supawave` GitHub repository",
+        "Updated PR-monitoring scripts, GitHub issue filters, and related operational docs to use the new repository slug so automation follows the renamed repo"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WelcomeWaveContentBuilder.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WelcomeWaveContentBuilder.java
@@ -41,7 +41,7 @@ import java.util.List;
 public final class WelcomeWaveContentBuilder {
 
   private static final String GROKIPEDIA_URL = "https://grokipedia.com/page/Google_Wave";
-  private static final String INCUBATOR_WAVE_URL = "https://github.com/vega113/incubator-wave";
+  private static final String SUPAWAVE_REPOSITORY_URL = "https://github.com/vega113/supawave";
   private static final String CHANGELOG_URL = "https://supawave.ai/changelog";
   private static final String API_DOCS_URL = "https://supawave.ai/api-docs";
   private static final String PUBLIC_URL = "https://supawave.ai/public";
@@ -128,7 +128,7 @@ public final class WelcomeWaveContentBuilder {
     appendBlankLine(doc);
     appendLine(doc, "Useful links");
     appendLinkedLine(doc, pendingLinks, "Grokipedia history", GROKIPEDIA_URL);
-    appendLinkedLine(doc, pendingLinks, "incubator-wave repository", INCUBATOR_WAVE_URL);
+    appendLinkedLine(doc, pendingLinks, "SupaWave repository", SUPAWAVE_REPOSITORY_URL);
     appendLinkedLine(doc, pendingLinks, "SupaWave changelog", CHANGELOG_URL);
     appendLinkedLine(doc, pendingLinks, "SupaWave API docs", API_DOCS_URL);
     appendLinkedLine(doc, pendingLinks, "Public directory", PUBLIC_URL);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WelcomeWaveCreatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WelcomeWaveCreatorTest.java
@@ -89,7 +89,7 @@ public class WelcomeWaveCreatorTest extends TestCase {
     assertTrue(rootText.contains("vega@supawave.ai"));
     assertTrue(rootText.contains("collapsed inline blips"));
     assertTrue(rootText.contains("Grokipedia history"));
-    assertTrue(rootText.contains("incubator-wave repository"));
+    assertTrue(rootText.contains("SupaWave repository"));
     assertTrue(rootText.contains("SupaWave changelog"));
     assertTrue(rootText.contains("SupaWave API docs"));
     assertTrue(rootText.contains("Public directory"));
@@ -97,7 +97,7 @@ public class WelcomeWaveCreatorTest extends TestCase {
     assertTrue(rootText.contains("TypeScript bot repository"));
     assertFalse(rootText.contains("https://"));
     assertManualLink(rootBlip.getContent(), "https://grokipedia.com/page/Google_Wave");
-    assertManualLink(rootBlip.getContent(), "https://github.com/vega113/incubator-wave");
+    assertManualLink(rootBlip.getContent(), "https://github.com/vega113/supawave");
     assertManualLink(rootBlip.getContent(), "https://supawave.ai/changelog");
     assertManualLink(rootBlip.getContent(), "https://supawave.ai/api-docs");
     assertManualLink(rootBlip.getContent(), "https://supawave.ai/public");


### PR DESCRIPTION
## Summary
- update live repo references from `vega113/incubator-wave` to `vega113/supawave` in operational docs and PR-monitoring tooling
- update the welcome wave repository link and regression tests to point at the renamed SupaWave GitHub repo
- add a changelog fragment covering the user-facing welcome-wave link update and the repo-slug automation follow-up

## Context
The GitHub repository rename to `vega113/supawave` was completed separately. This PR prepares the codebase and repo automation to follow the new slug cleanly.

## Validation
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `python3 -m unittest scripts.tests.test_pr_monitor`
- `node --test .github/scripts/codex-review-gate.test.js`
- `bash -n scripts/pr-monitor/wave-lanes-monitor.sh`
- `sbt "wave/testOnly *WelcomeWaveCreatorTest"`

## Notes
- historical spec/audit documents that mention the legacy slug were left unchanged on purpose
- deploy/Grafana scripts did not require a repo-slug change; they already key off `supawave` deployment paths and labels