### PR TITLE
fix(ci): retry transient ghcr push failures

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           docker build --tag "$IMAGE_REF" -f Dockerfile.prebuilt target/universal/stage
-          docker push "$IMAGE_REF"
+          bash scripts/docker-push-with-retry.sh "$IMAGE_REF"
 
       - name: Assemble deployment bundle
         run: |

--- a/journal/local-verification/2026-04-13-issue-869-ghcr-push-retry.md
+++ b/journal/local-verification/2026-04-13-issue-869-ghcr-push-retry.md
@@ -1,0 +1,21 @@
+Worktree: /Users/vega/devroot/worktrees/vega113-incubator-wave-pr-870-monitor
+Branch: codex/ghcr-push-retry-869
+PR: https://github.com/vega113/supawave/pull/870
+Plan: N/A (PR remediation batch)
+
+Changes:
+- Streamed `docker push` output through `tee` while preserving the retry helper log file for transient-error classification.
+- Added a regression test that proves `docker-push-with-retry.sh` emits push output before the mocked push process exits.
+
+Verification:
+- `python3 -m unittest scripts.tests.test_docker_push_with_retry`
+  - red: failed before the production fix with `_queue.Empty` because no push output was visible before the fake `docker push` exited
+  - green: passed after the streaming fix
+- `sbt compile`
+  - passed
+- `sbt test`
+  - passed (`2268` tests, `0` failed)
+
+Review remediation:
+- Addressed the open Codex review thread on `scripts/docker-push-with-retry.sh` by restoring live `docker push` progress output so GitHub Actions does not sit silent during long layer uploads.
+- Guarded the new `tee` pipeline by checking `PIPESTATUS` so a log-write failure still fails the helper explicitly instead of being mistaken for a successful push.

