### PR TITLE
[codex] add undo toast for tag removal

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-832-tag-undo-toast.md
+++ b/docs/superpowers/plans/2026-04-12-issue-832-tag-undo-toast.md
@@ -1,0 +1,133 @@
+# Tag Undo Toast Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace immediate tag-delete feedback with a 20-second undo toast that lets the user restore a removed tag.
+
+**Architecture:** Keep the underlying tag mutation simple: the remove click still removes the tag immediately, and a focused client-side undo manager tracks one restorable removal window and re-adds the tag if the user clicks restore before expiry. The GWT/UI surface stays compact by reusing the existing toast styling patterns instead of adding a new modal or model-layer soft delete flow.
+
+**Tech Stack:** GWT client Java, WavePanel tag controllers/renderers, JUnit 3 style tests with Mockito, changelog fragments.
+
+---
+
+### Task 1: Pin The Undo Behavior In A Unit Test
+
+**Files:**
+- Create: `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManagerTest.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+public void testUndoRestoresRemovedTagBeforeExpiry() {
+  Conversation conversation = mock(Conversation.class);
+  FakeScheduler scheduler = new FakeScheduler();
+  RecordingPresenter presenter = new RecordingPresenter();
+  UndoableTagRemovalManager manager =
+      new UndoableTagRemovalManager(scheduler, presenter, 20_000);
+
+  manager.tagRemoved(conversation, "urgent");
+
+  assertEquals("urgent", presenter.shownTag);
+  presenter.undoAction.run();
+
+  verify(conversation).addTag("urgent");
+  assertTrue(presenter.dismissed);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.UndoableTagRemovalManagerTest"`
+Expected: FAIL because `UndoableTagRemovalManager` does not exist yet.
+
+- [ ] **Step 3: Add the minimal manager implementation**
+
+```java
+final class UndoableTagRemovalManager {
+  void tagRemoved(Conversation conversation, String tagName) { ... }
+  void clearPendingRemoval() { ... }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.UndoableTagRemovalManagerTest"`
+Expected: PASS
+
+### Task 2: Wire Tag Removal To The Undo Toast
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java` or the manager-owned presenter if toast actions are implemented there
+
+- [ ] **Step 1: Update the remove-click path to queue an undo window**
+
+```java
+tag.first.removeTag(tag.second);
+undoableTagRemovalManager.tagRemoved(tag.first, tag.second);
+```
+
+- [ ] **Step 2: Add user-facing toast copy for remove + restore**
+
+```java
+@DefaultMessage("Removed tag: {0}")
+String removedTagToast(String tag);
+
+@DefaultMessage("Restore")
+String restoreTagAction();
+```
+
+- [ ] **Step 3: Keep only the latest pending restore active**
+
+```java
+manager.tagRemoved(firstConversation, "one");
+manager.tagRemoved(secondConversation, "two");
+// first restore window is dismissed, second remains active
+```
+
+- [ ] **Step 4: Re-run the focused test set**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.UndoableTagRemovalManagerTest"`
+Expected: PASS
+
+### Task 3: Record The User-Facing Change And Verify It
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-12-issue-832-tag-undo-toast.md`
+- Create: `journal/local-verification/2026-04-12-issue-832-tag-undo-toast.md`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+```md
+- Added a 20-second restore toast after removing a wave tag so accidental removals can be undone.
+```
+
+- [ ] **Step 2: Regenerate and validate the changelog**
+
+Run: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+Expected: exit 0
+
+- [ ] **Step 3: Run targeted automated verification**
+
+Run: `sbt "testOnly org.waveprotocol.wave.client.wavepanel.impl.edit.UndoableTagRemovalManagerTest org.waveprotocol.box.server.util.WavePanelTagsLayoutTest"`
+Expected: PASS
+
+- [ ] **Step 4: Run local app sanity verification and record it**
+
+Run: `bash scripts/worktree-boot.sh --port 9902`
+Expected: local server starts successfully for manual tag-remove/restore verification.
+
+- [ ] **Step 5: Commit the focused implementation**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManagerTest.java \
+  wave/config/changelog.d/2026-04-12-issue-832-tag-undo-toast.md \
+  wave/config/changelog.json \
+  journal/local-verification/2026-04-12-issue-832-tag-undo-toast.md
+git commit -m "feat: add undo toast for tag removal"
+```

