### PR TITLE
feat(harness): blocking doc and owner/freshness guardrails (#588)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
           bash -n scripts/deployment/bootstrap-linux-host.sh
           bash -n deploy/caddy/deploy.sh
           bash scripts/ci-validate-deploy-healthcheck.sh
+          python3 -m unittest scripts.tests.test_doc_guardrails -v
           python3 -m unittest scripts.tests.test_deploy_sanity_gate -v
           python3 -m unittest scripts.tests.test_deploy_overlap_safety -v
           python3 -m unittest scripts.tests.test_repair_corrupted_waves -v

--- a/.github/workflows/doc-guardrails.yml
+++ b/.github/workflows/doc-guardrails.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   doc-guardrails:
     name: Doc Link & Freshness Checks

--- a/.github/workflows/doc-guardrails.yml
+++ b/.github/workflows/doc-guardrails.yml
@@ -1,0 +1,22 @@
+name: Doc Guardrails
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  doc-guardrails:
+    name: Doc Link & Freshness Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check doc links
+        run: bash scripts/check-doc-links.sh
+
+      - name: Check doc freshness metadata
+        run: bash scripts/check-doc-freshness.sh

--- a/docs/BUILDING-sbt.md
+++ b/docs/BUILDING-sbt.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Building with SBT
 
 SBT is the canonical build system for Apache Wave. This document describes the

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Developer Setup (JDK 17, SBT, Protobuf)
 
 This guide helps you build and run the Apache Wave server on JDK 17.

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -36,6 +36,14 @@ Existing-worktree lane bootstrap
   initializes the gitignored local-verification record under
   `journal/local-verification/`.
 
+Doc guardrails
+- Two shell scripts enforce doc quality and run in CI on every PR:
+  - `bash scripts/check-doc-links.sh` — checks for broken markdown links under `docs/`.
+  - `bash scripts/check-doc-freshness.sh` — checks that covered docs listed in
+    `docs/DOC_REGISTRY.md` have required owner/freshness metadata.
+- Run both locally before pushing doc changes.
+- See [`docs/runbooks/doc-guardrails.md`](runbooks/doc-guardrails.md) for details.
+
 Troubleshooting
 - If SBT cannot find a suitable JDK, ensure JAVA_HOME is set to a JDK 17 and/or install via sdkman.
 - For protobuf errors, ensure you ran `sbt pst/assembly` before `sbt wave/compile` if building tasks individually.

--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -6,8 +6,8 @@ registry and fails CI when any listed doc is missing or has incomplete metadata.
 
 ## Required metadata header
 
-Every covered doc must have these four fields at the very top of the file,
-before the first `#` heading:
+Every covered doc must have these four fields within the first 10 lines of
+the file (before or after the opening `#` heading):
 
 ```
 Status: <value>
@@ -16,8 +16,8 @@ Updated: <YYYY-MM-DD>
 Review cadence: <value>
 ```
 
-**Status values**: `Canonical`, `Current`, `In Progress`, `Draft`, `Archive`.
-**Review cadence values**: `monthly`, `quarterly`, `on-change`.
+**Common status values** include: `Canonical`, `Current`, `In Progress`, `Draft`, `Archive`. Other values are accepted.
+**Common review cadence values** include: `monthly`, `quarterly`, `on-change`. Other values are accepted.
 
 ## How to add a new covered doc
 

--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -1,0 +1,47 @@
+# Doc Registry
+
+This file lists every documentation path that requires the standard metadata
+header block. The `scripts/check-doc-freshness.sh` guardrail reads this
+registry and fails CI when any listed doc is missing or has incomplete metadata.
+
+## Required metadata header
+
+Every covered doc must have these four fields at the very top of the file,
+before the first `#` heading:
+
+```
+Status: <value>
+Owner: <value>
+Updated: <YYYY-MM-DD>
+Review cadence: <value>
+```
+
+**Status values**: `Canonical`, `Current`, `In Progress`, `Draft`, `Archive`.
+**Review cadence values**: `monthly`, `quarterly`, `on-change`.
+
+## How to add a new covered doc
+
+1. Add the doc's repo-relative path to the list below.
+2. Add the four metadata fields at the top of the doc.
+3. Run `bash scripts/check-doc-freshness.sh` to confirm it passes.
+4. Commit both changes together.
+
+## Covered docs
+
+<!-- One path per line. Lines starting with # or empty lines are ignored. -->
+
+docs/runbooks/README.md
+docs/runbooks/browser-verification.md
+docs/runbooks/change-type-verification-matrix.md
+docs/runbooks/mongo-migrations.md
+docs/runbooks/worktree-diagnostics.md
+docs/runbooks/worktree-lane-lifecycle.md
+docs/README.md
+docs/DEV_SETUP.md
+docs/BUILDING-sbt.md
+docs/SMOKE_TESTS.md
+docs/current-state.md
+docs/github-issues.md
+docs/agents/README.md
+docs/architecture/README.md
+docs/deployment/README.md

--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -9,7 +9,7 @@ registry and fails CI when any listed doc is missing or has incomplete metadata.
 Every covered doc must have these four fields within the first 10 lines of
 the file (before or after the opening `#` heading):
 
-```
+```text
 Status: <value>
 Owner: <value>
 Updated: <YYYY-MM-DD>

--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -36,6 +36,7 @@ docs/runbooks/change-type-verification-matrix.md
 docs/runbooks/mongo-migrations.md
 docs/runbooks/worktree-diagnostics.md
 docs/runbooks/worktree-lane-lifecycle.md
+docs/runbooks/doc-guardrails.md
 docs/README.md
 docs/DEV_SETUP.md
 docs/BUILDING-sbt.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,9 @@
 # Docs Map
 
 Status: Canonical
+Owner: Project Maintainers
 Updated: 2026-04-04
+Review cadence: quarterly
 
 This directory keeps the existing documentation in place and adds a small map
 layer so readers can route by purpose instead of guessing from file names.

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-10
+Review cadence: quarterly
+
 # Smoke Tests Summary
 
 Date: 2026-04-10

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,7 +1,9 @@
 # Agent Docs Map
 
 Status: Canonical
+Owner: Project Maintainers
 Updated: 2026-04-04
+Review cadence: quarterly
 
 Start here if you are resuming work, routing a task, or figuring out which
 docs to trust first.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,9 @@
 # Architecture Docs Map
 
 Status: Canonical
+Owner: Project Maintainers
 Updated: 2026-04-04
+Review cadence: quarterly
 
 This map groups the durable technical references and historical ledgers that
 describe how the current Wave tree is structured.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -3,6 +3,7 @@
 Status: Canonical
 Updated: 2026-04-04
 Owner: Project Maintainers
+Review cadence: quarterly
 
 This document is the single starting point for resuming work on the current
 `incubator-wave` tree. It points new agents to the docs map, the live

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,3 +1,8 @@
+Status: Canonical
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Deployment Guide
 
 Apache Wave supports two first-class deployment flavors:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,7 +1,9 @@
 # Runbooks Map
 
 Status: Canonical
+Owner: Project Maintainers
 Updated: 2026-04-10
+Review cadence: quarterly
 
 Use this map for procedures you are expected to follow step by step: local
 setup, smoke checks, deployment, and operational routines.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -45,6 +45,11 @@ setup, smoke checks, deployment, and operational routines.
 - [`../deployment/email-deliverability-supawave.md`](../deployment/email-deliverability-supawave.md)
 - [`../deployment/mongo-hardening.md`](../deployment/mongo-hardening.md)
 
+## CI Guardrails
+
+- [`doc-guardrails.md`](doc-guardrails.md)
+  - Blocking doc-link and owner/freshness checks enforced on every PR.
+
 ## Operational Procedures
 
 - [`../pr-monitor-lanes.md`](../pr-monitor-lanes.md)

--- a/docs/runbooks/browser-verification.md
+++ b/docs/runbooks/browser-verification.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Browser Verification
 
 Use this runbook to decide when incubator-wave changes need real browser

--- a/docs/runbooks/change-type-verification-matrix.md
+++ b/docs/runbooks/change-type-verification-matrix.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Change-Type Verification Matrix
 
 Use this matrix after the base worktree boot/smoke flow succeeds. It decides

--- a/docs/runbooks/doc-guardrails.md
+++ b/docs/runbooks/doc-guardrails.md
@@ -35,7 +35,7 @@ required metadata markers in its first 10 lines:
 - `Status:` — e.g. Canonical, Current, In Progress, Draft, Archive
 - `Owner:` — e.g. Project Maintainers
 - `Updated:` — YYYY-MM-DD format
-- `Review cadence:` — monthly, quarterly, or on-change
+- `Review cadence:` — e.g. monthly, quarterly, on-change, or quarterly and when workflow conventions change
 
 ```bash
 bash scripts/check-doc-freshness.sh
@@ -44,8 +44,8 @@ bash scripts/check-doc-freshness.sh
 ## How to add a new covered doc
 
 1. Add the repo-relative path to `docs/DOC_REGISTRY.md` under `## Covered docs`.
-2. Add the four metadata fields at the top of the new doc, before the
-   first `#` heading:
+2. Add the four metadata fields within the first 10 lines of the new doc
+   (before or after the opening `#` heading):
 
    ```
    Status: Current

--- a/docs/runbooks/doc-guardrails.md
+++ b/docs/runbooks/doc-guardrails.md
@@ -5,8 +5,8 @@ Review cadence: quarterly
 
 # Doc Guardrails
 
-Two shell scripts enforce documentation quality in CI. Both run on every
-PR targeting `main` and block merge on failure.
+Two shell scripts enforce documentation quality in CI. Both run on pushes
+and PRs targeting `main` and `master` and block merge on failure.
 
 ## What the checks do
 
@@ -47,7 +47,7 @@ bash scripts/check-doc-freshness.sh
 2. Add the four metadata fields within the first 10 lines of the new doc
    (before or after the opening `#` heading):
 
-   ```
+   ```text
    Status: Current
    Owner: Project Maintainers
    Updated: 2026-04-17
@@ -67,7 +67,7 @@ bash scripts/check-doc-freshness.sh
 
 ### Broken link failure
 
-```
+```text
 [doc-links] FAIL: docs/runbooks/README.md:19 -> ../DEV_SETUP_TYPO.md (file not found)
 ```
 
@@ -77,7 +77,7 @@ or create the missing file.
 
 ### Missing metadata failure
 
-```
+```text
 [doc-freshness] FAIL: docs/runbooks/browser-verification.md — missing: Owner:, Review cadence:
 ```
 

--- a/docs/runbooks/doc-guardrails.md
+++ b/docs/runbooks/doc-guardrails.md
@@ -1,0 +1,98 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
+# Doc Guardrails
+
+Two shell scripts enforce documentation quality in CI. Both run on every
+PR targeting `main` and block merge on failure.
+
+## What the checks do
+
+### check-doc-links.sh
+
+Scans every `.md` file under `docs/` (excluding frozen snapshot
+directories) for markdown links that point to non-existent files.
+
+```bash
+bash scripts/check-doc-links.sh
+```
+
+Excluded directories (historical snapshots with stale source-code links):
+- `docs/superpowers/plans/`
+- `docs/superpowers/specs/`
+- `docs/JWT/`
+- `docs/plans/`
+
+Individual exclusions are listed in the script's `EXCLUDE_FILES` array.
+
+### check-doc-freshness.sh
+
+Reads `docs/DOC_REGISTRY.md` and verifies every listed doc has the four
+required metadata markers in its first 10 lines:
+
+- `Status:` — e.g. Canonical, Current, In Progress, Draft, Archive
+- `Owner:` — e.g. Project Maintainers
+- `Updated:` — YYYY-MM-DD format
+- `Review cadence:` — monthly, quarterly, or on-change
+
+```bash
+bash scripts/check-doc-freshness.sh
+```
+
+## How to add a new covered doc
+
+1. Add the repo-relative path to `docs/DOC_REGISTRY.md` under `## Covered docs`.
+2. Add the four metadata fields at the top of the new doc, before the
+   first `#` heading:
+
+   ```
+   Status: Current
+   Owner: Project Maintainers
+   Updated: 2026-04-17
+   Review cadence: quarterly
+   ```
+
+3. Run both checks locally to confirm they pass:
+
+   ```bash
+   bash scripts/check-doc-links.sh
+   bash scripts/check-doc-freshness.sh
+   ```
+
+4. Commit the registry entry and the doc together.
+
+## How to interpret failures
+
+### Broken link failure
+
+```
+[doc-links] FAIL: docs/runbooks/README.md:19 -> ../DEV_SETUP_TYPO.md (file not found)
+```
+
+The file at `docs/runbooks/README.md` line 19 has a link whose target does
+not exist when resolved relative to the file's directory. Fix the link path
+or create the missing file.
+
+### Missing metadata failure
+
+```
+[doc-freshness] FAIL: docs/runbooks/browser-verification.md — missing: Owner:, Review cadence:
+```
+
+The listed doc is in `docs/DOC_REGISTRY.md` but lacks one or more required
+metadata fields in its first 10 lines. Add the missing fields at the top
+of the file.
+
+## How to exclude a file from link checking
+
+If a doc legitimately contains links to paths outside the repo (source code
+references in historical snapshots), add it to the `EXCLUDE_FILES` or
+`EXCLUDE_DIRS` arrays at the top of `scripts/check-doc-links.sh`.
+
+## CI wiring
+
+The checks run in `.github/workflows/doc-guardrails.yml` as blocking steps
+on PRs targeting `main`. Neither step uses `continue-on-error` — any
+failure blocks merge.

--- a/docs/runbooks/doc-guardrails.md
+++ b/docs/runbooks/doc-guardrails.md
@@ -94,5 +94,5 @@ references in historical snapshots), add it to the `EXCLUDE_FILES` or
 ## CI wiring
 
 The checks run in `.github/workflows/doc-guardrails.yml` as blocking steps
