### PR TITLE
Fix wrapped pinned saved searches in the search toolbar

### DIFF
--- a/wave/config/changelog.d/2026-04-13-search-toolbar-wrap-pinned-saved-searches.json
+++ b/wave/config/changelog.d/2026-04-13-search-toolbar-wrap-pinned-saved-searches.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
+  "version": "Unreleased",
+  "date": "2026-04-13",
+  "title": "Wrap pinned saved searches onto another toolbar row",
+  "summary": "Pinned saved-search buttons in the search panel now wrap onto additional toolbar rows instead of forcing horizontal scrolling, and the search results panel follows the toolbar's rendered height.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Pinned saved searches in the search panel now remain visible by wrapping onto another toolbar row when space runs out",
+        "The search panel keeps its wave-count bar and result list aligned below the real wrapped toolbar height instead of overlapping the extra row"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,21 +1,5 @@
 [
   {
-    "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
-    "version": "Unreleased",
-    "date": "2026-04-13",
-    "title": "Wrap pinned saved searches onto another toolbar row",
-    "summary": "Pinned saved-search buttons in the search panel now wrap onto additional toolbar rows instead of forcing horizontal scrolling, and the search results panel follows the toolbar's rendered height.",
-    "sections": [
-      {
-        "type": "fix",
-        "items": [
-          "Pinned saved searches in the search panel now remain visible by wrapping onto another toolbar row when space runs out",
-          "The search panel keeps its wave-count bar and result list aligned below the real wrapped toolbar height instead of overlapping the extra row"
-        ]
-      }
-    ]
-  },
-  {
     "releaseId": "2026-04-13-same-name-index-upgrade-conflicts",
     "version": "PR #871",
     "date": "2026-04-13",

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
+    "version": "Unreleased",
+    "date": "2026-04-13",
+    "title": "Wrap pinned saved searches onto another toolbar row",
+    "summary": "Pinned saved-search buttons in the search panel now wrap onto additional toolbar rows instead of forcing horizontal scrolling, and the search results panel follows the toolbar's rendered height.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Pinned saved searches in the search panel now remain visible by wrapping onto another toolbar row when space runs out",
+          "The search panel keeps its wave-count bar and result list aligned below the real wrapped toolbar height instead of overlapping the extra row"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-same-name-index-upgrade-conflicts",
     "version": "PR #871",
     "date": "2026-04-13",

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
@@ -141,6 +141,7 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
   private Listener listener;
   private HandlerRegistration resizeRegistration;
   private JavaScriptObject toolbarResizeObserver;
+  private JavaScriptObject toolbarMutationObserver;
   private boolean panelOffsetSyncScheduled;
 
   /** Whether an infinite-scroll load-more request is in progress. */
@@ -292,15 +293,32 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
 
   private native void observeToolbarResize(Element toolbarEl) /*-{
     this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::disconnectToolbarResizeObserver()();
-    if (!$wnd.ResizeObserver || !toolbarEl) {
+    if (!toolbarEl) {
       return;
     }
     var self = this;
-    var observer = new $wnd.ResizeObserver(function() {
-      self.@org.waveprotocol.box.webclient.search.SearchPanelWidget::schedulePanelOffsetSync()();
-    });
-    observer.observe(toolbarEl);
-    this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver = observer;
+    if ($wnd.ResizeObserver) {
+      var resizeObserver = new $wnd.ResizeObserver(function() {
+        self.@org.waveprotocol.box.webclient.search.SearchPanelWidget::schedulePanelOffsetSync()();
+      });
+      resizeObserver.observe(toolbarEl);
+      this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver =
+          resizeObserver;
+      return;
+    }
+    if ($wnd.MutationObserver) {
+      var mutationObserver = new $wnd.MutationObserver(function() {
+        self.@org.waveprotocol.box.webclient.search.SearchPanelWidget::schedulePanelOffsetSync()();
+      });
+      mutationObserver.observe(toolbarEl, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true
+      });
+      this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarMutationObserver =
+          mutationObserver;
+    }
   }-*/;
 
   private native void disconnectToolbarResizeObserver() /*-{
@@ -310,6 +328,13 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
       observer.disconnect();
     }
     this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver = null;
+
+    var mutationObserver =
+        this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarMutationObserver;
+    if (mutationObserver && mutationObserver.disconnect) {
+      mutationObserver.disconnect();
+    }
+    this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarMutationObserver = null;
   }-*/;
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java
@@ -21,9 +21,15 @@ package org.waveprotocol.box.webclient.search;
 
 import org.waveprotocol.wave.model.util.Preconditions;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.dom.client.Style.Visibility;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
@@ -33,6 +39,7 @@ import com.google.gwt.resources.client.ImageResource.RepeatStyle;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 
 import org.waveprotocol.box.webclient.widget.frame.FramedPanel;
@@ -132,6 +139,9 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
         }
       }, 20);
   private Listener listener;
