### PR TITLE
fix(mongo): handle same-name index upgrade conflicts

### DIFF
--- a/wave/config/changelog.d/2026-04-13-same-name-index-upgrade-conflicts.json
+++ b/wave/config/changelog.d/2026-04-13-same-name-index-upgrade-conflicts.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-13-same-name-index-upgrade-conflicts",
+  "version": "PR #871",
+  "date": "2026-04-13",
+  "title": "Same-name index upgrade conflicts",
+  "summary": "Mongo delta-store startup now treats same-name index key-spec conflicts as upgradeable so legacy applied-version indexes can be repaired without forcing append-guard mode.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Mongo delta-store startup now upgrades legacy applied-version indexes when Mongo reports same-name key-spec conflicts, instead of refusing new delta writes until restart"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "releaseId": "2026-04-13-same-name-index-upgrade-conflicts",
+    "version": "PR #871",
+    "date": "2026-04-13",
+    "title": "Same-name index upgrade conflicts",
+    "summary": "Mongo delta-store startup now treats same-name index key-spec conflicts as upgradeable so legacy applied-version indexes can be repaired without forcing append-guard mode.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Mongo delta-store startup now upgrades legacy applied-version indexes when Mongo reports same-name key-spec conflicts, instead of refusing new delta writes until restart"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-12-worktree-diagnostics-runbook",
     "version": "PR #587",
     "date": "2026-04-12",

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
@@ -190,7 +190,7 @@ public class MongoDbDeltaStore implements DeltaStore {
     try {
       coll.createIndex(keys, uniqueOptions);
     } catch (MongoException initialFailure) {
-      if (isIndexOptionsConflict(initialFailure)) {
+      if (isIndexUpgradeConflict(initialFailure)) {
         LOG.info("MongoDbDeltaStore: upgrading applied-version index to unique");
         try {
           coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
@@ -236,7 +236,7 @@ public class MongoDbDeltaStore implements DeltaStore {
         .append("name", APPLIED_AT_VERSION_INDEX_NAME));
   }
 
-  private boolean isIndexOptionsConflict(MongoException error) {
+  private boolean isIndexUpgradeConflict(MongoException error) {
     return error.getCode() == INDEX_OPTIONS_CONFLICT
         || error.getCode() == INDEX_KEY_SPECS_CONFLICT
         || error.getMessage().contains("already exists with different options");

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbDeltaStore.java
@@ -50,6 +50,7 @@ public class MongoDbDeltaStore implements DeltaStore {
   private static final java.util.logging.Logger LOG =
       java.util.logging.Logger.getLogger(MongoDbDeltaStore.class.getName());
   private static final int INDEX_OPTIONS_CONFLICT = 85;
+  private static final int INDEX_KEY_SPECS_CONFLICT = 86;
   private static final String APPLIED_AT_VERSION_INDEX_NAME =
       MongoDbDeltaStoreUtil.FIELD_WAVE_ID + "_1_" + MongoDbDeltaStoreUtil.FIELD_WAVELET_ID
           + "_1_" + MongoDbDeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
@@ -237,6 +238,7 @@ public class MongoDbDeltaStore implements DeltaStore {
 
   private boolean isIndexOptionsConflict(MongoException error) {
     return error.getCode() == INDEX_OPTIONS_CONFLICT
+        || error.getCode() == INDEX_KEY_SPECS_CONFLICT
         || error.getMessage().contains("already exists with different options");
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
@@ -114,7 +114,7 @@ public class Mongo4DeltaStore implements DeltaStore {
     try {
       coll.createIndex(keys, uniqueOptions);
     } catch (MongoException initialFailure) {
-      if (isIndexOptionsConflict(initialFailure)) {
+      if (isIndexUpgradeConflict(initialFailure)) {
         LOG.info("Mongo4DeltaStore: upgrading applied-version index to unique");
         try {
           coll.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
@@ -159,7 +159,7 @@ public class Mongo4DeltaStore implements DeltaStore {
     coll.createIndex(keys, new IndexOptions().background(true).name(APPLIED_AT_VERSION_INDEX_NAME));
   }
 
-  private boolean isIndexOptionsConflict(MongoException error) {
+  private boolean isIndexUpgradeConflict(MongoException error) {
     return error.getCode() == INDEX_OPTIONS_CONFLICT
         || error.getCode() == INDEX_KEY_SPECS_CONFLICT
         || error.getMessage().contains("already exists with different options");

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DeltaStore.java
@@ -50,6 +50,7 @@ public class Mongo4DeltaStore implements DeltaStore {
 
   private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(Mongo4DeltaStore.class.getName());
   private static final int INDEX_OPTIONS_CONFLICT = 85;
+  private static final int INDEX_KEY_SPECS_CONFLICT = 86;
   private static final String APPLIED_AT_VERSION_INDEX_NAME =
       Mongo4DeltaStoreUtil.FIELD_WAVE_ID + "_1_" + Mongo4DeltaStoreUtil.FIELD_WAVELET_ID
           + "_1_" + Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
@@ -160,6 +161,7 @@ public class Mongo4DeltaStore implements DeltaStore {
 
   private boolean isIndexOptionsConflict(MongoException error) {
     return error.getCode() == INDEX_OPTIONS_CONFLICT
+        || error.getCode() == INDEX_KEY_SPECS_CONFLICT
         || error.getMessage().contains("already exists with different options");
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/MongoDeltaStoreAppendGuardTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/MongoDeltaStoreAppendGuardTest.java
@@ -43,6 +43,7 @@ import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class MongoDeltaStoreAppendGuardTest extends TestCase {
 
@@ -111,5 +112,48 @@ public final class MongoDeltaStoreAppendGuardTest extends TestCase {
       assertNotNull(e.getCause().getCause());
       assertTrue(e.getCause().getCause().getMessage().contains("drop failed"));
     }
+  }
+
+  public void testMongo4StoreTreatsIndexKeySpecsConflictAsUpgradeable() throws Exception {
+    MongoDatabase database = mock(MongoDatabase.class);
+    @SuppressWarnings("unchecked")
+    MongoCollection<Document> collection = mock(MongoCollection.class);
+    when(database.getCollection("deltas")).thenReturn(collection);
+
+    MongoException conflict = new MongoException(86,
+        "same name as the requested index");
+    AtomicInteger uniqueAttempts = new AtomicInteger();
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      if (Boolean.TRUE.equals(options.isUnique()) && uniqueAttempts.getAndIncrement() == 0) {
+        throw conflict;
+      }
+      return "ok";
+    }).when(collection).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    DeltaStore.DeltasAccess access = new Mongo4DeltaStore(database).open(NAME);
+
+    access.append(Collections.emptyList());
+  }
+
+  public void testMongoDbStoreTreatsIndexKeySpecsConflictAsUpgradeable() throws Exception {
+    DB database = mock(DB.class);
+    DBCollection collection = mock(DBCollection.class);
+    when(database.getCollection("deltas")).thenReturn(collection);
+
+    MongoException conflict = new MongoException(86,
+        "same name as the requested index");
+    AtomicInteger uniqueAttempts = new AtomicInteger();
+    doAnswer(invocation -> {
+      BasicDBObject options = invocation.getArgument(1);
+      if (Boolean.TRUE.equals(options.get("unique")) && uniqueAttempts.getAndIncrement() == 0) {
+        throw conflict;
+      }
+      return null;
+    }).when(collection).createIndex(any(BasicDBObject.class), any(BasicDBObject.class));
+
+    DeltaStore.DeltasAccess access = new MongoDbDeltaStore(database).open(NAME);
+
+    access.append(Collections.emptyList());
   }
 }


### PR DESCRIPTION
## Summary
- treat Mongo error `86` (`IndexKeySpecsConflict`) the same way as the existing index-options conflict upgrade path
- keep the existing fail-closed behavior only for cases where the unique-index upgrade actually cannot complete
- add regression coverage for both Mongo persistence implementations

## Why
Production hit a legacy-schema migration gap on `wiab.deltas`: the app tried to replace the non-unique applied-version index with a unique index using the same autogenerated name. Mongo returned error `86`, but the code only recognized error `85`, so startup fell into append-guard mode and all new delta writes were refused until restart.

This was not caused by the SHA-256 capability hash shown in robot logs. The failing condition was the Mongo index migration path.

## Verification
- `sbt --batch "set Test / testOptions := Seq(Tests.Argument(TestFrameworks.JUnit, \"-v\"))" "testOnly org.waveprotocol.box.server.persistence.MongoDeltaStoreAppendGuardTest"`
- `git diff --check`

## Production repair performed
- Backed up affected deltas/snapshots to `/Users/vega/devroot/worktrees/corrupted-wave-repair-871/journal/local-verification/2026-04-13-prod-corrupted-wave-backup.json`
- Repaired the five ambiguous wavelets in prod Mongo by deleting orphan or rollback-targeted delta branches
- Recreated `waveid_1_waveletid_1_transformed.appliedatversion_1` as a unique index in `wiab.deltas`
- Restarted `wave-blue`; fresh boot logs now show `Mongo4DeltaStore: ensured indexes on deltas collection` and no new post-restart matches for the previous index-conflict strings

## Remaining note
I have not yet observed a full post-restart 10-minute `StaleAnnotationSweeper` interval, so the strongest remaining live check is to watch the next scheduled sweep and confirm the old corrupted-wave stack traces do not reappear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB index conflict handling so legacy index mismatches are treated as upgradeable during startup, preventing write interruptions and enabling automated index repair.

* **Tests**
  * Added tests verifying index-upgrade behavior across MongoDB configurations to ensure reliable startup and append behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->