### PR TITLE
Fix Android root blip IME text corruption

### DIFF
--- a/wave/config/changelog.d/2026-04-13-android-ime-transient-selection.json
+++ b/wave/config/changelog.d/2026-04-13-android-ime-transient-selection.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-13-android-ime-transient-selection",
-  "version": "unreleased",
+  "version": "Unreleased",
   "title": "Fix remaining Android IME root-blip text corruption case",
   "summary": "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range.",
   "date": "2026-04-13",

--- a/wave/config/changelog.d/2026-04-13-android-ime-transient-selection.json
+++ b/wave/config/changelog.d/2026-04-13-android-ime-transient-selection.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-13-android-ime-transient-selection",
+  "version": "unreleased",
+  "title": "Fix remaining Android IME root-blip text corruption case",
+  "summary": "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range.",
+  "date": "2026-04-13",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -94,6 +94,21 @@
     ]
   },
   {
+    "releaseId": "2026-04-13-android-ime-transient-selection",
+    "version": "unreleased",
+    "title": "Fix remaining Android IME root-blip text corruption case",
+    "summary": "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range.",
+    "date": "2026-04-13",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range."
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-12-worktree-diagnostics-runbook",
     "version": "PR #587",
     "date": "2026-04-12",

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -95,7 +95,7 @@
   },
   {
     "releaseId": "2026-04-13-android-ime-transient-selection",
-    "version": "unreleased",
+    "version": "Unreleased",
     "title": "Fix remaining Android IME root-blip text corruption case",
     "summary": "Android/mobile IME composition no longer drops already-typed leading characters when Chrome temporarily promotes the composing word into a transient selection range.",
     "date": "2026-04-13",

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -469,12 +469,13 @@ public final class EditorEventHandler {
     }
   }
 
