### PR TITLE
[codex] Fix OT search tag routing and fallback policy

### DIFF
--- a/wave/config/changelog.d/2026-04-12-ot-search-tag-fallback.json
+++ b/wave/config/changelog.d/2026-04-12-ot-search-tag-fallback.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-ot-search-tag-fallback",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "OT search tag routing and fallback policy",
+  "summary": "Tag searches now stay on the OT/Lucene path when indexed search is enabled, and OT search no longer silently bootstraps or falls back to legacy HTTP polling unless an explicit fallback flag is enabled.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Tag queries now use Lucene candidate filtering in OT search mode instead of forcing the legacy tag-document path",
+        "Added an `ot-search-fallback` feature flag, defaulting off, so production OT search surfaces failures immediately instead of silently switching to legacy HTTP bootstrap or polling"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModel.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModel.java
@@ -111,7 +111,6 @@ public final class Lucene9QueryModel {
 
   private static boolean isLuceneHandledToken(TokenQueryType type) {
     return type == TokenQueryType.TITLE
-        || type == TokenQueryType.CONTENT
-        || type == TokenQueryType.TAG;
+        || type == TokenQueryType.CONTENT;
   }
 }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModel.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModel.java
@@ -77,6 +77,12 @@ public final class Lucene9QueryModel {
     return hasToken(TokenQueryType.TITLE) || hasToken(TokenQueryType.CONTENT);
   }
 
+  public boolean usesLuceneIndex() {
+    return hasToken(TokenQueryType.TITLE)
+        || hasToken(TokenQueryType.CONTENT)
+        || hasToken(TokenQueryType.TAG);
+  }
+
   public boolean hasTaskQuery() {
     return hasToken(TokenQueryType.TASKS);
   }