+  private HandlerRegistration resizeRegistration;
+  private JavaScriptObject toolbarResizeObserver;
+  private boolean panelOffsetSyncScheduled;
 
   /** Whether an infinite-scroll load-more request is in progress. */
   private boolean isLoadingMore = false;
@@ -151,6 +161,24 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
     toolbar.setOverflowEnabled(false);
     this.renderer = renderer;
     createLoadingSpinner();
+  }
+
+  @Override
+  protected void onLoad() {
+    super.onLoad();
+    ensureToolbarLayoutSync();
+    syncPanelOffsetsToToolbar();
+    schedulePanelOffsetSync();
+  }
+
+  @Override
+  protected void onUnload() {
+    disconnectToolbarResizeObserver();
+    if (resizeRegistration != null) {
+      resizeRegistration.removeHandler();
+      resizeRegistration = null;
+    }
+    super.onUnload();
   }
 
   /**
@@ -227,6 +255,63 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
     showLoadingSpinner(false);
   }
 
+  private void ensureToolbarLayoutSync() {
+    if (resizeRegistration == null) {
+      resizeRegistration = Window.addResizeHandler(new ResizeHandler() {
+        @Override
+        public void onResize(ResizeEvent event) {
+          schedulePanelOffsetSync();
+        }
+      });
+    }
+    observeToolbarResize(toolbar.getElement());
+  }
+
+  private void schedulePanelOffsetSync() {
+    if (panelOffsetSyncScheduled) {
+      return;
+    }
+    panelOffsetSyncScheduled = true;
+    Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        panelOffsetSyncScheduled = false;
+        syncPanelOffsetsToToolbar();
+      }
+    });
+  }
+
+  private void syncPanelOffsetsToToolbar() {
+    if (!isAttached()) {
+      return;
+    }
+    int waveCountTopPx = toolbar.getElement().getOffsetTop() + toolbar.getElement().getOffsetHeight();
+    waveCount.getStyle().setTop(waveCountTopPx, Unit.PX);
+    list.getStyle().setTop(waveCountTopPx + waveCount.getOffsetHeight(), Unit.PX);
+  }
+
+  private native void observeToolbarResize(Element toolbarEl) /*-{
+    this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::disconnectToolbarResizeObserver()();
+    if (!$wnd.ResizeObserver || !toolbarEl) {
+      return;
+    }
+    var self = this;
+    var observer = new $wnd.ResizeObserver(function() {
+      self.@org.waveprotocol.box.webclient.search.SearchPanelWidget::schedulePanelOffsetSync()();
+    });
+    observer.observe(toolbarEl);
+    this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver = observer;
+  }-*/;
+
+  private native void disconnectToolbarResizeObserver() /*-{
+    var observer =
+        this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver;
+    if (observer && observer.disconnect) {
+      observer.disconnect();
+    }
+    this.@org.waveprotocol.box.webclient.search.SearchPanelWidget::toolbarResizeObserver = null;
+  }-*/;
+
   @Override
   public void init(Listener listener) {
     Preconditions.checkState(this.listener == null, "this.listener == null");
@@ -267,6 +352,7 @@ public class SearchPanelWidget extends Composite implements SearchPanelView {
       waveCount.setInnerText(text);
       waveCount.getStyle().clearProperty("display");
     }
+    schedulePanelOffsetSync();
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/ToplevelToolbarWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/ToplevelToolbarWidget.java
@@ -160,17 +160,14 @@ public final class ToplevelToolbarWidget extends Composite
     this.overflowEnabled = overflowEnabled;
     overflowButton.setVisible(overflowEnabled);
     if (!overflowEnabled) {
-      // Prevent wrapping when overflow is disabled: without this, buttons that
-      // exceed the row width would wrap to a second line and push the toolbar
-      // beyond the 36px height contract. OverflowPanelUpdater is not active
-      // here so the wrapping would never be resolved via the submenu.
-      self.getElement().getStyle().setProperty("flexWrap", "nowrap");
-      self.addStyleName(res.css().noHorizontalScrollbar());
-      // Allow horizontal scroll so dynamically-added buttons (e.g. pinned saved
-      // searches from SearchPresenter.rebuildSavedSearchButtons) remain reachable
-      // when they exceed the row width, instead of being silently clipped.
-      self.getElement().getStyle().setProperty("overflowX", "auto");
-      self.getElement().getStyle().setProperty("overflowY", "hidden");
+      // When overflow is disabled, keep every button on the toplevel toolbar
+      // and let the shared flex-wrap contract create extra rows naturally.
+      // Callers that care about downstream layout must observe the toolbar's
+      // rendered height rather than assuming a single 36px row.
+      self.getElement().getStyle().clearProperty("flexWrap");
+      self.removeStyleName(res.css().noHorizontalScrollbar());
+      self.getElement().getStyle().clearProperty("overflowX");
+      self.getElement().getStyle().clearProperty("overflowY");
       restoreItemsToToplevel();
       overflowSubmenu.setState(State.INVISIBLE);
     } else {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -129,15 +129,25 @@ public final class ToolbarLayoutContractTest extends TestCase {
     assertTrue(javaSource.contains("toolbar.setOverflowEnabled(false);"));
   }
 
-  public void testOverflowDisabledAppliesNowrapInlineStyle() throws Exception {
+  public void testOverflowDisabledDoesNotForceSingleRowOrHorizontalScroll() throws Exception {
     String javaSource = read(
         "wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/ToplevelToolbarWidget.java");
 
-    // When overflow is disabled, flex-wrap: nowrap must be set as an inline style on the
-    // toolbar element so that buttons cannot wrap to a second row and breach the 36px contract.
-    // The shared CSS keeps flex-wrap: wrap so OverflowPanelUpdater can detect wrapping via offsetTop.
-    assertTrue(javaSource.contains("setProperty(\"flexWrap\", \"nowrap\")"));
-    assertTrue(javaSource.contains("clearProperty(\"flexWrap\")"));
+    assertFalse(javaSource.contains("setProperty(\"flexWrap\", \"nowrap\")"));
+    assertFalse(javaSource.contains("setProperty(\"overflowX\", \"auto\")"));
+    assertFalse(javaSource.contains("setProperty(\"overflowY\", \"hidden\")"));
+  }
+
+  public void testSearchPanelTracksActualToolbarHeightWhenLayoutChanges() throws Exception {
+    String javaSource = read(
+        "wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java");
+
+    assertTrue(javaSource.contains("toolbar.getElement().getOffsetTop() + toolbar.getElement().getOffsetHeight()"));
+    assertTrue(javaSource.contains("waveCount.getStyle().setTop("));
+    assertTrue(javaSource.contains("list.getStyle().setTop("));
+    assertTrue(javaSource.contains("Scheduler.get().scheduleDeferred"));
+    assertTrue(javaSource.contains("Window.addResizeHandler"));
+    assertTrue(javaSource.contains("ResizeObserver"));
   }
 
   public void testWaveToolbarsDoNotDisableOverflowByDefault() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -136,6 +136,10 @@ public final class ToolbarLayoutContractTest extends TestCase {
     assertFalse(javaSource.contains("setProperty(\"flexWrap\", \"nowrap\")"));
     assertFalse(javaSource.contains("setProperty(\"overflowX\", \"auto\")"));
     assertFalse(javaSource.contains("setProperty(\"overflowY\", \"hidden\")"));
+    assertTrue(javaSource.contains("clearProperty(\"flexWrap\")"));
+    assertTrue(javaSource.contains("removeStyleName(res.css().noHorizontalScrollbar())"));
+    assertTrue(javaSource.contains("clearProperty(\"overflowX\")"));
+    assertTrue(javaSource.contains("clearProperty(\"overflowY\")"));
   }
 
   public void testSearchPanelTracksActualToolbarHeightWhenLayoutChanges() throws Exception {
@@ -148,6 +152,10 @@ public final class ToolbarLayoutContractTest extends TestCase {
     assertTrue(javaSource.contains("Scheduler.get().scheduleDeferred"));
     assertTrue(javaSource.contains("Window.addResizeHandler"));
     assertTrue(javaSource.contains("ResizeObserver"));
+    assertTrue(javaSource.contains("MutationObserver"));
+    assertTrue(javaSource.contains("toolbarMutationObserver"));
+    assertTrue(javaSource.contains("disconnectToolbarResizeObserver()"));
+    assertTrue(javaSource.contains("resizeRegistration.removeHandler()"));
   }
 
   public void testWaveToolbarsDoNotDisableOverflowByDefault() throws Exception {


### PR DESCRIPTION
## Summary
- allow search toolbars with overflow disabled to wrap onto additional rows instead of forcing horizontal scrolling
- sync the search panel wave-count bar and results list to the toolbar's rendered height using deferred layout updates and `ResizeObserver`
- add toolbar contract coverage for wrapped disabled-overflow toolbars and search-panel height tracking
- add the changelog fragment and regenerate `wave/config/changelog.json`

## Testing
- `sbt "testOnly org.waveprotocol.box.server.util.ToolbarLayoutContractTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `PORT=9900 bash scripts/wave-smoke.sh check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned saved-search buttons now wrap onto additional toolbar rows when horizontal space is insufficient, eliminating forced horizontal scrolling.
  * Search results panel layout automatically adjusts to the toolbar's actual rendered height, keeping the wave-count bar and result list properly aligned below.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->