-on PRs targeting `main`. Neither step uses `continue-on-error` — any
-failure blocks merge.
+on push to `main` or `master` and on PRs targeting either branch. Neither
+step uses `continue-on-error` — any failure blocks merge.

--- a/docs/runbooks/mongo-migrations.md
+++ b/docs/runbooks/mongo-migrations.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Mongo Migrations Runbook
 
 This repo uses **Mongock** as the versioned startup migration mechanism for the

--- a/docs/runbooks/worktree-diagnostics.md
+++ b/docs/runbooks/worktree-diagnostics.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Worktree Diagnostics
 
 Use this runbook when an incubator-wave issue worktree needs a compact

--- a/docs/runbooks/worktree-lane-lifecycle.md
+++ b/docs/runbooks/worktree-lane-lifecycle.md
@@ -1,3 +1,8 @@
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-17
+Review cadence: quarterly
+
 # Worktree Lane Lifecycle
 
 Use this runbook when a GitHub issue lane already has its own incubator-wave

--- a/docs/superpowers/plans/2026-04-17-issue-588-doc-guardrails.md
+++ b/docs/superpowers/plans/2026-04-17-issue-588-doc-guardrails.md
@@ -1,0 +1,107 @@
+# Issue #588 — Blocking Doc & Owner/Freshness Guardrails
+
+Status: In Progress
+Created: 2026-04-17
+
+## Goal
+
+Turn deterministic documentation checks into blocking CI guardrails so broken
+doc links and missing owner/freshness metadata fail the build before merge.
+
+## Design Decisions
+
+### Covered-doc definition: DOC_REGISTRY.md
+
+Use a `docs/DOC_REGISTRY.md` file listing every doc path that requires the
+metadata block. Rationale:
+
+- Explicit — no heuristic to guess which docs are covered.
+- Easy to extend — add a line, commit, done.
+- The check script reads the registry; no magic directory scanning.
+
+### Metadata convention: plain-text header block
+
+Metadata lives at the very top of the file, before the first `#` heading:
+
+```
+Status: <value>
+Owner: <value>
+Updated: <YYYY-MM-DD>
+Review cadence: <value>
+```
+
+This matches the existing convention already used by `docs/github-issues.md`,
+`docs/runbooks/README.md`, and several architecture docs. Required fields for
+every covered doc: all four.
+
+### Covered docs (initial set)
+
+All runbooks:
+- docs/runbooks/README.md
+- docs/runbooks/browser-verification.md
+- docs/runbooks/change-type-verification-matrix.md
+- docs/runbooks/mongo-migrations.md
+- docs/runbooks/worktree-diagnostics.md
+- docs/runbooks/worktree-lane-lifecycle.md
+
+Canonical/authoritative docs referenced by runbooks or marked Canonical:
+- docs/README.md
+- docs/DEV_SETUP.md
+- docs/BUILDING-sbt.md
+- docs/SMOKE_TESTS.md
+- docs/current-state.md
+- docs/github-issues.md
+- docs/agents/README.md
+- docs/architecture/README.md
+- docs/deployment/README.md
+
+Total: 15 files.
+
+## Check Algorithms
+
+### check-doc-links.sh
+
+1. Find all `.md` files under `docs/`.
+2. Extract markdown links: `[text](path)` where path is a relative file path
+   (not http/https/mailto/anchor-only).
+3. Resolve each link relative to the file that contains it.
+4. If the resolved path does not exist, report it.
+5. Exit non-zero if any broken link found.
+
+Output format:
+```
+[doc-links] FAIL: docs/runbooks/README.md:19 -> ../DEV_SETUP_TYPO.md (file not found)
+[doc-links] OK: 142 links checked, 0 broken
+```
+
+### check-doc-freshness.sh
+
+1. Read `docs/DOC_REGISTRY.md` to get the list of covered doc paths.
+2. For each path, check that the file exists and contains all four required
+   markers (`Status:`, `Owner:`, `Updated:`, `Review cadence:`) in the
+   pre-heading block.
+3. Report missing markers per file.
+4. Exit non-zero if any covered doc is missing or has incomplete metadata.
+
+Output format:
+```
+[doc-freshness] FAIL: docs/runbooks/browser-verification.md — missing: Owner, Updated, Review cadence
+[doc-freshness] OK: 15 covered docs checked, all complete
+```
+
+## CI Wiring
+
+New `.github/workflows/doc-guardrails.yml`:
+- Triggers on: pull_request targeting main/master, push to main/master.
+- Single job with two steps: run check-doc-links.sh, run check-doc-freshness.sh.
+- Both steps are blocking (no continue-on-error).
+
+## Deliverables
+
+1. `scripts/check-doc-links.sh`
+2. `scripts/check-doc-freshness.sh`
+3. `docs/DOC_REGISTRY.md`
+4. Metadata headers added to all 15 covered docs
+5. `.github/workflows/doc-guardrails.yml`
+6. `docs/runbooks/doc-guardrails.md`
+7. Updated `docs/DEV_SETUP.md` and `docs/runbooks/README.md`