@@ -84,7 +90,7 @@ public final class Lucene9QueryModel {
   public String toLegacyQuery() {
     StringBuilder builder = new StringBuilder();
     for (Token token : tokens) {
-      if (token.getType() == TokenQueryType.TITLE || token.getType() == TokenQueryType.CONTENT) {
+      if (isLuceneHandledToken(token.getType())) {
         continue;
       }
       if (builder.length() > 0) {
@@ -101,5 +107,11 @@ public final class Lucene9QueryModel {
       }
     }
     return builder.toString();
+  }
+
+  private static boolean isLuceneHandledToken(TokenQueryType type) {
+    return type == TokenQueryType.TITLE
+        || type == TokenQueryType.CONTENT
+        || type == TokenQueryType.TAG;
   }
 }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImpl.java
@@ -68,7 +68,7 @@ public class Lucene9SearchProviderImpl implements SearchProvider {
         MAX_CANDIDATES);
     // Task-only queries stay on the legacy path because task semantics are defined against
     // authoritative wave annotations, not Lucene task-assignee terms.
-    if (!model.hasTextQuery()) {
+    if (!model.usesLuceneIndex()) {
       return paginate(query, legacyResult.getDigests(), startAt, numResults);
     }
 

--- a/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
+++ b/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
@@ -37,4 +37,20 @@ public final class SearchBootstrapUiState {
       boolean otSearchEnabled, boolean useOtSearch, boolean otSearchTimedOut) {
     return otSearchEnabled && !useOtSearch && !otSearchTimedOut;
   }
+
+  public static boolean shouldBootstrapViaHttpWhenOtStarts(
+      boolean otSearchEnabled, boolean otSearchFallbackEnabled) {
+    return !otSearchEnabled || otSearchFallbackEnabled;
+  }
+
+  public static boolean shouldUseHttpSearchForWindowRequest(
+      boolean otSearchEnabled, boolean useOtSearch, boolean otSearchFallbackEnabled) {
+    if (!otSearchEnabled) {
+      return true;
+    }
+    if (useOtSearch) {
+      return false;
+    }
+    return otSearchFallbackEnabled;
+  }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -30,6 +30,7 @@ public final class KnownFeatureFlags {
   static {
     List<FeatureFlag> defaults = new ArrayList<>();
     defaults.add(new FeatureFlag("ot-search", "OT/Lucene search (real-time wavelets + full-text indexing)", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("ot-search-fallback", "Allow OT search to bootstrap or fall back to legacy HTTP polling", false, Collections.emptyMap()));
     // "grafana-log-export": log forwarding is currently handled at the infrastructure level by the
     // Grafana Alloy agent (see deploy/supawave-host/configure-grafana-alloy.sh). This flag is
     // registered here so admins can see and toggle it via the feature-flags UI; a future PR will

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -1129,22 +1129,24 @@ public final class SearchPresenter
 
   @Override
   public void onShowMoreClicked() {
-    querySize += getPageSize();
+    int requestedSize = querySize + getPageSize();
     if (SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(
         otSearchEnabled, useOtSearch, otSearchFallbackEnabled)) {
+      querySize = requestedSize;
       doSearch();
     } else if (useOtSearch) {
+      querySize = requestedSize;
       if (canProjectOtSearchWindow(querySize, otSearchSnapshot)) {
         applyOtSearchResults();
       } else {
-        fallbackToPolling(
-            "OT search cannot serve query window " + querySize + " for query '" + queryText + "'",
-            null);
+        switchToHttpPollingForExpandedWindow(
+            "OT search cannot serve query window " + querySize + " for query '" + queryText + "'");
       }
     } else {
-      OT_SEARCH_LOG.warning(
-          "Ignoring show-more request while waiting for OT search data and HTTP fallback is disabled for query '"
-              + queryText + "'");
+      querySize = requestedSize;
+      OT_SEARCH_LOG.info(
+          "Queued show-more request for query '" + queryText
+              + "' until OT search data becomes available");
     }
   }
 
@@ -1433,9 +1435,8 @@ public final class SearchPresenter
         if (canProjectOtSearchWindow(querySize, otSearchSnapshot)) {
           applyOtSearchResults();
         } else {
-          fallbackToPolling(
-              "OT search snapshot is smaller than requested window for query '" + queryText + "'",
-              null);
+          switchToHttpPollingForExpandedWindow(
+              "OT search snapshot is smaller than requested window for query '" + queryText + "'");
         }
       }
     } catch (RuntimeException e) {
@@ -1508,6 +1509,20 @@ public final class SearchPresenter
     } else {
       OT_SEARCH_LOG.log(Level.WARNING, message + "; falling back to polling", cause);
     }
+    useOtSearch = false;
+    allowLoadingSkeletonDuringSearch = false;
+    otSearchTimedOut = false;
+    unsubscribeFromSearchWavelet();
+    otSearchDocument = null;
+    otSearchSnapshot = OtSearchSnapshot.empty();
+    otSearchReceivedData = false;
+    scheduler.cancel(otSearchTimeoutTask);
+    scheduler.cancel(searchUpdater);
+    startPolling();
+  }
+
+  private void switchToHttpPollingForExpandedWindow(String message) {
+    OT_SEARCH_LOG.warning(message + "; switching to HTTP search for the requested window");
     useOtSearch = false;
     allowLoadingSkeletonDuringSearch = false;
     otSearchTimedOut = false;

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -1142,11 +1142,18 @@ public final class SearchPresenter
         switchToHttpPollingForExpandedWindow(
             "OT search cannot serve query window " + querySize + " for query '" + queryText + "'");
       }
-    } else {
+    } else if (isHttpPollingActiveForCurrentQuery()) {
+      querySize = requestedSize;
+      doSearch();
+    } else if (otSearchWaveletName != null) {
       querySize = requestedSize;
       OT_SEARCH_LOG.info(
           "Queued show-more request for query '" + queryText
               + "' until OT search data becomes available");
+    } else {
+      OT_SEARCH_LOG.warning(
+          "Ignoring show-more request after OT search became unavailable for query '"
+              + queryText + "'");
     }
   }
 
@@ -1525,7 +1532,8 @@ public final class SearchPresenter
     OT_SEARCH_LOG.warning(message + "; switching to HTTP search for the requested window");
     useOtSearch = false;
     allowLoadingSkeletonDuringSearch = false;
-    otSearchTimedOut = false;
+    // Once OT has proven it cannot project this window, keep the query on HTTP.
+    otSearchTimedOut = true;
     unsubscribeFromSearchWavelet();
     otSearchDocument = null;
     otSearchSnapshot = OtSearchSnapshot.empty();
@@ -1543,13 +1551,28 @@ public final class SearchPresenter
     }
     useOtSearch = false;
     allowLoadingSkeletonDuringSearch = false;
