### PR TITLE
fix(toolbar): remove legacy sprite from pressed toolbar icons

### DIFF
--- a/wave/config/changelog.d/2026-04-16-toolbar-pressed-icon-sprite.json
+++ b/wave/config/changelog.d/2026-04-16-toolbar-pressed-icon-sprite.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-16-toolbar-pressed-icon-sprite",
+  "version": "PR #895",
+  "date": "2026-04-16",
+  "title": "Clean pressed background for toolbar toggle icons",
+  "summary": "Pressed horizontal toolbar buttons (pinned wave, pinned saved search, and other toggle icons) no longer render a two-tone gray/blue background.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the legacy buttonDown sprite under HorizontalToolbarButtonWidget pressed state so toggled toolbar icons now show a single clean rounded-blue overlay instead of a half-gray half-blue mix"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
@@ -81,7 +81,8 @@
   pointer-events: none;
 }
 
-.enabled.down > .overlay {
+.enabled.down > .overlay,
+.enabled:active > .overlay {
   background-color: rgba(0, 119, 182, 0.1);
   border: 1px solid rgba(0, 119, 182, 0.25);
 }

--- a/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
@@ -50,9 +50,13 @@
   transition: opacity 0.15s ease;
 }
 
-@sprite .self.enabled:active, .self.enabled.down {
-  gwt-image: 'buttonDown';
-}
+/*
+ * Pressed/toggled state is rendered via the rounded .overlay element below.
+ * The legacy buttonDown sprite was a fixed-size 64x24 PNG that couldn't match
+ * the button's variable size or the overlay's rounded corners, which caused
+ * a visible two-tone (gray sprite + blue overlay) background on pressed
+ * icons. The overlay alone provides a clean, full-coverage pressed style.
+ */
 
 @sprite .divider {
   gwt-image: 'divider';

--- a/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css
@@ -81,14 +81,14 @@
   pointer-events: none;
 }
 
+.enabled:hover > .overlay {
+  background-color: rgba(0, 119, 182, 0.08);
+}
+
 .enabled.down > .overlay,
 .enabled:active > .overlay {
   background-color: rgba(0, 119, 182, 0.1);
   border: 1px solid rgba(0, 119, 182, 0.25);
-}
-
-.enabled:hover > .overlay {
-  background-color: rgba(0, 119, 182, 0.08);
 }
 
 .visualElement {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -63,7 +63,8 @@ public final class ToolbarLayoutContractTest extends TestCase {
     String css = normalized(read(
         "wave/src/main/resources/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.css"));
 
-    assertTrue(css.contains(".enabled.down > .overlay {"));
+    assertTrue(css.contains(".enabled.down > .overlay,"));
+    assertTrue(css.contains(".enabled:active > .overlay {"));
     assertTrue(css.contains("background-color: rgba(0, 119, 182, 0.1);"));
     assertTrue(css.contains("border: 1px solid rgba(0, 119, 182, 0.25);"));
     assertFalse(css.contains(".enabled.down.compact > .overlay {"));


### PR DESCRIPTION
## Summary

Fixes the two-tone (half gray, half blue) background on pressed/toggled
toolbar icons in the wave panel and search toolbar — e.g. the pinned
wave icon, pinned saved-search icon, and other `HorizontalToolbarButtonWidget`
toggle buttons.

## Root cause

`HorizontalToolbarButtonWidget.css` was layering two pressed-state styles:

1. A legacy `@sprite .self.enabled:active, .self.enabled.down { gwt-image: 'buttonDown' }`
   rule that painted a fixed-size 64×24 gray PNG behind the button.
2. A modern rounded `.overlay` element with `rgba(0, 119, 182, 0.1)` blue
   background and `border-radius: 4px`.

Because the sprite can't stretch (buttons are `min-height: 36px` with
variable width) and has no rounded corners, the gray sprite showed
around the edges of the rounded blue overlay on every pressed icon,
producing the "half blue, half gray" look.

## Fix

Drop the legacy `@sprite` rule. The `.overlay` element already provides
a clean, full-coverage pressed-state visual. Added an in-file comment
explaining why the sprite was removed so it doesn't get re-introduced.
The unused `buttonDown()` `ImageResource` in the Java `ClientBundle` is
left in place to keep the diff minimal — GWT tolerates unused bundle
entries.

## Test plan

- [x] Registered a fresh user at `http://127.0.0.1:9898/auth/register`
- [x] Signed in, clicked the "Pinned waves" icon on the search toolbar — background is a single clean rounded blue
- [x] Created a wave, clicked "Pin" on the wave panel toolbar — same clean single-color pressed state
- [x] Programmatic check: `getComputedStyle` on every `.toolbar-btn-enabled` reports `background-image: none` (sprite no longer applied)
- [x] Pressed overlay is `rgba(0, 119, 182, 0.1)` on toggled buttons; hover overlay is `rgba(0, 119, 182, 0.08)` as before
- [ ] CI builds GWT client without errors (relies on bundled ClientBundle compilation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Toolbar toggle buttons now use a single rounded-blue pressed overlay for a consistent, cleaner pressed/toggled appearance.
  * Removed legacy sprite-driven pressed rendering that previously produced a mixed two-tone background; hover behavior remains unchanged.
* **Documentation**
  * Added a changelog entry describing the UI fix and the updated toolbar pressed-state visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->