### PR TITLE
[codex] Allow manual close for tag restore toast

### DIFF
--- a/journal/local-verification/2026-04-12-issue-866-tag-undo-manual-close.md
+++ b/journal/local-verification/2026-04-12-issue-866-tag-undo-manual-close.md
@@ -19,3 +19,9 @@ Verification:
 Review remediation:
 - Addressed Copilot inline review comment on `wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java`
   requesting explicit `type="button"` on the new toast action buttons.
+- Addressed CodeRabbit review feedback by guarding persistent toast action callbacks with
+  `if (!persistentToasts.containsKey(id)) { return; }` before dismiss/run so rapid repeated
+  clicks cannot fire undo/close more than once while the toast is fading out.
+- Reduced brittleness in `WavePanelTagsLayoutTest` by replacing the exact
+  `showPersistentInternal(id, message, level, null, null, null, null);` source assertion with
+  smaller stable token checks and a dedicated guard assertion.

--- a/journal/local-verification/2026-04-12-issue-866-tag-undo-manual-close.md
+++ b/journal/local-verification/2026-04-12-issue-866-tag-undo-manual-close.md
@@ -1,0 +1,21 @@
+Worktree: /Users/vega/devroot/worktrees/vega113-incubator-wave-pr-866-monitor
+Branch: codex/tag-undo-manual-close
+PR: https://github.com/vega113/supawave/pull/866
+Plan: N/A (PR remediation batch)
+
+Changes:
+- Added `type="button"` to persistent toast action buttons in `ToastNotification`.
+- Added a source-contract regression assertion in `WavePanelTagsLayoutTest`.
+
+Verification:
+- `sbt "testOnly org.waveprotocol.box.server.util.WavePanelTagsLayoutTest"`
+  - red: failed before the production fix because `actionBtn.setPropertyString("type", "button");` was absent
+  - green: passed after the production fix
+- `sbt compile`
+  - passed
+- `sbt test`
+  - passed (`2253` tests, `0` failed)
+
+Review remediation:
+- Addressed Copilot inline review comment on `wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java`
+  requesting explicit `type="button"` on the new toast action buttons.

