### PR TITLE
feat(harness): add worktree diagnostics bundle

### DIFF
--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -30,6 +30,11 @@ override into the smoke commands:
 3. `curl -sS http://localhost:9899/healthz`
 4. `PORT=9899 bash scripts/wave-smoke.sh stop`
 
+If the start/check flow fails or the issue/PR needs richer runtime detail, run
+`PORT=9899 bash scripts/worktree-diagnostics.sh --port 9899` and follow
+[docs/runbooks/worktree-diagnostics.md](runbooks/worktree-diagnostics.md) for
+the bundled evidence format.
+
 ## Browser verification baseline
 
 The standalone browser-smoke baseline remains:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -14,6 +14,8 @@ setup, smoke checks, deployment, and operational routines.
   - Standard browser-verification path built on the existing smoke baseline.
 - [`change-type-verification-matrix.md`](change-type-verification-matrix.md)
   - Quick reference for when smoke is enough versus when browser verification is required.
+- [`worktree-diagnostics.md`](worktree-diagnostics.md)
+  - One-command diagnostics bundle for failed or detail-heavy worktree verification.
 - [`../DEV_SETUP.md`](../DEV_SETUP.md)
   - Local requirements and setup notes.
 - [`../BUILDING-sbt.md`](../BUILDING-sbt.md)

--- a/docs/runbooks/worktree-diagnostics.md
+++ b/docs/runbooks/worktree-diagnostics.md
@@ -1,0 +1,99 @@
+# Worktree Diagnostics
+
+Use this runbook when an incubator-wave issue worktree needs a compact
+diagnostics bundle for a failed verification run or when an issue comment / PR
+summary needs more detail than raw command lines.
+
+## 1. What The Bundle Captures
+
+`scripts/worktree-diagnostics.sh` stays on top of the existing worktree flow. It
+does not stage or start the app. Instead, it captures the current state of the
+already-prepared worktree:
+
+- branch, worktree, port, runtime-config, and evidence-file metadata
+- current endpoint probe statuses for `/`, `/healthz`, `/readyz`, and the
+  compiled webclient asset
+- current `scripts/wave-smoke.sh check` output and exit status
+- last-N lines from the staged startup output (`wave_server.out`)
+- last-N lines from the staged server log (`logs/wave.log`,
+  `logs/wave-json.log`, or `wiab-server.log`, depending on the runtime)
+
+The command stays useful when the runtime is unhealthy. Missing files and
+non-zero smoke checks are rendered as evidence, not treated as fatal errors.
+
+## 2. Default Usage
+
+After `worktree-boot.sh` has prepared the staged app, use:
+
+```bash
+PORT=9900 bash scripts/worktree-diagnostics.sh --port 9900
+```
+
+Typical timing:
+
+1. after `PORT=9900 bash scripts/wave-smoke.sh check` fails
+2. after the smoke passes but the issue comment or PR needs richer detail
+3. after a startup timeout so the bundle can capture the startup and server-log
+   tails
+
+## 3. Persisted Output
+
+To keep a durable copy in the worktree-local verification area, use `--output`:
+
+```bash
+PORT=9900 bash scripts/worktree-diagnostics.sh --port 9900 \
+  --output journal/local-verification/2026-04-12-issue-587-worktree-diagnostics-bundle.md
+```
+
+This prints the bundle to stdout and writes the same Markdown to the requested
+file.
+
+## 4. Expected Output Shape
+
+The bundle contains these sections:
+
+- `# Worktree Diagnostics Bundle`
+- worktree metadata bullets
+- `## Endpoint Probes`
+- `## Smoke Check`
+- `## Startup Output Tail (...)`
+- `## Server Log Tail (...)`
+
+Example:
+
+````markdown
+# Worktree Diagnostics Bundle
+
+- Branch: issue-587-worktree-diagnostics-20260412
+- Worktree: /Users/vega/devroot/worktrees/issue-587-worktree-diagnostics-20260412
+- Port: 9900
+
+## Endpoint Probes
+
+- `GET /` -> `302`
+- `GET /healthz` -> `200`
+
+## Smoke Check
+
+- Command: `PORT=9900 bash scripts/wave-smoke.sh check`
+- Smoke exit: `1`
+
+```text
+ROOT_STATUS=302
+Unexpected health status: 500
+```
+````
+
+When files are missing, the bundle prints explicit `(missing: /path/to/file)`
+markers so the issue comment or PR summary can show exactly what was absent.
+
+## 5. How To Reference The Bundle
+
+Summarize the important lines in the issue comment or PR body:
+
+- endpoint statuses
+- smoke exit/result
+- the most relevant startup or server-log tail lines
+- the path to the saved diagnostics file when `--output` was used
+
+This keeps the issue/PR traceable without pasting an entire raw server log.

--- a/docs/runbooks/worktree-lane-lifecycle.md
+++ b/docs/runbooks/worktree-lane-lifecycle.md
@@ -65,8 +65,8 @@ The helper does four things:
 - creates the canonical local-verification record under
   `journal/local-verification/`
 
-The helper prints the exact `start`, `check`, and `stop` commands for the lane.
-Use those commands as printed.
+The helper prints the exact `start`, `check`, `diagnostics`, and `stop`
+commands for the lane. Use those commands as printed.
 
 ## 5. Handle port conflicts explicitly
 