-  static boolean isTransientImeRangeAfterFlush(
+  private static boolean isTransientImeRangeAfterFlush(
       FocusedContentRange selectionBeforeFlush, FocusedContentRange selectionAfterFlush) {
     return selectionBeforeFlush != null
         && selectionAfterFlush != null
         && selectionBeforeFlush.isCollapsed()
-        && !selectionAfterFlush.isCollapsed();
+        && !selectionAfterFlush.isCollapsed()
+        && selectionBeforeFlush.getFocus().equals(selectionAfterFlush.getFocus());
   }
 
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -416,6 +416,8 @@ public final class EditorEventHandler {
       logger.error().log("State was already IME during a compositionstart event!");
     }
 
+    FocusedContentRange selectionBeforeCompositionFlush = cachedSelection;
+
     // On mobile browsers (e.g. Android Chrome), keydown with keyCode 229 fires
     // before compositionstart. That keydown activates the typing extractor.
     // We must flush it here so that the typing extractor and the IME composition
@@ -434,7 +436,13 @@ public final class EditorEventHandler {
       caret = cachedSelection.getFocus();
     } else {
       event.setCaret(ContentPoint.fromPoint(cachedSelection.getFocus()));
-      caret = deleteCachedSelectionRangeAndInvalidate(true);
+      // Android/WebKit can promote a collapsed caret into a transient range for the
+      // currently composing word after the pre-composition keydown is flushed. That
+      // range belongs to the browser's IME state rather than to an explicit user
+      // replacement selection, so deleting it here drops the already-committed text.
+      caret = isTransientImeRangeAfterFlush(selectionBeforeCompositionFlush, cachedSelection)
+          ? cachedSelection.getFocus()
+          : deleteCachedSelectionRangeAndInvalidate(true);
     }
 
     state = State.COMPOSITION;
@@ -459,6 +467,14 @@ public final class EditorEventHandler {
     if (cachedSelection != null) {
       delayedCompositionMutationGuard.noteCompositionEnd();
     }
+  }
+
+  static boolean isTransientImeRangeAfterFlush(
+      FocusedContentRange selectionBeforeFlush, FocusedContentRange selectionAfterFlush) {
+    return selectionBeforeFlush != null
+        && selectionAfterFlush != null
+        && selectionBeforeFlush.isCollapsed()
+        && !selectionAfterFlush.isCollapsed();
   }
 
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -417,6 +417,8 @@ public final class EditorEventHandler {
     }
 
     FocusedContentRange selectionBeforeCompositionFlush = cachedSelection;
+    FocusedPointRange<Node> htmlSelectionBeforeCompositionFlush =
+        editorInteractor.getHtmlSelection();
 
     // On mobile browsers (e.g. Android Chrome), keydown with keyCode 229 fires
     // before compositionstart. That keydown activates the typing extractor.
@@ -439,8 +441,10 @@ public final class EditorEventHandler {
       // Android/WebKit can promote a collapsed caret into a transient range for the
       // currently composing word after the pre-composition keydown is flushed. That
       // range belongs to the browser's IME state rather than to an explicit user
-      // replacement selection, so deleting it here drops the already-committed text.
-      caret = isTransientImeRangeAfterFlush(selectionBeforeCompositionFlush, cachedSelection)
+      // replacement selection. Use the live pre-flush browser selection to
+      // distinguish the two, because cachedSelection may still be stale here.
+      caret = isTransientImeRangeAfterFlush(selectionBeforeCompositionFlush,
+          htmlSelectionBeforeCompositionFlush, cachedSelection)
           ? cachedSelection.getFocus()
           : deleteCachedSelectionRangeAndInvalidate(true);
     }
@@ -470,8 +474,12 @@ public final class EditorEventHandler {
   }
 
   private static boolean isTransientImeRangeAfterFlush(
-      FocusedContentRange selectionBeforeFlush, FocusedContentRange selectionAfterFlush) {
+      FocusedContentRange selectionBeforeFlush,
+      FocusedPointRange<Node> htmlSelectionBeforeFlush,
+      FocusedContentRange selectionAfterFlush) {
     return selectionBeforeFlush != null
+        && htmlSelectionBeforeFlush != null
+        && htmlSelectionBeforeFlush.isCollapsed()
         && selectionAfterFlush != null
         && selectionBeforeFlush.isCollapsed()
         && !selectionAfterFlush.isCollapsed()

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -735,6 +735,87 @@ public class EditorEventHandlerGwtTest
   }
 
   /**
+   * A stale collapsed selection before the flush must not hide a newer
+   * user-authored replacement range that really should be deleted.
+   */
+  public void testCompositionStartDeletesExplicitReplacementSelectionAfterFlush() {
+    FakeEditorEvent compositionStart = FakeEditorEvent.compositionSequence(0)[0];
+
+    final ContentTextNode staleNode =
+        new ContentTextNode(Document.get().createTextNode("stale"), null);
+    final ContentTextNode replacementNode =
+        new ContentTextNode(Document.get().createTextNode("replace"), null);
+    final Point<ContentNode> staleCaret = Point.inText(staleNode, 1);
+    final Point<ContentNode> rangeStart = Point.inText(replacementNode, 1);
+    final Point<ContentNode> rangeEnd = Point.inText(replacementNode, 5);
+    final Point<ContentNode> caretAfterDelete = Point.inText(replacementNode, 1);
+
+    final FocusedContentRange beforeFlushSelection = new FocusedContentRange(staleCaret);
+    final FocusedContentRange afterFlushSelection = new FocusedContentRange(rangeStart, rangeEnd);
+    final Point<ContentNode>[] compositionCaret = new Point[1];
+    final boolean[] deleteCalled = new boolean[1];
+
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    FakeEditorInteractor interactor = new FakeEditorInteractor() {
+      private int flushCount = 0;
+
+      @Override
+      public boolean notifyListeners(SignalEvent event) {
+        return false;
+      }
+
+      @Override
+      public boolean hasContentSelection() {
+        return true;
+      }
+
+      @Override
+      public boolean isEditing() {
+        return true;
+      }
+
+      @Override
+      public void forceFlush() {
+        flushCount++;
+      }
+
+      @Override
+      public FocusedContentRange getSelectionPoints() {
+        return flushCount >= 2 ? afterFlushSelection : beforeFlushSelection;
+      }
+
+      @Override
+      public void checkpoint(FocusedContentRange currentRange) {
+      }
+
+      @Override
+      public Point<ContentNode> deleteRange(
+          Point<ContentNode> first, Point<ContentNode> second, boolean isReplace) {
+        deleteCalled[0] = true;
+        assertEquals(rangeStart, first);
+        assertEquals(rangeEnd, second);
+        assertTrue(isReplace);
+        return caretAfterDelete;
+      }
+
+      @Override
+      public void setCaret(Point<ContentNode> caret) {
+        assertEquals(caretAfterDelete, caret);
+      }
+
+      @Override
+      public void compositionStart(Point<ContentNode> caret) {
+        compositionCaret[0] = caret;
+      }
+    };
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(compositionStart));
+    assertTrue(deleteCalled[0]);
+    assertEquals(caretAfterDelete, compositionCaret[0]);
+  }
+
+  /**
    * If delayed composition end produces no selection, the trailing DOM
    * mutation still has to reach the typing extractor or the browser-only text
    * never becomes a document operation.

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -674,6 +674,67 @@ public class EditorEventHandlerGwtTest
   }
 
   /**
+   * Android/WebKit can turn the current composing word into a transient range
+   * after the pre-composition flush. That range must not be deleted as if the
+   * user had explicitly selected text to replace.
+   */
+  public void testCompositionStartSkipsDeleteForTransientImeRangeAfterFlush() {
+    FakeEditorEvent compositionStart = FakeEditorEvent.compositionSequence(0)[0];
+
+    final ContentTextNode node = new ContentTextNode(Document.get().createTextNode("n"), null);
+    final Point<ContentNode> collapsedCaret = Point.inText(node, 1);
+    final Point<ContentNode> rangeStart = Point.inText(node, 0);
+    final Point<ContentNode> rangeEnd = Point.inText(node, 1);
+
+    final FocusedContentRange beforeFlushSelection = new FocusedContentRange(collapsedCaret);
+    final FocusedContentRange afterFlushSelection = new FocusedContentRange(rangeStart, rangeEnd);
+    final Point<ContentNode>[] compositionCaret = new Point[1];
+
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    FakeEditorInteractor interactor = new FakeEditorInteractor() {
+      private int flushCount = 0;
+
+      @Override
+      public boolean notifyListeners(SignalEvent event) {
+        return false;
+      }
+
+      @Override
+      public boolean hasContentSelection() {
+        return true;
+      }
+
+      @Override
+      public boolean isEditing() {
+        return true;
+      }
+
+      @Override
+      public void forceFlush() {
+        flushCount++;
+      }
+
+      @Override
+      public FocusedContentRange getSelectionPoints() {
+        return flushCount >= 2 ? afterFlushSelection : beforeFlushSelection;
+      }
+
+      @Override
+      public void compositionStart(Point<ContentNode> caret) {
+        compositionCaret[0] = caret;
+      }
+
+      @Override
+      public void checkpoint(FocusedContentRange currentRange) {
+      }
+    };
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(compositionStart));
+    assertEquals(rangeEnd, compositionCaret[0]);
+  }
+
+  /**
    * If delayed composition end produces no selection, the trailing DOM
    * mutation still has to reach the typing extractor or the browser-only text
    * never becomes a document operation.

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -688,6 +688,8 @@ public class EditorEventHandlerGwtTest
 
     final FocusedContentRange beforeFlushSelection = new FocusedContentRange(collapsedCaret);
     final FocusedContentRange afterFlushSelection = new FocusedContentRange(rangeStart, rangeEnd);
+    final FocusedPointRange<Node> htmlSelectionBeforeFlush =
+        new FocusedPointRange<Node>(toNodePoint(collapsedCaret));
     final Point<ContentNode>[] compositionCaret = new Point[1];
 
     FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
@@ -717,6 +719,11 @@ public class EditorEventHandlerGwtTest
       @Override
       public FocusedContentRange getSelectionPoints() {
         return flushCount >= 2 ? afterFlushSelection : beforeFlushSelection;
+      }
+
+      @Override
+      public FocusedPointRange<Node> getHtmlSelection() {
+        return htmlSelectionBeforeFlush;
       }
 
       @Override
@@ -752,6 +759,8 @@ public class EditorEventHandlerGwtTest
 
     final FocusedContentRange beforeFlushSelection = new FocusedContentRange(staleCaret);
     final FocusedContentRange afterFlushSelection = new FocusedContentRange(rangeStart, rangeEnd);
+    final FocusedPointRange<Node> htmlSelectionBeforeFlush =
+        new FocusedPointRange<Node>(toNodePoint(rangeStart), toNodePoint(rangeEnd));
     final Point<ContentNode>[] compositionCaret = new Point[1];
     final boolean[] deleteCalled = new boolean[1];
 
@@ -782,6 +791,98 @@ public class EditorEventHandlerGwtTest
       @Override
       public FocusedContentRange getSelectionPoints() {
         return flushCount >= 2 ? afterFlushSelection : beforeFlushSelection;
+      }
+
+      @Override
+      public FocusedPointRange<Node> getHtmlSelection() {
+        return htmlSelectionBeforeFlush;
+      }
+
+      @Override
+      public void checkpoint(FocusedContentRange currentRange) {
+      }
+
+      @Override
+      public Point<ContentNode> deleteRange(
+          Point<ContentNode> first, Point<ContentNode> second, boolean isReplace) {
+        deleteCalled[0] = true;
+        assertEquals(rangeStart, first);
+        assertEquals(rangeEnd, second);
+        assertTrue(isReplace);
+        return caretAfterDelete;
+      }
+
+      @Override
+      public void setCaret(Point<ContentNode> caret) {
+        assertEquals(caretAfterDelete, caret);
+      }
+
+      @Override
+      public void compositionStart(Point<ContentNode> caret) {
+        compositionCaret[0] = caret;
+      }
+    };
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(compositionStart));
+    assertTrue(deleteCalled[0]);
+    assertEquals(caretAfterDelete, compositionCaret[0]);
+  }
+
+  /**
+   * A real replacement selection can still share the stale caret as its focus
+   * when the browser preserves selection direction. That range still belongs
+   * to user-authored replacement text and must be deleted.
+   */
+  public void testCompositionStartDeletesSameFocusReplacementSelectionAfterFlush() {
+    FakeEditorEvent compositionStart = FakeEditorEvent.compositionSequence(0)[0];
+
+    final ContentTextNode replacementNode =
+        new ContentTextNode(Document.get().createTextNode("replace"), null);
+    final Point<ContentNode> staleCaret = Point.inText(replacementNode, 5);
+    final Point<ContentNode> rangeStart = Point.inText(replacementNode, 1);
+    final Point<ContentNode> rangeEnd = Point.inText(replacementNode, 5);
+    final Point<ContentNode> caretAfterDelete = Point.inText(replacementNode, 1);
+
+    final FocusedContentRange beforeFlushSelection = new FocusedContentRange(staleCaret);
+    final FocusedContentRange afterFlushSelection = new FocusedContentRange(rangeStart, rangeEnd);
+    final FocusedPointRange<Node> htmlSelectionBeforeFlush =
+        new FocusedPointRange<Node>(toNodePoint(rangeStart), toNodePoint(rangeEnd));
+    final Point<ContentNode>[] compositionCaret = new Point[1];
+    final boolean[] deleteCalled = new boolean[1];
+
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    FakeEditorInteractor interactor = new FakeEditorInteractor() {
+      private int flushCount = 0;
+
+      @Override
+      public boolean notifyListeners(SignalEvent event) {
+        return false;
+      }
+
+      @Override
+      public boolean hasContentSelection() {
+        return true;
+      }
+
+      @Override
+      public boolean isEditing() {
+        return true;
+      }
+
+      @Override
+      public void forceFlush() {
+        flushCount++;
+      }
+
+      @Override
+      public FocusedContentRange getSelectionPoints() {
+        return flushCount >= 2 ? afterFlushSelection : beforeFlushSelection;
+      }
+
+      @Override
+      public FocusedPointRange<Node> getHtmlSelection() {
+        return htmlSelectionBeforeFlush;
       }
 
       @Override


### PR DESCRIPTION
## Summary
- preserve Android/WebKit IME-owned transient selection ranges during `compositionStart` instead of deleting them as explicit replacements
- add regression coverage for the collapsed-to-range composition transition in `EditorEventHandlerGwtTest`
- add a changelog fragment and regenerate `wave/config/changelog.json`

## Testing
- `sbt 'compileGwt'`
- `sbt -batch Universal/stage`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android/mobile IME composition no longer drops already-typed leading characters when the composing word is temporarily promoted to a transient selection.

* **New Features**
  * Pinned saved-search buttons now wrap onto additional toolbar rows instead of forcing horizontal scrolling.
  * Next Unread icon updated from a bell to a directional chevron with an unread-accent dot.

* **Tests**
  * Added coverage for composition handling to ensure transient IME ranges preserve the caret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->