### PR TITLE
fix(editor): preserve first char of each word on Android IME

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ env.GCLOUD_HOSTED_METRICS_URL != '' && env.GCLOUD_HOSTED_METRICS_ID != '' && env.HAS_GCLOUD_RW_API_KEY == 'true' }}
         run: |
           release_url="https://github.com/grafana/alloy/releases/download/${GRAFANA_ALLOY_VERSION}"
-          curl -fsSL -o "$RUNNER_TEMP/alloy.zip" \
+          curl -fsSL -o "$RUNNER_TEMP/alloy-linux-amd64.zip" \
             "$release_url/alloy-linux-amd64.zip"
           curl -fsSL -o "$RUNNER_TEMP/SHA256SUMS" \
             "$release_url/SHA256SUMS"
@@ -60,7 +60,7 @@ jobs:
             cd "$RUNNER_TEMP"
             grep 'alloy-linux-amd64.zip$' SHA256SUMS | sha256sum -c -
           )
-          unzip -q "$RUNNER_TEMP/alloy.zip" -d "$RUNNER_TEMP/alloy"
+          unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip" -d "$RUNNER_TEMP/alloy"
           mkdir -p "$RUNNER_TEMP/bin"
           install "$RUNNER_TEMP/alloy/alloy-linux-amd64" "$RUNNER_TEMP/bin/alloy"
           chmod +x "$RUNNER_TEMP/bin/alloy"

--- a/journal/local-verification/2026-04-16-issue-891-pr-remediation.md
+++ b/journal/local-verification/2026-04-16-issue-891-pr-remediation.md
@@ -1,0 +1,21 @@
+Worktree: /Users/vega/devroot/worktrees/vega113-incubator-wave-pr-891-monitor
+Branch: monitor/vega113-incubator-wave/pr-891
+PR: https://github.com/vega113/supawave/pull/891
+
+Verification:
+- `python3 -m unittest scripts.tests.test_perf_workflow_config.PerfWorkflowConfigTest.test_perf_workflow_uses_same_filename_for_alloy_download_and_checksum`
+  - Result: failed before the workflow fix because `.github/workflows/perf.yml` downloaded `alloy.zip` but verified `alloy-linux-amd64.zip`
+- `python3 -m unittest scripts.tests.test_perf_workflow_config`
+  - Result: passed (`Ran 9 tests in 0.000s`)
+- `sbt devCompile && sbt compileGwtDev`
+  - Result: passed
+- `sbt compile`
+  - Result: passed
+- `sbt test`
+  - Result: passed (`Passed: Total 2289, Failed 0, Errors 0, Passed 2287, Skipped 2`)
+
+Review remediation summary:
+- Resolved the stale changelog review thread after confirming the branch already carried the requested `\"version\": \"PR #891\"` fix.
+- Fixed `.github/workflows/perf.yml` so the Grafana Alloy installer downloads, verifies, and unzips the same filename, which matches the failure seen in `Gatling Performance Tests`.
+- Added a workflow regression test to keep the download/checksum filename alignment covered.
+- Addressed the remaining CodeRabbit thread by asserting the checksum command uses the same `alloy-linux-amd64.zip` filename as the download and unzip steps.

--- a/scripts/tests/test_perf_workflow_config.py
+++ b/scripts/tests/test_perf_workflow_config.py
@@ -60,6 +60,13 @@ class PerfWorkflowConfigTest(unittest.TestCase):
     self.assertIn("SHA256SUMS", install_step)
     self.assertIn("sha256sum -c -", install_step)
 
+  def test_perf_workflow_uses_same_filename_for_alloy_download_and_checksum(self):
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    install_step = self._step_window(workflow, "Install Grafana Alloy")
+
+    self.assertIn('curl -fsSL -o "$RUNNER_TEMP/alloy-linux-amd64.zip" \\', install_step)
+    self.assertIn('unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip"', install_step)
+
   def test_perf_workflow_scopes_secrets_away_from_job_env(self):
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
     job_block = workflow.split("\n    steps:\n", 1)[0]

