### PR TITLE
Fix Android IME composition restart boundary

### DIFF
--- a/wave/config/changelog.d/2026-04-17-android-ime-cycle-boundary.json
+++ b/wave/config/changelog.d/2026-04-17-android-ime-cycle-boundary.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-17-android-ime-cycle-boundary",
+  "version": "Unreleased",
+  "date": "2026-04-17",
+  "title": "Preserve Android IME word starts across composition restarts",
+  "summary": "Android Chromium no longer drops the first letter of each composed word when the browser restarts IME composition before the editor's delayed composition-end flush runs.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Back-to-back Android IME composition cycles now flush the previous delayed composition end before the next cycle starts",
+        "Typing `new blip` in a new or empty blip now preserves both word-leading characters and the separating space on Android Chrome and Brave"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandler.java
@@ -167,25 +167,18 @@ public class CompositionEventHandler<V> {
       return;
     }
 
-    if (delayAfterTextInput) {
-      // We don't want to hit the merge logic below - if we've had a text input, always
-      // flush to ensure there's a corresponding compositionEnd, because the browser might
-      // be moving on to the next composition phase. But if it's a composition start
-      // straight after a composition end, then as of this writing it's safe to have them
-      // merged and avoid redundant events.
+    if (delayAfterTextInput
+        || (modifiesDomAndFiresTextInputAfterComposition && timer.isScheduled(endTask))) {
+      // A new native composition cycle started before the delayed application-side
+      // compositionEnd fired. Flush the old cycle now so the listener sees a real
+      // compositionEnd/compositionStart boundary instead of merging both cycles into
+      // one long app composition.
       assert appComposing();
       flush();
     }
 
     delayAfterTextInput = false;
     browserComposing = true;
-
-    if (modifiesDomAndFiresTextInputAfterComposition && timer.isScheduled(endTask)) {
-      // Got a composition start before our timer fired - just pretend the
-      // browser never left composition mode.
-      timer.cancel(endTask);
-      return;
-    }
 
     assert appComposing == false;
     appComposing = true;

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
@@ -101,7 +101,7 @@ public class CompositionEventHandlerTest extends TestCase {
 
   private void doSomeMoreTestsToCheckSaneState() {
     testBasicTiming();
-    testMergesInterleavedSecondCycle();
+    testFlushesInterleavedSecondCycleBeforeRestart();
     testDoesntMergeSecondCycleAfterTextInput();
     testDoesntEndWithTextInput();
   }
@@ -115,13 +115,16 @@ public class CompositionEventHandlerTest extends TestCase {
     verifyDone();
   }
 
-  public void testMergesInterleavedSecondCycle() {
+  public void testFlushesInterleavedSecondCycleBeforeRestart() {
     doStartUpdateEnd();
 
     handler.handleCompositionEvent(eventToken2, BrowserEvents.COMPOSITIONSTART);
+    InOrder ordered = inOrder(listener);
+    ordered.verify(listener).compositionEnd();
+    ordered.verify(listener).compositionStart(eventToken2);
     nothingElseUpToNow();
 
-    handler.handleCompositionEvent(eventToken, BrowserEvents.COMPOSITIONEND);
+    handler.handleCompositionEvent(eventToken2, BrowserEvents.COMPOSITIONEND);
     nothingElseUpToNow();
 
     tick();
@@ -267,12 +270,15 @@ public class CompositionEventHandlerTest extends TestCase {
     doStartUpdateEnd();
 
     handler.handleCompositionEvent(eventToken2, BrowserEvents.COMPOSITIONSTART);
+    InOrder ordered = inOrder(listener);
+    ordered.verify(listener).compositionEnd();
+    ordered.verify(listener).compositionStart(eventToken2);
     nothingElseUpToNow();
 
     tick();
     nothingElseUpToNow();
 
-    handler.handleCompositionEvent(eventToken, BrowserEvents.COMPOSITIONEND);
+    handler.handleCompositionEvent(eventToken2, BrowserEvents.COMPOSITIONEND);
     nothingElseUpToNow();
 
     tick();


### PR DESCRIPTION
## Summary
- Flush any delayed composition end before a new native composition cycle starts on Android/WebKit IME paths.
- Prevents the listener from merging two browser composition cycles into one long app composition, which was still dropping the first character and collapsing the space in `new blip`.
- Adds a regression to cover the back-to-back composition restart case, plus the existing delayed-end path.

## Testing
- `java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED -cp "$OUT:$FULL_CP" org.junit.runner.JUnitCore org.waveprotocol.wave.client.editor.event.CompositionEventHandlerTest`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android IME text composition behavior on Chrome and Brave browsers. Consecutive input cycles now properly preserve both composed words and separating spaces when typing in new or empty content areas on Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->