### PR TITLE
fix(reactions): show reaction authors on desktop and mobile

### DIFF
--- a/docs/superpowers/plans/2026-04-12-issue-833-reaction-authors.md
+++ b/docs/superpowers/plans/2026-04-12-issue-833-reaction-authors.md
@@ -1,0 +1,63 @@
+# Issue 833 Reaction Author Inspection Plan
+
+**Issue:** `#833`  
+**Goal:** Let users inspect who reacted to a blip on desktop and mobile without breaking the existing one-tap reaction toggle flow.
+
+## Investigation Summary
+
+- Reaction author data already exists in `ReactionDocument.Reaction#getAddresses()`.
+- The current client renderer collapses each reaction to `emoji + count` in `ReactionRowRenderer`.
+- `ReactionController` only handles primary click actions:
+  - clicking a chip toggles the signed-in user's reaction
+  - clicking the add button opens `ReactionPickerPopup`
+- There is no secondary author-inspection affordance, popup, or metadata path in the reaction row.
+
+## Root Cause
+
+The data layer preserves author addresses, but the reaction UI has no representation or event path for author inspection. The current implementation treats each chip as a single-purpose toggle button and discards the participant list at render time.
+
+## Approach
+
+1. Add a narrow custom reaction-authors popup that renders a Wave-native list of participants for one emoji.
+2. Extend the reaction row markup so each chip carries enough structured metadata for author inspection and better accessibility text.
+3. Extend `ReactionController` to support a secondary inspect gesture that preserves quick toggle:
+   - desktop: custom context-menu/right-click path
+   - touch/mobile: long-press path
+   - keyboard: context-menu key / `Shift+F10`
+4. Resolve display names through `ProfileManager` when available, with address fallback.
+5. Keep the primary click/tap path unchanged for toggle behavior.
+
+## Acceptance Criteria
+
+- Users can inspect the authors for a reaction from a desktop reaction chip without triggering a toggle.
+- Touch/mobile users have an equivalent custom interaction to inspect authors.
+- The author UI uses existing Wave popup chrome rather than browser-native tooltips/menus.
+- Author rows show a readable participant label, preferring profile display names when available.
+- Existing reaction toggle behavior still works.
+
+## Planned Files
+
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionController.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.css`
+- `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java`
+- `wave/config/changelog.d/2026-04-12-issue-833-reaction-authors.json`
+- `journal/local-verification/2026-04-12-issue-833-reaction-authors.md`
+
+## Verification Plan
+
+- Red/green renderer regression via the existing manual `javac` + `JUnitCore` harness for `ReactionRowRendererTest`.
+- Focused compile check for the touched reaction client classes.
+- Local browser sanity run against a dev server to verify:
+  - click still toggles reaction
+  - right-click opens authors popup on desktop
+  - long-press opens authors popup on touch/mobile emulation
+
+## Out Of Scope
+
+- Changing the reaction storage model
+- Adding new reaction types or multi-reaction-per-user behavior
+- Adding profile-card navigation from the author list
+- Reworking the picker or the reaction row layout beyond what the inspection affordance requires

--- a/wave/config/changelog.d/2026-04-12-issue-833-reaction-authors.json
+++ b/wave/config/changelog.d/2026-04-12-issue-833-reaction-authors.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-issue-833-reaction-authors",
+  "version": "PR #833",
+  "date": "2026-04-12",
+  "title": "Show who reacted on desktop and mobile",
+  "summary": "Adds a Wave-native reaction-authors popup so people can inspect who reacted without relying on browser-default menus or tooltips.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Reaction chips now expose a custom authors popup for desktop secondary actions and keyboard inspection",
+        "Mobile users can tap the reaction count to inspect who reacted without losing the quick reaction-toggle path"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-12-issue-833-reaction-authors.json
+++ b/wave/config/changelog.d/2026-04-12-issue-833-reaction-authors.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-12-issue-833-reaction-authors",
-  "version": "PR #833",
+  "version": "PR #862",
   "date": "2026-04-12",
   "title": "Show who reacted on desktop and mobile",
   "summary": "Adds a Wave-native reaction-authors popup so people can inspect who reacted without relying on browser-default menus or tooltips.",

--- a/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/StageThree.java
@@ -254,7 +254,8 @@ public interface StageThree {
           return true;
         }
       }, stageTwo.getConversations());
-      ReactionController.install(stageTwo.getConversations(), stageTwo.getViewIdMapper(), user);
+      ReactionController.install(stageTwo.getConversations(), stageTwo.getViewIdMapper(),
+          profiles, user);
       DraftModeController.install(panel, actions, edit);
       stageTwo.getDiffController().upgrade(edit);
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.css
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.css
@@ -1,0 +1,55 @@
+.self {
+  padding: 14px 16px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+  min-width: 220px;
+  max-width: 320px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1a365d;
+  margin-bottom: 2px;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: #718096;
+  margin-bottom: 10px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid #d6dee8;
+  background: #f8fbff;
+}
+
+.currentUserRow {
+  border-color: #90cdf4;
+  background: #ebf8ff;
+}
+
+.primary {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1a202c;
+  line-height: 1.3;
+}
+
+.secondary {
+  display: block;
+  font-size: 12px;
+  color: #718096;
+  line-height: 1.3;
+  margin-top: 2px;
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionAuthorsPopup.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.client.wavepanel.impl.reactions;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.StyleInjector;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Label;
+import org.waveprotocol.wave.client.widget.popup.AlignedPopupPositioner;
+import org.waveprotocol.wave.client.widget.popup.PopupChrome;
+import org.waveprotocol.wave.client.widget.popup.PopupChromeFactory;
+import org.waveprotocol.wave.client.widget.popup.PopupFactory;
+import org.waveprotocol.wave.client.widget.popup.UniversalPopup;
+
+import java.util.List;
+
+/**
+ * Popup listing the participants behind one reaction chip.
+ */
+public final class ReactionAuthorsPopup extends Composite {
+
+  public static final class Author {
+    private final String primaryText;
+    private final String secondaryText;
+    private final boolean currentUser;
+
+    public Author(String primaryText, String secondaryText, boolean currentUser) {
+      this.primaryText = primaryText;
+      this.secondaryText = secondaryText;
+      this.currentUser = currentUser;
+    }
+  }
+
+  interface Resources extends ClientBundle {
+    @Source("ReactionAuthorsPopup.css")
+    Style style();
+  }
+
+  interface Style extends CssResource {
+    String self();
+    String title();
+    String subtitle();
+    String list();
+    String row();
+    String currentUserRow();
+    String primary();
+    String secondary();
+  }
+
+  private static final Style style = GWT.<Resources>create(Resources.class).style();
+
+  static {
+    StyleInjector.inject(style.getText(), true);
+  }
+
+  private final UniversalPopup popup;
+
+  public static ReactionAuthorsPopup show(Element anchor, String emoji, List<Author> authors) {
+    ReactionAuthorsPopup popup = new ReactionAuthorsPopup(anchor, emoji, authors);
+    popup.show();
+    return popup;
+  }
+
+  private ReactionAuthorsPopup(Element anchor, String emoji, List<Author> authors) {
+    FlowPanel panel = new FlowPanel();
+    panel.addStyleName(style.self());
+
+    Label title = new Label(emoji + " reactions");
+    title.addStyleName(style.title());
+    panel.add(title);
+
+    Label subtitle = new Label(formatSubtitle(authors.size()));
+    subtitle.addStyleName(style.subtitle());
+    panel.add(subtitle);
+
+    FlowPanel list = new FlowPanel();
+    list.addStyleName(style.list());
+    for (Author author : authors) {
+      list.add(buildRow(author));
+    }
+    panel.add(list);
+
+    initWidget(panel);
+
+    PopupChrome chrome = PopupChromeFactory.createPopupChrome();
+    popup = PopupFactory.createPopup(anchor, AlignedPopupPositioner.BELOW_LEFT, chrome, true);
+    popup.add(this);
+  }
+
+  public void show() {
+    popup.show();
+  }
+
+  public void hide() {
+    popup.hide();
+  }
+
+  private FlowPanel buildRow(Author author) {
+    FlowPanel row = new FlowPanel();
+    row.addStyleName(style.row());
+    if (author.currentUser) {
+      row.addStyleName(style.currentUserRow());
+    }
+
+    String primaryText = author.currentUser
+        ? author.primaryText + " (you)"
+        : author.primaryText;
+    Label primary = new Label(primaryText);
+    primary.addStyleName(style.primary());
+    row.add(primary);
+
+    if (author.secondaryText != null && !author.secondaryText.isEmpty()) {
+      Label secondary = new Label(author.secondaryText);
+      secondary.addStyleName(style.secondary());
+      row.add(secondary);
+    }
+
+    return row;
+  }
+
+  private static String formatSubtitle(int count) {
+    return count == 1 ? "1 person reacted" : count + " people reacted";
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionController.java
@@ -19,13 +19,18 @@
 
 package org.waveprotocol.wave.client.wavepanel.impl.reactions;
 
+import com.google.gwt.core.client.Duration;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.EventTarget;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.gwt.user.client.Timer;
+import org.waveprotocol.wave.client.account.Profile;
+import org.waveprotocol.wave.client.account.ProfileManager;
 import org.waveprotocol.wave.client.wavepanel.view.ViewIdMapper;
 import org.waveprotocol.wave.client.wavepanel.view.dom.full.BlipViewBuilder;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
@@ -36,6 +41,7 @@ import org.waveprotocol.wave.model.conversation.ObservableConversationThread;
 import org.waveprotocol.wave.model.conversation.ObservableConversationView;
 import org.waveprotocol.wave.model.conversation.ReactionDataDocuments;
 import org.waveprotocol.wave.model.conversation.ReactionDocument;
+import org.waveprotocol.wave.model.conversation.TaskMetadataUtil;
 import org.waveprotocol.wave.model.document.DocHandler;
 import org.waveprotocol.wave.model.document.indexed.DocumentHandler;
 import org.waveprotocol.wave.model.document.ObservableDocument;
@@ -61,14 +67,20 @@ public final class ReactionController extends ConversationListenerImpl
     implements ObservableConversationView.Listener {
 
   public static ReactionController install(ObservableConversationView conversationView,
-      ViewIdMapper viewIdMapper, ParticipantId signedInUser) {
-    ReactionController controller = new ReactionController(conversationView, viewIdMapper, signedInUser);
+      ViewIdMapper viewIdMapper, ProfileManager profileManager, ParticipantId signedInUser) {
+    ReactionController controller =
+        new ReactionController(conversationView, viewIdMapper, profileManager, signedInUser);
     controller.install();
     return controller;
   }
 
+  private static final int LONG_PRESS_DELAY_MS = 450;
+  private static final int CONTEXT_MENU_KEY_CODE = 93;
+  private static final double INSPECT_SUPPRESSION_MS = 900d;
+
   private final ObservableConversationView conversationView;
   private final ViewIdMapper viewIdMapper;
+  private final ProfileManager profileManager;
   private final ParticipantId signedInUser;
   private final IdentityMap<ConversationBlip, DocHandler> handlers = CollectionUtils.createIdentityMap();
   private final Map<String, ObservableConversationBlip> blipsById = new HashMap<String, ObservableConversationBlip>();
@@ -76,11 +88,17 @@ public final class ReactionController extends ConversationListenerImpl
 
   private NativePreviewHandler previewHandler;
   private HandlerRegistration previewRegistration;
+  private Timer longPressTimer;
+  private String suppressedInspectBlipId;
+  private String suppressedInspectEmoji;
+  private double suppressedInspectUntilMs;
+  private ReactionAuthorsPopup authorsPopup;
 
   private ReactionController(ObservableConversationView conversationView, ViewIdMapper viewIdMapper,
-      ParticipantId signedInUser) {
+      ProfileManager profileManager, ParticipantId signedInUser) {
     this.conversationView = conversationView;
     this.viewIdMapper = viewIdMapper;
+    this.profileManager = profileManager;
     this.signedInUser = signedInUser;
   }
 
@@ -225,18 +243,32 @@ public final class ReactionController extends ConversationListenerImpl
     previewHandler = new NativePreviewHandler() {
       @Override
       public void onPreviewNativeEvent(NativePreviewEvent event) {
-        if (event.getTypeInt() != Event.ONCLICK || signedInUser == null) {
-          return;
-        }
+        String type = event.getNativeEvent().getType();
         EventTarget target = event.getNativeEvent().getEventTarget();
         if (target == null || !Element.is(target)) {
+          if ("touchend".equals(type) || "touchmove".equals(type) || "touchcancel".equals(type)) {
+            cancelLongPress();
+          }
           return;
         }
         Element element = Element.as(target);
         Element action = findReactionAction(element);
+        Element inspectTrigger = findInspectTrigger(element);
+
+        if ("touchstart".equals(type)) {
+          scheduleLongPress(action);
+          return;
+        }
+
+        if ("touchend".equals(type) || "touchmove".equals(type) || "touchcancel".equals(type)) {
+          cancelLongPress();
+          return;
+        }
+
         if (action == null) {
           return;
         }
+
         String blipId = action.getAttribute("data-reaction-blip-id");
         if (blipId == null || blipId.isEmpty()) {
           return;
@@ -246,14 +278,54 @@ public final class ReactionController extends ConversationListenerImpl
           return;
         }
         String emoji = action.getAttribute("data-reaction-emoji");
-        event.getNativeEvent().preventDefault();
-        event.getNativeEvent().stopPropagation();
-        event.cancel();
+
+        if ("contextmenu".equals(type) && emoji != null && !emoji.isEmpty()) {
+          cancelLongPress();
+          consume(event);
+          if (shouldSuppressInspect(blipId, emoji)) {
+            return;
+          }
+          showAuthorsPopup(action, blip, emoji, true);
+          return;
+        }
+
+        if ("keydown".equals(type) && emoji != null && !emoji.isEmpty()
+            && isInspectKey(event)) {
+          consume(event);
+          showAuthorsPopup(action, blip, emoji, false);
+          return;
+        }
+
+        if (!"click".equals(type)) {
+          return;
+        }
+
+        if (inspectTrigger != null && emoji != null && !emoji.isEmpty()) {
+          consume(event);
+          showAuthorsPopup(action, blip, emoji, false);
+          return;
+        }
+
+        if (shouldSuppressClick(blipId, emoji)) {
+          consume(event);
+          return;
+        }
+
         if (emoji != null && !emoji.isEmpty()) {
+          if (signedInUser == null) {
+            return;
+          }
+          consume(event);
+          hideAuthorsPopup();
           toggle(blip, emoji);
           return;
         }
         if ("true".equals(action.getAttribute("data-reaction-add"))) {
+          if (signedInUser == null) {
+            return;
+          }
+          consume(event);
+          hideAuthorsPopup();
           ReactionPickerPopup.show(new ReactionPickerPopup.Listener() {
             @Override
             public void onSelect(String emoji) {
@@ -267,6 +339,8 @@ public final class ReactionController extends ConversationListenerImpl
   }
 
   public void uninstall() {
+    cancelLongPress();
+    hideAuthorsPopup();
     if (previewRegistration != null) {
       previewRegistration.removeHandler();
       previewRegistration = null;
@@ -290,6 +364,21 @@ public final class ReactionController extends ConversationListenerImpl
     return null;
   }
 
+  private Element findInspectTrigger(Element start) {
+    Element current = start;
+    while (current != null) {
+      if (current.hasAttribute(ReactionRowRenderer.INSPECT_ATTR)) {
+        return current;
+      }
+      if (current.hasAttribute("data-reaction-emoji")
+          || current.hasAttribute("data-reaction-add")) {
+        return null;
+      }
+      current = current.getParentElement();
+    }
+    return null;
+  }
+
   private void toggle(ConversationBlip blip, String emoji) {
     ReactionDocument<org.waveprotocol.wave.model.document.Doc.N,
         org.waveprotocol.wave.model.document.Doc.E,
@@ -300,6 +389,154 @@ public final class ReactionController extends ConversationListenerImpl
       bindBlip((ObservableConversationBlip) blip);
     }
     render(blip);
+  }
+
+  private void consume(NativePreviewEvent event) {
+    event.getNativeEvent().preventDefault();
+    event.getNativeEvent().stopPropagation();
+    event.cancel();
+  }
+
+  private boolean isInspectKey(NativePreviewEvent event) {
+    int keyCode = event.getNativeEvent().getKeyCode();
+    return keyCode == CONTEXT_MENU_KEY_CODE
+        || (keyCode == KeyCodes.KEY_F10 && event.getNativeEvent().getShiftKey());
+  }
+
+  private void scheduleLongPress(Element action) {
+    cancelLongPress();
+    if (action == null || !action.hasAttribute("data-reaction-emoji")) {
+      return;
+    }
+    final String blipId = action.getAttribute("data-reaction-blip-id");
+    final String emoji = action.getAttribute("data-reaction-emoji");
+    if (blipId == null || blipId.isEmpty() || emoji == null || emoji.isEmpty()) {
+      return;
+    }
+    final ObservableConversationBlip blip = blipsById.get(blipId);
+    if (blip == null) {
+      return;
+    }
+    final Element anchor = action;
+    longPressTimer = new Timer() {
+      @Override
+      public void run() {
+        longPressTimer = null;
+        suppressInspect(blipId, emoji);
+        suppressClick(blipId, emoji);
+        showAuthorsPopup(anchor, blip, emoji, true);
+      }
+    };
+    longPressTimer.schedule(LONG_PRESS_DELAY_MS);
+  }
+
+  private void cancelLongPress() {
+    if (longPressTimer != null) {
+      longPressTimer.cancel();
+      longPressTimer = null;
+    }
+  }
+
+  private void showAuthorsPopup(Element anchor, ConversationBlip blip, String emoji,
+      boolean suppressFollowupInspect) {
+    ReactionDocument<org.waveprotocol.wave.model.document.Doc.N,
+        org.waveprotocol.wave.model.document.Doc.E,
+        org.waveprotocol.wave.model.document.Doc.T> reactionDocument =
+        ReactionDataDocuments.getIfPresent(blip);
+    if (reactionDocument == null) {
+      return;
+    }
+    ReactionDocument.Reaction reaction = findReaction(reactionDocument, emoji);
+    if (reaction == null || reaction.getAddresses() == null || reaction.getAddresses().isEmpty()) {
+      return;
+    }
+    hideAuthorsPopup();
+    authorsPopup = ReactionAuthorsPopup.show(anchor, emoji, buildAuthors(reaction));
+    if (suppressFollowupInspect) {
+      suppressInspect(blip.getId(), emoji);
+    }
+  }
+
+  private void hideAuthorsPopup() {
+    if (authorsPopup != null) {
+      authorsPopup.hide();
+      authorsPopup = null;
+    }
+  }
+
+  private ReactionDocument.Reaction findReaction(
+      ReactionDocument<org.waveprotocol.wave.model.document.Doc.N,
+          org.waveprotocol.wave.model.document.Doc.E,
+          org.waveprotocol.wave.model.document.Doc.T> reactionDocument,
+      String emoji) {
+    for (ReactionDocument.Reaction reaction : reactionDocument.getReactions()) {
+      if (reaction != null && emoji.equals(reaction.getEmoji())) {
+        return reaction;
+      }
+    }
+    return null;
+  }
+
+  private List<ReactionAuthorsPopup.Author> buildAuthors(ReactionDocument.Reaction reaction) {
+    List<ReactionAuthorsPopup.Author> authors = new ArrayList<ReactionAuthorsPopup.Author>();
+    for (String address : reaction.getAddresses()) {
+      authors.add(buildAuthor(address));
+    }
+    return authors;
+  }
+
+  private ReactionAuthorsPopup.Author buildAuthor(String address) {
+    String normalizedAddress = address == null ? "" : address.trim();
+    String primary = TaskMetadataUtil.formatParticipantDisplay(normalizedAddress);
+    String secondary = normalizedAddress;
+    if (profileManager != null && !normalizedAddress.isEmpty()) {
+      Profile profile = profileManager.getProfile(ParticipantId.ofUnsafe(normalizedAddress));
+      if (profile != null) {
+        String fullName = profile.getFullName() == null ? "" : profile.getFullName().trim();
+        if (!fullName.isEmpty() && !normalizedAddress.equals(fullName)) {
+          primary = fullName;
+        }
+      }
+    }
+    if (primary == null || primary.isEmpty()) {
+      primary = normalizedAddress;
+    }
+    if (primary.equals(secondary)) {
+      secondary = "";
+    }
+    boolean currentUser = signedInUser != null
+        && normalizedAddress.equals(signedInUser.getAddress());
+    return new ReactionAuthorsPopup.Author(primary, secondary, currentUser);
+  }
+
+  private void suppressInspect(String blipId, String emoji) {
+    suppressedInspectBlipId = blipId;
+    suppressedInspectEmoji = emoji;
+    suppressedInspectUntilMs = Duration.currentTimeMillis() + INSPECT_SUPPRESSION_MS;
+  }
+
+  private boolean shouldSuppressInspect(String blipId, String emoji) {
+    if (Duration.currentTimeMillis() > suppressedInspectUntilMs) {
+      clearSuppressedInspect();
+      return false;
+    }
+    return blipId != null && emoji != null
+        && blipId.equals(suppressedInspectBlipId)
+        && emoji.equals(suppressedInspectEmoji);
+  }
+
+  private void clearSuppressedInspect() {
+    suppressedInspectBlipId = null;
+    suppressedInspectEmoji = null;
+    suppressedInspectUntilMs = 0d;
+  }
+
+  private void suppressClick(String blipId, String emoji) {
+    suppressInspect(blipId, emoji);
+  }
+
+  private boolean shouldSuppressClick(String blipId, String emoji) {
+    return emoji != null && !emoji.isEmpty() && shouldSuppressInspect(blipId, emoji);
   }
 
   private void unbindConversation(ObservableConversation conversation) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionController.java
@@ -92,6 +92,9 @@ public final class ReactionController extends ConversationListenerImpl
   private String suppressedInspectBlipId;
   private String suppressedInspectEmoji;
   private double suppressedInspectUntilMs;
+  private String suppressedClickBlipId;
+  private String suppressedClickEmoji;
+  private double suppressedClickUntilMs;
   private ReactionAuthorsPopup authorsPopup;
 
   private ReactionController(ObservableConversationView conversationView, ViewIdMapper viewIdMapper,
@@ -444,10 +447,12 @@ public final class ReactionController extends ConversationListenerImpl
         org.waveprotocol.wave.model.document.Doc.T> reactionDocument =
         ReactionDataDocuments.getIfPresent(blip);
     if (reactionDocument == null) {
+      hideAuthorsPopup();
       return;
     }
     ReactionDocument.Reaction reaction = findReaction(reactionDocument, emoji);
     if (reaction == null || reaction.getAddresses() == null || reaction.getAddresses().isEmpty()) {
+      hideAuthorsPopup();
       return;
     }
     hideAuthorsPopup();
@@ -490,12 +495,16 @@ public final class ReactionController extends ConversationListenerImpl
     String primary = TaskMetadataUtil.formatParticipantDisplay(normalizedAddress);
     String secondary = normalizedAddress;
     if (profileManager != null && !normalizedAddress.isEmpty()) {
-      Profile profile = profileManager.getProfile(ParticipantId.ofUnsafe(normalizedAddress));
-      if (profile != null) {
-        String fullName = profile.getFullName() == null ? "" : profile.getFullName().trim();
-        if (!fullName.isEmpty() && !normalizedAddress.equals(fullName)) {
-          primary = fullName;
+      try {
+        Profile profile = profileManager.getProfile(ParticipantId.ofUnsafe(normalizedAddress));
+        if (profile != null) {
+          String fullName = profile.getFullName() == null ? "" : profile.getFullName().trim();
+          if (!fullName.isEmpty() && !normalizedAddress.equals(fullName)) {
+            primary = fullName;
+          }
         }
+      } catch (IllegalArgumentException e) {
+        // Fall back to the raw address when the participant id is malformed.
       }
     }
     if (primary == null || primary.isEmpty()) {
@@ -532,11 +541,25 @@ public final class ReactionController extends ConversationListenerImpl
   }
 
   private void suppressClick(String blipId, String emoji) {
-    suppressInspect(blipId, emoji);
+    suppressedClickBlipId = blipId;
+    suppressedClickEmoji = emoji;
+    suppressedClickUntilMs = Duration.currentTimeMillis() + INSPECT_SUPPRESSION_MS;
   }
 
   private boolean shouldSuppressClick(String blipId, String emoji) {
-    return emoji != null && !emoji.isEmpty() && shouldSuppressInspect(blipId, emoji);
+    if (Duration.currentTimeMillis() > suppressedClickUntilMs) {
+      clearSuppressedClick();
+      return false;
+    }
+    return blipId != null && emoji != null
+        && blipId.equals(suppressedClickBlipId)
+        && emoji.equals(suppressedClickEmoji);
+  }
+
+  private void clearSuppressedClick() {
+    suppressedClickBlipId = null;
+    suppressedClickEmoji = null;
+    suppressedClickUntilMs = 0d;
   }
 
   private void unbindConversation(ObservableConversation conversation) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -34,10 +34,12 @@ public final class ReactionRowRenderer {
   public static final String CHIP_CLASS = "waveReactionChip";
   public static final String CHIP_ACTIVE_CLASS = "waveReactionChipActive";
   public static final String ADD_CLASS = "waveReactionAdd";
+  public static final String INSPECT_ATTR = "data-reaction-inspect";
   private static final String EMOJI_CLASS = "waveReactionEmoji";
   private static final String COUNT_CLASS = "waveReactionCount";
   private static final String ADD_ICON_CLASS = "waveReactionAddIcon";
   private static final String ADD_BUTTON_LABEL = "Add reaction";
+  private static final String AUTHOR_DIALOG_HINT = "See who reacted";
   private static final String ADD_ICON_HTML =
       "<span class=\"" + ADD_ICON_CLASS + "\" aria-hidden=\"true\">"
           + "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" "
@@ -95,10 +97,12 @@ public final class ReactionRowRenderer {
     String safeEmoji = EscapeUtils.htmlEscape(emoji);
     html.appendHtmlConstant("<button type=\"button\" class=\"" + classes
         + "\" data-reaction-emoji=\"" + safeEmoji + "\" data-reaction-active=\""
-        + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\">");
+        + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
+        + "aria-haspopup=\"dialog\" title=\"" + AUTHOR_DIALOG_HINT + "\">");
     html.appendHtmlConstant("<span class=\"" + EMOJI_CLASS + "\">");
     html.appendEscaped(emoji);
-    html.appendHtmlConstant("</span> <span class=\"" + COUNT_CLASS + "\">");
+    html.appendHtmlConstant("</span> <span class=\"" + COUNT_CLASS + "\" "
+        + INSPECT_ATTR + "=\"true\" title=\"" + AUTHOR_DIALOG_HINT + "\">");
     html.append(count);
     html.appendHtmlConstant("</span></button>");
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java
@@ -97,8 +97,7 @@ public final class ReactionRowRenderer {
     String safeEmoji = EscapeUtils.htmlEscape(emoji);
     html.appendHtmlConstant("<button type=\"button\" class=\"" + classes
         + "\" data-reaction-emoji=\"" + safeEmoji + "\" data-reaction-active=\""
-        + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\" "
-        + "aria-haspopup=\"dialog\" title=\"" + AUTHOR_DIALOG_HINT + "\">");
+        + active + "\" data-reaction-blip-id=\"" + EscapeUtils.htmlEscape(blipId) + "\">");
     html.appendHtmlConstant("<span class=\"" + EMOJI_CLASS + "\">");
     html.appendEscaped(emoji);
     html.appendHtmlConstant("</span> <span class=\"" + COUNT_CLASS + "\" "

--- a/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
@@ -90,7 +90,22 @@ public final class ReactionRowRendererTest extends TestCase {
 
     String output = html.asString();
     assertTrue(output.contains("<span class=\"waveReactionEmoji\">thumbs_up</span>"));
-    assertTrue(output.contains("</span> <span class=\"waveReactionCount\">2</span>"));
+    assertTrue(output.contains("<span class=\"waveReactionCount\" data-reaction-inspect=\"true\" title=\"See who reacted\">2</span>"));
+  }
+
+  public void testRenderMarksReactionChipAsInspectable() {
+    SafeHtml html = ReactionRowRenderer.render(
+        "b+blip7",
+        Collections.singletonList(
+            new ReactionDocument.Reaction("thumbs_up",
+                Arrays.asList("alice@example.com", "bob@example.com"))),
+        "alice@example.com",
+        true);
+
+    String output = html.asString();
+    assertTrue(output.contains("aria-haspopup=\"dialog\""));
+    assertTrue(output.contains("title=\"See who reacted\""));
+    assertTrue(output.contains("data-reaction-inspect=\"true\""));
   }
 
   public void testRenderOmitsAddButtonWhenReadOnly() {

--- a/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java
@@ -103,9 +103,10 @@ public final class ReactionRowRendererTest extends TestCase {
         true);
 
     String output = html.asString();
-    assertTrue(output.contains("aria-haspopup=\"dialog\""));
-    assertTrue(output.contains("title=\"See who reacted\""));
+    assertFalse(output.contains("aria-haspopup=\"dialog\""));
+    assertTrue(output.contains("data-reaction-emoji=\"thumbs_up\""));
     assertTrue(output.contains("data-reaction-inspect=\"true\""));
+    assertTrue(output.contains("title=\"See who reacted\""));
   }
 
   public void testRenderOmitsAddButtonWhenReadOnly() {


### PR DESCRIPTION
## Summary
- add a Wave-native `ReactionAuthorsPopup` and wire reaction author resolution through `ProfileManager`
- keep quick reaction toggles intact while adding desktop secondary-action inspection and mobile count-tap inspection
- add the issue plan, renderer regression coverage, and a changelog fragment for the new reaction-author affordance

## Verification
- `python3 scripts/assemble-changelog.py --output wave/config/changelog.json`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt -Dsbt.supershell=false -Dsbt.boot.directory=/tmp/sbt-boot-issue-833 compile`
- `FULL_CP=$(sbt -Dsbt.supershell=false "show wave / Test / fullClasspath" | perl -ne 'while(/Attributed\(([^)]+)\)/g){ push @a, $1 } END { print join(":", @a) }') && OUT=/tmp/reaction-row-renderer-test-green && rm -rf "$OUT" && mkdir -p "$OUT" && javac -cp "$FULL_CP" -d "$OUT" wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtml.java wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlString.java wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/EscapeUtils.java wave/src/main/java/org/waveprotocol/wave/client/common/safehtml/SafeHtmlBuilder.java wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRenderer.java wave/src/test/java/org/waveprotocol/wave/client/wavepanel/impl/reactions/ReactionRowRendererTest.java && java -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore org.waveprotocol.wave.client.wavepanel.impl.reactions.ReactionRowRendererTest`
- `PORT=9912 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/reaction-authors-833-20260412/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/reaction-authors-833-20260412/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9912 bash scripts/wave-smoke.sh check`
- browser verification on the staged server via local Playwright automation:
  - registered a throwaway account
  - opened the welcome wave row
  - added a `👀` reaction
  - verified desktop author inspection via secondary keyboard action (`Shift+F10`)
  - verified mobile author inspection via tapping the reaction count

Closes #833.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspect who reacted: right-click (desktop), long-press/tap count (mobile), or keyboard (context-menu key / Shift+F10) opens an authors popup showing names and marking the current user.

* **Styles**
  * Added styled popup UI for listing reaction authors.

* **Documentation**
  * Added implementation plan and changelog entry describing behavior and verification criteria.

* **Tests**
  * Updated renderer tests to assert inspectable reaction markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->