### PR TITLE
Add importable Grafana analytics dashboard

### DIFF
--- a/deploy/supawave-host/README.md
+++ b/deploy/supawave-host/README.md
@@ -18,7 +18,7 @@ Automation for applying the production resource tuning from `deploy/production/`
 - `rollback.sh` — Restores `/etc/sysctl.conf`, `/etc/security/limits.conf`, PAM session files, and `/etc/fstab` from backups, disables swap, and removes `/swapfile`.
 - `install-grafana-alloy.sh` — Installs Grafana Alloy with Grafana Cloud onboarding variables.
 - `configure-grafana-alloy.sh` — Writes `/etc/alloy/config.alloy` for metrics+logs remote write and restarts `alloy.service`.
-- `grafana-dashboards/supawave-analytics-overview.json` — Starter Grafana dashboard you can import and point at your Prometheus and Loki datasources.
+- `grafana-dashboards/supawave-analytics-overview.json` — Starter Grafana dashboard you can import and point at your Prometheus datasource.
 
 Backups and snapshots are stored under `/var/backups/wave-supawave` (override with `BACKUP_DIR`). When running via `sudo`, use `sudo --preserve-env=BACKUP_DIR,SWAP_SIZE_GB ./provision.sh` to pass environment overrides through.
 
@@ -92,11 +92,9 @@ HTTP listener Alloy scrapes for Prometheus-format application metrics.
   into Grafana.
 - On import, map:
   - `DS_PROMETHEUS` to your Grafana Cloud metrics datasource
-  - `DS_LOKI` to your Grafana Cloud Loki datasource
 - The starter dashboard includes:
   - aggregate stat panels for the new `wave_analytics_*` counters
   - HTTP request-rate and p95 latency charts from `http_server_requests_*`
-  - Loki-backed top-wave and top-user tables based on exported analytics events
 
 ### Loki Query Contract
 
@@ -104,20 +102,6 @@ HTTP listener Alloy scrapes for Prometheus-format application metrics.
 - Low-level fallback selector: `{job="supawave/wave"}`
 - Alloy promotes these labels from each JSON log line: `level`, `logger`, `thread`
 - Fields such as `participantId` and `waveId` remain in the JSON payload; inspect or filter them with `| json` in Grafana/Loki instead of expecting them as labels
-- Analytics event logs now emit logfmt-style message fields:
-  - `analytics_event`
-  - `analytics_count`
-  - `participant_id` when user context exists
-  - `wave_id` when wave context exists
-- Useful LogQL starters:
-  - Recent analytics events:
-    - `{job="supawave/wave"} |= "analytics_event=" | logfmt`
-  - Top waves by public views over 24h:
-    - `topk(10, sum by (wave_id) (count_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="public_wave_page_view" [24h])))`
-  - Top users by activity events over 24h:
-    - `topk(10, sum by (participant_id) (count_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="active_user_event" [24h])))`
-  - Top users by blips created over 24h:
-    - `topk(10, sum by (participant_id) (sum_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="blips_created" | unwrap analytics_count [24h])))`
 
 ## Troubleshooting
 

--- a/deploy/supawave-host/README.md
+++ b/deploy/supawave-host/README.md
@@ -18,6 +18,7 @@ Automation for applying the production resource tuning from `deploy/production/`
 - `rollback.sh` — Restores `/etc/sysctl.conf`, `/etc/security/limits.conf`, PAM session files, and `/etc/fstab` from backups, disables swap, and removes `/swapfile`.
 - `install-grafana-alloy.sh` — Installs Grafana Alloy with Grafana Cloud onboarding variables.
 - `configure-grafana-alloy.sh` — Writes `/etc/alloy/config.alloy` for metrics+logs remote write and restarts `alloy.service`.
+- `grafana-dashboards/supawave-analytics-overview.json` — Starter Grafana dashboard you can import and point at your Prometheus and Loki datasources.
 
 Backups and snapshots are stored under `/var/backups/wave-supawave` (override with `BACKUP_DIR`). When running via `sudo`, use `sudo --preserve-env=BACKUP_DIR,SWAP_SIZE_GB ./provision.sh` to pass environment overrides through.
 
@@ -85,12 +86,38 @@ HTTP listener Alloy scrapes for Prometheus-format application metrics.
   - `wave_analytics_waves_created_total`
   - `wave_analytics_blips_created_total`
 
+### Starter Dashboard
+
+- Import `deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json`
+  into Grafana.
+- On import, map:
+  - `DS_PROMETHEUS` to your Grafana Cloud metrics datasource
+  - `DS_LOKI` to your Grafana Cloud Loki datasource
+- The starter dashboard includes:
+  - aggregate stat panels for the new `wave_analytics_*` counters
+  - HTTP request-rate and p95 latency charts from `http_server_requests_*`
+  - Loki-backed top-wave and top-user tables based on exported analytics events
+
 ### Loki Query Contract
 
 - Recommended service selector: `{service_name="supawave"}`
 - Low-level fallback selector: `{job="supawave/wave"}`
 - Alloy promotes these labels from each JSON log line: `level`, `logger`, `thread`
 - Fields such as `participantId` and `waveId` remain in the JSON payload; inspect or filter them with `| json` in Grafana/Loki instead of expecting them as labels
