### PR TITLE
[codex] Avoid blocking on loading wavelets and add load diagnostics

### DIFF
--- a/wave/config/changelog.d/2026-04-13-wavelet-load-diagnostics.json
+++ b/wave/config/changelog.d/2026-04-13-wavelet-load-diagnostics.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-wavelet-load-diagnostics",
+  "version": "PR #878",
+  "date": "2026-04-13",
+  "title": "Avoid blocking on loading wavelets",
+  "summary": "Wavelet-dependent cache and indexing paths now skip still-loading wavelets and emit load-state diagnostics instead of blocking on incomplete state.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Prevented cached wavelet invalidation and copy paths from blocking on wavelets that are still loading",
+        "Added wavelet load-state diagnostics so slow or timed-out loads report their state, age, and executor context in server logs"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
@@ -19,6 +19,7 @@
 package org.waveprotocol.box.server.waveserver.lucene9;
 
 import com.google.common.base.Function;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.typesafe.config.Config;
@@ -62,8 +63,10 @@ import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
+import org.waveprotocol.wave.model.wave.data.impl.WaveViewDataImpl;
 
 @Singleton
 public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, Closeable {
@@ -364,7 +367,10 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
     try {
       long elapsedNs;
       synchronized (this) {
-        elapsedNs = upsertWaveTimed(waveId);
+        elapsedNs = upsertWaveTimedFromCacheIfReady(waveId);
+        if (elapsedNs < 0) {
+          return;
+        }
         indexWriter.commit();
         searcherManager.maybeRefreshBlocking();
       }
@@ -474,12 +480,54 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
     return System.nanoTime() - startNs;
   }
 
+  private long upsertWaveTimedFromCacheIfReady(WaveId waveId)
+      throws WaveServerException, WaveletStateException, IOException {
+    long startNs = System.nanoTime();
+    WaveViewData wave = loadCachedWaveIfReadyForIncrementalUpdate(waveId);
+    if (wave == null) {
+      return -1L;
+    }
+    Document document = documentBuilder.build(metadataExtractor.extract(wave), wave);
+    indexWriter.updateDocument(new Term(Lucene9FieldNames.DOC_ID, waveId.serialise()), document);
+    return System.nanoTime() - startNs;
+  }
+
   private WaveViewData loadWave(WaveId waveId) throws WaveServerException, WaveletStateException {
     Set<WaveletId> waveletIds = waveletProvider.getWaveletIds(waveId);
     for (WaveletId waveletId : waveletIds) {
       waveletProvider.getSnapshot(WaveletName.of(waveId, waveletId));
     }
     return AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, MATCH_ALL, waveMap);
+  }
+
+  private WaveViewData loadCachedWaveIfReadyForIncrementalUpdate(WaveId waveId)
+      throws WaveServerException, WaveletStateException {
+    Set<WaveletId> waveletIds = waveletProvider.getWaveletIds(waveId);
+    WaveViewData wave = buildCachedWaveViewDataIfReady(waveId, waveletIds, waveMap);
+    if (wave == null && LOG.isLoggable(Level.FINE)) {
+      for (WaveletId waveletId : waveletIds) {
+        WaveletName waveletName = WaveletName.of(waveId, waveletId);
+        LOG.fine("Deferring incremental lucene9 update for " + waveletName
+            + " because cached state is not ready ("
+            + waveMap.describeCachedWaveletLoadState(waveletName) + ")");
+      }
+    }
+    return wave;
+  }
+
+  @VisibleForTesting
+  static WaveViewData buildCachedWaveViewDataIfReady(
+      WaveId waveId, Set<WaveletId> waveletIds, WaveMap waveMap) throws WaveletStateException {
+    WaveViewData view = WaveViewDataImpl.create(waveId);
+    for (WaveletId waveletId : waveletIds) {
+      WaveletName waveletName = WaveletName.of(waveId, waveletId);
+      ObservableWaveletData waveletData = waveMap.copyCachedWaveletDataIfLoaded(waveletName);
+      if (waveletData == null) {
+        return null;
+      }
+      view.addWavelet(waveletData);
+    }
+    return view;
   }
 
   /** Thread-safe rolling average tracker for incremental indexing times. */

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
@@ -49,6 +49,8 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.waveprotocol.box.server.persistence.lucene.Lucene9SearchIndexDirectory;
 import org.waveprotocol.box.server.persistence.lucene.LuceneIndexWriterFactory;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.AbstractSearchProviderImpl;
 import org.waveprotocol.box.server.waveserver.IndexException;
 import org.waveprotocol.box.server.waveserver.ReadableWaveletDataProvider;
@@ -367,10 +369,7 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
     try {
       long elapsedNs;
       synchronized (this) {
-        elapsedNs = upsertWaveTimedFromCacheIfReady(waveId);
-        if (elapsedNs < 0) {
-          return;
-        }
+        elapsedNs = upsertWaveTimedForIncrementalUpdate(waveId);
         indexWriter.commit();
         searcherManager.maybeRefreshBlocking();
       }
@@ -480,13 +479,12 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
     return System.nanoTime() - startNs;
   }
 
-  private long upsertWaveTimedFromCacheIfReady(WaveId waveId)
+  private long upsertWaveTimedForIncrementalUpdate(WaveId waveId)
       throws WaveServerException, WaveletStateException, IOException {
     long startNs = System.nanoTime();
-    WaveViewData wave = loadCachedWaveIfReadyForIncrementalUpdate(waveId);
-    if (wave == null) {
-      return -1L;
-    }
+    Set<WaveletId> waveletIds = waveletProvider.getWaveletIds(waveId);
+    WaveViewData wave =
+        buildWaveViewDataForIncrementalUpdate(waveId, waveletIds, waveMap, waveletProvider);
     Document document = documentBuilder.build(metadataExtractor.extract(wave), wave);
     indexWriter.updateDocument(new Term(Lucene9FieldNames.DOC_ID, waveId.serialise()), document);
     return System.nanoTime() - startNs;
@@ -500,21 +498,6 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
     return AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, MATCH_ALL, waveMap);
   }
 