@@ -128,11 +128,15 @@ After `scripts/worktree-boot.sh` finishes, run the printed commands in order:
 
 1. Start the server with the printed `JAVA_OPTS` and `PORT`.
 2. Run `bash scripts/wave-smoke.sh check`.
-3. If the change can affect browser-visible behavior, use
+3. If startup or smoke fails, or if the issue/PR needs richer runtime detail,
+   run `PORT=<port> bash scripts/worktree-diagnostics.sh --port <port>` and use
+   [`worktree-diagnostics.md`](worktree-diagnostics.md) for the bundled
+   evidence format.
+4. If the change can affect browser-visible behavior, use
    [`browser-verification.md`](browser-verification.md) and
    [`change-type-verification-matrix.md`](change-type-verification-matrix.md)
    to decide whether a browser pass is required and what narrow path to check.
-4. Stop the server with `bash scripts/wave-smoke.sh stop`.
+5. Stop the server with `bash scripts/wave-smoke.sh stop`.
 
 This runbook standardizes only the base lifecycle. Browser-verification
 expectations are standardized separately in

--- a/docs/superpowers/plans/2026-04-12-issue-587-worktree-diagnostics.md
+++ b/docs/superpowers/plans/2026-04-12-issue-587-worktree-diagnostics.md
@@ -1,0 +1,195 @@
+# Issue 587 Worktree Diagnostics Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one predictable diagnostics bundle command for issue worktrees so lanes can attach compact startup, endpoint, smoke, and log evidence to verification records.
+
+**Architecture:** Reuse the existing `scripts/worktree-boot.sh` plus `scripts/wave-smoke.sh` lifecycle instead of inventing new observability plumbing. Add one shell script that reads the current worktree state, probes the existing endpoints, captures the current smoke result, tails the staged startup/server logs, and emits one Markdown bundle that can be pasted into issue comments or written to a file. Document the flow in one runbook and cross-link it from the existing worktree-lane docs.
+
+**Tech Stack:** Bash, existing worktree/smoke scripts, Markdown runbooks, local staged server verification.
+
+---
+
+## Scope And Decisions
+
+- Keep the scope to one script: `scripts/worktree-diagnostics.sh`.
+- Keep the diagnostics bundle grounded in the current staged-worktree runtime:
+  - startup output from `target/universal/stage/wave_server.out` (or the legacy staged install equivalent)
+  - current endpoint probe statuses
+  - current `scripts/wave-smoke.sh check` output and exit status
+  - last-N lines from the staged server log (`logs/wave.log`, `logs/wave-json.log`, or `wiab-server.log`, depending on the runtime)
+- The diagnostics script must stay useful even when the server failed to start or `wave-smoke.sh check` returns non-zero; failures are evidence, not reasons for the diagnostics command to crash.
+- The script may optionally write the Markdown bundle to an explicit output file, but it should always be usable as a single command that prints paste-ready evidence.
+- Do not add a second diagnostics script, a metrics daemon, or a larger observability framework.
+
+## Files
+
+- Create: `scripts/worktree-diagnostics.sh`
+- Create: `scripts/test-worktree-diagnostics.sh`
+- Create: `docs/runbooks/worktree-diagnostics.md`
+- Modify: `scripts/worktree-boot.sh`
+- Modify: `docs/runbooks/worktree-lane-lifecycle.md`
+- Modify: `docs/runbooks/README.md`
+- Modify: `docs/SMOKE_TESTS.md`
+- Create: `wave/config/changelog.d/2026-04-12-worktree-diagnostics-runbook.json`
+
+## Risks And Non-Goals
+
+- The diagnostics bundle must not quietly report invented paths or green statuses. Missing files and failed smoke checks should stay explicit in the output.
+- The worktree helper already owns build prep and evidence-file creation. The diagnostics script should consume that state, not duplicate staging or server startup.
+- This task does not change browser-verification policy, add CI wiring, or alter how the server boots.
+
+## Task 1: Lock The Diagnostics Contract With A Failing Script Test
+
+**Files:**
+- Create: `scripts/test-worktree-diagnostics.sh`
+
+- [ ] **Step 1: Add a shell test that stubs the worktree environment and asserts the bundle shape**
+
+Create `scripts/test-worktree-diagnostics.sh` using the existing `scripts/test-feature-flag.sh` pattern:
+- create a temp fake repo root with `journal/runtime-config/`, `journal/local-verification/`, and a fake staged install dir
+- stub `git` so the diagnostics script sees a deterministic repo root and branch
+- stub `curl` so `/`, `/healthz`, `/readyz`, and `/webclient/webclient.nocache.js` return deterministic status codes
+- stub `scripts/wave-smoke.sh check` so the diagnostics script captures both the smoke output and its exit code
+- seed fake `wave_server.out` and `wiab-server.log` files with recognizable tail lines
+- assert the Markdown output contains the branch/worktree metadata, endpoint probe statuses, smoke exit/result, startup tail, and server-log tail
+
+- [ ] **Step 2: Run the new shell test and verify it fails for the expected reason**
+
+Run:
+```bash
+bash scripts/test-worktree-diagnostics.sh
+```
+
+Expected:
+- the command fails because `scripts/worktree-diagnostics.sh` does not exist yet or does not emit the expected diagnostics sections
+
+## Task 2: Implement The Diagnostics Script
+
+**Files:**
+- Create: `scripts/worktree-diagnostics.sh`
+- Modify: `scripts/worktree-boot.sh`
+
+- [ ] **Step 1: Add the diagnostics script with a narrow CLI**
+
+Implement `scripts/worktree-diagnostics.sh` with:
+- `--port <port>` defaulting to `PORT` or `9898`
+- `--lines <n>` defaulting to a small tail such as `40`
+- `--output <path>` to optionally persist the Markdown bundle
+- automatic discovery of:
+  - repo root and current branch via `git`
+  - staged install dir using the same `target/universal/stage` vs legacy fallback used by `wave-smoke.sh`
+  - current branch-scoped runtime config under `journal/runtime-config/`
+  - current local-verification record under `journal/local-verification/` when present
+
+- [ ] **Step 2: Make the diagnostics script resilient when the runtime is unhealthy**
+
+The script should:
+- probe `/`, `/healthz`, `/readyz`, and `/webclient/webclient.nocache.js` with curl and record raw HTTP statuses
+- run `PORT=<port> bash scripts/wave-smoke.sh check`, capture both stdout/stderr and the exit code, and continue even when that command fails
+- render missing log/config/evidence files as explicit `missing` lines instead of exiting
+- emit one Markdown bundle that is ready to paste into an issue comment or PR summary
+
+- [ ] **Step 3: Surface the new command from the existing worktree helper**
+
+Update `scripts/worktree-boot.sh` to print the diagnostics command alongside the existing `start`, `check`, and `stop` commands so issue lanes discover it from the normal worktree boot flow:
+
+```bash
+Diagnostics:
+  PORT=$PORT bash scripts/worktree-diagnostics.sh --port $PORT
+```
+
+- [ ] **Step 4: Re-run the shell test and verify it passes**
+
+Run:
+```bash
+bash scripts/test-worktree-diagnostics.sh
+```
+
+Expected:
+- the command exits `0`
+- output ends with a `PASS: ...` line for the diagnostics script contract
+
+## Task 3: Document The Diagnostics Flow
+
+**Files:**
+- Create: `docs/runbooks/worktree-diagnostics.md`
+- Modify: `docs/runbooks/worktree-lane-lifecycle.md`
+- Modify: `docs/runbooks/README.md`
+- Modify: `docs/SMOKE_TESTS.md`
+
+- [ ] **Step 1: Add the dedicated runbook**
+
+Create `docs/runbooks/worktree-diagnostics.md` covering:
+- when to run the diagnostics bundle
+  - after failed startup/smoke
+  - when an issue comment or PR summary needs more detail than raw command lines
+- the default command:
+
+```bash
+PORT=9900 bash scripts/worktree-diagnostics.sh --port 9900
+```
+
+- the optional persisted-output form:
+
+```bash
+PORT=9900 bash scripts/worktree-diagnostics.sh --port 9900 \
+  --output journal/local-verification/2026-04-12-issue-587-worktree-diagnostics-bundle.md
+```
+
+- the expected sections in the bundle and how to reference them from issue comments / PR summaries
+
+- [ ] **Step 2: Cross-link the new runbook from the existing verification docs**
+
+Update the existing runbooks/docs so they point to `docs/runbooks/worktree-diagnostics.md` as the bundled-detail path after `worktree-boot.sh` and `wave-smoke.sh`:
+- `docs/runbooks/worktree-lane-lifecycle.md`
+- `docs/runbooks/README.md`
+- `docs/SMOKE_TESTS.md`
+
+## Task 4: Verification And Evidence
+
+**Files:**
+- Create locally only if needed: `journal/local-verification/2026-04-12-issue-587-worktree-diagnostics-bundle.md`
+- Create: `wave/config/changelog.d/2026-04-12-worktree-diagnostics-runbook.json`
+
+- [ ] **Step 1: Run focused script verification**
+
+Run:
+```bash
+bash scripts/test-worktree-diagnostics.sh
+bash -n scripts/worktree-diagnostics.sh scripts/worktree-boot.sh
+```
+
+Expected:
+- the contract test passes
+- both scripts pass shell syntax validation
+
+- [ ] **Step 2: Run the real worktree boot + smoke + diagnostics flow**
+
+Run:
+```bash
+bash scripts/worktree-boot.sh --port 9904
+PORT=9904 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-587-worktree-diagnostics-20260412/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-587-worktree-diagnostics-20260412/wave/config/jaas.config' bash scripts/wave-smoke.sh start
+PORT=9904 bash scripts/wave-smoke.sh check
+PORT=9904 bash scripts/worktree-diagnostics.sh --port 9904 \
+  --output journal/local-verification/2026-04-12-issue-587-worktree-diagnostics-bundle.md
+PORT=9904 bash scripts/wave-smoke.sh stop
+```
+
+Expected:
+- `worktree-boot.sh` prints the diagnostics command for the selected port
+- the smoke check reports the expected root/health/webclient statuses
+- the diagnostics bundle file is written and contains endpoint probes, smoke output, startup output tail, and server-log tail
+- shutdown completes cleanly
+
+- [ ] **Step 3: Validate the changelog artifact**
+
+Run:
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Expected:
+- changelog assembly succeeds
+- changelog validation passes