--- a/scripts/docker-push-with-retry.sh
+++ b/scripts/docker-push-with-retry.sh
@@ -11,6 +11,16 @@ max_attempts="${DOCKER_PUSH_MAX_ATTEMPTS:-3}"
 retry_delay_seconds="${DOCKER_PUSH_RETRY_DELAY_SECONDS:-15}"
 transient_pattern='unknown blob|blob upload unknown|received unexpected HTTP status: 5[0-9][0-9]|5[0-9][0-9] Server Error|429 Too Many Requests|TLS handshake timeout|i/o timeout|connection reset by peer|EOF|unexpected EOF|net/http: timeout awaiting response headers'
 
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "DOCKER_PUSH_MAX_ATTEMPTS must be a positive integer; got: $max_attempts" >&2
+  exit 64
+fi
+
+if ! [[ "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "DOCKER_PUSH_RETRY_DELAY_SECONDS must be a non-negative integer; got: $retry_delay_seconds" >&2
+  exit 64
+fi
+
 attempt=1
 while [[ "$attempt" -le "$max_attempts" ]]; do
   log_file="$(mktemp)"

--- a/scripts/docker-push-with-retry.sh
+++ b/scripts/docker-push-with-retry.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <image-ref>" >&2
+  exit 64
+fi
+
+image_ref="$1"
+max_attempts="${DOCKER_PUSH_MAX_ATTEMPTS:-3}"
+retry_delay_seconds="${DOCKER_PUSH_RETRY_DELAY_SECONDS:-15}"
+transient_pattern='unknown blob|blob upload unknown|received unexpected HTTP status: 5[0-9][0-9]|5[0-9][0-9] Server Error|429 Too Many Requests|TLS handshake timeout|i/o timeout|connection reset by peer|EOF|unexpected EOF|net/http: timeout awaiting response headers'
+
+attempt=1
+while [[ "$attempt" -le "$max_attempts" ]]; do
+  log_file="$(mktemp)"
+  status=0
+  docker push "$image_ref" >"$log_file" 2>&1 || status=$?
+  cat "$log_file"
+
+  if [[ "$status" -eq 0 ]]; then
+    rm -f "$log_file"
+    exit 0
+  fi
+
+  if grep -Eiq "$transient_pattern" "$log_file"; then
+    rm -f "$log_file"
+    if [[ "$attempt" -lt "$max_attempts" ]]; then
+      echo "Transient docker push failure on attempt $attempt/$max_attempts, retrying in ${retry_delay_seconds}s..." >&2
+      sleep "$retry_delay_seconds"
+      attempt=$((attempt + 1))
+      continue
+    fi
+    echo "Docker push failed after $max_attempts attempts due to transient registry errors" >&2
+    exit "$status"
+  fi
+
+  rm -f "$log_file"
+  echo "Docker push failed with a non-transient error; failing fast without retry" >&2
+  exit "$status"
+done

--- a/scripts/docker-push-with-retry.sh
+++ b/scripts/docker-push-with-retry.sh
@@ -24,9 +24,18 @@ fi
 attempt=1
 while [[ "$attempt" -le "$max_attempts" ]]; do
   log_file="$(mktemp)"
-  status=0
-  docker push "$image_ref" >"$log_file" 2>&1 || status=$?
-  cat "$log_file"
+  set +e
+  docker push "$image_ref" 2>&1 | tee "$log_file"
+  pipe_status=("${PIPESTATUS[@]}")
+  set -e
+  status="${pipe_status[0]}"
+  tee_status="${pipe_status[1]}"
+
+  if [[ "$tee_status" -ne 0 ]]; then
+    rm -f "$log_file"
+    echo "Failed to persist docker push output while streaming logs" >&2
+    exit "$tee_status"
+  fi
 
   if [[ "$status" -eq 0 ]]; then
     rm -f "$log_file"

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -1,8 +1,10 @@
 import os
+import queue
 import shlex
 import stat
 import subprocess
 import tempfile
+import threading
 import textwrap
 import unittest
 from pathlib import Path
@@ -166,6 +168,69 @@ exit 1
       self.assertEqual("3", attempt_file.read_text(encoding="utf-8"))
       self.assertIn("unknown blob", f"{result.stdout}\n{result.stderr}")
       self.assertIn("failed after 3 attempts", f"{result.stdout}\n{result.stderr}")
+
+  def test_streams_docker_output_before_push_completes(self):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash to execute docker-push-with-retry.sh")
+
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "bin"
+      fake_bin.mkdir(parents=True)
+
+      self._write_executable(
+          fake_bin / "docker",
+          """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "push" ]]; then
+  echo "unexpected docker invocation: $*" >&2
+  exit 1
+fi
+
+echo "layer upload in progress"
+sleep 1
+echo "digest: sha256:test-stream size: 1234"
+""",
+      )
+
+      env = self._build_mock_command_env(
+          bash_path=bash_path,
+          fake_bin=fake_bin,
+      )
+      process = subprocess.Popen(  # noqa: S603 - trusted subprocess invocation in test harness
+          [bash_path, str(SCRIPT_PATH), "ghcr.io/example/wave:test"],
+          cwd=REPO_ROOT,
+          env=env,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          text=True,
+      )
+
+      try:
+        self.assertIsNotNone(process.stdout)
+        first_line_queue = queue.Queue()
+        reader = threading.Thread(
+            target=lambda: first_line_queue.put(process.stdout.readline()),
+            daemon=True,
+        )
+        reader.start()
+
+        first_line = first_line_queue.get(timeout=0.5)
+        stdout, stderr = process.communicate(timeout=5)
+      finally:
+        if process.poll() is None:
+          process.kill()
+          process.communicate()
+
+      self.assertEqual(
+          0,
+          process.returncode,
+          msg=f"retry script failed unexpectedly:\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}",
+      )
+      self.assertIn("layer upload in progress", first_line)
+      self.assertIn("digest: sha256:test-stream size: 1234", f"{first_line}{stdout}")
 
   def test_build_mock_command_env_prepends_fake_bin_and_resolved_bash_dir(self):
     with tempfile.TemporaryDirectory(prefix="docker-push-retry-env-") as tmp_dir:

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -6,6 +6,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -53,8 +54,10 @@ echo "digest: sha256:test size: 1234"
       )
       self._write_executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
 
-      env = os.environ.copy()
-      env["PATH"] = f"{fake_bin}:{env['PATH']}"
+      env = self._build_mock_command_env(
+          bash_path=bash_path,
+          fake_bin=fake_bin,
+      )
 
       result = subprocess.run(  # noqa: S603 - trusted subprocess invocation in test harness
           [bash_path, str(SCRIPT_PATH), "ghcr.io/example/wave:test"],
@@ -164,6 +167,21 @@ exit 1
       self.assertIn("unknown blob", f"{result.stdout}\n{result.stderr}")
       self.assertIn("failed after 3 attempts", f"{result.stdout}\n{result.stderr}")
 
+  def test_build_mock_command_env_prepends_fake_bin_and_resolved_bash_dir(self):
+    fake_bin = Path("/tmp/fake-bin")
+    bash_path = "/tmp/custom-bash/bash"
+
+    with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}):
+      env = self._build_mock_command_env(
+          bash_path=bash_path,
+          fake_bin=fake_bin,
+      )
+
+    self.assertEqual(
+        f"{fake_bin}{os.pathsep}{Path(bash_path).parent}{os.pathsep}/usr/bin:/bin",
+        env["PATH"],
+    )
+
   def test_rejects_invalid_retry_configuration(self):
     bash_path = self._bash_path()
     if bash_path is None:
