### PR TITLE
fix(deploy): retry apt-get in prebuilt Docker image build

### DIFF
--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -26,11 +26,30 @@
 FROM eclipse-temurin:17-jre
 LABEL org.waveprotocol.mongo-migration-marker-supported="true"
 ENV WAVE_HOME=/opt/wave
-RUN groupadd --system wave \
-    && apt-get update -qq \
-    && apt-get install -y -qq curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --gid wave --home-dir ${WAVE_HOME} --shell /usr/sbin/nologin wave
+# apt-get is wrapped in a retry loop because Ubuntu mirrors occasionally
+# serve stale index files during a mirror sync, causing hash-mismatch
+# errors ("File has unexpected size ... Mirror sync in progress?") that
+# fail the whole deploy. The retry loop with backoff rides out such
+# transient windows (typically a few minutes). Acquire::Retries handles
+# flaky connections within a single apt invocation; the outer loop
+# handles hash-mismatch errors across mirror sync windows.
+RUN set -eu; \
+    groupadd --system wave; \
+    apt_opts='-o Acquire::Retries=3 -o Acquire::http::Timeout=30'; \
+    attempt=1; max_attempts=5; \
+    until apt-get update -qq $apt_opts \
+          && apt-get install -y -qq --no-install-recommends $apt_opts curl; do \
+      if [ "$attempt" -ge "$max_attempts" ]; then \
+        echo "apt-get failed after $max_attempts attempts" >&2; \
+        exit 1; \
+      fi; \
+      delay=$((attempt * 10)); \
+      echo "apt-get failed on attempt $attempt/$max_attempts, retrying in ${delay}s..." >&2; \
+      sleep "$delay"; \
+      attempt=$((attempt + 1)); \
+    done; \
+    rm -rf /var/lib/apt/lists/*; \
+    useradd --system --gid wave --home-dir ${WAVE_HOME} --shell /usr/sbin/nologin wave
 WORKDIR ${WAVE_HOME}
 COPY --chown=wave:wave . ${WAVE_HOME}/
 RUN mkdir -p ${WAVE_HOME}/logs && chown wave:wave ${WAVE_HOME}/logs

--- a/wave/config/changelog.d/2026-04-16-deploy-apt-retry.json
+++ b/wave/config/changelog.d/2026-04-16-deploy-apt-retry.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-16-deploy-apt-retry",
+  "version": "PR #894",
+  "date": "2026-04-16",
+  "title": "Harden prebuilt Docker build against Ubuntu mirror sync errors",
+  "summary": "The production deploy pipeline now retries apt-get inside Dockerfile.prebuilt with progressive backoff, so a transient Ubuntu mirror hash-mismatch no longer aborts the whole deploy.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Wrapped apt-get update/install in Dockerfile.prebuilt in a retry loop with progressive backoff and Acquire::Retries so transient mirror sync hiccups do not fail the deploy"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Prod deploy run [24527301260](https://github.com/vega113/supawave/actions/runs/24527301260/job/71700890661#step:12:108) failed during `docker build -f Dockerfile.prebuilt` because the Ubuntu mirror was mid-sync when `apt-get update` ran, producing a hash-mismatch error:
  > `E: Failed to fetch http://archive.ubuntu.com/.../Packages.gz  File has unexpected size (2155936 != 2156089). Mirror sync in progress?`
- A single transient mirror hiccup killed the entire deploy because the `RUN groupadd && apt-get update && apt-get install curl && ...` step had no retry logic.
- Wrap the apt sequence in a shell retry loop with progressive backoff (10s → 40s, up to 5 attempts) and set `Acquire::Retries=3` / `Acquire::http::Timeout=30` so apt also retries within a single invocation.
- The outer loop rides out multi-minute mirror sync windows; the inner `Acquire::Retries` handles flaky connections. Also added `--no-install-recommends` to keep the layer minimal.

## Test plan

- [x] `docker build -f Dockerfile.prebuilt` succeeded locally on the happy path (apt succeeded on attempt 1, 5.4s).
- [x] Shell-level unit test of the loop: transient-fail-then-succeed path retries and succeeds; exhaustion path exits with code 1 after `max_attempts`.
- [ ] CI: `Deploy to Contabo` workflow green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Image builds now automatically retry package installation up to five times with linear backoff to improve resilience against transient network errors.
  * Added configurable retry and timeout options for more robust handling of network or mirror issues during builds.
  * Reduced image size by excluding recommended packages during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->