### PR TITLE
fix(search): reuse lucene index on startup

### DIFF
--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -341,8 +341,9 @@ wait_for_slot_health() {
   local remaining_seconds
   local sleep_seconds
   started_at=$(date +%s)
-  # Lucene-backed production startups can legitimately take several minutes
-  # before /healthz answers while indexes are rebuilt from MongoDB.
+  # Lucene-backed production startups can legitimately take some time before
+  # /healthz answers while the new slot waits for the Lucene write lock or
+  # performs an initial build for an empty Lucene index.
   while true; do
     if curl -sf "http://localhost:${port}/healthz" > /dev/null 2>&1; then
       return 0

--- a/docs/superpowers/plans/2026-04-13-lucene-startup-reuse-plan.md
+++ b/docs/superpowers/plans/2026-04-13-lucene-startup-reuse-plan.md
@@ -1,0 +1,88 @@
+# Lucene Startup Reuse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reuse an existing Lucene index at startup instead of repairing every wave, while still building an empty index and preserving explicit admin rebuilds.
+
+**Architecture:** Narrow the change to `Lucene9WaveIndexerImpl.remakeIndex()` by extracting a helper that classifies startup behavior into initial build, forced full rebuild, or reuse-existing-index. Keep the admin-triggered rebuild path unchanged and update deploy comments to match the runtime behavior.
+
+**Tech Stack:** Java, JUnit 4, Mockito, Lucene 9, Typesafe Config
+
+---
+
+## File Map
+
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java`
+- Modify: `deploy/caddy/deploy.sh`
+
+### Task 1: Add failing Lucene startup tests
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that prove:
+- existing index + rebuild disabled skips startup repair
+- empty index still performs a startup build
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sbt "testOnly org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImplTest"`
+Expected: FAIL because current startup behavior still loads wavelets and rebuilds when docs already exist.
+
+### Task 2: Implement minimal startup behavior change
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+
+- [ ] **Step 1: Extract startup action helper**
+
+Introduce a small helper/enum that classifies startup as:
+- initial build
+- full rebuild
+- reuse existing index
+
+- [ ] **Step 2: Use the helper from `remakeIndex()`**
+
+Make `remakeIndex()` return early for the reuse-existing-index case and only call `loadAllWavelets()` / `doRebuild(...)` for initial build or forced full rebuild.
+
+- [ ] **Step 3: Keep admin rebuild untouched**
+
+Do not change `forceRemakeIndex(...)`; only avoid recording a startup reindex when startup reused the existing index and no rebuild actually ran.
+
+### Task 3: Update operator-facing comments
+
+**Files:**
+- Modify: `deploy/caddy/deploy.sh`
+
+- [ ] **Step 1: Fix the startup comment**
+
+Update the deploy comment so it no longer claims startup always rebuilds Lucene from MongoDB and instead describes empty-index builds and lock handoff as the relevant startup delays.
+
+### Task 4: Verify and review
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run focused tests**
+
+Run: `sbt "testOnly org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImplTest"`
+Expected: PASS
+
+- [ ] **Step 2: Self-review the diff**
+
+Inspect the diff to confirm:
+- skip path is explicit and readable
+- admin rebuild path is unchanged
+- comments match code behavior
+
+- [ ] **Step 3: Run a narrow second check if needed**
+
+If the Lucene test touched shared helpers or config-sensitive behavior, run:
+`sbt "testOnly org.waveprotocol.box.server.waveserver.ReindexServiceTest org.waveprotocol.box.server.rpc.AdminServletTest"`
+
+Expected: PASS

--- a/docs/superpowers/specs/2026-04-13-lucene-startup-reuse-design.md
+++ b/docs/superpowers/specs/2026-04-13-lucene-startup-reuse-design.md
@@ -1,0 +1,55 @@
+# Lucene Startup Reuse Design
+
+**Goal:** Stop Lucene startup from reprocessing every wave when a reusable on-disk index already exists, while preserving initial bootstrapping for empty indexes and manual rebuilds from admin operations.
+
+## Problem
+
+The current Lucene startup path always calls `remakeIndex()`. When the index already contains documents and `core.lucene9_rebuild_on_startup=false`, the code still performs an "incremental repair" by loading all wavelets and upserting every wave document. This keeps deploy/startup time proportional to total wave count even though the Lucene files are persisted on shared storage.
+
+## Decision
+
+- If the Lucene index is empty, startup must build it from storage.
+- If `core.lucene9_rebuild_on_startup=true`, startup must do a full rebuild.
+- If the Lucene index already has documents and `core.lucene9_rebuild_on_startup=false`, startup must reuse the existing index and skip all startup Lucene repair.
+- Manual rebuild remains available only through the admin operations reindex path.
+
+## Design
+
+### Lucene startup decision
+
+Extract the startup decision in `Lucene9WaveIndexerImpl` into a small helper with self-describing naming so `remakeIndex()` reads as explicit behavior rather than nested conditionals.
+
+The helper should classify startup into:
+
+- initial build
+- forced full rebuild
+- reuse existing index
+
+Only the first two paths should call `loadAllWavelets()` and `doRebuild(...)`.
+
+### Admin rebuild
+
+Do not change `forceRemakeIndex(...)` or the admin servlet/reindex service flow. That path remains the explicit operator repair tool.
+
+### Comments and operator docs
+
+Update stale deploy comments that currently imply startup always rebuilds Lucene from MongoDB. Comments should describe the actual behavior:
+
+- empty index may require an initial build
+- rolling deploys may wait on the Lucene write lock
+- startup no longer performs corpus-wide Lucene repair when an index already exists and rebuild-on-startup is disabled
+
+## Testing
+
+Add focused Lucene indexer tests for:
+
+- empty index still triggers startup build
+- existing index with rebuild-on-startup disabled skips startup repair
+- existing index with rebuild-on-startup enabled still performs full rebuild
+
+## Non-goals
+
+- background verification/repair
+- new admin UI
+- changing the manual reindex endpoint behavior
+- changing search query semantics

--- a/wave/config/changelog.d/2026-04-13-lucene-startup-reuse.json
+++ b/wave/config/changelog.d/2026-04-13-lucene-startup-reuse.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-lucene-startup-reuse",
+  "version": "PR #888",
+  "date": "2026-04-13",
+  "title": "Reuse Lucene indexes across startup",
+  "summary": "Wave startup now reuses an existing Lucene index when rebuild-on-startup is disabled, avoiding full corpus repair on every restart while preserving empty-index bootstrap and explicit rebuilds.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Lucene startup now skips the old startup repair pass when a reusable on-disk index already exists and `core.lucene9_rebuild_on_startup` is false",
+        "Empty Lucene directories still trigger an initial build and explicit admin reindex operations still perform full rebuilds"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -127,6 +127,39 @@
     ]
   },
   {
+    "releaseId": "2026-04-13-lucene-startup-reuse",
+    "version": "PR #888",
+    "date": "2026-04-13",
+    "title": "Reuse Lucene indexes across startup",
+    "summary": "Wave startup now reuses an existing Lucene index when rebuild-on-startup is disabled, avoiding full corpus repair on every restart while preserving empty-index bootstrap and explicit rebuilds.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Lucene startup now skips the old startup repair pass when a reusable on-disk index already exists and `core.lucene9_rebuild_on_startup` is false",
+          "Empty Lucene directories still trigger an initial build and explicit admin reindex operations still perform full rebuilds"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-grafana-admin-analytics",
+    "version": "PR #884",
+    "date": "2026-04-13",
+    "title": "Move admin analytics out to Grafana",
+    "summary": "Wave no longer renders an admin analytics tab; the remaining analytics signals are exported through `/metrics` and the Grafana Alloy pipeline instead of being stored and queried inside the app.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Removed the /admin Analytics tab and its server-side analytics API/history storage paths",
+          "Wave now exports aggregate analytics counters through the existing Prometheus `/metrics` endpoint for Grafana dashboards and alerts",
+          "Updated the SupaWave Alloy host configuration and runbook so Grafana Cloud scrapes Wave application metrics directly"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-ghcr-push-retry",
     "version": "PR #870",
     "date": "2026-04-13",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -513,7 +513,7 @@ public class ServerMain {
       ReindexService reindexService = injector.getInstance(ReindexService.class);
       if (lucene9Indexer.getLastReindexStats() != null) {
         reindexService.recordStartupReindex(lucene9Indexer.getLastReindexStats());
-      } else {
+      } else if (lucene9Indexer.getLastRebuildWaveCount() >= 0) {
         reindexService.recordStartupReindex(lucene9Indexer.getLastRebuildWaveCount());
       }
     }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImpl.java
@@ -100,6 +100,12 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
   private final IncrementalIndexStats incrementalStats = new IncrementalIndexStats();
   private final IncrementalIndexStats queryStats = new IncrementalIndexStats();
 
+  private enum StartupIndexAction {
+    INITIAL_BUILD,
+    FULL_REBUILD,
+    REUSE_EXISTING_INDEX
+  }
+
   @Inject
   public Lucene9WaveIndexerImpl(WaveMap waveMap, WaveletProvider waveletProvider,
       Lucene9SearchIndexDirectory directory, WaveMetadataExtractor metadataExtractor,
@@ -159,32 +165,35 @@ public class Lucene9WaveIndexerImpl implements WaveIndexer, WaveBus.Subscriber, 
   public synchronized void remakeIndex() throws WaveletStateException, WaveServerException {
     try {
       int existingDocs = indexWriter.getDocStats().numDocs;
-      if (existingDocs > 0 && rebuildOnStartup) {
+      StartupIndexAction startupAction = determineStartupIndexAction(existingDocs);
+      if (startupAction == StartupIndexAction.FULL_REBUILD) {
         LOG.info("Full rebuild of Lucene9 index (had " + existingDocs
             + " docs, lucene9_rebuild_on_startup=true)");
         indexWriter.deleteAll();
-      } else if (existingDocs > 0) {
+      } else if (startupAction == StartupIndexAction.REUSE_EXISTING_INDEX) {
         LOG.info("Lucene9 index has " + existingDocs
-            + " documents, running incremental repair");
+            + " documents, reusing existing index and skipping startup repair");
+        return;
       } else {
         LOG.info("Lucene9 index is empty, performing initial build");
       }
-      boolean fullRebuild = (existingDocs > 0 && rebuildOnStartup) || existingDocs == 0;
-      try {
-        waveMap.loadAllWavelets();
-      } catch (WaveletStateException e) {
-        if (fullRebuild) {
-          throw e;
-        }
-        LOG.log(Level.WARNING,
-            "loadAllWavelets failed during incremental repair, using cached waves", e);
-      }
-      ReindexStats stats = doRebuild(fullRebuild, null);
+      waveMap.loadAllWavelets();
+      ReindexStats stats = doRebuild(true, null);
       lastRebuildWaveCount = stats.waveCount;
       lastReindexStats = stats;
     } catch (IOException e) {
       throw new IndexException(e);
     }
+  }
+
+  private StartupIndexAction determineStartupIndexAction(int existingDocs) {
+    if (existingDocs <= 0) {
+      return StartupIndexAction.INITIAL_BUILD;
+    }
+    if (rebuildOnStartup) {
+      return StartupIndexAction.FULL_REBUILD;
+    }
+    return StartupIndexAction.REUSE_EXISTING_INDEX;
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/lucene9/Lucene9WaveIndexerImplTest.java
@@ -6,15 +6,28 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
 import org.junit.Before;
 import org.junit.Test;
+import org.waveprotocol.box.common.ExceptionalIterator;
 import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.persistence.lucene.Lucene9SearchIndexDirectory;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.waveserver.WaveMap;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
@@ -106,5 +119,83 @@ public final class Lucene9WaveIndexerImplTest {
     assertEquals(1, Iterables.size(view.getWavelets()));
     assertNotSame(persistedWavelet, Iterables.getOnlyElement(view.getWavelets()));
     verify(waveletProvider).getSnapshot(waveletName);
+  }
+
+  @Test
+  public void remakeIndexSkipsStartupRepairWhenIndexAlreadyExistsAndRebuildDisabled()
+      throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    when(waveletProvider.getWaveIds()).thenReturn(ExceptionalIterator.Empty.create());
+
+    try (ByteBuffersDirectory directory = seedIndexWithSingleDocument();
+         Lucene9WaveIndexerImpl indexer =
+             newIndexer(waveMap, waveletProvider, directory, rebuildOnStartupConfig(false))) {
+      indexer.remakeIndex();
+    }
+
+    verify(waveMap, never()).loadAllWavelets();
+  }
+
+  @Test
+  public void remakeIndexBuildsWhenIndexIsEmpty() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    when(waveletProvider.getWaveIds()).thenReturn(ExceptionalIterator.Empty.create());
+
+    try (ByteBuffersDirectory directory = new ByteBuffersDirectory();
+         Lucene9WaveIndexerImpl indexer =
+             newIndexer(waveMap, waveletProvider, directory, rebuildOnStartupConfig(false))) {
+      indexer.remakeIndex();
+    }
+
+    verify(waveMap).loadAllWavelets();
+  }
+
+  @Test
+  public void remakeIndexFullRebuildsWhenConfigured() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    when(waveletProvider.getWaveIds()).thenReturn(ExceptionalIterator.Empty.create());
+
+    try (ByteBuffersDirectory directory = seedIndexWithSingleDocument();
+         Lucene9WaveIndexerImpl indexer =
+             newIndexer(waveMap, waveletProvider, directory, rebuildOnStartupConfig(true))) {
+      indexer.remakeIndex();
+
+      assertEquals(0, indexer.getIndexedDocCount());
+    }
+
+    verify(waveMap).loadAllWavelets();
+  }
+
+  private Lucene9WaveIndexerImpl newIndexer(
+      WaveMap waveMap,
+      WaveletProvider waveletProvider,
+      ByteBuffersDirectory directory,
+      Config config) throws Exception {
+    Lucene9SearchIndexDirectory searchIndexDirectory = mock(Lucene9SearchIndexDirectory.class);
+    WaveMetadataExtractor metadataExtractor = mock(WaveMetadataExtractor.class);
+    WaveDocumentBuilder documentBuilder = mock(WaveDocumentBuilder.class);
+
+    when(searchIndexDirectory.getDirectory()).thenReturn(directory);
+    return new Lucene9WaveIndexerImpl(
+        waveMap, waveletProvider, searchIndexDirectory, metadataExtractor, documentBuilder, config);
+  }
+
+  private Config rebuildOnStartupConfig(boolean rebuildOnStartup) {
+    return ConfigFactory.parseString(
+        "core.lucene9_rebuild_on_startup = " + rebuildOnStartup);
+  }
+
+  private ByteBuffersDirectory seedIndexWithSingleDocument() throws IOException {
+    ByteBuffersDirectory directory = new ByteBuffersDirectory();
+    try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(new StandardAnalyzer()))) {
+      Document document = new Document();
+      document.add(new StringField("doc_id", "seed", Store.YES));
+      writer.addDocument(document);
+      writer.commit();
+    }
+    return directory;
   }
 }


### PR DESCRIPTION
## Summary
- skip Lucene startup repair when an existing on-disk index is present and `core.lucene9_rebuild_on_startup` is false
- keep empty-index bootstrap and explicit admin-triggered rebuild behavior intact
- stop recording a startup reindex when startup simply reuses the existing index, and update the stale deploy comment

## Verification
- `sbt "testOnly org.waveprotocol.box.server.waveserver.lucene9.Lucene9WaveIndexerImplTest"`
- `sbt "jakartaTest:testOnly org.waveprotocol.box.server.waveserver.ReindexServiceTest"`

## Notes
- I also attempted to target `AdminServletTest` directly via `testOnly`, but the default `Test` selector returned `No tests to run`; the production change does not touch that class directly.