--- a/docs/superpowers/plans/2026-04-17-issue-588-doc-guardrails.md
+++ b/docs/superpowers/plans/2026-04-17-issue-588-doc-guardrails.md
@@ -55,7 +55,7 @@ Canonical/authoritative docs referenced by runbooks or marked Canonical:
 - docs/architecture/README.md
 - docs/deployment/README.md
 
-Total: 15 files.
+Total: 16 files.
 
 ## Check Algorithms
 
@@ -86,7 +86,7 @@ Output format:
 Output format:
 ```
 [doc-freshness] FAIL: docs/runbooks/browser-verification.md — missing: Owner, Updated, Review cadence
-[doc-freshness] OK: 15 covered docs checked, all complete
+[doc-freshness] OK: 16 covered docs checked, all complete
 ```
 
 ## CI Wiring
@@ -101,7 +101,7 @@ New `.github/workflows/doc-guardrails.yml`:
 1. `scripts/check-doc-links.sh`
 2. `scripts/check-doc-freshness.sh`
 3. `docs/DOC_REGISTRY.md`
-4. Metadata headers added to all 15 covered docs
+4. Metadata headers added to all 16 covered docs
 5. `.github/workflows/doc-guardrails.yml`
 6. `docs/runbooks/doc-guardrails.md`
 7. Updated `docs/DEV_SETUP.md` and `docs/runbooks/README.md`

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -27,6 +27,9 @@ while IFS= read -r line; do
     in_section=1
     continue
   fi
