### PR TITLE
[codex] Restore deploy health wait window

### DIFF
--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -309,13 +309,17 @@ start_target_slot() {
 
 wait_for_slot_health() {
   local port=$1
-  local retries=90
+  local interval_seconds="${WAVE_SLOT_HEALTH_INTERVAL_SECONDS:-2}"
+  local timeout_seconds="${WAVE_SLOT_HEALTH_TIMEOUT_SECONDS:-420}"
+  local retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
   local i=0
+  # Lucene-backed production startups can legitimately take several minutes
+  # before /healthz answers while indexes are rebuilt from MongoDB.
   while [ $i -lt $retries ]; do
     if curl -sf "http://localhost:${port}/healthz" > /dev/null 2>&1; then
       return 0
     fi
-    sleep 2
+    sleep "$interval_seconds"
     i=$((i + 1))
   done
   return 1

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -311,6 +311,10 @@ wait_for_slot_health() {
   local port=$1
   local interval_seconds="${WAVE_SLOT_HEALTH_INTERVAL_SECONDS:-2}"
   local timeout_seconds="${WAVE_SLOT_HEALTH_TIMEOUT_SECONDS:-420}"
+  if ! [[ "$interval_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_INTERVAL_SECONDS must be a positive integer (got: '${interval_seconds}')" >&2
+    return 1
+  fi
   local retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
   local i=0
   # Lucene-backed production startups can legitimately take several minutes

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -321,7 +321,7 @@ wait_for_slot_health() {
   fi
   local retries=1
   if [ "$timeout_seconds" -gt 0 ]; then
-    retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
+    retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds + 1 ))
   fi
   local i=0
   # Lucene-backed production startups can legitimately take several minutes

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -315,11 +315,14 @@ wait_for_slot_health() {
     echo "[deploy] ERROR: WAVE_SLOT_HEALTH_INTERVAL_SECONDS must be a positive integer (got: '${interval_seconds}')" >&2
     return 1
   fi
-  if ! [[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
-    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a positive integer (got: '${timeout_seconds}')" >&2
+  if ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]]; then
+    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer (got: '${timeout_seconds}')" >&2
     return 1
   fi
-  local retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
+  local retries=1
+  if [ "$timeout_seconds" -gt 0 ]; then
+    retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
+  fi
   local i=0
   # Lucene-backed production startups can legitimately take several minutes
   # before /healthz answers while indexes are rebuilt from MongoDB.
@@ -327,8 +330,11 @@ wait_for_slot_health() {
     if curl -sf "http://localhost:${port}/healthz" > /dev/null 2>&1; then
       return 0
     fi
-    sleep "$interval_seconds"
     i=$((i + 1))
+    if [ $i -ge $retries ]; then
+      break
+    fi
+    sleep "$interval_seconds"
   done
   return 1
 }

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -315,6 +315,10 @@ wait_for_slot_health() {
     echo "[deploy] ERROR: WAVE_SLOT_HEALTH_INTERVAL_SECONDS must be a positive integer (got: '${interval_seconds}')" >&2
     return 1
   fi
+  if ! [[ "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a positive integer (got: '${timeout_seconds}')" >&2
+    return 1
+  fi
   local retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds ))
   local i=0
   # Lucene-backed production startups can legitimately take several minutes

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -319,10 +319,7 @@ wait_for_slot_health() {
     echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer without leading zeros (got: '${timeout_seconds}')" >&2
     return 1
   fi
-  local retries=1
-  if [ "$timeout_seconds" -gt 0 ]; then
-    retries=$(( (timeout_seconds + interval_seconds - 1) / interval_seconds + 1 ))
-  fi
+  local retries=$(( timeout_seconds / interval_seconds + 1 ))
   local i=0
   # Lucene-backed production startups can legitimately take several minutes
   # before /healthz answers while indexes are rebuilt from MongoDB.

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -315,8 +315,8 @@ wait_for_slot_health() {
     echo "[deploy] ERROR: WAVE_SLOT_HEALTH_INTERVAL_SECONDS must be a positive integer (got: '${interval_seconds}')" >&2
     return 1
   fi
-  if ! [[ "$timeout_seconds" =~ ^[0-9]+$ ]]; then
-    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer (got: '${timeout_seconds}')" >&2
+  if ! [[ "$timeout_seconds" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer without leading zeros (got: '${timeout_seconds}')" >&2
     return 1
   fi
   local retries=1

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -319,19 +319,27 @@ wait_for_slot_health() {
     echo "[deploy] ERROR: WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer without leading zeros (got: '${timeout_seconds}')" >&2
     return 1
   fi
-  local retries=$(( timeout_seconds / interval_seconds + 1 ))
-  local i=0
+  local started_at
+  local elapsed_seconds
+  local remaining_seconds
+  local sleep_seconds
+  started_at=$(date +%s)
   # Lucene-backed production startups can legitimately take several minutes
   # before /healthz answers while indexes are rebuilt from MongoDB.
-  while [ $i -lt $retries ]; do
+  while true; do
     if curl -sf "http://localhost:${port}/healthz" > /dev/null 2>&1; then
       return 0
     fi
-    i=$((i + 1))
-    if [ $i -ge $retries ]; then
+    elapsed_seconds=$(( $(date +%s) - started_at ))
+    if [ "$elapsed_seconds" -ge "$timeout_seconds" ]; then
       break
     fi
-    sleep "$interval_seconds"
+    remaining_seconds=$(( timeout_seconds - elapsed_seconds ))
+    sleep_seconds=$interval_seconds
+    if [ "$remaining_seconds" -lt "$sleep_seconds" ]; then
+      sleep_seconds=$remaining_seconds
+    fi
+    sleep "$sleep_seconds"
   done
   return 1
 }

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -32,6 +32,26 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         200,
     )
 
+  def test_deploy_accepts_health_on_timeout_boundary_probe(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        extra_env={"WAVE_SLOT_HEALTH_TIMEOUT_SECONDS": "420"},
+        health_success_after=211,
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"deploy should accept health on the timeout-boundary probe:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    self.assertEqual(
+        211,
+        int((temp_dir / "health-count").read_text(encoding="utf-8").strip()),
+    )
+
   def test_deploy_rejects_zero_health_interval_with_cleanup(self):
     result, temp_dir = self._run_script(
         command="deploy",

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -32,6 +32,42 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         200,
     )
 
+  def test_deploy_rejects_zero_health_interval_with_cleanup(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        extra_env={"WAVE_SLOT_HEALTH_INTERVAL_SECONDS": "0"},
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn(
+        "WAVE_SLOT_HEALTH_INTERVAL_SECONDS must be a positive integer",
+        result.stderr,
+    )
+    self.assertFalse((temp_dir / "health-count").exists())
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
+    self.assertIn("stop wave-green", ops)
+
+  def test_deploy_rejects_negative_health_timeout_with_cleanup(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        extra_env={"WAVE_SLOT_HEALTH_TIMEOUT_SECONDS": "-1"},
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn(
+        "WAVE_SLOT_HEALTH_TIMEOUT_SECONDS must be a non-negative integer",
+        result.stderr,
+    )
+    self.assertFalse((temp_dir / "health-count").exists())
+    ops = (temp_dir / "ops.log").read_text(encoding="utf-8")
+    self.assertIn("stop wave-green", ops)
+
   def test_deploy_stops_old_slot_immediately_after_swap(self):
     result, temp_dir = self._run_script(
         command="deploy",
@@ -150,6 +186,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
       active_slot: str,
       previous_slot: str | None,
       running_services: list[str],
+      extra_env: dict[str, str] | None = None,
       stop_fail_services: list[str] | None = None,
       ps_error_services: list[str] | None = None,
       reload_fail_on_calls: list[int] | None = None,
@@ -322,6 +359,8 @@ exit 1
     env["WWW_HOST"] = "www.supawave.ai"
     env["SANITY_ADDRESS"] = "testregister"
     env["SANITY_PASSWORD"] = "testregister"
+    if extra_env:
+      env.update(extra_env)
 
     result = subprocess.run(
         [bash_path, str(DEPLOY_SCRIPT), command],

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -13,6 +13,25 @@ BUILD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build.yml"
 
 
 class DeployOverlapSafetyTest(unittest.TestCase):
+  def test_deploy_waits_long_enough_for_slow_startup(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        health_success_after=200,
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"deploy failed unexpectedly:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    self.assertGreaterEqual(
+        int((temp_dir / "health-count").read_text(encoding="utf-8").strip()),
+        200,
+    )
+
   def test_deploy_stops_old_slot_immediately_after_swap(self):
     result, temp_dir = self._run_script(
         command="deploy",
@@ -134,6 +153,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
       stop_fail_services: list[str] | None = None,
       ps_error_services: list[str] | None = None,
       reload_fail_on_calls: list[int] | None = None,
+      health_success_after: int = 1,
   ):
     bash_path = self._bash_path()
     if bash_path is None:
@@ -152,6 +172,7 @@ class DeployOverlapSafetyTest(unittest.TestCase):
       (deploy_root / "shared" / "previous-slot").write_text(f"{previous_slot}\n", encoding="utf-8")
     ops_log = temp_dir / "ops.log"
     reload_count = temp_dir / "reload-count"
+    health_count = temp_dir / "health-count"
     stop_fail_checks = "\n".join(
         f'if [[ "$cmd" == *" stop {service}"* ]]; then exit 1; fi'
         for service in stop_fail_services
@@ -238,6 +259,15 @@ for ((i=1;i<=$#;i++)); do
   fi
 done
 if [[ "$args" == *"http://localhost:9899/healthz"* ]]; then
+  count=0
+  if [[ -f "__HEALTH_COUNT__" ]]; then
+    count=$(<"__HEALTH_COUNT__")
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" > "__HEALTH_COUNT__"
+  if (( count < __HEALTH_SUCCESS_AFTER__ )); then
+    exit 1
+  fi
   if [ -n "$out" ]; then
     printf '%s' "${out//%{http_code}/200}"
   fi
@@ -262,10 +292,16 @@ if [[ "$args" == *"https://wave.supawave.ai/"* ]]; then
   exit 0
 fi
 exit 1
-""",
+""".replace("__HEALTH_COUNT__", str(health_count)).replace(
+            "__HEALTH_SUCCESS_AFTER__", str(health_success_after)
+        ),
     )
     self._write_executable(
         fake_bin / "systemctl",
+        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+    )
+    self._write_executable(
+        fake_bin / "sleep",
         "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
     )
     self._write_executable(

--- a/scripts/tests/test_deploy_overlap_safety.py
+++ b/scripts/tests/test_deploy_overlap_safety.py
@@ -52,6 +52,29 @@ class DeployOverlapSafetyTest(unittest.TestCase):
         int((temp_dir / "health-count").read_text(encoding="utf-8").strip()),
     )
 
+  def test_deploy_accepts_health_on_remaining_timeout_probe(self):
+    result, temp_dir = self._run_script(
+        command="deploy",
+        active_slot="blue",
+        previous_slot=None,
+        running_services=["caddy", "wave-blue"],
+        extra_env={
+            "WAVE_SLOT_HEALTH_INTERVAL_SECONDS": "60",
+            "WAVE_SLOT_HEALTH_TIMEOUT_SECONDS": "90",
+        },
+        health_success_after=3,
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"deploy should probe once more at the remaining timeout boundary:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    self.assertEqual(
+        3,
+        int((temp_dir / "health-count").read_text(encoding="utf-8").strip()),
+    )
+
   def test_deploy_rejects_zero_health_interval_with_cleanup(self):
     result, temp_dir = self._run_script(
         command="deploy",
@@ -230,6 +253,8 @@ class DeployOverlapSafetyTest(unittest.TestCase):
     ops_log = temp_dir / "ops.log"
     reload_count = temp_dir / "reload-count"
     health_count = temp_dir / "health-count"
+    fake_now = temp_dir / "fake-now"
+    fake_now.write_text("0\n", encoding="utf-8")
     stop_fail_checks = "\n".join(
         f'if [[ "$cmd" == *" stop {service}"* ]]; then exit 1; fi'
         for service in stop_fail_services
@@ -359,7 +384,25 @@ exit 1
     )
     self._write_executable(
         fake_bin / "sleep",
-        "#!/usr/bin/env bash\nset -euo pipefail\nexit 0\n",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+duration="${{1:-0}}"
+current=$(<"{fake_now}")
+printf '%s\n' "$((current + duration))" > "{fake_now}"
+exit 0
+""",
+    )
+    self._write_executable(
+        fake_bin / "date",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${{1:-}}" == "+%s" ]]; then
+  cat "{fake_now}"
+  exit 0
+fi
+echo "unexpected date invocation: $*" >&2
+exit 1
+""",
     )
     self._write_executable(
         fake_bin / "systemd-run",

--- a/wave/config/changelog.d/2026-04-13-deploy-health-wait-window.json
+++ b/wave/config/changelog.d/2026-04-13-deploy-health-wait-window.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-deploy-health-wait-window",
+  "version": "PR #883",
+  "date": "2026-04-13",
+  "title": "Restore deploy health wait window",
+  "summary": "Blue-green deploys now wait up to seven minutes for the target slot to report healthy, with the poll interval and timeout still configurable through environment variables.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Restored the default slot health wait window from the old 180-second cutoff to 420 seconds so slower Lucene-backed startups can finish before deploys abort",
+        "Kept the slot health polling interval and timeout configurable through deploy environment variables without requiring script edits"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,21 +1,5 @@
 [
   {
-    "releaseId": "2026-04-13-wavelet-load-diagnostics",
-    "version": "PR #878",
-    "date": "2026-04-13",
-    "title": "Avoid blocking on loading wavelets",
-    "summary": "Wavelet-dependent cache and indexing paths now skip still-loading wavelets and emit load-state diagnostics instead of blocking on incomplete state.",
-    "sections": [
-      {
-        "type": "fix",
-        "items": [
-          "Prevented cached wavelet invalidation and copy paths from blocking on wavelets that are still loading",
-          "Added wavelet load-state diagnostics so slow or timed-out loads report their state, age, and executor context in server logs"
-        ]
-      }
-    ]
-  },
-  {
     "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
     "version": "Unreleased",
     "date": "2026-04-13",
@@ -105,22 +89,6 @@
         "items": [
           "Deploy builds now push images through a retry helper that retries known transient registry and network failures before giving up.",
           "The retry helper now validates its retry-count and retry-delay environment variables and regression coverage now includes fail-fast, retry exhaustion, and invalid-config cases."
-        ]
-      }
-    ]
-  },
-  {
-    "releaseId": "2026-04-13-deploy-health-wait-window",
-    "version": "PR #883",
-    "date": "2026-04-13",
-    "title": "Restore deploy health wait window",
-    "summary": "Blue-green deploys now wait up to seven minutes for the target slot to report healthy, with the poll interval and timeout still configurable through environment variables.",
-    "sections": [
-      {
-        "type": "fix",
-        "items": [
-          "Restored the default slot health wait window from the old 180-second cutoff to 420 seconds so slower Lucene-backed startups can finish before deploys abort",
-          "Kept the slot health polling interval and timeout configurable through deploy environment variables without requiring script edits"
         ]
       }
     ]

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "releaseId": "2026-04-13-wavelet-load-diagnostics",
+    "version": "PR #878",
+    "date": "2026-04-13",
+    "title": "Avoid blocking on loading wavelets",
+    "summary": "Wavelet-dependent cache and indexing paths now skip still-loading wavelets and emit load-state diagnostics instead of blocking on incomplete state.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Prevented cached wavelet invalidation and copy paths from blocking on wavelets that are still loading",
+          "Added wavelet load-state diagnostics so slow or timed-out loads report their state, age, and executor context in server logs"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-search-toolbar-wrap-pinned-saved-searches",
     "version": "Unreleased",
     "date": "2026-04-13",
@@ -89,6 +105,22 @@
         "items": [
           "Deploy builds now push images through a retry helper that retries known transient registry and network failures before giving up.",
           "The retry helper now validates its retry-count and retry-delay environment variables and regression coverage now includes fail-fast, retry exhaustion, and invalid-config cases."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-deploy-health-wait-window",
+    "version": "PR #883",
+    "date": "2026-04-13",
+    "title": "Restore deploy health wait window",
+    "summary": "Blue-green deploys now wait up to seven minutes for the target slot to report healthy, with the poll interval and timeout still configurable through environment variables.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored the default slot health wait window from the old 180-second cutoff to 420 seconds so slower Lucene-backed startups can finish before deploys abort",
+          "Kept the slot health polling interval and timeout configurable through deploy environment variables without requiring script edits"
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- restore the blue-green slot health poll to a 420 second default startup window
- keep the wait configurable via env so deploys can be tuned without editing the script
- add a regression test that reproduces a slot becoming healthy after more than 180 seconds

## Root cause
Deploy run `24337745666` failed because `deploy/caddy/deploy.sh` still hard-stopped after `90 * 2s = 180s`, even though production Lucene-backed startups were already known to take up to 420 seconds before `/healthz` answers. The job log shows `wave-blue` started at `2026-04-13T10:12:34Z` and the script aborted at `2026-04-13T10:15:36Z`, which matches the old timeout exactly.

## Verification
- `python3 -m unittest scripts.tests.test_deploy_overlap_safety scripts.tests.test_deploy_sanity_gate`

Refs #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deployment health polling interval and timeout are configurable via environment variables; defaults restore a longer wait window.
* **Bug Fixes**
  * Invalid health timing values are rejected with a clear error and non-zero exit to prevent misconfiguration.
* **Tests**
  * New tests cover slow health startups and invalid timing configs, verifying retries, cleanup, and expected logs.
* **Documentation**
  * Added changelog entry documenting the deploy health wait window and configurability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->