### PR TITLE
[codex] Disable Mongock transactions on standalone Mongo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -352,6 +352,7 @@ Test / testOptions += Tests.Filter { name =>
       || name.contains(".server.persistence.file.")
       || name.contains(".server.persistence.protos.")
       || name.endsWith(".MongoMigrationRunnerTest")
+      || name.endsWith(".MongockMongoMigrationRunnerTest")
       || name.endsWith(".MongoMigrationBaselineTest")
       || name.endsWith(".MongoDeltaStoreAppendGuardTest")
   )

--- a/wave/config/changelog.d/2026-04-13-mongock-standalone-transactions.json
+++ b/wave/config/changelog.d/2026-04-13-mongock-standalone-transactions.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-mongock-standalone-transactions",
+  "version": "PR #886",
+  "date": "2026-04-13",
+  "title": "Disable Mongock transactions for standalone Mongo deployments",
+  "summary": "Mongo-backed startup migrations now disable Mongock transactions so standalone MongoDB deployments can apply schema changes without replica-set transaction support.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Disabled Mongock transaction usage before the startup migration runner executes against Mongo v4",
+        "Kept the driver on primary reads while leaving read and write concern overrides unchanged"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -95,6 +95,22 @@
     ]
   },
   {
+    "releaseId": "2026-04-13-mongock-standalone-transactions",
+    "version": "PR #886",
+    "date": "2026-04-13",
+    "title": "Disable Mongock transactions for standalone Mongo deployments",
+    "summary": "Mongo-backed startup migrations now disable Mongock transactions so standalone MongoDB deployments can apply schema changes without replica-set transaction support.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Disabled Mongock transaction usage before the startup migration runner executes against Mongo v4",
+          "Kept the driver on primary reads while leaving read and write concern overrides unchanged"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-mongock-provider-gating",
     "version": "Unreleased",
     "date": "2026-04-13",
@@ -122,6 +138,22 @@
         "items": [
           "Deploy builds now push images through a retry helper that retries known transient registry and network failures before giving up.",
           "The retry helper now validates its retry-count and retry-delay environment variables and regression coverage now includes fail-fast, retry exhaustion, and invalid-config cases."
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-deploy-health-wait-window",
+    "version": "PR #883",
+    "date": "2026-04-13",
+    "title": "Restore deploy health wait window",
+    "summary": "Blue-green deploys now wait up to seven minutes for the target slot to report healthy, with the poll interval and timeout still configurable through environment variables.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Restored the default slot health wait window from the old 180-second cutoff to 420 seconds so slower Lucene-backed startups can finish before deploys abort",
+          "Kept the slot health polling interval and timeout configurable through deploy environment variables without requiring script edits"
         ]
       }
     ]

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -24,6 +24,7 @@ import com.mongodb.client.MongoDatabase;
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
 import io.mongock.runner.core.executor.MongockRunner;
 import io.mongock.runner.standalone.MongockStandalone;
+import org.bson.Document;
 import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
 import org.waveprotocol.box.server.persistence.MongoMigrationRunner;
 import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DbProvider;
@@ -58,11 +59,11 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
         config.getDatabase(),
         config.getUsername(),
         config.getPassword())) {
+      MongoDatabase database = provider.provideMongoDatabase();
       MongoSync4Driver driver =
           MongoSync4Driver.withDefaultLock(provider.provideMongoClient(), config.getDatabase());
-      configureDriverDefaults(driver);
+      configureDriverDefaults(driver, database);
 
-      MongoDatabase database = provider.provideMongoDatabase();
       MongockRunner runner = MongockStandalone.builder()
           .setDriver(driver)
           .setExecutionId(EXECUTION_ID)
@@ -78,8 +79,15 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
     }
   }
 