+- Analytics event logs now emit logfmt-style message fields:
+  - `analytics_event`
+  - `analytics_count`
+  - `participant_id` when user context exists
+  - `wave_id` when wave context exists
+- Useful LogQL starters:
+  - Recent analytics events:
+    - `{job="supawave/wave"} |= "analytics_event=" | logfmt`
+  - Top waves by public views over 24h:
+    - `topk(10, sum by (wave_id) (count_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="public_wave_page_view" [24h])))`
+  - Top users by activity events over 24h:
+    - `topk(10, sum by (participant_id) (count_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="active_user_event" [24h])))`
+  - Top users by blips created over 24h:
+    - `topk(10, sum by (participant_id) (sum_over_time({job="supawave/wave"} |= "analytics_event=" | logfmt | analytics_event="blips_created" | unwrap analytics_count [24h])))`
 
 ## Troubleshooting
 

--- a/deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json
+++ b/deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json
@@ -1,0 +1,660 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.2"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_public_wave_page_views_total[$__range])",
+          "legendFormat": "page views",
+          "refId": "A"
+        }
+      ],
+      "title": "Public Page Views",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_public_wave_api_views_total[$__range])",
+          "legendFormat": "api views",
+          "refId": "A"
+        }
+      ],
+      "title": "Public API Views",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_users_registered_total[$__range])",
+          "legendFormat": "registrations",
+          "refId": "A"
+        }
+      ],
+      "title": "Registrations",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_active_user_events_total[$__range])",
+          "legendFormat": "activity events",
+          "refId": "A"
+        }
+      ],
+      "title": "Active User Events",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_waves_created_total[$__range])",
+          "legendFormat": "waves created",
+          "refId": "A"
+        }
+      ],
+      "title": "Waves Created",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "increase(wave_analytics_blips_created_total[$__range])",
+          "legendFormat": "blips created",
+          "refId": "A"
+        }
+      ],
+      "title": "Blips Created",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{job=\"supawave/wave\"}[5m]))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Request Rate by URI",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{job=\"supawave/wave\"}[5m])))",
+          "legendFormat": "{{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP p95 Latency by URI",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (wave_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"public_wave_page_view\" [$__range])))",
+          "instant": true,
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Waves by Public Views",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "id": 10,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (participant_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"active_user_event\" [$__range])))",
+          "instant": true,
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Users by Activity Events",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "id": 11,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.2",
+      "targets": [
+        {
+          "expr": "topk(10, sum by (participant_id) (sum_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"blips_created\" | unwrap analytics_count [$__range])))",
+          "instant": true,
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Users by Blips Created",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "content": "### Loki event queries\n\nRecent analytics events:\n\n```logql\n{job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt\n```\n\nTop waves by public page views:\n\n```logql\ntopk(10, sum by (wave_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"public_wave_page_view\" [24h])))\n```\n\nTop users by activity:\n\n```logql\ntopk(10, sum by (participant_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"active_user_event\" [24h])))\n```\n\nTop users by blips created:\n\n```logql\ntopk(10, sum by (participant_id) (sum_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"blips_created\" | unwrap analytics_count [24h])))\n```",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.4.2",
+      "title": "Loki Query Starters",
+      "type": "text"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "supawave",
+    "analytics",
+    "grafana"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "SupaWave Analytics Overview",
+  "uid": "supawave-analytics-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json
+++ b/deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json
@@ -6,13 +6,6 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
-    },
-    {
-      "name": "DS_LOKI",
-      "label": "Loki",
-      "type": "datasource",
-      "pluginId": "loki",
-      "pluginName": "Loki"
     }
   ],
   "__requires": [
@@ -50,12 +43,6 @@
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "loki",
-      "name": "Loki",
       "version": ""
     }
   ],
@@ -521,119 +508,6 @@
       ],
       "title": "HTTP p95 Latency by URI",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 12
-      },
-      "id": 9,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "expr": "topk(10, sum by (wave_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"public_wave_page_view\" [$__range])))",
-          "instant": true,
-          "queryType": "instant",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Waves by Public Views",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "id": 10,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "expr": "topk(10, sum by (participant_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"active_user_event\" [$__range])))",
-          "instant": true,
-          "queryType": "instant",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Users by Activity Events",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "${DS_LOKI}"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "id": 11,
-      "options": {
-        "showHeader": true
-      },
-      "pluginVersion": "10.4.2",
-      "targets": [
-        {
-          "expr": "topk(10, sum by (participant_id) (sum_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"blips_created\" | unwrap analytics_count [$__range])))",
-          "instant": true,
-          "queryType": "instant",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Users by Blips Created",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "grafana",
-        "uid": "-- Grafana --"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 12,
-      "options": {
-        "content": "### Loki event queries\n\nRecent analytics events:\n\n```logql\n{job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt\n```\n\nTop waves by public page views:\n\n```logql\ntopk(10, sum by (wave_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"public_wave_page_view\" [24h])))\n```\n\nTop users by activity:\n\n```logql\ntopk(10, sum by (participant_id) (count_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"active_user_event\" [24h])))\n```\n\nTop users by blips created:\n\n```logql\ntopk(10, sum by (participant_id) (sum_over_time({job=\"supawave/wave\"} |= \"analytics_event=\" | logfmt | analytics_event=\"blips_created\" | unwrap analytics_count [24h])))\n```",
-        "mode": "markdown"
-      },
-      "pluginVersion": "10.4.2",
-      "title": "Loki Query Starters",
-      "type": "text"
     }
   ],
   "refresh": "30s",

--- a/scripts/tests/test_grafana_alloy_logging_config.py
+++ b/scripts/tests/test_grafana_alloy_logging_config.py
@@ -10,6 +10,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ALLOY_CONFIG_SCRIPT = REPO_ROOT / "deploy" / "supawave-host" / "configure-grafana-alloy.sh"
 LOGBACK_CONFIG = REPO_ROOT / "wave" / "config" / "logback.xml"
+HOST_README = REPO_ROOT / "deploy" / "supawave-host" / "README.md"
+DASHBOARD_PATH = (
+    REPO_ROOT / "deploy" / "supawave-host" / "grafana-dashboards" / "supawave-analytics-overview.json"
+)
 
 
 def _jar(*parts: str) -> Path:
@@ -92,6 +96,18 @@ def emit_structured_log_entry() -> dict:
 
 
 class GrafanaAlloyLoggingConfigTest(unittest.TestCase):
+  def test_host_readme_does_not_claim_logfmt_analytics_events(self):
+    readme_text = HOST_README.read_text(encoding="utf-8")
+
+    self.assertNotIn("analytics_event", readme_text)
+    self.assertNotIn("analytics_count", readme_text)
+
+  def test_dashboard_does_not_reference_nonexistent_logfmt_analytics_fields(self):
+    dashboard_text = DASHBOARD_PATH.read_text(encoding="utf-8")
+
+    self.assertNotIn("analytics_event", dashboard_text)
+    self.assertNotIn("analytics_count", dashboard_text)
+
   def test_logback_emits_microsecond_precision_json_timestamp(self):
     entry = emit_structured_log_entry()
 

--- a/wave/config/changelog.d/2026-04-13-grafana-analytics-dashboard-import.json
+++ b/wave/config/changelog.d/2026-04-13-grafana-analytics-dashboard-import.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-13-grafana-analytics-dashboard-import",
+  "version": "PR #889",
+  "date": "2026-04-13",
+  "title": "Add an importable Grafana analytics dashboard",
+  "summary": "Added a starter Grafana dashboard for Wave analytics counters and aligned the host docs with the metrics and JSON-log signals the runtime actually emits.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a starter Grafana dashboard for the exported `wave_analytics_*` Prometheus counters plus request-rate and p95 latency charts",
+        "Documented the dashboard import path and removed references to unsupported logfmt analytics event queries so the runbook matches the current Wave and Alloy pipeline"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.json
+++ b/wave/config/changelog.json
@@ -143,6 +143,38 @@
     ]
   },
   {
+    "releaseId": "2026-04-13-mongo-marker-pipefail",
+    "version": "PR #887",
+    "date": "2026-04-13",
+    "title": "Avoid false Mongo migration marker failures on SIGPIPE",
+    "summary": "Deploy verification now treats a matched Mongock completion marker as success even when the Docker logs pipeline exits with SIGPIPE after `grep -q` stops reading.",
+    "sections": [
+      {
+        "type": "fix",
+        "items": [
+          "Deployment marker verification now captures recent container logs before searching for the Mongock completion message so `set -o pipefail` does not turn a successful match into a failure",
+          "Added regression coverage for the `docker compose logs --since ... | grep -q` SIGPIPE path that previously misreported completed migrations as missing"
+        ]
+      }
+    ]
+  },
+  {
+    "releaseId": "2026-04-13-grafana-analytics-dashboard-import",
+    "version": "PR #889",
+    "date": "2026-04-13",
+    "title": "Add an importable Grafana analytics dashboard",
+    "summary": "Added a starter Grafana dashboard for Wave analytics counters and aligned the host docs with the metrics and JSON-log signals the runtime actually emits.",
+    "sections": [
+      {
+        "type": "feature",
+        "items": [
+          "Added a starter Grafana dashboard for the exported `wave_analytics_*` Prometheus counters plus request-rate and p95 latency charts",
+          "Documented the dashboard import path and removed references to unsupported logfmt analytics event queries so the runbook matches the current Wave and Alloy pipeline"
+        ]
+      }
+    ]
+  },
+  {
     "releaseId": "2026-04-13-grafana-admin-analytics",
     "version": "PR #884",
     "date": "2026-04-13",


### PR DESCRIPTION
## Summary
- add an importable Grafana dashboard JSON for SupaWave analytics and HTTP performance
- document how to import it in Grafana and bind the Prometheus/Loki datasources

## Verification
- `python3 -m json.tool deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json >/dev/null`

## Notes
- This PR intentionally contains only the dashboard artifact and the host README instructions.
- It does not change Wave runtime behavior.