--- a/scripts/test-worktree-diagnostics.sh
+++ b/scripts/test-worktree-diagnostics.sh
@@ -56,7 +56,10 @@ make_curl_stub() {
 #!/usr/bin/env bash
 set -euo pipefail
 
-url="${*: -1}"
+url=""
+for arg in "$@"; do
+  url="${arg}"
+done
 status="000"
 case "${url}" in
   */healthz) status="${TEST_HEALTH_STATUS-200}" ;;
@@ -91,6 +94,7 @@ EOF
 
 seed_runtime_artifacts() {
   local repo_root="$1"
+  local evidence_date="$2"
   mkdir -p \
     "${repo_root}/target/universal/stage" \
     "${repo_root}/journal/runtime-config" \
@@ -108,25 +112,26 @@ EOF
   cat > "${repo_root}/journal/runtime-config/issue-587-worktree-diagnostics-20260412-port-9904.application.conf" <<'EOF'
 http_frontend_addresses = ["127.0.0.1:9904"]
 EOF
-  cat > "${repo_root}/journal/local-verification/2026-04-12-issue-587-worktree-diagnostics.md" <<'EOF'
+  cat > "${repo_root}/journal/local-verification/${evidence_date}-issue-587-worktree-diagnostics-20260412.md" <<'EOF'
 # Local Verification
 - pending
 EOF
 }
 
 run_bundle_shape_case() {
-  local temp_dir repo_root bin_dir output_path output
+  local temp_dir repo_root bin_dir output_path output prior_date
 
   temp_dir="$(mktemp -d)"
   repo_root="${temp_dir}/repo"
   bin_dir="${temp_dir}/bin"
   output_path="${temp_dir}/bundle.md"
+  prior_date="2026-04-11"
   mkdir -p "${repo_root}" "${bin_dir}"
 
   make_git_stub "${bin_dir}"
   make_curl_stub "${bin_dir}"
   make_fake_smoke_script "${repo_root}"
-  seed_runtime_artifacts "${repo_root}"
+  seed_runtime_artifacts "${repo_root}" "${prior_date}"
 
   output="$(
     PATH="${bin_dir}:${PATH}" \
@@ -145,20 +150,24 @@ run_bundle_shape_case() {
   assert_contains "${output}" "Port: 9904"
   assert_contains "${output}" '`GET /healthz` -> `200`'
   assert_contains "${output}" 'Smoke exit: `0`'
+  assert_contains "${output}" "Runtime config: ${repo_root}/journal/runtime-config/issue-587-worktree-diagnostics-20260412-port-9904.application.conf"
+  assert_contains "${output}" "Evidence file: ${repo_root}/journal/local-verification/${prior_date}-issue-587-worktree-diagnostics-20260412.md"
   assert_contains "${output}" "startup line 2"
   assert_contains "${output}" "server log final"
-  assert_file_contains "${output_path}" "Runtime config:"
-  assert_file_contains "${output_path}" "Evidence file:"
+  assert_file_contains "${output_path}" "Evidence file: ${repo_root}/journal/local-verification/${prior_date}-issue-587-worktree-diagnostics-20260412.md"
 
   rm -rf "${temp_dir}"
 }
 
 run_missing_artifacts_case() {
-  local temp_dir repo_root bin_dir output
+  local temp_dir repo_root bin_dir output today missing_runtime missing_evidence
 
   temp_dir="$(mktemp -d)"
   repo_root="${temp_dir}/repo"
   bin_dir="${temp_dir}/bin"
+  today="$(date +%F)"
+  missing_runtime="${repo_root}/journal/runtime-config/issue-587-worktree-diagnostics-20260412-port-9904.application.conf"
+  missing_evidence="${repo_root}/journal/local-verification/${today}-issue-587-worktree-diagnostics-20260412.md"
   mkdir -p "${repo_root}" "${bin_dir}" "${repo_root}/scripts"
 
   make_git_stub "${bin_dir}"
@@ -178,17 +187,59 @@ run_missing_artifacts_case() {
     "${SCRIPT_PATH}" --port 9904 --lines 5
   )" || fail "expected diagnostics bundle to stay usable when artifacts are missing"
 
-  assert_contains "${output}" "Runtime config: missing"
-  assert_contains "${output}" "Evidence file: missing"
+  assert_contains "${output}" "Runtime config: (missing: ${missing_runtime})"
+  assert_contains "${output}" "Evidence file: (missing: ${missing_evidence})"
   assert_contains "${output}" 'Smoke exit: `1`'
   assert_contains "${output}" "(missing:"
 
   rm -rf "${temp_dir}"
 }
 
+run_empty_probe_status_case() {
+  local temp_dir repo_root bin_dir output
+
+  temp_dir="$(mktemp -d)"
+  repo_root="${temp_dir}/repo"
+  bin_dir="${temp_dir}/bin"
+  mkdir -p "${repo_root}" "${bin_dir}"
+
+  make_git_stub "${bin_dir}"
+  make_curl_stub "${bin_dir}"
+  make_fake_smoke_script "${repo_root}"
+  seed_runtime_artifacts "${repo_root}" "2026-04-12"
+
+  output="$(
+    PATH="${bin_dir}:${PATH}" \
+    TEST_REPO_ROOT="${repo_root}" \
+    TEST_BRANCH="issue-587-worktree-diagnostics-20260412" \
+    TEST_ROOT_STATUS=302 \
+    TEST_HEALTH_STATUS="" \
+    TEST_READY_STATUS=200 \
+    TEST_WEBCLIENT_STATUS=200 \
+    TEST_SMOKE_EXIT=0 \
+    "${SCRIPT_PATH}" --port 9904 --lines 2
+  )" || fail "expected diagnostics bundle to tolerate empty curl status output"
+
+  assert_contains "${output}" '`GET /healthz` -> `000`'
+
+  rm -rf "${temp_dir}"
+}
+
+run_missing_option_value_case() {
+  local output
+
+  if output="$("${SCRIPT_PATH}" --port 2>&1)"; then
+    fail "expected --port without a value to fail"
+  fi
+
+  assert_contains "${output}" "--port requires a value"
+}
+
 main() {
   run_bundle_shape_case
   run_missing_artifacts_case
+  run_empty_probe_status_case
+  run_missing_option_value_case
   printf 'PASS: scripts/worktree-diagnostics.sh bundle contract\n'
 }
 

