### PR TITLE
Fix Grafana Alloy checksum install step in perf workflow

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ env.GCLOUD_HOSTED_METRICS_URL != '' && env.GCLOUD_HOSTED_METRICS_ID != '' && env.HAS_GCLOUD_RW_API_KEY == 'true' }}
         run: |
           release_url="https://github.com/grafana/alloy/releases/download/${GRAFANA_ALLOY_VERSION}"
-          curl -fsSL -o "$RUNNER_TEMP/alloy.zip" \
+          curl -fsSL -o "$RUNNER_TEMP/alloy-linux-amd64.zip" \
             "$release_url/alloy-linux-amd64.zip"
           curl -fsSL -o "$RUNNER_TEMP/SHA256SUMS" \
             "$release_url/SHA256SUMS"
@@ -60,7 +60,7 @@ jobs:
             cd "$RUNNER_TEMP"
             grep 'alloy-linux-amd64.zip$' SHA256SUMS | sha256sum -c -
           )
-          unzip -q "$RUNNER_TEMP/alloy.zip" -d "$RUNNER_TEMP/alloy"
+          unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip" -d "$RUNNER_TEMP/alloy"
           mkdir -p "$RUNNER_TEMP/bin"
           install "$RUNNER_TEMP/alloy/alloy-linux-amd64" "$RUNNER_TEMP/bin/alloy"
           chmod +x "$RUNNER_TEMP/bin/alloy"

--- a/scripts/tests/test_perf_workflow_config.py
+++ b/scripts/tests/test_perf_workflow_config.py
@@ -57,8 +57,11 @@ class PerfWorkflowConfigTest(unittest.TestCase):
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
     install_step = self._step_window(workflow, "Install Grafana Alloy")
 
+    self.assertIn('curl -fsSL -o "$RUNNER_TEMP/alloy-linux-amd64.zip"', install_step)
     self.assertIn("SHA256SUMS", install_step)
+    self.assertIn("grep 'alloy-linux-amd64.zip$' SHA256SUMS", install_step)
     self.assertIn("sha256sum -c -", install_step)
+    self.assertNotIn('curl -fsSL -o "$RUNNER_TEMP/alloy.zip"', install_step)
 
   def test_perf_workflow_scopes_secrets_away_from_job_env(self):
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/tests/test_perf_workflow_config.py
+++ b/scripts/tests/test_perf_workflow_config.py
@@ -61,7 +61,9 @@ class PerfWorkflowConfigTest(unittest.TestCase):
     self.assertIn("SHA256SUMS", install_step)
     self.assertIn("grep 'alloy-linux-amd64.zip$' SHA256SUMS", install_step)
     self.assertIn("sha256sum -c -", install_step)
+    self.assertIn('unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip"', install_step)
     self.assertNotIn('curl -fsSL -o "$RUNNER_TEMP/alloy.zip"', install_step)
+    self.assertNotIn('unzip "$RUNNER_TEMP/alloy.zip"', install_step)
 
   def test_perf_workflow_scopes_secrets_away_from_job_env(self):
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/scripts/tests/test_perf_workflow_config.py
+++ b/scripts/tests/test_perf_workflow_config.py
@@ -64,6 +64,7 @@ class PerfWorkflowConfigTest(unittest.TestCase):
     self.assertIn('unzip -q "$RUNNER_TEMP/alloy-linux-amd64.zip"', install_step)
     self.assertNotIn('curl -fsSL -o "$RUNNER_TEMP/alloy.zip"', install_step)
     self.assertNotIn('unzip "$RUNNER_TEMP/alloy.zip"', install_step)
+    self.assertNotIn('unzip -q "$RUNNER_TEMP/alloy.zip"', install_step)
 
   def test_perf_workflow_scopes_secrets_away_from_job_env(self):
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/wave/config/changelog.d/2026-04-16-perf-alloy-install-checksum.json
+++ b/wave/config/changelog.d/2026-04-16-perf-alloy-install-checksum.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-16-perf-alloy-install-checksum",
+  "version": "PR #892",
+  "date": "2026-04-16",
+  "title": "Fix perf Alloy archive verification",
+  "summary": "The performance workflow now verifies and unpacks the same Grafana Alloy archive filename so checksum validation does not fail before the perf job starts.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Aligned the perf workflow's Alloy checksum verification and unzip steps on the same architecture-specific archive filename"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- fix the Grafana Alloy install step to download the archive using the same filename referenced by the SHA256SUMS entry
- keep the unzip/install path aligned with the verified archive name
- add a workflow regression test so future edits catch this mismatch before CI

## Test Plan
-   python3 -m unittest scripts.tests.test_perf_workflow_config
-   tmpdir=$(mktemp -d) && release_url='https://github.com/grafana/alloy/releases/download/v1.11.2' && curl -fsSL -o "$tmpdir/alloy-linux-amd64.zip" "$release_url/alloy-linux-amd64.zip" && curl -fsSL -o "$tmpdir/SHA256SUMS" "$release_url/SHA256SUMS" && (cd "$tmpdir" && grep 'alloy-linux-amd64.zip$' SHA256SUMS | sha256sum -c -)

## Root Cause
The workflow downloaded the archive to , but the checksum step validated the SHA256SUMS line for .  uses the filename embedded in SHA256SUMS, so it looked for a file that was never created and failed before install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Performance workflow now downloads, verifies, and unpacks the correct architecture-specific Grafana Alloy archive to prevent checksum mismatches during perf runs.

* **Tests**
  * Tests strengthened to assert architecture-specific archive download, checksum verification, and extraction, and to ensure the generic archive path is not used.

* **Chores**
  * Added changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->