+  if [[ "$in_section" -eq 1 && "$line" == "## "* ]]; then
+    break
+  fi
   [ "$in_section" -eq 0 ] && continue
 
   # Skip blanks, comments, and HTML comment lines

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── check-doc-freshness.sh ──────────────────────────────────────────
+# Verifies that every doc listed in docs/DOC_REGISTRY.md has the
+# required owner/freshness metadata block in its first 10 lines.
+# Exits non-zero if any covered doc is missing or has incomplete metadata.
+# ─────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REGISTRY="$REPO_ROOT/docs/DOC_REGISTRY.md"
+
+REQUIRED_MARKERS=("Status:" "Owner:" "Updated:" "Review cadence:")
+
+if [ ! -f "$REGISTRY" ]; then
+  echo "[doc-freshness] ERROR: registry not found at docs/DOC_REGISTRY.md" >&2
+  exit 2
+fi
+
+# Parse the registry: take lines after "## Covered docs", skip blanks,
+# comments, and the HTML comment line.
+in_section=0
+doc_paths=()
+while IFS= read -r line; do
+  if [[ "$line" == "## Covered docs"* ]]; then
+    in_section=1
+    continue
+  fi
+  [ "$in_section" -eq 0 ] && continue
+
+  # Skip blanks, comments, and HTML comment lines
+  [[ -z "$line" ]] && continue
+  [[ "$line" == "#"* ]] && continue
+  [[ "$line" == "<!--"* ]] && continue
+
+  doc_paths+=("$line")
+done < "$REGISTRY"
+
+if [ ${#doc_paths[@]} -eq 0 ]; then
+  echo "[doc-freshness] ERROR: no doc paths found in registry" >&2
+  exit 2
+fi
+
+total=${#doc_paths[@]}
+failed=0
+failures=""
+
+for doc_path in "${doc_paths[@]}"; do
+  full_path="$REPO_ROOT/$doc_path"
+
+  if [ ! -f "$full_path" ]; then
+    echo "[doc-freshness] FAIL: $doc_path — file not found"
+    failed=$((failed + 1))
+    failures="yes"
+    continue
+  fi
+
+  # Read the first 10 lines
+  header="$(head -n 10 "$full_path")"
+
+  missing=()
+  for marker in "${REQUIRED_MARKERS[@]}"; do
+    if ! echo "$header" | grep -q "^${marker}"; then
+      missing+=("$marker")
+    fi
+  done
+
+  if [ ${#missing[@]} -gt 0 ]; then
+    missing_str=""
+    for m in "${missing[@]}"; do
+      [ -n "$missing_str" ] && missing_str="$missing_str, "
+      missing_str="$missing_str${m}"
+    done
+    echo "[doc-freshness] FAIL: $doc_path — missing: $missing_str"
+    failed=$((failed + 1))
+    failures="yes"
+  fi
+done
+
+echo "[doc-freshness] $total covered docs checked, $failed incomplete"
+
+if [ -n "$failures" ]; then
+  exit 1
+fi

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ── check-doc-links.sh ──────────────────────────────────────────────
+# -- check-doc-links.sh --------------------------------------------------
 # Finds broken intra-repo markdown links under docs/.
 # Exits non-zero if any link target is missing.
 #
 # Excludes frozen snapshot directories (plans, specs, JWT inventories)
 # whose source-code links are expected to drift as code evolves.
-# ────────────────────────────────────────────────────────────────────
+# -----------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -53,16 +53,46 @@ is_excluded() {
 # skipping URLs, mailto, and anchor-only references.
 extract_links() {
   local file="$1"
-  awk '{
+  awk '
+  function trim(value) {
+    sub(/^[[:space:]]+/, "", value)
+    sub(/[[:space:]]+$/, "", value)
+    return value
+  }
+
+  function strip_markdown_title(value, gt) {
+    value = trim(value)
+
+    if (value ~ /^<[^>]+>[[:space:]]*$/) {
+      return substr(value, 2, length(value) - 2)
+    }
+
+    if (value ~ /^<[^>]+>[[:space:]]*("[^"]*"|'\''[^'\'']*'\''|\([^)]*\))$/) {
+      gt = index(value, ">")
+      return substr(value, 2, gt - 2)
+    }
+
+    sub(/[[:space:]]+"[^"]*"$/, "", value)
+    sub(/[[:space:]]+'\''[^'\'']*'\''$/, "", value)
+    sub(/[[:space:]]+\([^)]*\)$/, "", value)
+    value = trim(value)
+
+    if (value ~ /^<[^>]+>$/) {
+      value = substr(value, 2, length(value) - 2)
+    }
+
+    return value
+  }
+
+  {
     line = $0
     lnum = NR
     while (match(line, /\[[^\]]*\]\([^)]+\)/)) {
       full = substr(line, RSTART, RLENGTH)
       paren = index(full, "(")
-      target = substr(full, paren + 1, length(full) - paren - 1)
-      # Strip optional Markdown link title: path "title" or path 'title'
-      sub(/ .*$/, "", target)
+      target = strip_markdown_title(substr(full, paren + 1, length(full) - paren - 1))
       line = substr(line, RSTART + RLENGTH)
+      if (target == "") continue
       if (target ~ /^https?:\/\// || target ~ /^mailto:/) continue
       if (target ~ /^#/) continue
       print lnum " " target

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -51,12 +51,15 @@ is_excluded() {
 
 canonicalize_existing_path() {
   local candidate="$1"
-  local parent
 
   [ -e "$candidate" ] || return 1
 
-  parent="$(cd "$(dirname "$candidate")" && pwd -P)" || return 1
-  printf '%s/%s\n' "$parent" "$(basename "$candidate")"
+  python3 - "$candidate" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
 }
 
 # extract_links FILE
@@ -75,6 +78,37 @@ extract_links() {
     sub(/^[[:space:]]+/, "", value)
     sub(/[[:space:]]+$/, "", value)
     return value
+  }
+
+  function strip_inline_code(value,   result, i, tick_count, marker, closing_offset) {
+    result = ""
+    i = 1
+
+    while (i <= length(value)) {
+      if (substr(value, i, 1) != "`") {
+        result = result substr(value, i, 1)
+        i++
+        continue
+      }
+
+      tick_count = 1
+      while (substr(value, i + tick_count, 1) == "`") {
+        tick_count++
+      }
+
+      marker = substr(value, i, tick_count)
+      closing_offset = index(substr(value, i + tick_count), marker)
+
+      if (!closing_offset) {
+        result = result substr(value, i, 1)
+        i++
+        continue
+      }
+
+      i += closing_offset + (2 * tick_count) - 1
+    }
+
+    return result
   }
 
   function strip_markdown_title(value, gt) {
@@ -145,7 +179,7 @@ extract_links() {
       next
     }
     if (in_fence) next
-    line = $0
+    line = strip_inline_code($0)
     lnum = NR
     while (1) {
       target = extract_next_target(line)

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -188,7 +188,7 @@ extract_links() {
       if (!link_complete) continue
       if (target == "") continue
       target = strip_markdown_title(target)
-      if (target ~ /^https?:\/\// || target ~ /^mailto:/) continue
+      if (target ~ /^[a-zA-Z][a-zA-Z0-9+.-]*:/) continue
       if (target ~ /^#/) continue
       print lnum " " target
     }

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ── check-doc-links.sh ──────────────────��───────────────────────────
+# ── check-doc-links.sh ──────────────────────────────────────────────
 # Finds broken intra-repo markdown links under docs/.
 # Exits non-zero if any link target is missing.
 #
 # Excludes frozen snapshot directories (plans, specs, JWT inventories)
 # whose source-code links are expected to drift as code evolves.
-# ───────────────────────────────────────────────���─────────────────────
+# ────────────────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -60,6 +60,8 @@ extract_links() {
       full = substr(line, RSTART, RLENGTH)
       paren = index(full, "(")
       target = substr(full, paren + 1, length(full) - paren - 1)
+      # Strip optional Markdown link title: path "title" or path 'title'
+      sub(/ .*$/, "", target)
       line = substr(line, RSTART + RLENGTH)
       if (target ~ /^https?:\/\// || target ~ /^mailto:/) continue
       if (target ~ /^#/) continue

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── check-doc-links.sh ──────────────────��───────────────────────────
+# Finds broken intra-repo markdown links under docs/.
+# Exits non-zero if any link target is missing.
+#
+# Excludes frozen snapshot directories (plans, specs, JWT inventories)
+# whose source-code links are expected to drift as code evolves.
+# ───────────────────────────────────────────────���─────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCS_DIR="$REPO_ROOT/docs"
+
+# Directories excluded from link checking (frozen snapshots with
+# source-code-relative links that are not maintained).
+EXCLUDE_DIRS=(
+  "docs/superpowers/plans"
+  "docs/superpowers/specs"
+  "docs/JWT"
+  "docs/plans"
+)
+
+# Individual files excluded (historical docs with stale source-code links
+# from pre-Jakarta/pre-SBT era).
+EXCLUDE_FILES=(
+  "docs/j2cl-gwt3-inventory.md"
+  "docs/persistence-topology-audit.md"
+)
+
+total=0
+broken=0
+failures=""
+
+is_excluded() {
+  local rel_path="$1"
+  for excl in "${EXCLUDE_DIRS[@]}"; do
+    if [[ "$rel_path" == "$excl/"* ]]; then
+      return 0
+    fi
+  done
+  for excl in "${EXCLUDE_FILES[@]}"; do
+    if [[ "$rel_path" == "$excl" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# extract_links FILE
+# Outputs: LINE_NUMBER<space>TARGET for each markdown link in FILE,
+# skipping URLs, mailto, and anchor-only references.
+extract_links() {
+  local file="$1"
+  awk '{
+    line = $0
+    lnum = NR
+    while (match(line, /\[[^\]]*\]\([^)]+\)/)) {
+      full = substr(line, RSTART, RLENGTH)
+      paren = index(full, "(")
+      target = substr(full, paren + 1, length(full) - paren - 1)
+      line = substr(line, RSTART + RLENGTH)
+      if (target ~ /^https?:\/\// || target ~ /^mailto:/) continue
+      if (target ~ /^#/) continue
+      print lnum " " target
+    }
+  }' "$file"
+}
+
+while IFS= read -r md_file; do
+  rel_file="${md_file#"$REPO_ROOT"/}"
+
+  if is_excluded "$rel_file"; then
+    continue
+  fi
+
+  file_dir="$(dirname "$md_file")"
+
+  while read -r line_num target; do
+    [ -z "$target" ] && continue
+
+    # Strip anchor fragment from the path
+    path_part="${target%%#*}"
+    [ -z "$path_part" ] && continue
+
+    # Resolve relative to the file's directory
+    resolved="$file_dir/$path_part"
+
+    total=$((total + 1))
+
+    if [ ! -e "$resolved" ]; then
+      echo "[doc-links] FAIL: $rel_file:$line_num -> $target (file not found)"
+      broken=$((broken + 1))
+      failures="yes"
+    fi
+  done < <(extract_links "$md_file")
+done < <(find "$DOCS_DIR" -name '*.md' | sort)
+
+echo "[doc-links] $total links checked, $broken broken"
+
+if [ -n "$failures" ]; then
+  exit 1
+fi

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -54,6 +54,8 @@ is_excluded() {
 extract_links() {
   local file="$1"
   awk '
+  BEGIN { in_fence = 0 }
+
   function trim(value) {
     sub(/^[[:space:]]+/, "", value)
     sub(/[[:space:]]+$/, "", value)
@@ -84,7 +86,10 @@ extract_links() {
     return value
   }
 
+  /^[[:space:]]*```/ { in_fence = !in_fence; next }
+
   {
+    if (in_fence) next
     line = $0
     lnum = NR
     while (match(line, /\[[^\]]*\]\([^)]+\)/)) {

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT_REAL="$(cd "$REPO_ROOT" && pwd -P)"
 DOCS_DIR="$REPO_ROOT/docs"
 
 # Directories excluded from link checking (frozen snapshots with
@@ -48,6 +49,16 @@ is_excluded() {
   return 1
 }
 
+canonicalize_existing_path() {
+  local candidate="$1"
+  local parent
+
+  [ -e "$candidate" ] || return 1
+
+  parent="$(cd "$(dirname "$candidate")" && pwd -P)" || return 1
+  printf '%s/%s\n' "$parent" "$(basename "$candidate")"
+}
+
 # extract_links FILE
 # Outputs: LINE_NUMBER<space>TARGET for each markdown link in FILE,
 # skipping URLs, mailto, and anchor-only references.
@@ -55,6 +66,10 @@ extract_links() {
   local file="$1"
   awk '
   BEGIN { in_fence = 0 }
+
+  function is_fence_line(value) {
+    return value ~ /^[[:space:]]*(```|~~~)/
+  }
 
   function trim(value) {
     sub(/^[[:space:]]+/, "", value)
@@ -85,10 +100,11 @@ extract_links() {
 
     return value
   }
-
-  /^[[:space:]]*```/ { in_fence = !in_fence; next }
-
   {
+    if (is_fence_line($0)) {
+      in_fence = !in_fence
+      next
+    }
     if (in_fence) next
     line = $0
     lnum = NR
@@ -126,8 +142,12 @@ while IFS= read -r md_file; do
 
     total=$((total + 1))
 
-    if [ ! -e "$resolved" ]; then
+    if ! canonical_resolved="$(canonicalize_existing_path "$resolved")"; then
       echo "[doc-links] FAIL: $rel_file:$line_num -> $target (file not found)"
+      broken=$((broken + 1))
+      failures="yes"
+    elif [[ "$canonical_resolved" != "$REPO_ROOT_REAL" && "$canonical_resolved" != "$REPO_ROOT_REAL/"* ]]; then
+      echo "[doc-links] FAIL: $rel_file:$line_num -> $target (outside repository root)"
       broken=$((broken + 1))
       failures="yes"
     fi

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -100,6 +100,45 @@ extract_links() {
 
     return value
   }
+
+  function extract_next_target(text,   start, open_index, target_start, i, ch, depth) {
+    link_found = 0
+    link_complete = 0
+    link_match_end = 0
+
+    start = match(text, /\[[^][]*\]\(/)
+    if (!start) {
+      return ""
+    }
+
+    link_found = 1
+    open_index = start + RLENGTH - 1
+    target_start = open_index + 1
+    depth = 1
+
+    for (i = target_start; i <= length(text); i++) {
+      ch = substr(text, i, 1)
+
+      if (ch == "\\" && i < length(text)) {
+        i++
+        continue
+      }
+
+      if (ch == "(") {
+        depth++
+      } else if (ch == ")") {
+        depth--
+        if (depth == 0) {
+          link_complete = 1
+          link_match_end = i
+          return substr(text, target_start, i - target_start)
+        }
+      }
+    }
+
+    link_match_end = open_index
+    return ""
+  }
   {
     if (is_fence_line($0)) {
       in_fence = !in_fence
@@ -108,12 +147,13 @@ extract_links() {
     if (in_fence) next
     line = $0
     lnum = NR
-    while (match(line, /\[[^\]]*\]\([^)]+\)/)) {
-      full = substr(line, RSTART, RLENGTH)
-      paren = index(full, "(")
-      target = strip_markdown_title(substr(full, paren + 1, length(full) - paren - 1))
-      line = substr(line, RSTART + RLENGTH)
+    while (1) {
+      target = extract_next_target(line)
+      if (!link_found) break
+      line = substr(line, link_match_end + 1)
+      if (!link_complete) continue
       if (target == "") continue
+      target = strip_markdown_title(target)
       if (target ~ /^https?:\/\// || target ~ /^mailto:/) continue
       if (target ~ /^#/) continue
       print lnum " " target

--- a/scripts/tests/test_doc_guardrails.py
+++ b/scripts/tests/test_doc_guardrails.py
@@ -154,6 +154,34 @@ class DocGuardrailsScriptTest(unittest.TestCase):
     self.assertEqual(0, result.returncode)
     self.assertIn("[doc-links] 1 links checked, 0 broken", result.stdout)
 
+  def test_check_doc_links_rejects_symlink_targets_outside_repo_root(self) -> None:
+    outside_doc = self.temp_dir / "outside.md"
+    outside_doc.write_text("# Outside\n", encoding="utf-8")
+    symlink_path = self.repo / "docs" / "link.md"
+    symlink_path.symlink_to(outside_doc)
+    self._write("docs/guide.md", "[Symlink](link.md)\n")
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(1, result.returncode)
+    self.assertIn(
+        "[doc-links] FAIL: docs/guide.md:1 -> link.md (outside repository root)",
+        result.stdout,
+    )
+    self.assertIn("[doc-links] 1 links checked, 1 broken", result.stdout)
+
+  def test_check_doc_links_ignores_inline_code_span_links(self) -> None:
+    self._write("docs/real.md", "# Real\n")
+    self._write(
+        "docs/guide.md",
+        "Use `[Inline](missing.md)` for examples.\n\n[Real](real.md)\n",
+    )
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 1 links checked, 0 broken", result.stdout)
+
   def test_check_doc_freshness_stops_after_covered_docs_section(self) -> None:
     self._write(
         "docs/DOC_REGISTRY.md",

--- a/scripts/tests/test_doc_guardrails.py
+++ b/scripts/tests/test_doc_guardrails.py
@@ -1,0 +1,176 @@
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_DOC_LINKS = REPO_ROOT / "scripts" / "check-doc-links.sh"
+CHECK_DOC_FRESHNESS = REPO_ROOT / "scripts" / "check-doc-freshness.sh"
+DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+
+def run_command(
+    args: list[str], *, cwd: Path, timeout_context: str
+) -> subprocess.CompletedProcess[str]:
+  try:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+  except subprocess.TimeoutExpired as exc:
+    raise AssertionError(
+        f"{timeout_context} timed out after "
+        f"{DEFAULT_SUBPROCESS_TIMEOUT_SECONDS}s: {args}"
+    ) from exc
+
+
+class DocGuardrailsScriptTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.temp_dir = Path(tempfile.mkdtemp(prefix="doc-guardrails-"))
+    self.repo = self.temp_dir / "repo"
+    (self.repo / "docs").mkdir(parents=True, exist_ok=True)
+    (self.repo / "scripts").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(CHECK_DOC_LINKS, self.repo / "scripts" / CHECK_DOC_LINKS.name)
+    shutil.copy2(
+        CHECK_DOC_FRESHNESS,
+        self.repo / "scripts" / CHECK_DOC_FRESHNESS.name,
+    )
+
+  def tearDown(self) -> None:
+    shutil.rmtree(self.temp_dir)
+
+  def test_check_doc_links_accepts_titles_and_angle_brackets(self) -> None:
+    self._write("README.md", "# Root\n")
+    self._write("docs/sub dir/other.md", "# Other\n")
+    self._write(
+        "docs/guide.md",
+        textwrap.dedent(
+            """
+            [Root](../README.md "repo root")
+            [Other](<sub dir/other.md> 'nested doc')
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 2 links checked, 0 broken", result.stdout)
+    self.assertEqual("", result.stderr)
+
+  def test_check_doc_links_reports_broken_links(self) -> None:
+    self._write("docs/guide.md", "[Missing](missing.md)\n")
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(1, result.returncode)
+    self.assertIn(
+        "[doc-links] FAIL: docs/guide.md:1 -> missing.md (file not found)",
+        result.stdout,
+    )
+    self.assertIn("[doc-links] 1 links checked, 1 broken", result.stdout)
+
+  def test_check_doc_links_skips_excluded_directories(self) -> None:
+    self._write(
+        "docs/superpowers/plans/frozen.md",
+        "[Stale](../../missing.md)\n",
+    )
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 0 links checked, 0 broken", result.stdout)
+
+  def test_check_doc_freshness_stops_after_covered_docs_section(self) -> None:
+    self._write(
+        "docs/DOC_REGISTRY.md",
+        textwrap.dedent(
+            """
+            ## Covered docs
+
+            docs/runbooks/example.md
+
+            ## Notes
+
+            this should not be parsed as a path
+            """
+        ).strip()
+        + "\n",
+    )
+    self._write(
+        "docs/runbooks/example.md",
+        textwrap.dedent(
+            """
+            Status: Current
+            Owner: Project Maintainers
+            Updated: 2026-04-17
+            Review cadence: quarterly
+
+            # Example
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_FRESHNESS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-freshness] 1 covered docs checked, 0 incomplete", result.stdout)
+
+  def test_check_doc_freshness_reports_missing_markers(self) -> None:
+    self._write(
+        "docs/DOC_REGISTRY.md",
+        textwrap.dedent(
+            """
+            ## Covered docs
+
+            docs/runbooks/example.md
+            """
+        ).strip()
+        + "\n",
+    )
+    self._write(
+        "docs/runbooks/example.md",
+        textwrap.dedent(
+            """
+            Status: Current
+            Updated: 2026-04-17
+
+            # Example
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_FRESHNESS.name)
+
+    self.assertEqual(1, result.returncode)
+    self.assertIn(
+        "[doc-freshness] FAIL: docs/runbooks/example.md — missing: Owner:, Review cadence:",
+        result.stdout,
+    )
+    self.assertIn("[doc-freshness] 1 covered docs checked, 1 incomplete", result.stdout)
+
+  def _run_script(self, script_name: str) -> subprocess.CompletedProcess[str]:
+    return run_command(
+        ["bash", str(self.repo / "scripts" / script_name)],
+        cwd=self.repo,
+        timeout_context=f"{script_name} invocation",
+    )
+
+  def _write(self, relative_path: str, content: str) -> None:
+    target = self.repo / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/tests/test_doc_guardrails.py
+++ b/scripts/tests/test_doc_guardrails.py
@@ -78,6 +78,27 @@ class DocGuardrailsScriptTest(unittest.TestCase):
     )
     self.assertIn("[doc-links] 1 links checked, 1 broken", result.stdout)
 
+  def test_check_doc_links_ignores_fenced_code_block_links(self) -> None:
+    self._write("README.md", "# Root\n")
+    self._write(
+        "docs/guide.md",
+        textwrap.dedent(
+            """
+            [README](../README.md)
+
+            ```
+            [Broken](nonexistent.md)
+            ```
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 1 links checked, 0 broken", result.stdout)
+
   def test_check_doc_links_skips_excluded_directories(self) -> None:
     self._write(
         "docs/superpowers/plans/frozen.md",
@@ -158,6 +179,49 @@ class DocGuardrailsScriptTest(unittest.TestCase):
         result.stdout,
     )
     self.assertIn("[doc-freshness] 1 covered docs checked, 1 incomplete", result.stdout)
+
+  def test_check_doc_freshness_requires_markers_within_first_10_lines(self) -> None:
+    self._write(
+        "docs/DOC_REGISTRY.md",
+        textwrap.dedent(
+            """
+            ## Covered docs
+
+            docs/runbooks/example.md
+            """
+        ).strip()
+        + "\n",
+    )
+    self._write(
+        "docs/runbooks/example.md",
+        textwrap.dedent(
+            """
+            # Example Doc
+
+            Line three.
+            Line four.
+            Line five.
+            Line six.
+            Line seven.
+            Line eight.
+            Line nine.
+            Line ten.
+            Status: Current
+            Owner: Project Maintainers
+            Updated: 2026-04-17
+            Review cadence: quarterly
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_FRESHNESS.name)
+
+    self.assertEqual(1, result.returncode)
+    self.assertIn(
+        "[doc-freshness] FAIL: docs/runbooks/example.md — missing: Status:, Owner:, Updated:, Review cadence:",
+        result.stdout,
+    )
 
   def _run_script(self, script_name: str) -> subprocess.CompletedProcess[str]:
     return run_command(

--- a/scripts/tests/test_doc_guardrails.py
+++ b/scripts/tests/test_doc_guardrails.py
@@ -145,6 +145,15 @@ class DocGuardrailsScriptTest(unittest.TestCase):
     )
     self.assertIn("[doc-links] 1 links checked, 1 broken", result.stdout)
 
+  def test_check_doc_links_accepts_balanced_parentheses_in_targets(self) -> None:
+    self._write("docs/foo(bar).md", "# API\n")
+    self._write("docs/guide.md", "[API](foo(bar).md)\n")
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 1 links checked, 0 broken", result.stdout)
+
   def test_check_doc_freshness_stops_after_covered_docs_section(self) -> None:
     self._write(
         "docs/DOC_REGISTRY.md",

--- a/scripts/tests/test_doc_guardrails.py
+++ b/scripts/tests/test_doc_guardrails.py
@@ -110,6 +110,41 @@ class DocGuardrailsScriptTest(unittest.TestCase):
     self.assertEqual(0, result.returncode)
     self.assertIn("[doc-links] 0 links checked, 0 broken", result.stdout)
 
+  def test_check_doc_links_ignores_fenced_code_blocks(self) -> None:
+    self._write("docs/real.md", "# Real\n")
+    self._write(
+        "docs/guide.md",
+        textwrap.dedent(
+            """
+            ```md
+            [Literal example](missing.md)
+            ```
+
+            [Real link](real.md)
+            """
+        ).strip()
+        + "\n",
+    )
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(0, result.returncode)
+    self.assertIn("[doc-links] 1 links checked, 0 broken", result.stdout)
+
+  def test_check_doc_links_rejects_targets_outside_repo_root(self) -> None:
+    outside_doc = self.temp_dir / "outside.md"
+    outside_doc.write_text("# Outside\n", encoding="utf-8")
+    self._write("docs/guide.md", "[Escape](../../outside.md)\n")
+
+    result = self._run_script(CHECK_DOC_LINKS.name)
+
+    self.assertEqual(1, result.returncode)
+    self.assertIn(
+        "[doc-links] FAIL: docs/guide.md:1 -> ../../outside.md (outside repository root)",
+        result.stdout,
+    )
+    self.assertIn("[doc-links] 1 links checked, 1 broken", result.stdout)
+
   def test_check_doc_freshness_stops_after_covered_docs_section(self) -> None:
     self._write(
         "docs/DOC_REGISTRY.md",


### PR DESCRIPTION
## Summary

Closes #588

Adds two blocking CI guardrails for documentation quality:

- **`scripts/check-doc-links.sh`** — scans all `.md` files under `docs/` for broken intra-repo markdown links (excluding frozen plan/spec snapshots). Exits non-zero with per-file/per-link failure report.
- **`scripts/check-doc-freshness.sh`** — reads `docs/DOC_REGISTRY.md` and verifies every covered doc has `Status:`, `Owner:`, `Updated:`, and `Review cadence:` metadata in its first 10 lines. Exits non-zero with per-doc report.

### Deliverables

1. `scripts/check-doc-links.sh` — shell-first link checker
2. `scripts/check-doc-freshness.sh` — shell-first metadata checker
3. `docs/DOC_REGISTRY.md` — registry of 16 covered docs requiring metadata
4. Metadata headers added/completed on all 16 covered docs
5. `.github/workflows/doc-guardrails.yml` — blocking CI on PRs to main
6. `docs/runbooks/doc-guardrails.md` — runbook for usage, extension, and troubleshooting
7. Updated `docs/DEV_SETUP.md` and `docs/runbooks/README.md` with guardrail references

### Design choices

- **DOC_REGISTRY.md over magic detection**: explicit registry of covered docs — no heuristics, easy to extend.
- **Top-of-file metadata convention**: matches existing pattern in `docs/github-issues.md` and others. Check looks in the first 10 lines to accommodate both pre-heading and post-heading placement.
- **Excluded snapshot dirs**: `docs/superpowers/plans/`, `docs/superpowers/specs/`, `docs/JWT/`, `docs/plans/` contain frozen snapshots with source-code-relative links that drift as code evolves. These are excluded from link checking.
- **Separate workflow**: lightweight `doc-guardrails.yml` (~5s) runs independently of the main build.

### How to run locally

```bash
bash scripts/check-doc-links.sh
bash scripts/check-doc-freshness.sh
```

### Failure output examples

```
[doc-links] FAIL: docs/runbooks/README.md:61 -> nonexistent-file.md (file not found)
[doc-links] 153 links checked, 1 broken
```

```
[doc-freshness] FAIL: docs/runbooks/browser-verification.md — missing: Owner:
[doc-freshness] 16 covered docs checked, 1 incomplete
```

### Out of scope

- Jakarta wrong-edit detection (#589, already merged)
- Broad style linting
- No new frameworks — pure shell (bash + awk)
- No server verification needed (doc/CI shell scripts only)

## Test plan

- [x] Both scripts pass clean against current worktree state
- [x] Deliberately broken link detected with clear per-file/per-link output
- [x] Deliberately removed metadata marker detected with clear per-doc output
- [x] Reverted breakage → both scripts pass clean again
- [ ] CI workflow runs on PR and both steps pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now enforces documentation guardrails on pushes and PRs to main/master, blocking merges for broken links or missing doc metadata.

* **Documentation**
  * Added a central docs registry and standardized per-doc metadata (Status, Owner, Updated, Review cadence) across covered docs.
  * Published runbooks and contributor guidance describing the guardrails and local validation steps.

* **Tests**
  * Added unit tests to validate the documentation guardrail checks.

* **Chores**
  * CI build updated to run guardrail tests as part of validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->