### PR TITLE
Fix OT search bootstrap to load from the subscription channel

### DIFF
--- a/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequest.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequest.java
@@ -289,4 +289,35 @@ public interface ProtocolOpenRequest {
 
   /** Sets viewportLimit. */
   void setViewportLimit(int viewportLimit);
+
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+
+  /** Returns whether searchQuery has been set. */
+  boolean hasSearchQuery();
+
+  /** Clears the value of searchQuery. */
+  void clearSearchQuery();
+
+  /** Returns searchQuery, or null if hasn't been set. */
+  String getSearchQuery();
+
+  /** Sets searchQuery. */
+  void setSearchQuery(String searchQuery);
 }

--- a/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequestBuilder.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequestBuilder.java
@@ -234,6 +234,26 @@ public final class ProtocolOpenRequestBuilder {
    * under the License.
    */
   private Integer viewportLimit;
+
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+  private String searchQuery;
   public ProtocolOpenRequestBuilder() {
   }
 
@@ -445,6 +465,34 @@ public final class ProtocolOpenRequestBuilder {
     return this;
   }
 
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+  public ProtocolOpenRequestBuilder clearSearchQuery() {
+    searchQuery = null;
+    return this;
+  }
+
+  public ProtocolOpenRequestBuilder setSearchQuery(String value) {
+    this.searchQuery = value;
+    return this;
+  }
+
   /** Builds a {@link ProtocolOpenRequest} using this builder and a factory. */
   public ProtocolOpenRequest build(Factory factory) {
     ProtocolOpenRequest message = factory.create();
@@ -596,6 +644,27 @@ public final class ProtocolOpenRequestBuilder {
      * under the License.
      */
     message.setViewportLimit(viewportLimit);
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License");
+     you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    message.setSearchQuery(searchQuery);
     return message;
   }
 

--- a/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequestUtil.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/ProtocolOpenRequestUtil.java
@@ -218,6 +218,27 @@ public final class ProtocolOpenRequestUtil {
      */
     if (m1.hasViewportLimit() != m2.hasViewportLimit()) return false;
     if (m1.hasViewportLimit() && (m1.getViewportLimit() != m2.getViewportLimit())) return false;
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (m1.hasSearchQuery() != m2.hasSearchQuery()) return false;
+    if (m1.hasSearchQuery() && !m1.getSearchQuery().equals(m2.getSearchQuery())) return false;
     return true;
   }
 
@@ -382,6 +403,27 @@ public final class ProtocolOpenRequestUtil {
      * under the License.
      */
     result = (31 * result) + (message.hasViewportLimit() ? Integer.valueOf(message.getViewportLimit()).hashCode() : 0);
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License");
+     you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    result = (31 * result) + (message.hasSearchQuery() ? message.getSearchQuery().hashCode() : 0);
     return result;
   }
 

--- a/gen/messages/org/waveprotocol/box/common/comms/gson/ProtocolOpenRequestGsonImpl.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/gson/ProtocolOpenRequestGsonImpl.java
@@ -415,6 +415,47 @@ public final class ProtocolOpenRequestGsonImpl extends ProtocolOpenRequestImpl
        */
       json.add("7", new JsonPrimitive(message.getViewportLimit()));
     }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (message.hasSearchQuery()) {
+
+      /**
+       * Licensed to the Apache Software Foundation (ASF) under one
+       * or more contributor license agreements. See the NOTICE file
+       * distributed with this work for additional information
+       * regarding copyright ownership. The ASF licenses this file
+       * to you under the Apache License, Version 2.0 (the
+       * "License"); you may not use this file except in compliance
+       * with the License. You may obtain a copy of the License at
+       *
+       * http://www.apache.org/licenses/LICENSE-2.0
+       *
+       * Unless required by applicable law or agreed to in writing,
+       * software distributed under the License is distributed on an
+       * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       * KIND, either express or implied. See the License for the
+       * specific language governing permissions and limitations
+       * under the License.
+       */
+      json.add("8", new JsonPrimitive(message.getSearchQuery()));
+    }
     return json;
   }
 
@@ -726,6 +767,50 @@ public final class ProtocolOpenRequestGsonImpl extends ProtocolOpenRequestImpl
          * under the License.
          */
         setViewportLimit(elem.getAsInt());
+      }
+    }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (jsonObject.has("8")) {
+      JsonElement elem = jsonObject.get("8");
+      if (!elem.isJsonNull()) {
+
+        /**
+         * Licensed to the Apache Software Foundation (ASF) under one
+         * or more contributor license agreements. See the NOTICE file
+         * distributed with this work for additional information
+         * regarding copyright ownership. The ASF licenses this file
+         * to you under the Apache License, Version 2.0 (the
+         * "License"); you may not use this file except in compliance
+         * with the License. You may obtain a copy of the License at
+         *
+         * http://www.apache.org/licenses/LICENSE-2.0
+         *
+         * Unless required by applicable law or agreed to in writing,
+         * software distributed under the License is distributed on an
+         * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+         * KIND, either express or implied. See the License for the
+         * specific language governing permissions and limitations
+         * under the License.
+         */
+        setSearchQuery(elem.getAsString());
       }
     }
   }

--- a/gen/messages/org/waveprotocol/box/common/comms/impl/ProtocolOpenRequestImpl.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/impl/ProtocolOpenRequestImpl.java
@@ -230,6 +230,26 @@ public class ProtocolOpenRequestImpl implements ProtocolOpenRequest {
    * under the License.
    */
   private Integer viewportLimit;
+
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+  private String searchQuery;
   public ProtocolOpenRequestImpl() {
   }
 
@@ -396,6 +416,30 @@ public class ProtocolOpenRequestImpl implements ProtocolOpenRequest {
       setViewportLimit(message.getViewportLimit());
     } else {
       clearViewportLimit();
+    }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (message.hasSearchQuery()) {
+      setSearchQuery(message.getSearchQuery());
+    } else {
+      clearSearchQuery();
     }
   }
 