+    otSearchTimedOut = true;
     unsubscribeFromSearchWavelet();
     otSearchDocument = null;
     otSearchSnapshot = OtSearchSnapshot.empty();
     otSearchReceivedData = false;
     scheduler.cancel(otSearchTimeoutTask);
     scheduler.cancel(searchUpdater);
+    clearSearchResultsAfterOtFailure();
     render();
+  }
+
+  private boolean isHttpPollingActiveForCurrentQuery() {
+    return !useOtSearch && otSearchWaveletName == null && scheduler.isScheduled(searchUpdater);
+  }
+
+  private void clearSearchResultsAfterOtFailure() {
+    querySize = getPageSize();
+    if (search instanceof SimpleSearch) {
+      ((SimpleSearch) search).replaceResults(0, Collections.<SearchService.DigestSnapshot>emptyList());
+    } else {
+      search.cancel();
+    }
   }
 
   private boolean shouldShowLoadingSkeleton() {

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -207,6 +207,7 @@ public final class SearchPresenter
   private final RemoteViewServiceMultiplexer channel;
   private WaveStore waveStore;
   private boolean otSearchEnabled;
+  private boolean otSearchFallbackEnabled;
   private boolean useOtSearch;
   /** Set to true once the first snapshot or delta arrives for the OT search wavelet. */
   private boolean otSearchReceivedData;
@@ -418,22 +419,10 @@ public final class SearchPresenter
   }
 
   private static boolean supportsOtSearch(String query) {
-    boolean supportsOtSearch = true;
-    if (query != null) {
-      supportsOtSearch = !containsTagFilter(query);
-    }
-    return supportsOtSearch;
-  }
-
-  private static boolean containsTagFilter(String query) {
-    String[] tokens = query.split("\\s+");
-    for (String token : tokens) {
-      int separatorIndex = token.indexOf(':');
-      if (separatorIndex > 0 && "tag".equals(token.substring(0, separatorIndex))) {
-        return true;
-      }
-    }
-    return false;
+    // Query-shape heuristics caused false negatives for tag: searches. OT search
+    // supports the full search query surface; real runtime failures still fall
+    // back through the explicit ot-search-fallback gate below.
+    return true;
   }
 
   static boolean shouldUsePolling(boolean otSearchEnabled, boolean otSearchReady) {
@@ -458,9 +447,12 @@ public final class SearchPresenter
       return;
     }
     subscribeToSearchWavelet(queryText);