--- a/scripts/test-worktree-diagnostics.sh
+++ b/scripts/test-worktree-diagnostics.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_PATH="${ROOT_DIR}/scripts/worktree-diagnostics.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    fail "expected output to contain: ${needle}"
+  fi
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+
+  [[ -f "${path}" ]] || fail "expected file to exist: ${path}"
+  local content
+  content="$(cat "${path}")"
+  assert_contains "${content}" "${needle}"
+}
+
+make_git_stub() {
+  local stub_path="$1/git"
+  cat > "${stub_path}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1-} ${2-}" in
+  "rev-parse --show-toplevel")
+    printf '%s\n' "${TEST_REPO_ROOT}"
+    ;;
+  "branch --show-current")
+    printf '%s\n' "${TEST_BRANCH}"
+    ;;
+  *)
+    printf 'unsupported git invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "${stub_path}"
+}
+
+make_curl_stub() {
+  local stub_path="$1/curl"
+  cat > "${stub_path}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+status="000"
+case "${url}" in
+  */healthz) status="${TEST_HEALTH_STATUS-200}" ;;
+  */readyz) status="${TEST_READY_STATUS-200}" ;;
+  */webclient/webclient.nocache.js) status="${TEST_WEBCLIENT_STATUS-200}" ;;
+  */) status="${TEST_ROOT_STATUS-302}" ;;
+esac
+printf '%s' "${status}"
+EOF
+  chmod +x "${stub_path}"
+}
+
+make_fake_smoke_script() {
+  local repo_root="$1"
+  mkdir -p "${repo_root}/scripts"
+  cat > "${repo_root}/scripts/wave-smoke.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1-}" != "check" ]]; then
+  printf 'unsupported smoke invocation: %s\n' "$*" >&2
+  exit 1
+fi
+
+printf '%s\n' "${TEST_SMOKE_OUTPUT:-ROOT_STATUS=302
+HEALTH_STATUS=200
+WEBCLIENT_STATUS=200}"
+exit "${TEST_SMOKE_EXIT:-0}"
+EOF
+  chmod +x "${repo_root}/scripts/wave-smoke.sh"
+}
+
+seed_runtime_artifacts() {
+  local repo_root="$1"
+  mkdir -p \
+    "${repo_root}/target/universal/stage" \
+    "${repo_root}/journal/runtime-config" \
+    "${repo_root}/journal/local-verification"
+  cat > "${repo_root}/target/universal/stage/wave_server.out" <<'EOF'
+startup line 1
+startup line 2
+startup final line
+EOF
+  cat > "${repo_root}/target/universal/stage/wiab-server.log" <<'EOF'
+server log 1
+server log 2
+server log final
+EOF
+  cat > "${repo_root}/journal/runtime-config/issue-587-worktree-diagnostics-20260412-port-9904.application.conf" <<'EOF'
+http_frontend_addresses = ["127.0.0.1:9904"]
+EOF
+  cat > "${repo_root}/journal/local-verification/2026-04-12-issue-587-worktree-diagnostics.md" <<'EOF'
+# Local Verification
+- pending
+EOF
+}
+
+run_bundle_shape_case() {
+  local temp_dir repo_root bin_dir output_path output
+
+  temp_dir="$(mktemp -d)"
+  repo_root="${temp_dir}/repo"
+  bin_dir="${temp_dir}/bin"
+  output_path="${temp_dir}/bundle.md"
+  mkdir -p "${repo_root}" "${bin_dir}"
+
+  make_git_stub "${bin_dir}"
+  make_curl_stub "${bin_dir}"
+  make_fake_smoke_script "${repo_root}"
+  seed_runtime_artifacts "${repo_root}"
+
+  output="$(
+    PATH="${bin_dir}:${PATH}" \
+    TEST_REPO_ROOT="${repo_root}" \
+    TEST_BRANCH="issue-587-worktree-diagnostics-20260412" \
+    TEST_ROOT_STATUS=302 \
+    TEST_HEALTH_STATUS=200 \
+    TEST_READY_STATUS=200 \
+    TEST_WEBCLIENT_STATUS=200 \
+    TEST_SMOKE_EXIT=0 \
+    "${SCRIPT_PATH}" --port 9904 --lines 2 --output "${output_path}"
+  )" || fail "expected diagnostics bundle command to succeed"
+
+  assert_contains "${output}" "# Worktree Diagnostics Bundle"
+  assert_contains "${output}" "Branch: issue-587-worktree-diagnostics-20260412"
+  assert_contains "${output}" "Port: 9904"
+  assert_contains "${output}" '`GET /healthz` -> `200`'
+  assert_contains "${output}" 'Smoke exit: `0`'
+  assert_contains "${output}" "startup line 2"
+  assert_contains "${output}" "server log final"
+  assert_file_contains "${output_path}" "Runtime config:"
+  assert_file_contains "${output_path}" "Evidence file:"
+
+  rm -rf "${temp_dir}"
+}
+
+run_missing_artifacts_case() {
+  local temp_dir repo_root bin_dir output
+
+  temp_dir="$(mktemp -d)"
+  repo_root="${temp_dir}/repo"
+  bin_dir="${temp_dir}/bin"
+  mkdir -p "${repo_root}" "${bin_dir}" "${repo_root}/scripts"
+
+  make_git_stub "${bin_dir}"
+  make_curl_stub "${bin_dir}"
+  make_fake_smoke_script "${repo_root}"
+
+  output="$(
+    PATH="${bin_dir}:${PATH}" \
+    TEST_REPO_ROOT="${repo_root}" \
+    TEST_BRANCH="issue-587-worktree-diagnostics-20260412" \
+    TEST_ROOT_STATUS=000 \
+    TEST_HEALTH_STATUS=000 \
+    TEST_READY_STATUS=000 \
+    TEST_WEBCLIENT_STATUS=000 \
+    TEST_SMOKE_EXIT=1 \
+    TEST_SMOKE_OUTPUT=$'ROOT_STATUS=000\nUnexpected root status: 000' \
+    "${SCRIPT_PATH}" --port 9904 --lines 5
+  )" || fail "expected diagnostics bundle to stay usable when artifacts are missing"
+
+  assert_contains "${output}" "Runtime config: missing"
+  assert_contains "${output}" "Evidence file: missing"
+  assert_contains "${output}" 'Smoke exit: `1`'
+  assert_contains "${output}" "(missing:"
+
+  rm -rf "${temp_dir}"
+}
+
+main() {
+  run_bundle_shape_case
+  run_missing_artifacts_case
+  printf 'PASS: scripts/worktree-diagnostics.sh bundle contract\n'
+}
+
+main "$@"

