### PR TITLE
[codex] Avoid pipefail on Mongo migration marker check

### DIFF
--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -415,7 +415,7 @@ verify_mongo_migration_completion() {
   fi
 
   migration_logs="$(dc logs --no-color --since "$started_at" "wave-${slot}" 2>&1 || true)"
-  if printf '%s' "$migration_logs" | grep -Fq "Completed Mongock Mongo schema migrations"; then
+  if grep -Fq "Completed Mongock Mongo schema migrations" <<< "$migration_logs"; then
     return 0
   fi
 

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -393,7 +393,7 @@ slot_supports_mongo_migration_marker() {
 
 verify_mongo_migration_completion() {
   local slot=$1
-  local container_id started_at
+  local container_id started_at migration_logs
   if ! slot_requires_mongo_migration_verification "$slot"; then
     return 0
   fi
@@ -414,8 +414,8 @@ verify_mongo_migration_completion() {
     return 1
   fi
 
-  if dc logs --no-color --since "$started_at" "wave-${slot}" 2>&1 \
-      | grep -Fq "Completed Mongock Mongo schema migrations"; then
+  migration_logs="$(dc logs --no-color --since "$started_at" "wave-${slot}" 2>&1 || true)"
+  if printf '%s' "$migration_logs" | grep -Fq "Completed Mongock Mongo schema migrations"; then
     return 0
   fi
 

--- a/scripts/tests/test_mongo_migration_bootstrap.py
+++ b/scripts/tests/test_mongo_migration_bootstrap.py
@@ -20,7 +20,13 @@ class MongoMigrationBootstrapTest(unittest.TestCase):
     self.assertNotIn("SANITY_ADDRESS and SANITY_PASSWORD must both be set", combined)
 
   def test_deploy_reaches_sanity_gate_when_migration_success_log_is_present(self):
-    result = self._run_deploy(log_output="Completed Mongock Mongo schema migrations\n")
+    result = self._run_deploy(
+        log_output=(
+            "wave booting\n"
+            "Completed Mongock Mongo schema migrations\n"
+            "wave ready for sanity checks\n"
+        )
+    )
 
     self.assertNotEqual(0, result.returncode)
     combined = f"{result.stdout}\n{result.stderr}"

--- a/scripts/tests/test_mongo_migration_bootstrap.py
+++ b/scripts/tests/test_mongo_migration_bootstrap.py
@@ -27,6 +27,17 @@ class MongoMigrationBootstrapTest(unittest.TestCase):
     self.assertIn("SANITY_ADDRESS and SANITY_PASSWORD must both be set", combined)
     self.assertNotIn("did not report Mongo migration completion", combined)
 
+  def test_deploy_accepts_marker_when_logs_command_returns_sigpipe_after_match(self):
+    result = self._run_deploy(
+        log_output="Completed Mongock Mongo schema migrations\n",
+        since_log_exit_code=141,
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    combined = f"{result.stdout}\n{result.stderr}"
+    self.assertIn("SANITY_ADDRESS and SANITY_PASSWORD must both be set", combined)
+    self.assertNotIn("did not report Mongo migration completion", combined)
+
   def test_deploy_checks_unquoted_hocon_mongo_values(self):
     result = self._run_deploy(
         log_output="wave started without migration marker\n",
@@ -258,6 +269,7 @@ core {
       full_log_output: str | None = None,
       wave_image: str = "ghcr.io/example/wave:test",
       marker_supported: bool = True,
+      since_log_exit_code: int = 0,
       application_conf: str = """\
 core {
   mongodb_driver = "v4"
@@ -307,6 +319,7 @@ case "$cmd" in
     ;;
   *" logs --no-color --since 2026-04-13T11:00:00Z wave-green"*)
     printf '%s' {log_output!r}
+    exit {since_log_exit_code}
     ;;
   *" logs --no-color wave-green"*)
     printf '%s' {full_log_output!r}

--- a/wave/config/changelog.d/2026-04-13-mongo-marker-pipefail.json
+++ b/wave/config/changelog.d/2026-04-13-mongo-marker-pipefail.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-mongo-marker-pipefail",
+  "version": "PR #887",
+  "date": "2026-04-13",
+  "title": "Avoid false Mongo migration marker failures on SIGPIPE",
+  "summary": "Deploy verification now treats a matched Mongock completion marker as success even when the Docker logs pipeline exits with SIGPIPE after `grep -q` stops reading.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Deployment marker verification now captures recent container logs before searching for the Mongock completion message so `set -o pipefail` does not turn a successful match into a failure",
+        "Added regression coverage for the `docker compose logs --since ... | grep -q` SIGPIPE path that previously misreported completed migrations as missing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- stop the Mongo migration marker gate from false-failing when `docker compose logs` returns nonzero after emitting the success marker
- keep the gate semantics the same: success still requires `Completed Mongock Mongo schema migrations` in the current startup logs
- add a regression test for the SIGPIPE/pipefail case

## Root cause
The latest deploy did not fail at `/healthz` or at the sanity gate.

On the host, `wave-blue` booted successfully:
- Mongock completed and logged `Completed Mongock Mongo schema migrations`
- Lucene reindex completed
- Jetty bound `0.0.0.0:9898`

But the deploy step still exited with:
- `[deploy] ERROR: wave-blue did not report Mongo migration completion`

The false negative comes from this pipeline under `set -o pipefail`:

`dc logs --no-color --since "$started_at" "wave-${slot}" | grep -Fq "Completed Mongock Mongo schema migrations"`

When `grep -q` finds the marker and exits early, the upstream `docker compose logs` process can terminate nonzero, which makes the whole pipeline fail under `pipefail` even though the success marker was present.

## Verification
- remote investigation:
  - `ssh supawave "docker logs wave-blue 2>&1 | rg 'Completed Mongock|Starting server|Started ServerConnector'"`
  - `ssh supawave "export DEPLOY_ROOT=/home/ubuntu/supawave ...; docker compose ... logs --since \"$started\" wave-blue | rg 'Completed Mongock|Starting server|Started ServerConnector'"`
- local committed verification:
  - `python3 -m unittest scripts.tests.test_mongo_migration_bootstrap scripts.tests.test_deploy_overlap_safety scripts.tests.test_deploy_sanity_gate`
  - result: `Ran 29 tests in 29.209s OK`

Refs #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment verification now recognizes Mongo migration completion when container log retrieval terminates with a signal (e.g., SIGPIPE), preventing false deployment failures by checking captured recent logs for the completion marker.

* **Tests**
  * Added regression tests covering log-reading commands that end with signal-related exit codes after the migration completion marker.

* **Documentation**
  * Added a changelog entry documenting the fix and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->