-    doSearch();
-    // Do NOT start the repeating poll here. OT handles live updates;
-    // otSearchTimeoutTask starts polling if OT times out or falls back.
+    if (SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(
+        otSearchEnabled, otSearchFallbackEnabled)) {
+      doSearch();
+    }
+    // Do NOT start the repeating poll here. OT handles live updates. If fallback is enabled,
+    // timeout / reconnect paths can still move to legacy HTTP search explicitly.
   }
 
   /**
@@ -477,6 +469,7 @@ public final class SearchPresenter
     searchQueryHandlerRegistration =
         ClientEvents.get().addSearchQueryEventHandler(searchQueryEventHandler);
     otSearchEnabled = Session.get().hasFeature("ot-search") && channel != null;
+    otSearchFallbackEnabled = Session.get().hasFeature("ot-search-fallback");
     if (otSearchEnabled) {
       useOtSearch = false;
       networkStatusHandlerRegistration =
@@ -1137,9 +1130,10 @@ public final class SearchPresenter
   @Override
   public void onShowMoreClicked() {
     querySize += getPageSize();
-    if (shouldUsePolling(otSearchEnabled, useOtSearch)) {
+    if (SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(
+        otSearchEnabled, useOtSearch, otSearchFallbackEnabled)) {
       doSearch();
-    } else {
+    } else if (useOtSearch) {
       if (canProjectOtSearchWindow(querySize, otSearchSnapshot)) {
         applyOtSearchResults();
       } else {
@@ -1147,6 +1141,10 @@ public final class SearchPresenter
             "OT search cannot serve query window " + querySize + " for query '" + queryText + "'",
             null);
       }
+    } else {
+      OT_SEARCH_LOG.warning(
+          "Ignoring show-more request while waiting for OT search data and HTTP fallback is disabled for query '"
+              + queryText + "'");
     }
   }
 
@@ -1501,6 +1499,10 @@ public final class SearchPresenter
   }
 
   private void fallbackToPolling(String message, Throwable cause) {
+    if (!otSearchFallbackEnabled) {
+      failOtSearchWithoutFallback(message, cause);
+      return;
+    }
     if (cause == null) {
       OT_SEARCH_LOG.warning(message + "; falling back to polling");
     } else {
@@ -1516,6 +1518,23 @@ public final class SearchPresenter
     scheduler.cancel(otSearchTimeoutTask);
     scheduler.cancel(searchUpdater);
     startPolling();
+  }
+
+  private void failOtSearchWithoutFallback(String message, Throwable cause) {
+    if (cause == null) {
+      OT_SEARCH_LOG.severe(message + "; HTTP fallback disabled");
+    } else {
+      OT_SEARCH_LOG.log(Level.SEVERE, message + "; HTTP fallback disabled", cause);
+    }
+    useOtSearch = false;
+    allowLoadingSkeletonDuringSearch = false;
+    unsubscribeFromSearchWavelet();
+    otSearchDocument = null;
+    otSearchSnapshot = OtSearchSnapshot.empty();
+    otSearchReceivedData = false;
+    scheduler.cancel(otSearchTimeoutTask);
+    scheduler.cancel(searchUpdater);
+    render();
   }
 
   private boolean shouldShowLoadingSkeleton() {
@@ -1546,6 +1565,12 @@ public final class SearchPresenter
       return;
     }
     otSearchTimedOut = true;
+    if (!otSearchFallbackEnabled) {
+      failOtSearchWithoutFallback(
+          "OT search timed out for query '" + queryText + "'",
+          null);
+      return;
+    }
     OT_SEARCH_LOG.warning(
         "OT search timed out for query '" + queryText + "'; falling back to HTTP polling");
     unsubscribeFromSearchWavelet();

--- a/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
@@ -38,4 +38,17 @@ public final class SearchPresenterLoadingStateTest extends TestCase {
     assertFalse(SearchBootstrapUiState.shouldRetryOtSubscriptionOnReconnect(true, true, false));
     assertFalse(SearchBootstrapUiState.shouldRetryOtSubscriptionOnReconnect(false, false, false));
   }
+
+  public void testOtBootstrapHttpFallbackRequiresExplicitFlag() {
+    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, false));
+    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, true));
+    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(false, false));
+  }
+
+  public void testShowMoreHttpFallbackRequiresExplicitFlagWhenOtNotReady() {
+    assertFalse(SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(true, false, false));
+    assertTrue(SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(true, false, true));
+    assertFalse(SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(true, true, true));
+    assertTrue(SearchBootstrapUiState.shouldUseHttpSearchForWindowRequest(false, false, false));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
@@ -62,6 +62,7 @@ public final class FeatureFlagServiceTest {
     service = new FeatureFlagService(store);
 
     assertFalse(service.getEnabledFlagNames(null).contains("ot-search"));
+    assertFalse(service.getEnabledFlagNames(null).contains("ot-search-fallback"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
@@ -80,14 +80,15 @@ public class Lucene9QueryModelTest extends TestCase {
     assertFalse("tag: queries are indexed but are not text queries", model.hasTextQuery());
   }
 
-  public void testTagQueryIsExcludedFromLegacyQuery() throws InvalidQueryException {
+  public void testTagQueryIsPreservedInLegacyQueryForDigestHydration()
+      throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("tag:project-x");
-    assertEquals("", model.toLegacyQuery());
+    assertEquals("tag:project-x", model.toLegacyQuery());
   }
 
-  public void testTagWithUnreadKeepsUnreadInLegacyQuery() throws InvalidQueryException {
+  public void testTagWithUnreadKeepsTagFilterInLegacyQuery() throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("tag:project-x unread:true");
-    assertEquals("unread:true", model.toLegacyQuery());
+    assertEquals("tag:project-x unread:true", model.toLegacyQuery());
   }
 
   public void testTitleIsExcludedFromLegacyQuery() throws InvalidQueryException {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9QueryModelTest.java
@@ -77,12 +77,17 @@ public class Lucene9QueryModelTest extends TestCase {
 
   public void testTagQueryHasNoTextQuery() throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("tag:project-x");
-    assertFalse("tag: queries should stay on the legacy filter path", model.hasTextQuery());
+    assertFalse("tag: queries are indexed but are not text queries", model.hasTextQuery());
   }
 
-  public void testTagQueryIsIncludedInLegacyQuery() throws InvalidQueryException {
+  public void testTagQueryIsExcludedFromLegacyQuery() throws InvalidQueryException {
     Lucene9QueryModel model = parser.parse("tag:project-x");
-    assertEquals("tag:project-x", model.toLegacyQuery());
+    assertEquals("", model.toLegacyQuery());
+  }
+
+  public void testTagWithUnreadKeepsUnreadInLegacyQuery() throws InvalidQueryException {
+    Lucene9QueryModel model = parser.parse("tag:project-x unread:true");
+    assertEquals("unread:true", model.toLegacyQuery());
   }
 
   public void testTitleIsExcludedFromLegacyQuery() throws InvalidQueryException {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
@@ -58,17 +58,17 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
     verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
   }
 
-  public void testPureTagQueryUsesLuceneCandidatesAndLegacyDigests() throws Exception {
+  public void testPureTagQueryKeepsLegacyTagFilterForDigestHydration() throws Exception {
     SimpleSearchProviderImpl legacySearchProvider = Mockito.mock(SimpleSearchProviderImpl.class);
     Lucene9WaveIndexerImpl indexer = Mockito.mock(Lucene9WaveIndexerImpl.class);
-    SearchResult legacyResult = new SearchResult("");
+    SearchResult legacyResult = new SearchResult("tag:project-x");
     legacyResult.addDigest(new SearchResult.Digest(
         "Project X", "snippet", "example.com!w+project-x", Collections.singletonList(
         "user@example.com"), 123L, 123L, 0, 1));
     legacyResult.setTotalResults(1);
 
     when(legacySearchProvider.search(ParticipantId.ofUnsafe("user@example.com"),
-        "", 0, 10000)).thenReturn(legacyResult);
+        "tag:project-x", 0, 10000)).thenReturn(legacyResult);
     when(indexer.searchWaveIds(any(), any(), anyInt())).thenReturn(
         new LinkedHashSet<>(Collections.singletonList(WaveId.of("example.com", "w+project-x"))));
 
@@ -84,6 +84,8 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
     assertEquals(1, result.getTotalResults());
     assertEquals(1, result.getNumResults());
     assertEquals("example.com!w+project-x", result.getDigests().get(0).getWaveId());
+    verify(legacySearchProvider).search(
+        ParticipantId.ofUnsafe("user@example.com"), "tag:project-x", 0, 10000);
     verify(indexer).searchWaveIds(any(), any(), eq(10000));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9SearchProviderImplTest.java
@@ -20,14 +20,17 @@ package org.waveprotocol.box.server.waveserver.lucene9;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.wave.api.SearchResult;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import junit.framework.TestCase;
 import org.mockito.Mockito;
+import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
@@ -55,17 +58,19 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
     verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
   }
 
-  public void testPureTagQueryReturnsLegacyResultsWithoutLuceneSearch() {
+  public void testPureTagQueryUsesLuceneCandidatesAndLegacyDigests() throws Exception {
     SimpleSearchProviderImpl legacySearchProvider = Mockito.mock(SimpleSearchProviderImpl.class);
     Lucene9WaveIndexerImpl indexer = Mockito.mock(Lucene9WaveIndexerImpl.class);
-    SearchResult legacyResult = new SearchResult("tag:project-x");
+    SearchResult legacyResult = new SearchResult("");
     legacyResult.addDigest(new SearchResult.Digest(
         "Project X", "snippet", "example.com!w+project-x", Collections.singletonList(
         "user@example.com"), 123L, 123L, 0, 1));
     legacyResult.setTotalResults(1);
 
     when(legacySearchProvider.search(ParticipantId.ofUnsafe("user@example.com"),
-        "tag:project-x", 0, 10000)).thenReturn(legacyResult);
+        "", 0, 10000)).thenReturn(legacyResult);
+    when(indexer.searchWaveIds(any(), any(), anyInt())).thenReturn(
+        new LinkedHashSet<>(Collections.singletonList(WaveId.of("example.com", "w+project-x"))));
 
     Lucene9SearchProviderImpl provider = new Lucene9SearchProviderImpl(
         legacySearchProvider,
@@ -79,6 +84,6 @@ public final class Lucene9SearchProviderImplTest extends TestCase {
     assertEquals(1, result.getTotalResults());
     assertEquals(1, result.getNumResults());
     assertEquals("example.com!w+project-x", result.getDigests().get(0).getWaveId());
-    verify(indexer, never()).searchWaveIds(any(), any(), anyInt());
+    verify(indexer).searchWaveIds(any(), any(), eq(10000));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
@@ -335,7 +335,7 @@ public final class SearchPresenterTest extends TestCase {
     assertEquals(1, scheduler.countTasksScheduled());
   }
 
-  public void testOnShowMoreFallsBackToPollingWhenOtSnapshotCannotGrowWindow()
+  public void testOnShowMoreSwitchesToHttpWhenOtSnapshotCannotGrowWindow()
       throws Exception {
     FakeTimerService scheduler = new FakeTimerService();
     SimpleSearch search = new SimpleSearch(new FakeSearchService(), null);
@@ -344,6 +344,7 @@ public final class SearchPresenterTest extends TestCase {
         null);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", false);
     setBooleanField(presenter, "useOtSearch", true);
     setIntField(presenter, "querySize", 45);
     setField(

--- a/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
@@ -237,6 +237,7 @@ public final class SearchPresenterTest extends TestCase {
         null);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
 
     presenter.bootstrapOtSearch();
 
@@ -246,7 +247,7 @@ public final class SearchPresenterTest extends TestCase {
     assertEquals(1, scheduler.countTasksScheduled());
   }
 
-  public void testBootstrapOtSearchFallsBackToPollingForTagQuery() throws Exception {
+  public void testBootstrapOtSearchSubscribesTagQueryToOtSearch() throws Exception {
     FakeTimerService scheduler = new FakeTimerService();
     FakeSearch search = new FakeSearch();
     WaveWebSocketClient socket = Mockito.mock(WaveWebSocketClient.class);
@@ -257,11 +258,12 @@ public final class SearchPresenterTest extends TestCase {
         channel);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     setField(presenter, "queryText", "tag:work");
 
     presenter.bootstrapOtSearch();
 
-    Mockito.verify(socket, Mockito.never()).open(Mockito.any());
+    Mockito.verify(socket).open(Mockito.any());
     assertEquals(1, search.findCalls);
     assertEquals("tag:work", search.lastQuery);
     assertEquals(30, search.lastSize);
@@ -280,6 +282,7 @@ public final class SearchPresenterTest extends TestCase {
         channel);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     setField(presenter, "queryText", "notag:foo");
 
     presenter.bootstrapOtSearch();
@@ -301,6 +304,7 @@ public final class SearchPresenterTest extends TestCase {
         channel);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     setField(presenter, "queryText", "TAG:work");
 
     presenter.bootstrapOtSearch();
@@ -319,6 +323,7 @@ public final class SearchPresenterTest extends TestCase {
         null);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     setBooleanField(presenter, "useOtSearch", true);
 
     presenter.onFolderActionCompleted("archive");
@@ -369,6 +374,7 @@ public final class SearchPresenterTest extends TestCase {
         channel);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
 
     presenter.bootstrapOtSearch();
 
@@ -395,6 +401,7 @@ public final class SearchPresenterTest extends TestCase {
         channel);
 
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     presenter.bootstrapOtSearch();
     // Advance past OT_SEARCH_TIMEOUT_MS (5000 ms) so the timeout task fires.
     scheduler.tick(6000);
@@ -441,6 +448,7 @@ public final class SearchPresenterTest extends TestCase {
 
     view.setHasVisibleDigests(true);
     setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", true);
     setBooleanField(presenter, "useOtSearch", false);
     setBooleanField(presenter, "otSearchTimedOut", false);
 
@@ -448,6 +456,26 @@ public final class SearchPresenterTest extends TestCase {
 
     assertEquals(1, search.findCalls);
     assertFalse(getBooleanField(presenter, "allowLoadingSkeletonDuringSearch"));
+  }
+
+  public void testBootstrapOtSearchSkipsHttpBootstrapWhenFallbackDisabled()
+      throws Exception {
+    FakeTimerService scheduler = new FakeTimerService();
+    FakeSearch search = new FakeSearch();
+    WaveWebSocketClient socket = Mockito.mock(WaveWebSocketClient.class);
+    RemoteViewServiceMultiplexer channel =
+        new RemoteViewServiceMultiplexer(socket, "alice@example.com");
+    SearchPresenter presenter = new SearchPresenter(
+        scheduler, search, new FakeSearchPanelView(), NO_OP_ACTION_HANDLER, new FakeProfiles(),
+        channel);
+
+    setBooleanField(presenter, "otSearchEnabled", true);
+    setBooleanField(presenter, "otSearchFallbackEnabled", false);
+
+    presenter.bootstrapOtSearch();
+
+    Mockito.verify(socket).open(Mockito.any());
+    assertEquals(0, search.findCalls);
   }
 
   private static void setBooleanField(SearchPresenter presenter, String fieldName, boolean value)


### PR DESCRIPTION
## Summary
- keep `tag:` queries on the OT/Lucene path when indexed search is enabled
- add an explicit `ot-search-fallback` feature flag and default it off so OT failures are not silently masked by HTTP bootstrap/polling in production
- preserve the legacy simple-search tag path when OT/Lucene is unavailable

## Root Cause
- the client hard-disabled OT search for `tag:` queries and always bootstrapped OT mode with a normal HTTP `/search` request
- the Lucene provider also treated pure `tag:` queries as legacy-only, which forced tag searches back onto the old tag-document filter path and hid OT failures behind polling

## Verification
- `sbt "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.search.SearchPresenterLoadingStateTest org.waveprotocol.box.server.waveserver.lucene9.Lucene9QueryModelTest org.waveprotocol.box.server.waveserver.lucene9.Lucene9SearchProviderImplTest org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest org.waveprotocol.box.server.waveserver.FeatureFlaggedSearchProviderImplTest" "Test / compile"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`

## Notes
- self-review found no blocker in the final diff
- the repo's current SBT test discovery still does not list the older `org.waveprotocol.box.webclient.search.SearchPresenterTest` class, so presenter wiring was compile-verified and policy-verified via `SearchPresenterLoadingStateTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag queries now route through the indexed search path when OT search is active.
  * New feature flag "ot-search-fallback" (disabled by default) to control OT→legacy polling fallback.

* **Bug Fixes**
  * More explicit control over OT bootstrap, show-more expansions, and timeout behavior to prevent silent fallback to HTTP polling.

* **Tests**
  * Updated tests to cover OT fallback gating and tag-query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->