@@ -684,6 +728,45 @@ public class ProtocolOpenRequestImpl implements ProtocolOpenRequest {
     this.viewportLimit = value;
   }
 
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+
+  @Override
+  public boolean hasSearchQuery() {
+    return searchQuery != null;
+  }
+
+  @Override
+  public void clearSearchQuery() {
+    searchQuery = null;
+  }
+
+  @Override
+  public String getSearchQuery() {
+    return searchQuery;
+  }
+
+  @Override
+  public void setSearchQuery(String value) {
+    this.searchQuery = value;
+  }
+
   /** Provided to subclasses to clear all fields, for example when deserializing. */
   protected void reset() {
 
@@ -832,6 +915,27 @@ public class ProtocolOpenRequestImpl implements ProtocolOpenRequest {
      * under the License.
      */
     this.viewportLimit = null;
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License");
+     you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    this.searchQuery = null;
   }
 
   @Override

--- a/gen/messages/org/waveprotocol/box/common/comms/jso/ProtocolOpenRequestJsoImpl.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/jso/ProtocolOpenRequestJsoImpl.java
@@ -109,6 +109,7 @@ public final class ProtocolOpenRequestJsoImpl extends org.waveprotocol.wave.comm
   private static final String keyViewportStartBlipId = "5";
   private static final String keyViewportDirection = "6";
   private static final String keyViewportLimit = "7";
+  private static final String keySearchQuery = "8";
   protected ProtocolOpenRequestJsoImpl() {
   }
 
@@ -446,6 +447,47 @@ public final class ProtocolOpenRequestJsoImpl extends org.waveprotocol.wave.comm
   @Override
   public void setViewportLimit(int value) {
     setPropertyAsInteger(this, keyViewportLimit, value);
+  }
+
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+
+  @Override
+  public boolean hasSearchQuery() {
+    return hasProperty(this, keySearchQuery);
+  }
+
+  @Override
+  public void clearSearchQuery() {
+    if (hasProperty(this, keySearchQuery)) {
+      deleteProperty(this, keySearchQuery);
+    }
+  }
+
+  @Override
+  public String getSearchQuery() {
+    return hasProperty(this, keySearchQuery) ? getPropertyAsString(this, keySearchQuery) : null;
+  }
+
+  @Override
+  public void setSearchQuery(String value) {
+    setPropertyAsString(this, keySearchQuery, value);
   }
 
   @Override

--- a/gen/messages/org/waveprotocol/box/common/comms/proto/ProtocolOpenRequestProtoImpl.java
+++ b/gen/messages/org/waveprotocol/box/common/comms/proto/ProtocolOpenRequestProtoImpl.java
@@ -297,6 +297,30 @@ org.waveprotocol.wave.communication.proto.ProtoWrapper<org.waveprotocol.box.comm
     } else {
       clearViewportLimit();
     }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (message.hasSearchQuery()) {
+      setSearchQuery(message.getSearchQuery());
+    } else {
+      clearSearchQuery();
+    }
   }
 
   /**
@@ -637,6 +661,49 @@ org.waveprotocol.wave.communication.proto.ProtoWrapper<org.waveprotocol.box.comm
    * under the License.
    */
 
+  @Override
+  public boolean hasSearchQuery() {
+    switchToProto();
+    return proto.hasSearchQuery();
+  }
+
+  @Override
+  public void clearSearchQuery() {
+    switchToProtoBuilder();
+    protoBuilder.clearSearchQuery();
+  }
+
+  @Override
+  public String getSearchQuery() {
+    switchToProto();
+    return proto.getSearchQuery();
+  }
+
+  @Override
+  public void setSearchQuery(String value) {
+    switchToProtoBuilder();
+    protoBuilder.setSearchQuery(value);
+  }
+
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements. See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership. The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License. You may obtain a copy of the License at
+   *
+   * http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing,
+   * software distributed under the License is distributed on an
+   * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   * KIND, either express or implied. See the License for the
+   * specific language governing permissions and limitations
+   * under the License.
+   */
+
   /** Get or create a WaveletVersionProtoImpl from a WaveletVersion. */
   private WaveletVersionProtoImpl getOrCreateWaveletVersionProtoImpl(WaveletVersion message) {
     if (message instanceof WaveletVersionProtoImpl) {
@@ -832,6 +899,28 @@ org.waveprotocol.wave.communication.proto.ProtoWrapper<org.waveprotocol.box.comm
     if (hasViewportLimit()) {
       json.add("7", new JsonPrimitive(getViewportLimit()));
     }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (hasSearchQuery()) {
+      json.add("8", new JsonPrimitive(getSearchQuery()));
+    }
     return json;
   }
 
@@ -1019,6 +1108,31 @@ org.waveprotocol.wave.communication.proto.ProtoWrapper<org.waveprotocol.box.comm
       JsonElement elem = jsonObject.get("7");
       if (!elem.isJsonNull()) {
         setViewportLimit(elem.getAsInt());
+      }
+    }
+
+    /**
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements. See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership. The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License. You may obtain a copy of the License at
+     *
+     * http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing,
+     * software distributed under the License is distributed on an
+     * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     * KIND, either express or implied. See the License for the
+     * specific language governing permissions and limitations
+     * under the License.
+     */
+    if (jsonObject.has("8")) {
+      JsonElement elem = jsonObject.get("8");
+      if (!elem.isJsonNull()) {
+        setSearchQuery(elem.getAsString());
       }
     }
   }

--- a/journal/local-verification/2026-04-13-issue-874-ot-search-bootstrap-pr-remediation.md
+++ b/journal/local-verification/2026-04-13-issue-874-ot-search-bootstrap-pr-remediation.md
@@ -11,6 +11,8 @@ Verification:
   - Result: `changelog validation passed`
 - `sbt compile && sbt test`
   - Result: passed (`Total 2271, Failed 0, Errors 0, Passed 2271`)
+- `sbt --batch Universal/stage`
+  - Result: passed
 
 Review remediation summary:
 - Reject OT search bootstrap opens when the supplied `waveId` does not match the computed synthetic search wave for the query.