--- a/scripts/tests/test_perf_workflow_config.py
+++ b/scripts/tests/test_perf_workflow_config.py
@@ -65,6 +65,7 @@ class PerfWorkflowConfigTest(unittest.TestCase):
     install_step = self._step_window(workflow, "Install Grafana Alloy")
 
     self.assertIn('curl -fsSL -o "$RUNNER_TEMP/alloy-linux-amd64.zip" \\', install_step)
+    self.assertIn("grep 'alloy-linux-amd64.zip$' SHA256SUMS | sha256sum -c -", install_step)
     self.assertIn('unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip"', install_step)
 
   def test_perf_workflow_scopes_secrets_away_from_job_env(self):

--- a/wave/config/changelog.d/2026-04-16-android-ime-first-char-drop.json
+++ b/wave/config/changelog.d/2026-04-16-android-ime-first-char-drop.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-16-android-ime-first-char-drop",
-  "version": "PR",
+  "version": "PR #891",
   "date": "2026-04-16",
   "title": "Preserve every word when typing into a blip on Android",
   "summary": "Android Chrome and Brave were silently dropping the first character of every composed word (typing \"new blip\" produced \"ewlip\") because the editor's mutation handler was activating the typing extractor mid-composition. The IME composition flow now owns DOM character mutations between compositionstart and compositionend, so the typing extractor no longer stomps on the IME scratch container as it is torn down.",

--- a/wave/config/changelog.d/2026-04-16-android-ime-first-char-drop.json
+++ b/wave/config/changelog.d/2026-04-16-android-ime-first-char-drop.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-16-android-ime-first-char-drop",
+  "version": "PR",
+  "date": "2026-04-16",
+  "title": "Preserve every word when typing into a blip on Android",
+  "summary": "Android Chrome and Brave were silently dropping the first character of every composed word (typing \"new blip\" produced \"ewlip\") because the editor's mutation handler was activating the typing extractor mid-composition. The IME composition flow now owns DOM character mutations between compositionstart and compositionend, so the typing extractor no longer stomps on the IME scratch container as it is torn down.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Android IME composition no longer drops the first character of each word when typing into a new or existing blip",
+        "DOM character mutations that arrive between compositionstart and compositionend are now handled exclusively by the composition flow, avoiding a stale typing-extractor state that survived compositionend"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -310,7 +310,22 @@ public final class EditorEventHandler {
               return false;
             }
 