@@ -221,8 +239,10 @@ exit 99
       image_ref: str,
       extra_env: dict[str, str] | None = None,
   ) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
-    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env = DockerPushWithRetryTest._build_mock_command_env(
+        bash_path=bash_path,
+        fake_bin=fake_bin,
+    )
     if extra_env:
       env.update(extra_env)
     return subprocess.run(  # noqa: S603 - trusted subprocess invocation in test harness
@@ -233,6 +253,18 @@ exit 99
         text=True,
         check=False,
     )
+
+  @staticmethod
+  def _build_mock_command_env(
+      bash_path: str,
+      fake_bin: Path,
+  ) -> dict[str, str]:
+    env = os.environ.copy()
+    path_parts = [str(fake_bin), str(Path(bash_path).parent)]
+    if current_path := env.get("PATH"):
+      path_parts.append(current_path)
+    env["PATH"] = os.pathsep.join(path_parts)
+    return env
 
   @staticmethod
   def _bash_path() -> str | None:

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -1,0 +1,100 @@
+import os
+import shlex
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "docker-push-with-retry.sh"
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-contabo.yml"
+
+
+class DockerPushWithRetryTest(unittest.TestCase):
+  def test_retries_unknown_blob_then_succeeds(self):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash >= 4 to execute docker-push-with-retry.sh")
+
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "bin"
+      fake_bin.mkdir(parents=True)
+      attempt_file = temp_dir / "attempts.txt"
+      quoted_attempt_file = shlex.quote(str(attempt_file))
+
+      self._write_executable(
+          fake_bin / "docker",
+          f"""#!/usr/bin/env bash
+set -euo pipefail
+attempt_file={quoted_attempt_file}
+attempts=0
+if [[ -f "$attempt_file" ]]; then
+  attempts=$(cat "$attempt_file")
+fi
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$attempt_file"
+
+if [[ "${{1:-}}" != "push" ]]; then
+  echo "unexpected docker invocation: $*" >&2
+  exit 1
+fi
+
+if [[ "$attempts" -eq 1 ]]; then
+  echo "unknown blob" >&2
+  exit 1
+fi
+
+echo "digest: sha256:test size: 1234"
+""",
+      )
+      self._write_executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+      env = os.environ.copy()
+      env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+      result = subprocess.run(
+          [bash_path, str(SCRIPT_PATH), "ghcr.io/example/wave:test"],
+          cwd=REPO_ROOT,
+          env=env,
+          capture_output=True,
+          text=True,
+          check=False,
+      )
+
+      self.assertEqual(
+          0,
+          result.returncode,
+          msg=f"retry script failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+      )
+      self.assertEqual("2", attempt_file.read_text(encoding="utf-8"))
+      self.assertIn("unknown blob", f"{result.stdout}\n{result.stderr}")
+
+  def test_deploy_workflow_uses_retry_helper_for_registry_push(self):
+    workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+
+    self.assertIn('docker build --tag "$IMAGE_REF" -f Dockerfile.prebuilt target/universal/stage', workflow)
+    self.assertIn('bash scripts/docker-push-with-retry.sh "$IMAGE_REF"', workflow)
+
+  @staticmethod
+  def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+  @staticmethod
+  def _bash_path() -> str | None:
+    for candidate in (os.environ.get("TEST_BASH"), "/opt/homebrew/bin/bash", "/usr/local/bin/bash", "/bin/bash"):
+      if not candidate:
+        continue
+      path = Path(candidate)
+      if not path.is_file() or not os.access(path, os.X_OK):
+        continue
+      return str(path)
+    return None
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -17,7 +17,7 @@ class DockerPushWithRetryTest(unittest.TestCase):
   def test_retries_unknown_blob_then_succeeds(self):
     bash_path = self._bash_path()
     if bash_path is None:
-      self.skipTest("requires bash >= 4 to execute docker-push-with-retry.sh")
+      self.skipTest("requires bash to execute docker-push-with-retry.sh")
 
     with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
       temp_dir = Path(tmp_dir)
@@ -73,6 +73,136 @@ echo "digest: sha256:test size: 1234"
       self.assertEqual("2", attempt_file.read_text(encoding="utf-8"))
       self.assertIn("unknown blob", f"{result.stdout}\n{result.stderr}")
 
+  def test_fails_fast_on_non_transient_error(self):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash to execute docker-push-with-retry.sh")
+
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "bin"
+      fake_bin.mkdir(parents=True)
+      attempt_file = temp_dir / "attempts.txt"
+      quoted_attempt_file = shlex.quote(str(attempt_file))
+
+      self._write_executable(
+          fake_bin / "docker",
+          f"""#!/usr/bin/env bash
+set -euo pipefail
+attempt_file={quoted_attempt_file}
+attempts=0
+if [[ -f "$attempt_file" ]]; then
+  attempts=$(cat "$attempt_file")
+fi
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$attempt_file"
+
+if [[ "${{1:-}}" != "push" ]]; then
+  echo "unexpected docker invocation: $*" >&2
+  exit 1
+fi
+
+echo "manifest unknown" >&2
+exit 1
+""",
+      )
+
+      result = self._run_script(
+          bash_path=bash_path,
+          fake_bin=fake_bin,
+          image_ref="ghcr.io/example/wave:test",
+      )
+
+      self.assertNotEqual(0, result.returncode)
+      self.assertEqual("1", attempt_file.read_text(encoding="utf-8"))
+      self.assertIn("non-transient error", f"{result.stdout}\n{result.stderr}")
+
+  def test_exits_non_zero_after_max_transient_attempts(self):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash to execute docker-push-with-retry.sh")
+
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "bin"
+      fake_bin.mkdir(parents=True)
+      attempt_file = temp_dir / "attempts.txt"
+      quoted_attempt_file = shlex.quote(str(attempt_file))
+
+      self._write_executable(
+          fake_bin / "docker",
+          f"""#!/usr/bin/env bash
+set -euo pipefail
+attempt_file={quoted_attempt_file}
+attempts=0
+if [[ -f "$attempt_file" ]]; then
+  attempts=$(cat "$attempt_file")
+fi
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$attempt_file"
+
+if [[ "${{1:-}}" != "push" ]]; then
+  echo "unexpected docker invocation: $*" >&2
+  exit 1
+fi
+
+echo "unknown blob" >&2
+exit 1
+""",
+      )
+      self._write_executable(fake_bin / "sleep", "#!/usr/bin/env bash\nexit 0\n")
+
+      result = self._run_script(
+          bash_path=bash_path,
+          fake_bin=fake_bin,
+          image_ref="ghcr.io/example/wave:test",
+          extra_env={"DOCKER_PUSH_MAX_ATTEMPTS": "3"},
+      )
+
+      self.assertNotEqual(0, result.returncode)
+      self.assertEqual("3", attempt_file.read_text(encoding="utf-8"))
+      self.assertIn("unknown blob", f"{result.stdout}\n{result.stderr}")
+      self.assertIn("failed after 3 attempts", f"{result.stdout}\n{result.stderr}")
+
+  def test_rejects_invalid_retry_configuration(self):
+    bash_path = self._bash_path()
+    if bash_path is None:
+      self.skipTest("requires bash to execute docker-push-with-retry.sh")
+
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "bin"
+      fake_bin.mkdir(parents=True)
+      self._write_executable(
+          fake_bin / "docker",
+          """#!/usr/bin/env bash
+set -euo pipefail
+echo "docker should not run for invalid retry config" >&2
+exit 99
+""",
+      )
+
+      cases = (
+          (
+              {"DOCKER_PUSH_MAX_ATTEMPTS": "0"},
+              "DOCKER_PUSH_MAX_ATTEMPTS must be a positive integer",
+          ),
+          (
+              {"DOCKER_PUSH_RETRY_DELAY_SECONDS": "nope"},
+              "DOCKER_PUSH_RETRY_DELAY_SECONDS must be a non-negative integer",
+          ),
+      )
+      for extra_env, expected_message in cases:
+        with self.subTest(extra_env=extra_env):
+          result = self._run_script(
+              bash_path=bash_path,
+              fake_bin=fake_bin,
+              image_ref="ghcr.io/example/wave:test",
+              extra_env=extra_env,
+          )
+          self.assertEqual(64, result.returncode)
+          self.assertIn(expected_message, f"{result.stdout}\n{result.stderr}")
+
   def test_deploy_workflow_uses_retry_helper_for_registry_push(self):
     workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
 
@@ -83,6 +213,26 @@ echo "digest: sha256:test size: 1234"
   def _write_executable(path: Path, content: str) -> None:
     path.write_text(textwrap.dedent(content), encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+  @staticmethod
+  def _run_script(
+      bash_path: str,
+      fake_bin: Path,
+      image_ref: str,
+      extra_env: dict[str, str] | None = None,
+  ) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    if extra_env:
+      env.update(extra_env)
+    return subprocess.run(
+        [bash_path, str(SCRIPT_PATH), image_ref],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
   @staticmethod
   def _bash_path() -> str | None:

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -56,7 +56,7 @@ echo "digest: sha256:test size: 1234"
       env = os.environ.copy()
       env["PATH"] = f"{fake_bin}:{env['PATH']}"
 
-      result = subprocess.run(
+      result = subprocess.run(  # noqa: S603 - trusted subprocess invocation in test harness
           [bash_path, str(SCRIPT_PATH), "ghcr.io/example/wave:test"],
           cwd=REPO_ROOT,
           env=env,
@@ -225,7 +225,7 @@ exit 99
     env["PATH"] = f"{fake_bin}:{env['PATH']}"
     if extra_env:
       env.update(extra_env)
-    return subprocess.run(
+    return subprocess.run(  # noqa: S603 - trusted subprocess invocation in test harness
         [bash_path, str(SCRIPT_PATH), image_ref],
         cwd=REPO_ROOT,
         env=env,

--- a/scripts/tests/test_docker_push_with_retry.py
+++ b/scripts/tests/test_docker_push_with_retry.py
@@ -168,19 +168,21 @@ exit 1
       self.assertIn("failed after 3 attempts", f"{result.stdout}\n{result.stderr}")
 
   def test_build_mock_command_env_prepends_fake_bin_and_resolved_bash_dir(self):
-    fake_bin = Path("/tmp/fake-bin")
-    bash_path = "/tmp/custom-bash/bash"
+    with tempfile.TemporaryDirectory(prefix="docker-push-retry-env-") as tmp_dir:
+      temp_dir = Path(tmp_dir)
+      fake_bin = temp_dir / "fake-bin"
+      bash_path = str(temp_dir / "custom-bash" / "bash")
 
-    with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}):
-      env = self._build_mock_command_env(
-          bash_path=bash_path,
-          fake_bin=fake_bin,
+      with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}):
+        env = self._build_mock_command_env(
+            bash_path=bash_path,
+            fake_bin=fake_bin,
+        )
+
+      self.assertEqual(
+          f"{fake_bin}{os.pathsep}{Path(bash_path).parent}{os.pathsep}/usr/bin:/bin",
+          env["PATH"],
       )
-
-    self.assertEqual(
-        f"{fake_bin}{os.pathsep}{Path(bash_path).parent}{os.pathsep}/usr/bin:/bin",
-        env["PATH"],
-    )
 
   def test_rejects_invalid_retry_configuration(self):
     bash_path = self._bash_path()

--- a/wave/config/changelog.d/2026-04-13-ghcr-push-retry.json
+++ b/wave/config/changelog.d/2026-04-13-ghcr-push-retry.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-ghcr-push-retry",
+  "version": "PR #870",
+  "date": "2026-04-13",
+  "title": "Retry transient GHCR push failures during deploy builds",
+  "summary": "The Contabo deploy workflow now retries transient GHCR push failures and rejects invalid retry settings instead of silently skipping pushes or crashing mid-loop.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Deploy builds now push images through a retry helper that retries known transient registry and network failures before giving up.",
+        "The retry helper now validates its retry-count and retry-delay environment variables and regression coverage now includes fail-fast, retry exhaustion, and invalid-config cases."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -15,6 +15,22 @@
     ]
   },
   {
+    "releaseId": "2026-04-13-ghcr-push-retry",
+    "version": "PR #870",
+    "date": "2026-04-13",
+    "title": "Retry transient GHCR push failures during deploy builds",
+    "summary": "The Contabo deploy workflow now retries transient GHCR push failures and rejects invalid retry settings instead of silently skipping pushes or crashing mid-loop.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Deploy builds now push images through a retry helper that retries known transient registry and network failures before giving up.",
+          "The retry helper now validates its retry-count and retry-delay environment variables and regression coverage now includes fail-fast, retry exhaustion, and invalid-config cases."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-12-worktree-diagnostics-runbook",
     "version": "PR #587",
     "date": "2026-04-12",


### PR DESCRIPTION
## Summary
- retry transient GHCR `docker push` failures such as `unknown blob`
- keep fail-fast behavior for non-transient push errors
- wire the Contabo deploy workflow to the new retry helper

## Root cause
The latest production deploy failed in `Build and push container image` after the image build itself completed successfully. The failing line in run `24316778047` was GHCR returning `unknown blob` during `docker push ghcr.io/vega113/supawave:993c60fe192a6352e0e178556f83cd568d9fe955`, which points to a transient registry push failure rather than a broken staged artifact.

Closes #869

## Verification
- `python3 -m unittest discover -s scripts/tests -p 'test_docker_push_with_retry.py'`
- `python3 -m unittest discover -s scripts/tests -p 'test_deploy_sanity_gate.py'`
- `bash -n scripts/docker-push-with-retry.sh`

## Notes
- Triggered a rerun of failed jobs for Actions run `24316778047` while preparing this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now uses a retry helper for container image pushes; it retries known transient registry/network failures and validates retry-count and retry-delay settings, failing fast on non-retryable errors.
* **Tests**
  * Added tests covering retry success, fail-fast on non-retryable errors, retry exhaustion, invalid retry configuration, and CI workflow integration.
* **Documentation**
  * Added changelog entries documenting the push-retry helper and its validated settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->