-  private WaveViewData loadCachedWaveIfReadyForIncrementalUpdate(WaveId waveId)
-      throws WaveServerException, WaveletStateException {
-    Set<WaveletId> waveletIds = waveletProvider.getWaveletIds(waveId);
-    WaveViewData wave = buildCachedWaveViewDataIfReady(waveId, waveletIds, waveMap);
-    if (wave == null && LOG.isLoggable(Level.FINE)) {
-      for (WaveletId waveletId : waveletIds) {
-        WaveletName waveletName = WaveletName.of(waveId, waveletId);
-        LOG.fine("Deferring incremental lucene9 update for " + waveletName
-            + " because cached state is not ready ("
-            + waveMap.describeCachedWaveletLoadState(waveletName) + ")");
-      }
-    }
-    return wave;
-  }
-
   @VisibleForTesting
   static WaveViewData buildCachedWaveViewDataIfReady(
       WaveId waveId, Set<WaveletId> waveletIds, WaveMap waveMap) throws WaveletStateException {
@@ -526,6 +509,35 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
         return null;
       }
       view.addWavelet(waveletData);
+    }
+    return view;
+  }
+
+  @VisibleForTesting
+  static WaveViewData buildWaveViewDataForIncrementalUpdate(WaveId waveId,
+      Set<WaveletId> waveletIds, WaveMap waveMap, WaveletProvider waveletProvider)
+      throws WaveServerException, WaveletStateException {
+    WaveViewData cachedView = buildCachedWaveViewDataIfReady(waveId, waveletIds, waveMap);
+    if (cachedView != null) {
+      return cachedView;
+    }
+
+    if (LOG.isLoggable(Level.FINE)) {
+      for (WaveletId waveletId : waveletIds) {
+        WaveletName waveletName = WaveletName.of(waveId, waveletId);
+        LOG.fine("Cached state not ready for incremental lucene9 update on " + waveletName
+            + "; indexing from committed snapshot ("
+            + waveMap.describeCachedWaveletLoadState(waveletName) + ")");
+      }
+    }
+    WaveViewData view = WaveViewDataImpl.create(waveId);
+    for (WaveletId waveletId : waveletIds) {
+      WaveletName waveletName = WaveletName.of(waveId, waveletId);
+      CommittedWaveletSnapshot snapshot = waveletProvider.getSnapshot(waveletName);
+      if (snapshot == null || snapshot.snapshot == null) {
+        throw new WaveServerException("Missing committed snapshot for " + waveletName);
+      }
+      view.addWavelet(WaveletDataUtil.copyWavelet(snapshot.snapshot));
     }
     return view;
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/executor/ExecutorsModule.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/executor/ExecutorsModule.java
@@ -154,9 +154,12 @@ public class ExecutorsModule extends AbstractModule {
     if (threadCount < 0) {
       executor = Executors.newCachedThreadPool(threadFactory);
     } else if (threadCount == 1) {
-      executor = Executors.newSingleThreadExecutor(threadFactory);
+      executor = new ThreadPoolExecutor(
+          1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(), threadFactory);
     } else {
-      executor = Executors.newFixedThreadPool(threadCount, threadFactory);
+      executor = new ThreadPoolExecutor(
+          threadCount, threadCount, 0L, TimeUnit.MILLISECONDS,
+          new LinkedBlockingQueue<Runnable>(), threadFactory);
     }
     RequestScopeExecutor scopeExecutor = executorProvider.get();
     scopeExecutor.setExecutor(executor, name);

--- a/wave/src/main/java/org/waveprotocol/box/server/executor/RequestScopeExecutor.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/executor/RequestScopeExecutor.java
@@ -22,6 +22,7 @@ import com.google.inject.Inject;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -54,6 +55,31 @@ public class RequestScopeExecutor implements Executor, Shutdownable {
     Preconditions.checkArgument(this.executor == null, "Executor is already defined.");
     this.executor = executor;
     ShutdownManager.getInstance().register(this, name, ShutdownPriority.Task);
+  }
+
+  public String describeState() {
+    return describeExecutor(executor);
+  }
+
+  public static String describeExecutor(Executor executor) {
+    if (executor == null) {
+      return "executor=null";
+    }
+    if (executor instanceof RequestScopeExecutor) {
+      return ((RequestScopeExecutor) executor).describeState();
+    }
+    if (executor instanceof ThreadPoolExecutor) {
+      ThreadPoolExecutor tpe = (ThreadPoolExecutor) executor;
+      return "executor=" + executor.getClass().getSimpleName()
+          + ", poolSize=" + tpe.getPoolSize()
+          + ", active=" + tpe.getActiveCount()
+          + ", queued=" + tpe.getQueue().size()
+          + ", completed=" + tpe.getCompletedTaskCount();
+    }
+    if (executor instanceof ExecutorService) {
+      return "executor=" + executor.getClass().getSimpleName();
+    }
+    return "executor=" + executor.getClass().getSimpleName();
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImpl.java
@@ -257,6 +257,11 @@ public class MemoryPerUserWaveViewHandlerImpl
       if (container == null) {
         return;
       }
+      if (!container.isLoaded()) {
+        LOG.fine("Skipping cached version check while wavelet is still loading for "
+            + waveletName + " (" + container.describeLoadState() + ")");
+        return;
+      }
       HashedVersion cachedVersion = container.getLastCommittedVersion();
       if (cachedVersion == null || cachedVersion.getVersion() < version.getVersion()) {
         invalidateWaveBestEffort(waveletName.waveId);

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeper.java
@@ -62,6 +62,10 @@ import java.util.concurrent.TimeUnit;
 public class StaleAnnotationSweeper {
 
   private static final Log LOG = Log.get(StaleAnnotationSweeper.class);
+  private static final String ROOT_BLIP_LOCKED_ERROR =
+      "The root blip is locked. Editing is not allowed here.";
+  private static final String WAVE_LOCKED_ERROR =
+      "This wave is locked. Editing and replies are not allowed.";
 
   /**
    * Editing sessions open for longer than this are considered stale (client crashed/disconnected
@@ -474,8 +478,14 @@ public class StaleAnnotationSweeper {
 
         @Override
         public void onFailure(String errorMessage) {
-          // Common causes: version conflict (concurrent delta) or author no longer a participant.
-          // Both are benign — the next sweep will retry with a fresh snapshot version.
+          // Common causes: version conflict (concurrent delta), author no longer a participant,
+          // or cleanup on a legitimately locked wave/root blip. All are benign — the next sweep
+          // will retry with a fresh snapshot version, except lock denials which are expected.
+          if (isLegitimateLockDenial(errorMessage)) {
+            LOG.fine("StaleAnnotationSweeper: skipping cleanup for locked document "
+                + waveletName + "/" + docId + ": " + errorMessage);
+            return;
+          }
           LOG.warning("StaleAnnotationSweeper: batch cleanup failed for "
               + waveletName + "/" + docId + ": " + errorMessage);
         }
@@ -486,5 +496,9 @@ public class StaleAnnotationSweeper {
           + waveletName + "/" + docId, e);
       return false;
     }
+  }
+
+  private static boolean isLegitimateLockDenial(String errorMessage) {
+    return ROOT_BLIP_LOCKED_ERROR.equals(errorMessage) || WAVE_LOCKED_ERROR.equals(errorMessage);
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeper.java
@@ -499,6 +499,8 @@ public class StaleAnnotationSweeper {
   }
 
   private static boolean isLegitimateLockDenial(String errorMessage) {
-    return ROOT_BLIP_LOCKED_ERROR.equals(errorMessage) || WAVE_LOCKED_ERROR.equals(errorMessage);
+    return errorMessage != null
+        && (errorMessage.contains(ROOT_BLIP_LOCKED_ERROR)
+            || errorMessage.contains(WAVE_LOCKED_ERROR));
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
@@ -36,6 +36,7 @@ import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -133,6 +134,23 @@ public class WaveMap {
       return null;
     }
     return wave.getCachedWavelet(waveletName.waveletId);
+  }
+
+  public ObservableWaveletData copyCachedWaveletDataIfLoaded(WaveletName waveletName)
+      throws WaveletStateException {
+    WaveletContainer wavelet = getCachedWavelet(waveletName);
+    if (wavelet == null || !wavelet.isLoaded()) {
+      return null;
+    }
+    return wavelet.copyWaveletData();
+  }
+
+  public String describeCachedWaveletLoadState(WaveletName waveletName) {
+    WaveletContainer wavelet = getCachedWavelet(waveletName);
+    if (wavelet == null) {
+      return "state=UNCACHED";
+    }
+    return wavelet.describeLoadState();
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerModule.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerModule.java
@@ -29,6 +29,7 @@ import com.google.inject.Singleton;
 import com.typesafe.config.Config;
 import org.waveprotocol.box.server.executor.ExecutorAnnotations.StorageContinuationExecutor;
 import org.waveprotocol.box.server.executor.ExecutorAnnotations.WaveletLoadExecutor;
+import org.waveprotocol.box.server.executor.RequestScopeExecutor;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.SnapshotStore;
 import org.waveprotocol.wave.crypto.*;
@@ -37,6 +38,7 @@ import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.version.HashedVersionFactory;
 import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
 import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
+import org.waveprotocol.wave.util.logging.Log;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
@@ -46,6 +48,7 @@ import java.util.concurrent.Executor;
  *
  */
 public class WaveServerModule extends AbstractModule {
+  private static final Log LOG = Log.get(WaveServerModule.class);
   private static final IdURIEncoderDecoder URI_CODEC =
       new IdURIEncoderDecoder(new JavaUrlCodec());
   private static final HashedVersionFactory HASH_FACTORY = new HashedVersionFactoryImpl(URI_CODEC);
@@ -161,15 +164,38 @@ public class WaveServerModule extends AbstractModule {
   static ListenableFuture<DeltaStoreBasedWaveletState> loadWaveletState(Executor executor,
       final DeltaStore deltaStore, final SnapshotStore snapshotStore, final int snapshotInterval,
       final WaveletName waveletName, final Executor persistExecutor) {
+    final long scheduledAtMs = System.currentTimeMillis();
     ListenableFutureTask<DeltaStoreBasedWaveletState> task =
         ListenableFutureTask.create(
            new Callable<DeltaStoreBasedWaveletState>() {
              @Override
              public DeltaStoreBasedWaveletState call() throws PersistenceException {
-               return DeltaStoreBasedWaveletState.create(deltaStore.open(waveletName),
-                   snapshotStore, snapshotInterval, persistExecutor);
+               long startAtMs = System.currentTimeMillis();
+               if (LOG.isFineLoggable()) {
+                 LOG.fine("Starting initial wavelet load for " + waveletName
+                     + " after queuedMs=" + (startAtMs - scheduledAtMs)
+                     + " on " + RequestScopeExecutor.describeExecutor(executor));
+               }
+               try {
+                 DeltaStoreBasedWaveletState state = DeltaStoreBasedWaveletState.create(
+                     deltaStore.open(waveletName), snapshotStore, snapshotInterval, persistExecutor);
+                 if (LOG.isFineLoggable()) {
+                   LOG.fine("Finished initial wavelet load for " + waveletName
+                       + " in " + (System.currentTimeMillis() - startAtMs) + "ms");
+                 }
+                 return state;
+               } catch (PersistenceException e) {
+                 LOG.warning("Initial wavelet load failed for " + waveletName
+                     + " after " + (System.currentTimeMillis() - startAtMs) + "ms"
+                     + " on " + RequestScopeExecutor.describeExecutor(executor), e);
+                 throw e;
+               }
              }
            });
+    if (LOG.isFineLoggable()) {
+      LOG.fine("Scheduling initial wavelet load for " + waveletName
+          + " on " + RequestScopeExecutor.describeExecutor(executor));
+    }
     executor.execute(task);
     return task;
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainer.java
@@ -52,6 +52,20 @@ interface WaveletContainer {
   /** Returns the name of the wavelet. */
   WaveletName getWaveletName();
 
+  /**
+   * @return true when the initial storage load has completed and the container is ready for reads.
+   */
+  default boolean isLoaded() {
+    return true;
+  }
+
+  /**
+   * Returns a short diagnostic string describing the current load state of the container.
+   */
+  default String describeLoadState() {
+    return "state=UNKNOWN";
+  }
+
   /** Returns a snapshot copy of the wavelet state. */
   ObservableWaveletData copyWaveletData() throws WaveletStateException;
 

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainer.java
@@ -56,14 +56,14 @@ interface WaveletContainer {
    * @return true when the initial storage load has completed and the container is ready for reads.
    */
   default boolean isLoaded() {
-    return true;
+    return false;
   }
 
   /**
    * Returns a short diagnostic string describing the current load state of the container.
    */
   default String describeLoadState() {
-    return "state=UNKNOWN";
+    return "state=UNKNOWN, loaded=false";
   }
 
   /** Returns a snapshot copy of the wavelet state. */

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -20,6 +20,7 @@
 package org.waveprotocol.box.server.waveserver;
 
 import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.executor.RequestScopeExecutor;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -90,6 +91,10 @@ abstract class WaveletContainerImpl implements WaveletContainer {
   }
 
   private final Executor storageContinuationExecutor;
+  private final ListenableFuture<? extends WaveletState> waveletStateFuture;
+  private final long loadCreatedAtMs;
+  private volatile long loadListenerStartedAtMs = -1L;
+  private volatile long loadCompletedAtMs = -1L;
 
   private final Lock readLock;
   private final ReentrantReadWriteLock.WriteLock writeLock;
@@ -116,6 +121,8 @@ abstract class WaveletContainerImpl implements WaveletContainer {
       Executor storageContinuationExecutor) {
     this.waveletName = waveletName;
     this.notifiee = notifiee;
+    this.waveletStateFuture = waveletStateFuture;
+    this.loadCreatedAtMs = System.currentTimeMillis();
     this.sharedDomainParticipantId =
         waveDomain != null ? ParticipantIdUtil.makeUnsafeSharedDomainParticipantId(waveDomain)
             : null;
@@ -128,6 +135,12 @@ abstract class WaveletContainerImpl implements WaveletContainer {
         new Runnable() {
           @Override
           public void run() {
+            loadListenerStartedAtMs = System.currentTimeMillis();
+            if (LOG.isFineLoggable()) {
+              LOG.fine("Finishing initial wavelet load for " + getWaveletName()
+                  + " after ageMs=" + (loadListenerStartedAtMs - loadCreatedAtMs)
+                  + " on " + RequestScopeExecutor.describeExecutor(storageContinuationExecutor));
+            }
             acquireWriteLock();
             try {
               Preconditions.checkState(waveletState == null,
@@ -151,7 +164,12 @@ abstract class WaveletContainerImpl implements WaveletContainer {
               LOG.severe("Unexpected exception loading wavelet " + getWaveletName(), e);
               state = State.CORRUPTED;
             } finally {
+              loadCompletedAtMs = System.currentTimeMillis();
               releaseWriteLock();
+            }
+            if (LOG.isFineLoggable()) {
+              LOG.fine("Initial wavelet load completion for " + getWaveletName()
+                  + ": " + describeLoadState());
             }
             loadLatch.countDown();
           }
@@ -207,6 +225,8 @@ abstract class WaveletContainerImpl implements WaveletContainer {
     Preconditions.checkState(!writeLock.isHeldByCurrentThread(), "should not hold write lock");
     try {
       if (!loadLatch.await(AWAIT_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        LOG.warning("Timed out waiting for wavelet to load " + getWaveletName()
+            + " -- " + describeLoadState());
         throw new WaveletStateException("Timed out waiting for wavelet to load");
       }
     } catch (InterruptedException e) {
@@ -276,6 +296,26 @@ abstract class WaveletContainerImpl implements WaveletContainer {
   @Override
   public WaveletName getWaveletName() {
     return waveletName;
+  }
+
+  @Override
+  public boolean isLoaded() {
+    return loadLatch.getCount() == 0 && state == State.OK;
+  }
+
+  @Override
+  public String describeLoadState() {
+    long now = System.currentTimeMillis();
+    return "state=" + state
+        + ", ageMs=" + (now - loadCreatedAtMs)
+        + ", futureDone=" + waveletStateFuture.isDone()
+        + ", listenerStartedMs=" + formatLoadOffset(loadListenerStartedAtMs)
+        + ", completedMs=" + formatLoadOffset(loadCompletedAtMs)
+        + ", storageContinuation=" + RequestScopeExecutor.describeExecutor(storageContinuationExecutor);
+  }
+
+  private String formatLoadOffset(long timestampMs) {
+    return timestampMs >= 0 ? Long.toString(timestampMs - loadCreatedAtMs) : "pending";
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -225,14 +225,19 @@ abstract class WaveletContainerImpl implements WaveletContainer {
     Preconditions.checkState(!writeLock.isHeldByCurrentThread(), "should not hold write lock");
     try {
       if (!loadLatch.await(AWAIT_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        LOG.warning("Timed out waiting for wavelet to load " + getWaveletName()
-            + " -- " + describeLoadState());
-        throw new WaveletStateException("Timed out waiting for wavelet to load");
+        String timeoutMessage = formatAwaitLoadTimeoutMessage();
+        LOG.warning(timeoutMessage);
+        throw new WaveletStateException(timeoutMessage);
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new WaveletStateException("Interrupted waiting for wavelet to load");
     }
+  }
+
+  String formatAwaitLoadTimeoutMessage() {
+    return "Timed out waiting for wavelet to load " + getWaveletName()
+        + " (" + describeLoadState() + ")";
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveletContainerImpl.java
@@ -105,7 +105,7 @@ abstract class WaveletContainerImpl implements WaveletContainer {
   private final CountDownLatch loadLatch = new CountDownLatch(1);
   /** Is set at most once, before loadLatch is counted down. */
   private WaveletState waveletState;
-  private State state = State.LOADING;
+  private volatile State state = State.LOADING;
 
   /**
    * Constructs an empty WaveletContainer for a wavelet.

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplJUnit4Test.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplJUnit4Test.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JUnit4 wrapper so sbt/junit-interface discovers the
+ * {@link MemoryPerUserWaveViewHandlerImplTest} cases reliably.
+ */
+public class MemoryPerUserWaveViewHandlerImplJUnit4Test
+    extends MemoryPerUserWaveViewHandlerImplTest {
+
+  @Before
+  public void init() throws Exception {
+    super.setUp();
+  }
+
+  @Test
+  public void retrievePerUserWaveViewReloadsColdWaveMap() {
+    super.testRetrievePerUserWaveViewReloadsColdWaveMap();
+  }
+
+  @Test
+  public void rapidCacheMissesShareSingleLoad() {
+    super.testRapidCacheMissesShareSingleLoad();
+  }
+
+  @Test
+  public void retrievePerUserWaveViewCacheHitSkipsReload() {
+    super.testRetrievePerUserWaveViewCacheHitSkipsReload();
+  }
+
+  @Test
+  public void waveletCommittedSkipsInvalidateWhenCommittedVersionCheckRequiresWriteLock()
+      throws Exception {
+    super.testWaveletCommittedSkipsInvalidateWhenCommittedVersionCheckRequiresWriteLock();
+  }
+
+  @Test
+  public void waveletCommittedMarksWaveMapDirtyWhenInvalidateThrowsRuntimeException()
+      throws Exception {
+    super.testWaveletCommittedMarksWaveMapDirtyWhenInvalidateThrowsRuntimeException();
+  }
+
+  @Test
+  public void waveletCommittedSkipsInvalidateWhenCachedWaveletStillLoading()
+      throws Exception {
+    super.testWaveletCommittedSkipsInvalidateWhenCachedWaveletStillLoading();
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplJUnit4Test.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplJUnit4Test.java
@@ -21,11 +21,14 @@ package org.waveprotocol.box.server.waveserver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * JUnit4 wrapper so sbt/junit-interface discovers the
  * {@link MemoryPerUserWaveViewHandlerImplTest} cases reliably.
  */
+@RunWith(JUnit4.class)
 public class MemoryPerUserWaveViewHandlerImplJUnit4Test
     extends MemoryPerUserWaveViewHandlerImplTest {
 

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -19,6 +19,9 @@
 
 package org.waveprotocol.box.server.waveserver;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -195,6 +198,51 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
 
     handler.retrievePerUserWaveView(PARTICIPANT);
     assertEquals(2, reloadingWaveMap.getLoadAllWaveletsCallCount());
+  }
+
+  public void testWaveletCommittedSkipsInvalidateWhenCachedWaveletStillLoading()
+      throws Exception {
+    LocalWaveletContainer loadingContainer = mock(LocalWaveletContainer.class);
+    when(loadingContainer.getWaveletName()).thenReturn(WAVELET_NAME);
+    when(loadingContainer.hasParticipant(PARTICIPANT)).thenReturn(true);
+    when(loadingContainer.isLoaded()).thenReturn(false);
+    when(loadingContainer.describeLoadState()).thenReturn("state=LOADING");
+    when(loadingContainer.getLastCommittedVersion()).thenThrow(
+        new IllegalStateException("should not read version while loading"));
+
+    ReloadingWaveMap reloadingWaveMap =
+        new ReloadingWaveMap(
+            new DeltaStoreBasedSnapshotStore(
+                new org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore(), null),
+            new LocalWaveletContainer.Factory() {
+              @Override
+              public LocalWaveletContainer create(
+                  WaveletNotificationSubscriber notifiee,
+                  WaveletName waveletName,
+                  String domain) {
+                throw new UnsupportedOperationException();
+              }
+            },
+            new RemoteWaveletContainer.Factory() {
+              @Override
+              public RemoteWaveletContainer create(
+                  WaveletNotificationSubscriber notifiee,
+                  WaveletName waveletName,
+                  String domain) {
+                throw new UnsupportedOperationException();
+              }
+            },
+            createLoadedWaves(
+                loadingContainer));
+    MemoryPerUserWaveViewHandlerImpl handler =
+        new MemoryPerUserWaveViewHandlerImpl(reloadingWaveMap);
+
+    handler.retrievePerUserWaveView(PARTICIPANT);
+    assertEquals(1, reloadingWaveMap.getLoadAllWaveletsCallCount());
+
+    handler.waveletCommitted(WAVELET_NAME, HashedVersion.unsigned(2L));
+
+    assertEquals(0, reloadingWaveMap.getInvalidateWaveCallCount());
   }
 
   private static ImmutableMap<WaveId, Wave> createLoadedWaves(LocalWaveletContainer container)

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MemoryPerUserWaveViewHandlerImplTest.java
@@ -420,6 +420,16 @@ public class MemoryPerUserWaveViewHandlerImplTest extends TestCase {
     }
 
     @Override
+    public boolean isLoaded() {
+      return true;
+    }
+
+    @Override
+    public String describeLoadState() {
+      return "state=OK, loaded=true";
+    }
+
+    @Override
     public ObservableWaveletData copyWaveletData() {
       throw new UnsupportedOperationException();
     }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeperTest.java
@@ -21,6 +21,7 @@ package org.waveprotocol.box.server.waveserver;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,7 +63,13 @@ import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Unit tests for {@link StaleAnnotationSweeper}.
@@ -255,5 +262,85 @@ public class StaleAnnotationSweeperTest extends TestCase {
         any(WaveletName.class),
         any(ProtocolWaveletDelta.class),
         any(WaveletProvider.SubmitRequestListener.class));
+  }
+
+  public void testSweepDoesNotWarnForRootLockDenial() throws Exception {
+    assertLockDenialIsNotWarned("The root blip is locked. Editing is not allowed here.");
+  }
+
+  public void testSweepDoesNotWarnForAllLockDenial() throws Exception {
+    assertLockDenialIsNotWarned("This wave is locked. Editing and replies are not allowed.");
+  }
+
+  private void assertLockDenialIsNotWarned(String errorMessage) throws Exception {
+    CapturingOperationSink<WaveletOperation> output = new CapturingOperationSink<>();
+    OpBasedWavelet wavelet = buildWavelet(output);
+
+    WaveletBasedConversation.makeWaveletConversational(wavelet);
+    ConversationBlip blip = conversationUtil.buildConversation(wavelet)
+        .getRoot().getRootThread().appendBlip();
+
+    long staleStartMs = 1000L;
+    blip.getContent().setAnnotation(0, 1, "user/d/session-stale",
+        ALICE.getAddress() + "," + staleStartMs + ",");
+
+    waveletData.setVersion(waveletData.getVersion() + 1);
+    setupProvider(waveletData);
+
+    doAnswer(invocation -> {
+      WaveletProvider.SubmitRequestListener listener =
+          (WaveletProvider.SubmitRequestListener) invocation.getArguments()[2];
+      listener.onFailure(errorMessage);
+      return null;
+    }).when(mockProvider).submitRequest(
+        eq(WAVELET_NAME),
+        any(ProtocolWaveletDelta.class),
+        any(WaveletProvider.SubmitRequestListener.class));
+
+    Logger logger = Logger.getLogger(StaleAnnotationSweeper.class.getName());
+    List<LogRecord> records = new ArrayList<>();
+    Handler captureHandler = new Handler() {
+      @Override
+      public void publish(LogRecord record) {
+        records.add(record);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() throws SecurityException {}
+    };
+
+    Level savedLevel = logger.getLevel();
+    boolean savedUseParent = logger.getUseParentHandlers();
+    logger.addHandler(captureHandler);
+    logger.setLevel(Level.ALL);
+    logger.setUseParentHandlers(false);
+    try {
+      sweeper.sweep();
+    } finally {
+      logger.removeHandler(captureHandler);
+      logger.setLevel(savedLevel);
+      logger.setUseParentHandlers(savedUseParent);
+    }
+
+    boolean warned = false;
+    boolean loggedFine = false;
+    for (LogRecord record : records) {
+      if (record.getMessage() != null
+          && record.getMessage().contains(WAVELET_NAME + "/" + blip.getId())
+          && record.getMessage().contains(errorMessage)) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+          warned = true;
+        }
+        if (record.getLevel().intValue() <= Level.INFO.intValue()) {
+          loggedFine = true;
+        }
+      }
+    }
+
+    assertFalse("Legitimate lock denial should not be logged as warning", warned);
+    assertTrue("Legitimate lock denial should still be logged at a low level", loggedFine);
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/StaleAnnotationSweeperTest.java
@@ -272,6 +272,11 @@ public class StaleAnnotationSweeperTest extends TestCase {
     assertLockDenialIsNotWarned("This wave is locked. Editing and replies are not allowed.");
   }
 
+  public void testSweepDoesNotWarnForLockDenialWithAdditionalContext() throws Exception {
+    assertLockDenialIsNotWarned(
+        "Blocked by policy: This wave is locked. Editing and replies are not allowed. [lockId=7]");
+  }
+
   private void assertLockDenialIsNotWarned(String errorMessage) throws Exception {
     CapturingOperationSink<WaveletOperation> output = new CapturingOperationSink<>();
     OpBasedWavelet wavelet = buildWavelet(output);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 
 import junit.framework.TestCase;
@@ -238,6 +239,26 @@ public class WaveletContainerTest extends TestCase {
     assertEquals(localWavelet.getCurrentVersion(), oldVersion);
   }
 
+  public void testLoadStateDescriptionReflectsPendingAndCompletedLoad() throws Exception {
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    SettableFuture<WaveletState> pendingState = SettableFuture.create();
+    TestWaveletContainer container =
+        new TestWaveletContainer(localWaveletName, notifiee, pendingState);
+
+    assertFalse(container.isLoaded());
+    assertTrue(container.describeLoadState().contains("state=LOADING"));
+
+    DeltaStore deltaStore = new MemoryDeltaStore();
+    WaveletState loadedState =
+        DeltaStoreBasedWaveletState.create(deltaStore.open(localWaveletName), PERSIST_EXECUTOR);
+    pendingState.set(loadedState);
+
+    container.awaitLoad();
+
+    assertTrue(container.isLoaded());
+    assertTrue(container.describeLoadState().contains("state=OK"));
+  }
+
   public void testLocalEmptyDelta() throws Exception {
     ProtocolSignedDelta emptyDelta = ProtocolSignedDelta.newBuilder()
         .addSignature(fakeSignature1)
@@ -406,6 +427,12 @@ public class WaveletContainerTest extends TestCase {
     TestWaveletContainer(WaveletName waveletName, WaveletNotificationSubscriber notifiee,
         WaveletState waveletState) {
       super(waveletName, notifiee, Futures.immediateFuture(waveletState), localDomain,
+          STORAGE_CONTINUATION_EXECUTOR);
+    }
+
+    TestWaveletContainer(WaveletName waveletName, WaveletNotificationSubscriber notifiee,
+        SettableFuture<WaveletState> waveletStateFuture) {
+      super(waveletName, notifiee, waveletStateFuture, localDomain,
           STORAGE_CONTINUATION_EXECUTOR);
     }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
@@ -33,10 +33,13 @@ import com.google.protobuf.ByteString;
 
 import junit.framework.TestCase;
 
+import org.waveprotocol.box.common.Receiver;
 import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
 import org.waveprotocol.wave.federation.Proto.ProtocolHashedVersion;
+import org.waveprotocol.wave.federation.Proto.ProtocolAppliedWaveletDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignature;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
@@ -58,7 +61,10 @@ import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.version.HashedVersionFactory;
 import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -259,6 +265,25 @@ public class WaveletContainerTest extends TestCase {
     assertTrue(container.describeLoadState().contains("state=OK"));
   }
 
+  public void testWaveletContainerDefaultsAreConservative() {
+    WaveletContainer container = new ConservativeDefaultWaveletContainer();
+
+    assertFalse(container.isLoaded());
+    assertEquals("state=UNKNOWN, loaded=false", container.describeLoadState());
+  }
+
+  public void testAwaitLoadTimeoutMessageIncludesWaveletDiagnostics() throws Exception {
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    SettableFuture<WaveletState> pendingState = SettableFuture.create();
+    TestWaveletContainer container =
+        new TestWaveletContainer(localWaveletName, notifiee, pendingState);
+
+    String message = container.formatAwaitLoadTimeoutMessage();
+
+    assertTrue(message.contains(localWaveletName.toString()));
+    assertTrue(message.contains("state=LOADING"));
+  }
+
   public void testLocalEmptyDelta() throws Exception {
     ProtocolSignedDelta emptyDelta = ProtocolSignedDelta.newBuilder()
         .addSignature(fakeSignature1)
@@ -421,6 +446,75 @@ public class WaveletContainerTest extends TestCase {
 
   private static ProtocolWaveletDelta serialize(WaveletDelta d) {
     return CoreWaveletOperationSerializer.serialize(d);
+  }
+
+  private static final class ConservativeDefaultWaveletContainer implements WaveletContainer {
+    @Override
+    public WaveletName getWaveletName() {
+      return localWaveletName;
+    }
+
+    @Override
+    public ObservableWaveletData copyWaveletData() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CommittedWaveletSnapshot getSnapshot() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T applyFunction(com.google.common.base.Function<ReadableWaveletData, T> function) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void requestHistory(HashedVersion versionStart, HashedVersion versionEnd,
+        Receiver<ByteStringMessage<ProtocolAppliedWaveletDelta>> receiver) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void requestTransformedHistory(HashedVersion versionStart, HashedVersion versionEnd,
+        Receiver<TransformedWaveletDelta> receiver) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean checkAccessPermission(ParticipantId participantId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HashedVersion getLastCommittedVersion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasParticipant(ParticipantId participant) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParticipantId getCreator() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ParticipantId getSharedDomainParticipant() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HashedVersion getHashedVersion(long version) {
+      throw new UnsupportedOperationException();
+    }
   }
 
   private static final class TestWaveletContainer extends WaveletContainerImpl {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
@@ -1,10 +1,22 @@
 package org.waveprotocol.box.server.waveserver.lucene9;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Iterables;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import org.junit.Test;
+import org.waveprotocol.box.server.waveserver.WaveMap;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
 
 public final class Lucene9WaveIndexerImplTest {
   @Test
@@ -24,5 +36,38 @@ public final class Lucene9WaveIndexerImplTest {
     }
 
     assertEquals(3L, stats.getCount());
+  }
+
+  @Test
+  public void buildCachedWaveViewDataIfReadyReturnsNullWhenCachedWaveletStillLoading()
+      throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveId waveId = WaveId.of("example.com", "wave");
+    WaveletId waveletId = WaveletId.of("example.com", "conv+root");
+    WaveletName waveletName = WaveletName.of(waveId, waveletId);
+
+    when(waveMap.copyCachedWaveletDataIfLoaded(waveletName)).thenReturn(null);
+    when(waveMap.describeCachedWaveletLoadState(waveletName)).thenReturn("state=LOADING");
+
+    assertNull(Lucene9WaveIndexerImpl.buildCachedWaveViewDataIfReady(
+        waveId, Collections.singleton(waveletId), waveMap));
+  }
+
+  @Test
+  public void buildCachedWaveViewDataIfReadyBuildsViewWhenAllWaveletsLoaded()
+      throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveId waveId = WaveId.of("example.com", "wave");
+    WaveletId waveletId = WaveletId.of("example.com", "conv+root");
+    WaveletName waveletName = WaveletName.of(waveId, waveletId);
+    ObservableWaveletData waveletData = mock(ObservableWaveletData.class);
+
+    when(waveMap.copyCachedWaveletDataIfLoaded(waveletName)).thenReturn(waveletData);
+
+    WaveViewData view = Lucene9WaveIndexerImpl.buildCachedWaveViewDataIfReady(
+        waveId, Collections.singleton(waveletId), waveMap);
+
+    assertNotNull(view);
+    assertEquals(1, Iterables.size(view.getWavelets()));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
@@ -2,23 +2,45 @@ package org.waveprotocol.box.server.waveserver.lucene9;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.WaveMap;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
 
 public final class Lucene9WaveIndexerImplTest {
+  private static final ParticipantId PARTICIPANT = ParticipantId.ofUnsafe("author@example.com");
+  private static final HashedVersion VERSION_ZERO = HashedVersion.unsigned(0L);
+
+  private WaveId waveId;
+  private WaveletId waveletId;
+  private WaveletName waveletName;
+
+  @Before
+  public void setUpIdentifiers() {
+    waveId = WaveId.of("example.com", "wave");
+    waveletId = WaveletId.of("example.com", "conv+root");
+    waveletName = WaveletName.of(waveId, waveletId);
+  }
+
   @Test
   public void incrementalIndexStatsHandlesCounterOverflow() throws Exception {
     Lucene9WaveIndexerImpl.IncrementalIndexStats stats =
@@ -42,9 +64,6 @@ public final class Lucene9WaveIndexerImplTest {
   public void buildCachedWaveViewDataIfReadyReturnsNullWhenCachedWaveletStillLoading()
       throws Exception {
     WaveMap waveMap = mock(WaveMap.class);
-    WaveId waveId = WaveId.of("example.com", "wave");
-    WaveletId waveletId = WaveletId.of("example.com", "conv+root");
-    WaveletName waveletName = WaveletName.of(waveId, waveletId);
 
     when(waveMap.copyCachedWaveletDataIfLoaded(waveletName)).thenReturn(null);
     when(waveMap.describeCachedWaveletLoadState(waveletName)).thenReturn("state=LOADING");
@@ -57,9 +76,6 @@ public final class Lucene9WaveIndexerImplTest {
   public void buildCachedWaveViewDataIfReadyBuildsViewWhenAllWaveletsLoaded()
       throws Exception {
     WaveMap waveMap = mock(WaveMap.class);
-    WaveId waveId = WaveId.of("example.com", "wave");
-    WaveletId waveletId = WaveletId.of("example.com", "conv+root");
-    WaveletName waveletName = WaveletName.of(waveId, waveletId);
     ObservableWaveletData waveletData = mock(ObservableWaveletData.class);
 
     when(waveMap.copyCachedWaveletDataIfLoaded(waveletName)).thenReturn(waveletData);
@@ -69,5 +85,26 @@ public final class Lucene9WaveIndexerImplTest {
 
     assertNotNull(view);
     assertEquals(1, Iterables.size(view.getWavelets()));
+  }
+
+  @Test
+  public void buildWaveViewDataForIncrementalUpdateFallsBackToCommittedSnapshots()
+      throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    ObservableWaveletData persistedWavelet = WaveletDataUtil.createEmptyWavelet(
+        waveletName, PARTICIPANT, VERSION_ZERO, 1L);
+
+    when(waveMap.copyCachedWaveletDataIfLoaded(waveletName)).thenReturn(null);
+    when(waveletProvider.getSnapshot(waveletName)).thenReturn(
+        new CommittedWaveletSnapshot(persistedWavelet, VERSION_ZERO));
+
+    WaveViewData view = Lucene9WaveIndexerImpl.buildWaveViewDataForIncrementalUpdate(
+        waveId, Collections.singleton(waveletId), waveMap, waveletProvider);
+
+    assertNotNull(view);
+    assertEquals(1, Iterables.size(view.getWavelets()));
+    assertNotSame(persistedWavelet, Iterables.getOnlyElement(view.getWavelets()));
+    verify(waveletProvider).getSnapshot(waveletName);
   }
 }


### PR DESCRIPTION
## Summary
- add wavelet load lifecycle diagnostics with executor state and queue depth details
- avoid blocking post-commit cache/version checks on freshly loading wavelets
- make lucene9 incremental indexing defer when cached wavelet state is not ready instead of triggering blocking reloads
- downgrade legitimate stale-annotation sweeper lock denials from warning noise to low-level logs
- add a JUnit4 wrapper so `MemoryPerUserWaveViewHandlerImpl` coverage is actually discovered by sbt

## Root Cause
A wavelet container can remain in `LOADING` long enough that post-commit readers hit `awaitLoad()` and time out. Two commit-tail readers were vulnerable:
- per-user wave-view cache invalidation read `getLastCommittedVersion()` from a cached container even when that container was still loading
- lucene9 incremental indexing rebuilt wave views through the normal read path, which can block on a freshly reloaded container

The new diagnostics distinguish whether the delay is in the initial load work or in the load-completion listener backlog, and include executor queue state to make the next timeout actionable.

## Validation
- `sbt "testOnly org.waveprotocol.box.server.waveserver.MemoryPerUserWaveViewHandlerImplJUnit4Test org.waveprotocol.box.server.waveserver.StaleAnnotationSweeperTest org.waveprotocol.box.server.waveserver.WaveletContainerTest org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImplTest"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added load-state diagnostics (status, age, executor info) to server logs
  * Incremental indexing now prefers cached wavelet data and defers when cache is incomplete

* **Bug Fixes**
  * Prevented blocking on still-loading wavelets
  * Suppressed noisy warnings for expected lock-denial failures during cleanup

* **Tests**
  * Added tests for load-state behavior, incremental indexing fallbacks, and lock-denial handling

* **Documentation**
  * Added changelog entry for this release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->