--- a/journal/local-verification/2026-04-13-issue-874-ot-search-bootstrap-pr-remediation.md
+++ b/journal/local-verification/2026-04-13-issue-874-ot-search-bootstrap-pr-remediation.md
@@ -1,0 +1,19 @@
+Worktree: /Users/vega/devroot/worktrees/vega113-incubator-wave-pr-874-monitor
+Branch: monitor/vega113-incubator-wave/pr-874
+PR: https://github.com/vega113/supawave/pull/874
+
+Verification:
+- `sbt 'testOnly org.waveprotocol.box.server.frontend.WaveClientRpcImplTest org.waveprotocol.box.search.SearchPresenterLoadingStateTest org.waveprotocol.box.webclient.search.SearchPresenterTest'`
+  - Result: passed
+- `python3 scripts/assemble-changelog.py`
+  - Result: `assembled 173 entries -> wave/config/changelog.json`
+- `python3 scripts/validate-changelog.py`
+  - Result: `changelog validation passed`
+- `sbt compile && sbt test`
+  - Result: passed (`Total 2271, Failed 0, Errors 0, Passed 2271`)
+
+Review remediation summary:
+- Reject OT search bootstrap opens when the supplied `waveId` does not match the computed synthetic search wave for the query.
+- Preserve search results after OT bootstrap failure only when they belong to the current query; clear stale results from previous queries.
+- Remove the dead `otSearchFallbackEnabled` parameter from `SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(...)`.
+- Revalidated the generated changelog workflow with assemble + validate instead of removing the assembled file, which this repo expects to be regenerated.

--- a/wave/config/changelog.d/2026-04-13-search-bootstrap-safety.json
+++ b/wave/config/changelog.d/2026-04-13-search-bootstrap-safety.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-search-bootstrap-safety",
+  "version": "Unreleased",
+  "date": "2026-04-13",
+  "title": "OT search protocol bootstrap",
+  "summary": "OT search subscriptions now carry the raw query to the server and receive their first snapshot on the OT channel itself, removing the old dependency on an HTTP `/search` bootstrap.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Search wavelet open requests now include the raw search query so the server can compute and publish the initial live-search snapshot immediately",
+        "OT search cold-start no longer depends on a side-effect from the legacy `/search` servlet before the sidebar can populate"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-04-13-search-bootstrap-safety",
+    "version": "Unreleased",
+    "date": "2026-04-13",
+    "title": "OT search protocol bootstrap",
+    "summary": "OT search subscriptions now carry the raw query to the server and receive their first snapshot on the OT channel itself, removing the old dependency on an HTTP `/search` bootstrap.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Search wavelet open requests now include the raw search query so the server can compute and publish the initial live-search snapshot immediately",
+          "OT search cold-start no longer depends on a side-effect from the legacy `/search` servlet before the sidebar can populate"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-same-name-index-upgrade-conflicts",
     "version": "PR #871",
     "date": "2026-04-13",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -51,6 +51,7 @@ import org.waveprotocol.box.server.waveserver.*;
 import org.waveprotocol.box.server.waveserver.ReindexService;
 import org.waveprotocol.box.server.waveserver.search.SearchWaveletSnapshotPublisher;
 import org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImpl;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
 import org.waveprotocol.wave.crypto.CertPathStore;
 import org.waveprotocol.wave.federation.FederationTransport;
 import org.waveprotocol.wave.federation.noop.NoOpFederationModule;
@@ -466,7 +467,7 @@ public class ServerMain {
             injector.getInstance(SearchProvider.class),
             injector.getInstance(SearchWaveletSnapshotPublisher.class));
     org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.Interface rpcImpl =
-        WaveClientRpcImpl.create(frontend, false);
+        WaveClientRpcImpl.create(frontend, false, injector.getInstance(SearchWaveletManager.class));
     server.registerService(org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.newReflectiveService(rpcImpl));
     new StaleAnnotationSweeper(provider).start();
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -49,6 +49,7 @@ import org.waveprotocol.box.server.shutdown.ShutdownPriority;
 import org.waveprotocol.box.server.shutdown.Shutdownable;
 import org.waveprotocol.box.server.waveserver.*;
 import org.waveprotocol.box.server.waveserver.ReindexService;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletSnapshotPublisher;
 import org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImpl;
 import org.waveprotocol.wave.crypto.CertPathStore;
 import org.waveprotocol.wave.federation.FederationTransport;
