### PR TITLE
fix(robot-rpc): surface failed streaming reply commits

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-836-robot-rpc-streaming-fix.md
+++ b/docs/superpowers/plans/2026-04-12-issue-836-robot-rpc-streaming-fix.md
@@ -1,0 +1,95 @@
+# Issue #836 Robot RPC Streaming Reply Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `/robot/rpc` from returning a successful `newBlipId` when the underlying reply-creation delta failed to commit, so streamed follow-on writes do not receive phantom reply ids.
+
+**Architecture:** Keep the existing `blip.createChild` and `document.modify` server behavior, but change the Jakarta robot RPC servlet to capture delta-submission failures before serializing responses. If a write operation in the batch fails during commit, convert its JSON-RPC response into an error instead of returning the pre-submit success payload.
+
+**Tech Stack:** Jakarta robot RPC servlet, WaveletProvider submit callbacks, JUnit 4, Mockito, sbt.
+
+---
+
+### Task 1: Add A Failing Servlet Regression Test
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServletScopeEnforcementTest.java`
+
+- [ ] **Step 1: Add a regression test for failed delta submission**
+
+Add a test that:
+- submits one mutating operation through the Jakarta `BaseApiServlet`
+- uses a custom `OperationService` that records a success response and a real delta in the context
+- forces `waveletProvider.submitRequest(...)` to invoke `listener.onFailure("delta failed")`
+- asserts the serialized response list contains an error response for that operation instead of the pre-submit success payload
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+sbt "testOnly org.waveprotocol.box.server.robots.dataapi.BaseApiServletScopeEnforcementTest"
+```
+
+Expected: FAIL because the servlet currently returns success responses even when `submitRequest` reports failure.
+
+### Task 2: Convert Submission Failures Into JSON-RPC Errors
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServlet.java`
+
+- [ ] **Step 1: Capture submit failures during response handling**
+
+Update `handleResults(...)` so it uses a listener that records submission failures instead of only logging them.
+
+- [ ] **Step 2: Rewrite mutating operation responses on submit failure**
+
+When at least one delta submission fails:
+- convert each non-error mutating operation response in the current request to `JsonRpcResponse.error(...)`
+- keep pre-existing execution errors intact
+- keep read-only operation responses unchanged
+
+- [ ] **Step 3: Rerun the focused servlet test**
+
+Run:
+
+```bash
+sbt "testOnly org.waveprotocol.box.server.robots.dataapi.BaseApiServletScopeEnforcementTest"
+```
+
+Expected: PASS.
+
+### Task 3: Verify The Targeted Robot Streaming Surface
+
+**Files:**
+- Modify: `journal/local-verification/2026-04-12-issue-836-robot-rpc-streaming.md`
+
+- [ ] **Step 1: Run the focused verification set**
+
+Run:
+
+```bash
+sbt "testOnly org.waveprotocol.box.server.robots.dataapi.BaseApiServletScopeEnforcementTest"
+sbt "testOnly org.waveprotocol.examples.robots.gptbot.SupaWaveApiClientTest"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Record the commands and outcomes**
+
+Write the exact verification commands and results to:
+
+```text
+journal/local-verification/2026-04-12-issue-836-robot-rpc-streaming.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add \
+  docs/superpowers/plans/2026-04-12-issue-836-robot-rpc-streaming-fix.md \
+  wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServlet.java \
+  wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServletScopeEnforcementTest.java \
+  journal/local-verification/2026-04-12-issue-836-robot-rpc-streaming.md
+git commit -m "fix(robot-rpc): fail create-child responses when commit fails"
+```

