### PR TITLE
Add Mongock startup migrations with Mongo-backed provider gating

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -262,6 +262,8 @@ libraryDependencies ++= Seq(
   "javax.jdo"                      % "jdo2-api"                   % "2.1",
   "org.mongodb"                    % "mongo-java-driver"          % "2.11.2" % Provided,  // compile-only; excluded from runtime (Gradle runtimeClasspath.exclude)
   "org.mongodb"                    % "mongodb-driver-sync"        % MongoV4,
+  "io.mongock"                     % "mongock-standalone"         % "5.5.1",
+  "io.mongock"                     % "mongodb-sync-v4-driver"     % "5.5.1",
 
   // --- Cache ---
   "com.github.ben-manes.caffeine"  % "caffeine"                   % "3.1.8",

--- a/wave/config/changelog.d/2026-04-13-mongock-provider-gating.json
+++ b/wave/config/changelog.d/2026-04-13-mongock-provider-gating.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-mongock-provider-gating",
+  "version": "Unreleased",
+  "date": "2026-04-13",
+  "title": "Gate Mongock startup migrations to Mongo-backed persistence",
+  "summary": "Wave startup now runs Mongock migrations only when the active core persistence path is MongoDB on the v4 driver, avoiding unnecessary migration startup work for file- or memory-backed deployments.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Mongo-backed v4 deployments now run the startup migration runner exactly once during persistence wiring",
+        "File- and memory-backed deployments skip Mongock entirely even if Mongo connection settings are present in the config"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
+    "version": "Unreleased",
+    "date": "2026-04-13",
+    "title": "Wrap pinned saved searches onto another toolbar row",
+    "summary": "Pinned saved-search buttons in the search panel now wrap onto additional toolbar rows instead of forcing horizontal scrolling, and the search results panel follows the toolbar's rendered height.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Pinned saved searches in the search panel now remain visible by wrapping onto another toolbar row when space runs out",
+          "The search panel keeps its wave-count bar and result list aligned below the real wrapped toolbar height instead of overlapping the extra row"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-search-bootstrap-safety",
     "version": "Unreleased",
     "date": "2026-04-13",
@@ -26,6 +42,37 @@
         "type": "fix",
         "items": [
           "Mongo delta-store startup now upgrades legacy applied-version indexes when Mongo reports same-name key-spec conflicts, instead of refusing new delta writes until restart"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-next-unread-icon",
+    "version": "Unreleased",
+    "date": "2026-04-13",
+    "title": "Clarify the Next Unread toolbar icon",
+    "summary": "The wave toolbar now uses a directional chevron plus unread-accent dot for Next Unread instead of a bell, making the action easier to recognize at a glance.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Replaced the Next Unread bell glyph with a clearer directional chevron and unread-colored dot in the wave toolbar"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-mongock-provider-gating",
+    "version": "Unreleased",
+    "date": "2026-04-13",
+    "title": "Gate Mongock startup migrations to Mongo-backed persistence",
+    "summary": "Wave startup now runs Mongock migrations only when the active core persistence path is MongoDB on the v4 driver, avoiding unnecessary migration startup work for file- or memory-backed deployments.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Mongo-backed v4 deployments now run the startup migration runner exactly once during persistence wiring",
+          "File- and memory-backed deployments skip Mongock entirely even if Mongo connection settings are present in the config"
         ]
       }
     ]

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/MongoMigrationRunnerJakartaTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/MongoMigrationRunnerJakartaTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import junit.framework.TestCase;
+
+public final class MongoMigrationRunnerJakartaTest extends TestCase {
+
+  public void testRunsMigrationsForMongoBackedV4Config() {
+    RecordingMongoMigrationRunnerFactory factory = new RecordingMongoMigrationRunnerFactory();
+    PersistenceModule module = new PersistenceModule(mongoBackedConfig(), factory);
+
+    module.runMongoMigrationsIfNeeded();
+
+    assertEquals(1, factory.createCalls);
+    assertEquals(1, factory.runner.runCalls);
+  }
+
+  public void testSkipsMigrationsForFileBackedConfigEvenWhenMongoDriverIsV4() {
+    RecordingMongoMigrationRunnerFactory factory = new RecordingMongoMigrationRunnerFactory();
+    PersistenceModule module = new PersistenceModule(fileBackedConfigWithMongoDriverV4(), factory);
+
+    module.runMongoMigrationsIfNeeded();
+
+    assertEquals(0, factory.createCalls);
+    assertEquals(0, factory.runner.runCalls);
+  }
+
+  public void testRunsMigrationsOnlyOncePerModuleInstance() {
+    RecordingMongoMigrationRunnerFactory factory = new RecordingMongoMigrationRunnerFactory();
+    PersistenceModule module = new PersistenceModule(mongoBackedConfig(), factory);
+
+    module.runMongoMigrationsIfNeeded();
+    module.runMongoMigrationsIfNeeded();
+
+    assertEquals(1, factory.createCalls);
+    assertEquals(1, factory.runner.runCalls);
+  }
+
+  private static Config mongoBackedConfig() {
+    return ConfigFactory.parseString(
+        "core {\n"
+            + "  signer_info_store_type = \"mongodb\"\n"
+            + "  attachment_store_type = \"mongodb\"\n"
+            + "  account_store_type = \"mongodb\"\n"
+            + "  contact_store_type = \"mongodb\"\n"
+            + "  delta_store_type = \"mongodb\"\n"
+            + "  mongodb_host = \"mongo\"\n"
+            + "  mongodb_port = 27017\n"
+            + "  mongodb_database = \"wiab\"\n"
+            + "  mongodb_driver = \"v4\"\n"
+            + "}\n");
+  }
+
+  private static Config fileBackedConfigWithMongoDriverV4() {
+    return ConfigFactory.parseString(
+        "core {\n"
+            + "  signer_info_store_type = \"file\"\n"
+            + "  attachment_store_type = \"disk\"\n"
+            + "  account_store_type = \"file\"\n"
+            + "  contact_store_type = \"memory\"\n"
+            + "  delta_store_type = \"file\"\n"
+            + "  mongodb_host = \"mongo\"\n"
+            + "  mongodb_port = 27017\n"
+            + "  mongodb_database = \"wiab\"\n"
+            + "  mongodb_driver = \"v4\"\n"
+            + "}\n");
+  }
+
+  private static final class RecordingMongoMigrationRunnerFactory
+      implements MongoMigrationRunnerFactory {
+    private int createCalls;
+    private final RecordingMongoMigrationRunner runner = new RecordingMongoMigrationRunner();
+
+    @Override
+    public MongoMigrationRunner create(MongoMigrationConfig config) {
+      createCalls++;
+      return runner;
+    }
+  }
+
+  private static final class RecordingMongoMigrationRunner implements MongoMigrationRunner {
+    private int runCalls;
+
+    @Override
+    public void run() {
+      runCalls++;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
@@ -123,6 +123,10 @@ public final class MongoMigrationConfig {
     return isMongoStoreType(contactStoreType);
   }
 
+  public boolean usesMongoContactMessageStore() {
+    return isMongoStoreType(accountStoreType) && isMongoV4Driver();
+  }
+
   public boolean usesMongoAnalyticsCounters() {
     return analyticsCountersEnabled && isMongoStoreType(accountStoreType) && isMongoV4Driver();
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence;
+
+/**
+ * Effective Mongo migration input derived from the Wave persistence config.
+ */
+public final class MongoMigrationConfig {
+
+  private final String signerInfoStoreType;
+  private final String attachmentStoreType;
+  private final String accountStoreType;
+  private final String deltaStoreType;
+  private final String contactStoreType;
+  private final String host;
+  private final String port;
+  private final String database;
+  private final String username;
+  private final String password;
+  private final String mongoDriver;
+  private final boolean analyticsCountersEnabled;
+
+  public MongoMigrationConfig(String signerInfoStoreType, String attachmentStoreType,
+      String accountStoreType, String deltaStoreType, String contactStoreType, String host,
+      String port, String database, String username, String password, String mongoDriver,
+      boolean analyticsCountersEnabled) {
+    this.signerInfoStoreType = signerInfoStoreType;
+    this.attachmentStoreType = attachmentStoreType;
+    this.accountStoreType = accountStoreType;
+    this.deltaStoreType = deltaStoreType;
+    this.contactStoreType = contactStoreType;
+    this.host = host;
+    this.port = port;
+    this.database = database;
+    this.username = username;
+    this.password = password;
+    this.mongoDriver = mongoDriver;
+    this.analyticsCountersEnabled = analyticsCountersEnabled;
+  }
+
+  public String getSignerInfoStoreType() {
+    return signerInfoStoreType;
+  }
+
+  public String getAttachmentStoreType() {
+    return attachmentStoreType;
+  }
+
+  public String getAccountStoreType() {
+    return accountStoreType;
+  }
+
+  public String getDeltaStoreType() {
+    return deltaStoreType;
+  }
+
+  public String getContactStoreType() {
+    return contactStoreType;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public String getPort() {
+    return port;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getMongoDriver() {
+    return mongoDriver;
+  }
+
+  public boolean isAnalyticsCountersEnabled() {
+    return analyticsCountersEnabled;
+  }
+
+  public boolean isMongoV4Driver() {
+    return "v4".equalsIgnoreCase(mongoDriver);
+  }
+
+  public boolean usesMongoBackedCoreStore() {
+    return isMongoStoreType(signerInfoStoreType)
+        || isMongoStoreType(attachmentStoreType)
+        || isMongoStoreType(accountStoreType)
+        || isMongoStoreType(deltaStoreType)
+        || isMongoStoreType(contactStoreType);
+  }
+
+  public boolean usesMongoDeltaStore() {
+    return isMongoStoreType(deltaStoreType);
+  }
+
+  public boolean usesMongoContactStore() {
+    return isMongoStoreType(contactStoreType);
+  }
+
+  public boolean usesMongoAnalyticsCounters() {
+    return analyticsCountersEnabled && isMongoStoreType(accountStoreType) && isMongoV4Driver();
+  }
+
+  private static boolean isMongoStoreType(String storeType) {
+    return "mongodb".equalsIgnoreCase(storeType);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationRunner.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence;
+
+/**
+ * Runs Mongo schema migrations before Mongo-backed stores are bound at startup.
+ */
+public interface MongoMigrationRunner {
+
+  void run();
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationRunnerFactory.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationRunnerFactory.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence;
+
+/**
+ * Factory seam used to construct the concrete migration runner only when the
+ * effective persistence configuration is actually Mongo-backed.
+ */
+public interface MongoMigrationRunnerFactory {
+
+  MongoMigrationRunner create(MongoMigrationConfig config);
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/PersistenceModule.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/PersistenceModule.java
@@ -39,6 +39,7 @@ import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
 import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
 import org.waveprotocol.box.server.persistence.memory.MemorySnapshotStore;
 import org.waveprotocol.box.server.persistence.memory.MemoryStore;
+import org.waveprotocol.box.server.persistence.migrations.MongockMongoMigrationRunnerFactory;
 import org.waveprotocol.box.server.persistence.mongodb.MongoDbProvider;
 import org.waveprotocol.box.server.waveserver.DeltaStore;
 import org.waveprotocol.wave.crypto.CertPathStore;
@@ -83,10 +84,17 @@ public class PersistenceModule extends AbstractModule {
   private final String mongoDBPassword;
   private final String mongoDriver;
   private final boolean analyticsCountersEnabled;
+  private final MongoMigrationConfig mongoMigrationConfig;
+  private final MongoMigrationRunnerFactory mongoMigrationRunnerFactory;
+  private boolean mongoMigrationsExecuted;
 
 
   @Inject
   public PersistenceModule(Config config) {
+    this(config, new MongockMongoMigrationRunnerFactory());
+  }
+
+  PersistenceModule(Config config, MongoMigrationRunnerFactory mongoMigrationRunnerFactory) {
     this.signerInfoStoreType = config.getString("core.signer_info_store_type");
     this.attachmentStoreType = config.getString("core.attachment_store_type");
     this.accountStoreType = config.getString("core.account_store_type");
@@ -101,6 +109,20 @@ public class PersistenceModule extends AbstractModule {
     this.mongoDriver = config.hasPath("core.mongodb_driver") ? config.getString("core.mongodb_driver") : "v2";
     this.analyticsCountersEnabled = config.hasPath("core.analytics_counters_enabled")
         && config.getBoolean("core.analytics_counters_enabled");
+    this.mongoMigrationConfig = new MongoMigrationConfig(
+        signerInfoStoreType,
+        attachmentStoreType,
+        accountStoreType,
+        deltaStoreType,
+        contactStoreType,
+        mongoDBHost,
+        mongoDBPort,
+        mongoDBdatabase,
+        mongoDBUsername,
+        mongoDBPassword,
+        mongoDriver,
+        analyticsCountersEnabled);
+    this.mongoMigrationRunnerFactory = mongoMigrationRunnerFactory;
   }
 
   /**
@@ -123,6 +145,7 @@ public class PersistenceModule extends AbstractModule {
 
   @Override
   protected void configure() {
+    runMongoMigrationsIfNeeded();
     bindCertPathStore();
     bindAttachmentStore();
     bindAccountStore();
@@ -132,6 +155,20 @@ public class PersistenceModule extends AbstractModule {
     bindContactMessageStore();
     bindFeatureFlagStore();
     bindAnalyticsCounterStore();
+  }
+
+  void runMongoMigrationsIfNeeded() {
+    if (mongoMigrationsExecuted || !shouldRunMongoMigrations()) {
+      return;
+    }
+    MongoMigrationRunner runner = mongoMigrationRunnerFactory.create(mongoMigrationConfig);
+    runner.run();
+    mongoMigrationsExecuted = true;
+  }
+
+  boolean shouldRunMongoMigrations() {
+    return mongoMigrationConfig.isMongoV4Driver()
+        && mongoMigrationConfig.usesMongoBackedCoreStore();
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -19,9 +19,7 @@
 
 package org.waveprotocol.box.server.persistence.migrations;
 
-import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
-import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoDatabase;
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
 import io.mongock.runner.core.executor.MongockRunner;
@@ -62,9 +60,7 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
         config.getPassword())) {
       MongoSync4Driver driver =
           MongoSync4Driver.withDefaultLock(provider.provideMongoClient(), config.getDatabase());
-      driver.setWriteConcern(WriteConcern.MAJORITY);
-      driver.setReadConcern(ReadConcern.MAJORITY);
-      driver.setReadPreference(ReadPreference.primary());
+      configureDriverDefaults(driver);
 
       MongoDatabase database = provider.provideMongoDatabase();
       MongockRunner runner = MongockStandalone.builder()
@@ -80,5 +76,9 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
       runner.execute();
       LOG.info("Completed Mongock Mongo schema migrations");
     }
+  }
+
+  static void configureDriverDefaults(MongoSync4Driver driver) {
+    driver.setReadPreference(ReadPreference.primary());
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoDatabase;
+import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
+import io.mongock.runner.core.executor.MongockRunner;
+import io.mongock.runner.standalone.MongockStandalone;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+import org.waveprotocol.box.server.persistence.MongoMigrationRunner;
+import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DbProvider;
+import org.waveprotocol.box.server.persistence.migrations.changesets.BaselineMongoSchema_001;
+import org.waveprotocol.box.server.persistence.migrations.changesets.DeltaAppliedVersionUniqueIndex_002;
+
+/**
+ * Runs the Mongock startup migration pass for MongoDB v4-backed deployments.
+ */
+final class MongockMongoMigrationRunner implements MongoMigrationRunner {
+
+  private static final java.util.logging.Logger LOG =
+      java.util.logging.Logger.getLogger(MongockMongoMigrationRunner.class.getName());
+  private static final String EXECUTION_ID = "wave-startup";
+
+  private final MongoMigrationConfig config;
+
+  MongockMongoMigrationRunner(MongoMigrationConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public void run() {
+    if (!config.isMongoV4Driver()) {
+      throw new IllegalStateException(
+          "Mongo migrations require mongodb_driver=v4, found " + config.getMongoDriver());
+    }
+
+    try (Mongo4DbProvider provider = new Mongo4DbProvider(
+        config.getHost(),
+        config.getPort(),
+        config.getDatabase(),
+        config.getUsername(),
+        config.getPassword())) {
+      MongoSync4Driver driver =
+          MongoSync4Driver.withDefaultLock(provider.provideMongoClient(), config.getDatabase());
+      driver.setWriteConcern(WriteConcern.MAJORITY);
+      driver.setReadConcern(ReadConcern.MAJORITY);
+      driver.setReadPreference(ReadPreference.primary());
+
+      MongoDatabase database = provider.provideMongoDatabase();
+      MongockRunner runner = MongockStandalone.builder()
+          .setDriver(driver)
+          .setExecutionId(EXECUTION_ID)
+          .addMigrationClass(BaselineMongoSchema_001.class)
+          .addMigrationClass(DeltaAppliedVersionUniqueIndex_002.class)
+          .addDependency(MongoMigrationConfig.class, config)
+          .addDependency(MongoDatabase.class, database)
+          .buildRunner();
+
+      LOG.info("Running Mongock Mongo schema migrations");
+      runner.execute();
+      LOG.info("Completed Mongock Mongo schema migrations");
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerFactory.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations;
+
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+import org.waveprotocol.box.server.persistence.MongoMigrationRunner;
+import org.waveprotocol.box.server.persistence.MongoMigrationRunnerFactory;
+
+/**
+ * Default factory for the Mongock-backed Mongo migration runner.
+ */
+public final class MongockMongoMigrationRunnerFactory implements MongoMigrationRunnerFactory {
+
+  @Override
+  public MongoMigrationRunner create(MongoMigrationConfig config) {
+    return new MongockMongoMigrationRunner(config);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchema_001.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchema_001.java
@@ -53,7 +53,7 @@ public final class BaselineMongoSchema_001 {
       ensureDeltaResultingVersionIndex();
       ensureSnapshotIndex();
     }
-    if (config.usesMongoContactStore()) {
+    if (config.usesMongoContactMessageStore()) {
       ensureContactMessageIndexes();
     }
     if (config.usesMongoAnalyticsCounters()) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchema_001.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchema_001.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations.changesets;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.ChangeUnitConstructor;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.bson.Document;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DeltaStoreUtil;
+
+/**
+ * Creates the current canonical baseline indexes for Mongo-backed Wave stores.
+ */
+@ChangeUnit(id = "baseline-mongo-schema", order = "001", author = "codex")
+public final class BaselineMongoSchema_001 {
+
+  private final MongoDatabase database;
+  private final MongoMigrationConfig config;
+
+  @ChangeUnitConstructor
+  public BaselineMongoSchema_001(MongoDatabase database, MongoMigrationConfig config) {
+    this.database = database;
+    this.config = config;
+  }
+
+  @Execution
+  public void execution() {
+    if (config.usesMongoDeltaStore()) {
+      ensureDeltaLookupIndex();
+      ensureDeltaResultingVersionIndex();
+      ensureSnapshotIndex();
+    }
+    if (config.usesMongoContactStore()) {
+      ensureContactMessageIndexes();
+    }
+    if (config.usesMongoAnalyticsCounters()) {
+      ensureAnalyticsCounterIndex();
+    }
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+    // Compatible baseline indexes are intentionally not rolled back automatically.
+  }
+
+  private void ensureDeltaLookupIndex() {
+    MongoCollection<Document> deltas = database.getCollection("deltas");
+    deltas.createIndex(
+        Indexes.ascending(
+            Mongo4DeltaStoreUtil.FIELD_WAVE_ID,
+            Mongo4DeltaStoreUtil.FIELD_WAVELET_ID),
+        new IndexOptions().background(true));
+  }
+
+  private void ensureDeltaResultingVersionIndex() {
+    MongoCollection<Document> deltas = database.getCollection("deltas");
+    deltas.createIndex(
+        Indexes.ascending(
+            Mongo4DeltaStoreUtil.FIELD_WAVE_ID,
+            Mongo4DeltaStoreUtil.FIELD_WAVELET_ID,
+            Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_RESULTINGVERSION_VERSION),
+        new IndexOptions().background(true));
+  }
+
+  private void ensureSnapshotIndex() {
+    MongoCollection<Document> snapshots = database.getCollection("snapshots");
+    snapshots.createIndex(
+        Indexes.compoundIndex(
+            Indexes.ascending("waveId"),
+            Indexes.ascending("waveletId"),
+            Indexes.descending("version")),
+        new IndexOptions().background(true));
+  }
+
+  private void ensureContactMessageIndexes() {
+    MongoCollection<Document> contactMessages = database.getCollection("contact_messages");
+    contactMessages.createIndex(Indexes.descending("createdAt"));
+    contactMessages.createIndex(Indexes.ascending("status"));
+  }
+
+  private void ensureAnalyticsCounterIndex() {
+    MongoCollection<Document> analytics = database.getCollection("analytics_hourly");
+    analytics.createIndex(
+        Indexes.ascending("hour"),
+        new IndexOptions().unique(true));
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
@@ -124,7 +124,14 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
         "Migration could not enforce the unique applied-version index; "
             + "restoring the non-unique fallback index instead.",
         failure);
-    restoreNonUniqueIndex(deltas, keys);
+    try {
+      restoreNonUniqueIndex(deltas, keys);
+    } catch (MongoException restoreFailure) {
+      LOG.log(java.util.logging.Level.WARNING,
+          "Migration failed to restore the non-unique applied-version index; "
+              + "keeping startup alive in degraded mode until the index is repaired.",
+          restoreFailure);
+    }
   }
 
   private static boolean isIndexUpgradeConflict(MongoException error) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
@@ -44,6 +44,10 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
   private static final String APPLIED_AT_VERSION_INDEX_NAME =
       Mongo4DeltaStoreUtil.FIELD_WAVE_ID + "_1_" + Mongo4DeltaStoreUtil.FIELD_WAVELET_ID
           + "_1_" + Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
+  private static final Document APPLIED_AT_VERSION_INDEX_KEY = new Document(
+      Mongo4DeltaStoreUtil.FIELD_WAVE_ID, 1)
+      .append(Mongo4DeltaStoreUtil.FIELD_WAVELET_ID, 1)
+      .append(Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION, 1);
 
   private final MongoDatabase database;
   private final MongoMigrationConfig config;
@@ -77,8 +81,12 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
       if (!isIndexUpgradeConflict(initialFailure)) {
         throw initialFailure;
       }
-      deltas.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
-      deltas.createIndex(keys, options);
+      deltas.dropIndex(findConflictingIndexName(deltas));
+      try {
+        deltas.createIndex(keys, options);
+      } catch (MongoException retryFailure) {
+        restoreNonUniqueIndex(deltas, keys);
+      }
     }
   }
 
@@ -87,9 +95,27 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
     // The old non-unique index shape is not restored automatically.
   }
 
+  private static String findConflictingIndexName(MongoCollection<Document> deltas) {
+    for (Document index : deltas.listIndexes()) {
+      Document key = index.get("key", Document.class);
+      if (APPLIED_AT_VERSION_INDEX_KEY.equals(key)) {
+        String name = index.getString("name");
+        if (name != null && !name.isEmpty()) {
+          return name;
+        }
+      }
+    }
+    return APPLIED_AT_VERSION_INDEX_NAME;
+  }
+
+  private static void restoreNonUniqueIndex(MongoCollection<Document> deltas, Bson keys) {
+    deltas.createIndex(keys, new IndexOptions().background(true).name(APPLIED_AT_VERSION_INDEX_NAME));
+  }
+
   private static boolean isIndexUpgradeConflict(MongoException error) {
+    String message = error.getMessage();
     return error.getCode() == INDEX_OPTIONS_CONFLICT
         || error.getCode() == INDEX_KEY_SPECS_CONFLICT
-        || error.getMessage().contains("already exists with different options");
+        || (message != null && message.contains("already exists with different options"));
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
@@ -80,6 +80,10 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
     try {
       deltas.createIndex(keys, options);
     } catch (MongoException initialFailure) {
+      if (isDuplicateKeyFailure(initialFailure)) {
+        restoreNonUniqueIndexWithWarning(deltas, keys, initialFailure);
+        return;
+      }
       if (!isIndexUpgradeConflict(initialFailure)) {
         throw initialFailure;
       }
@@ -87,11 +91,7 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
       try {
         deltas.createIndex(keys, options);
       } catch (MongoException retryFailure) {
-        LOG.log(java.util.logging.Level.WARNING,
-            "Migration could not enforce the unique applied-version index; "
-                + "restoring the non-unique fallback index instead.",
-            retryFailure);
-        restoreNonUniqueIndex(deltas, keys);
+        restoreNonUniqueIndexWithWarning(deltas, keys, retryFailure);
       }
     }
   }
@@ -118,10 +118,23 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
     deltas.createIndex(keys, new IndexOptions().background(true).name(APPLIED_AT_VERSION_INDEX_NAME));
   }
 
+  private static void restoreNonUniqueIndexWithWarning(MongoCollection<Document> deltas, Bson keys,
+      MongoException failure) {
+    LOG.log(java.util.logging.Level.WARNING,
+        "Migration could not enforce the unique applied-version index; "
+            + "restoring the non-unique fallback index instead.",
+        failure);
+    restoreNonUniqueIndex(deltas, keys);
+  }
+
   private static boolean isIndexUpgradeConflict(MongoException error) {
     String message = error.getMessage();
     return error.getCode() == INDEX_OPTIONS_CONFLICT
         || error.getCode() == INDEX_KEY_SPECS_CONFLICT
         || (message != null && message.contains("already exists with different options"));
+  }
+
+  private static boolean isDuplicateKeyFailure(MongoException error) {
+    return error.getCode() == 11000;
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations.changesets;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.ChangeUnitConstructor;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DeltaStoreUtil;
+
+/**
+ * Upgrades the deltas applied-version index to the canonical unique form.
+ */
+@ChangeUnit(id = "delta-applied-version-unique-index", order = "002", author = "codex")
+public final class DeltaAppliedVersionUniqueIndex_002 {
+
+  private static final int INDEX_OPTIONS_CONFLICT = 85;
+  private static final int INDEX_KEY_SPECS_CONFLICT = 86;
+  private static final String APPLIED_AT_VERSION_INDEX_NAME =
+      Mongo4DeltaStoreUtil.FIELD_WAVE_ID + "_1_" + Mongo4DeltaStoreUtil.FIELD_WAVELET_ID
+          + "_1_" + Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION + "_1";
+
+  private final MongoDatabase database;
+  private final MongoMigrationConfig config;
+
+  @ChangeUnitConstructor
+  public DeltaAppliedVersionUniqueIndex_002(MongoDatabase database,
+      MongoMigrationConfig config) {
+    this.database = database;
+    this.config = config;
+  }
+
+  @Execution
+  public void execution() {
+    if (!config.usesMongoDeltaStore()) {
+      return;
+    }
+
+    MongoCollection<Document> deltas = database.getCollection("deltas");
+    Bson keys = Indexes.ascending(
+        Mongo4DeltaStoreUtil.FIELD_WAVE_ID,
+        Mongo4DeltaStoreUtil.FIELD_WAVELET_ID,
+        Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION);
+    IndexOptions options = new IndexOptions()
+        .background(true)
+        .name(APPLIED_AT_VERSION_INDEX_NAME)
+        .unique(true);
+
+    try {
+      deltas.createIndex(keys, options);
+    } catch (MongoException initialFailure) {
+      if (!isIndexUpgradeConflict(initialFailure)) {
+        throw initialFailure;
+      }
+      deltas.dropIndex(APPLIED_AT_VERSION_INDEX_NAME);
+      deltas.createIndex(keys, options);
+    }
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+    // The old non-unique index shape is not restored automatically.
+  }
+
+  private static boolean isIndexUpgradeConflict(MongoException error) {
+    return error.getCode() == INDEX_OPTIONS_CONFLICT
+        || error.getCode() == INDEX_KEY_SPECS_CONFLICT
+        || error.getMessage().contains("already exists with different options");
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndex_002.java
@@ -39,6 +39,8 @@ import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DeltaStoreUtil;
 @ChangeUnit(id = "delta-applied-version-unique-index", order = "002", author = "codex")
 public final class DeltaAppliedVersionUniqueIndex_002 {
 
+  private static final java.util.logging.Logger LOG =
+      java.util.logging.Logger.getLogger(DeltaAppliedVersionUniqueIndex_002.class.getName());
   private static final int INDEX_OPTIONS_CONFLICT = 85;
   private static final int INDEX_KEY_SPECS_CONFLICT = 86;
   private static final String APPLIED_AT_VERSION_INDEX_NAME =
@@ -85,6 +87,10 @@ public final class DeltaAppliedVersionUniqueIndex_002 {
       try {
         deltas.createIndex(keys, options);
       } catch (MongoException retryFailure) {
+        LOG.log(java.util.logging.Level.WARNING,
+            "Migration could not enforce the unique applied-version index; "
+                + "restoring the non-unique fallback index instead.",
+            retryFailure);
         restoreNonUniqueIndex(deltas, keys);
       }
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DbProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4DbProvider.java
@@ -81,6 +81,16 @@ public class Mongo4DbProvider implements AutoCloseable {
     } catch (Exception ignore) {}
   }
 
+  public MongoClient provideMongoClient() {
+    ensure();
+    return client;
+  }
+
+  public MongoDatabase provideMongoDatabase() {
+    ensure();
+    return db;
+  }
+
   public CertPathStore provideMongoDbStore() { ensure(); return new Mongo4SignerInfoStore(db); }
 
   public AttachmentStore provideMongoDbAttachmentStore() { ensure(); return new Mongo4AttachmentStore(db); }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
+import org.junit.Test;
+
+public final class MongockMongoMigrationRunnerTest {
+
+  @Test
+  public void testConfigureDriverDefaultsKeepsPrimaryReadPreferenceWithoutOverridingConcerns() {
+    MongoSync4Driver driver = mock(MongoSync4Driver.class);
+
+    MongockMongoMigrationRunner.configureDriverDefaults(driver);
+
+    verify(driver).setReadPreference(ReadPreference.primary());
+    verify(driver, never()).setReadConcern(any(ReadConcern.class));
+    verify(driver, never()).setWriteConcern(any(WriteConcern.class));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchemaChangeUnitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/BaselineMongoSchemaChangeUnitTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations.changesets;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.Test;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+
+public final class BaselineMongoSchemaChangeUnitTest {
+
+  @Test
+  public void testExecutionIndexesContactMessagesWhenAccountStoreUsesMongoV4() {
+    MongoCollection<Document> contactMessages = collection();
+    BaselineMongoSchema_001 changeUnit = changeUnit(
+        mongoContactMessageConfig(),
+        contactMessages,
+        collection(),
+        collection(),
+        collection());
+
+    changeUnit.execution();
+
+    verify(contactMessages, times(2)).createIndex(org.mockito.ArgumentMatchers.any());
+  }
+
+  private static BaselineMongoSchema_001 changeUnit(MongoMigrationConfig config,
+      MongoCollection<Document> contactMessages, MongoCollection<Document> deltas,
+      MongoCollection<Document> snapshots, MongoCollection<Document> analytics) {
+    MongoDatabase database = mock(MongoDatabase.class);
+    when(database.getCollection("contact_messages")).thenReturn(contactMessages);
+    when(database.getCollection("deltas")).thenReturn(deltas);
+    when(database.getCollection("snapshots")).thenReturn(snapshots);
+    when(database.getCollection("analytics_hourly")).thenReturn(analytics);
+    return new BaselineMongoSchema_001(database, config);
+  }
+
+  private static MongoMigrationConfig mongoContactMessageConfig() {
+    return new MongoMigrationConfig(
+        "file",
+        "disk",
+        "mongodb",
+        "file",
+        "memory",
+        "mongo",
+        "27017",
+        "wiab",
+        "",
+        "",
+        "v4",
+        false);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static MongoCollection<Document> collection() {
+    return mock(MongoCollection.class);
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
@@ -56,6 +56,7 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
@@ -161,6 +162,36 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
     }
 
     assertEquals(1, handler.warningCount());
+  }
+
+  @Test
+  public void testExecutionKeepsStartupAliveWhenLegacyIndexRestoreFails() {
+    MongoCollection<Document> deltas = deltasCollection();
+    MongoException duplicateData = new MongoException(11000, "duplicate key");
+    MongoException restoreFailure = new MongoException(91, "transient restore failure");
+    AtomicInteger createCalls = new AtomicInteger();
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      int call = createCalls.getAndIncrement();
+      if (call == 0) {
+        throw duplicateData;
+      }
+      assertFalse(Boolean.TRUE.equals(options.isUnique()));
+      throw restoreFailure;
+    }).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    Logger logger = Logger.getLogger(DeltaAppliedVersionUniqueIndex_002.class.getName());
+    RecordingLogHandler handler = new RecordingLogHandler();
+    logger.addHandler(handler);
+    try {
+      changeUnit(deltas).execution();
+    } finally {
+      logger.removeHandler(handler);
+    }
+
+    assertEquals(2, createCalls.get());
+    assertEquals(2, handler.warningCount());
+    assertTrue(handler.containsMessage("failed to restore the non-unique applied-version index"));
   }
 
   @Test
@@ -404,6 +435,15 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
         }
       }
       return count;
+    }
+
+    private boolean containsMessage(String fragment) {
+      for (LogRecord record : records) {
+        if (record.getMessage() != null && record.getMessage().contains(fragment)) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.persistence.migrations.changesets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.ListIndexesIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
+
+  @Test
+  public void testExecutionDropsConflictingIndexByDiscoveredName() {
+    MongoCollection<Document> deltas = deltasCollection();
+    when(deltas.listIndexes()).thenReturn(indexesWith(
+        new Document("name", "legacy_applied_at_version")
+            .append("key", appliedAtVersionKey())));
+
+    MongoException conflict = new MongoException(86, "same key pattern with different name");
+    AtomicInteger uniqueAttempts = new AtomicInteger();
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      if (Boolean.TRUE.equals(options.isUnique()) && uniqueAttempts.getAndIncrement() == 0) {
+        throw conflict;
+      }
+      return "ok";
+    }).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    changeUnit(deltas).execution();
+
+    verify(deltas).dropIndex("legacy_applied_at_version");
+  }
+
+  @Test
+  public void testExecutionRestoresNonUniqueIndexWhenUniqueRetryHitsDuplicateData() {
+    MongoCollection<Document> deltas = deltasCollection();
+    when(deltas.listIndexes()).thenReturn(indexesWith(
+        new Document("name", "legacy_applied_at_version")
+            .append("key", appliedAtVersionKey())));
+
+    MongoException conflict = new MongoException(86, "same key pattern with different name");
+    MongoException duplicateData = new MongoException(11000, "duplicate key");
+    AtomicInteger createCalls = new AtomicInteger();
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      int call = createCalls.getAndIncrement();
+      if (call == 0) {
+        throw conflict;
+      }
+      if (call == 1) {
+        throw duplicateData;
+      }
+      assertFalse(Boolean.TRUE.equals(options.isUnique()));
+      return "restored";
+    }).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    changeUnit(deltas).execution();
+
+    assertEquals(3, createCalls.get());
+  }
+
+  @Test
+  public void testExecutionRethrowsOriginalMongoExceptionWhenMessageIsNull() {
+    MongoCollection<Document> deltas = deltasCollection();
+    MongoException initialFailure = new MongoException(99, null);
+    doThrow(initialFailure).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    try {
+      changeUnit(deltas).execution();
+      fail("Expected MongoException");
+    } catch (MongoException e) {
+      assertSame(initialFailure, e);
+    }
+  }
+
+  private static DeltaAppliedVersionUniqueIndex_002 changeUnit(MongoCollection<Document> deltas) {
+    MongoDatabase database = mock(MongoDatabase.class);
+    when(database.getCollection("deltas")).thenReturn(deltas);
+    return new DeltaAppliedVersionUniqueIndex_002(database, mongoDeltaConfig());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static MongoCollection<Document> deltasCollection() {
+    return mock(MongoCollection.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ListIndexesIterable<Document> indexesWith(Document... indexes) {
+    ListIndexesIterable<Document> iterable = mock(ListIndexesIterable.class);
+    when(iterable.iterator()).thenReturn(new IteratorCursor(Arrays.asList(indexes).iterator()));
+    return iterable;
+  }
+
+  private static Document appliedAtVersionKey() {
+    return new Document("waveId", 1)
+        .append("waveletId", 1)
+        .append("transformed.appliedAtVersion", 1);
+  }
+
+  private static MongoMigrationConfig mongoDeltaConfig() {
+    return new MongoMigrationConfig(
+        "file",
+        "disk",
+        "file",
+        "mongodb",
+        "memory",
+        "mongo",
+        "27017",
+        "wiab",
+        "",
+        "",
+        "v4",
+        false);
+  }
+
+  private static final class IteratorCursor implements MongoCursor<Document> {
+    private final Iterator<Document> iterator;
+
+    private IteratorCursor(Iterator<Document> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public Document next() {
+      return iterator.next();
+    }
+
+    @Override
+    public Document tryNext() {
+      return hasNext() ? next() : null;
+    }
+
+    @Override
+    public int available() {
+      return hasNext() ? 1 : 0;
+    }
+
+    @Override
+    public void remove() {
+      iterator.remove();
+    }
+
+    @Override
+    public com.mongodb.ServerCursor getServerCursor() {
+      return null;
+    }
+
+    @Override
+    public com.mongodb.ServerAddress getServerAddress() {
+      return null;
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
@@ -111,6 +111,26 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
   }
 
   @Test
+  public void testExecutionRestoresNonUniqueIndexWhenFirstUniqueCreateHitsDuplicateData() {
+    MongoCollection<Document> deltas = deltasCollection();
+    MongoException duplicateData = new MongoException(11000, "duplicate key");
+    AtomicInteger createCalls = new AtomicInteger();
+    doAnswer(invocation -> {
+      IndexOptions options = invocation.getArgument(1);
+      int call = createCalls.getAndIncrement();
+      if (call == 0) {
+        throw duplicateData;
+      }
+      assertFalse(Boolean.TRUE.equals(options.isUnique()));
+      return "restored";
+    }).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    changeUnit(deltas).execution();
+
+    assertEquals(2, createCalls.get());
+  }
+
+  @Test
   public void testExecutionLogsWarningWhenUniqueRetryFallsBackToNonUniqueIndex() {
     MongoCollection<Document> deltas = deltasCollection();
     when(deltas.listIndexes()).thenReturn(indexesWith(

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/changesets/DeltaAppliedVersionUniqueIndexChangeUnitTest.java
@@ -31,15 +31,27 @@ import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.IndexOptions;
 import org.bson.Document;
+import com.mongodb.Function;
 import org.bson.conversions.Bson;
 import org.junit.Test;
 import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DeltaStoreUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -99,6 +111,39 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
   }
 
   @Test
+  public void testExecutionLogsWarningWhenUniqueRetryFallsBackToNonUniqueIndex() {
+    MongoCollection<Document> deltas = deltasCollection();
+    when(deltas.listIndexes()).thenReturn(indexesWith(
+        new Document("name", "legacy_applied_at_version")
+            .append("key", appliedAtVersionKey())));
+
+    MongoException conflict = new MongoException(86, "same key pattern with different name");
+    MongoException duplicateData = new MongoException(11000, "duplicate key");
+    AtomicInteger createCalls = new AtomicInteger();
+    doAnswer(invocation -> {
+      int call = createCalls.getAndIncrement();
+      if (call == 0) {
+        throw conflict;
+      }
+      if (call == 1) {
+        throw duplicateData;
+      }
+      return "restored";
+    }).when(deltas).createIndex(any(Bson.class), any(IndexOptions.class));
+
+    Logger logger = Logger.getLogger(DeltaAppliedVersionUniqueIndex_002.class.getName());
+    RecordingLogHandler handler = new RecordingLogHandler();
+    logger.addHandler(handler);
+    try {
+      changeUnit(deltas).execution();
+    } finally {
+      logger.removeHandler(handler);
+    }
+
+    assertEquals(1, handler.warningCount());
+  }
+
+  @Test
   public void testExecutionRethrowsOriginalMongoExceptionWhenMessageIsNull() {
     MongoCollection<Document> deltas = deltasCollection();
     MongoException initialFailure = new MongoException(99, null);
@@ -125,15 +170,13 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
 
   @SuppressWarnings("unchecked")
   private static ListIndexesIterable<Document> indexesWith(Document... indexes) {
-    ListIndexesIterable<Document> iterable = mock(ListIndexesIterable.class);
-    when(iterable.iterator()).thenReturn(new IteratorCursor(Arrays.asList(indexes).iterator()));
-    return iterable;
+    return new FixedListIndexesIterable(Arrays.asList(indexes));
   }
 
   private static Document appliedAtVersionKey() {
-    return new Document("waveId", 1)
-        .append("waveletId", 1)
-        .append("transformed.appliedAtVersion", 1);
+    return new Document(Mongo4DeltaStoreUtil.FIELD_WAVE_ID, 1)
+        .append(Mongo4DeltaStoreUtil.FIELD_WAVELET_ID, 1)
+        .append(Mongo4DeltaStoreUtil.FIELD_TRANSFORMED_APPLIEDATVERSION, 1);
   }
 
   private static MongoMigrationConfig mongoDeltaConfig() {
@@ -196,6 +239,151 @@ public final class DeltaAppliedVersionUniqueIndexChangeUnitTest {
     @Override
     public com.mongodb.ServerAddress getServerAddress() {
       return null;
+    }
+  }
+
+  private static class FixedMongoIterable<T> implements MongoIterable<T> {
+    private final List<T> values;
+
+    private FixedMongoIterable(List<T> values) {
+      this.values = values;
+    }
+
+    @Override
+    public MongoCursor<T> iterator() {
+      return new IteratorCursorAdapter<>(values.iterator());
+    }
+
+    @Override
+    public MongoCursor<T> cursor() {
+      return iterator();
+    }
+
+    @Override
+    public T first() {
+      return values.isEmpty() ? null : values.get(0);
+    }
+
+    @Override
+    public <U> MongoIterable<U> map(Function<T, U> mapper) {
+      List<U> mapped = new ArrayList<>(values.size());
+      for (T value : values) {
+        mapped.add(mapper.apply(value));
+      }
+      return new FixedMongoIterable<>(mapped);
+    }
+
+    @Override
+    public <A extends Collection<? super T>> A into(A target) {
+      target.addAll(values);
+      return target;
+    }
+
+    @Override
+    public MongoIterable<T> batchSize(int batchSize) {
+      return this;
+    }
+  }
+
+  private static final class FixedListIndexesIterable extends FixedMongoIterable<Document>
+      implements ListIndexesIterable<Document> {
+
+    private FixedListIndexesIterable(List<Document> values) {
+      super(values);
+    }
+
+    @Override
+    public ListIndexesIterable<Document> maxTime(long maxTime, TimeUnit timeUnit) {
+      return this;
+    }
+
+    @Override
+    public ListIndexesIterable<Document> batchSize(int batchSize) {
+      return this;
+    }
+
+    @Override
+    public ListIndexesIterable<Document> comment(String comment) {
+      return this;
+    }
+
+    @Override
+    public ListIndexesIterable<Document> comment(org.bson.BsonValue comment) {
+      return this;
+    }
+  }
+
+  private static final class IteratorCursorAdapter<T> implements MongoCursor<T> {
+    private final Iterator<T> iterator;
+
+    private IteratorCursorAdapter(Iterator<T> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+      return iterator.next();
+    }
+
+    @Override
+    public T tryNext() {
+      return hasNext() ? next() : null;
+    }
+
+    @Override
+    public int available() {
+      return hasNext() ? 1 : 0;
+    }
+
+    @Override
+    public void remove() {
+      iterator.remove();
+    }
+
+    @Override
+    public com.mongodb.ServerCursor getServerCursor() {
+      return null;
+    }
+
+    @Override
+    public com.mongodb.ServerAddress getServerAddress() {
+      return null;
+    }
+  }
+
+  private static final class RecordingLogHandler extends Handler {
+    private final CopyOnWriteArrayList<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private int warningCount() {
+      int count = 0;
+      for (LogRecord record : records) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+          count++;
+        }
+      }
+      return count;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add Mongock standalone and MongoDB v4 driver dependencies
- introduce a Mongo migration runner, config model, and factory seam for startup execution
- run migrations from `PersistenceModule` only when the effective core persistence config is Mongo-backed with the v4 driver
- add initial change units for baseline Mongo schema/index setup and the delta applied-version unique index upgrade
- add Jakarta tests covering Mongo-backed execution, file-backed skipping, and one-time runner invocation

## Testing
- `sbt "jakartaTest:testOnly org.waveprotocol.box.server.persistence.MongoMigrationRunnerJakartaTest"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now runs MongoDB v4 migrations once for Mongo-backed core persistence; adds resilient baseline and index-upgrade migrations.

* **Bug Fixes / UI**
  * Toolbar layout now wraps pinned saved searches to avoid horizontal scrolling; Next Unread icon updated to a directional chevron with unread accent.

* **Tests**
  * Added tests covering conditional migration execution, single-run semantics, and index-upgrade retry/drop/error behaviors.

* **Chores**
  * Added Mongock MongoDB integration dependencies.

* **Documentation**
  * Added changelog entries describing migration gating and UI notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->