### PR TITLE
[codex] Prevent split-brain wavelet corruption during deploy overlap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           bash scripts/ci-validate-deploy-healthcheck.sh
           python3 -m unittest scripts.tests.test_deploy_sanity_gate -v
           python3 -m unittest scripts.tests.test_deploy_overlap_safety -v
+          python3 -m unittest scripts.tests.test_repair_corrupted_waves -v
           WAVE_IMAGE_BLUE=ghcr.io/example/wave:test \
           DEPLOY_ROOT=/tmp/supawave \
           CANONICAL_HOST=wave.example.test \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           bash -n deploy/caddy/deploy.sh
           bash scripts/ci-validate-deploy-healthcheck.sh
           python3 -m unittest scripts.tests.test_deploy_sanity_gate -v
+          python3 -m unittest scripts.tests.test_deploy_overlap_safety -v
           WAVE_IMAGE_BLUE=ghcr.io/example/wave:test \
           DEPLOY_ROOT=/tmp/supawave \
           CANONICAL_HOST=wave.example.test \

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -483,6 +483,7 @@ revert_swap() {
   local restored_slot=$1
   local reverted_slot=$2
   local reason=$3
+  local routing_restored=0
 
   echo "[deploy] ERROR: ${reason}" >&2
   if ! generate_upstream "$restored_slot"; then
@@ -490,9 +491,15 @@ revert_swap() {
   else
     if ! reload_caddy; then
       echo "[deploy] ERROR: failed to reload Caddy while reverting swap to ${restored_slot}" >&2
+    else
+      routing_restored=1
     fi
   fi
-  best_effort_stop_slot "$reverted_slot"
+  if [ "$routing_restored" -eq 1 ]; then
+    best_effort_stop_slot "$reverted_slot"
+  else
+    echo "[deploy] WARNING: leaving wave-${reverted_slot} running because rollback routing was not restored" >&2
+  fi
   exit 1
 }
 

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -452,17 +452,20 @@ post_swap_smoke() {
   return 0
 }
 
-schedule_cooldown() {
+stop_replaced_slot() {
   local old_slot=$1
-  local systemd_scope=""
-  if [ "$(id -u)" -ne 0 ]; then
-    systemd_scope="--user"
+  if dc stop "wave-${old_slot}" 2>/dev/null; then
+    return 0
   fi
-  systemctl $systemd_scope stop "wave-cooldown.service" 2>/dev/null || true
-  if ! systemd-run $systemd_scope --on-active=30min --unit="wave-cooldown" \
-      -- docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" stop "wave-${old_slot}" 2>/dev/null; then
-    echo "[deploy] WARNING: failed to schedule cooldown timer — old slot will stay running"
+
+  echo "[deploy] WARNING: graceful stop failed for wave-${old_slot}; forcing shutdown" >&2
+  dc kill "wave-${old_slot}" 2>/dev/null || true
+
+  if dc ps "wave-${old_slot}" --format json 2>/dev/null | grep -q '"running"'; then
+    echo "[deploy] ERROR: replaced slot wave-${old_slot} is still running" >&2
+    return 1
   fi
+  return 0
 }
 
 update_state() {
@@ -520,7 +523,7 @@ deploy_release() {
   fi
 
   update_state
-  schedule_cooldown "$ACTIVE_SLOT"
+  stop_replaced_slot "$ACTIVE_SLOT"
   echo "[deploy] Deploy complete. Active: ${TARGET_SLOT}"
 }
 
@@ -578,7 +581,7 @@ rollback_release() {
   current=$(cat "$deploy_root/shared/active-slot")
   echo "$prev" > "$deploy_root/shared/active-slot"
   echo "$current" > "$deploy_root/shared/previous-slot"
-  schedule_cooldown "$current"
+  stop_replaced_slot "$current"
   echo "[deploy] Rolled back to ${prev}"
 }
 
@@ -603,7 +606,8 @@ show_status() {
   echo "Cooldown timer:"
   local systemd_scope=""
   [ "$(id -u)" -ne 0 ] && systemd_scope="--user"
-  systemctl $systemd_scope status wave-cooldown.timer 2>/dev/null || echo "  (none active)"
+  systemctl $systemd_scope status wave-cooldown.timer 2>/dev/null \
+    || echo "  disabled (replaced slot stops immediately)"
 }
 
 # ---------------------------------------------------------------------------

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -454,6 +454,7 @@ post_swap_smoke() {
 
 stop_replaced_slot() {
   local old_slot=$1
+  local ps_output=""
   if dc stop "wave-${old_slot}" 2>/dev/null; then
     return 0
   fi
@@ -461,7 +462,12 @@ stop_replaced_slot() {
   echo "[deploy] WARNING: graceful stop failed for wave-${old_slot}; forcing shutdown" >&2
   dc kill "wave-${old_slot}" 2>/dev/null || true
 
-  if dc ps "wave-${old_slot}" --format json 2>/dev/null | grep -q '"running"'; then
+  if ! ps_output="$(dc ps "wave-${old_slot}" --format json 2>/dev/null)"; then
+    echo "[deploy] ERROR: unable to verify whether replaced slot wave-${old_slot} is still running" >&2
+    return 1
+  fi
+
+  if printf '%s\n' "$ps_output" | grep -q '"running"'; then
     echo "[deploy] ERROR: replaced slot wave-${old_slot} is still running" >&2
     return 1
   fi

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -474,6 +474,28 @@ stop_replaced_slot() {
   return 0
 }
 
+best_effort_stop_slot() {
+  local slot=$1
+  dc stop "wave-${slot}" 2>/dev/null || dc kill "wave-${slot}" 2>/dev/null || true
+}
+
+revert_swap() {
+  local restored_slot=$1
+  local reverted_slot=$2
+  local reason=$3
+
+  echo "[deploy] ERROR: ${reason}" >&2
+  if ! generate_upstream "$restored_slot"; then
+    echo "[deploy] ERROR: failed to regenerate upstream for ${restored_slot} while reverting swap" >&2
+  else
+    if ! reload_caddy; then
+      echo "[deploy] ERROR: failed to reload Caddy while reverting swap to ${restored_slot}" >&2
+    fi
+  fi
+  best_effort_stop_slot "$reverted_slot"
+  exit 1
+}
+
 update_state() {
   echo "$TARGET_SLOT" > "$deploy_root/shared/active-slot"
   echo "$ACTIVE_SLOT" > "$deploy_root/shared/previous-slot"
@@ -528,8 +550,11 @@ deploy_release() {
     exit 1
   fi
 
+  if ! stop_replaced_slot "$ACTIVE_SLOT"; then
+    revert_swap "$ACTIVE_SLOT" "$TARGET_SLOT" \
+      "replaced slot ${ACTIVE_SLOT} failed to stop after deploy swap; reverting"
+  fi
   update_state
-  stop_replaced_slot "$ACTIVE_SLOT"
   echo "[deploy] Deploy complete. Active: ${TARGET_SLOT}"
 }
 
@@ -544,6 +569,8 @@ rollback_release() {
 
   local prev_port
   prev_port=$([ "$prev" = "blue" ] && echo 9898 || echo 9899)
+  local current
+  current=$(cat "$deploy_root/shared/active-slot")
 
   if ! dc ps "wave-${prev}" --format json 2>/dev/null | grep -q '"running"'; then
     local prev_image
@@ -576,18 +603,17 @@ rollback_release() {
 
   if ! post_swap_smoke; then
     echo "[deploy] ERROR: post-rollback proxy smoke failed, reverting"
-    local current_active
-    current_active=$(cat "$deploy_root/shared/active-slot")
-    generate_upstream "$current_active"
+    generate_upstream "$current"
     reload_caddy
     exit 1
   fi
 
-  local current
-  current=$(cat "$deploy_root/shared/active-slot")
+  if ! stop_replaced_slot "$current"; then
+    revert_swap "$current" "$prev" \
+      "replaced slot ${current} failed to stop after rollback swap; reverting"
+  fi
   echo "$prev" > "$deploy_root/shared/active-slot"
   echo "$current" > "$deploy_root/shared/previous-slot"
-  stop_replaced_slot "$current"
   echo "[deploy] Rolled back to ${prev}"
 }
 

--- a/scripts/repair_corrupted_waves.py
+++ b/scripts/repair_corrupted_waves.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+DISCOVERY_JS = r"""
+const groups = db.deltas.aggregate([
+  {$group:{
+    _id:{waveid:'$waveid', waveletid:'$waveletid', applied:'$transformed.appliedatversion'},
+    count:{$sum:1}
+  }},
+  {$match:{count:{$gt:1}}},
+  {$sort:{'_id.waveid':1,'_id.waveletid':1,'_id.applied':1}}
+]).toArray();
+
+for (const group of groups) {
+  const docs = db.deltas.find(
+    {
+      waveid: group._id.waveid,
+      waveletid: group._id.waveletid,
+      'transformed.appliedatversion': group._id.applied
+    }
+  ).sort({'transformed.applicationtimestamp': 1, _id: 1}).toArray();
+
+  const later = db.deltas.find(
+    {
+      waveid: group._id.waveid,
+      waveletid: group._id.waveletid,
+      'transformed.appliedatversion': {$gt: group._id.applied}
+    },
+    {
+      appliedatversion: 1,
+      transformed: 1,
+      _id: 0
+    }
+  ).sort({'transformed.appliedatversion': 1}).toArray();
+
+  print(EJSON.stringify({group, docs, later}));
+}
+"""
+
+
+@dataclass
+class DuplicateDoc:
+  doc_id: str
+  author: str
+  application_ts: int
+  applied_version: int
+  applied_hash: str
+  resulting_version: int
+  resulting_hash: str
+  op_types: list[str]
+  blip_ids: list[str]
+  op_count: int
+
+
+@dataclass
+class GroupClassification:
+  status: str
+  reason: str
+  keep_doc_id: str | None
+  drop_doc_ids: list[str]
+
+
+def unwrap_extended_json(value: Any) -> Any:
+  if isinstance(value, dict):
+    if "$numberLong" in value:
+      return int(value["$numberLong"])
+    if "$oid" in value:
+      return value["$oid"]
+    if "$binary" in value:
+      return value["$binary"]["base64"]
+    return {k: unwrap_extended_json(v) for k, v in value.items()}
+  if isinstance(value, list):
+    return [unwrap_extended_json(v) for v in value]
+  return value
+
+
+def normalize_group(raw: dict[str, Any]) -> dict[str, Any]:
+  payload = unwrap_extended_json(raw)
+  group = payload["group"]
+  docs = []
+  for doc in payload["docs"]:
+    transformed = doc["transformed"]
+    ops = transformed["ops"]
+    docs.append(
+        DuplicateDoc(
+            doc_id=doc["_id"],
+            author=transformed["author"]["address"],
+            application_ts=transformed["applicationtimestamp"],
+            applied_version=transformed["appliedatversion"],
+            applied_hash=doc["appliedatversion"]["historyhash"],
+            resulting_version=transformed["resultingversion"]["version"],
+            resulting_hash=transformed["resultingversion"]["historyhash"],
+            op_types=[op["type"] for op in ops],
+            blip_ids=[op.get("blipid", "") for op in ops],
+            op_count=len(ops),
+        )
+    )
+  later_hashes = {
+      later_doc["appliedatversion"]["historyhash"]
+      for later_doc in payload["later"]
+  }
+  return {
+      "waveid": group["_id"]["waveid"],
+      "waveletid": group["_id"]["waveletid"],
+      "applied_version": group["_id"]["applied"],
+      "docs": docs,
+      "raw_docs": payload["docs"],
+      "later_hashes": later_hashes,
+  }
+
+
+def classify_group(group: dict[str, Any]) -> GroupClassification:
+  docs: list[DuplicateDoc] = group["docs"]
+  later_hashes: set[str] = group["later_hashes"]
+
+  winner_ids = [doc.doc_id for doc in docs if doc.resulting_hash in later_hashes]
+  if len(set(winner_ids)) > 1:
+    return GroupClassification(
+        status="ambiguous",
+        reason="multiple duplicate branches are referenced by later history",
+        keep_doc_id=None,
+        drop_doc_ids=[],
+    )
+  if not winner_ids:
+    return GroupClassification(
+        status="ambiguous",
+        reason="no unique surviving branch found in later history",
+        keep_doc_id=None,
+        drop_doc_ids=[],
+    )
+
+  same_author = len({doc.author for doc in docs}) == 1
+  same_resulting_version = len({doc.resulting_version for doc in docs}) == 1
+  same_op_type_shape = len({tuple(doc.op_types) for doc in docs}) == 1
+  same_blip_shape = len({tuple(doc.blip_ids) for doc in docs}) == 1
+  one_op_each = all(doc.op_count == 1 for doc in docs)
+
+  if not (same_author and same_resulting_version and same_op_type_shape and same_blip_shape and one_op_each):
+    return GroupClassification(
+        status="ambiguous",
+        reason="duplicate branches are not a single-author single-op replay shape",
+        keep_doc_id=None,
+        drop_doc_ids=[],
+    )
+
+  keep_doc_id = winner_ids[0]
+  drop_doc_ids = [doc.doc_id for doc in docs if doc.doc_id != keep_doc_id]
+  return GroupClassification(
+      status="safe",
+      reason="single surviving branch and duplicate docs look like same-author one-op replay",
+      keep_doc_id=keep_doc_id,
+      drop_doc_ids=drop_doc_ids,
+  )
+
+
+def classify_waves(groups: list[dict[str, Any]]) -> dict[str, Any]:
+  waves: dict[str, dict[str, Any]] = {}
+  for group in groups:
+    classification = classify_group(group)
+    wave = waves.setdefault(
+        group["waveid"],
+        {
+            "waveid": group["waveid"],
+            "waveletid": group["waveletid"],
+            "groups": [],
+            "safe_to_repair": True,
+        },
+    )
+    wave["groups"].append(
+        {
+            "applied_version": group["applied_version"],
+            "status": classification.status,
+            "reason": classification.reason,
+            "keep_doc_id": classification.keep_doc_id,
+            "drop_doc_ids": classification.drop_doc_ids,
+            "docs": [
+                {
+                    "doc_id": doc.doc_id,
+                    "author": doc.author,
+                    "application_ts": doc.application_ts,
+                    "resulting_version": doc.resulting_version,
+                    "op_types": doc.op_types,
+                    "blip_ids": doc.blip_ids,
+                }
+                for doc in group["docs"]
+            ],
+        }
+    )
+    if classification.status != "safe":
+      wave["safe_to_repair"] = False
+
+  for wave in waves.values():
+    wave["status"] = "safe" if wave["safe_to_repair"] else "ambiguous"
+  return waves
+
+
+def run_discovery(shell_command: str) -> list[dict[str, Any]]:
+  proc = subprocess.run(
+      shell_command,
+      input=DISCOVERY_JS,
+      text=True,
+      shell=True,
+      executable="/bin/bash",
+      capture_output=True,
+      check=False,
+  )
+  if proc.returncode != 0:
+    raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"mongo shell failed: {proc.returncode}")
+
+  groups = []
+  for line in proc.stdout.splitlines():
+    line = line.strip()
+    if not line:
+      continue
+    start = line.find("{")
+    if start < 0:
+      continue
+    groups.append(normalize_group(json.loads(line[start:])))
+  return groups
+
+
+def render_text_report(waves: dict[str, Any]) -> str:
+  lines = []
+  safe = [wave for wave in waves.values() if wave["status"] == "safe"]
+  ambiguous = [wave for wave in waves.values() if wave["status"] != "safe"]
+  lines.append(f"safe_to_repair={len(safe)}")
+  lines.append(f"ambiguous={len(ambiguous)}")
+  for wave in sorted(waves.values(), key=lambda item: item["waveid"]):
+    lines.append(f"{wave['status']}: {wave['waveid']}")
+    for group in wave["groups"]:
+      lines.append(
+          f"  applied={group['applied_version']} status={group['status']} reason={group['reason']}"
+      )
+      if group["keep_doc_id"]:
+        lines.append(f"  keep={group['keep_doc_id']} drop={','.join(group['drop_doc_ids'])}")
+  return "\n".join(lines)
+
+
+def collect_safe_repairs(waves: dict[str, Any]) -> list[dict[str, Any]]:
+  repairs = []
+  for wave in waves.values():
+    if wave["status"] != "safe":
+      continue
+    drop_doc_ids = []
+    for group in wave["groups"]:
+      drop_doc_ids.extend(group["drop_doc_ids"])
+    repairs.append(
+        {
+            "waveid": wave["waveid"],
+            "waveletid": wave["waveletid"],
+            "drop_doc_ids": drop_doc_ids,
+        }
+    )
+  return repairs
+
+
+def apply_safe_repairs(shell_command: str, repairs: list[dict[str, Any]], backup_path: str | None) -> None:
+  if not repairs:
+    return
+  if not backup_path:
+    raise RuntimeError("--apply-safe requires --backup-file so dropped docs are recorded")
+
+  backup_payload = {"repairs": repairs}
+  with open(backup_path, "w", encoding="utf-8") as fh:
+    json.dump(backup_payload, fh, indent=2, sort_keys=True)
+
+  js_lines = []
+  for repair in repairs:
+    ids = ", ".join(f'ObjectId("{doc_id}")' for doc_id in repair["drop_doc_ids"])
+    js_lines.append(
+        "db.deltas.deleteMany({_id: {$in: [" + ids + "]}});"
+    )
+    js_lines.append(
+        "db.snapshots.deleteMany({waveId: "
+        + json.dumps(repair["waveid"])
+        + ", waveletId: "
+        + json.dumps(repair["waveletid"])
+        + "});"
+    )
+  proc = subprocess.run(
+      shell_command,
+      input="\n".join(js_lines) + "\n",
+      text=True,
+      shell=True,
+      executable="/bin/bash",
+      capture_output=True,
+      check=False,
+  )
+  if proc.returncode != 0:
+    raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"mongo shell failed: {proc.returncode}")
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(description="Classify duplicate applied-version wavelet histories.")
+  parser.add_argument(
+      "--mongo-shell",
+      default="mongosh --quiet wiab",
+      help="Shell command that accepts Mongo JS on stdin and prints JSON lines to stdout.",
+  )
+  parser.add_argument(
+      "--format",
+      choices=("text", "json"),
+      default="text",
+      help="Output format.",
+  )
+  parser.add_argument(
+      "--apply-safe",
+      action="store_true",
+      help="Delete orphan delta docs only for waves classified as safe.",
+  )
+  parser.add_argument(
+      "--backup-file",
+      help="Write repair metadata here before any --apply-safe deletions.",
+  )
+  args = parser.parse_args()
+
+  waves = classify_waves(run_discovery(args.mongo_shell))
+  if args.apply_safe:
+    apply_safe_repairs(args.mongo_shell, collect_safe_repairs(waves), args.backup_file)
+  if args.format == "json":
+    print(json.dumps(waves, indent=2, sort_keys=True))
+  else:
+    print(render_text_report(waves))
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/repair_corrupted_waves.py
+++ b/scripts/repair_corrupted_waves.py
@@ -163,8 +163,9 @@ def classify_waves(groups: list[dict[str, Any]]) -> dict[str, Any]:
   waves: dict[str, dict[str, Any]] = {}
   for group in groups:
     classification = classify_group(group)
+    wave_key = f"{group['waveid']}::{group['waveletid']}"
     wave = waves.setdefault(
-        group["waveid"],
+        wave_key,
         {
             "waveid": group["waveid"],
             "waveletid": group["waveletid"],
@@ -231,8 +232,8 @@ def render_text_report(waves: dict[str, Any]) -> str:
   ambiguous = [wave for wave in waves.values() if wave["status"] != "safe"]
   lines.append(f"safe_to_repair={len(safe)}")
   lines.append(f"ambiguous={len(ambiguous)}")
-  for wave in sorted(waves.values(), key=lambda item: item["waveid"]):
-    lines.append(f"{wave['status']}: {wave['waveid']}")
+  for wave in sorted(waves.values(), key=lambda item: (item["waveid"], item["waveletid"])):
+    lines.append(f"{wave['status']}: {wave['waveid']} {wave['waveletid']}")
     for group in wave["groups"]:
       lines.append(
           f"  applied={group['applied_version']} status={group['status']} reason={group['reason']}"

--- a/scripts/repair_corrupted_waves.py
+++ b/scripts/repair_corrupted_waves.py
@@ -119,15 +119,17 @@ def classify_group(group: dict[str, Any]) -> GroupClassification:
   docs: list[DuplicateDoc] = group["docs"]
   later_hashes: set[str] = group["later_hashes"]
 
-  winner_ids = [doc.doc_id for doc in docs if doc.resulting_hash in later_hashes]
-  if len(set(winner_ids)) > 1:
+  winner_hashes = list(dict.fromkeys(
+      doc.resulting_hash for doc in docs if doc.resulting_hash in later_hashes
+  ))
+  if len(winner_hashes) > 1:
     return GroupClassification(
         status="ambiguous",
         reason="multiple duplicate branches are referenced by later history",
         keep_doc_id=None,
         drop_doc_ids=[],
     )
-  if not winner_ids:
+  if not winner_hashes:
     return GroupClassification(
         status="ambiguous",
         reason="no unique surviving branch found in later history",
@@ -149,7 +151,8 @@ def classify_group(group: dict[str, Any]) -> GroupClassification:
         drop_doc_ids=[],
     )
 
-  keep_doc_id = winner_ids[0]
+  surviving_hash = winner_hashes[0]
+  keep_doc_id = next(doc.doc_id for doc in docs if doc.resulting_hash == surviving_hash)
   drop_doc_ids = [doc.doc_id for doc in docs if doc.doc_id != keep_doc_id]
   return GroupClassification(
       status="safe",
@@ -256,6 +259,10 @@ def collect_safe_repairs(waves: dict[str, Any]) -> list[dict[str, Any]]:
             "waveid": wave["waveid"],
             "waveletid": wave["waveletid"],
             "drop_doc_ids": drop_doc_ids,
+            "snapshot_delete_filter": {
+                "waveId": wave["waveid"],
+                "waveletId": wave["waveletid"],
+            },
         }
     )
   return repairs
@@ -274,14 +281,18 @@ def apply_safe_repairs(shell_command: str, repairs: list[dict[str, Any]], backup
   js_lines = []
   for repair in repairs:
     ids = ", ".join(f'ObjectId("{doc_id}")' for doc_id in repair["drop_doc_ids"])
+    snapshot_delete_filter = repair.get("snapshot_delete_filter", {
+        "waveId": repair["waveid"],
+        "waveletId": repair["waveletid"],
+    })
     js_lines.append(
         "db.deltas.deleteMany({_id: {$in: [" + ids + "]}});"
     )
     js_lines.append(
         "db.snapshots.deleteMany({waveId: "
-        + json.dumps(repair["waveid"])
+        + json.dumps(snapshot_delete_filter["waveId"])
         + ", waveletId: "
-        + json.dumps(repair["waveletid"])
+        + json.dumps(snapshot_delete_filter["waveletId"])
         + "});"
     )
   proc = subprocess.run(

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -107,6 +107,24 @@ class DeployOverlapSafetyTest(unittest.TestCase):
     ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
     self.assertIn("stop wave-blue", ops)
 
+  def test_revert_swap_keeps_new_slot_running_when_routing_restore_fails(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        stop_fail_services=["wave-blue"],
+        reload_fail_on_calls=[2],
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn(
+        "failed to reload Caddy while reverting swap to blue",
+        result.stderr,
+    )
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
+    self.assertNotIn("stop wave-green", ops)
+
   def _run_script(
       self,
       command: str,
@@ -115,6 +133,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
       running_services: list[str],
       stop_fail_services: list[str] | None = None,
       ps_error_services: list[str] | None = None,
+      reload_fail_on_calls: list[int] | None = None,
   ):
     bash_path = self._bash_path()
     if bash_path is None:
@@ -122,6 +141,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
 
     stop_fail_services = stop_fail_services or []
     ps_error_services = ps_error_services or []
+    reload_fail_on_calls = reload_fail_on_calls or []
     temp_dir = Path(tempfile.mkdtemp(prefix="deploy-overlap-safety-"))
     fake_bin = temp_dir / "bin"
     fake_bin.mkdir(parents=True)
@@ -131,6 +151,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
     if previous_slot is not None:
       (deploy_root / "shared" / "previous-slot").write_text(f"{previous_slot}\n", encoding="utf-8")
     ops_log = temp_dir / "ops.log"
+    reload_count = temp_dir / "reload-count"
     stop_fail_checks = "\n".join(
         f'if [[ "$cmd" == *" stop {service}"* ]]; then exit 1; fi'
         for service in stop_fail_services
@@ -172,6 +193,15 @@ set -euo pipefail
     exit 0
     ;;
   *" exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile"*)
+    count=0
+    if [[ -f "{reload_count}" ]]; then
+      count=$(<"{reload_count}")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" > "{reload_count}"
+    case "$count" in
+{textwrap.indent("".join(f"      {call}) exit 1 ;;\n" for call in reload_fail_on_calls), "    ")}
+    esac
     exit 0
     ;;
   *" stop wave-blue"*)

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -14,7 +14,7 @@ BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
 
 class DeployOverlapSafetyTest(unittest.TestCase):
   def test_deploy_stops_old_slot_immediately_after_swap(self):
-    result, ops_log = self._run_script(
+    result, temp_dir = self._run_script(
         command="deploy",
         active_slot="blue",
         previous_slot=None,
@@ -26,12 +26,12 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         result.returncode,
         msg=f"deploy failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
     )
-    ops = ops_log.read_text(encoding="utf-8")
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
     self.assertIn("stop wave-blue", ops)
     self.assertNotIn("systemd-run", ops)
 
   def test_rollback_stops_replaced_slot_immediately_after_swap(self):
-    result, ops_log = self._run_script(
+    result, temp_dir = self._run_script(
         command="rollback",
         active_slot="green",
         previous_slot="blue",
@@ -43,7 +43,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         result.returncode,
         msg=f"rollback failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
     )
-    ops = ops_log.read_text(encoding="utf-8")
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
     self.assertIn("stop wave-green", ops)
     self.assertNotIn("systemd-run", ops)
 

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -1,0 +1,212 @@
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_SCRIPT = REPO_ROOT / "deploy" / "caddy" / "deploy.sh"
+BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
+
+
+class DeployOverlapSafetyTest(unittest.TestCase):
+  def test_deploy_stops_old_slot_immediately_after_swap(self):
+    result, ops_log = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"deploy failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    ops = ops_log.read_text(encoding="utf-8")
+    self.assertIn("stop wave-blue", ops)
+    self.assertNotIn("systemd-run", ops)
+
+  def test_rollback_stops_replaced_slot_immediately_after_swap(self):
+    result, ops_log = self._run_script(
+        command="rollback",
+        active_slot="green",
+        previous_slot="blue",
+        running_services=["caddy", "wave-blue", "wave-green"],
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"rollback failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    ops = ops_log.read_text(encoding="utf-8")
+    self.assertIn("stop wave-green", ops)
+    self.assertNotIn("systemd-run", ops)
+
+  def test_build_workflow_runs_overlap_safety_regression(self):
+    workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
+    self.assertIn("scripts.tests.test_deploy_overlap_safety", workflow)
+
+  def _run_script(self, command: str, active_slot: str, previous_slot: str | None, running_services: list[str]):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash >= 4 to execute deploy/caddy/deploy.sh")
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="deploy-overlap-safety-"))
+    fake_bin = temp_dir / "bin"
+    fake_bin.mkdir(parents=True)
+    deploy_root = temp_dir / "deploy-root"
+    (deploy_root / "shared").mkdir(parents=True)
+    (deploy_root / "shared" / "active-slot").write_text(f"{active_slot}\n", encoding="utf-8")
+    if previous_slot is not None:
+      (deploy_root / "shared" / "previous-slot").write_text(f"{previous_slot}\n", encoding="utf-8")
+    ops_log = temp_dir / "ops.log"
+    running_checks = "\n".join(
+        f'if [[ "$cmd" == *" ps {service} --format json"* ]]; then '
+        f'printf \'{{"Service":"{service}","State":"running"}}\\n\'; exit 0; fi'
+        for service in running_services
+    )
+
+    self._write_executable(
+        fake_bin / "docker",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "{ops_log}"
+cmd="$*"
+case "$cmd" in
+  "compose version")
+    exit 0
+    ;;
+  "pull ghcr.io/example/wave:test")
+    exit 0
+    ;;
+  *" ps caddy --format json"*)
+    printf '{{"Service":"caddy","State":"running"}}\\n'
+    exit 0
+    ;;
+  *" up -d wave-green"*)
+    exit 0
+    ;;
+  *" up -d wave-blue"*)
+    exit 0
+    ;;
+  *" exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile"*)
+    exit 0
+    ;;
+  *" stop wave-blue"*)
+    exit 0
+    ;;
+  *" stop wave-green"*)
+    exit 0
+    ;;
+  "run --rm --network host "*|*"run --rm --network host "*)
+    exit 0
+    ;;
+esac
+{running_checks}
+echo "unexpected docker invocation: $cmd" >&2
+exit 1
+""",
+    )
+    self._write_executable(
+        fake_bin / "curl",
+        """#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+out=""
+for ((i=1;i<=$#;i++)); do
+  if [ "${!i}" = "-w" ]; then
+    j=$((i+1))
+    out="${!j}"
+  fi
+done
+if [[ "$args" == *"http://localhost:9899/healthz"* ]]; then
+  if [ -n "$out" ]; then
+    printf '%s' "${out//%{http_code}/200}"
+  fi
+  exit 0
+fi
+if [[ "$args" == *"http://localhost:9898/healthz"* ]]; then
+  if [ -n "$out" ]; then
+    printf '%s' "${out//%{http_code}/200}"
+  fi
+  exit 0
+fi
+if [[ "$args" == *"https://supawave.ai/healthz"* ]]; then
+  if [ -n "$out" ]; then
+    printf '%s' "${out//%{http_code}/200}"
+  fi
+  exit 0
+fi
+if [[ "$args" == *"https://wave.supawave.ai/"* ]]; then
+  if [ -n "$out" ]; then
+    printf '%s' "${out//%{http_code}/301}"
+  fi
+  exit 0
+fi
+exit 1
+""",
+    )
+    self._write_executable(
+        fake_bin / "systemctl",
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    )
+    self._write_executable(
+        fake_bin / "systemd-run",
+        "#!/usr/bin/env bash\nset -euo pipefail\necho unexpected systemd-run \"$*\" >&2\nexit 1\n",
+    )
+    self._write_executable(
+        fake_bin / "flock",
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["DEPLOY_ROOT"] = str(deploy_root)
+    env["WAVE_IMAGE"] = "ghcr.io/example/wave:test"
+    env["CANONICAL_HOST"] = "supawave.ai"
+    env["ROOT_HOST"] = "wave.supawave.ai"
+    env["WWW_HOST"] = "www.supawave.ai"
+    env["SANITY_ADDRESS"] = "testregister"
+    env["SANITY_PASSWORD"] = "testregister"
+
+    result = subprocess.run(
+        [bash_path, str(DEPLOY_SCRIPT), command],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, ops_log
+
+  @staticmethod
+  def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+  @staticmethod
+  def _bash_path() -> str | None:
+    for candidate in (os.environ.get("TEST_BASH"), "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash"):
+      if not candidate:
+        continue
+      path = Path(candidate)
+      if not path.is_file() or not os.access(path, os.X_OK):
+        continue
+      version = subprocess.run(
+          [str(path), "-c", 'printf "%s" "${BASH_VERSINFO[0]}"'],
+          capture_output=True,
+          text=True,
+          check=True,
+      ).stdout.strip()
+      if version.isdigit() and int(version) >= 4:
+        return str(path)
+    return None
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -51,11 +51,37 @@ class DeployOverlapSafetyTest(unittest.TestCase):
     workflow = BUILD_WORKFLOW.read_text(encoding="utf-8")
     self.assertIn("scripts.tests.test_deploy_overlap_safety", workflow)
 
-  def _run_script(self, command: str, active_slot: str, previous_slot: str | None, running_services: list[str]):
+  def test_deploy_fails_closed_when_old_slot_status_cannot_be_verified(self):
+    result, _ = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        stop_fail_services=["wave-blue"],
+        ps_error_services=["wave-blue"],
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn(
+        "unable to verify whether replaced slot wave-blue is still running",
+        result.stderr,
+    )
+
+  def _run_script(
+      self,
+      command: str,
+      active_slot: str,
+      previous_slot: str | None,
+      running_services: list[str],
+      stop_fail_services: list[str] | None = None,
+      ps_error_services: list[str] | None = None,
+  ):
     bash_path = self._bash_path()
     if bash_path is None:
       self.skipTest("requires bash >= 4 to execute deploy/caddy/deploy.sh")
 
+    stop_fail_services = stop_fail_services or []
+    ps_error_services = ps_error_services or []
     temp_dir = Path(tempfile.mkdtemp(prefix="deploy-overlap-safety-"))
     fake_bin = temp_dir / "bin"
     fake_bin.mkdir(parents=True)
@@ -65,6 +91,15 @@ class DeployOverlapSafetyTest(unittest.TestCase):
     if previous_slot is not None:
       (deploy_root / "shared" / "previous-slot").write_text(f"{previous_slot}\n", encoding="utf-8")
     ops_log = temp_dir / "ops.log"
+    stop_fail_checks = "\n".join(
+        f'if [[ "$cmd" == *" stop {service}"* ]]; then exit 1; fi'
+        for service in stop_fail_services
+    )
+    ps_error_checks = "\n".join(
+        f'if [[ "$cmd" == *" ps {service} --format json"* ]]; then '
+        f'echo "docker ps failed for {service}" >&2; exit 2; fi'
+        for service in ps_error_services
+    )
     running_checks = "\n".join(
         f'if [[ "$cmd" == *" ps {service} --format json"* ]]; then '
         f'printf \'{{"Service":"{service}","State":"running"}}\\n\'; exit 0; fi'
@@ -75,9 +110,11 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         fake_bin / "docker",
         f"""#!/usr/bin/env bash
 set -euo pipefail
-printf '%s\\n' "$*" >> "{ops_log}"
-cmd="$*"
-case "$cmd" in
+	printf '%s\\n' "$*" >> "{ops_log}"
+	cmd="$*"
+	{stop_fail_checks}
+	{ps_error_checks}
+	case "$cmd" in
   "compose version")
     exit 0
     ;;

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -67,6 +67,46 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         result.stderr,
     )
 
+  def test_deploy_reverts_swap_when_replaced_slot_stays_running(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        stop_fail_services=["wave-blue"],
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn("replaced slot wave-blue is still running", result.stderr)
+    self.assertEqual("blue", (temp_dir / "deploy-root" / "shared" / "active-slot").read_text(encoding="utf-8").strip())
+    self.assertIn(
+        "# active: blue",
+        (temp_dir / "deploy-root" / "shared" / "upstream.caddy").read_text(encoding="utf-8"),
+    )
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
+    self.assertIn("stop wave-green", ops)
+
+  def test_rollback_reverts_swap_when_replaced_slot_stays_running(self):
+    result, temp_dir = self._run_script(
+        command="rollback",
+        active_slot="green",
+        previous_slot="blue",
+        running_services=["caddy", "wave-blue", "wave-green"],
+        stop_fail_services=["wave-green"],
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn("replaced slot wave-green is still running", result.stderr)
+    shared_dir = temp_dir / "deploy-root" / "shared"
+    self.assertEqual("green", (shared_dir / "active-slot").read_text(encoding="utf-8").strip())
+    self.assertEqual("blue", (shared_dir / "previous-slot").read_text(encoding="utf-8").strip())
+    self.assertIn(
+        "# active: green",
+        (shared_dir / "upstream.caddy").read_text(encoding="utf-8"),
+    )
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
+    self.assertIn("stop wave-blue", ops)
+
   def _run_script(
       self,
       command: str,
@@ -138,6 +178,12 @@ set -euo pipefail
     exit 0
     ;;
   *" stop wave-green"*)
+    exit 0
+    ;;
+  *" kill wave-blue"*)
+    exit 0
+    ;;
+  *" kill wave-green"*)
     exit 0
     ;;
   "run --rm --network host "*|*"run --rm --network host "*)
@@ -219,7 +265,7 @@ exit 1
         text=True,
         check=False,
     )
-    return result, ops_log
+    return result, temp_dir
 
   @staticmethod
   def _write_executable(path: Path, content: str) -> None:

--- a/scripts/tests/test_repair_corrupted_waves.py
+++ b/scripts/tests/test_repair_corrupted_waves.py
@@ -1,0 +1,147 @@
+import unittest
+
+from scripts.repair_corrupted_waves import classify_group
+from scripts.repair_corrupted_waves import collect_safe_repairs
+
+
+def make_group(applied_version, docs, later_hashes):
+  return {
+      "waveid": "supawave.ai/test",
+      "waveletid": "supawave.ai!conv+root",
+      "applied_version": applied_version,
+      "docs": docs,
+      "later_hashes": set(later_hashes),
+  }
+
+
+class DuplicateGroupClassificationTest(unittest.TestCase):
+  def test_safe_group_keeps_single_surviving_replay_branch(self):
+    docs = [
+        type("Doc", (), {
+            "doc_id": "old",
+            "author": "vega@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 38,
+            "applied_hash": "H38",
+            "resulting_version": 39,
+            "resulting_hash": "dead",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "new",
+            "author": "vega@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 38,
+            "applied_hash": "H38",
+            "resulting_version": 39,
+            "resulting_hash": "live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+    ]
+    result = classify_group(make_group(38, docs, {"live"}))
+    self.assertEqual("safe", result.status)
+    self.assertEqual("new", result.keep_doc_id)
+    self.assertEqual(["old"], result.drop_doc_ids)
+
+  def test_ambiguous_when_multiple_branches_continue(self):
+    docs = [
+        type("Doc", (), {
+            "doc_id": "a",
+            "author": "vega@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 233,
+            "applied_hash": "H233",
+            "resulting_version": 234,
+            "resulting_hash": "left",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "b",
+            "author": "vega@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 233,
+            "applied_hash": "H233",
+            "resulting_version": 234,
+            "resulting_hash": "right",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+    ]
+    result = classify_group(make_group(233, docs, {"left", "right"}))
+    self.assertEqual("ambiguous", result.status)
+    self.assertIsNone(result.keep_doc_id)
+
+  def test_ambiguous_when_replay_shape_differs(self):
+    docs = [
+        type("Doc", (), {
+            "doc_id": "cursor-close",
+            "author": "register3@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 297,
+            "applied_hash": "H297",
+            "resulting_version": 298,
+            "resulting_hash": "dead",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+cursor"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "bot-reply",
+            "author": "gpt-ts-bot@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 297,
+            "applied_hash": "H297",
+            "resulting_version": 301,
+            "resulting_hash": "live",
+            "op_types": [
+                "WaveletBlipOperation",
+                "WaveletBlipOperation",
+                "WaveletBlipOperation",
+                "WaveletBlipOperation",
+            ],
+            "blip_ids": ["conversation", "b+reply", "conversation", "b+reply"],
+            "op_count": 4,
+        })(),
+    ]
+    result = classify_group(make_group(297, docs, {"live"}))
+    self.assertEqual("ambiguous", result.status)
+    self.assertIn("single-author single-op replay", result.reason)
+
+  def test_collect_safe_repairs_only_includes_fully_safe_waves(self):
+    waves = {
+        "safe-wave": {
+            "waveid": "safe-wave",
+            "waveletid": "wavelet",
+            "status": "safe",
+            "groups": [
+                {"drop_doc_ids": ["a", "b"]},
+                {"drop_doc_ids": ["c"]},
+            ],
+        },
+        "ambiguous-wave": {
+            "waveid": "ambiguous-wave",
+            "waveletid": "wavelet",
+            "status": "ambiguous",
+            "groups": [
+                {"drop_doc_ids": ["x"]},
+            ],
+        },
+    }
+
+    repairs = collect_safe_repairs(waves)
+
+    self.assertEqual(
+        [{"waveid": "safe-wave", "waveletid": "wavelet", "drop_doc_ids": ["a", "b", "c"]}],
+        repairs,
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_repair_corrupted_waves.py
+++ b/scripts/tests/test_repair_corrupted_waves.py
@@ -1,5 +1,8 @@
+import json
+import tempfile
 import unittest
 
+from scripts.repair_corrupted_waves import apply_safe_repairs
 from scripts.repair_corrupted_waves import classify_group
 from scripts.repair_corrupted_waves import classify_waves
 from scripts.repair_corrupted_waves import collect_safe_repairs
@@ -85,6 +88,40 @@ class DuplicateGroupClassificationTest(unittest.TestCase):
     self.assertEqual("ambiguous", result.status)
     self.assertIsNone(result.keep_doc_id)
 
+  def test_safe_when_multiple_docs_share_single_surviving_hash(self):
+    docs = [
+        type("Doc", (), {
+            "doc_id": "older-live",
+            "author": "vega@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 233,
+            "applied_hash": "H233",
+            "resulting_version": 234,
+            "resulting_hash": "live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "newer-live",
+            "author": "vega@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 233,
+            "applied_hash": "H233",
+            "resulting_version": 234,
+            "resulting_hash": "live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+    ]
+
+    result = classify_group(make_group(233, docs, {"live"}))
+
+    self.assertEqual("safe", result.status)
+    self.assertEqual("older-live", result.keep_doc_id)
+    self.assertEqual(["newer-live"], result.drop_doc_ids)
+
   def test_ambiguous_when_replay_shape_differs(self):
     docs = [
         type("Doc", (), {
@@ -145,7 +182,15 @@ class DuplicateGroupClassificationTest(unittest.TestCase):
     repairs = collect_safe_repairs(waves)
 
     self.assertEqual(
-        [{"waveid": "safe-wave", "waveletid": "wavelet", "drop_doc_ids": ["a", "b", "c"]}],
+        [{
+            "waveid": "safe-wave",
+            "waveletid": "wavelet",
+            "drop_doc_ids": ["a", "b", "c"],
+            "snapshot_delete_filter": {
+                "waveId": "safe-wave",
+                "waveletId": "wavelet",
+            },
+        }],
         repairs,
     )
 
@@ -227,9 +272,34 @@ class DuplicateGroupClassificationTest(unittest.TestCase):
             "waveid": "supawave.ai/shared-wave",
             "waveletid": "supawave.ai!conv+root",
             "drop_doc_ids": ["old"],
+            "snapshot_delete_filter": {
+                "waveId": "supawave.ai/shared-wave",
+                "waveletId": "supawave.ai!conv+root",
+            },
         }],
         repairs,
     )
+
+  def test_apply_safe_repairs_records_snapshot_delete_filter_in_backup(self):
+    repairs = [{
+        "waveid": "supawave.ai/shared-wave",
+        "waveletid": "supawave.ai!conv+root",
+        "drop_doc_ids": ["abc123"],
+        "snapshot_delete_filter": {
+            "waveId": "supawave.ai/shared-wave",
+            "waveletId": "supawave.ai!conv+root",
+        },
+    }]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+      backup_path = f"{temp_dir}/backup.json"
+
+      apply_safe_repairs("cat >/dev/null", repairs, backup_path)
+
+      with open(backup_path, encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    self.assertEqual(repairs, payload["repairs"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_repair_corrupted_waves.py
+++ b/scripts/tests/test_repair_corrupted_waves.py
@@ -1,13 +1,20 @@
 import unittest
 
 from scripts.repair_corrupted_waves import classify_group
+from scripts.repair_corrupted_waves import classify_waves
 from scripts.repair_corrupted_waves import collect_safe_repairs
 
 
-def make_group(applied_version, docs, later_hashes):
+def make_group(
+    applied_version,
+    docs,
+    later_hashes,
+    waveid="supawave.ai/test",
+    waveletid="supawave.ai!conv+root",
+):
   return {
-      "waveid": "supawave.ai/test",
-      "waveletid": "supawave.ai!conv+root",
+      "waveid": waveid,
+      "waveletid": waveletid,
       "applied_version": applied_version,
       "docs": docs,
       "later_hashes": set(later_hashes),
@@ -139,6 +146,88 @@ class DuplicateGroupClassificationTest(unittest.TestCase):
 
     self.assertEqual(
         [{"waveid": "safe-wave", "waveletid": "wavelet", "drop_doc_ids": ["a", "b", "c"]}],
+        repairs,
+    )
+
+  def test_classify_waves_keeps_wavelets_separate_within_same_wave(self):
+    safe_docs = [
+        type("Doc", (), {
+            "doc_id": "old",
+            "author": "vega@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 38,
+            "applied_hash": "H38",
+            "resulting_version": 39,
+            "resulting_hash": "dead",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "new",
+            "author": "vega@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 38,
+            "applied_hash": "H38",
+            "resulting_version": 39,
+            "resulting_hash": "live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+abc"],
+            "op_count": 1,
+        })(),
+    ]
+    ambiguous_docs = [
+        type("Doc", (), {
+            "doc_id": "left",
+            "author": "vega@supawave.ai",
+            "application_ts": 1,
+            "applied_version": 52,
+            "applied_hash": "H52",
+            "resulting_version": 53,
+            "resulting_hash": "left-live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+left"],
+            "op_count": 1,
+        })(),
+        type("Doc", (), {
+            "doc_id": "right",
+            "author": "vega@supawave.ai",
+            "application_ts": 2,
+            "applied_version": 52,
+            "applied_hash": "H52",
+            "resulting_version": 53,
+            "resulting_hash": "right-live",
+            "op_types": ["WaveletBlipOperation"],
+            "blip_ids": ["b+left"],
+            "op_count": 1,
+        })(),
+    ]
+
+    waves = classify_waves([
+        make_group(
+            38,
+            safe_docs,
+            {"live"},
+            waveid="supawave.ai/shared-wave",
+            waveletid="supawave.ai!conv+root",
+        ),
+        make_group(
+            52,
+            ambiguous_docs,
+            {"left-live", "right-live"},
+            waveid="supawave.ai/shared-wave",
+            waveletid="supawave.ai!conv+sidebar",
+        ),
+    ])
+
+    repairs = collect_safe_repairs(waves)
+
+    self.assertEqual(
+        [{
+            "waveid": "supawave.ai/shared-wave",
+            "waveletid": "supawave.ai!conv+root",
+            "drop_doc_ids": ["old"],
+        }],
         repairs,
     )
 

--- a/wave/config/changelog.d/2026-04-12-split-brain-wavelet-safety.json
+++ b/wave/config/changelog.d/2026-04-12-split-brain-wavelet-safety.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-12-split-brain-wavelet-safety",
+  "version": "PR #868",
+  "date": "2026-04-12",
+  "title": "Split-brain wavelet safety",
+  "summary": "Deploy overlap handling now shuts down replaced slots more defensively, stale wavelet persists fail fast without wedging the queue, and the corrupted-wave repair classifier keeps sibling wavelets independent.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Deploy rollback and cutover now fail closed if the replaced slot cannot be verified as stopped, instead of treating a failed `docker compose ps` check as success",
+        "Stale wavelet persist failures now clear or reschedule queued persistence work so later callers do not hang behind an unexecuted retry task",
+        "Corrupted-wave repair classification now buckets duplicate history by both wave id and wavelet id so one ambiguous sibling no longer blocks a safe repair on the same wave"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,0 +1,2860 @@
+[
+  {
+    "releaseId": "2026-04-12-worktree-diagnostics-runbook",
+    "version": "PR #587",
+    "date": "2026-04-12",
+    "title": "Added Worktree Diagnostics Bundle Guidance",
+    "summary": "Adds a bundled diagnostics command and runbook so issue worktrees can capture compact startup, smoke, endpoint, and log evidence without inventing a separate observability workflow.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Add scripts/worktree-diagnostics.sh: emits a Markdown diagnostics bundle with endpoint probes, smoke-check output, startup tail, and server-log tail for the current worktree runtime",
+          "Add docs/runbooks/worktree-diagnostics.md: explains when to run the bundle, what it captures, and how to reference it from issue comments and PR summaries",
+          "Update scripts/worktree-boot.sh, docs/runbooks/worktree-lane-lifecycle.md, docs/runbooks/README.md, and docs/SMOKE_TESTS.md so the diagnostics bundle is discoverable from the existing worktree verification flow"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-toolbar-toggle-active-surface",
+    "version": "PR #847",
+    "date": "2026-04-12",
+    "title": "Fix top-panel toggle button active surface",
+    "summary": "The Pin and Archive top-panel buttons now keep a full-width active highlight instead of showing only a partial pressed background when toggled on.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored the shared down-state overlay for compact top-panel icon buttons like Pin and Archive so the active highlight spans the full button width",
+          "Removed the compact-only down-state override that reintroduced a split active background on toggled toolbar buttons"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-tag-undo-toast",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Add a restore window for tag removal",
+    "summary": "Removing a wave tag now shows a 20-second restore toast so accidental tag deletes can be undone without reopening the tag editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Tag removal now shows a compact restore toast instead of a passive confirmation-only message",
+          "Restoring a just-removed tag re-adds it from the toast action without leaving the current wave"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-tag-undo-manual-close",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Let users close tag restore toasts",
+    "summary": "Tag-removal restore toasts now include a manual close action that immediately finalizes the delete instead of keeping the restore window open.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Tag removal toasts now include a Close action alongside Restore",
+          "Closing the toast immediately clears the pending restore window so the delete is finalized at once"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-tag-search-stale-wave-cache",
+    "version": "PR #855",
+    "date": "2026-04-12",
+    "title": "Keep tag search fresh after wave cache commit notifications",
+    "summary": "Fixes stale `tag:` results when a cached wave lags behind a newer committed wavelet version delivered through commit notifications.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Invalidate a cached wave only when a commit notification proves the cached wavelet version is older than the committed version",
+          "Preserve fresh local wave state so immediate metadata searches still reuse the in-memory cache when no newer committed data exists",
+          "Add regression coverage for existing tag documents, stale shared-store caches, and pure `tag:` queries that must stay on the legacy search path"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-supawave-repo-rename",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Update SupaWave repository references after GitHub rename",
+    "summary": "The app welcome wave and the repo’s operational tooling now point at the renamed SupaWave GitHub repository instead of the legacy incubator-wave slug.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Updated the in-app welcome wave repository link and label to point at the renamed `vega113/supawave` GitHub repository",
+          "Updated PR-monitoring scripts, GitHub issue filters, and related operational docs to use the new repository slug so automation follows the renamed repo"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-supawave-grafana-log-discovery",
+    "version": "PR #852",
+    "date": "2026-04-12",
+    "title": "Fix SupaWave Grafana log discovery",
+    "summary": "Grafana Alloy now tails only SupaWave's structured JSON log files and the host docs call out the correct selectors for finding those logs in Grafana.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Updated the SupaWave Alloy file tailer to target the structured `wave-json*.log` files so Loki discovery stays aligned with the JSON parser pipeline",
+          "Documented the SupaWave Grafana selectors and troubleshooting steps needed to confirm Alloy is shipping the application logs correctly"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-split-brain-wavelet-safety",
+    "version": "PR #868",
+    "date": "2026-04-12",
+    "title": "Split-brain wavelet safety",
+    "summary": "Deploy overlap handling now shuts down replaced slots more defensively, stale wavelet persists fail fast without wedging the queue, and the corrupted-wave repair classifier keeps sibling wavelets independent.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Deploy rollback and cutover now fail closed if the replaced slot cannot be verified as stopped, instead of treating a failed `docker compose ps` check as success",
+          "Stale wavelet persist failures now clear or reschedule queued persistence work so later callers do not hang behind an unexecuted retry task",
+          "Corrupted-wave repair classification now buckets duplicate history by both wave id and wavelet id so one ambiguous sibling no longer blocks a safe repair on the same wave"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-search-panel-unread-reload",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Search panel unread reload fix",
+    "summary": "Search results now stop reviving stale unread counts for public/shared waves after a page reload when the stored user-data wavelet only has the legacy empty read-state.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search digests now treat legacy empty public/shared user-data read-state the same as the original bootstrap case, so reopening the app no longer brings back stale unread badges",
+          "The unread:true search path now uses the same legacy empty-UDW repair logic as digest generation, keeping unread filters aligned with the sidebar count"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-search-metadata-coverage",
+    "version": "PR #853",
+    "date": "2026-04-12",
+    "title": "Cover search metadata paths for tags, mentions, and tasks",
+    "summary": "Added regression coverage to ensure tag, mention, and task searches continue to route through the expected metadata and legacy-query paths.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Added Lucene query-model and provider regression coverage so pure tag queries stay on the legacy metadata filter path",
+          "Added end-to-end coverage for mention and task metadata search lookups so assigned and mentioned waves remain discoverable"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-save-indicator-uncommitted",
+    "version": "Unreleased",
+    "title": "Fix stale saved indicator during local edits",
+    "summary": "The topbar save state now treats locally uncommitted wave changes as unsaved instead of waiting only for server acknowledgements.",
+    "date": "2026-04-12",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The topbar save state now treats locally uncommitted wave changes as unsaved instead of waiting only for server acknowledgements."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-robot-rpc-submit-failure",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Robot RPC commit-failure responses",
+    "summary": "Robot RPC write calls now return JSON-RPC errors when the underlying delta fails to commit, instead of returning a success payload with a reply id that was never persisted.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The Jakarta robot RPC servlet now rewrites optimistic write responses into JSON-RPC errors when delta submission fails, so streaming bots do not receive phantom newBlipId values",
+          "Added a regression test covering submitRequest failure handling for mutating robot RPC operations"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-ot-search-tag-fallback",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "OT search tag routing and fallback policy",
+    "summary": "Tag searches now stay on the OT/Lucene path when indexed search is enabled, and OT search no longer silently bootstraps or falls back to legacy HTTP polling unless an explicit fallback flag is enabled.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Tag queries now use Lucene candidate filtering in OT search mode instead of forcing the legacy tag-document path",
+          "Added an `ot-search-fallback` feature flag, defaulting off, so production OT search surfaces failures immediately instead of silently switching to legacy HTTP bootstrap or polling"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-mobile-toolbar-blip-visibility",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Keep mobile blips visible beneath wrapped edit toolbars",
+    "summary": "The wave conversation scroller now follows the real rendered toolbar height on mobile, so wrapped edit toolbars no longer cover the first blip while you edit.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "When the mobile edit toolbar grows beyond a single row, the conversation pane now shifts down to keep the first blip fully visible",
+          "Toolbar height changes from reflow and viewport resizing now resync the wave panel instead of leaving blip content hidden under the toolbar"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-mobile-edit-loss-regression",
+    "version": "fix/mobile-edit-loss-regression",
+    "date": "2026-04-12",
+    "title": "Fix mobile new-blip edit loss after delayed composition teardown",
+    "summary": "New blips on mobile no longer lose typed text when the browser finishes composition without restoring a selection before the trailing DOM mutation arrives.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Allowed the trailing DOM mutation fallback to materialize browser-owned text when delayed composition end returns no editor selection",
+          "Preserved the mobile new-blip flow where text previously appeared locally but disappeared after Done or reload"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-issue-833-reaction-authors",
+    "version": "PR #862",
+    "date": "2026-04-12",
+    "title": "Show who reacted on desktop and mobile",
+    "summary": "Adds a Wave-native reaction-authors popup so people can inspect who reacted without relying on browser-default menus or tooltips.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Reaction chips now expose a custom authors popup for desktop secondary actions and keyboard inspection",
+          "Mobile users can tap the reaction count to inspect who reacted without losing the quick reaction-toggle path"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-issue-714-jakarta-shadow-removal",
+    "version": "PR #858",
+    "date": "2026-04-12",
+    "title": "Remove Jakarta/Main Shadow Source Duplicates",
+    "summary": "Removed same-path Jakarta/main shadow classes and tightened the duplicate-source regression guard so formatting changes cannot bypass it.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed remaining duplicate Java source shadows between main and jakarta-overrides for the Jakarta migration closeout",
+          "Hardened the duplicate-source regression test so exact exclude sets must still parse correctly even if build.sbt formatting changes"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-inline-tag-composer",
+    "version": "Unreleased",
+    "date": "2026-04-12",
+    "title": "Move tag creation into the tag bar",
+    "summary": "Adding tags now happens inline in the existing tag bar so mobile no longer opens a cramped modal popup for tag entry.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The tag add button now opens a compact inline composer directly in the tags bar instead of a centered popup dialog",
+          "Inline tag entry keeps comma-separated tag creation and keyboard shortcuts while fitting cleanly inside the mobile tags footer"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-gwt-dev-compile-tasks",
+    "version": "PR #844",
+    "date": "2026-04-12",
+    "title": "Keep draft GWT dev output out of the production war tree",
+    "summary": "Updated the new dev GWT compile task to emit draft artifacts into a separate directory so production packaging continues to rely on full compileGwt output.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "compileGwtDev now writes draft Safari-only GWT output into war-dev instead of war.",
+          "Added a changelog fragment for the new dev-only GWT compile task behavior."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-gwt-cssresource-warnings",
+    "version": "PR #854",
+    "date": "2026-04-12",
+    "title": "Silence unsupported CssResource constructs in GWT wave panel CSS",
+    "summary": "Removes unsupported `@media` and `calc()` usage from legacy GWT CssResource inputs and adds a regression test so compileGwt stops emitting parser warnings for the affected wave panel resources.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed unsupported CssResource syntax from the affected wave panel CSS resources.",
+          "Added a regression test that fails if the blocked `@media` or `calc()` constructs return."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-deploy-sanity-gate",
+    "version": "PR #867",
+    "date": "2026-04-12",
+    "title": "Fail Deploys Without Sanity Credentials",
+    "summary": "Deploy automation now fails closed when sanity-check credentials are missing so production rollouts cannot silently skip the post-deploy gate.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Require SANITY_ADDRESS and SANITY_PASSWORD before deploy runs continue so the deploy sanity gate cannot be bypassed by missing configuration",
+          "Documented the deploy sanity credential requirement alongside the deploy workflow guard and regression test coverage"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-12-deploy-failure-cancelled-runs",
+    "version": "PR #865",
+    "date": "2026-04-12",
+    "title": "Suppress false deploy-failure alerts on cancelled runs",
+    "summary": "Deploy failure issue creation and notification now ignore cancelled runs without hiding real deploy or pre-deploy failures.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Deploy-failure alerts now skip cancelled runs while still firing for real deploy failures and early job failures.",
+          "The deploy workflow no longer depends on checked-out helper code to decide whether failure alerts should run."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-11-reaction-picker-close",
+    "version": "PR #834",
+    "date": "2026-04-11",
+    "title": "Close the reaction picker reliably after selection",
+    "summary": "Prevents duplicate add-reaction popups from lingering after a reaction is chosen and keeps repeated keyboard and click interactions stable.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The add-reaction picker now tracks a single active popup so repeated activation does not leave stale popups behind",
+          "The picker moves focus into the emoji grid on open so keyboard selection continues in the active popup"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-11-fix-operationqueue-random",
+    "version": "PR #842",
+    "date": "2026-04-11",
+    "title": "Fix insecure random number generation in OperationQueue",
+    "summary": "Replaced java.util.Random with java.security.SecureRandom for the ID_GENERATOR field in OperationQueue.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Replaced java.util.Random with java.security.SecureRandom for generating temporary IDs in OperationQueue to fix a security vulnerability."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-11-fix-md5-gravatar",
+    "version": "PR #NNN",
+    "date": "2026-04-11",
+    "title": "Fix MD5 vulnerability in Gravatar URL generation",
+    "summary": "Upgraded the hashing algorithm in HtmlRenderer from MD5 to SHA-256 for generating avatar URLs.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Upgraded Gravatar email hashing algorithm from MD5 to SHA-256 to resolve a security vulnerability."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-11-android-ime-corruption",
+    "version": "PR #831",
+    "date": "2026-04-11",
+    "title": "Fix Android IME word-boundary corruption",
+    "summary": "Android/mobile editing no longer double-applies delayed post-composition DOM mutations that dropped leading letters and spaces while finishing a blip.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Stopped delayed Android IME composition end from falling through into the legacy DOM-mutation typing fallback in the same mutation event",
+          "Preserved word-leading characters and inter-word spacing for the empty-blip editing path that could collapse `new blip` to `ewlip` on Android"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-wave-reactions",
+    "version": "PR #799",
+    "date": "2026-04-10",
+    "title": "Wave Reactions",
+    "summary": "Blips now support lightweight emoji reactions with inline counts and quick toggles.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added lightweight emoji reactions on wave blips with quick add, remove, and replace interactions",
+          "Reaction counts now render inline on reacted blips without changing the message text itself"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-task-assignee-label-prefix",
+    "version": "PR #787",
+    "date": "2026-04-10",
+    "title": "Wave Tasks: cleaner assignee labels",
+    "summary": "Task assignee labels now show the selected participant identifier without the extra owner prefix.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Task assignee pills now display just the selected participant label instead of prefixing it with \"Owner\""
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-tags-ux-mobile",
+    "version": "PR #820",
+    "date": "2026-04-10",
+    "title": "Tag chips now filter search",
+    "summary": "Wave tags now use a mobile-friendlier chip layout where tapping the chip filters search and a separate inline affordance removes the tag.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Tapping a tag chip now applies a `tag:<name>` search filter instead of opening the remove-confirm popup",
+          "Tag removal now uses its own explicit inline affordance, so the destructive action is no longer bound to the main chip tap target",
+          "The old centered remove-confirm popup is no longer part of the tag-removal flow, which keeps the interaction compact and usable on mobile"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-search-freshness-critical",
+    "version": "fix/search-freshness-critical",
+    "date": "2026-04-10",
+    "title": "Restore search freshness for newly shared waves and newly added tags",
+    "summary": "Fixes a search freshness regression where recent participant/tag mutations could be missed when a per-user search view rebuilt during the reload cooldown window.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Per-user search view rebuilds now force a full wave-map refresh after recent non-search wave mutations instead of incorrectly reusing the cooldown path",
+          "Added regression coverage for participant visibility, content searchability, and tag searchability on the runtime memory-view search path",
+          "Extended the Java E2E suite to verify Bob can find a newly shared wave by content term and that `tag:<newtag>` returns the wave after a fresh tag mutation"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-robot-streaming-replies",
+    "version": "PR #811",
+    "date": "2026-04-10",
+    "title": "Robot Streaming Replies",
+    "summary": "Robots can now progressively stream reply text into a dedicated wave blip using the documented createChild plus document.modify pattern.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Documented and example-backed support for progressive robot replies that create one reply blip and update it incrementally with document.modify",
+          "Robot docs now direct clients to use the passive bundle's rpcServerUrl hint for follow-on reply writes instead of hardcoding a single RPC endpoint"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-robot-rpcserverurl-legacy-refresh",
+    "version": "PR #720 follow-up",
+    "date": "2026-04-10",
+    "title": "Robots: Refresh Legacy Passive Capability RPC Hints",
+    "summary": "Passive robots with legacy stored capabilities now refresh before event delivery so rpcServerUrl matches the configured OAuth mode after restart.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Passive robots now refresh legacy capability snapshots that are missing rpcServerUrl before generating event bundles",
+          "Two-legged passive robots restored from older persisted records now recover /robot/rpc instead of falling back to the Data API endpoint"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-robot-rpcserverurl-auth-mode",
+    "version": "PR #720",
+    "date": "2026-04-10",
+    "title": "Robots: Auth-Mode-Aware rpcServerUrl Advertisement",
+    "summary": "Passive robot event bundles now advertise the JSON-RPC endpoint that matches the robot's configured OAuth mode.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Passive robots using 2-legged OAuth now receive /robot/rpc in EventMessageBundle.rpcServerUrl",
+          "Passive robots using 3-legged OAuth now receive /robot/dataapi/rpc in EventMessageBundle.rpcServerUrl"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-registration-ux-tests",
+    "version": "PR #800",
+    "date": "2026-04-10",
+    "title": "Registration UX Test Coverage",
+    "summary": "Adds servlet-level regression tests for the PRG-based post-registration UX flow.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Added test coverage for GET /auth/signin?registered=1 rendering the account-created success banner",
+          "Added test coverage for GET /auth/register?check-email=1 rendering the check-your-inbox page"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-registration-success-ux",
+    "version": "PR #795",
+    "date": "2026-04-10",
+    "title": "Registration Success Guidance",
+    "summary": "Registration now guides you into sign-in or email activation with clearer next steps instead of leaving you on the signup form.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Successful direct registrations now send you to sign-in with a clear account-created state",
+          "Email-confirmation registrations now open a dedicated check-your-inbox page with the activation steps",
+          "Trying to sign in before activation now shows an action-required state instead of looking like bad credentials"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-mobile-text-corruption",
+    "version": "PR #813",
+    "title": "Fix Android mobile text corruption while editing",
+    "summary": "Android/mobile IME edits no longer corrupt persisted text by dropping leading characters and spaces during composition-driven editing.",
+    "date": "2026-04-10",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Android/mobile IME edits no longer corrupt persisted text by dropping leading characters and spaces during composition-driven editing."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-mobile-search-panel-expand",
+    "version": "PR #818",
+    "date": "2026-04-10",
+    "title": "Mobile search panel stays hidden while editing",
+    "summary": "Android/mobile blip edit sessions now preserve horizontal focus scroll state so the search panel does not slide over the typing area.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Preserved both vertical and horizontal ancestor scroll positions when the mobile editor focuses",
+          "Prevented the off-canvas search panel from being revealed over the active blip editor during Android/mobile edit startup"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-mobile-edit-loss-focus",
+    "version": "PR #796",
+    "date": "2026-04-10",
+    "title": "Mobile edit persistence follow-up",
+    "summary": "Android/mobile edit sessions now restore a valid caret when opening a blip editor, preventing typed text from appearing only locally and disappearing after reload.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored mobile editor focus initialization so edit sessions start with a valid caret instead of a DOM-only typing surface",
+          "Fixed both existing-blip edits and brand-new reply blips losing typed text after reload because no document ops were generated"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-824-mobile-picker-types",
+    "version": "Unreleased",
+    "date": "2026-04-10",
+    "title": "Mobile attachment picker reliably handles gallery and file selections",
+    "summary": "The mobile attachment popup now avoids stale hidden-file-input state and duplicate chooser launches so camera, gallery, and general file selections reach the upload flow more reliably.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Reset the hidden attachment input before and after each mobile picker session so gallery and file selections are not dropped when the chooser reuses prior single-file state",
+          "Prevent the nested Select Files button from triggering the native file picker twice, preserving the working camera path while improving photos, videos, and general file selection behavior"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-823-pin-icon-consistency",
+    "version": "PR #825",
+    "date": "2026-04-10",
+    "title": "Unify the pin icon across search and wave toolbars",
+    "summary": "Uses the same pin glyph in the wave action toolbar that already appears in the search toolbar so the two compact toolbars read consistently.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The wave toolbar pin action now uses the same thumbtack-style icon as the search toolbar while keeping the existing compact toolbar sizing and alignment"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-822-reaction-chip-anchor",
+    "version": "PR #822",
+    "date": "2026-04-10",
+    "title": "Polish reaction chip alignment",
+    "summary": "Keeps the add-reaction affordance anchored and aligns reaction emoji/counts more cleanly within the existing Wave pill styling.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Reaction rows now keep the add-reaction control anchored at the leading edge instead of shifting when reactions are toggled",
+          "Reaction chips now render explicit emoji and count spans so the pill content aligns more cleanly on a shared visual baseline"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-812-mobile-attachment-upload",
+    "version": "Unreleased",
+    "date": "2026-04-10",
+    "title": "Mobile attachment upload resilience fixes",
+    "summary": "Mobile image uploads are now more tolerant of browser-specific file-picker and clipboard behavior, reducing silent failures when selecting or pasting images into a wave.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Attachment selection now recovers from mobile browsers that return from the file chooser without delivering the hidden input's normal change event",
+          "Image paste upload now falls back to clipboard files when browsers do not populate clipboardData.items for pasted images"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-807-mention-direction-icon",
+    "version": "fix/mention-direction-icon",
+    "date": "2026-04-10",
+    "title": "Polish mention previous/next toolbar icons",
+    "summary": "The wave-toolbar mention navigation buttons now use clearer directional arrows while keeping the existing mention control behavior and toolbar styling.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Prev @ and Next @ buttons in the wave toolbar now show clearer left/right direction cues",
+          "Mention navigation behavior is unchanged; only the toolbar icon treatment was polished"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-806-reaction-add-icon",
+    "version": "PR #806",
+    "date": "2026-04-10",
+    "title": "Use a clearer add-reaction icon",
+    "summary": "Replaces the generic plus reaction affordance with a reaction-specific icon that reads more clearly in the wave UI.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The add-reaction control now uses a compact reaction icon instead of a bare plus",
+          "The reaction add button keeps the existing chip styling while reading more clearly as a reaction action"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-801-toolbar-split-background",
+    "version": "PR #801",
+    "date": "2026-04-10",
+    "title": "Fix split active background on wave toolbar buttons",
+    "summary": "Keeps clicked and toggled wave-toolbar buttons on one coherent active surface instead of layering two mismatched background treatments.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Wave-toolbar buttons like Pin now render a single coherent active background when toggled on",
+          "The compact toolbar active-state polish stays scoped to the clicked/toggled wave-toolbar button treatment"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-issue-786-toolbar-topbar-restore",
+    "version": "PR #786",
+    "date": "2026-04-10",
+    "title": "Restore the search toolbar chrome and remove temporary overflow affordance",
+    "summary": "Restores the intended toolbar-strip treatment for search and wave action rows, keeps refresh in the search toolbar, and removes the visible search-toolbar overflow button.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search and wave toolbars render with the intended contained toolbar chrome again",
+          "The search toolbar keeps its refresh action while dropping the temporary ... overflow control"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-grafana-alloy-timestamp-fix",
+    "version": "PR #793",
+    "date": "2026-04-10",
+    "title": "Fix Grafana Alloy timestamp parsing for Wave JSON logs",
+    "summary": "Switched the Alloy timestamp format from millisecond to RFC3339Nano so microsecond-precision timestamps emitted by Wave JSON logs are parsed correctly and logs appear in Grafana.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Changed Grafana Alloy timestamp format from `2006-01-02T15:04:05.000Z07:00` (millisecond) to `RFC3339Nano` to match the microsecond-precision timestamps emitted by logstash-logback-encoder",
+          "Added deploy-time diagnostics: script now prints WAVE_LOG_PATH, WAVE_TIMESTAMP_FORMAT, matched log files, and writes a syslog audit line when Loki shipping is configured",
+          "Added structured JSON log output path logging at Wave server startup for operator visibility",
+          "Added regression tests: Python unittest for Alloy config timestamp contract and Jakarta test for startup log diagnostic"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-browser-verification-runbook-followup",
+    "version": "PR #802",
+    "date": "2026-04-10",
+    "title": "Browser verification runbook wording follow-up",
+    "summary": "Clarifies the browser-verification runbook language around smoke checks, browser passes, and evidence capture.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Clarified that smoke checks prove the server boots, health responds, and the compiled web client asset is present",
+          "Clarified that the browser pass is only for the narrow auth, routing, or UI behavior that curl cannot prove"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-10-browser-verification-runbook",
+    "version": "PR #586",
+    "date": "2026-04-10",
+    "title": "Standardized Browser Verification Runbooks",
+    "summary": "Adds a browser-verification runbook and change-type matrix so agent lanes know when curl/smoke is enough and when a real browser pass is required, without introducing a new browser framework.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Add docs/runbooks/browser-verification.md: defines the default UI-affecting verification path built on the existing wave-smoke-ui.sh and worktree-boot.sh + wave-smoke.sh baseline",
+          "Add docs/runbooks/change-type-verification-matrix.md: decision matrix covering server-only, servlet/auth, GWT client/UI, packaging, and deployment-only change types",
+          "Update docs/runbooks/worktree-lane-lifecycle.md: step 7 cross-links to the new browser-verification and change-type matrix runbooks",
+          "Update docs/SMOKE_TESTS.md: adds browser-verification baseline section pointing to the new runbooks",
+          "Update docs/runbooks/README.md: indexes the two new runbooks under Local Development"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-welcome-wave-polish",
+    "version": "PR #762",
+    "date": "2026-04-09",
+    "title": "Welcome wave polish",
+    "summary": "The welcome wave now has clearer navigation guidance, stronger bot coaching for gpt-ts-bot@supawave.ai, public-wave discovery via the @ icon in the left search panel, and direct internal wave links across the onboarding/public support waves.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added gpt-ts-bot@supawave.ai guidance with concrete usage instructions in the welcome wave",
+          "Explained public-wave discovery via the @ icon in the left search panel",
+          "Added direct wave:// links to all six onboarding/public support waves"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-welcome-wave-nav-titles",
+    "version": "PR #773",
+    "date": "2026-04-09",
+    "title": "Welcome wave: real onboarding wave titles in navigation",
+    "summary": "The wave-to-wave navigation block in the welcome wave now uses the actual onboarding wave titles instead of generic 'Wave 0'–'Wave 5' placeholders.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Navigation links in the welcome wave now show real titles: 'SupaWave Community — Questions, Feedback & Support', 'Welcome to SupaWave', 'Search Like a Pro', 'Collaboration Features', 'Making Waves Public', and 'Tips, Shortcuts, and Hidden Features'"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-user-menu-density",
+    "version": "PR #761",
+    "date": "2026-04-09",
+    "title": "Denser User Menu Layout",
+    "summary": "The account dropdown now uses tighter spacing and clearer grouped sections so common actions are easier to scan.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Reduced excess vertical whitespace between user-menu actions while preserving the existing SupaWave topbar styling",
+          "Added a clearer signed-in header and tighter section grouping for account, API, support, legal, and sign-out actions"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-toolbar-svg-icons",
+    "version": "PR #748",
+    "date": "2026-04-09",
+    "title": "Toolbar SVG Icon Polish and Hover Effects",
+    "summary": "Replaces toolbar PNG sprites with refined SVG icons and adds smooth hover and press visual feedback.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Replaced edit toolbar PNG sprites with polished SVG icons using lighter 18px strokes",
+          "Added smooth hover color transition and press scale effect on toolbar icon buttons",
+          "Scoped icon hover effects to enabled buttons only to avoid misleading disabled state feedback",
+          "Converted toolbar button layout to flex-based for improved vertical centering and touch sizing"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-toolbar-icon-canvas-fit",
+    "version": "PR #780",
+    "date": "2026-04-09",
+    "title": "Increase toolbar icon canvas size for tighter vertical fit",
+    "summary": "Bumps the shared toolbar icon display size from 17px to 20px so search and wave toolbar icons fill more of the existing 36px action buttons without changing toolbar heights or panel offsets.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search and wave toolbar icons render at 20px inside the existing action buttons, reducing visible vertical dead space without changing toolbar layout"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-toolbar-canvas-containment",
+    "version": "PR #783",
+    "date": "2026-04-09",
+    "title": "Polish toolbar action canvas containment",
+    "summary": "Search and wave toolbar icons now sit inside a clearer solid action canvas instead of reading against the faded edge of the bar.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search and wave toolbar action icons now render inside a subtle inset canvas that keeps them visually contained within the toolbar strip"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-tasks-default-query",
+    "version": "PR #777",
+    "date": "2026-04-09",
+    "title": "Tasks button shows all assigned tasks by default",
+    "summary": "The Tasks toolbar button now opens `tasks:me` instead of `tasks:me unread:true`, showing all assigned tasks rather than only unread ones.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Tasks toolbar button click now sets the search query to `tasks:me`, displaying all tasks assigned to the current user",
+          "Unread badge polling continues to use `tasks:me unread:true` so badge counts remain accurate"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-task-strikethrough",
+    "version": "PR #752",
+    "date": "2026-04-09",
+    "title": "Strikethrough Styling for Completed Task Lines",
+    "summary": "Completed wave tasks now render with strikethrough text and a dimmed color, providing clear visual feedback on task status. Styling is applied on toggle and on document load, and cleaned up correctly when a task checkbox is removed.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Apply text-decoration: line-through and color: #767676 to the enclosing paragraph when a task checkbox is checked",
+          "Remove styling when the checkbox is unchecked (guarded against multiple task checkboxes per paragraph)",
+          "Clean up stale task-completed class via onDeactivated when a checked task checkbox is deleted",
+          "Only affects task checkboxes (name prefixed with task:); generic form checkboxes are unaffected"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-task-search-enabled-by-default",
+    "version": "PR #771",
+    "date": "2026-04-09",
+    "title": "Enable task-search feature flag by default",
+    "summary": "The task-search feature flag now defaults to enabled so fresh deployments show tasks search help and toolbar without a manual MongoDB record.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Changed task-search default in KnownFeatureFlags from false to true — prevents silent hide of tasks:all search help and Tasks toolbar button on new deployments or DB resets"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-task-query-help",
+    "version": "PR #755",
+    "date": "2026-04-09",
+    "title": "Clarify task search semantics and help examples",
+    "summary": "Search now supports `tasks:all` for any visible task wave, and the search help panel explains the supported task-query forms more clearly.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Added `tasks:all` to find waves you can access that contain any task, alongside the existing `tasks:me` and user-targeted task queries",
+          "Updated search help with clickable task-query examples for `tasks:all`, `tasks:me`, `tasks:user@domain`, local-domain shorthand such as `tasks:alice`, and `tasks:all unread:true`"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-task-metadata-ui",
+    "version": "PR #782",
+    "date": "2026-04-09",
+    "title": "Wave Tasks: assignee picker, due dates, and clearer ownership",
+    "summary": "Tasks in the wave editor now open a metadata popup for assignee and due date, and the task row shows explicit owner and due-date pills so ownership is easier to understand at a glance.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Insert Task now opens an in-wave task details popup where you can assign the task to any current wave participant and set or clear a due date",
+          "Task rows now render explicit owner and due-date pills beside the checkbox, using utility styling that stays visually distinct from @mentions",
+          "Clicking the task metadata pills reopens the same popup so assignee and due date can be edited after the task is created"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-search-panel-icon-alignment",
+    "version": "PR #749",
+    "date": "2026-04-09",
+    "title": "Fix vertical centering of toolbar icons",
+    "summary": "Switches toolbar button layout from float/margin centering to flexbox and adds a universal CSS rule to suppress the inline SVG baseline gap.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Replace float/margin-top centering in HorizontalToolbarButtonWidget with inline-flex + align-items:center for robust vertical alignment",
+          "Add .visualElement svg { display: block } CSS rule to eliminate the inline baseline/descender gap for all toolbar SVG icons universally"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-paste-image-upload",
+    "version": "PR #750",
+    "date": "2026-04-09",
+    "title": "Paste-to-Upload Images in Wave Editor",
+    "summary": "Adds clipboard image paste support to the wave editor: Ctrl+V/Cmd+V with an image on the clipboard automatically uploads and inserts the image inline at the cursor position.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Paste an image from clipboard directly into the wave editor via Ctrl+V/Cmd+V",
+          "Spinner toast appears during upload; image renders inline at paste cursor on success",
+          "Error toast shown if upload fails or times out after 60 seconds",
+          "Text paste behaviour is unaffected — falls through normally when no image is present"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-multi-file-upload-thumbnails",
+    "version": "PR #756",
+    "date": "2026-04-09",
+    "title": "Multi-File Upload with Thumbnail Previews and Captions",
+    "summary": "Redesigns the attachment upload dialog with multi-file selection, per-file thumbnail previews, inline captions, real XHR progress bars, image compression, and drag-and-drop support.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Select and upload multiple files at once via the attachment popup",
+          "Thumbnail previews for images; file-type icon badges for non-image files",
+          "Per-file caption input inserted into the wave alongside each attachment",
+          "Real XHR upload progress bars with wave-shimmer animation per card",
+          "Optional image compression with configurable display size (S/M/L) before upload",
+          "Drag-and-drop files onto the drop zone to populate the selection",
+          "Remove individual files from the pending batch before uploading",
+          "Graceful error handling: failed uploads stay visible; queue continues to the next file"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-mobile-edit-loss",
+    "version": "Unreleased",
+    "date": "2026-04-09",
+    "title": "Mobile edit persistence fix",
+    "summary": "Android/mobile blip edits now commit pending IME text before the editor closes, preventing text that looked saved locally from disappearing after reload.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Committed pending IME composition text before mobile edit sessions detach the editor",
+          "Added webdriver hooks for editor pending-input inspection while debugging the mobile edit-loss path"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-issue-781-attachment-id-encoding",
+    "version": "Unreleased",
+    "date": "2026-04-09",
+    "title": "Fix attachment metadata lookups for plus-sign ids",
+    "summary": "URL-encodes attachment ids before the Wave client requests `/attachmentsInfo`, so image and file metadata still load when ids contain `+`.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Attachment thumbnails and image metadata now load correctly when the stored attachment id contains a plus sign"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-issue-766-toolbar-scale-density",
+    "version": "PR #766",
+    "date": "2026-04-09",
+    "title": "Polish toolbar icon scale and containment",
+    "summary": "Reduces the shared toolbar SVG display size so search and wave toolbars feel better centered inside the existing compact bars.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search and wave toolbar icons render with slightly lighter visual density while keeping the same compact toolbar height"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-09-issue-757-toolbar-clip-spacing",
+    "version": "PR #757",
+    "date": "2026-04-09",
+    "title": "Fix toolbar clipping and compact spacing",
+    "summary": "Fixes the remaining 24px legacy toolbar height assumptions, tightens compact icon-button spacing, and aligns the search toolbar SVG contract with the wave/edit toolbars.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search, wave, and edit toolbar icons now render fully without vertical clipping, including wrapped edit-toolbar rows on narrow widths",
+          "Compact toolbar buttons use denser spacing and the search toolbar now shares the polished 18px SVG wrapper/sizing contract"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-worktree-boot-lifecycle",
+    "version": "PR #736",
+    "date": "2026-04-08",
+    "title": "Standardized Worktree Lane Boot Lifecycle",
+    "summary": "Adds a worktree boot helper script and runbook so agent lanes can reliably start, verify, and shut down isolated development environments without tribal knowledge.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Add scripts/worktree-boot.sh: stages the app, detects port conflicts, writes a port-specific runtime config, and initializes the local-verification journal entry",
+          "Add docs/runbooks/worktree-lane-lifecycle.md: single runbook covering worktree creation through shutdown",
+          "Update scripts/wave-smoke.sh to honor PORT from the environment with numeric validation",
+          "Document the journal/local-verification/ evidence contract in AGENTS.md and the agent orchestration plan"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-welcome-wave-onboarding",
+    "version": "PR #760",
+    "date": "2026-04-08",
+    "title": "Welcome wave onboarding refresh",
+    "summary": "New accounts now receive a richer SupaWave welcome wave with guided product onboarding, inline advanced details, and a clearer path for AI-oriented collaboration.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Replaced the minimal welcome wave with a field-guide style onboarding wave that explains what Wave is, why it is different, and how to start using it",
+          "Added inline detail blips for history, Firefly naming, robot/API orientation, and active modernization topics so advanced context stays available without overwhelming the main path",
+          "Welcome-wave creation now happens when an account becomes usable: immediately when email confirmation is disabled, or after successful email confirmation when it is enabled"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-wave-tasks",
+    "version": "PR #739",
+    "date": "2026-04-08",
+    "title": "Wave Tasks: assignable inline tasks with due dates and task search",
+    "summary": "Introduces inline tasks within wave documents — assignable to participants, searchable via `tasks:me`, and tracked with a badge in the search panel.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Inline task creation via Insert Task toolbar button — inserts a checkbox element with task annotations (id, assignee, due date, reminders)",
+          "Task search via `tasks:me` and `tasks:user@domain` tokens in both legacy and Lucene9 search paths",
+          "Search panel toolbar badge showing count of open tasks assigned to the current user",
+          "Per-wave task count badge in the search digest list",
+          "Reminder offsets stored in document model (`task/reminders` annotation) for future in-app surfacing",
+          "Server and public HTML renderers emit disabled checkboxes for task elements"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-search-stale-results-unread-filter",
+    "version": "PR #733",
+    "date": "2026-04-08",
+    "title": "Fix Stale Search Results and Unread Filter",
+    "summary": "Empty search queries now clear the wave list, and the unread:true filter correctly excludes read waves.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed wave list not clearing when search returns zero results — header showed '0-0 of 0' but previous results remained visible",
+          "Fixed unread:true filter returning read waves due to readState-based path iterating orphaned blip documents; now uses supplement-based counting consistent with digest generation"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-inline-wave-images",
+    "version": "PR #738",
+    "date": "2026-04-08",
+    "title": "Render Medium And Large Attachments As Inline Images",
+    "summary": "Image attachments now use true inline rendering for medium and large display modes instead of just enlarging thumbnail cards.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Medium and large image attachments now render from the original attachment image for a more Telegram-like inline photo experience",
+          "Image attachments keep their attachment-backed document model while preserving thumbnail mode for compact displays",
+          "New image uploads now default to medium display size instead of small thumbnails"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-inline-image-api",
+    "version": "PR #744",
+    "date": "2026-04-08",
+    "title": "Support Attachment-Backed Inline Images In The Robot API",
+    "summary": "Robots can now author attachment-backed inline images with optional display sizing through the Java/Data API surface.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Java robots can insert attachment-backed inline images with Image(attachmentId, caption) and optional display-size values of small, medium, or large",
+          "document.modify now accepts non-form elements for inline image insertion instead of rejecting IMAGE elements server-side",
+          "The published API docs now describe the importAttachment plus document.modify flow for attachment-backed inline images"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-inline-attachment-review-fixes",
+    "version": "PR #741",
+    "date": "2026-04-08",
+    "title": "Fix Inline Attachment Display Regressions",
+    "summary": "Follow-up fixes to PR #738 addressing source-selection regressions, thumbnail flicker, and premature attachment URL loads.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Legacy style=\"full\" attachments now correctly use attachment source even when content metadata is temporarily unavailable (fullMode check precedes contentImage guard)",
+          "Thumbnail size callbacks no longer trigger redundant URL reloads when the attachment source is already active",
+          "Attachment size callbacks only trigger image loads when the attachment is the active source, reducing premature requests before the malware guard runs"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-fix-profile-bio-newlines",
+    "version": "PR #723",
+    "date": "2026-04-08",
+    "title": "Fix Profile Bio Newlines",
+    "summary": "Multi-line bios now display correctly in profile cards and the profile edit form.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed newlines entered in bio being stored as literal \\n sequences due to a broken JSON escape parser",
+          "Legacy bios with literal \\n sequences are migrated to real newlines on read when safe to do so"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-fix-attachment-rectangle-shape",
+    "version": "PR #747",
+    "date": "2026-04-08",
+    "title": "Fix Image Attachment Ellipse Shape",
+    "summary": "Image attachments were rendered with an oval/ellipse appearance due to an overly large border-radius on the thumbnail container. Reduced container border-radius to 6px and removed separate image border-radius so the container's overflow:hidden cleanly clips corners to a proper rectangle.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Image attachment thumbnails now display as rectangles with subtle 6px rounded corners instead of oval/ellipse shapes",
+          "Removed asymmetric border-radius (8px top only) from the image element; container overflow:hidden now handles corner clipping consistently"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-contact-public-access",
+    "version": "PR #732",
+    "date": "2026-04-08",
+    "title": "Contact Form Accessible to Unauthenticated Users",
+    "summary": "The /contact page is now publicly accessible — anonymous visitors can view and submit the contact form without signing in.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed auth redirect from ContactServlet.doGet so unauthenticated users receive the contact form instead of being sent to sign-in",
+          "Anonymous POST submissions are now accepted; email is read from the request body and validated for format",
+          "Added IP-based rate limiting (max 3 submissions per IP per hour) to prevent abuse",
+          "Added honeypot field to silently discard bot submissions",
+          "Sanitized all input fields: control characters stripped (including \\r for SMTP header injection prevention) and field lengths capped",
+          "Updated HTML form: email field is editable and required for anonymous users, pre-filled and read-only for authenticated users; file attachment zone removed"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-blip-newline-rendering",
+    "version": "PR #729",
+    "date": "2026-04-08",
+    "title": "Fix Robot Blip Newline Rendering",
+    "summary": "Newlines in robot-authored blip content are now converted to <line/> elements so they render correctly in the wave editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Robot blip content containing literal \\n characters is now split into proper <line/> elements on insert",
+          "Fixes #725: robot-generated multi-line blips were displayed as a single collapsed line"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-08-admin-contact-notification-badge",
+    "version": "PR #734",
+    "date": "2026-04-08",
+    "title": "Admin Contact Notification Badge",
+    "summary": "Admin and owner users now see an envelope icon in the top bar with a real-time badge showing unread contact message counts.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Envelope icon appears in the top bar for admin and owner roles, between the wifi icon and user avatar",
+          "Red badge with unread contact message count, updated every 30 seconds via polling",
+          "Pulsating red glow animation when there are unread messages",
+          "Clicking the icon navigates to /admin#contacts and auto-activates the Contact Messages tab",
+          "Admin page supports hash-based deep-linking for contacts, users, and other tabs"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-stale-annotation-sweeper",
+    "version": "PR #711",
+    "date": "2026-04-07",
+    "title": "Server-side sweeper clears stale editor annotations from crashed sessions",
+    "summary": "A new background StaleAnnotationSweeper service runs every 10 minutes and submits cleanup deltas to close any user/d/ or user/e/ editor-session annotations older than 30 minutes, preventing crashed-session stale annotations from blocking bots indefinitely.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "New StaleAnnotationSweeper service sweeps all wavelets every 10 minutes and closes stale open editor-session annotations (user/d/ and user/e/) older than 30 minutes",
+          "GptBotRobot isBlipBeingEdited() now treats sessions with startTimeMs older than 30 minutes as stale so the GPT bot no longer skips blips with lingering crashed-session annotations",
+          "EventGenerator allEditingSessionsClosed() uses the same 30-minute TTL so BLIP_EDITING_DONE fires correctly even when stale sessions remain on a blip",
+          "Cleanup deltas are attributed to the first current participant rather than the annotation-derived user ID, closing a potential identity-spoofing vector"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-search-help-clickable-examples",
+    "version": "PR #713",
+    "date": "2026-04-07",
+    "title": "Clickable Examples in Search Help Panel",
+    "summary": "All search examples in the help panel are now clickable and execute the search immediately.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Concrete filter rows (in:inbox, in:archive, in:all, in:pinned, with:@, unread:true, mentions:me) are now clickable spans that execute the search when clicked",
+          "Abstract filter rows (with:user@domain, creator:user@domain, tag:name, title:text, content:text) now show a clickable 'try:' example in the description column",
+          "All sort-option rows (orderby:datedesc, orderby:dateasc, etc.) are now clickable",
+          "Combination examples (in:inbox tag:important, mentions:me unread:true, and more) are shown as a clickable grid in the Combinations section",
+          "Removed the separate 'Examples — click to search' section; all examples are now integrated into the reference tables"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-review-gate-quiet-window",
+    "version": "PR #706",
+    "date": "2026-04-07",
+    "title": "Review Gate Quiet Window Extended to 10 Minutes",
+    "summary": "Increased the Codex review gate quiet window from 5 minutes to 10 minutes to prevent post-merge review bot comments from being missed.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Extended REVIEW_WINDOW_MS from 5 minutes to 10 minutes in the codex review gate script to ensure review bot comments arriving shortly after merge are captured",
+          "Updated all user-facing messages, test constants, and workflow comments to reflect the new 10-minute window"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-pr-monitor-path-detection",
+    "version": "PR #707",
+    "date": "2026-04-07",
+    "title": "PR Monitor Path-Based PR Number Detection",
+    "summary": "PR monitor now extracts PR numbers from worktree paths when pane titles lack a PR# marker, preventing unbounded accumulation of stale panes.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Detect PR numbers from pane worktree paths (pr-NNN-lane) as fallback when title has no PR# marker — panes with generic 'Claude Code' titles are now correctly identified and cleaned up",
+          "Re-read pane list inside the PART 2 loop each iteration to prevent duplicate lane creation when launch_interactive_agent sleeps during startup"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-pinned-waves-inbox-top",
+    "version": "PR #719",
+    "date": "2026-04-07",
+    "title": "Pinned Waves Sort to Top in Inbox",
+    "summary": "Pinned waves are promoted to the top of the inbox and displayed with a pin icon. Explicit sort orders (orderby:) are respected and suppress pin promotion.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Pinned waves appear at the top of in:inbox results (no orderby), sorted date-desc within each group",
+          "Pin icon shown next to pinned waves in all search result views",
+          "Explicit orderby: modifier disables pin promotion to respect user-chosen sort order"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-new-blip-indicator",
+    "version": "PR #696",
+    "date": "2026-04-07",
+    "title": "New Messages Pill Indicator",
+    "summary": "A floating pill appears when new messages arrive below the viewport, letting you jump to unread content with one click.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added floating 'N new messages' pill when scrolled up in a conversation",
+          "Clicking the pill scrolls to the new content and dismisses it",
+          "Pill auto-dismisses when scrolling near the bottom",
+          "Feature-flagged via 'new-blip-indicator' server flag (off by default)"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-mention-ux-overhaul",
+    "version": "PR #726",
+    "date": "2026-04-07",
+    "title": "Mention UX Overhaul",
+    "summary": "Redesigned mention indicators with a red dot badge, per-wave unread counts, and in-wave navigation to the first @mention blip.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Red dot badge on the @ toolbar icon now shows accurate unread mention count using deduplicated wave IDs",
+          "Per-wave @N badges in mention-search results correctly survive polling updates without disappearing",
+          "Prev @/Next @ toolbar buttons now navigate directly to the first mention blip within a wave",
+          "Legacy toolbar callers without a signed-in user no longer render non-functional Prev @/Next @ buttons",
+          "Mention focus falls back to root blip when no blip is focused on initial wave load"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-mention-unread-badge",
+    "version": "PR #698",
+    "date": "2026-04-07",
+    "title": "Unread Mentions Badge",
+    "summary": "See at a glance how many waves have unread @mentions of you, and jump to the next one with a single click.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added unread mentions badge on the @ toolbar icon showing count of mentioned waves with unread messages",
+          "Added floating @N navigation button to cycle through waves with unread mentions",
+          "New feature flag: mention-unread-badge (requires mentions-search to also be enabled)"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-mention-tracker-robustness",
+    "version": "PR #705",
+    "date": "2026-04-07",
+    "title": "Mention Tracker Robustness",
+    "summary": "Fixes a loop where multi-page mention scans on slow connections were perpetually cancelled before completing.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Stale-request watchdog now resets per page fetch so slow-but-progressing multi-page scans are not incorrectly cancelled",
+          "Watchdog timer now uses the injected TimerService for consistency and testability",
+          "Duplicate wave IDs across paginated results are now deduplicated before updating the badge count"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-fix-profile-image-url",
+    "version": "PR #703",
+    "date": "2026-04-07",
+    "title": "Fix Profile Image URL Construction",
+    "summary": "Profile avatars now display correctly for users who have uploaded a custom profile photo.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed 431 error caused by base64 image data being used as a URL path segment in profile avatar requests",
+          "InitialsProfilesFetcher and GravatarProfilesFetcher now correctly use the user address as the proxy URL key instead of the raw base64 attachment ID"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-fix-flag-override-precedence",
+    "version": "PR #704",
+    "date": "2026-04-07",
+    "title": "Feature Flag Override Precedence Fix",
+    "summary": "User-specific feature flag overrides now take precedence over global enabled state, ensuring admins can disable features for individual users even when globally enabled.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Feature flag user overrides now take precedence over global enabled state — a user-specific disabled override correctly disables the flag even when globally enabled",
+          "Fixed thread-safety issue in getEnabledFlagNames() that could mix cache generations during concurrent refresh"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-fix-editor-cursor",
+    "version": "PR #708",
+    "date": "2026-04-07",
+    "title": "Fix Editor Cursor Corruption During Typing",
+    "summary": "Fixed an intermittent bug where characters could be inserted at incorrect positions mid-word during typing in the blip editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed cursor corruption in the OT editor caused by AnnotationPainter's async transparentSlice DOM mutations displacing the browser caret without saving/restoring the selection",
+          "transparentSlice in ContentDocument.FullContent now wraps DOM mutations with selectionMaintainer.saveSelection/restoreSelection, consistent with all other transparent DOM operations"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-07-ci-unit-tests",
+    "version": "PR #700",
+    "date": "2026-04-07",
+    "title": "CI: Unit Tests in PR Build Pipeline",
+    "summary": "Unit tests now run automatically on every pull request, catching regressions before merge.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added sbt unit test execution to the GitHub Actions PR build pipeline",
+          "Test/update step retries up to 3 times to avoid transient dependency resolution failures"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-upgrade-banner-status-messages",
+    "version": "PR #665",
+    "date": "2026-04-06",
+    "title": "Smarter Upgrade Banner Messages",
+    "summary": "The upgrade popup now shows context-appropriate messages instead of a generic 'new version' notice for minor deploys.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Minor deploys (no changelog fragment) now show 'A minor update has been applied.' instead of the misleading generic update message",
+          "Partial changelog deploys now show the first release title with 'and other updates.' for better clarity"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-unread-count-fix",
+    "version": "PR #681",
+    "date": "2026-04-06",
+    "title": "Fix Premature Unread Badge Clear on Wave Open",
+    "summary": "Unread counts in the search panel no longer disappear when opening a wave that has unread blips from bots or other participants.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Opening a wave no longer immediately zeroes the unread badge in the search panel; the badge now reflects actual read state as reported by the supplement"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-mobile-websocket-reconnect",
+    "version": "PR #663",
+    "date": "2026-04-06",
+    "title": "Fix Android mobile reconnect after server deploy",
+    "summary": "Android Chrome users no longer see the connection indicator flip from green to yellow when they start writing after a server deploy.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Android: stale WebSocket onclose from old socket no longer triggers false reconnect after successful reconnection"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-mention-subscription-test-fix",
+    "version": "PR #676",
+    "date": "2026-04-06",
+    "title": "Fix mention-subscription test for non-participants",
+    "summary": "Fixes a failing unit test that verified mention subscriptions are triggered for non-participant users at waveletCommitted.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed Mockito stub overload mismatch in SearchWaveletUpdaterTest: DocOpCursor extends DocInitializationCursor, so any() resolved to the wrong apply() overload, preventing the test from verifying mention subscription dispatch to non-participants"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-lucene-realtime-index-fix",
+    "version": "PR #686",
+    "date": "2026-04-06",
+    "title": "Fix Lucene real-time indexer: consumer thread diagnostics and field regression tests",
+    "summary": "Adds consumer thread health logging (startup, per-enqueue at FINE, heartbeat every 100 updates) to diagnose silent index-stall after startup. Adds 7 regression tests validating that tag and mention fields are stored and queryable via in-memory Lucene round-trips.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Lucene index consumer thread now logs startup and a heartbeat every 100 processed updates",
+          "waveletCommitted() logs each enqueue at FINE level for per-wave visibility when needed",
+          "Added regression tests: tag fields stored in index, mention fields stored, empty mentions skipped, tag TermQuery round-trip, tag mismatch, mention TermQuery round-trip, re-index updates tag correctly"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-gptbot-smart-reply",
+    "version": "PR #680",
+    "date": "2026-04-06",
+    "title": "GPT Bot Smart Reply Improvements",
+    "summary": "Four improvements to the gpt-bot: editing guard, root-thread replies, per-wave conversation memory, and web search.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Bot now waits for editing to finish (user/d annotation cleared) before responding to DOCUMENT_CHANGED events",
+          "Bot replies are appended to the root thread instead of as inline child blips",
+          "Per-wave conversation history with token-based pruning (len/4 estimate, drops oldest turns when >80 000 tokens)",
+          "Web search tool via OpenAI function calling backed by DuckDuckGo instant answers"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Sibling follow-up heuristic restricted to non-root threads to prevent over-triggering after root-thread replies",
+          "Conversation history reads are now properly synchronized against concurrent pruning"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-gptbot-mention-fix",
+    "version": "PR #664",
+    "date": "2026-04-06",
+    "title": "Fix gpt-bot @mention handling and reply-thread continuations",
+    "summary": "The gpt-bot now reliably responds to @mentions and to follow-up messages sent in its reply threads without requiring a re-typed @mention. Three root causes were addressed: missing DOCUMENT_CHANGED capability causing the server to stop dispatching events, a missing PARENT context causing the parent-blip lookup to fail in production, and an empty-blip guard to prevent premature replies when new thread blips are created.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Declare DOCUMENT_CHANGED capability in the bot XML so the server delivers @mention events after a capability refresh",
+          "Changed capability context from SELF,SIBLINGS to SELF,SIBLINGS,PARENT so parent blips are included in event bundles",
+          "Bot now replies to follow-up messages in its reply threads without requiring a re-typed @mention",
+          "Guard against empty WAVELET_BLIP_CREATED events triggering premature bot replies before the user has typed"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-gptbot-editing-guard",
+    "version": "PR #685",
+    "date": "2026-04-06",
+    "title": "GPT Bot Editing Guard Fix",
+    "summary": "The GPT bot now correctly detects when a user has finished editing, so it replies after editing ends instead of being permanently silenced.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed GPT bot editing guard: bot was checking annotation existence instead of value, causing it to never reply to @mentions"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-gptbot-behavior-fix",
+    "version": "PR #675",
+    "date": "2026-04-06",
+    "title": "gpt-bot: reply to bot-thread continuations and default to OpenAI engine",
+    "summary": "The gpt-bot now responds to all messages in threads where it has previously replied, not just explicit @mentions. Inline-reply siblings are also covered via a thread-scan. The startup default engine is changed from echo to openai (with graceful fallback to echo when OPENAI_API_KEY is absent), and the contributor check now uses anyMatch instead of only the last contributor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Bot now responds to follow-up replies in threads it participated in even when @mention is absent",
+          "Added isBotThreadReply helper that uses anyMatch across all contributors (not just last) for correctness",
+          "Inline-reply thread siblings are scanned so inline continuations inside a bot blip also trigger replies",
+          "gptbot-start.sh default engine changed from echo to openai; falls back to echo with a warning when OPENAI_API_KEY is not set"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-fix-mentions-me-search",
+    "version": "fix/mentions-me-search",
+    "date": "2026-04-06",
+    "title": "Fix mentions:me search returning all waves",
+    "summary": "The mentions:me search query was returning all waves instead of only waves where the user was mentioned. The Lucene9 search provider was stripping the mentions: token from the legacy query, bypassing filterByMentions in SimpleSearchProviderImpl. The Lucene MENTIONED field is also unreliable for waves indexed before the mentions feature was deployed. Fix routes mentions: filters back through the legacy annotation-based filterByMentions path, which reads directly from wave data and is always authoritative.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "mentions:me search now correctly returns only waves where the current user has a mention annotation, instead of returning all accessible waves"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-echo-bot-separate",
+    "version": "PR #667",
+    "date": "2026-04-06",
+    "title": "Echo Bot Separation and Smarter Echo Timing",
+    "summary": "The echo bot is now a separate robot registration (echo-bot@supawave.ai) and replies only once when you finish editing a message, not on every keystroke.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Introduced echo-bot@supawave.ai as a dedicated echo robot on port 8088",
+          "Added GPTBOT_SUBMITTED_ONLY flag: when true, the bot skips DOCUMENT_CHANGED events and only replies after blip editing is complete (BLIP_SUBMITTED)",
+          "Added echobot-start.sh and echobot-stop.sh startup scripts"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Fixed mktemp race in gptbot-start.sh by using a proper XXXXXXXX suffix pattern",
+          "Added named Cloudflare tunnel support via CLOUDFLARE_TUNNEL_NAME for persistent bot URLs"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-echo-bot-document-changed-fix",
+    "version": "PR #679",
+    "date": "2026-04-06",
+    "title": "Fix Echo-Bot Not Responding to Messages",
+    "summary": "Echo-bot now processes DOCUMENT_CHANGED events regardless of the submittedOnly setting, restoring replies after BLIP_SUBMITTED was phased out.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "GptBotRobot now handles DOCUMENT_CHANGED events when submittedOnly=true — BLIP_SUBMITTED is phased out in modern Wave, so DOCUMENT_CHANGED is the authoritative blip-committed signal"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-bot-profile-popup",
+    "version": "PR #674",
+    "date": "2026-04-06",
+    "title": "Bot Profile Popup",
+    "summary": "Show a bot profile popup when clicking a bot avatar in a wave.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Clicking a bot's avatar or participant icon now opens a profile popup showing the bot's name, address, description, owner, and registration date. Bots display a robot icon avatar and have no Edit Profile or Send Message buttons."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-06-blip-editing-done",
+    "version": "PR #687",
+    "date": "2026-04-06",
+    "title": "New BLIP_EDITING_DONE robot event replaces removed BLIP_SUBMITTED",
+    "summary": "Robots can now subscribe to BLIP_EDITING_DONE — a synthetic event fired when all editing sessions on a blip are complete. BLIP_SUBMITTED has been removed entirely (it was never generated by the server). GptBotRobot updated to use BLIP_EDITING_DONE as its primary trigger.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "New BLIP_EDITING_DONE event type synthesized by EventGenerator when all user/d/ annotations have end timestamps",
+          "GptBotRobot now subscribes to BLIP_EDITING_DONE for reliable editing-completion detection",
+          "Removed BLIP_SUBMITTED event type, BlipSubmittedEvent class, and onBlipSubmitted handler — the event was never generated by the server"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-saved-searches-popup-mobile-responsiveness",
+    "version": "PR #631",
+    "date": "2026-04-05",
+    "title": "Fit saved-searches popups on mobile",
+    "summary": "Saved-searches editor dialogs now clamp to the viewport and let their controls wrap on narrow screens, avoiding horizontal overflow on mobile.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Popup dialogs now shrink to fit smaller viewports instead of overflowing the screen",
+          "Saved-search toolbar and row layouts now wrap before they break the mobile layout"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-rtl-support",
+    "version": "PR #635",
+    "date": "2026-04-05",
+    "title": "RTL language support with auto-detection and toolbar toggle",
+    "summary": "Paragraphs now use dir=\"auto\" for browser-native RTL auto-detection (Hebrew, Arabic). Added RTL/LTR toolbar buttons for manual override. Clicking an active direction button returns the paragraph to auto mode.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Paragraphs with no explicit direction render with dir=\"auto\" — the browser detects RTL from the first strong bidi character (same algorithm as Gmail)",
+          "RTL and LTR toggle buttons in the editor toolbar let users force a paragraph direction",
+          "Clicking an active direction button returns the paragraph to auto-detect mode",
+          "CSS uses text-align:start so RTL paragraphs naturally align right without an explicit alignment override",
+          "Explicit LTR stored as d=\"l\"; explicit RTL as d=\"r\"; auto state has no d attribute"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Toggling direction off now clears any alignment that was implicitly set by the direction toggle",
+          "Indentation uses margin-inline-start for bidi-correct indent on both auto-detected and explicit RTL paragraphs"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-robot-form-elements-update-fixes",
+    "version": "PR #616",
+    "date": "2026-04-05",
+    "title": "Refine robot form element updates",
+    "summary": "Robot form element updates now preserve the existing wire format, and the form-value event docs reflect the supported value-backed element types.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "UPDATE_ELEMENT now rewrites form elements through their XML serializer instead of setting invalid attributes",
+          "Checkbox updates keep the existing default value unless it is explicitly changed",
+          "FORM_VALUE_CHANGED is documented for value-attribute-backed form elements only"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-prolonged-reconnect-reload",
+    "version": "PR #615",
+    "date": "2026-04-05",
+    "title": "Reload after prolonged reconnect to resync the client",
+    "summary": "The client now performs a hard reload after a long disconnect so it can recover cleanly from deploys or server restarts.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Automatically reloads the page after a disconnect lasting longer than 5 seconds once the connection is restored",
+          "Preserves short disconnects as normal network hiccups without forcing a reload"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-null-sink-reconnect-guard",
+    "version": "PR #627",
+    "date": "2026-04-05",
+    "title": "Save edits before prolonged reconnect reloads",
+    "summary": "Prolonged reconnects now end the active edit session before the client reloads, so the browser resyncs from a clean state without discarding draft changes.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Reloads after prolonged disconnects now always resync the client once the connection is restored",
+          "Any active edit session is ended before the reload so draft changes are saved first"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-mention-support",
+    "version": "PR #623",
+    "date": "2026-04-05",
+    "title": "Add @mention support in the editor and search UI",
+    "summary": "Adds inline mention autocomplete and rendering, mention-aware search, and a backend capability gate so the search UI only advertises mentions where they are supported. The follow-up fix also rejects raw mentions queries on Solr so they fail closed instead of returning incorrect results.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Typing @ in the editor opens a participant autocomplete popup and inserts highlighted mention annotations",
+          "Search results can be filtered with mentions:me where the backend supports mention search",
+          "The search help panel and Mentions toolbar button are hidden on Solr deployments that do not support mention search",
+          "Raw mentions queries on Solr are rejected instead of producing incorrect results"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-gptbot-document-changed-guard",
+    "version": "PR #613",
+    "date": "2026-04-05",
+    "title": "Use DOCUMENT_CHANGED with editor-activity guard for passive robot replies",
+    "summary": "The gpt-bot example robot now uses DOCUMENT_CHANGED (since BLIP_SUBMITTED is not implemented server-side) with an editor-annotation guard to avoid per-keystroke replies. Also adds OpenAI Chat Completions engine and diagnostic logging to RobotsGateway.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added OpenAI Chat Completions engine for gpt-bot (set GPTBOT_CODEX_ENGINE=openai)",
+          "Added diagnostic INFO logging to RobotsGateway passive dispatch path"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Passive DOCUMENT_CHANGED replies now wait for editor annotations (user/d/, user/e/) to clear before responding",
+          "Fixed null root wavelet crash in search panel snippet rendering (WaveBasedDigest)"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-feature-flag-persist-admin-set-ot-search",
+    "version": "PR #636",
+    "date": "2026-04-05",
+    "title": "Preserve admin-set feature flags across restarts",
+    "summary": "Startup seeding now leaves an existing ot-search flag untouched, so admin-set enabled or disabled state survives restarts. Fresh deploys still initialize ot-search from the deployment default.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Startup seeding only creates ot-search when the flag is missing from the database",
+          "Fresh deployments continue to initialize ot-search from the configured default"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-blip-panel-cleanup",
+    "version": "PR #634",
+    "date": "2026-04-05",
+    "title": "Clean up blip panel: remove ID display, hide edit hint on mobile",
+    "summary": "Removes the debugging blip-ID label from blip headers and hides the keyboard-shortcut hint on mobile viewports where it is irrelevant.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed the monospace blip-ID span and click-to-copy handler from blip headers",
+          "Edit-mode hint (Shift+Enter / Esc) is now hidden on viewports narrower than 768px"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-05-admin-ops-lucene-query-stats",
+    "version": "PR #633",
+    "date": "2026-04-05",
+    "title": "Add Lucene query stats to Operations",
+    "summary": "The admin Operations page now shows Lucene query counts and rolling average query time in a dedicated sub-tab, alongside the existing overview and OT Search metrics. The ops status API now emits locale-stable Lucene timing fields so the page keeps loading across JVM locales.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added a Lucene sub-tab to the Operations page for query stats and related search-index metrics",
+          "Exposed Lucene query count and average query time from the ops status API",
+          "Kept the admin UI's timing displays stable across JVM locales"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-04-robot-url-normalization-echo-engine",
+    "version": "PR #607",
+    "date": "2026-04-04",
+    "title": "Fix gpt-bot robot URL handling and add echo engine",
+    "summary": "Keeps custom robot base paths intact when passive robots fetch capabilities or post callbacks, and adds an echo completion engine for local gpt-bot runs.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added an echo completion engine for gpt-bot local testing without a Codex CLI process"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Passive capabilities fetches now preserve custom robot base paths instead of stripping them to the origin",
+          "Passive callback posts now only treat URLs as normalized when their path actually ends with /_wave/robot/jsonrpc"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-04-admin-analytics-tab",
+    "version": "PR #605",
+    "date": "2026-04-04",
+    "title": "Add admin analytics tab",
+    "summary": "The admin dashboard now surfaces wave, blip, user activity, and public-wave engagement metrics in a new analytics tab with live view tracking.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added an Analytics tab to /admin with wave totals, blip totals, login/activity windows, private/public partitions, top public waves, and top active users",
+          "Live public-wave page/API views are now tracked since process start so the admin analytics view can rank public waves by actual observed traffic"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-03-search-startup-warmup-default-off",
+    "version": "PR #600",
+    "date": "2026-04-03",
+    "title": "Stop blocking startup on eager search warmup",
+    "summary": "Search startup no longer pre-builds the owner wave view by default, so deploys and reloads reach the app shell faster while real search requests keep the existing lazy rebuild path.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Moved startup search warmup behind a new search.startup_wave_view_warmup config flag that defaults to false",
+          "Added focused Jakarta coverage for disabled startup warmup, owner normalization, fallback wave-map warmup, and non-fatal warmup failures"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-03-architecture-docs-links",
+    "version": "PR #592",
+    "date": "2026-04-03",
+    "title": "Extract durable architecture references",
+    "summary": "Moves long-lived architecture guidance into dedicated docs and surfaces those references from the README documentation map.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added links in the README.md Documentation map section for the Jakarta dual-source rules, runtime entrypoints and wiring, and dev persistence topology references"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-02-ot-search-public-wave-batching",
+    "version": "PR #579",
+    "date": "2026-04-02",
+    "title": "Reduce OT search write amplification on hot public waves",
+    "summary": "OT search now keeps low-latency updates for low-fanout searches while batching hot public-wave updates back to a polling-equivalent cadence with new ops visibility.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Batch hot public OT search edits per wave",
+          "Keep low-fanout OT search behavior unchanged",
+          "Expose batching counters in admin ops status",
+          "Speed up affected-subscription lookup with a direct user-to-subscriptions index",
+          "Add focused coverage for hot-wave and boundary scenarios"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-02-ot-search-local-seeding",
+    "version": "PR #577",
+    "date": "2026-04-02",
+    "title": "Enable OT search locally",
+    "summary": "Seeds the ot-search feature flag from server config so local runtime state stays aligned with the OT-search gate.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "OT search now follows search.ot_search_enabled in the persistent feature-flag store",
+          "Fresh local stores no longer advertise ot-search as enabled unless the server config turns it on"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-02-gpt-bot-example-robot",
+    "version": "PR #580",
+    "date": "2026-04-02",
+    "title": "Add the gpt-bot example robot",
+    "summary": "Adds a copyable Java gpt-bot example with Wave callback endpoints, mention-driven replies, and safer default runtime settings.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added a standalone gpt-bot example server with capabilities.xml, profile, and callback handling",
+          "Local Codex invocation now powers mention-driven replies in the example robot",
+          "README.md and docs/gpt-bot.md document local run, Cloudflare tunnel, and robot registration steps"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Codex runs stay sandboxed by default unless GPTBOT_CODEX_UNSAFE_BYPASS=true is set",
+          "Mention handling now deduplicates overlapping blip events and fetches SupaWave context only for actionable mentions",
+          "HTTP worker threads now use caller-runs backpressure, callback tokens are redacted from status output, callback auth no longer depends on public URL exposure, and invalid env values fall back to defaults with warnings"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-01-jwt-robot-api-migration",
+    "version": "PR #557",
+    "date": "2026-04-01",
+    "title": "JWT Robot API Migration with Scope Enforcement",
+    "summary": "Robot and Data APIs now enforce per-operation JWT scopes, add a /robot/token endpoint alias, and provide migration support for legacy pre-scoped long-lived tokens.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added /robot/token endpoint as an alias for /robot/dataapi/token for improved API discoverability",
+          "Implemented per-operation JWT scope enforcement for Data and Robot APIs",
+          "Notify operations (robot.notify, robot.notifyCapabilitiesHash) now require only data:read scope instead of wave:robot:active"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Fixed shared mutable state race condition in BaseApiServlet operations list handling",
+          "Added migration fallback for legacy unscoped tokens that defaults scopes by token type",
+          "Scope validation errors now return HTTP 403 instead of 401 to properly distinguish insufficient scope from invalid token",
+          "Removed duplicate JWT validation in DataApiServlet and ActiveApiServlet"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-30-xss-avatar-escape",
+    "version": "PR #485",
+    "date": "2026-03-30",
+    "title": "Security: Avatar XSS Fix",
+    "summary": "Escape avatar URL values in HTML attribute context to prevent stored XSS via attacker-controlled profile image URLs.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Escape avatar src attribute values in participant, blip author, and digest views to prevent stored XSS"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-30-sanitize-rendered-link-image-urls",
+    "version": "PR #486",
+    "date": "2026-03-30",
+    "title": "Harden rendered URL sanitizer",
+    "summary": "Replaces the URI-based link/image URL sanitizer with a permissive scheme-extraction check that handles URLs with spaces, adds wave:// support, and rejects protocol-relative URLs.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "URLs with unencoded spaces (e.g. search query strings) are no longer incorrectly dropped by the /render endpoint",
+          "Internal wave:// and waveid:// links remain navigable in rendered HTML output",
+          "Protocol-relative URLs (//host/path) are now rejected to prevent open-redirect attacks"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-30-runtime-static-assets",
+    "version": "PR #482",
+    "date": "2026-03-30",
+    "title": "Restore runtime static assets under root war",
+    "summary": "Ensures favicons, authentication CSS, logo, and images are served correctly after relocating runtime static assets.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Move auth CSS, favicons, logo, and image assets into war/static to match the runtime asset root."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-30-logo-url-default-fix",
+    "date": "2026-03-30",
+    "title": "Fix default logoUrl path after static asset restructure",
+    "summary": "Updates the default logoUrl client flag from static/images/logo.png to static/logo.png to prevent a 404 after the logo was moved out of the images/ subdirectory.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Corrected default logoUrl from static/images/logo.png to static/logo.png to match the new asset location and prevent runtime 404s."
+        ]
+      }
+    ],
+    "version": "PR #484"
+  },
+  {
+    "releaseId": "2026-03-30-jakarta-session-websocket-auth-hardening",
+    "version": "PR #480",
+    "date": "2026-03-30",
+    "title": "Jakarta Session and WebSocket Auth Hardening",
+    "summary": "Jakarta session-token lookup now always resolves auth tokens, and invalid WebSocket auth closes with a policy-violation reason.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Enabled Jakarta session-token lookup for token-based auth without a feature flag",
+          "Closed invalid-auth WebSocket messages with a policy-violation reason and aligned the server log message"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-29-robot-control-room-upgrades",
+    "version": "PR #478",
+    "date": "2026-03-29",
+    "title": "Robot Control Room Upgrades",
+    "summary": "Robot owners can now manage richer robot metadata, pause unsafe automations, and keep secrets masked after the initial reveal.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added robot descriptions, created/updated timestamps, pause state, and owner-only dashboard actions for updating callback URLs, descriptions, and deleting robots",
+          "Kept newly created or rotated secrets available for one-time copy while masking secret previews in the dashboard and starter prompt",
+          "Added a dashboard Test Bot action that refreshes robot capabilities after a callback URL is configured"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Blocked paused robots from receiving client-credentials API tokens or passive runtime updates"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-wave-scroll-tags-overlap",
+    "version": "PR #425",
+    "date": "2026-03-28",
+    "title": "Tagged Wave Scroll Fix",
+    "summary": "The bottom of a wave now stays reachable above the tags bar.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Aligned the wave scroll offset with the full rendered tags-bar height so bottom content is no longer clipped behind it"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-unread-search-read-state-fix",
+    "version": "PR #412",
+    "date": "2026-03-28",
+    "title": "Unread Search Read-State Fix",
+    "summary": "Unread-only searches now evaluate persisted read state so read waves stop leaking into unread results.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Unread-only searches now use wavelet read-state data instead of relying on the conversation-model supplement path",
+          "Read waves no longer remain in `unread:true` results when every matching wave has already been opened"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-shared-wave-pinning",
+    "version": "PR #417",
+    "date": "2026-03-28",
+    "title": "Shared Wave Pinning",
+    "summary": "Pinning and unpinning now works for waves you can access even when you are not the wave owner.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed shared-wave pin and unpin requests so they update your per-user state without requiring wave ownership"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-search-refresh-stability",
+    "version": "PR #443",
+    "date": "2026-03-28",
+    "title": "Search Refresh Stability",
+    "summary": "Search refreshes no longer preserve stale sidebar rows when the latest result set is empty.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed simple search refresh handling so empty result updates clear stale wave rows instead of leaving old unread/message counts behind"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-search-panel-unread-accuracy",
+    "version": "PR #411",
+    "date": "2026-03-28",
+    "title": "Search Panel Unread Accuracy",
+    "summary": "Opened waves now keep the correct unread state in the polling search panel.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Stopped opened search results from dropping back to a stale local read state before the polling digest catches up",
+          "Kept higher live unread and message counts when the open wave has newer local state than the last search snapshot"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-search-bootstrap-loading-ux",
+    "version": "PR #414",
+    "date": "2026-03-28",
+    "title": "Search Bootstrap Loading UX",
+    "summary": "The search panel now shows loading skeletons only for blank OT bootstrap loads and keeps direct-search results visible while OT overlay state times out cleanly.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The search panel now renders loading skeleton rows only when an OT-enabled bootstrap starts from an empty result set",
+          "Refreshing search results keeps the current result rows visible instead of blanking the panel while the next direct-search request is in flight",
+          "If OT overlay data never arrives, the client now clears that waiting state without blanking direct-search results or retrying OT reconnect forever"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-save-status-reliability",
+    "version": "PR #432",
+    "date": "2026-03-28",
+    "title": "Save Status Reliability",
+    "summary": "Save warnings now clear more reliably after reconnects and wavelet resets.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a case where the saving indicator could stay yellow and keep showing the slow-save warning after a disconnected wavelet was replaced."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-save-recovery",
+    "version": "PR #419",
+    "date": "2026-03-28",
+    "title": "Save Recovery",
+    "summary": "Wave tabs recover cleanly after websocket reconnects instead of getting stuck in a long-saving state.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Reopened wave streams now accept the new websocket channel id instead of filtering against a stale one",
+          "Active wave views now fail fast on websocket disconnect so the client reconnect flow can resubscribe and clear stuck saving indicators"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-robot-registration-polish",
+    "version": "PR #430",
+    "date": "2026-03-28",
+    "title": "Robot Registration Polish",
+    "summary": "The robot registration success page now keeps long credentials readable without breaking the layout.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Redesigned the Robot Registered page with a more polished SupaWave presentation",
+          "Long consumer token secrets now wrap cleanly on desktop and narrow screens instead of overflowing the card"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-robot-registration-flow",
+    "version": "PR #434",
+    "date": "2026-03-28",
+    "title": "Robot Registration Flow",
+    "summary": "Robot registration now lets you create credentials first, add the callback URL later, and keeps `-bot` reserved for robots.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Robot registration now lets you mint credentials first and add or update the callback URL later without rotating the secret",
+          "Robot usernames must end with `-bot`, and regular user registrations now reject that reserved suffix"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Pending robots can no longer use the `client_credentials` token flow until a callback URL is configured"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-robot-dashboard-management",
+    "version": "PR #455",
+    "date": "2026-03-28",
+    "title": "Robot Dashboard Management",
+    "summary": "Added a new authenticated robot management dashboard to manage API tokens and callback URLs.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Robot management dashboard where users can see robots they own, update callback URLs, and rotate compromised secrets",
+          "Generated user and robot Data API JWTs from the new dashboard",
+          "Consolidated user top bar menu with grouped sections for easier access to Account, Automation / APIs, Product / Support, and Legal surfaces"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-robot-control-room-hardening",
+    "version": "PR #431",
+    "date": "2026-03-28",
+    "title": "Robot Control Room Hardening",
+    "summary": "Robot owners can now rotate secrets safely from the control room, and legacy robot claims keep working after the onboarding redesign.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added secret rotation to the authenticated /account/robots control room without forcing a callback URL change"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Robot registration now keeps its sign-in return path and requires an XSRF token before creating or claiming a robot",
+          "Legacy ownerless robots can be claimed during re-registration even when their callback URL is unchanged"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-reply-editor-stability",
+    "version": "PR #437",
+    "date": "2026-03-28",
+    "title": "Reply Editor Stability",
+    "summary": "Deleting all text in a new reply no longer crashes the editor.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Flushed pending editor typing state before detaching a blip editor during reply transitions"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-realtime-search-stability",
+    "version": "2026-03-28",
+    "date": "2026-03-28",
+    "title": "Realtime Search Stability",
+    "summary": "Experimental OT-backed search now degrades more safely when the live snapshot cannot satisfy the requested result window, and the server only tracks live search state for active subscribers.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Expanded OT search result lists now fall back to polling instead of getting stuck behind a 50-result live snapshot",
+          "Search wavelet bootstrap registration now skips inactive listeners and re-evaluates participant subscriptions conservatively to avoid stale live results"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-public-wave-unread-badges-fix",
+    "version": "PR #420",
+    "date": "2026-03-28",
+    "title": "Public Wave Search Badges",
+    "summary": "Public wave search results no longer show stale fully unread badges after you open them.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Corrected the search panel so `with:@` public wave results keep read badges in sync when a public/shared wave opens without a user-data wavelet snapshot"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-profile-last-seen",
+    "version": "PR #423",
+    "date": "2026-03-28",
+    "title": "Profile Last Seen",
+    "summary": "Profile cards now show last seen when a user allows it, and hide it when they turn it off.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Successful sign-in and ongoing authenticated activity now update the profile last-seen timestamp",
+          "Turning off Show last seen removes the field from the profile card response"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-lucene9-admin-flags",
+    "version": "PR #421",
+    "date": "2026-03-28",
+    "title": "Rollout Flags Show Up Before First Enablement",
+    "summary": "Admin feature flags now list prepared rollout flags like lucene9 before they have been saved once.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "The admin feature flags screen now shows code-known rollout flags even when no stored flag record exists yet",
+          "Stored rollout flag settings still override the default placeholder entry once a flag has been saved"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-link-affordance-followup",
+    "version": "PR #435",
+    "date": "2026-03-28",
+    "title": "Wavier Link References",
+    "summary": "Wave links now use a distinct SupaWave accent treatment before hover.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Changed blip links to a wavy ocean underline with a tinted accent shade so they stand apart from ordinary blue text",
+          "Kept visited links clearly clickable with a separate lavender tint instead of blending back into body copy"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-link-affordance",
+    "version": "PR #433",
+    "date": "2026-03-28",
+    "title": "Clearer Link Styling",
+    "summary": "Links in wave content now look clickable before hover.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored visible underlines for links inside wave content while keeping the existing Supawave link colors"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-landing-page-accuracy",
+    "version": "PR #424",
+    "date": "2026-03-28",
+    "title": "Landing Page Accuracy",
+    "summary": "The landing page now reflects the product capabilities that are available today.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Removed the landing page federation claim until federation is actually supported",
+          "Added landing page messaging for Robot registration and Data API token support"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-inline-reply-refresh-placement",
+    "version": "PR #447",
+    "date": "2026-03-28",
+    "title": "Inline Reply Refresh Stability",
+    "summary": "Inline replies now preserve their anchor more reliably when created from the current selection.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Stabilized inline reply anchor placement by flushing the active editor before reading the current selection"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-direct-messages-stay-explicit",
+    "version": "PR #422",
+    "date": "2026-03-28",
+    "title": "Direct Messages Stay Explicit",
+    "summary": "Two-person waves no longer turn into direct messages unless you start them from Send Message.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Ordinary waves with two participants now stay ordinary waves",
+          "Only profile-card Send Message conversations are treated as locked direct messages"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-deleted-blip-next-unread",
+    "version": "PR #438",
+    "date": "2026-03-28",
+    "title": "Deleted Blip Focus Recovery",
+    "summary": "Deleting a reply now preserves unread navigation by moving focus to the next surviving blip or its containing parent.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed a crashy unread-navigation case when deleting a blip that still contained the currently focused descendant.",
+          "When a deleted reply has no remaining siblings, focus now falls back to the containing parent blip instead of jumping unpredictably."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-archive-search-fix",
+    "version": "PR #418",
+    "date": "2026-03-28",
+    "title": "Archive Search Fix",
+    "summary": "Archived waves now leave the inbox immediately and show up in archived results.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Fixed inbox and archived search filters so per-user archive state is honored even for waves without a full manifest structure."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-api-docs-discovery",
+    "version": "PR #406",
+    "date": "2026-03-28",
+    "title": "API Docs Discovery",
+    "summary": "API consumers and LLM agents can now discover the SupaWave docs from dedicated llms entrypoints and direct links across the product.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Published `/llms.txt` and `/llms-full.txt` as LLM-friendly API docs entrypoints",
+          "Added direct `/api-docs` links in the landing-page navigation bar, hero section, footer, and signed-in app menu"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-28-ai-robot-onboarding",
+    "version": "PR #436",
+    "date": "2026-03-28",
+    "title": "AI Robot Onboarding",
+    "summary": "Robot creation now starts from a SupaWave control room with an AI starter prompt, a one-hour Data API JWT, and clearer API docs for humans and LLMs.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "New authenticated /account/robots control room for creating pending robots and activating callback URLs later",
+          "Ready Google AI Studio / Gemini starter prompt with standardized SUPAWAVE_* environment variable names",
+          "Automatic one-hour Data API JWT generation inside the control room prompt"
+        ]
+      },
+      {
+        "type": "feature",
+        "items": [
+          "Added a Robot & Data API entry point to the signed-in app menu",
+          "Expanded /api-docs and /api/llm.txt with Build with AI guidance, minimal common operations, and clearer security/error notes"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-unread-only-search-filter",
+    "version": "PR #403",
+    "date": "2026-03-27",
+    "title": "Unread-Only Search Filter",
+    "summary": "You can now narrow SupaWave search results to waves with unread blips only.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added the unread:true search filter for inbox, archive, pinned, and combined searches"
+        ]
+      },
+      {
+        "type": "fix",
+        "items": [
+          "Updated the search help popup with unread-only examples"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-title-content-search",
+    "version": "PR #381",
+    "date": "2026-03-27",
+    "title": "Title and Content Search Filters",
+    "summary": "Search can now target wave titles or any blip content explicitly.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added title: search for root blip titles",
+          "Added content: search across conversational blips",
+          "Updated search help with clickable examples for the new filters"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-search-reset-inbox",
+    "version": "PR #390",
+    "date": "2026-03-27",
+    "title": "Smarter Empty Search Reset",
+    "summary": "Clearing the search box now returns you to the inbox instead of leaving the app in an empty-query state.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Empty or whitespace-only searches now normalize back to in:inbox"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-search-bootstrap-recovery",
+    "version": "PR #398",
+    "date": "2026-03-27",
+    "title": "Search Bootstrap Recovery",
+    "summary": "The left search panel now restores itself reliably even when OT search is enabled.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search now performs an immediate direct bootstrap before depending on OT updates",
+          "Archive and inbox actions refresh search results correctly again"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-restore-last-wave",
+    "version": "PR #394",
+    "date": "2026-03-27",
+    "title": "Restore Your Last Wave",
+    "summary": "SupaWave can reopen your last active wave after login or refresh and focus the next unread blip.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "When no URL fragment is present, SupaWave restores the last opened wave from local storage",
+          "Wave opens now focus the last unread blip before falling back to the last blip"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-release-aware-upgrade-notes",
+    "version": "PR #405",
+    "date": "2026-03-27",
+    "title": "Release-Aware Upgrade Notes",
+    "summary": "Upgrade banners now map to the deployed release notes instead of always showing the newest changelog entry.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The upgrade banner now links to the exact deployed release notes when the release mapping is known",
+          "Deploy metadata now keeps changelog release mapping aligned across upgrades and rollbacks"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-ot-search-live-updates",
+    "version": "PR #384",
+    "date": "2026-03-27",
+    "title": "Realtime OT Search",
+    "summary": "SupaWave can subscribe to realtime search wavelets when the ot-search feature flag is enabled.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added OT-powered realtime search subscriptions behind the ot-search flag"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-ot-search-fallback",
+    "version": "PR #388",
+    "date": "2026-03-27",
+    "title": "OT Search Fallback",
+    "summary": "Experimental OT search now falls back automatically when realtime search data does not arrive in time.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "The search panel no longer stays blank when OT search is enabled but no search-wavelet data arrives"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-lucene9-search-rollout",
+    "version": "PR #389",
+    "date": "2026-03-27",
+    "title": "Lucene 9 Search Rollout",
+    "summary": "A new Lucene 9 BM25 search backend is available behind the lucene9 feature flag.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added Lucene 9 full-text search with richer parsing and BM25 ranking behind the lucene9 flag"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-live-unread-digests",
+    "version": "PR #397",
+    "date": "2026-03-27",
+    "title": "Live Unread Digests",
+    "summary": "Unread counts stay accurate during polling and OT-driven search refreshes.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search refreshes now preserve live unread digest proxies instead of replacing them with stale snapshots"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-latest-activity-sort",
+    "version": "PR #386",
+    "date": "2026-03-27",
+    "title": "More Accurate Latest-Activity Sorting",
+    "summary": "Date-based sorting now reflects the most recent conversational activity across the whole wave.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Wave search ordering now uses the latest conversational wavelet activity instead of only the root wavelet"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-inline-anchor-stability",
+    "version": "PR #402",
+    "date": "2026-03-27",
+    "title": "Inline Reply Stability",
+    "summary": "Inline replies no longer crash when SupaWave encounters a stale inline anchor reference.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Missing inline anchor references now fall back safely instead of throwing an Item not found client error"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-implicit-content-search",
+    "version": "PR #392",
+    "date": "2026-03-27",
+    "title": "Implicit Content Search",
+    "summary": "Bare words in the search box now behave like content filters automatically.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Plain search terms such as hello or meeting notes now search wave content without requiring content:"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-changelog-system",
+    "version": "PR #383",
+    "date": "2026-03-27",
+    "title": "Changelog System",
+    "summary": "You can now review recent SupaWave releases from the app and see what changed after a deploy.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added the /changelog page with release history",
+          "Added What's New links in the app menu and landing page"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-03-27-api-docs",
+    "version": "PR #387",
+    "date": "2026-03-27",
+    "title": "Built-In API Docs",
+    "summary": "SupaWave now ships human and LLM-friendly API documentation directly inside the app.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added /api-docs, /api/openapi.json, and /api/llm.txt for the Data and Robot APIs"
+        ]
+      }
+    ]
+  }
+]

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaCollection.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaCollection.java
@@ -50,6 +50,8 @@ public class MongoDbDeltaCollection implements DeltaStore.DeltasAccess {
 
   /** MongoDB Collection object for delta storage */
   private final DBCollection deltaDbCollection;
+  /** Non-null when store startup decided new writes must fail closed. */
+  private final PersistenceException appendGuardFailure;
 
   /**
    * Construct a new Delta Access object for the wavelet
@@ -57,9 +59,11 @@ public class MongoDbDeltaCollection implements DeltaStore.DeltasAccess {
    * @param waveletName The wavelet name.
    * @param deltaDbCollection The MongoDB deltas collection
    */
-  public MongoDbDeltaCollection(WaveletName waveletName, DBCollection deltaDbCollection) {
+  public MongoDbDeltaCollection(WaveletName waveletName, DBCollection deltaDbCollection,
+      PersistenceException appendGuardFailure) {
     this.waveletName = waveletName;
     this.deltaDbCollection = deltaDbCollection;
+    this.appendGuardFailure = appendGuardFailure;
   }
 
   @Override
@@ -193,6 +197,11 @@ public class MongoDbDeltaCollection implements DeltaStore.DeltasAccess {
 
   @Override
   public void append(Collection<WaveletDeltaRecord> newDeltas) throws PersistenceException {
+    if (appendGuardFailure != null) {
+      throw new PersistenceException(
+          "Refusing delta writes for " + waveletName + ": " + appendGuardFailure.getMessage(),
+          appendGuardFailure);
+    }
 
     try {
       for (WaveletDeltaRecord delta : newDeltas) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaCollection.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaCollection.java
@@ -194,12 +194,16 @@ public class MongoDbDeltaCollection implements DeltaStore.DeltasAccess {
   @Override
   public void append(Collection<WaveletDeltaRecord> newDeltas) throws PersistenceException {
 
-    for (WaveletDeltaRecord delta : newDeltas) {
-      // Using Journaled Write Concern
-      // (http://docs.mongodb.org/manual/core/write-concern/#journaled)
-      deltaDbCollection.insert(MongoDbDeltaStoreUtil.serialize(delta,
-          waveletName.waveId.serialise(), waveletName.waveletId.serialise()),
-          WriteConcern.JOURNALED);
+    try {
+      for (WaveletDeltaRecord delta : newDeltas) {
+        // Using Journaled Write Concern
+        // (http://docs.mongodb.org/manual/core/write-concern/#journaled)
+        deltaDbCollection.insert(MongoDbDeltaStoreUtil.serialize(delta,
+            waveletName.waveId.serialise(), waveletName.waveletId.serialise()),
+            WriteConcern.JOURNALED);
+      }
+    } catch (RuntimeException e) {
+      throw new PersistenceException("Failed to append delta for " + waveletName, e);
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
@@ -191,8 +191,8 @@ public class MongoDbDeltaStore implements DeltaStore {
     } catch (MongoException initialFailure) {
       if (isIndexOptionsConflict(initialFailure)) {
         LOG.info("MongoDbDeltaStore: upgrading applied-version index to unique");
-        coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
         try {
+          coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
           coll.createIndex(keys, uniqueOptions);
           return;
         } catch (MongoException retryFailure) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
@@ -59,6 +59,8 @@ public class MongoDbDeltaStore implements DeltaStore {
 
   /** Database connection object */
   private final DB database;
+  /** Non-null when the store could not enforce append safety and must fail closed. */
+  private volatile PersistenceException appendGuardFailure = null;
 
   /**
    * Construct a new store
@@ -73,7 +75,7 @@ public class MongoDbDeltaStore implements DeltaStore {
   @Override
   public DeltasAccess open(WaveletName waveletName) throws PersistenceException {
 
-    return new MongoDbDeltaCollection(waveletName, getDeltaDbCollection());
+    return new MongoDbDeltaCollection(waveletName, getDeltaDbCollection(), appendGuardFailure);
   }
 
   @Override
@@ -194,18 +196,38 @@ public class MongoDbDeltaStore implements DeltaStore {
           coll.createIndex(keys, uniqueOptions);
           return;
         } catch (MongoException retryFailure) {
-          restoreNonUniqueAppliedAtVersionIndex(coll, keys);
-          LOG.warning(
+          disableWritesAndRestoreLegacyIndex(
+              coll,
+              keys,
               "MongoDbDeltaStore: applied-version uniqueness upgrade blocked by existing data; "
-                  + "run corrupted-wave repair before retrying. " + retryFailure.getMessage());
+                  + "refusing new delta writes until corrupted-wave repair completes and the "
+                  + "server restarts.",
+              retryFailure);
           return;
         }
       }
-      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
-      LOG.warning(
+      disableWritesAndRestoreLegacyIndex(
+          coll,
+          keys,
           "MongoDbDeltaStore: unable to enforce unique applied-version writes; "
-              + "leaving the legacy index in place. " + initialFailure.getMessage());
+              + "refusing new delta writes until the index issue is fixed and the server "
+              + "restarts.",
+          initialFailure);
     }
+  }
+
+  private void disableWritesAndRestoreLegacyIndex(DBCollection coll, BasicDBObject keys,
+      String message, MongoException cause) {
+    if (appendGuardFailure == null) {
+      appendGuardFailure = new PersistenceException(message, cause);
+    }
+    try {
+      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+    } catch (MongoException restoreFailure) {
+      LOG.warning("MongoDbDeltaStore: failed to restore legacy applied-version index after "
+          + "disabling writes: " + restoreFailure.getMessage());
+    }
+    LOG.warning(message + " " + cause.getMessage());
   }
 
   private void restoreNonUniqueAppliedAtVersionIndex(DBCollection coll, BasicDBObject keys) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
@@ -47,6 +47,12 @@ import java.util.List;
  *
  */
 public class MongoDbDeltaStore implements DeltaStore {
+  private static final java.util.logging.Logger LOG =
+      java.util.logging.Logger.getLogger(MongoDbDeltaStore.class.getName());
+  private static final int INDEX_OPTIONS_CONFLICT = 85;
+  private static final String APPLIED_AT_VERSION_INDEX_NAME =
+      MongoDbDeltaStoreUtil.FIELD_WAVE_ID + "_1_" + MongoDbDeltaStoreUtil.FIELD_WAVELET_ID
+          + "_1_" + MongoDbDeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
 
   /** Name of the MongoDB collection to store Deltas */
   private static final String DELTAS_COLLECTION = "deltas";
@@ -61,6 +67,7 @@ public class MongoDbDeltaStore implements DeltaStore {
    */
   public MongoDbDeltaStore(DB database) {
     this.database = database;
+    ensureIndexes();
   }
 
   @Override
@@ -146,5 +153,68 @@ public class MongoDbDeltaStore implements DeltaStore {
    */
   private DBCollection getDeltaDbCollection() {
     return database.getCollection(DELTAS_COLLECTION);
+  }
+
+  private void ensureIndexes() {
+    try {
+      DBCollection coll = getDeltaDbCollection();
+      BasicDBObject bg = new BasicDBObject("background", true);
+
+      coll.createIndex(new BasicDBObject()
+          .append(MongoDbDeltaStoreUtil.FIELD_WAVE_ID, 1)
+          .append(MongoDbDeltaStoreUtil.FIELD_WAVELET_ID, 1), bg);
+
+      ensureAppliedAtVersionIndex(coll);
+
+      coll.createIndex(new BasicDBObject()
+          .append(MongoDbDeltaStoreUtil.FIELD_WAVE_ID, 1)
+          .append(MongoDbDeltaStoreUtil.FIELD_WAVELET_ID, 1)
+          .append(MongoDbDeltaStoreUtil.FIELD_TRANSFORMED_RESULTINGVERSION_VERSION, 1), bg);
+    } catch (MongoException e) {
+      LOG.warning("MongoDbDeltaStore: failed to create indexes on deltas collection: "
+          + e.getMessage());
+    }
+  }
+
+  private void ensureAppliedAtVersionIndex(DBCollection coll) {
+    BasicDBObject keys = new BasicDBObject()
+        .append(MongoDbDeltaStoreUtil.FIELD_WAVE_ID, 1)
+        .append(MongoDbDeltaStoreUtil.FIELD_WAVELET_ID, 1)
+        .append(MongoDbDeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION, 1);
+    BasicDBObject uniqueOptions = new BasicDBObject("background", true)
+        .append("name", APPLIED_AT_VERSION_INDEX_NAME)
+        .append("unique", true);
+    try {
+      coll.createIndex(keys, uniqueOptions);
+    } catch (MongoException initialFailure) {
+      if (isIndexOptionsConflict(initialFailure)) {
+        LOG.info("MongoDbDeltaStore: upgrading applied-version index to unique");
+        coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
+        try {
+          coll.createIndex(keys, uniqueOptions);
+          return;
+        } catch (MongoException retryFailure) {
+          restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+          LOG.warning(
+              "MongoDbDeltaStore: applied-version uniqueness upgrade blocked by existing data; "
+                  + "run corrupted-wave repair before retrying. " + retryFailure.getMessage());
+          return;
+        }
+      }
+      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+      LOG.warning(
+          "MongoDbDeltaStore: unable to enforce unique applied-version writes; "
+              + "leaving the legacy index in place. " + initialFailure.getMessage());
+    }
+  }
+
+  private void restoreNonUniqueAppliedAtVersionIndex(DBCollection coll, BasicDBObject keys) {
+    coll.createIndex(keys, new BasicDBObject("background", true)
+        .append("name", APPLIED_AT_VERSION_INDEX_NAME));
+  }
+
+  private boolean isIndexOptionsConflict(MongoException error) {
+    return error.getCode() == INDEX_OPTIONS_CONFLICT
+        || error.getMessage().contains("already exists with different options");
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaCollection.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaCollection.java
@@ -49,6 +49,8 @@ public class Mongo4DeltaCollection implements DeltaStore.DeltasAccess {
 
   /** MongoDB Collection object for delta storage */
   private final MongoCollection<Document> deltaCollection;
+  /** Non-null when store startup decided new writes must fail closed. */
+  private final PersistenceException appendGuardFailure;
 
   /**
    * Construct a new Delta Access object for the wavelet
@@ -56,9 +58,11 @@ public class Mongo4DeltaCollection implements DeltaStore.DeltasAccess {
    * @param waveletName The wavelet name.
    * @param deltaCollection The MongoDB deltas collection
    */
-  public Mongo4DeltaCollection(WaveletName waveletName, MongoCollection<Document> deltaCollection) {
+  public Mongo4DeltaCollection(WaveletName waveletName, MongoCollection<Document> deltaCollection,
+      PersistenceException appendGuardFailure) {
     this.waveletName = waveletName;
     this.deltaCollection = deltaCollection;
+    this.appendGuardFailure = appendGuardFailure;
   }
 
   @Override
@@ -190,6 +194,11 @@ public class Mongo4DeltaCollection implements DeltaStore.DeltasAccess {
 
   @Override
   public void append(Collection<WaveletDeltaRecord> newDeltas) throws PersistenceException {
+    if (appendGuardFailure != null) {
+      throw new PersistenceException(
+          "Refusing delta writes for " + waveletName + ": " + appendGuardFailure.getMessage(),
+          appendGuardFailure);
+    }
     try {
       for (WaveletDeltaRecord delta : newDeltas) {
         deltaCollection.insertOne(Mongo4DeltaStoreUtil.serialize(delta,

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaCollection.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaCollection.java
@@ -196,7 +196,7 @@ public class Mongo4DeltaCollection implements DeltaStore.DeltasAccess {
             waveletName.waveId.serialise(), waveletName.waveletId.serialise()));
       }
     } catch (RuntimeException e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException("Failed to append delta for " + waveletName, e);
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
@@ -115,8 +115,8 @@ public class Mongo4DeltaStore implements DeltaStore {
     } catch (MongoException initialFailure) {
       if (isIndexOptionsConflict(initialFailure)) {
         LOG.info("Mongo4DeltaStore: upgrading applied-version index to unique");
-        coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
         try {
+          coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
           coll.createIndex(keys, uniqueOptions);
           return;
         } catch (MongoException retryFailure) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
@@ -59,6 +59,8 @@ public class Mongo4DeltaStore implements DeltaStore {
 
   /** MongoDB database connection object */
   private final MongoDatabase database;
+  /** Non-null when the store could not enforce append safety and must fail closed. */
+  private volatile PersistenceException appendGuardFailure = null;
 
   /**
    * Construct a new store
@@ -118,18 +120,38 @@ public class Mongo4DeltaStore implements DeltaStore {
           coll.createIndex(keys, uniqueOptions);
           return;
         } catch (MongoException retryFailure) {
-          restoreNonUniqueAppliedAtVersionIndex(coll, keys);
-          LOG.warning(
+          disableWritesAndRestoreLegacyIndex(
+              coll,
+              keys,
               "Mongo4DeltaStore: applied-version uniqueness upgrade blocked by existing data; "
-                  + "run corrupted-wave repair before retrying. " + retryFailure.getMessage());
+                  + "refusing new delta writes until corrupted-wave repair completes and the "
+                  + "server restarts.",
+              retryFailure);
           return;
         }
       }
-      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
-      LOG.warning(
+      disableWritesAndRestoreLegacyIndex(
+          coll,
+          keys,
           "Mongo4DeltaStore: unable to enforce unique applied-version writes; "
-              + "leaving the legacy index in place. " + initialFailure.getMessage());
+              + "refusing new delta writes until the index issue is fixed and the server "
+              + "restarts.",
+          initialFailure);
     }
+  }
+
+  private void disableWritesAndRestoreLegacyIndex(MongoCollection<Document> coll, Bson keys,
+      String message, MongoException cause) {
+    if (appendGuardFailure == null) {
+      appendGuardFailure = new PersistenceException(message, cause);
+    }
+    try {
+      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+    } catch (MongoException restoreFailure) {
+      LOG.warning("Mongo4DeltaStore: failed to restore legacy applied-version index after "
+          + "disabling writes: " + restoreFailure.getMessage());
+    }
+    LOG.warning(message + " " + cause.getMessage());
   }
 
   private void restoreNonUniqueAppliedAtVersionIndex(MongoCollection<Document> coll, Bson keys) {
@@ -143,7 +165,7 @@ public class Mongo4DeltaStore implements DeltaStore {
 
   @Override
   public DeltasAccess open(WaveletName waveletName) throws PersistenceException {
-    return new Mongo4DeltaCollection(waveletName, getDeltaCollection());
+    return new Mongo4DeltaCollection(waveletName, getDeltaCollection(), appendGuardFailure);
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
@@ -49,6 +49,10 @@ import java.util.Set;
 public class Mongo4DeltaStore implements DeltaStore {
 
   private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(Mongo4DeltaStore.class.getName());
+  private static final int INDEX_OPTIONS_CONFLICT = 85;
+  private static final String APPLIED_AT_VERSION_INDEX_NAME =
+      Mongo4DeltaStoreUtil.FIELD_WAVE_ID + "_1_" + Mongo4DeltaStoreUtil.FIELD_WAVELET_ID
+          + "_1_" + Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
 
   /** Name of the MongoDB collection to store Deltas */
   private static final String DELTAS_COLLECTION = "deltas";
@@ -81,13 +85,7 @@ public class Mongo4DeltaStore implements DeltaStore {
           Indexes.ascending(Mongo4DeltaStoreUtil.FIELD_WAVE_ID, Mongo4DeltaStoreUtil.FIELD_WAVELET_ID),
           bg);
 
-      // Compound index for version-based delta retrieval
-      coll.createIndex(
-          Indexes.ascending(
-              Mongo4DeltaStoreUtil.FIELD_WAVE_ID,
-              Mongo4DeltaStoreUtil.FIELD_WAVELET_ID,
-              Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION),
-          bg);
+      ensureAppliedAtVersionIndex(coll);
 
       // Compound index for end-version lookups
       coll.createIndex(
@@ -101,6 +99,46 @@ public class Mongo4DeltaStore implements DeltaStore {
     } catch (MongoException e) {
       LOG.warning("Mongo4DeltaStore: failed to create indexes on deltas collection: " + e.getMessage());
     }
+  }
+
+  private void ensureAppliedAtVersionIndex(MongoCollection<Document> coll) {
+    Bson keys = Indexes.ascending(
+        Mongo4DeltaStoreUtil.FIELD_WAVE_ID,
+        Mongo4DeltaStoreUtil.FIELD_WAVELET_ID,
+        Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION);
+    IndexOptions uniqueOptions =
+        new IndexOptions().background(true).name(APPLIED_AT_VERSION_INDEX_NAME).unique(true);
+    try {
+      coll.createIndex(keys, uniqueOptions);
+    } catch (MongoException initialFailure) {
+      if (isIndexOptionsConflict(initialFailure)) {
+        LOG.info("Mongo4DeltaStore: upgrading applied-version index to unique");
+        coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
+        try {
+          coll.createIndex(keys, uniqueOptions);
+          return;
+        } catch (MongoException retryFailure) {
+          restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+          LOG.warning(
+              "Mongo4DeltaStore: applied-version uniqueness upgrade blocked by existing data; "
+                  + "run corrupted-wave repair before retrying. " + retryFailure.getMessage());
+          return;
+        }
+      }
+      restoreNonUniqueAppliedAtVersionIndex(coll, keys);
+      LOG.warning(
+          "Mongo4DeltaStore: unable to enforce unique applied-version writes; "
+              + "leaving the legacy index in place. " + initialFailure.getMessage());
+    }
+  }
+
+  private void restoreNonUniqueAppliedAtVersionIndex(MongoCollection<Document> coll, Bson keys) {
+    coll.createIndex(keys, new IndexOptions().background(true).name(APPLIED_AT_VERSION_INDEX_NAME));
+  }
+
+  private boolean isIndexOptionsConflict(MongoException error) {
+    return error.getCode() == INDEX_OPTIONS_CONFLICT
+        || error.getMessage().contains("already exists with different options");
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
@@ -326,27 +326,26 @@ class DeltaStoreBasedWaveletState implements WaveletState {
           // Done, version is already persisted.
           version = last;
         } else {
-          HashedVersion expectedDurableVersion = (last == null) ? versionZero : last;
-          HashedVersion durableEndVersion = deltasAccess.getEndVersion();
-          if (durableEndVersion != null && !durableEndVersion.equals(expectedDurableVersion)) {
-            throw new PersistenceException("Refusing to persist stale wavelet state for "
-                + deltasAccess.getWaveletName() + ": expected durable end version "
-                + expectedDurableVersion + " but found " + durableEndVersion);
-          }
-          ImmutableList.Builder<WaveletDeltaRecord> deltas = ImmutableList.builder();
-          HashedVersion v = (last == null) ? versionZero : last;
-          do {
-            WaveletDeltaRecord d = cachedDeltas.get(v);
-            if (d == null) {
-              throw new PersistenceException("Missing cached delta for "
-                  + deltasAccess.getWaveletName() + " at applied version " + v
-                  + " while persisting up to " + version);
+          HashedVersion persistBaseVersion = resolvePersistBaseVersion(last, version);
+          if (persistBaseVersion.getVersion() >= version.getVersion()) {
+            version = persistBaseVersion;
+          } else {
+            ImmutableList.Builder<WaveletDeltaRecord> deltas = ImmutableList.builder();
+            HashedVersion v = persistBaseVersion;
+            do {
+              WaveletDeltaRecord d = getCachedDeltaOrThrow(v, version,
+                  "while persisting up to ");
+              deltas.add(d);
+              v = d.getResultingVersion();
+            } while (v.getVersion() < version.getVersion());
+            Preconditions.checkState(v.equals(version));
+            try {
+              deltasAccess.append(deltas.build());
+            } catch (PersistenceException e) {
+              recoverableAppendFailureBase.set(persistBaseVersion);
+              throw e;
             }
-            deltas.add(d);
-            v = d.getResultingVersion();
-          } while (v.getVersion() < version.getVersion());
-          Preconditions.checkState(v.equals(version));
-          deltasAccess.append(deltas.build());
+          }
         }
         // After successful delta persistence, store a pending snapshot if any.
         // Atomically consume the pending copy, then check whether its version
@@ -391,6 +390,7 @@ class DeltaStoreBasedWaveletState implements WaveletState {
             Preconditions.checkState(last == lastPersistedVersion.get(),
                 "lastPersistedVersion changed while we were writing to storage");
             lastPersistedVersion.set(version);
+            recoverableAppendFailureBase.set(null);
           }
           queuedTask = nextPersistTask;
           nextPersistTask = null;
@@ -406,6 +406,63 @@ class DeltaStoreBasedWaveletState implements WaveletState {
     }
   };
 
+  private HashedVersion resolvePersistBaseVersion(HashedVersion last, HashedVersion targetVersion)
+      throws PersistenceException {
+    HashedVersion expectedDurableVersion = (last == null) ? versionZero : last;
+    HashedVersion durableEndVersion = deltasAccess.getEndVersion();
+    if (durableEndVersion == null) {
+      if (last != null) {
+        throw new PersistenceException("Unexpected empty delta store for "
+            + deltasAccess.getWaveletName() + ": expected durable end version "
+            + expectedDurableVersion + " while persisting up to " + targetVersion);
+      }
+      return expectedDurableVersion;
+    }
+    if (durableEndVersion.equals(expectedDurableVersion)) {
+      return expectedDurableVersion;
+    }
+    HashedVersion failedAppendBase = recoverableAppendFailureBase.get();
+    if (failedAppendBase != null && failedAppendBase.equals(expectedDurableVersion)) {
+      HashedVersion recoveredVersion = findRecoverableDurablePrefix(
+          expectedDurableVersion, durableEndVersion, targetVersion);
+      if (recoveredVersion != null) {
+        LOG.warning("Recovering durable prefix for " + deltasAccess.getWaveletName()
+            + ": advancing persist base from " + expectedDurableVersion + " to "
+            + recoveredVersion + " after a previous append failure");
+        return recoveredVersion;
+      }
+    }
+    throw new PersistenceException("Refusing to persist stale wavelet state for "
+        + deltasAccess.getWaveletName() + ": expected durable end version "
+        + expectedDurableVersion + " but found " + durableEndVersion);
+  }
+
+  private HashedVersion findRecoverableDurablePrefix(HashedVersion expectedDurableVersion,
+      HashedVersion durableEndVersion, HashedVersion targetVersion) throws PersistenceException {
+    if (durableEndVersion.getVersion() <= expectedDurableVersion.getVersion()
+        || durableEndVersion.getVersion() > targetVersion.getVersion()) {
+      return null;
+    }
+    HashedVersion v = expectedDurableVersion;
+    while (v.getVersion() < durableEndVersion.getVersion()) {
+      WaveletDeltaRecord d = getCachedDeltaOrThrow(v, targetVersion,
+          "while reconciling durable prefix " + durableEndVersion + " for ");
+      v = d.getResultingVersion();
+    }
+    return v.equals(durableEndVersion) ? durableEndVersion : null;
+  }
+
+  private WaveletDeltaRecord getCachedDeltaOrThrow(HashedVersion appliedVersion,
+      HashedVersion targetVersion, String contextPrefix) throws PersistenceException {
+    WaveletDeltaRecord d = cachedDeltas.get(appliedVersion);
+    if (d == null) {
+      throw new PersistenceException("Missing cached delta for "
+          + deltasAccess.getWaveletName() + " at applied version " + appliedVersion + " "
+          + contextPrefix + targetVersion);
+    }
+    return d;
+  }
+
   /** Keyed by appliedAtVersion. */
   private final ConcurrentNavigableMap<HashedVersion, ByteStringMessage<ProtocolAppliedWaveletDelta>> appliedDeltas =
       new ConcurrentSkipListMap<HashedVersion, ByteStringMessage<ProtocolAppliedWaveletDelta>>();
@@ -413,6 +470,13 @@ class DeltaStoreBasedWaveletState implements WaveletState {
   /** Keyed by appliedAtVersion. */
   private final ConcurrentNavigableMap<HashedVersion, WaveletDeltaRecord> cachedDeltas =
       new ConcurrentSkipListMap<HashedVersion, WaveletDeltaRecord>();
+
+  /**
+   * Records the durable base version for the most recent append that threw, so
+   * a later retry can distinguish a partial self-append from an unrelated stale writer.
+   */
+  private final AtomicReference<HashedVersion> recoverableAppendFailureBase =
+      new AtomicReference<HashedVersion>(null);
 
   /** Is null if the wavelet state is empty. */
   private WaveletData snapshot;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
@@ -313,80 +313,90 @@ class DeltaStoreBasedWaveletState implements WaveletState {
     public Void call() throws PersistenceException {
       HashedVersion last;
       HashedVersion version;
+      ListenableFutureTask<Void> queuedTask = null;
+      boolean succeeded = false;
       synchronized (persistLock) {
         last = lastPersistedVersion.get();
         version = latestVersionToPersist;
       }
-      if (last != null && version.getVersion() <= last.getVersion()) {
-        LOG.info("Attempt to persist version " + version
-            + " smaller than last persisted version " + last);
-        // Done, version is already persisted.
-        version = last;
-      } else {
-        HashedVersion expectedDurableVersion = (last == null) ? versionZero : last;
-        HashedVersion durableEndVersion = deltasAccess.getEndVersion();
-        if (durableEndVersion != null && !durableEndVersion.equals(expectedDurableVersion)) {
-          throw new PersistenceException("Refusing to persist stale wavelet state for "
-              + deltasAccess.getWaveletName() + ": expected durable end version "
-              + expectedDurableVersion + " but found " + durableEndVersion);
-        }
-        ImmutableList.Builder<WaveletDeltaRecord> deltas = ImmutableList.builder();
-        HashedVersion v = (last == null) ? versionZero : last;
-        do {
-          WaveletDeltaRecord d = cachedDeltas.get(v);
-          deltas.add(d);
-          v = d.getResultingVersion();
-        } while (v.getVersion() < version.getVersion());
-        Preconditions.checkState(v.equals(version));
-        deltasAccess.append(deltas.build());
-      }
-      // After successful delta persistence, store a pending snapshot if any.
-      // Atomically consume the pending copy, then check whether its version
-      // is covered by the deltas we just persisted.  If the snapshot is ahead
-      // of what is durable, put it back for the next persist task.
-      if (snapshotStore != null) {
-        ReadableWaveletData snapCopy = pendingSnapshotCopy.getAndSet(null);
-        if (snapCopy != null) {
-          if (snapCopy.getHashedVersion().getVersion() <= version.getVersion()) {
-            // Safe to store: all referenced deltas are durable.
-            try {
-              WaveletSnapshot proto = SnapshotSerializer.serializeWavelet(
-                  snapCopy, snapCopy.getHashedVersion());
-              PersistedWaveletSnapshot persisted = PersistedWaveletSnapshot.newBuilder()
-                  .setWaveId(snapCopy.getWaveId().serialise())
-                  .setSnapshot(proto)
-                  .build();
-              snapshotStore.storeSnapshot(
-                  deltasAccess.getWaveletName(),
-                  persisted.toByteArray(),
-                  snapCopy.getHashedVersion().getVersion());
-            } catch (Exception e) {
-              LOG.warning("Failed to store snapshot at version "
-                  + snapCopy.getHashedVersion().getVersion() + " for "
-                  + deltasAccess.getWaveletName() + ": " + e);
-              // Non-fatal: snapshots are optimization only
-            }
-          } else {
-            // Snapshot is ahead of persisted deltas -- put it back.
-            // Use compareAndSet(null, snapCopy) so we don't clobber a
-            // newer copy that appendDelta() may have set concurrently.
-            // If CAS fails, the newer copy subsumes this one (and will
-            // be picked up by the next persist task).
-            pendingSnapshotCopy.compareAndSet(null, snapCopy);
-          }
-        }
-      }
-      synchronized (persistLock) {
-        Preconditions.checkState(last == lastPersistedVersion.get(),
-            "lastPersistedVersion changed while we were writing to storage");
-        lastPersistedVersion.set(version);
-        if (nextPersistTask != null) {
-          persistExecutor.execute(nextPersistTask);
-          nextPersistTask = null;
+      try {
+        if (last != null && version.getVersion() <= last.getVersion()) {
+          LOG.info("Attempt to persist version " + version
+              + " smaller than last persisted version " + last);
+          // Done, version is already persisted.
+          version = last;
         } else {
-          latestVersionToPersist = null;
+          HashedVersion expectedDurableVersion = (last == null) ? versionZero : last;
+          HashedVersion durableEndVersion = deltasAccess.getEndVersion();
+          if (durableEndVersion != null && !durableEndVersion.equals(expectedDurableVersion)) {
+            throw new PersistenceException("Refusing to persist stale wavelet state for "
+                + deltasAccess.getWaveletName() + ": expected durable end version "
+                + expectedDurableVersion + " but found " + durableEndVersion);
+          }
+          ImmutableList.Builder<WaveletDeltaRecord> deltas = ImmutableList.builder();
+          HashedVersion v = (last == null) ? versionZero : last;
+          do {
+            WaveletDeltaRecord d = cachedDeltas.get(v);
+            deltas.add(d);
+            v = d.getResultingVersion();
+          } while (v.getVersion() < version.getVersion());
+          Preconditions.checkState(v.equals(version));
+          deltasAccess.append(deltas.build());
+        }
+        // After successful delta persistence, store a pending snapshot if any.
+        // Atomically consume the pending copy, then check whether its version
+        // is covered by the deltas we just persisted. If the snapshot is ahead
+        // of what is durable, put it back for the next persist task.
+        if (snapshotStore != null) {
+          ReadableWaveletData snapCopy = pendingSnapshotCopy.getAndSet(null);
+          if (snapCopy != null) {
+            if (snapCopy.getHashedVersion().getVersion() <= version.getVersion()) {
+              // Safe to store: all referenced deltas are durable.
+              try {
+                WaveletSnapshot proto = SnapshotSerializer.serializeWavelet(
+                    snapCopy, snapCopy.getHashedVersion());
+                PersistedWaveletSnapshot persisted = PersistedWaveletSnapshot.newBuilder()
+                    .setWaveId(snapCopy.getWaveId().serialise())
+                    .setSnapshot(proto)
+                    .build();
+                snapshotStore.storeSnapshot(
+                    deltasAccess.getWaveletName(),
+                    persisted.toByteArray(),
+                    snapCopy.getHashedVersion().getVersion());
+              } catch (Exception e) {
+                LOG.warning("Failed to store snapshot at version "
+                    + snapCopy.getHashedVersion().getVersion() + " for "
+                    + deltasAccess.getWaveletName() + ": " + e);
+                // Non-fatal: snapshots are optimization only
+              }
+            } else {
+              // Snapshot is ahead of persisted deltas -- put it back.
+              // Use compareAndSet(null, snapCopy) so we don't clobber a
+              // newer copy that appendDelta() may have set concurrently.
+              // If CAS fails, the newer copy subsumes this one (and will
+              // be picked up by the next persist task).
+              pendingSnapshotCopy.compareAndSet(null, snapCopy);
+            }
           }
         }
+        succeeded = true;
+      } finally {
+        synchronized (persistLock) {
+          if (succeeded) {
+            Preconditions.checkState(last == lastPersistedVersion.get(),
+                "lastPersistedVersion changed while we were writing to storage");
+            lastPersistedVersion.set(version);
+          }
+          queuedTask = nextPersistTask;
+          nextPersistTask = null;
+          if (queuedTask == null) {
+            latestVersionToPersist = null;
+          }
+        }
+        if (queuedTask != null) {
+          persistExecutor.execute(queuedTask);
+        }
+      }
       return null;
     }
   };

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
@@ -323,6 +323,13 @@ class DeltaStoreBasedWaveletState implements WaveletState {
         // Done, version is already persisted.
         version = last;
       } else {
+        HashedVersion expectedDurableVersion = (last == null) ? versionZero : last;
+        HashedVersion durableEndVersion = deltasAccess.getEndVersion();
+        if (durableEndVersion != null && !durableEndVersion.equals(expectedDurableVersion)) {
+          throw new PersistenceException("Refusing to persist stale wavelet state for "
+              + deltasAccess.getWaveletName() + ": expected durable end version "
+              + expectedDurableVersion + " but found " + durableEndVersion);
+        }
         ImmutableList.Builder<WaveletDeltaRecord> deltas = ImmutableList.builder();
         HashedVersion v = (last == null) ? versionZero : last;
         do {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
@@ -337,6 +337,11 @@ class DeltaStoreBasedWaveletState implements WaveletState {
           HashedVersion v = (last == null) ? versionZero : last;
           do {
             WaveletDeltaRecord d = cachedDeltas.get(v);
+            if (d == null) {
+              throw new PersistenceException("Missing cached delta for "
+                  + deltasAccess.getWaveletName() + " at applied version " + v
+                  + " while persisting up to " + version);
+            }
             deltas.add(d);
             v = d.getResultingVersion();
           } while (v.getVersion() < version.getVersion());

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -245,17 +245,21 @@ abstract class WaveletContainerImpl implements WaveletContainer {
         new Runnable() {
           @Override
           public void run() {
-            boolean persisted = false;
-            try {
-              result.get();
-              persisted = true;
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-              LOG.severe("Version " + version, e);
-            }
-            if (!persisted) {
-              return;
+            // This listener only runs once the persist future is complete. Clear any stale worker
+            // interrupt before reading the result so successful commits still flush/notify and the
+            // executor thread does not stay poisoned for later callbacks.
+            Thread.interrupted();
+            while (true) {
+              try {
+                result.get();
+                break;
+              } catch (InterruptedException e) {
+                // The future is already complete when this listener runs; retry after clearing a
+                // stale worker interrupt so we do not drop a successful commit notification.
+              } catch (ExecutionException e) {
+                LOG.severe("Version " + version, e);
+                return;
+              }
             }
             acquireWriteLock();
             try {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -245,12 +245,17 @@ abstract class WaveletContainerImpl implements WaveletContainer {
         new Runnable() {
           @Override
           public void run() {
+            boolean persisted = false;
             try {
               result.get();
+              persisted = true;
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
             } catch (ExecutionException e) {
               LOG.severe("Version " + version, e);
+            }
+            if (!persisted) {
+              return;
             }
             acquireWriteLock();
             try {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/MongoDeltaStoreAppendGuardTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/MongoDeltaStoreAppendGuardTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.MongoException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import junit.framework.TestCase;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.waveprotocol.box.server.persistence.mongodb.MongoDbDeltaStore;
+import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DeltaStore;
+import org.waveprotocol.box.server.waveserver.DeltaStore;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+
+import java.util.Collections;
+
+public final class MongoDeltaStoreAppendGuardTest extends TestCase {
+
+  private static final WaveletName NAME = WaveletName.of(
+      WaveId.of("example.com", "append-guard-wave"),
+      WaveletId.of("example.com", "conv+root"));
+
+  public void testMongo4StoreDisablesWritesWhenUniqueIndexDropFails() throws Exception {
+    MongoDatabase database = mock(MongoDatabase.class);
+    @SuppressWarnings("unchecked")
+    MongoCollection<Document> collection = mock(MongoCollection.class);
+    when(database.getCollection("deltas")).thenReturn(collection);
+
+    MongoException conflict = new MongoException(85,
+        "index already exists with different options");
+    MongoException dropFailure = new MongoException("drop failed");
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      if (Boolean.TRUE.equals(options.isUnique())) {
+        throw conflict;
+      }
+      return "ok";
+    }).when(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+    doThrow(dropFailure).when(collection).dropIndex(any(String.class));
+
+    DeltaStore.DeltasAccess access = new Mongo4DeltaStore(database).open(NAME);
+
+    try {
+      access.append(Collections.emptyList());
+      fail("Expected append guard to fail closed");
+    } catch (PersistenceException e) {
+      assertTrue(e.getMessage().contains("Refusing delta writes"));
+      assertTrue(e.getMessage().contains("refusing new delta writes"));
+      assertNotNull(e.getCause());
+      assertNotNull(e.getCause().getCause());
+      assertTrue(e.getCause().getCause().getMessage().contains("drop failed"));
+    }
+  }
+
+  public void testMongoDbStoreDisablesWritesWhenUniqueIndexDropFails() throws Exception {
+    DB database = mock(DB.class);
+    DBCollection collection = mock(DBCollection.class);
+    when(database.getCollection("deltas")).thenReturn(collection);
+
+    MongoException conflict = new MongoException(85,
+        "index already exists with different options");
+    MongoException dropFailure = new MongoException("drop failed");
+    doAnswer(invocation -> {
+      BasicDBObject options = invocation.getArgument(1);
+      if (Boolean.TRUE.equals(options.get("unique"))) {
+        throw conflict;
+      }
+      return null;
+    }).when(collection).createIndex(any(BasicDBObject.class), any(BasicDBObject.class));
+    doThrow(dropFailure).when(collection).dropIndex(any(String.class));
+
+    DeltaStore.DeltasAccess access = new MongoDbDeltaStore(database).open(NAME);
+
+    try {
+      access.append(Collections.emptyList());
+      fail("Expected append guard to fail closed");
+    } catch (PersistenceException e) {
+      assertTrue(e.getMessage().contains("Refusing delta writes"));
+      assertTrue(e.getMessage().contains("refusing new delta writes"));
+      assertNotNull(e.getCause());
+      assertNotNull(e.getCause().getCause());
+      assertTrue(e.getCause().getCause().getMessage().contains("drop failed"));
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
@@ -28,6 +28,7 @@ import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.testing.DeltaTestUtil;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.version.HashedVersionFactory;
 import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
@@ -141,6 +142,32 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
     }
   }
 
+  public void testPersistRetriesAfterRecoverablePartialAppendFailure() throws Exception {
+    DeltaStore.DeltasAccess durable = store.open(NAME);
+    WaveletState state = DeltaStoreBasedWaveletState.create(
+        new PartiallyFailingDeltasAccess(durable), PERSIST_EXECUTOR);
+    WaveletDeltaRecord first = makeDelta(V0, 1234567890L, 1);
+    WaveletDeltaRecord second = makeDelta(first.getResultingVersion(), 1234567891L, 1);
+
+    state.appendDelta(first);
+    state.appendDelta(second);
+
+    try {
+      state.persist(second.getResultingVersion()).get();
+      fail("Expected initial partial append failure");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof PersistenceException);
+      assertTrue(e.getCause().getMessage().contains("simulated partial append failure"));
+    }
+
+    state.persist(second.getResultingVersion()).get();
+
+    assertEquals(second.getResultingVersion(), durable.getEndVersion());
+    assertEquals(second.getResultingVersion(), state.getLastPersistedVersion());
+    assertNotNull(durable.getDelta(0));
+    assertNotNull(durable.getDelta(first.getResultingVersion().getVersion()));
+  }
+
   // TODO(soren): We need to add tests here that verify interactions with storage.
   // The base tests only test the public interface, not any interactions with the storage system.
 
@@ -152,5 +179,77 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
         appliedAtVersion,
         applied,
         AppliedDeltaUtil.buildTransformedDelta(applied, delta));
+  }
+
+  private static final class PartiallyFailingDeltasAccess implements DeltaStore.DeltasAccess {
+    private final DeltaStore.DeltasAccess delegate;
+    private boolean failOnce = true;
+
+    private PartiallyFailingDeltasAccess(DeltaStore.DeltasAccess delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public WaveletName getWaveletName() {
+      return delegate.getWaveletName();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+
+    @Override
+    public HashedVersion getEndVersion() {
+      return delegate.getEndVersion();
+    }
+
+    @Override
+    public WaveletDeltaRecord getDelta(long version) throws java.io.IOException {
+      return delegate.getDelta(version);
+    }
+
+    @Override
+    public WaveletDeltaRecord getDeltaByEndVersion(long version) throws java.io.IOException {
+      return delegate.getDeltaByEndVersion(version);
+    }
+
+    @Override
+    public HashedVersion getAppliedAtVersion(long version) throws java.io.IOException {
+      return delegate.getAppliedAtVersion(version);
+    }
+
+    @Override
+    public HashedVersion getResultingVersion(long version) throws java.io.IOException {
+      return delegate.getResultingVersion(version);
+    }
+
+    @Override
+    public ByteStringMessage<org.waveprotocol.wave.federation.Proto.ProtocolAppliedWaveletDelta>
+        getAppliedDelta(long version) throws java.io.IOException {
+      return delegate.getAppliedDelta(version);
+    }
+
+    @Override
+    public TransformedWaveletDelta getTransformedDelta(long version) throws java.io.IOException {
+      return delegate.getTransformedDelta(version);
+    }
+
+    @Override
+    public void append(java.util.Collection<WaveletDeltaRecord> deltas) throws PersistenceException {
+      if (failOnce) {
+        failOnce = false;
+        for (WaveletDeltaRecord delta : deltas) {
+          delegate.append(java.util.Collections.singletonList(delta));
+          throw new PersistenceException("simulated partial append failure");
+        }
+      }
+      delegate.append(deltas);
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+      delegate.close();
+    }
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
+import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
@@ -35,7 +36,6 @@ import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutionException;
-import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
 
 /**
  * Runs wavelet state tests with the {@link DeltaStoreBasedWaveletState}.
@@ -93,6 +93,33 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
     WaveletDeltaRecord persisted = store.open(NAME).getDelta(0);
     assertNotNull(persisted);
     assertEquals(delta.getResultingVersion(), persisted.getResultingVersion());
+  }
+
+  public void testPersistRejectsStaleWriterWithoutLeavingQueueStuck() throws Exception {
+    WaveletState stale = createEmptyState(NAME);
+    WaveletState fresh = createEmptyState(NAME);
+    WaveletDeltaRecord delta = makeDelta(V0, 1234567890L, 1);
+
+    fresh.appendDelta(delta);
+    fresh.persist(delta.getResultingVersion()).get();
+
+    stale.appendDelta(delta);
+    try {
+      stale.persist(delta.getResultingVersion()).get();
+      fail("Expected stale persist to be rejected");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof PersistenceException);
+    }
+
+    var retry = stale.persist(delta.getResultingVersion());
+    assertTrue("stale retry should fail fast instead of hanging", retry.isDone());
+    try {
+      retry.get();
+      fail("Expected stale retry to be rejected");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof PersistenceException);
+      assertTrue(e.getCause().getMessage().contains("stale"));
+    }
   }
 
   // TODO(soren): We need to add tests here that verify interactions with storage.

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
@@ -122,6 +122,25 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
     }
   }
 
+  public void testPersistFailsClearlyWhenCachedDeltaIsMissing() throws Exception {
+    WaveletState state = createEmptyState(NAME);
+    WaveletDeltaRecord first = makeDelta(V0, 1234567890L, 1);
+    WaveletDeltaRecord second = makeDelta(first.getResultingVersion(), 1234567891L, 1);
+
+    state.appendDelta(first);
+    state.appendDelta(second);
+    state.flush(second.getResultingVersion());
+
+    try {
+      state.persist(second.getResultingVersion()).get();
+      fail("Expected persist to fail when an in-memory delta is missing");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof PersistenceException);
+      assertTrue(e.getCause().getMessage().contains("Missing cached delta"));
+      assertTrue(e.getCause().getMessage().contains(NAME.toString()));
+    }
+  }
+
   // TODO(soren): We need to add tests here that verify interactions with storage.
   // The base tests only test the public interface, not any interactions with the storage system.
 

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
@@ -21,10 +21,21 @@ package org.waveprotocol.box.server.waveserver;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
+import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.testing.DeltaTestUtil;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.version.HashedVersionFactory;
+import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutionException;
+import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
 
 /**
  * Runs wavelet state tests with the {@link DeltaStoreBasedWaveletState}.
@@ -33,6 +44,15 @@ import java.util.concurrent.Executor;
  */
 public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
 
+  private static final WaveletName NAME = WaveletName.of(
+      WaveId.of("example.com", "stale-wave"),
+      WaveletId.of("example.com", "conv+root"));
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("author@example.com");
+  private static final DeltaTestUtil UTIL = new DeltaTestUtil(AUTHOR);
+  private static final IdURIEncoderDecoder URI_CODEC =
+      new IdURIEncoderDecoder(new JavaUrlCodec());
+  private static final HashedVersionFactory HASH_FACTORY = new HashedVersionFactoryImpl(URI_CODEC);
+  private static final HashedVersion V0 = HASH_FACTORY.createVersionZero(NAME);
   private final Executor PERSIST_EXECUTOR = MoreExecutors.directExecutor();
   private DeltaStore store;
 
@@ -53,6 +73,38 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
     return;
   }
 
+  public void testPersistRejectsStaleWriterWhenStorageAlreadyAdvanced() throws Exception {
+    WaveletState stale = createEmptyState(NAME);
+    WaveletState fresh = createEmptyState(NAME);
+    WaveletDeltaRecord delta = makeDelta(V0, 1234567890L, 1);
+
+    fresh.appendDelta(delta);
+    fresh.persist(delta.getResultingVersion()).get();
+
+    stale.appendDelta(delta);
+    try {
+      stale.persist(delta.getResultingVersion()).get();
+      fail("Expected stale persist to be rejected");
+    } catch (ExecutionException e) {
+      assertTrue(e.getCause() instanceof PersistenceException);
+      assertTrue(e.getCause().getMessage().contains("stale"));
+    }
+
+    WaveletDeltaRecord persisted = store.open(NAME).getDelta(0);
+    assertNotNull(persisted);
+    assertEquals(delta.getResultingVersion(), persisted.getResultingVersion());
+  }
+
   // TODO(soren): We need to add tests here that verify interactions with storage.
   // The base tests only test the public interface, not any interactions with the storage system.
+
+  private static WaveletDeltaRecord makeDelta(HashedVersion appliedAtVersion, long timestamp,
+      int numOps) throws Exception {
+    var delta = UTIL.makeNoOpDelta(appliedAtVersion, timestamp, numOps);
+    var applied = WaveServerTestUtil.buildAppliedDelta(delta, timestamp);
+    return new WaveletDeltaRecord(
+        appliedAtVersion,
+        applied,
+        AppliedDeltaUtil.buildTransformedDelta(applied, delta));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
@@ -289,6 +289,31 @@ public class WaveletContainerTest extends TestCase {
         localWaveletName, localVersion0, ImmutableSet.of(localDomain));
   }
 
+  public void testInterruptedPersistListenerStillFlushesAndNotifiesCommit() throws Exception {
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    WaveletState successfulState = mock(WaveletState.class);
+    when(successfulState.getWaveletName()).thenReturn(localWaveletName);
+    when(successfulState.persist(localVersion0)).thenReturn(Futures.<Void>immediateFuture(null));
+
+    TestWaveletContainer container =
+        new TestWaveletContainer(localWaveletName, notifiee, successfulState);
+    container.awaitLoad();
+
+    boolean interruptedAfterListener = false;
+    try {
+      Thread.currentThread().interrupt();
+      container.triggerPersist(localVersion0, ImmutableSet.of(localDomain));
+      interruptedAfterListener = Thread.interrupted();
+    } finally {
+      Thread.interrupted();
+    }
+
+    verify(successfulState).flush(localVersion0);
+    verify(notifiee).waveletCommitted(
+        localWaveletName, localVersion0, ImmutableSet.of(localDomain));
+    assertFalse(interruptedAfterListener);
+  }
+
   // Utilities
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
@@ -20,6 +20,9 @@
 package org.waveprotocol.box.server.waveserver;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -30,6 +33,7 @@ import com.google.protobuf.ByteString;
 import junit.framework.TestCase;
 
 import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
+import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
 import org.waveprotocol.wave.federation.Proto.ProtocolHashedVersion;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignature;
@@ -267,6 +271,24 @@ public class WaveletContainerTest extends TestCase {
     }
   }
 
+  public void testFailedPersistDoesNotFlushOrNotifyCommit() throws Exception {
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    WaveletState failingState = mock(WaveletState.class);
+    when(failingState.getWaveletName()).thenReturn(localWaveletName);
+    when(failingState.persist(localVersion0)).thenReturn(
+        Futures.<Void>immediateFailedFuture(new PersistenceException("boom")));
+
+    TestWaveletContainer container =
+        new TestWaveletContainer(localWaveletName, notifiee, failingState);
+    container.awaitLoad();
+
+    container.triggerPersist(localVersion0, ImmutableSet.of(localDomain));
+
+    verify(failingState, never()).flush(localVersion0);
+    verify(notifiee, never()).waveletCommitted(
+        localWaveletName, localVersion0, ImmutableSet.of(localDomain));
+  }
+
   // Utilities
 
   /**
@@ -353,5 +375,22 @@ public class WaveletContainerTest extends TestCase {
 
   private static ProtocolWaveletDelta serialize(WaveletDelta d) {
     return CoreWaveletOperationSerializer.serialize(d);
+  }
+
+  private static final class TestWaveletContainer extends WaveletContainerImpl {
+    TestWaveletContainer(WaveletName waveletName, WaveletNotificationSubscriber notifiee,
+        WaveletState waveletState) {
+      super(waveletName, notifiee, Futures.immediateFuture(waveletState), localDomain,
+          STORAGE_CONTINUATION_EXECUTOR);
+    }
+
+    void triggerPersist(HashedVersion version, ImmutableSet<String> domainsToNotify) {
+      acquireWriteLock();
+      try {
+        persist(version, domainsToNotify);
+      } finally {
+        releaseWriteLock();
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- stop the replaced slot immediately after deploy or rollback instead of leaving it writable behind a cooldown timer
- add a deploy regression that asserts the old slot is stopped immediately and wire it into build validation
- reject stale wavelet persistence when durable history has already advanced, so a stale writer cannot silently append from an out-of-date base version

## Root Cause
The corrupted wavelets are not caused by `StaleAnnotationSweeper`; the sweeper is only surfacing already-broken history.

The real corruption shape in Mongo is duplicate delta records for the same wavelet and the same `transformed.appliedatversion`, which creates a branched history. `DeltaStoreBasedWaveletState.create()` expects one linear chain, so replay eventually fails with `IllegalArgumentException: invalid end version`, and the container is marked `CORRUPTED`.

Evidence gathered on `supawave`:
- duplicate applied-version groups exist in `wiab.deltas` for seven wavelets
- affected wavelets include `supawave.ai/w+ym474i8gvwwiA`, `w+qAkAiwsbG-G`, `w+LOZnVKm1gWA`, and `w+r8ICgSfrJzA`
- one broken wave (`w+ym474i8gvwwiA`) has two different authors (`register3@supawave.ai` and `gpt-ts-bot@supawave.ai`) persisting from the same applied version `297`
- the duplicate-write timestamps line up with blue/green deploy overlap windows on April 8, 9, 10, and 12, 2026

The most plausible mechanism is split-brain overlap: during the post-swap cooldown, both slots stay alive and can still mutate shared state through lingering WebSockets and background workers. Mongo currently accepts both writes, so the wave history branches silently.

## What This Fix Changes
- deploy/rollback no longer leave the replaced slot running for 30 minutes after traffic moves
- the app now refuses to persist cached deltas when storage already advanced underneath the current state object

That prevents the exact corruption shape above even if a stale writer slips through again.

## Verification
- `docker run --rm -e TEST_BASH=/bin/bash -v "$PWD":/repo -w /repo python:3.12 bash -lc 'python3 -m unittest scripts.tests.test_deploy_overlap_safety -v'`
- `sbt --batch "wave/testOnly org.waveprotocol.box.server.waveserver.DeltaStoreBasedWaveletStateTest"`
- `bash -n deploy/caddy/deploy.sh`
- workflow YAML parse via `python3` + `yaml.safe_load(...)`
- `git diff --check`

## Residual Follow-up
This PR does not attempt risky automatic repair of already-corrupted wave histories. Some of the existing duplicate branches are ambiguous and need targeted repair tooling or manual adjudication. It does, however, prevent new branches from being created by the same overlap/stale-writer path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to detect and optionally repair duplicated/ambiguous delta documents in wave histories, with reporting and safe-apply modes.
  * Added a changelog entry documenting these fixes.

* **Bug Fixes**
  * Deployment now stops replaced service instances immediately and fails closed if stopped-slot verification fails.
  * Persistence now validates durable state to prevent stale writes and avoids leaving queued tasks blocked.
  * Improved database append/index handling and clearer persistence error reporting.

* **Tests**
  * Added regression tests for immediate-stop deployment, repair logic, and durability checks; CI now runs these tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->