--- a/wave/config/changelog.d/2026-04-12-robot-rpc-submit-failure.json
+++ b/wave/config/changelog.d/2026-04-12-robot-rpc-submit-failure.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-robot-rpc-submit-failure",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Robot RPC commit-failure responses",
+  "summary": "Robot RPC write calls now return JSON-RPC errors when the underlying delta fails to commit, instead of returning a success payload with a reply id that was never persisted.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The Jakarta robot RPC servlet now rewrites optimistic write responses into JSON-RPC errors when delta submission fails, so streaming bots do not receive phantom newBlipId values",
+        "Added a regression test covering submitRequest failure handling for mutating robot RPC operations"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServlet.java
@@ -44,6 +44,7 @@ import org.waveprotocol.wave.util.logging.Log;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -206,10 +207,27 @@ public abstract class BaseApiServlet extends HttpServlet {
   }
 
   private void handleResults(
-      OperationResults results, HttpServletResponse resp,
+      OperationContextImpl results, HttpServletResponse resp,
       List<OperationRequest> operations, ProtocolVersion version)
       throws IOException {
-    OperationUtil.submitDeltas(results, waveletProvider, LOGGING_REQUEST_LISTENER);
+    List<String> submitFailures = new ArrayList<String>();
+    OperationUtil.submitDeltas(results, waveletProvider, new WaveletProvider.SubmitRequestListener() {
+      @Override
+      public void onFailure(String errorMessage) {
+        submitFailures.add(errorMessage);
+        LOGGING_REQUEST_LISTENER.onFailure(errorMessage);
+      }
+
+      @Override
+      public void onSuccess(
+          int operationsApplied,
+          org.waveprotocol.wave.model.version.HashedVersion hashedVersionAfterApplication,
+          long applicationTimestamp) {
+        LOGGING_REQUEST_LISTENER.onSuccess(
+            operationsApplied, hashedVersionAfterApplication, applicationTimestamp);
+      }
+    });
+    applySubmissionFailures(results, operations, submitFailures);
 
     LinkedList<JsonRpcResponse> responses = Lists.newLinkedList();
     for (OperationRequest operation : operations) {
@@ -228,5 +246,29 @@ public abstract class BaseApiServlet extends HttpServlet {
       writer.flush();
     }
     resp.setStatus(HttpServletResponse.SC_OK);
+  }
+
+  private void applySubmissionFailures(
+      OperationContextImpl results, List<OperationRequest> operations, List<String> submitFailures) {
+    if (submitFailures.isEmpty()) {
+      return;
+    }
+
+    String errorMessage = String.join("; ", submitFailures);
+    for (OperationRequest operation : operations) {
+      if (!isMutatingOperation(operation)) {
+        continue;
+      }
+      JsonRpcResponse response = results.getResponse(operation.getId());
+      if (response == null || !response.isError()) {
+        results.replaceErrorResponse(operation, errorMessage);
+      }
+    }
+  }
+
+  private boolean isMutatingOperation(OperationRequest operation) {
+    OpScopeMapper.OpType opType = mapOperationToOpType(operation);
+    return opType != OpScopeMapper.OpType.FETCH_WAVE
+        && opType != OpScopeMapper.OpType.LIST_WAVES;
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/OperationContextImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/OperationContextImpl.java
@@ -180,6 +180,14 @@ public class OperationContextImpl implements OperationContext, OperationResults 
     setResponse(operation.getId(), JsonRpcResponse.error(operation.getId(), errorMessage));
   }
 
+  /**
+   * Replaces an existing response when a later stage (for example delta submission)
+   * invalidates the optimistic operation result.
+   */
+  public void replaceErrorResponse(OperationRequest operation, String errorMessage) {
+    responses.put(operation.getId(), JsonRpcResponse.error(operation.getId(), errorMessage));
+  }
+
   @Override
   public void processEvent(OperationRequest operation, Event event) throws InvalidRequestException {
     // Create JSON-RPC error response.

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServletScopeEnforcementTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/dataapi/BaseApiServletScopeEnforcementTest.java
@@ -18,19 +18,28 @@
  */
 package org.waveprotocol.box.server.robots.dataapi;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.wave.api.BlipData;
+import com.google.wave.api.InvalidRequestException;
+import com.google.wave.api.JsonRpcConstant.ParamsProperty;
+import com.google.wave.api.JsonRpcResponse;
 import com.google.wave.api.OperationRequest;
+import com.google.wave.api.OperationType;
 import com.google.wave.api.ProtocolVersion;
 import com.google.wave.api.RobotSerializer;
 import com.google.wave.api.data.converter.EventDataConverter;
 import com.google.wave.api.data.converter.EventDataConverterManager;
+import com.google.wave.api.OperationRequest.Parameter;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -43,15 +52,30 @@ import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.waveprotocol.box.server.robots.OperationServiceRegistry;
+import org.waveprotocol.box.server.robots.OperationContext;
+import org.waveprotocol.box.server.robots.RobotWaveletData;
 import org.waveprotocol.box.server.robots.operations.OperationService;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.model.document.operation.DocInitialization;
+import org.waveprotocol.wave.model.document.operation.impl.DocInitializationBuilder;
+import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.version.HashedVersionFactory;
+import org.waveprotocol.wave.model.version.HashedVersionZeroFactoryImpl;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 
 /**
  * Unit tests for per-operation scope enforcement in {@link BaseApiServlet}.
@@ -68,6 +92,15 @@ public class BaseApiServletScopeEnforcementTest {
 
   private static final ParticipantId PARTICIPANT =
       ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId OTHER_PARTICIPANT =
+      ParticipantId.ofUnsafe("bob@example.com");
+  private static final IdURIEncoderDecoder URI_CODEC =
+      new IdURIEncoderDecoder(new JavaUrlCodec());
+  private static final HashedVersionFactory HASH_FACTORY =
+      new HashedVersionZeroFactoryImpl(URI_CODEC);
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "waveid");
+  private static final WaveletId WAVELET_ID = WaveletId.of("example.com", "conv+root");
+  private static final WaveletName WAVELET_NAME = WaveletName.of(WAVE_ID, WAVELET_ID);
 
   private RobotSerializer robotSerializer;
   private EventDataConverterManager converterManager;
@@ -175,7 +208,66 @@ public class BaseApiServletScopeEnforcementTest {
     verify(resp, never()).sendError(eq(HttpServletResponse.SC_FORBIDDEN), anyString());
   }
 
+  @Test
+  public void testSubmitFailureConvertsMutatingResponseToError() throws Exception {
+    OperationRequest modifyOp = new OperationRequest("wavelet.appendBlip", "op1");
+    BlipData blipData =
+        new BlipData(WAVE_ID.serialise(), WAVELET_ID.serialise(), "TBD_test_blip", "hello");
+    blipData.setBlipId("TBD_test_blip");
+    modifyOp.addParameter(Parameter.of(ParamsProperty.WAVE_ID, WAVE_ID.serialise()));
+    modifyOp.addParameter(Parameter.of(ParamsProperty.WAVELET_ID, WAVELET_ID.serialise()));
+    modifyOp.addParameter(Parameter.of(ParamsProperty.BLIP_DATA, blipData));
+    List<OperationRequest> ops = Collections.singletonList(modifyOp);
+    when(robotSerializer.deserializeOperations(any())).thenReturn(ops);
+    when(robotSerializer.serialize(any(), any(Type.class), any(ProtocolVersion.class)))
+        .thenReturn("[]");
+
+    when(operationRegistry.getServiceFor(eq(OperationType.WAVELET_APPEND_BLIP)))
+        .thenReturn(new FailingDeltaSubmitService());
+    doAnswer(invocation -> {
+      WaveletProvider.SubmitRequestListener listener = invocation.getArgument(2);
+      listener.onFailure("delta failed");
+      return null;
+    }).when(waveletProvider).submitRequest(eq(WAVELET_NAME), any(), any());
+
+    boolean handled =
+        servlet.invokeProcessOpsRequest(req, resp, PARTICIPANT, Set.of(OpScopeMapper.SCOPE_WAVE_DATA_WRITE));
+
+    ArgumentCaptor<Object> responsesCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(robotSerializer).serialize(responsesCaptor.capture(), any(Type.class), any(ProtocolVersion.class));
+    @SuppressWarnings("unchecked")
+    List<JsonRpcResponse> responses = (List<JsonRpcResponse>) responsesCaptor.getValue();
+
+    assertTrue(handled);
+    assertEquals(1, responses.size());
+    assertTrue(responses.get(0).isError());
+    assertEquals("delta failed", responses.get(0).getErrorMessage());
+  }
+
   // --- Minimal concrete subclass to expose processOpsRequest ---
+
+  private static RobotWaveletData createWaveletWithPendingDelta() {
+    org.waveprotocol.wave.model.version.HashedVersion versionZero =
+        HASH_FACTORY.createVersionZero(WAVELET_NAME);
+    ObservableWaveletData waveletData =
+        WaveletDataUtil.createEmptyWavelet(WAVELET_NAME, PARTICIPANT, versionZero, 0L);
+    DocInitialization content = new DocInitializationBuilder().build();
+    waveletData.createDocument(
+        "b+example", PARTICIPANT, Collections.singletonList(PARTICIPANT), content, 0L, 0);
+
+    RobotWaveletData wavelet = new RobotWaveletData(waveletData, versionZero);
+    wavelet.getOpBasedWavelet(PARTICIPANT).addParticipant(OTHER_PARTICIPANT);
+    return wavelet;
+  }
+
+  private static final class FailingDeltaSubmitService implements OperationService {
+    @Override
+    public void execute(OperationRequest operation, OperationContext context, ParticipantId participant)
+        throws InvalidRequestException {
+      context.putWavelet(WAVE_ID, WAVELET_ID, createWaveletWithPendingDelta());
+      context.constructResponse(operation, Map.of(ParamsProperty.BLIP_ID, "b+created"));
+    }
+  }
 
   /**
    * Concrete subclass of BaseApiServlet for testing.
@@ -191,10 +283,10 @@ public class BaseApiServletScopeEnforcementTest {
       super(robotSerializer, converterManager, waveletProvider, operationRegistry, conversationUtil);
     }
 
-    public void invokeProcessOpsRequest(HttpServletRequest req, HttpServletResponse resp,
-                                        ParticipantId participant, Set<String> tokenScopes)
+    public boolean invokeProcessOpsRequest(HttpServletRequest req, HttpServletResponse resp,
+                                           ParticipantId participant, Set<String> tokenScopes)
         throws IOException {
-      processOpsRequest(req, resp, participant, tokenScopes);
+      return processOpsRequest(req, resp, participant, tokenScopes);
     }
   }
 }


### PR DESCRIPTION
## Summary
- rewrite optimistic robot RPC write responses into JSON-RPC errors when delta submission fails
- add a regression test covering mutating servlet responses after `submitRequest` failure
- add an issue-specific plan and changelog fragment for the robot RPC fix

## Verification
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `sbt "testOnly org.waveprotocol.box.server.robots.dataapi.BaseApiServletScopeEnforcementTest"`
- `sbt "testOnly org.waveprotocol.examples.robots.gptbot.SupaWaveApiClientTest"`
- `git diff --check`

## Review
- Self review completed against the staged diff before commit.
- Residual risk: on multi-operation batches, mutating operations now all surface the submit failure if any delta in that batch fails. Issue #836 uses single-operation streaming writes, so this matches the affected path.

## Traceability
- Plan: `docs/superpowers/plans/2026-04-12-issue-836-robot-rpc-streaming-fix.md`
- Local verification record: `journal/local-verification/2026-04-12-issue-836-robot-rpc-streaming.md`

Closes #836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Robot RPC write operations now return JSON-RPC error responses when the underlying delta submission fails, instead of returning a success response with a phantom reply ID that was never persisted.

* **Tests**
  * Added regression test coverage for submission failure handling in robot RPC mutating operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->