--- a/scripts/worktree-boot.sh
+++ b/scripts/worktree-boot.sh
@@ -20,7 +20,7 @@ What it does:
   - stages the app with sbt Universal/stage
   - writes a port-specific runtime config under journal/runtime-config/
   - creates a local-verification journal entry under journal/local-verification/
-  - prints the exact start/check/stop commands for the selected port
+  - prints the exact start/check/diagnostics/stop commands for the selected port
 EOF
 }
 
@@ -199,6 +199,9 @@ Start:
 
 Check:
   PORT=$PORT bash scripts/wave-smoke.sh check
+
+Diagnostics:
+  PORT=$PORT bash scripts/worktree-diagnostics.sh --port $PORT
 
 Stop:
   PORT=$PORT bash scripts/wave-smoke.sh stop

--- a/scripts/worktree-diagnostics.sh
+++ b/scripts/worktree-diagnostics.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-9898}"
+LINES=40
+OUTPUT_PATH=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/worktree-diagnostics.sh [--port <port>] [--lines <n>] [--output <path>]
+
+Purpose:
+  Collect a compact diagnostics bundle for the current incubator-wave worktree.
+
+What it records:
+  - worktree, branch, runtime-config, and evidence-file metadata
+  - current endpoint probe statuses
+  - current `scripts/wave-smoke.sh check` output and exit status
+  - last-N lines from the staged startup output and server log
+EOF
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+sanitize_slug() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-'
+}
+
+trim_edge_dashes() {
+  local value="$1"
+  value="${value##-}"
+  value="${value%%-}"
+  printf '%s' "$value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)
+      PORT="${2:-}"
+      shift 2
+      ;;
+    --lines)
+      LINES="${2:-}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ "$PORT" =~ ^[0-9]+$ ]] || fail "--port must be numeric"
+(( PORT >= 1 && PORT <= 65535 )) || fail "--port must be between 1 and 65535"
+[[ "$LINES" =~ ^[0-9]+$ ]] || fail "--lines must be numeric"
+(( LINES >= 1 )) || fail "--lines must be at least 1"
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[[ -n "$ROOT" ]] || fail "Run this helper from inside an incubator-wave git worktree"
+ROOT=$(cd "$ROOT" && pwd)
+
+BRANCH=$(git branch --show-current)
+[[ -n "$BRANCH" ]] || fail "Could not determine the current branch"
+
+if [[ -d "$ROOT/target/universal/stage" ]]; then
+  INSTALL_DIR="$ROOT/target/universal/stage"
+else
+  INSTALL_DIR="$ROOT/wave/build/install/wave"
+fi
+
+BRANCH_SLUG=$(trim_edge_dashes "$(sanitize_slug "$BRANCH")")
+RUNTIME_CONFIG="$ROOT/journal/runtime-config/${BRANCH_SLUG}-port-${PORT}.application.conf"
+
+ISSUE_NUMBER=""
+SLUG_PART="$BRANCH"
+if [[ "$BRANCH" =~ ^issue-([0-9]+)-(.+)$ ]]; then
+  ISSUE_NUMBER="${BASH_REMATCH[1]}"
+  SLUG_PART="${BASH_REMATCH[2]}"
+fi
+
+EVIDENCE_SLUG=$(trim_edge_dashes "$(sanitize_slug "$SLUG_PART")")
+DATE_STAMP=$(date +%F)
+if [[ -n "$ISSUE_NUMBER" ]]; then
+  EVIDENCE_FILE="$ROOT/journal/local-verification/$DATE_STAMP-issue-$ISSUE_NUMBER-$EVIDENCE_SLUG.md"
+else
+  EVIDENCE_FILE="$ROOT/journal/local-verification/$DATE_STAMP-branch-$EVIDENCE_SLUG.md"
+fi
+
+STARTUP_LOG="$INSTALL_DIR/wave_server.out"
+
+resolve_server_log() {
+  local candidate
+  for candidate in \
+    "$INSTALL_DIR/wiab-server.log" \
+    "$INSTALL_DIR/logs/wave.log" \
+    "$INSTALL_DIR/logs/wave-json.log"
+  do
+    if [[ -f "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return
+    fi
+  done
+
+  printf '%s' "$INSTALL_DIR/logs/wave.log"
+}
+
+SERVER_LOG="$(resolve_server_log)"
+
+probe_status() {
+  local path="$1"
+  curl -sS --max-time 5 -o /dev/null -w "%{http_code}" "http://localhost:$PORT$path" 2>/dev/null || true
+}
+
+tail_section() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    printf '```text\n'
+    tail -n "$LINES" "$path"
+    printf '\n```\n'
+  else
+    printf '(missing: %s)\n' "$path"
+  fi
+}
+
+smoke_output="$(
+  cd "$ROOT"
+  PORT="$PORT" bash "$ROOT/scripts/wave-smoke.sh" check 2>&1
+)" && smoke_status=0 || smoke_status=$?
+
+render_bundle() {
+  cat <<EOF
+# Worktree Diagnostics Bundle
+
+- Branch: $BRANCH
+- Worktree: $ROOT
+- Port: $PORT
+- Install dir: $INSTALL_DIR
+- Runtime config: $(if [[ -f "$RUNTIME_CONFIG" ]]; then printf '%s' "$RUNTIME_CONFIG"; else printf 'missing'; fi)
+- Evidence file: $(if [[ -f "$EVIDENCE_FILE" ]]; then printf '%s' "$EVIDENCE_FILE"; else printf 'missing'; fi)
+- Generated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+## Endpoint Probes
+
+- \`GET /\` -> \`$(probe_status "/")\`
+- \`GET /healthz\` -> \`$(probe_status "/healthz")\`
+- \`GET /readyz\` -> \`$(probe_status "/readyz")\`
+- \`GET /webclient/webclient.nocache.js\` -> \`$(probe_status "/webclient/webclient.nocache.js")\`
+
+## Smoke Check
+
+- Command: \`PORT=$PORT bash scripts/wave-smoke.sh check\`
+- Smoke exit: \`$smoke_status\`
+
+\`\`\`text
+$smoke_output
+\`\`\`
+
+## Startup Output Tail ($STARTUP_LOG)
+
+EOF
+  tail_section "$STARTUP_LOG"
+  cat <<EOF
+
+## Server Log Tail ($SERVER_LOG)
+
+EOF
+  tail_section "$SERVER_LOG"
+}
+
+if [[ -n "$OUTPUT_PATH" ]]; then
+  mkdir -p "$(dirname "$OUTPUT_PATH")"
+  render_bundle | tee "$OUTPUT_PATH"
+else
+  render_bundle
+fi

--- a/scripts/worktree-diagnostics.sh
+++ b/scripts/worktree-diagnostics.sh
@@ -26,6 +26,13 @@ fail() {
   exit 1
 }
 
+require_option_value() {
+  local option="$1"
+  if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+    fail "$option requires a value"
+  fi
+}
+
 sanitize_slug() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-'
 }
@@ -40,14 +47,17 @@ trim_edge_dashes() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --port)
+      require_option_value "$1" "${2-}"
       PORT="${2:-}"
       shift 2
       ;;
     --lines)
+      require_option_value "$1" "${2-}"
       LINES="${2:-}"
       shift 2
       ;;
     --output)
+      require_option_value "$1" "${2-}"
       OUTPUT_PATH="${2:-}"
       shift 2
       ;;
@@ -91,10 +101,39 @@ fi
 
 EVIDENCE_SLUG=$(trim_edge_dashes "$(sanitize_slug "$SLUG_PART")")
 DATE_STAMP=$(date +%F)
+
+resolve_evidence_file() {
+  local fallback="$1"
+  local candidate newest
+  local -a matches=()
+
+  shopt -s nullglob
+  if [[ -n "$ISSUE_NUMBER" ]]; then
+    matches=("$ROOT"/journal/local-verification/*-issue-"$ISSUE_NUMBER"-"$EVIDENCE_SLUG".md)
+  else
+    matches=("$ROOT"/journal/local-verification/*-branch-"$EVIDENCE_SLUG".md)
+  fi
+  shopt -u nullglob
+
+  if (( ${#matches[@]} == 0 )); then
+    printf '%s' "$fallback"
+    return
+  fi
+
+  newest="${matches[0]}"
+  for candidate in "${matches[@]:1}"; do
+    if [[ "$candidate" -nt "$newest" ]]; then
+      newest="$candidate"
+    fi
+  done
+
+  printf '%s' "$newest"
+}
+
 if [[ -n "$ISSUE_NUMBER" ]]; then
-  EVIDENCE_FILE="$ROOT/journal/local-verification/$DATE_STAMP-issue-$ISSUE_NUMBER-$EVIDENCE_SLUG.md"
+  EVIDENCE_FILE="$(resolve_evidence_file "$ROOT/journal/local-verification/$DATE_STAMP-issue-$ISSUE_NUMBER-$EVIDENCE_SLUG.md")"
 else
-  EVIDENCE_FILE="$ROOT/journal/local-verification/$DATE_STAMP-branch-$EVIDENCE_SLUG.md"
+  EVIDENCE_FILE="$(resolve_evidence_file "$ROOT/journal/local-verification/$DATE_STAMP-branch-$EVIDENCE_SLUG.md")"
 fi
 
 STARTUP_LOG="$INSTALL_DIR/wave_server.out"
@@ -119,7 +158,12 @@ SERVER_LOG="$(resolve_server_log)"
 
 probe_status() {
   local path="$1"
-  curl -sS --max-time 5 -o /dev/null -w "%{http_code}" "http://localhost:$PORT$path" 2>/dev/null || true
+  local status
+  status="$(curl -sS --max-time 5 -o /dev/null -w "%{http_code}" "http://localhost:$PORT$path" 2>/dev/null || true)"
+  if [[ -z "$status" ]]; then
+    status="000"
+  fi
+  printf '%s' "$status"
 }
 
 tail_section() {
@@ -138,6 +182,15 @@ smoke_output="$(
   PORT="$PORT" bash "$ROOT/scripts/wave-smoke.sh" check 2>&1
 )" && smoke_status=0 || smoke_status=$?
 
+format_path_status() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    printf '%s' "$path"
+  else
+    printf '(missing: %s)' "$path"
+  fi
+}
+
 render_bundle() {
   cat <<EOF
 # Worktree Diagnostics Bundle
@@ -146,8 +199,8 @@ render_bundle() {
 - Worktree: $ROOT
 - Port: $PORT
 - Install dir: $INSTALL_DIR
-- Runtime config: $(if [[ -f "$RUNTIME_CONFIG" ]]; then printf '%s' "$RUNTIME_CONFIG"; else printf 'missing'; fi)
-- Evidence file: $(if [[ -f "$EVIDENCE_FILE" ]]; then printf '%s' "$EVIDENCE_FILE"; else printf 'missing'; fi)
+- Runtime config: $(format_path_status "$RUNTIME_CONFIG")
+- Evidence file: $(format_path_status "$EVIDENCE_FILE")
 - Generated at: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 ## Endpoint Probes

--- a/wave/config/changelog.d/2026-04-12-worktree-diagnostics-runbook.json
+++ b/wave/config/changelog.d/2026-04-12-worktree-diagnostics-runbook.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-12-worktree-diagnostics-runbook",
+  "version": "PR #587",
+  "date": "2026-04-12",
+  "title": "Added Worktree Diagnostics Bundle Guidance",
+  "summary": "Adds a bundled diagnostics command and runbook so issue worktrees can capture compact startup, smoke, endpoint, and log evidence without inventing a separate observability workflow.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Add scripts/worktree-diagnostics.sh: emits a Markdown diagnostics bundle with endpoint probes, smoke-check output, startup tail, and server-log tail for the current worktree runtime",
+        "Add docs/runbooks/worktree-diagnostics.md: explains when to run the bundle, what it captures, and how to reference it from issue comments and PR summaries",
+        "Update scripts/worktree-boot.sh, docs/runbooks/worktree-lane-lifecycle.md, docs/runbooks/README.md, and docs/SMOKE_TESTS.md so the diagnostics bundle is discoverable from the existing worktree verification flow"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `scripts/worktree-diagnostics.sh` plus a shell contract test for the bundled worktree diagnostics path
- add `docs/runbooks/worktree-diagnostics.md` and cross-link it from the existing worktree/smoke runbooks
- surface the diagnostics command from `scripts/worktree-boot.sh` and add the matching changelog fragment

## Verification
- `bash scripts/test-worktree-diagnostics.sh`
- `bash -n scripts/worktree-diagnostics.sh scripts/worktree-boot.sh`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9904` after `python3 scripts/assemble-changelog.py`
- `PORT=9904 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-587-worktree-diagnostics-20260412/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-587-worktree-diagnostics-20260412/wave/config/jaas.config' bash scripts/wave-smoke.sh start && PORT=9904 bash scripts/worktree-diagnostics.sh --port 9904 --output journal/local-verification/2026-04-12-issue-587-worktree-diagnostics-bundle.md && PORT=9904 bash scripts/wave-smoke.sh stop`

Closes #587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worktree diagnostics bundle that captures runtime metadata, endpoint probe results, smoke check status, and server log excerpts in a single Markdown bundle.

* **Documentation**
  * Added dedicated runbook with usage guidance and evidence interpretation.
  * Updated worktree boot flow to expose the diagnostics command alongside existing start/check/stop operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->