-            if (cachedSelection.isCollapsed()
+            if (state == State.COMPOSITION) {
+              // The IME composition flow owns DOM character mutations while
+              // we are between compositionstart and compositionend. On
+              // Android Chrome the first such mutation arrives while the
+              // selection is still collapsed (the browser has not yet
+              // promoted the composing word into a range), so the
+              // non-collapsed guard above does not short-circuit. If we
+              // started the typing extractor here its TypingState would
+              // survive compositionend, reference the IME scratch container
+              // that is about to be torn down, and the next forceFlush would
+              // drop the first character of every composed word (typing
+              // "new blip" would yield "ewlip").
+              logger.trace().logPlainText(
+                  "Ignoring DOM character mutation during IME composition; "
+                      + "composition flow owns this mutation");
+            } else if (cachedSelection.isCollapsed()
                 && delayedCompositionMutationGuard.shouldSkipDomCharacterMutation()) {
               logger.trace().logPlainText(
                   "Ignoring DOM character mutation immediately after IME composition end");

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -34,6 +34,7 @@ import org.waveprotocol.wave.client.common.util.SignalEvent.KeyModifier;
 import org.waveprotocol.wave.client.common.util.SignalEvent.KeySignalType;
 import org.waveprotocol.wave.client.common.util.SignalKeyLogic;
 import org.waveprotocol.wave.client.common.util.UserAgent;
+import org.waveprotocol.wave.client.editor.constants.BrowserEvents;
 import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.content.ContentNode;
 import org.waveprotocol.wave.client.editor.content.ContentPoint;
@@ -1007,6 +1008,42 @@ public class EditorEventHandlerGwtTest
     assertEquals(EditorEventHandler.State.COMPOSITION, handler.getState());
     assertFalse(handler.handleEvent(mutation));
     assertEquals(EditorEventHandler.State.NORMAL, handler.getState());
+
+    interactor.checkExpectations();
+  }
+
+  /**
+   * Android Chrome fires the first DOMCharacterDataModified of a composed
+   * word while the selection is still collapsed, before the browser has
+   * promoted the composing word into a range. The composition flow owns
+   * text insertion in this state, so the typing extractor must not be
+   * started here. Previously it was, and the resulting TypingState
+   * survived compositionend, dereferenced the torn-down IME scratch
+   * container on the next forceFlush, and dropped the first character of
+   * every composed word (typing "new blip" produced "ewlip").
+   */
+  public void testDomCharacterMutationDuringCompositionSkipsTypingExtractor() {
+    FakeEditorEvent compositionStart = FakeEditorEvent.compositionSequence(0)[0];
+    FakeEditorEvent mutation = FakeEditorEvent.create(BrowserEvents.DOMCharacterDataModified);
+
+    Point<ContentNode> caret = Point.inText(
+        new ContentTextNode(Document.get().createTextNode("n"), null), 1);
+    FocusedContentRange collapsedSelection = new FocusedContentRange(caret);
+
+    FakeEditorInteractor interactor = setupFakeEditorInteractor(collapsedSelection);
+    FakeEditorEventsSubHandler subHandler = new FakeEditorEventsSubHandler();
+    subHandler.call(FakeEditorEventsSubHandler.HANDLE_DOM_MUTATION).anyOf();
+    interactor.call(FakeEditorInteractor.COMPOSITION_START).nOf(1).withArgs(caret);
+    // NOTIFYING_TYPING_EXTRACTOR is intentionally not declared — the mutation
+    // during composition must not activate the typing extractor.
+
+    EditorEventHandler handler = createEditorEventHandler(interactor, subHandler);
+
+    assertFalse(handler.handleEvent(compositionStart));
+    assertEquals(EditorEventHandler.State.COMPOSITION, handler.getState());
+
+    assertFalse(handler.handleEvent(mutation));
+    assertEquals(EditorEventHandler.State.COMPOSITION, handler.getState());
 
     interactor.checkExpectations();
   }


### PR DESCRIPTION
## Summary

- On Android Chrome and Brave (Galaxy S25 Ultra), typing into a blip silently dropped the first character of every composed word — typing `new blip` produced `ewlip`.
- Root cause: the first `DOMCharacterDataModified` of each composition arrives while selection is still collapsed (before the browser promotes the composing word into a range), so the existing non-collapsed guard from `fa10ca5db0` does not short-circuit. The mutation handler then starts the `TypingExtractor` mid-composition; that `TypingState` survives `compositionend`, dereferences the IME scratch span torn down by `imeExtractor.deactivate`, and the next `forceFlush` drops the first char of every composed word. The inter-word space is lost in the same pass.
- Fix: short-circuit the DOM character mutation branch in `EditorEventHandler` when `state == State.COMPOSITION`. Composition flow already owns text reconciliation between `compositionstart` and `compositionend`, and the trailing-mutation fallback still fires from the `NORMAL` state when `compositionEnd` returns null.
- Adds a missing `BrowserEvents` import to `EditorEventHandlerGwtTest.java` that was already used by tests added in PR #877.

## Earlier related fixes

#628, #817, #828, #831, #850, #877 — this PR targets the specific pattern the earlier fixes did not cover (collapsed-selection mid-composition mutation notification).

## Test plan

- [x] `sbt test` — 2287 passed, 2 skipped, 0 failures
- [x] `sbt compileGwtDev` — GWT editor module compiles cleanly
- [x] New regression test `testDomCharacterMutationDuringCompositionSkipsTypingExtractor` covers the collapsed-selection mid-composition case
- [x] Copilot (Opus) review pass — root cause, fix, and test structure confirmed
- [ ] Manual verification on Galaxy S25 Ultra (Chrome + Brave): typing `new blip` in a new and existing blip must record the full text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue causing the first character of composed words to be dropped on Android Chrome and Brave during IME input.

* **Tests**
  * Added a test ensuring DOM character mutations during IME composition do not start the typing extractor.
  * Added a test verifying the perf workflow uses a consistent filename for the Alloy download/unzip step.

* **Chores**
  * Updated CI workflow step to use the specific Alloy artifact filename.

* **Documentation**
  * Added a changelog entry and local verification journal documenting the fixes and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->