-  static void configureDriverDefaults(MongoSync4Driver driver) {
-    driver.disableTransaction();
+  static void configureDriverDefaults(MongoSync4Driver driver, MongoDatabase database) {
+    if (shouldDisableTransactions(database)) {
+      driver.disableTransaction();
+    }
     driver.setReadPreference(ReadPreference.primary());
+  }
+
+  static boolean shouldDisableTransactions(MongoDatabase database) {
+    Document topology = database.runCommand(new Document("isMaster", 1));
+    return !topology.containsKey("setName") && !"isdbgrid".equals(topology.getString("msg"));
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -19,6 +19,7 @@
 
 package org.waveprotocol.box.server.persistence.migrations;
 
+import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoDatabase;
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
@@ -87,7 +88,14 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
   }
 
   static boolean shouldDisableTransactions(MongoDatabase database) {
-    Document topology = database.runCommand(new Document("isMaster", 1));
-    return !topology.containsKey("setName") && !"isdbgrid".equals(topology.getString("msg"));
+    try {
+      Document topology = database.runCommand(new Document("isMaster", 1));
+      return !topology.containsKey("setName") && !"isdbgrid".equals(topology.getString("msg"));
+    } catch (MongoException e) {
+      LOG.warning(
+          "Could not determine MongoDB topology for Mongock; disabling transactions. Cause: "
+              + e.getMessage());
+      return true;
+    }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -79,6 +79,7 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
   }
 
   static void configureDriverDefaults(MongoSync4Driver driver) {
+    driver.disableTransaction();
     driver.setReadPreference(ReadPreference.primary());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public final class MongockMongoMigrationRunnerTest {
 
   @Test
-  public void testConfigureDriverDefaultsKeepsPrimaryReadPreferenceWithoutOverridingConcerns() {
+  public void testConfigureDriverDefaultsDisablesTransactionsAndSetsPrimaryReadPreferenceWithoutOverridingConcerns() {
     MongoSync4Driver driver = mock(MongoSync4Driver.class);
 
     MongockMongoMigrationRunner.configureDriverDefaults(driver);

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
@@ -22,23 +22,43 @@ package org.waveprotocol.box.server.persistence.migrations;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
+import com.mongodb.client.MongoDatabase;
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
 import org.junit.Test;
+import org.bson.Document;
 
 public final class MongockMongoMigrationRunnerTest {
 
   @Test
-  public void testConfigureDriverDefaultsDisablesTransactionsAndSetsPrimaryReadPreferenceWithoutOverridingConcerns() {
+  public void testConfigureDriverDefaultsDisablesTransactionsForStandaloneMongo() {
     MongoSync4Driver driver = mock(MongoSync4Driver.class);
+    MongoDatabase database = mock(MongoDatabase.class);
+    when(database.runCommand(any(Document.class))).thenReturn(new Document("ok", 1.0));
 
-    MongockMongoMigrationRunner.configureDriverDefaults(driver);
+    MongockMongoMigrationRunner.configureDriverDefaults(driver, database);
 
     verify(driver).disableTransaction();
+    verify(driver).setReadPreference(ReadPreference.primary());
+    verify(driver, never()).setReadConcern(any(ReadConcern.class));
+    verify(driver, never()).setWriteConcern(any(WriteConcern.class));
+  }
+
+  @Test
+  public void testConfigureDriverDefaultsKeepsTransactionsForReplicaSets() {
+    MongoSync4Driver driver = mock(MongoSync4Driver.class);
+    MongoDatabase database = mock(MongoDatabase.class);
+    when(database.runCommand(any(Document.class)))
+        .thenReturn(new Document("ok", 1.0).append("setName", "rs0"));
+
+    MongockMongoMigrationRunner.configureDriverDefaults(driver, database);
+
+    verify(driver, never()).disableTransaction();
     verify(driver).setReadPreference(ReadPreference.primary());
     verify(driver, never()).setReadConcern(any(ReadConcern.class));
     verify(driver, never()).setWriteConcern(any(WriteConcern.class));

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
@@ -63,4 +63,19 @@ public final class MongockMongoMigrationRunnerTest {
     verify(driver, never()).setReadConcern(any(ReadConcern.class));
     verify(driver, never()).setWriteConcern(any(WriteConcern.class));
   }
+
+  @Test
+  public void testConfigureDriverDefaultsKeepsTransactionsForMongos() {
+    MongoSync4Driver driver = mock(MongoSync4Driver.class);
+    MongoDatabase database = mock(MongoDatabase.class);
+    when(database.runCommand(any(Document.class)))
+        .thenReturn(new Document("ok", 1.0).append("msg", "isdbgrid"));
+
+    MongockMongoMigrationRunner.configureDriverDefaults(driver, database);
+
+    verify(driver, never()).disableTransaction();
+    verify(driver).setReadPreference(ReadPreference.primary());
+    verify(driver, never()).setReadConcern(any(ReadConcern.class));
+    verify(driver, never()).setWriteConcern(any(WriteConcern.class));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunnerTest.java
@@ -38,6 +38,7 @@ public final class MongockMongoMigrationRunnerTest {
 
     MongockMongoMigrationRunner.configureDriverDefaults(driver);
 
+    verify(driver).disableTransaction();
     verify(driver).setReadPreference(ReadPreference.primary());
     verify(driver, never()).setReadConcern(any(ReadConcern.class));
     verify(driver, never()).setWriteConcern(any(WriteConcern.class));


### PR DESCRIPTION
## Summary
- disable Mongock transactions in the standalone MongoDB builder path
- keep the existing primary read preference behavior unchanged
- lock the regression down with a focused driver-defaults test

## Root cause
The deploy failures are not hitting the sanity gate. On the Contabo host, `wave-blue` exits about 3 seconds after container start, so the deploy script's slot health probe (`curl http://localhost:<slot>/healthz`) never sees a listening server.

The startup crash is:
- `io.mongock.api.exception.MongockException`
- caused by `com.mongodb.MongoClientException: This MongoDB deployment does not support retryable writes`
- with Mongo reporting `Transaction numbers are only allowed on a replica set member or mongos`

This started with commit `869098e` (`Add Mongock startup migrations with Mongo-backed provider gating`). Production uses a standalone MongoDB container, so Mongock's transactional default is incompatible there.

## Verification
- remote investigation:
  - `ssh supawave "docker inspect wave-blue --format ..."`
  - `ssh supawave "docker logs --tail 200 wave-blue"`
- local committed verification:
  - regenerate `wave` test classpath via sbt
  - `java --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED -cp "$CP" org.junit.runner.JUnitCore org.waveprotocol.box.server.persistence.migrations.MongockMongoMigrationRunnerTest org.waveprotocol.box.server.persistence.MongoMigrationRunnerTest`
  - result: `OK (4 tests)`

Refs #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction handling for MongoDB v4 on standalone deployments; primary reads and existing read/write concerns remain unchanged.
  * Restored blue-green deploy slot health wait window to the default 420 seconds; polling interval and timeout remain configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->