--- a/wave/config/changelog.d/2026-04-12-tag-undo-toast.json
+++ b/wave/config/changelog.d/2026-04-12-tag-undo-toast.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-tag-undo-toast",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Add a restore window for tag removal",
+  "summary": "Removing a wave tag now shows a 20-second restore toast so accidental tag deletes can be undone without reopening the tag editor.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Tag removal now shows a compact restore toast instead of a passive confirmation-only message",
+        "Restoring a just-removed tag re-adds it from the toast action without leaving the current wave"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
@@ -64,6 +64,7 @@ import java.util.Map;
 public final class TagController {
 
   private static final TagMessages messages = GWT.create(TagMessages.class);
+  private static final String TAG_REMOVAL_TOAST_ID = "tag-removal-undo";
 
   /**
    * Builds and installs the tag control feature.
@@ -78,6 +79,26 @@ public final class TagController {
   private final TagsViewBuilder.Css tagsCss = WavePanelResourceLoader.getTags().css();
   private final Map<String, InlineTagEditor> inlineEditors =
       new HashMap<String, InlineTagEditor>();
+  private final UndoableTagRemovalManager undoableTagRemovalManager =
+      new UndoableTagRemovalManager(
+          new UndoableTagRemovalManager.GwtScheduler(),
+          new UndoableTagRemovalManager.Presenter() {
+            @Override
+            public void show(String tagName, Runnable onUndo) {
+              ToastNotification.showPersistentAction(
+                  TAG_REMOVAL_TOAST_ID,
+                  messages.removedTagUndoToast(tagName),
+                  ToastNotification.Level.INFO,
+                  messages.restoreTagAction(),
+                  onUndo);
+            }
+
+            @Override
+            public void dismiss() {
+              ToastNotification.dismissPersistent(TAG_REMOVAL_TOAST_ID);
+            }
+          },
+          UndoableTagRemovalManager.DEFAULT_RESTORE_WINDOW_MS);
 
   private TagController(DomAsViewProvider views, ModelAsViewProvider models) {
     this.views = views;
@@ -150,7 +171,7 @@ public final class TagController {
       final Pair<Conversation, String> tag = models.getTag(tagView);
       if (tag != null) {
         tag.first.removeTag(tag.second);
-        ToastNotification.showInfo(messages.removedTagToast(tag.second));
+        undoableTagRemovalManager.tagRemoved(tag.first, tag.second);
       }
     }
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.wavepanel.impl.edit;
+
+import com.google.gwt.user.client.Timer;
+
+import org.waveprotocol.wave.model.conversation.Conversation;
+
+/**
+ * Tracks one pending tag-removal restore window.
+ *
+ * <p>Tag removal stays immediate at the model layer. This helper only keeps a
+ * short-lived undo opportunity alive in the client and re-adds the removed tag
+ * if the user restores it before expiry.
+ */
+final class UndoableTagRemovalManager {
+
+  static final int DEFAULT_RESTORE_WINDOW_MS = 20_000;
+
+  interface Cancellable {
+    void cancel();
+  }
+
+  interface Scheduler {
+    Cancellable schedule(int delayMs, Runnable runnable);
+  }
+
+  interface Presenter {
+    void show(String tagName, Runnable onUndo);
+    void dismiss();
+  }
+
+  static final class GwtScheduler implements Scheduler {
+    @Override
+    public Cancellable schedule(int delayMs, final Runnable runnable) {
+      final Timer timer = new Timer() {
+        @Override
+        public void run() {
+          runnable.run();
+        }
+      };
+      timer.schedule(delayMs);
+      return new Cancellable() {
+        @Override
+        public void cancel() {
+          timer.cancel();
+        }
+      };
+    }
+  }
+
+  private final Scheduler scheduler;
+  private final Presenter presenter;
+  private final int restoreWindowMs;
+
+  private PendingRemoval pendingRemoval;
+  private Cancellable pendingExpiry;
+
+  UndoableTagRemovalManager(Scheduler scheduler, Presenter presenter, int restoreWindowMs) {
+    this.scheduler = scheduler;
+    this.presenter = presenter;
+    this.restoreWindowMs = restoreWindowMs;
+  }
+
+  void tagRemoved(Conversation conversation, String tagName) {
+    if (conversation == null || tagName == null || tagName.isEmpty()) {
+      return;
+    }
+
+    clearPendingRemoval();
+    pendingRemoval = new PendingRemoval(conversation, tagName);
+    presenter.show(tagName, new Runnable() {
+      @Override
+      public void run() {
+        undoPendingRemoval();
+      }
+    });
+    pendingExpiry = scheduler.schedule(restoreWindowMs, new Runnable() {
+      @Override
+      public void run() {
+        clearPendingRemoval();
+      }
+    });
+  }
+
+  void clearPendingRemoval() {
+    if (pendingExpiry != null) {
+      pendingExpiry.cancel();
+      pendingExpiry = null;
+    }
+    if (pendingRemoval != null) {
+      pendingRemoval = null;
+      presenter.dismiss();
+    }
+  }
+
+  private void undoPendingRemoval() {
+    if (pendingRemoval == null) {
+      return;
+    }
+
+    Conversation conversation = pendingRemoval.conversation;
+    String tagName = pendingRemoval.tagName;
+    clearPendingRemoval();
+    conversation.addTag(tagName);
+  }
+
+  private static final class PendingRemoval {
+    private final Conversation conversation;
+    private final String tagName;
+
+    private PendingRemoval(Conversation conversation, String tagName) {
+      this.conversation = conversation;
+      this.tagName = tagName;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java
@@ -22,7 +22,7 @@ package org.waveprotocol.wave.client.wavepanel.impl.edit.i18n;
 import com.google.gwt.i18n.client.Messages;
 
 /**
- * i18n messages for the tag controller (add/remove dialogs).
+ * i18n messages for the tag controller.
  *
  * Ported from Wiab.pro.
  *
@@ -45,5 +45,8 @@ public interface TagMessages extends Messages {
   String addTagHint();
 
   @DefaultMessage("Removed tag: {0}")
-  String removedTagToast(String tag);
+  String removedTagUndoToast(String tag);
+
+  @DefaultMessage("Restore")
+  String restoreTagAction();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -22,6 +22,7 @@ package org.waveprotocol.wave.client.widget.toast;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 
 import java.util.HashMap;
@@ -103,6 +104,25 @@ public final class ToastNotification {
    * @param level severity / color theme
    */
   public static void showPersistent(String id, String message, Level level) {
+    showPersistentInternal(id, message, level, null, null);
+  }
+
+  /**
+   * Shows a persistent toast with an inline action button.
+   *
+   * @param id a caller-chosen identifier so the correct toast can be dismissed
+   * @param message text to display
+   * @param level severity / color theme
+   * @param actionLabel button text shown to the user
+   * @param action callback run when the action is clicked
+   */
+  public static void showPersistentAction(
+      String id, String message, Level level, String actionLabel, Runnable action) {
+    showPersistentInternal(id, message, level, actionLabel, action);
+  }
+
+  private static void showPersistentInternal(
+      final String id, String message, Level level, String actionLabel, final Runnable action) {
     if (id == null) {
       return;
     }
@@ -151,12 +171,48 @@ public final class ToastNotification {
     ts.setProperty("fontWeight", "500");
     ts.setProperty("borderRadius", "8px");
     ts.setProperty("boxShadow", "0 4px 12px rgba(0,0,0,0.25)");
+    ts.setProperty("display", "inline-flex");
+    ts.setProperty("alignItems", "center");
+    ts.setProperty("justifyContent", "center");
+    ts.setProperty("gap", "12px");
 
     // Fade-in animation
     ts.setProperty("opacity", "0");
     ts.setProperty("transition", "opacity 300ms ease");
 
-    toast.setInnerText(message);
+    Element messageEl = Document.get().createSpanElement();
+    messageEl.setInnerText(message);
+    toast.appendChild(messageEl);
+
+    if (actionLabel != null && !actionLabel.isEmpty() && action != null) {
+      Element actionBtn = Document.get().createButtonElement();
+      actionBtn.setInnerText(actionLabel);
+      Style actionStyle = actionBtn.getStyle();
+      actionStyle.setProperty("background", "rgba(255,255,255,0.16)");
+      actionStyle.setProperty("border", "1px solid rgba(255,255,255,0.28)");
+      actionStyle.setProperty("borderRadius", "999px");
+      actionStyle.setProperty("color", "#fff");
+      actionStyle.setProperty("cursor", "pointer");
+      actionStyle.setProperty("fontSize", "12px");
+      actionStyle.setProperty("fontWeight", "600");
+      actionStyle.setProperty("padding", "4px 10px");
+      actionStyle.setProperty("whiteSpace", "nowrap");
+
+      Event.sinkEvents(actionBtn, Event.ONCLICK);
+      Event.setEventListener(actionBtn, new com.google.gwt.user.client.EventListener() {
+        @Override
+        public void onBrowserEvent(Event event) {
+          if (Event.ONCLICK == event.getTypeInt()) {
+            event.preventDefault();
+            event.stopPropagation();
+            dismissPersistent(id);
+            action.run();
+          }
+        }
+      });
+      toast.appendChild(actionBtn);
+    }
+
     Document.get().getBody().appendChild(toast);
     persistentToasts.put(id, toast);
     updatePersistentToastPositions();

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -119,6 +119,23 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     assertTrue(presenter.contains("onQueryEntered();"));
   }
 
+  public void testTagRemovalUsesUndoRestoreWindowInsteadOfPassiveToast() throws Exception {
+    String controller =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java");
+    String manager =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java");
+    String messages =
+        read("wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java");
+
+    assertTrue(controller.contains("undoableTagRemovalManager.tagRemoved("));
+    assertFalse(controller.contains("ToastNotification.showInfo(messages.removedTagToast("));
+    assertTrue(manager.contains("DEFAULT_RESTORE_WINDOW_MS = 20_000"));
+    assertTrue(manager.contains("conversation.addTag(tagName);"));
+    assertTrue(manager.contains("presenter.show(tagName, new Runnable()"));
+    assertTrue(messages.contains("String removedTagUndoToast(String tag)"));
+    assertTrue(messages.contains("String restoreTagAction()"));
+  }
+
   private String read(String relativePath) throws IOException {
     return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
   }


### PR DESCRIPTION
## Summary
- replace the passive tag-removal toast with a 20-second restore toast
- add a focused undo manager for tag removals so the restore window survives unrelated passive toasts
- document the change with a changelog fragment and repo plan artifact

## Root cause
Tag removal used the dedicated remove affordance, deleted the tag immediately, and only showed a passive informational toast. That provided no recovery path for accidental tag deletes.

## Verification
- `sbt "testOnly org.waveprotocol.box.server.util.WavePanelTagsLayoutTest org.waveprotocol.box.server.util.WavePanelCssCompatibilityTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9902`
- `PORT=9902 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-832-tag-undo-toast-20260412/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-832-tag-undo-toast-20260412/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9902 bash scripts/wave-smoke.sh check`
- Browser pass on `http://127.0.0.1:9902/`: registered `tagundo832a@local.net`, added tag `soft832`, verified remove shows `Removed tag: soft832` + `Restore`, verified restore re-adds the tag, then verified leaving the second toast untouched removes the toast while the tag stays deleted

Closes #832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave tag removal now displays a dismissible toast notification with a 20-second undo window. Users can restore accidentally removed tags via the "Restore" action without reopening the tag editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->