--- a/wave/config/changelog.d/2026-04-12-tag-undo-manual-close.json
+++ b/wave/config/changelog.d/2026-04-12-tag-undo-manual-close.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-12-tag-undo-manual-close",
+  "version": "Unreleased",
+  "date": "2026-04-12",
+  "title": "Let users close tag restore toasts",
+  "summary": "Tag-removal restore toasts now include a manual close action that immediately finalizes the delete instead of keeping the restore window open.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Tag removal toasts now include a Close action alongside Restore",
+        "Closing the toast immediately clears the pending restore window so the delete is finalized at once"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TagController.java
@@ -84,13 +84,15 @@ public final class TagController {
           new UndoableTagRemovalManager.GwtScheduler(),
           new UndoableTagRemovalManager.Presenter() {
             @Override
-            public void show(String tagName, Runnable onUndo) {
-              ToastNotification.showPersistentAction(
+            public void show(String tagName, Runnable onUndo, Runnable onClose) {
+              ToastNotification.showPersistentActions(
                   TAG_REMOVAL_TOAST_ID,
                   messages.removedTagUndoToast(tagName),
                   ToastNotification.Level.INFO,
                   messages.restoreTagAction(),
-                  onUndo);
+                  onUndo,
+                  messages.closeTagAction(),
+                  onClose);
             }
 
             @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/UndoableTagRemovalManager.java
@@ -43,7 +43,7 @@ final class UndoableTagRemovalManager {
   }
 
   interface Presenter {
-    void show(String tagName, Runnable onUndo);
+    void show(String tagName, Runnable onUndo, Runnable onClose);
     void dismiss();
   }
 
@@ -91,6 +91,11 @@ final class UndoableTagRemovalManager {
       public void run() {
         undoPendingRemoval();
       }
+    }, new Runnable() {
+      @Override
+      public void run() {
+        closePendingRemoval();
+      }
     });
     pendingExpiry = scheduler.schedule(restoreWindowMs, new Runnable() {
       @Override
@@ -118,8 +123,20 @@ final class UndoableTagRemovalManager {
 
     Conversation conversation = pendingRemoval.conversation;
     String tagName = pendingRemoval.tagName;
-    clearPendingRemoval();
+    clearPendingRemovalWithoutPresenterDismiss();
     conversation.addTag(tagName);
+  }
+
+  private void closePendingRemoval() {
+    clearPendingRemovalWithoutPresenterDismiss();
+  }
+
+  private void clearPendingRemovalWithoutPresenterDismiss() {
+    if (pendingExpiry != null) {
+      pendingExpiry.cancel();
+      pendingExpiry = null;
+    }
+    pendingRemoval = null;
   }
 
   private static final class PendingRemoval {

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/i18n/TagMessages.java
@@ -49,4 +49,7 @@ public interface TagMessages extends Messages {
 
   @DefaultMessage("Restore")
   String restoreTagAction();
+
+  @DefaultMessage("Close")
+  String closeTagAction();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -441,6 +441,9 @@ public final class ToastNotification {
         if (Event.ONCLICK == event.getTypeInt()) {
           event.preventDefault();
           event.stopPropagation();
+          if (!persistentToasts.containsKey(id)) {
+            return;
+          }
           dismissPersistent(id);
           action.run();
         }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -104,7 +104,7 @@ public final class ToastNotification {
    * @param level severity / color theme
    */
   public static void showPersistent(String id, String message, Level level) {
-    showPersistentInternal(id, message, level, null, null);
+    showPersistentInternal(id, message, level, null, null, null, null);
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -419,6 +419,7 @@ public final class ToastNotification {
     }
 
     Element actionBtn = Document.get().createButtonElement();
+    actionBtn.setPropertyString("type", "button");
     actionBtn.setInnerText(actionLabel);
     Style actionStyle = actionBtn.getStyle();
     actionStyle.setProperty("background",

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java
@@ -118,11 +118,46 @@ public final class ToastNotification {
    */
   public static void showPersistentAction(
       String id, String message, Level level, String actionLabel, Runnable action) {
-    showPersistentInternal(id, message, level, actionLabel, action);
+    showPersistentInternal(id, message, level, actionLabel, action, null, null);
+  }
+
+  /**
+   * Shows a persistent toast with primary and secondary inline actions.
+   *
+   * @param id a caller-chosen identifier so the correct toast can be dismissed
+   * @param message text to display
+   * @param level severity / color theme
+   * @param actionLabel primary button text shown to the user
+   * @param action callback run when the primary action is clicked
+   * @param secondaryActionLabel secondary button text shown to the user
+   * @param secondaryAction callback run when the secondary action is clicked
+   */
+  public static void showPersistentActions(
+      String id,
+      String message,
+      Level level,
+      String actionLabel,
+      Runnable action,
+      String secondaryActionLabel,
+      Runnable secondaryAction) {
+    showPersistentInternal(
+        id,
+        message,
+        level,
+        actionLabel,
+        action,
+        secondaryActionLabel,
+        secondaryAction);
   }
 
   private static void showPersistentInternal(
-      final String id, String message, Level level, String actionLabel, final Runnable action) {
+      final String id,
+      String message,
+      Level level,
+      String actionLabel,
+      final Runnable action,
+      String secondaryActionLabel,
+      final Runnable secondaryAction) {
     if (id == null) {
       return;
     }
@@ -184,34 +219,8 @@ public final class ToastNotification {
     messageEl.setInnerText(message);
     toast.appendChild(messageEl);
 
-    if (actionLabel != null && !actionLabel.isEmpty() && action != null) {
-      Element actionBtn = Document.get().createButtonElement();
-      actionBtn.setInnerText(actionLabel);
-      Style actionStyle = actionBtn.getStyle();
-      actionStyle.setProperty("background", "rgba(255,255,255,0.16)");
-      actionStyle.setProperty("border", "1px solid rgba(255,255,255,0.28)");
-      actionStyle.setProperty("borderRadius", "999px");
-      actionStyle.setProperty("color", "#fff");
-      actionStyle.setProperty("cursor", "pointer");
-      actionStyle.setProperty("fontSize", "12px");
-      actionStyle.setProperty("fontWeight", "600");
-      actionStyle.setProperty("padding", "4px 10px");
-      actionStyle.setProperty("whiteSpace", "nowrap");
-
-      Event.sinkEvents(actionBtn, Event.ONCLICK);
-      Event.setEventListener(actionBtn, new com.google.gwt.user.client.EventListener() {
-        @Override
-        public void onBrowserEvent(Event event) {
-          if (Event.ONCLICK == event.getTypeInt()) {
-            event.preventDefault();
-            event.stopPropagation();
-            dismissPersistent(id);
-            action.run();
-          }
-        }
-      });
-      toast.appendChild(actionBtn);
-    }
+    appendPersistentActionButton(toast, id, actionLabel, action, false);
+    appendPersistentActionButton(toast, id, secondaryActionLabel, secondaryAction, true);
 
     Document.get().getBody().appendChild(toast);
     persistentToasts.put(id, toast);
@@ -397,5 +406,45 @@ public final class ToastNotification {
       toast.getStyle().setProperty("bottom", bottomPx + "px");
       index++;
     }
+  }
+
+  private static void appendPersistentActionButton(
+      Element toast,
+      final String id,
+      String actionLabel,
+      final Runnable action,
+      boolean secondaryAction) {
+    if (actionLabel == null || actionLabel.isEmpty() || action == null) {
+      return;
+    }
+
+    Element actionBtn = Document.get().createButtonElement();
+    actionBtn.setInnerText(actionLabel);
+    Style actionStyle = actionBtn.getStyle();
+    actionStyle.setProperty("background",
+        secondaryAction ? "rgba(255,255,255,0.08)" : "rgba(255,255,255,0.16)");
+    actionStyle.setProperty("border",
+        secondaryAction ? "1px solid rgba(255,255,255,0.18)" : "1px solid rgba(255,255,255,0.28)");
+    actionStyle.setProperty("borderRadius", "999px");
+    actionStyle.setProperty("color", "#fff");
+    actionStyle.setProperty("cursor", "pointer");
+    actionStyle.setProperty("fontSize", "12px");
+    actionStyle.setProperty("fontWeight", secondaryAction ? "500" : "600");
+    actionStyle.setProperty("padding", "4px 10px");
+    actionStyle.setProperty("whiteSpace", "nowrap");
+
+    Event.sinkEvents(actionBtn, Event.ONCLICK);
+    Event.setEventListener(actionBtn, new com.google.gwt.user.client.EventListener() {
+      @Override
+      public void onBrowserEvent(Event event) {
+        if (Event.ONCLICK == event.getTypeInt()) {
+          event.preventDefault();
+          event.stopPropagation();
+          dismissPersistent(id);
+          action.run();
+        }
+      }
+    });
+    toast.appendChild(actionBtn);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -132,8 +132,21 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     assertTrue(manager.contains("DEFAULT_RESTORE_WINDOW_MS = 20_000"));
     assertTrue(manager.contains("conversation.addTag(tagName);"));
     assertTrue(manager.contains("presenter.show(tagName, new Runnable()"));
+    assertTrue(manager.contains("Runnable onClose"));
     assertTrue(messages.contains("String removedTagUndoToast(String tag)"));
     assertTrue(messages.contains("String restoreTagAction()"));
+    assertTrue(messages.contains("String closeTagAction()"));
+    assertTrue(controller.contains("ToastNotification.showPersistentActions("));
+    assertTrue(controller.contains("messages.closeTagAction()"));
+  }
+
+  public void testPersistentToastSupportsManualCloseAction() throws Exception {
+    String toast =
+        read("wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java");
+
+    assertTrue(toast.contains("showPersistentActions("));
+    assertTrue(toast.contains("secondaryActionLabel"));
+    assertTrue(toast.contains("secondaryAction"));
   }
 
   private String read(String relativePath) throws IOException {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -148,6 +148,7 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     assertTrue(toast.contains("showPersistentActions("));
     assertTrue(toast.contains("secondaryActionLabel"));
     assertTrue(toast.contains("secondaryAction"));
+    assertTrue(toast.contains("actionBtn.setPropertyString(\"type\", \"button\");"));
   }
 
   private String read(String relativePath) throws IOException {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -144,11 +144,13 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     String toast =
         read("wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java");
 
-    assertTrue(toast.contains("showPersistentInternal(id, message, level, null, null, null, null);"));
+    assertTrue(toast.contains("showPersistentInternal("));
+    assertTrue(toast.contains("id, message, level, null, null, null, null"));
     assertTrue(toast.contains("showPersistentActions("));
     assertTrue(toast.contains("secondaryActionLabel"));
     assertTrue(toast.contains("secondaryAction"));
     assertTrue(toast.contains("actionBtn.setPropertyString(\"type\", \"button\");"));
+    assertTrue(toast.contains("if (!persistentToasts.containsKey(id)) {"));
   }
 
   private String read(String relativePath) throws IOException {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelTagsLayoutTest.java
@@ -144,6 +144,7 @@ public final class WavePanelTagsLayoutTest extends TestCase {
     String toast =
         read("wave/src/main/java/org/waveprotocol/wave/client/widget/toast/ToastNotification.java");
 
+    assertTrue(toast.contains("showPersistentInternal(id, message, level, null, null, null, null);"));
     assertTrue(toast.contains("showPersistentActions("));
     assertTrue(toast.contains("secondaryActionLabel"));
     assertTrue(toast.contains("secondaryAction"));


### PR DESCRIPTION
## Summary
- add a `Close` action to the tag-removal restore toast
- clear the pending restore window immediately when the toast is closed manually
- extend the existing source-contract regression test and add a changelog fragment

## Why
Tag removal already happens immediately in the client model, but the restore toast had no explicit dismissal path. This change lets users finalize the delete right away instead of waiting for the restore timer to expire.

## Testing
- `sbt "testOnly org.waveprotocol.box.server.util.WavePanelTagsLayoutTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag removal notifications now include a "Close" action button alongside "Restore", letting users finalize pending deletions immediately; persistent notifications properly support two inline actions and correct button typing.

* **Tests**
  * Added/updated tests to verify dual-action persistent notification behavior, manual-close support, and guard behavior to prevent duplicate callback firing.

* **Documentation**
  * Added a local verification note describing validation steps and test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->