@@ -457,7 +458,13 @@ public class ServerMain {
     WaveletProvider provider = injector.getInstance(WaveletProvider.class);
     WaveletInfo waveletInfo = WaveletInfo.create(hashFactory, provider);
     injector.getInstance(SearchWaveletDispatcher.class).initialize(waveletInfo);
-    ClientFrontend frontend = ClientFrontendImpl.create(provider, waveBus, waveletInfo);
+    ClientFrontend frontend =
+        ClientFrontendImpl.create(
+            provider,
+            waveBus,
+            waveletInfo,
+            injector.getInstance(SearchProvider.class),
+            injector.getInstance(SearchWaveletSnapshotPublisher.class));
     org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.Interface rpcImpl =
         WaveClientRpcImpl.create(frontend, false);
     server.registerService(org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.newReflectiveService(rpcImpl));

--- a/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
+++ b/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
@@ -40,7 +40,7 @@ public final class SearchBootstrapUiState {
 
   public static boolean shouldBootstrapViaHttpWhenOtStarts(
       boolean otSearchEnabled, boolean otSearchFallbackEnabled) {
-    return !otSearchEnabled || otSearchFallbackEnabled;
+    return !otSearchEnabled;
   }
 
   public static boolean shouldUseHttpSearchForWindowRequest(

--- a/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
+++ b/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
@@ -38,8 +38,7 @@ public final class SearchBootstrapUiState {
     return otSearchEnabled && !useOtSearch && !otSearchTimedOut;
   }
 
-  public static boolean shouldBootstrapViaHttpWhenOtStarts(
-      boolean otSearchEnabled, boolean otSearchFallbackEnabled) {
+  public static boolean shouldBootstrapViaHttpWhenOtStarts(boolean otSearchEnabled) {
     return !otSearchEnabled;
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontend.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontend.java
@@ -89,6 +89,17 @@ public interface ClientFrontend {
    *        knows
    * @param openListener callback for updates.
    */
+  default void openRequest(ParticipantId loggedInUser, WaveId waveId, IdFilter waveletIdFilter,
+      Collection<WaveClientRpc.WaveletVersion> knownWavelets, OpenListener openListener) {
+    openRequest(loggedInUser, waveId, waveletIdFilter, knownWavelets, null, openListener);
+  }
+
+  /**
+   * Request to open a wave or virtual search subscription. {@code searchQuery}
+   * is populated only for OT search wavelet subscriptions so the server can
+   * bootstrap the initial snapshot during the open flow itself.
+   */
   void openRequest(ParticipantId loggedInUser, WaveId waveId, IdFilter waveletIdFilter,
-      Collection<WaveClientRpc.WaveletVersion> knownWavelets, OpenListener openListener);
+      Collection<WaveClientRpc.WaveletVersion> knownWavelets, @Nullable String searchQuery,
+      OpenListener openListener);
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
@@ -21,14 +21,17 @@ package org.waveprotocol.box.server.frontend;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import com.google.wave.api.SearchResult;
 
 import org.waveprotocol.box.common.DeltaSequence;
 import org.waveprotocol.box.common.comms.WaveClientRpc;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
+import org.waveprotocol.box.server.waveserver.SearchProvider;
 import org.waveprotocol.box.server.waveserver.WaveBus;
 import org.waveprotocol.box.server.waveserver.WaveServerException;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletSnapshotPublisher;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.model.id.IdFilter;
 import org.waveprotocol.wave.model.id.IdUtil;
@@ -48,6 +51,8 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.Nullable;
+
 
 /**
  * Implements {@link ClientFrontend}.
@@ -62,6 +67,8 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
 
   private final WaveletProvider waveletProvider;
   private final WaveletInfo waveletInfo;
+  @Nullable private final SearchProvider searchProvider;
+  @Nullable private final SearchWaveletSnapshotPublisher searchSnapshotPublisher;
 
   /**
    * Creates a client frontend and subscribes it to the wave bus.
@@ -70,9 +77,21 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
    */
   public static ClientFrontendImpl create(WaveletProvider waveletProvider, WaveBus wavebus,
       WaveletInfo waveletInfo) throws WaveServerException {
+    return create(waveletProvider, wavebus, waveletInfo, null, null);
+  }
+
+  /**
+   * Creates a client frontend with optional search bootstrap services and subscribes it to the
+   * wave bus.
+   */
+  public static ClientFrontendImpl create(WaveletProvider waveletProvider, WaveBus wavebus,
+      WaveletInfo waveletInfo, @Nullable SearchProvider searchProvider,
+      @Nullable SearchWaveletSnapshotPublisher searchSnapshotPublisher)
+      throws WaveServerException {
 
     ClientFrontendImpl impl =
-        new ClientFrontendImpl(waveletProvider, waveletInfo);
+        new ClientFrontendImpl(
+            waveletProvider, waveletInfo, searchProvider, searchSnapshotPublisher);
 
     wavebus.subscribe(impl);
     return impl;
@@ -87,13 +106,24 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
   @VisibleForTesting
   ClientFrontendImpl(
       WaveletProvider waveletProvider, WaveletInfo waveletInfo) {
+    this(waveletProvider, waveletInfo, null, null);
+  }
+
+  @VisibleForTesting
+  ClientFrontendImpl(
+      WaveletProvider waveletProvider, WaveletInfo waveletInfo,
+      @Nullable SearchProvider searchProvider,
+      @Nullable SearchWaveletSnapshotPublisher searchSnapshotPublisher) {
     this.waveletProvider = waveletProvider;
     this.waveletInfo = waveletInfo;
+    this.searchProvider = searchProvider;
+    this.searchSnapshotPublisher = searchSnapshotPublisher;
   }
 
   @Override
   public void openRequest(ParticipantId loggedInUser, WaveId waveId, IdFilter waveletIdFilter,
-      Collection<WaveClientRpc.WaveletVersion> knownWavelets, OpenListener openListener) {
+      Collection<WaveClientRpc.WaveletVersion> knownWavelets, @Nullable String searchQuery,
+      OpenListener openListener) {
     LOG.info("received openRequest from " + loggedInUser + " for " + waveId + ", filter "
         + waveletIdFilter + ", known wavelets: " + knownWavelets);
 
@@ -122,6 +152,18 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
     WaveViewSubscription subscription =
         userManager.subscribe(waveId, waveletIdFilter, channelId, openListener);
     LOG.info("Subscribed " + loggedInUser + " to " + waveId + " channel " + channelId);
+
+    if (searchQuery != null && !searchQuery.isEmpty()
+        && searchProvider != null && searchSnapshotPublisher != null) {
+      if (!bootstrapSearchSubscription(
+          loggedInUser, searchQuery, userManager, subscription, openListener)) {
+        return;
+      }
+      WaveletName dummyWaveletName = createDummyWaveletName(waveId);
+      LOG.fine("sending marker for " + dummyWaveletName);
+      openListener.onUpdate(dummyWaveletName, null, DeltaSequence.empty(), null, true, null);
+      return;
+    }
 
     Set<WaveletId> waveletIds;
     try {
@@ -179,6 +221,34 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
     }
     LOG.fine("sending marker for " + dummyWaveletName);
     openListener.onUpdate(dummyWaveletName, null, DeltaSequence.empty(), null, true, null);
+  }
+
+  private boolean bootstrapSearchSubscription(ParticipantId loggedInUser, String searchQuery,
+      UserManager userManager, WaveViewSubscription subscription, OpenListener openListener) {
+    try {
+      if (!searchSnapshotPublisher.hasLiveSubscription(loggedInUser, searchQuery)) {
+        throw new IllegalStateException(
+            "Search subscription was not registered for query '" + searchQuery + "'");
+      }
+      SearchResult searchResult =
+          searchProvider.search(
+              loggedInUser,
+              searchQuery,
+              0,
+              SearchWaveletSnapshotPublisher.LIVE_SEARCH_NUM_RESULTS);
+      if (searchResult == null) {
+        searchResult = new SearchResult(searchQuery);
+        searchResult.setTotalResults(0);
+      }
+      searchSnapshotPublisher.publishBootstrap(loggedInUser, searchQuery, searchResult);
+      return true;
+    } catch (RuntimeException e) {
+      LOG.warning("Failed to bootstrap OT search subscription for " + loggedInUser
+          + " query '" + searchQuery + "'", e);
+      userManager.unsubscribe(subscription);
+      openListener.onFailure("Failed to bootstrap search subscription for query '" + searchQuery + "'");
+      return false;
+    }
   }
 
   private String generateChannelID() {

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -33,6 +33,7 @@ import org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveletUpdate;
 import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
 import org.waveprotocol.box.server.common.SnapshotSerializer;
 import org.waveprotocol.box.server.rpc.ServerRpcController;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
 import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
 import org.waveprotocol.wave.concurrencycontrol.channel.dto.FragmentsPayload;
 import org.waveprotocol.wave.model.id.SegmentId;
@@ -52,7 +53,6 @@ import org.slf4j.MDC;
 
 import java.util.Collections;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -87,6 +87,7 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   private final ClientFrontend frontend;
   private final boolean handleAuthentication;
+  @Nullable private final SearchWaveletManager searchWaveletManager;
 
   // Optional: fragments handler to emit ProtocolFragments in updates
   private static volatile FragmentsViewChannelHandler fragmentsHandler;
@@ -110,12 +111,23 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
    */
   public static WaveClientRpcImpl create(ClientFrontend frontend,
       boolean handleAuthentication) {
-    return new WaveClientRpcImpl(frontend, handleAuthentication);
+    return create(frontend, handleAuthentication, null);
   }
 
-  private WaveClientRpcImpl(ClientFrontend frontend, boolean handleAuthentication) {
+  public static WaveClientRpcImpl create(
+      ClientFrontend frontend,
+      boolean handleAuthentication,
+      @Nullable SearchWaveletManager searchWaveletManager) {
+    return new WaveClientRpcImpl(frontend, handleAuthentication, searchWaveletManager);
+  }
+
+  private WaveClientRpcImpl(
+      ClientFrontend frontend,
+      boolean handleAuthentication,
+      @Nullable SearchWaveletManager searchWaveletManager) {
     this.frontend = frontend;
     this.handleAuthentication = handleAuthentication;
+    this.searchWaveletManager = searchWaveletManager;
   }
 
   @Override
@@ -138,12 +150,16 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       MDC.put("participantId", loggedInUser.getAddress());
     }
     try {
+      String searchQuery = request.hasSearchQuery() ? request.getSearchQuery() : null;
+      if (!validateSearchOpenRequest(controller, loggedInUser, waveId, searchQuery)) {
+        return;
+      }
       frontend.openRequest(
           loggedInUser,
           waveId,
           waveletIdFilter,
           request.getKnownWaveletList(),
-          request.hasSearchQuery() ? request.getSearchQuery() : null,
+          searchQuery,
           new ClientFrontend.OpenListener() {
           @Override
           public void onFailure(String errorMessage) {
@@ -279,6 +295,26 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       MDC.remove("waveId");
       MDC.remove("participantId");
     }
+  }
+
+  private boolean validateSearchOpenRequest(
+      RpcController controller,
+      @Nullable ParticipantId loggedInUser,
+      WaveId waveId,
+      @Nullable String searchQuery) {
+    if (searchQuery == null || searchQuery.isEmpty() || searchWaveletManager == null
+        || loggedInUser == null) {
+      return true;
+    }
+    WaveletName expectedSearchWaveletName =
+        searchWaveletManager.computeWaveletName(loggedInUser, searchQuery);
+    if (expectedSearchWaveletName.waveId.equals(waveId)) {
+      return true;
+    }
+    LOG.warning("Rejecting search open for " + waveId + " query '" + searchQuery
+        + "' expected " + expectedSearchWaveletName.waveId);
+    controller.setFailed("Invalid search query for target wave");
+    return false;
   }
 
   /** Returns true if the wavelet id represents a synthetic open/marker wavelet. */

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -138,8 +138,13 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       MDC.put("participantId", loggedInUser.getAddress());
     }
     try {
-    frontend.openRequest(loggedInUser, waveId, waveletIdFilter, request.getKnownWaveletList(),
-        new ClientFrontend.OpenListener() {
+      frontend.openRequest(
+          loggedInUser,
+          waveId,
+          waveletIdFilter,
+          request.getKnownWaveletList(),
+          request.hasSearchQuery() ? request.getSearchQuery() : null,
+          new ClientFrontend.OpenListener() {
           @Override
           public void onFailure(String errorMessage) {
             LOG.warning("openRequest failure: " + errorMessage);

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeClientFrontend.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeClientFrontend.java
@@ -41,6 +41,8 @@ import java.util.Map;
   * receives wavelet listener events.
   */
 public class FakeClientFrontend implements ClientFrontend, WaveBus.Subscriber {
+  public String lastSearchQuery;
+
   private static class SubmitRecord {
     final SubmitRequestListener listener;
     final int operations;
@@ -86,7 +88,9 @@ public class FakeClientFrontend implements ClientFrontend, WaveBus.Subscriber {
 
   @Override
   public void openRequest(ParticipantId participant, WaveId waveId, IdFilter waveletIdFilter,
-      Collection<WaveClientRpc.WaveletVersion> knownWavelets, OpenListener openListener) {
+      Collection<WaveClientRpc.WaveletVersion> knownWavelets, String searchQuery,
+      OpenListener openListener) {
+    lastSearchQuery = searchQuery;
     openListeners.put(waveId, openListener);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeWaveServer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeWaveServer.java
@@ -70,14 +70,15 @@ public class FakeWaveServer extends FakeClientFrontend {
 
   @Override
   public void openRequest(ParticipantId participant, WaveId waveId, IdFilter waveletIdFilter,
-      Collection<WaveClientRpc.WaveletVersion> knownWavelets, OpenListener openListener) {
+      Collection<WaveClientRpc.WaveletVersion> knownWavelets, @Nullable String searchQuery,
+      OpenListener openListener) {
     if (user == null) {
       user = participant;
     } else {
       Preconditions.checkArgument(participant.equals(user), "Unexpected user");
     }
 
-    super.openRequest(participant, waveId, waveletIdFilter, knownWavelets, openListener);
+    super.openRequest(participant, waveId, waveletIdFilter, knownWavelets, searchQuery, openListener);
 
     Map<WaveletId, WaveletData> wavelets = waves.get(waveId);
     if (wavelets != null) {

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java
@@ -159,6 +159,28 @@ public final class RemoteViewServiceMultiplexer implements WaveWebSocketCallback
   }
 
   /**
+   * Opens a virtual search wavelet subscription. The raw query is sent
+   * alongside the open request so the server can bootstrap the initial search
+   * snapshot directly on the OT channel.
+   */
+  public void openSearch(WaveId id, IdFilter filter, String searchQuery,
+      WaveWebSocketCallback stream) {
+    registerStream(id, stream);
+
+    ProtocolOpenRequestJsoImpl request = ProtocolOpenRequestJsoImpl.create();
+    request.setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(id));
+    request.setParticipantId(userId);
+    request.setSearchQuery(searchQuery);
+    for (String prefix : filter.getPrefixes()) {
+      request.addWaveletIdPrefix(prefix);
+    }
+    for (WaveletId wid : filter.getIds()) {
+      request.addWaveletIdPrefix(wid.getId());
+    }
+    socket.open(request);
+  }
+
+  /**
    * Opens a wave stream with optional viewport hints for server-side fragments.
    *
    * Parameter semantics and edge cases:

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -1389,7 +1389,10 @@ public final class SearchPresenter
       otSearchWaveletName = computeSearchWaveletName(Session.get().getAddress(), query);
       useOtSearch = false;
       Collection<WaveletId> ids = Collections.singleton(otSearchWaveletName.waveletId);
-      channel.open(otSearchWaveletName.waveId, IdFilter.of(ids, Collections.<String>emptyList()),
+      channel.openSearch(
+          otSearchWaveletName.waveId,
+          IdFilter.of(ids, Collections.<String>emptyList()),
+          query,
           otSearchUpdateHandler);
       // Schedule a timeout: if no data arrives, fall back to polling.
       scheduler.scheduleDelayed(otSearchTimeoutTask, OT_SEARCH_TIMEOUT_MS);
@@ -1558,12 +1561,18 @@ public final class SearchPresenter
     otSearchReceivedData = false;
     scheduler.cancel(otSearchTimeoutTask);
     scheduler.cancel(searchUpdater);
-    clearSearchResultsAfterOtFailure();
+    if (!hasReadySearchResults()) {
+      clearSearchResultsAfterOtFailure();
+    }
     render();
   }
 
   private boolean isHttpPollingActiveForCurrentQuery() {
     return !useOtSearch && otSearchWaveletName == null && scheduler.isScheduled(searchUpdater);
+  }
+
+  private boolean hasReadySearchResults() {
+    return search.getState() == State.READY;
   }
 
   private void clearSearchResultsAfterOtFailure() {

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -1486,7 +1486,7 @@ public final class SearchPresenter
     for (int i = 0; i < visible; i++) {
       digests.add(otSearchSnapshot.getDigests().get(i));
     }
-    ((SimpleSearch) search).replaceResults(otSearchSnapshot.getTotal(), digests);
+    ((SimpleSearch) search).replaceResults(queryText, otSearchSnapshot.getTotal(), digests);
   }
 
   private static boolean canProjectOtSearchWindow(int requestedSize, OtSearchSnapshot snapshot) {
@@ -1561,7 +1561,7 @@ public final class SearchPresenter
     otSearchReceivedData = false;
     scheduler.cancel(otSearchTimeoutTask);
     scheduler.cancel(searchUpdater);
-    if (!hasReadySearchResults()) {
+    if (!hasResultsForCurrentQuery()) {
       clearSearchResultsAfterOtFailure();
     }
     render();
@@ -1571,14 +1571,16 @@ public final class SearchPresenter
     return !useOtSearch && otSearchWaveletName == null && scheduler.isScheduled(searchUpdater);
   }
 
-  private boolean hasReadySearchResults() {
-    return search.getState() == State.READY;
+  private boolean hasResultsForCurrentQuery() {
+    return search instanceof SimpleSearch
+        && ((SimpleSearch) search).hasResultsForQuery(queryText);
   }
 
   private void clearSearchResultsAfterOtFailure() {
     querySize = getPageSize();
     if (search instanceof SimpleSearch) {
-      ((SimpleSearch) search).replaceResults(0, Collections.<SearchService.DigestSnapshot>emptyList());
+      ((SimpleSearch) search).replaceResults(
+          queryText, 0, Collections.<SearchService.DigestSnapshot>emptyList());
     } else {
       search.cancel();
     }

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -447,8 +447,7 @@ public final class SearchPresenter
       return;
     }
     subscribeToSearchWavelet(queryText);
-    if (SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(
-        otSearchEnabled, otSearchFallbackEnabled)) {
+    if (SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(otSearchEnabled)) {
       doSearch();
     }
     // Do NOT start the repeating poll here. OT handles live updates. If fallback is enabled,

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SimpleSearch.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SimpleSearch.java
@@ -282,6 +282,7 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
     digests.clear();
     results.clear();
     total = 0;
+    resultQuery = null;
   }
 
   @Override
@@ -309,7 +310,7 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
         if (outstanding == this) {
           outstanding = null;
           previousRequest = null;
-          handleSuccess(total, 0, snapshots);
+          handleSuccess(query, total, 0, snapshots);
         }
       }
     };
@@ -330,9 +331,17 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
   }
 
   void replaceResults(int total, List<DigestSnapshot> snapshots) {
+    replaceResults(previousQuery, total, snapshots);
+  }
+
+  void replaceResults(String query, int total, List<DigestSnapshot> snapshots) {
     outstanding = null;
     previousRequest = null;
-    handleSuccess(total, 0, snapshots);
+    handleSuccess(query, total, 0, snapshots);
+  }
+
+  boolean hasResultsForQuery(String query) {
+    return query != null && query.equals(resultQuery);
   }
 
   /**
@@ -347,7 +356,8 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
   /**
    * Copies the digest snapshots into this search result's state.
    */
-  private void handleSuccess(int total, int from, List<DigestSnapshot> newDigests) {
+  private void handleSuccess(String query, int total, int from, List<DigestSnapshot> newDigests) {
+    resultQuery = query;
     if (SearchResultUpdate.isVacuousRefresh(
         this.total,
         results,
@@ -433,6 +443,8 @@ public final class SimpleSearch implements Search, WaveStore.Listener {
   private static String digestId(WaveId waveId) {
     return ModernIdSerialiser.INSTANCE.serialiseWaveId(waveId);
   }
+
+  private String resultQuery;
 
   /**
    * Ensures that the result list is at least a certain size.

--- a/wave/src/proto/proto/org/waveprotocol/box/common/comms/waveclient-rpc.proto
+++ b/wave/src/proto/proto/org/waveprotocol/box/common/comms/waveclient-rpc.proto
@@ -93,6 +93,10 @@ message ProtocolOpenRequest {
   optional string viewport_start_blip_id = 5;
   optional string viewport_direction = 6; // "forward" (default) or "backward"
   optional int32 viewport_limit = 7;      // max blip segments to include (default 5)
+  // Raw search query for virtual OT search wavelet subscriptions.
+  // Present only when opening a search wavelet so the server can bootstrap the
+  // initial snapshot without depending on an out-of-band HTTP /search request.
+  optional string search_query = 8;
 }
 
 // A pair of (wavelet id, wavelet version)

--- a/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
@@ -40,9 +40,8 @@ public final class SearchPresenterLoadingStateTest extends TestCase {
   }
 
   public void testOtBootstrapUsesOtChannelWhenEnabled() {
-    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, false));
-    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, true));
-    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(false, false));
+    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true));
+    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(false));
   }
 
   public void testShowMoreHttpFallbackRequiresExplicitFlagWhenOtNotReady() {

--- a/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
@@ -39,9 +39,9 @@ public final class SearchPresenterLoadingStateTest extends TestCase {
     assertFalse(SearchBootstrapUiState.shouldRetryOtSubscriptionOnReconnect(false, false, false));
   }
 
-  public void testOtBootstrapHttpFallbackRequiresExplicitFlag() {
+  public void testOtBootstrapUsesOtChannelWhenEnabled() {
     assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, false));
-    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, true));
+    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true, true));
     assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(false, false));
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/ClientFrontendImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/ClientFrontendImplTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.wave.api.SearchResult;
 
 import junit.framework.TestCase;
 
@@ -47,8 +48,13 @@ import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
 import org.waveprotocol.box.server.frontend.ClientFrontend.OpenListener;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.WaveServerException;
+import org.waveprotocol.box.server.waveserver.SearchProvider;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
+import org.waveprotocol.box.server.waveserver.search.SearchIndexer;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletDataProvider;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletSnapshotPublisher;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.model.id.IdConstants;
 import org.waveprotocol.wave.model.id.IdFilter;
@@ -145,6 +151,47 @@ public class ClientFrontendImplTest extends TestCase {
     OpenListener listener = openWave(IdFilters.ALL_IDS);
     verifyChannelId(listener);
     verifyMarker(listener, WAVE_ID);
+  }
+
+  public void testSearchOpenBootstrapsSnapshotDuringOpen() throws Exception {
+    SearchProvider searchProvider = mock(SearchProvider.class);
+    SearchWaveletManager searchWaveletManager = new SearchWaveletManager();
+    SearchWaveletDispatcher dispatcher = new SearchWaveletDispatcher();
+    dispatcher.initialize(waveletInfo);
+    SearchWaveletSnapshotPublisher snapshotPublisher =
+        new SearchWaveletSnapshotPublisher(
+            dispatcher,
+            searchWaveletManager,
+            new SearchIndexer(),
+            new SearchWaveletDataProvider());
+    clientFrontend =
+        new ClientFrontendImpl(waveletProvider, waveletInfo, searchProvider, snapshotPublisher);
+
+    String query = "mentions:me";
+    WaveletName searchWaveletName = searchWaveletManager.computeWaveletName(USER, query);
+    SearchResult searchResult = createSearchResult(query, "example.com/w+abc", 1);
+    when(searchProvider.search(
+        USER, query, 0, SearchWaveletSnapshotPublisher.LIVE_SEARCH_NUM_RESULTS))
+        .thenReturn(searchResult);
+
+    OpenListener listener = mock(OpenListener.class);
+    IdFilter filter = IdFilter.of(
+        Collections.singleton(searchWaveletName.waveletId),
+        Collections.<String>emptySet());
+
+    clientFrontend.openRequest(
+        USER, searchWaveletName.waveId, filter, NO_KNOWN_WAVELETS, query, listener);
+
+    verify(searchProvider).search(
+        USER, query, 0, SearchWaveletSnapshotPublisher.LIVE_SEARCH_NUM_RESULTS);
+    verify(listener).onUpdate(
+        eq(searchWaveletName),
+        any(CommittedWaveletSnapshot.class),
+        eq(DeltaSequence.empty()),
+        any(HashedVersion.class),
+        isNullMarker(),
+        any(String.class));
+    verifyMarker(listener, searchWaveletName.waveId);
   }
 
   public void testTwoSubscriptionsReceiveDifferentChannelIds() {
@@ -341,6 +388,22 @@ public class ClientFrontendImplTest extends TestCase {
       long timestamp, WaveletOperation... operations) {
     return TransformedWaveletDelta.cloneOperations(author, endVersion, timestamp,
         Arrays.asList(operations));
+  }
+
+  private static SearchResult createSearchResult(String query, String waveId, int totalResults) {
+    SearchResult searchResult = new SearchResult(query);
+    searchResult.setTotalResults(totalResults);
+    searchResult.addDigest(
+        new SearchResult.Digest(
+            "Title",
+            "Snippet",
+            waveId,
+            Collections.singletonList(USER.getAddress()),
+            123L,
+            123L,
+            1,
+            2));
+    return searchResult;
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcFragmentsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcFragmentsTest.java
@@ -163,7 +163,7 @@ public final class WaveClientRpcFragmentsTest {
     // Frontend stub calls listener.onUpdate with no snapshot but with committedVersion
     ClientFrontend frontend = new ClientFrontend() {
       @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
-      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, OpenListener listener) {
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
         WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
         WaveletName wn = WaveletName.of(waveId, wid);
         listener.onUpdate(wn, null, java.util.Collections.emptyList(), HashedVersion.unsigned(5), null, "ch-2");
@@ -200,7 +200,7 @@ public final class WaveClientRpcFragmentsTest {
     private static WaveClientRpcImpl makeWaveClientRpc() {
         ClientFrontend frontend = new ClientFrontend() {
           @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
-          @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, OpenListener listener) {
+          @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
             WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
             WaveletName wn = WaveletName.of(waveId, wid);
             ReadableWaveletData data = new ReadableWaveletDataStub(waveId, wid, HashedVersion.unsigned(9))

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
@@ -35,6 +35,7 @@ import org.waveprotocol.box.server.frontend.testing.FakeClientFrontend;
 import org.waveprotocol.box.server.rpc.testing.FakeServerRpcController;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.util.testing.TestingConstants;
+import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletOperation;
 import org.waveprotocol.wave.model.id.InvalidIdException;
@@ -67,6 +68,7 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
   private int counter = 0;
 
   private FakeClientFrontend frontend;
+  private SearchWaveletManager searchWaveletManager;
 
   private WaveClientRpcImpl rpcImpl;
 
@@ -88,7 +90,8 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
     counter = 0;
     controller = new FakeServerRpcController();
     frontend = new FakeClientFrontend();
-    rpcImpl = WaveClientRpcImpl.create(frontend, false);
+    searchWaveletManager = new SearchWaveletManager();
+    rpcImpl = WaveClientRpcImpl.create(frontend, false, searchWaveletManager);
   }
 
   // TODO(arb): test with channelIds.
@@ -165,9 +168,11 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
   }
 
   public void testOpenForwardsSearchQueryToFrontend() {
+    WaveletName searchWaveletName =
+        searchWaveletManager.computeWaveletName(PARTICIPANT, "mentions:me");
     ProtocolOpenRequest request = ProtocolOpenRequest.newBuilder()
         .setParticipantId(USER)
-        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(WAVE_ID))
+        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(searchWaveletName.waveId))
         .setSearchQuery("mentions:me")
         .build();
 
@@ -179,6 +184,25 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
 
     assertEquals("mentions:me", frontend.lastSearchQuery);
     assertFalse(controller.failed());
+  }
+
+  public void testOpenRejectsMismatchedSearchQueryWaveId() {
+    ProtocolOpenRequest request = ProtocolOpenRequest.newBuilder()
+        .setParticipantId(USER)
+        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(WAVE_ID))
+        .setSearchQuery("mentions:me")
+        .build();
+
+    rpcImpl.open(controller, request, new RpcCallback<ProtocolWaveletUpdate>() {
+      @Override
+      public void run(ProtocolWaveletUpdate update) {
+        fail("Unexpected callback");
+      }
+    });
+
+    assertTrue(controller.failed());
+    assertTrue(controller.errorText().contains("search query"));
+    assertEquals(null, frontend.lastSearchQuery);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
@@ -164,6 +164,23 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
     assertFalse(controller.failed());
   }
 
+  public void testOpenForwardsSearchQueryToFrontend() {
+    ProtocolOpenRequest request = ProtocolOpenRequest.newBuilder()
+        .setParticipantId(USER)
+        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(WAVE_ID))
+        .setSearchQuery("mentions:me")
+        .build();
+
+    rpcImpl.open(controller, request, new RpcCallback<ProtocolWaveletUpdate>() {
+      @Override
+      public void run(ProtocolWaveletUpdate update) {
+      }
+    });
+
+    assertEquals("mentions:me", frontend.lastSearchQuery);
+    assertFalse(controller.failed());
+  }
+
   /**
    * Tests that a failed submit results in the proper submit failure response.
    */

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
@@ -129,7 +129,7 @@ public final class WaveClientRpcViewportHintsTest {
   private static WaveClientRpcImpl makeWaveClientRpc() {
     ClientFrontend frontend = new ClientFrontend() {
       @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
-      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, OpenListener listener) {
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
         WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
         WaveletName wn = WaveletName.of(waveId, wid);
         ReadableWaveletData data = providerDataWithBlips(waveId, wid, 20);

--- a/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/webclient/search/SearchPresenterTest.java
@@ -479,6 +479,36 @@ public final class SearchPresenterTest extends TestCase {
     assertEquals(0, search.findCalls);
   }
 
+  public void testOtFailureClearsStaleResultsFromPreviousQuery() throws Exception {
+    FakeTimerService scheduler = new FakeTimerService();
+    SimpleSearch search = new SimpleSearch(new FakeSearchService(), null);
+    SearchPresenter presenter = new SearchPresenter(
+        scheduler, search, new FakeSearchPanelView(), NO_OP_ACTION_HANDLER, new FakeProfiles(),
+        null);
+
+    search.replaceResults("in:inbox", 1, createDigestSnapshots(1));
+    setField(presenter, "queryText", "tag:work");
+
+    invokeFailOtSearchWithoutFallback(presenter);
+
+    assertEquals(0, search.getTotal());
+  }
+
+  public void testOtFailureKeepsResultsForCurrentQuery() throws Exception {
+    FakeTimerService scheduler = new FakeTimerService();
+    SimpleSearch search = new SimpleSearch(new FakeSearchService(), null);
+    SearchPresenter presenter = new SearchPresenter(
+        scheduler, search, new FakeSearchPanelView(), NO_OP_ACTION_HANDLER, new FakeProfiles(),
+        null);
+
+    search.replaceResults("tag:work", 1, createDigestSnapshots(1));
+    setField(presenter, "queryText", "tag:work");
+
+    invokeFailOtSearchWithoutFallback(presenter);
+
+    assertEquals(1, search.getTotal());
+  }
+
   private static void setBooleanField(SearchPresenter presenter, String fieldName, boolean value)
       throws Exception {
     Field field = SearchPresenter.class.getDeclaredField(fieldName);
@@ -520,6 +550,14 @@ public final class SearchPresenterTest extends TestCase {
         "handleOtSearchNetworkStatus", NetworkStatusEvent.class);
     method.setAccessible(true);
     method.invoke(presenter, new NetworkStatusEvent(status));
+  }
+
+  private static void invokeFailOtSearchWithoutFallback(SearchPresenter presenter)
+      throws Exception {
+    Method method = SearchPresenter.class.getDeclaredMethod(
+        "failOtSearchWithoutFallback", String.class, Throwable.class);
+    method.setAccessible(true);
+    method.invoke(presenter, "test", null);
   }
 
   private static List<SearchService.DigestSnapshot> createDigestSnapshots(int count) {


### PR DESCRIPTION
## Summary
- extend `ProtocolOpenRequest` to carry the raw search query for OT search subscriptions
- bootstrap the initial search snapshot during server-side `openRequest` instead of relying on a separate `/search` side effect
- update the web client OT search path to use the query-aware open flow
- keep generated protocol bindings and frontend test doubles in sync with the new open-request shape
- add a changelog entry for the OT search protocol bootstrap change

## Testing
- `sbt "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcImplTest org.waveprotocol.box.server.frontend.ClientFrontendImplTest org.waveprotocol.box.search.SearchPresenterLoadingStateTest"`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can include raw search queries when opening subscriptions so the server can publish initial live-search snapshots over the primary protocol channel.

* **Bug Fixes**
  * OT search bootstrap now uses the OT channel (no HTTP-side bootstrap); mismatched query/wave opens are rejected and stale results are cleared.

* **Tests**
  * New and updated tests for search query forwarding, OT bootstrap behavior, and failure handling.

* **Documentation**
  * Changelog and local verification guidance updated for the OT search bootstrap change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->