### PR TITLE
docs: refresh J2CL baseline after phase 0 cleanup

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,7 +1,7 @@
 # Apache Wave Current State and Resumption Guide
 
 Status: Canonical
-Updated: 2026-04-04
+Updated: 2026-04-18
 Owner: Project Maintainers
 Review cadence: quarterly
 
@@ -68,8 +68,8 @@ Read these files first when resuming work:
     - Durable source-selection, runtime wiring, and dev-persistence references.
 14. [docs/modernization-plan.md](modernization-plan.md), [docs/jetty-migration.md](jetty-migration.md), [docs/migrate-conversation-renderer-to-apache-wave.md](migrate-conversation-renderer-to-apache-wave.md), and [docs/blocks-adoption-plan.md](blocks-adoption-plan.md)
     - Historical ledgers that still hold useful implementation detail.
-15. [docs/j2cl-gwt3-inventory.md](j2cl-gwt3-inventory.md) and [docs/j2cl-gwt3-decision-memo.md](j2cl-gwt3-decision-memo.md)
-    - Phase 8 inventory and no-go-for-now decision context.
+15. [docs/j2cl-gwt3-inventory.md](j2cl-gwt3-inventory.md), [docs/j2cl-gwt3-decision-memo.md](j2cl-gwt3-decision-memo.md), and [docs/j2cl-preparatory-work.md](j2cl-preparatory-work.md)
+    - Refreshed post-Phase-0 J2CL baseline, no-go-for-now decision context, and current follow-on issue chain.
 16. [docs/epics/README.md](epics/README.md) and [../.beads/README.md](../.beads/README.md)
     - Historical Beads archive references only.
 
@@ -93,9 +93,17 @@ Read these files first when resuming work:
   present. Treat that as build plumbing, not as the canonical user workflow.
 - Phase 6 protobuf and server-side Guava work are already closed in the
   modernization ledger.
-- The Phase 8 planning artifacts now exist:
+- The Phase 8 baseline docs have been refreshed after the merged Phase 0 cleanup:
   - `docs/j2cl-gwt3-inventory.md`
   - `docs/j2cl-gwt3-decision-memo.md`
+  - `docs/j2cl-preparatory-work.md`
+- The active GitHub issue chain for the next J2CL steps is:
+  - `#904` umbrella tracker
+  - `#900` sidecar build
+  - `#903` pure-logic extraction
+  - `#902` transport replacement
+  - `#898` `GWTTestCase` split
+  - `#901` first UI slice
 
 ### Wiab.pro core work that is already imported
 
@@ -220,9 +228,10 @@ fragments (HTTP fetch mode), and quasi-deletion UI.
    `wave/config/`, the jar name is stable, and build/run guidance lives in
    `docs/BUILDING-sbt.md`.
 10. Packaging and DX verification still need a post-Jakarta pass.
-11. Phase 8 now has a measured inventory and a no-go-for-now decision memo,
-   but the prerequisite reduction tasks for any future J2CL work are still
-   open.
+11. Phase 8 now has a refreshed post-Phase-0 inventory and decision memo; the
+   remaining work is no longer generic prerequisite cleanup, but the specific
+   GitHub issue chain for sidecar build, pure-logic extraction, transport,
+   test-harness migration, and the first UI slice.
 12. The documentation surface is now intentionally split between one canonical
    resume guide, a few live ledgers, and GitHub Issues; do not re-open one-off
    plan docs when the live backlog already captures the work.
@@ -254,9 +263,11 @@ fragments (HTTP fetch mode), and quasi-deletion UI.
 - MongoDB v4 delta store completion.
 - Library upgrade closure.
 - SBT parity, packaging, and DX verification.
-- J2CL / GWT 3 follow-on planning based on:
+- J2CL / GWT 3 follow-on execution based on:
   - `docs/j2cl-gwt3-inventory.md`
   - `docs/j2cl-gwt3-decision-memo.md`
+  - `docs/j2cl-preparatory-work.md`
+  - issue chain `#904` -> `#900` -> `#903` -> `#902` -> `#898` -> `#901`
 
 ### 3. Wiab core import completion
 

--- a/docs/j2cl-gwt3-decision-memo.md
+++ b/docs/j2cl-gwt3-decision-memo.md
@@ -1,9 +1,9 @@
 # J2CL / GWT 3 Decision Memo
 
 Status: Current
-Updated: 2026-03-18
+Updated: 2026-04-18
 Owner: Project Maintainers
-Task: `incubator-wave-modernization.6`
+Task: `#899`
 
 ## Decision Summary
 
@@ -13,91 +13,93 @@ Reason:
 
 - the current client still depends heavily on JSNI and `JavaScriptObject`
 - UiBinder and `GWT.create(...)` remain central to UI composition
-- the `.gwt.xml` module graph and deferred-binding surface are still large
-- the test harness still depends on legacy hosted GWT paths
-- there is no existing JsInterop / Elemental2 bridge layer to migrate toward
+- the GWT client build is still an isolated legacy toolchain in `build.sbt`
+- the test harness still carries legacy `GWTTestCase` debt
+- there is still no existing JsInterop / Elemental2 bridge layer or J2CL sidecar
 
-A J2CL move is still plausible in the long term, but the current repo is not at
-a safe migration starting point.
+The important update is not the decision itself; it is the baseline. The repo
+is now better prepared than the March snapshot implied because several
+prerequisite cleanups are already complete, but it is still not at a safe
+full-app migration starting point.
 
 ## Evidence Basis
 
 See [docs/j2cl-gwt3-inventory.md](./j2cl-gwt3-inventory.md).
 
-The short version is:
+Current short version:
 
-- `163` `.gwt.xml` files
-- `57` `GWT.create(...)` callsites
-- `59` JSNI / `JavaScriptObject`-heavy files
-- `232` JSNI native methods
-- `30` UiBinder-related Java files
-- `26` `.ui.xml` templates
-- `27` `GWTTestCase` tests
+- `129` `.gwt.xml` files
+- `84` `GWT.create(...)` callsites
+- `114` JSNI / `JavaScriptObject`-heavy files
+- `238` JSNI native methods
+- `27` UiBinder-related Java files
+- `23` `.ui.xml` templates
+- `24` `GWTTestCase` tests
 - no JsInterop / Elemental2 bridge layer
+- no J2CL sidecar build yet
+- `guava-gwt` already removed
+- gadget/htmltemplate client cleanup already landed
+- `WaveContext` already uses the shared `BlipReadStateMonitor` contract
 
 ## Go / No-Go
 
 - Full-app migration now: `No-go`
-- Preparatory reduction work: `Go`
-- Narrow bridge pilot in one vertical slice: `Go after dependency cleanup and module-surface reduction`
+- Staged migration preparation: `Go`
+- Isolated J2CL build scaffold: `Go`
+- Narrow transport replacement path: `Go`
+- First UI vertical slice after scaffold and transport: `Go`
 
-## Narrowest Viable First Wave
+## Narrowest Viable Next Wave
 
-The first migration wave should not try to move the whole app.
+The next wave should still avoid trying to move the whole app.
 
-The narrowest viable wave is:
+The narrowest viable sequence is now:
 
-1. reduce module/deferred-binding complexity
-2. isolate client dependency debt
-3. create one modern browser-interop seam
-4. prove one small JSNI/`JavaScriptObject` replacement path end-to-end
+1. stand up the isolated J2CL sidecar build
+2. keep shrinking pure-logic and test debt
+3. replace one transport / websocket / JSON seam end-to-end
+4. prove one first UI vertical slice on top of that stack
 
 Only after that should the project revisit a broader compiler/runtime switch.
 
-## Recommended Follow-on Tasks
+## Active Follow-On Issues
 
-These should be handled as follow-on tasks in dependency order:
+These are the current dependency-ordered follow-on issues:
 
-1. Module graph reduction for the web client
-   - goal: reduce `.gwt.xml` inheritance and deferred-binding sprawl before any migration
-2. Client dependency cleanup
-   - goal: isolate or remove `guava-gwt` and identify GWT-only runtime dependencies
-3. JsInterop / Elemental2 bridge pilot
-   - goal: define one modern browser interop seam that does not depend on JSNI
-4. JSNI / `JavaScriptObject` elimination in one vertical slice
-   - candidate slice: communication/websocket/browser interop rather than the full editor
-5. GWT test harness replacement strategy
-   - goal: classify what moves to plain JVM tests, what needs browser-runner coverage, and what can be retired
-6. UiBinder replacement strategy
-   - goal: pick one UI area and replace it incrementally instead of trying to rewrite all templates at once
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
+2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
+3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
+4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
+5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
+6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
 
 ## Explicit Non-Starter Moves
 
-These are not recommended as the next step:
+These are still not recommended as the next step:
 
 - trying to flip the entire client from GWT 2.x to J2CL in one pass
-- rewriting `WebClient`, `StageThree`, editor internals, gadgets, and widgets simultaneously
-- replacing the hosted test harness after the migration has already started
-- assuming the current GWT build/test surface is small enough to treat as incidental
+- rewriting `WebClient`, `StageThree`, the editor internals, and the wavepanel
+  simultaneously
+- pretending the transport rewrite can be skipped while the client still runs
+  through generated JSO message families and the GWT websocket wrapper
+- deferring the test-harness replacement story until after UI migration has
+  already started
 
 ## What Would Change This Decision
 
 The decision can be revisited after these conditions are met:
 
-- the module graph is materially smaller
-- deferred-binding usage is reduced or isolated
-- one JsInterop/Elemental2 seam exists in production code
-- one JSNI-heavy vertical slice has been retired successfully
-- the project has a post-hosted-GWT testing story
+- the J2CL sidecar build exists and produces a usable bundle
+- one JsInterop / Elemental2 seam exists in production code
+- the transport / websocket / generated-JSON stack has one successful
+  replacement path
+- the remaining GWT-only test debt has an explicit post-GWT home
+- one real UI slice has shipped behind the staged migration path
 
 ## Recommended Status
 
-Track this task as completed once:
+Treat the original “inventory and memo exist” milestone as complete, and treat
+the current status as “staged follow-on execution underway.”
 
-- the inventory document exists
-- this memo exists
-- the modernization ledger points at both documents
-- the GitHub Issue records the artifact paths and proposed follow-on task titles
-
-The migration itself should remain a later follow-on effort, not an implied next
-commit.
+The migration itself should remain a later follow-on effort, not an implied
+next commit.

--- a/docs/j2cl-gwt3-inventory.md
+++ b/docs/j2cl-gwt3-inventory.md
@@ -1,75 +1,84 @@
 # J2CL / GWT 3 Inventory
 
 Status: Current
-Updated: 2026-03-18
+Updated: 2026-04-18
 Owner: Project Maintainers
-Task: `incubator-wave-modernization.6`
+Task: `#899`
 
-This document records the current GWT-specific surface area in `incubator-wave` so
-future migration work starts from measured constraints rather than broad guesses.
-It is an inventory, not a migration implementation plan.
+This document records the current GWT-specific surface area in
+`incubator-wave` so future migration work starts from measured constraints
+rather than broad guesses. It is an inventory, not a migration implementation
+plan.
 
 ## Evidence Snapshot
 
-Re-verified on the `j2cl-inventory` branch:
+Re-verified on the `issue-899-j2cl-doc-refresh` worktree on 2026-04-18:
 
-- `.gwt.xml` files: `163`
-- `GWT.create(...)` callsites: `57`
-- UiBinder-related Java files: `30`
-- `.ui.xml` templates: `26`
-- `JavaScriptObject` / JSNI-heavy files: `59`
-- JSNI native methods: `232`
-- `GWTTestCase` tests: `27`
-- `<replace-with>` directives: `11`
+- `.gwt.xml` files: `129`
+- `GWT.create(...)` callsites: `84`
+- UiBinder-related Java files: `27`
+- `.ui.xml` templates: `23`
+- `JavaScriptObject` / JSNI-heavy files: `114`
+- JSNI native methods: `238`
+- `GWTTestCase` tests: `24`
+- `<replace-with>` directives: `0`
 - custom `Generator` subclasses: `0`
 - JsInterop-annotated files: `0`
 - Elemental / Elemental2 imports: `0`
 
-These numbers are large enough that the current blocker is not one subsystem.
-The migration surface is spread across build tooling, module wiring, browser
-interop, UI composition, and test infrastructure.
+Important counting notes:
+
+- The `GWT.create(...)` count uses `wave/src/main/java`, `wave/src/test/java`,
+  and `gen/messages`, which includes one remaining test helper callsite.
+- The JSNI / `JavaScriptObject` file count is pattern-based and currently
+  includes `wave/src/main/java/org/waveprotocol/pst/templates/jso/jso.st`
+  because that file still contains the legacy JSO template text.
+
+These numbers are still large enough that the blocker is not one subsystem.
+The remaining migration surface is spread across build tooling, transport,
+browser interop, UI composition, and test infrastructure. The difference from
+the March inventory is that several prerequisite cleanups are already done, so
+the repo should no longer be described as if it were still at the original
+`163` / `136` era baseline.
 
 ## Build And Toolchain
 
-The client build is still explicitly GWT 2.x-centric in [wave/build.gradle](../wave/build.gradle):
+The client build is still explicitly GWT-centric in [build.sbt](../build.sbt):
 
 - `compileGwt`
-- `compileGwtDev`
-- `gwtCodeServer`
-- `gwtDev2`
-- `testGwt`
-- `testGwtHosted`
+- the isolated `Gwt` configuration
+- `gwt-dev`
+- `gwt-user`
+- `gwt-codeserver`
 
-The dependency surface still includes:
+What changed since the earlier inventory:
 
-- `org.gwtproject:gwt-user`
-- `org.gwtproject:gwt-dev`
-- `org.gwtproject:gwt-codeserver`
-- `com.google.guava:guava-gwt`
+- `guava-gwt` is no longer present in `build.sbt`
+- the repo still has no `j2cl/` sidecar
+- the browser client still depends on the dedicated GWT compile/runtime path
 
-The current toolchain picture means a J2CL move is not just a compiler swap. The
-repo still assumes a dedicated GWT compile/test/runtime path.
+The current toolchain picture means a J2CL move is still not just a compiler
+swap, but the dependency-cleanup story is no longer blocked on `guava-gwt`.
 
 ## Module Graph And Deferred Binding
 
-Top-level module hubs:
+Top-level module hubs still include:
 
 - [WebClient.gwt.xml](../wave/src/main/resources/org/waveprotocol/box/webclient/WebClient.gwt.xml)
 - [Client.gwt.xml](../wave/src/main/resources/org/waveprotocol/wave/client/Client.gwt.xml)
 
 Observed characteristics:
 
-- The app module inherits many feature modules rather than one narrow runtime root.
-- Deferred binding is still active through `<replace-with>` directives.
-- The module graph still carries browser- and platform-specific branching.
-- There are no custom generator classes in the current tree, which helps, but the
-  `.gwt.xml` graph is still large and operationally important.
+- the app module still inherits many feature modules rather than one narrow
+  runtime root
+- the module graph is still operationally important at `129` total `.gwt.xml`
+  files
+- active `<replace-with>` directives are now gone from the measured baseline
+- the earlier user-agent, popup, and logger deferred-binding cleanup has
+  already moved those seams to runtime selection
 
-Representative deferred-binding clusters:
-
-- `org/waveprotocol/wave/client/common/util/Util.gwt.xml`
-- `org/waveprotocol/wave/client/widget/popup/Popup.gwt.xml`
-- `org/waveprotocol/wave/client/debug/logger/Logger.gwt.xml`
+This means the module graph problem is now size and GWT centrality, not the
+same deferred-binding sprawl described in the older snapshot.
 
 ## Entrypoints And App Shell
 
@@ -79,110 +88,122 @@ The current client still centers around classic GWT app composition:
 - [StageThree.java](../wave/src/main/java/org/waveprotocol/wave/client/StageThree.java)
 - [ClientEvents.java](../wave/src/main/java/org/waveprotocol/wave/client/events/ClientEvents.java)
 
-This means any migration plan has to account for application bootstrap,
+This means any migration plan still has to account for application bootstrap,
 client-side event wiring, and shared runtime abstractions rather than only leaf
 widgets.
 
 ## Browser Interop And JSNI
 
-This is the highest-risk migration surface.
+This remains the highest-risk migration surface.
 
 Measured surface:
 
-- `59` files with `JavaScriptObject` or JSNI usage
-- `232` JSNI native methods
+- `114` files with `JavaScriptObject` or JSNI usage
+- `238` JSNI native methods
 
 Representative high-risk clusters:
 
 - `wave/src/main/java/org/waveprotocol/wave/communication/gwt/`
 - `wave/src/main/java/org/waveprotocol/wave/client/common/util/`
 - `wave/src/main/java/org/waveprotocol/wave/client/editor/selection/html/`
-- `wave/src/main/java/org/waveprotocol/wave/client/doodad/experimental/htmltemplate/`
-- `wave/src/main/java/org/waveprotocol/wave/client/gadget/renderer/`
 - `wave/src/main/java/org/waveprotocol/box/webclient/stat/gwtevent/`
 - `wave/src/main/java/com/google/gwt/websockets/client/`
+- generated `gen/messages/**/jso/**`
+
+What changed since the earlier inventory:
+
+- the gadget and htmltemplate client trees are already gone
+- the remaining risk is now more concentrated in transport, editor selection,
+  common browser helpers, and generated JSO transport code
 
 Blocker assessment:
 
-- The codebase has no existing JsInterop bridge seam.
-- Browser interop is embedded in the main runtime, not isolated behind one thin
-  compatibility layer.
-- Gadget and editor-related interop are especially risky because they combine
-  browser behavior with Wave-specific data and rendering flow.
+- the codebase still has no existing JsInterop / Elemental2 bridge seam
+- browser interop is still embedded in the main runtime instead of isolated
+  behind one thin compatibility layer
+- the transport / websocket / generated-JSON stack is now the clearest
+  representative replacement target
 
 ## UiBinder And Widget Composition
 
 Measured surface:
 
-- `30` UiBinder-related Java files
-- `26` `.ui.xml` templates
-- `57` total `GWT.create(...)` callsites, many used for binders/resources/factories
+- `27` UiBinder-related Java files
+- `23` `.ui.xml` templates
+- `84` total `GWT.create(...)` callsites
 
 Representative UI clusters:
 
 - application shell and inbox/search UI under `org/waveprotocol/box/webclient/`
 - popup/profile/widget stacks under `org/waveprotocol/wave/client/widget/`
-- gadget renderer UI under `org/waveprotocol/wave/client/gadget/renderer/`
+- wavepanel UI under `org/waveprotocol/wave/client/wavepanel/`
 - attachment/image widgets under `org/waveprotocol/wave/client/doodad/attachment/`
 
 Blocker assessment:
 
-- UiBinder is not incidental; it is a core composition mechanism across the UI.
-- `GWT.create(...)` is used for more than resources. It also participates in
-  binders and runtime factories.
-- A migration plan needs to separate easy `GWT.create(...)` use (resources,
-  messages) from harder runtime/deferred-binding uses.
+- UiBinder is still a core composition mechanism across the UI
+- `GWT.create(...)` is still used for more than resources; it also participates
+  in binders, messages, and runtime factories
+- the search panel remains the best first UI slice because it is smaller than
+  the full app shell or editor and is already called out in the staged
+  migration plan
 
 ## Test Harness Debt
 
 Measured surface:
 
-- `27` `GWTTestCase` tests
-- dedicated `testGwt` and `testGwtHosted` execution paths remain in the build
+- `24` `GWTTestCase` tests
+- dedicated hosted/browser-era GWT validation paths still exist in the repo
 
 Implications:
 
-- The migration requires a testing strategy, not just a source rewrite.
-- Some client tests can move to plain JVM tests.
-- Browser-semantics and widget tests will need a different runner or staged
-  replacement.
-- Hosted GWT assumptions are still part of the current validation story.
+- the migration still requires a testing strategy, not just a source rewrite
+- some client tests can move to plain JVM tests
+- browser-semantics and widget tests still need an explicit post-GWT home
 
-## Dependency Blockers
+## Dependency And Architecture Blockers
 
-The main dependency-specific blockers are:
+The main blockers now are:
 
-- `guava-gwt` still present on the client compile path
 - direct dependency on GWT browser/widget/runtime APIs
 - no JsInterop / Elemental2 bridge layer
-- GWT-specific websocket/browser wrappers still in use
+- JSO/JSNI transport and generated message families
+- the GWT-specific websocket/browser wrappers
+- lingering GWT-only test infrastructure
 
-This means the project is not yet at the point where a J2CL migration is a
-compiler choice. Several dependency and abstraction seams need to be created
-first.
+Important completed prerequisite work:
 
-## Migration Sequencing Candidates
+- `guava-gwt` removal is already done
+- gadget/htmltemplate client tree removal is already done
+- `WaveContext` already depends on shared
+  `org.waveprotocol.wave.model.document.BlipReadStateMonitor`
 
-The current inventory supports this dependency-ordered follow-on sequence:
+This means the project is still not yet at the point where a J2CL migration is
+just a compiler choice, but several earlier prerequisite reductions are now
+closed rather than still open.
 
-1. Reduce module graph and deferred-binding sprawl
-2. Clean client dependencies, especially `guava-gwt` and browser/runtime-only GWT APIs
-3. Introduce a JsInterop / Elemental2 bridge seam in one narrow vertical slice
-4. Eliminate JSNI / `JavaScriptObject` in one representative runtime area
-5. Replace hosted GWT test execution with a new validation strategy
-6. Replace UiBinder incrementally in selected UI areas
+## Active Follow-On Issue Chain
+
+The current GitHub-native follow-on sequence is:
+
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
+2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
+3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
+4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
+5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
+6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
 
 ## Bottom Line
 
-A direct full-app J2CL migration is not the next executable step.
+A direct full-app J2CL migration is still not the next executable step.
 
-The measured blocker pattern is:
+The measured blocker pattern is now:
 
-- too much JSNI/browser interop
-- too much UiBinder/deferred binding
-- too much legacy GWT test infrastructure
-- no existing modern browser-interop seam
+- too much JSNI / browser interop concentrated in transport and editor helpers
+- too much UiBinder / GWT widget composition still in the live UI
+- too much legacy GWT-only test infrastructure
+- no existing modern browser-interop seam or J2CL sidecar build
 
-That does not rule out a future J2CL path. It means the repo first needs a
-series of preparatory reductions so the migration target becomes narrow enough
-to execute safely.
+That does not rule out a future J2CL path. It means the repo should now be
+described as “post-prerequisite cleanup but pre-sidecar / pre-transport
+replacement,” not as if it were still at the original pre-cleanup baseline.

--- a/docs/j2cl-preparatory-work.md
+++ b/docs/j2cl-preparatory-work.md
@@ -1,170 +1,72 @@
 # J2CL / GWT 3 Preparatory Work
 
-Status: In Progress
-Updated: 2026-03-24
+Status: Current
+Updated: 2026-04-18
 Parent: [j2cl-gwt3-decision-memo.md](./j2cl-gwt3-decision-memo.md)
 
-This document tracks the first two recommended follow-on tasks from the decision
-memo: module graph reduction and client dependency cleanup.
+This document originally tracked the first two recommended follow-on tasks from
+the March decision memo: module graph reduction and client dependency cleanup.
+Those preparatory tasks have now moved materially farther than the older text
+here implied, so this page should be read as a completed-prep summary plus an
+explicit handoff to the current GitHub issue chain.
 
----
+## Preparatory Work Already Landed
 
-## Task 1: Module Graph Reduction
+### Module graph reduction
 
-### Baseline
+The measured `.gwt.xml` baseline is now:
 
-The repository contained **163** `.gwt.xml` files across three locations:
+- `104` production modules under `wave/src/main/resources/`
+- `25` test modules under `wave/src/test/resources/`
+- `0` duplicate test modules under `wave/src/test/java/`
+- `129` total `.gwt.xml` files
 
-| Location | Count | Purpose |
-|---|---|---|
-| `wave/src/main/resources/` | 112 | Production GWT modules |
-| `wave/src/test/resources/` | 26 | Canonical test modules |
-| `wave/src/test/java/` | 25 | Duplicate test modules (identical copies) |
+This confirms the old duplicate-test-module cleanup is already reflected in the
+live branch and should no longer be described as an in-progress reduction from
+`163` to `136`.
 
-### Inheritance graph summary
+### Client dependency cleanup
 
-The three entry-point modules compiled by the build are:
+The earlier `guava-gwt` cleanup is no longer pending:
 
-- `org.waveprotocol.box.webclient.WebClientProd` (production)
-- `org.waveprotocol.box.webclient.WebClientDev` (development / Super Dev Mode)
-- `org.waveprotocol.box.webclient.WebClientDemo` (demo with remote logging)
+- `guava-gwt` has already been removed from `build.sbt`
+- the stale docs that described `guava-gwt` as still present are now historical
+  context, not the current repo state
 
-All three inherit from the shared `WebClient.gwt.xml` base module, which pulls in
-a deep transitive graph of ~80 production modules.
+### Additional prerequisite cleanup now complete
 
-Additional entry points exist for testing harnesses:
+The repo is also past several earlier preparatory blockers:
 
-- `org.waveprotocol.wave.client.testing.UndercurrentHarness`
-- `org.waveprotocol.wave.client.editor.harness.EditorTest`
-- `org.waveprotocol.wave.client.editor.examples.img.TestModule`
+- gadget and htmltemplate client trees are already removed
+- `WaveContext` already uses the shared
+  `org.waveprotocol.wave.model.document.BlipReadStateMonitor`
+- the remaining blocker story is now centered on sidecar build, transport,
+  browser interop, UiBinder, and legacy GWT-only tests
 
-### Issues found
+## Preparatory Work Still Open
 
-1. **25 identical duplicate test `.gwt.xml` files** existed in both
-   `src/test/java/` and `src/test/resources/`. GWT's module resolution picked up
-   whichever appeared first on the classpath, making the `src/test/java/` copies
-   redundant. One pair (`wavepanel/tests.gwt.xml`) diverged slightly -- the
-   `src/test/java` version had two extra inherits.
+The following items remain open after the landed cleanup:
 
-2. **2 unused API modules** (`com.google.wave.api.robot.Robot` and
-   `com.google.wave.api.data.Data`) were never inherited by any other module.
-   The underlying Java packages (`com.google.wave.api.robot` and
-   `com.google.wave.api.data`) are server-side code not compiled by GWT.
+- no J2CL sidecar build or `j2cl/` subtree yet
+- no JsInterop / Elemental2 bridge seam yet
+- the transport / websocket / generated JSO message stack is still GWT-specific
+- UiBinder and `GWT.create(...)` are still widespread in the client UI
+- `GWTTestCase` debt still needs an explicit JVM/browser split
 
-3. **Duplicate inherits** in `wavepanel/event/Event.gwt.xml` listed
-   `org.waveprotocol.box.stat.Stat` twice.
+## Current Follow-On Issue Chain
 
-4. **Transitively redundant inherits** in `WebClient.gwt.xml` -- for example,
-   `model.Model` is inherited directly but also transitively through `Client`,
-   `Editor`, `Wave`, `Account`, and `Conversation`. These are harmless (GWT
-   deduplicates them) and serve as documentation, so they were left in place.
+The active GitHub-native sequence is:
 
-5. **25 modules are never inherited** by any other module. Most of these are leaf
-   modules (entry points, test harnesses, or optional feature modules like
-   `Collapse`, `Diff`, `Dialog`, `Reader`, `Dom`). They are all reachable through
-   Java source inclusion rather than module inheritance. No action needed.
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
+2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
+3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
+4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
+5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
+6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
 
-### Changes made
+## Summary
 
-| Change | Files affected | Net reduction |
-|---|---|---|
-| Remove 24 identical duplicate test modules from `src/test/java/` | -24 files | -24 |
-| Merge + remove 1 divergent test module (`wavepanel/tests.gwt.xml`) | -1 file, +1 inherits line in resources copy | -1 |
-| Remove unused `Robot.gwt.xml` and `Data.gwt.xml` | -2 files | -2 |
-| Fix duplicate inherits in `Event.gwt.xml` | 1 file edited | 0 (cleanup) |
-
-**Result: 163 -> 136 `.gwt.xml` files (17% reduction)**
-
-### Modules with deferred binding (kept, require future work)
-
-These modules contain `<replace-with>`, `<define-property>`, `<set-property>`, or
-`<property-provider>` rules that block straightforward J2CL migration:
-
-- `client/common/util/Util.gwt.xml` -- `UserAgentStaticProperties` dispatch (mobile, Firefox, Safari)
-- `client/common/util/useragents.gwt.xml` -- `mobile.user.agent` property definition
-- `client/debug/logger/Logger.gwt.xml` -- `loglevel` property and `LogLevel` dispatch
-- `client/widget/popup/Popup.gwt.xml` -- `PopupProvider` / `PopupChromeProvider` dispatch (mobile vs desktop)
-- `client/editor/harness/EditorHarness.gwt.xml` -- test configuration properties
-- `client/testing/UndercurrentHarness.gwt.xml` -- test configuration properties
-
-These are candidates for replacement with runtime feature detection or
-`@JsType`-based dispatch in a future task.
-
----
-
-## Task 2: Client Dependency Cleanup
-
-### Guava usage in client code
-
-The client source tree (`wave/src/main/java/org/waveprotocol/wave/client/`)
-imports only **5 distinct Guava APIs**:
-
-| Import | File count | J2CL-compatible? |
-|---|---|---|
-| `com.google.common.base.Preconditions` | 58 | Yes (source-level replacement trivial) |
-| `com.google.common.annotations.VisibleForTesting` | 50 | Yes (annotation only, no runtime effect) |
-| `com.google.common.collect.BiMap` | 1 | Partial (available in guava-gwt but not J2CL Guava) |
-| `com.google.common.collect.HashBiMap` | 1 | Partial (same file as BiMap) |
-| `com.google.common.base.Joiner` | 1 | Yes (simple replacement with String.join) |
-
-**Key finding**: the client code's actual Guava surface is extremely narrow.
-`Preconditions` and `@VisibleForTesting` account for 108 of 111 import sites.
-
-### Guava usage in transitively-compiled model/communication code
-
-The `wave.model`, `wave.communication`, and `wave.concurrencycontrol` packages
-are compiled into the GWT client. Their Guava usage is also limited:
-
-- `@GwtCompatible` annotation (1 file in model)
-- `@VisibleForTesting` annotation (3 files)
-- `Preconditions` references in comments (model has its own `Preconditions` class)
-- 1 import of `com.google.common.base.Preconditions` in `communication`
-
-### guava-gwt status
-
-`guava-gwt` 20.0 is currently declared as:
-- `compileOnly` in the main dependencies (for GWT compilation)
-- Explicitly in the `gwt` configuration (for GWT compiler classpath)
-- Explicitly excluded from `runtimeClasspath` and `testRuntimeClasspath`
-
-**Recommendation**: `guava-gwt` cannot be safely removed yet because it provides
-the `com.google.common.base.Base` and `com.google.common.collect.Collect` GWT
-module XML files that are inherited throughout the module graph (9 and 5
-inherits respectively). However, the actual runtime API surface is small enough
-that a future task could:
-
-1. Replace `Preconditions.checkNotNull/checkArgument/checkState` with a local
-   utility (the model layer already has `org.waveprotocol.wave.model.util.Preconditions`)
-2. Remove `@VisibleForTesting` imports (or replace with a local annotation)
-3. Replace the single `BiMap` / `HashBiMap` usage with a plain `HashMap` + reverse map
-4. Replace the single `Joiner` usage with `String.join`
-5. After the above, drop the `com.google.common.base.Base` and
-   `com.google.common.collect.Collect` inherits from the module graph
-6. Finally remove `guava-gwt` from all configurations
-
-### GWT-only dependencies that block J2CL
-
-| Dependency | Role | Migration blocker? |
-|---|---|---|
-| `guava-gwt:20.0` | Provides GWT-compatible Guava modules | Yes -- see plan above |
-| `gwt-user` | Core GWT runtime (`Widget`, `JSNI`, `GWT.create`) | Yes -- fundamental to current arch |
-| `gwt-dev` | GWT compiler | Yes -- replaced by J2CL compiler |
-| `gwt-websockets` | WebSocket support via `com.google.gwt.websockets` | Yes -- needs JsInterop replacement |
-
----
-
-## Summary and Next Steps
-
-The module graph has been reduced from 163 to 136 files. The remaining modules
-are intentionally retained and reachable. The client's Guava surface is narrow (mostly
-`Preconditions` and `@VisibleForTesting`) and ready for source-level replacement
-in a follow-on task.
-
-Recommended next tasks (from the decision memo):
-
-1. **Replace narrow Guava usage** -- swap 111 import sites for local utilities,
-   then drop `guava-gwt`
-2. **JsInterop / Elemental2 bridge pilot** -- define one modern browser interop
-   seam that does not depend on JSNI
-3. **JSNI elimination in one vertical slice** -- candidate: websocket/browser
-   interop layer
+The preparatory phase should now be described as “partially completed and
+re-baselined,” not as if the repo were still waiting on `guava-gwt` removal or
+duplicate-module cleanup. The next execution work is issue-driven, not
+discovery-driven.

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -773,19 +773,25 @@ Task P8-T1: Feasibility assessment and roadmap
   - 2026-03-18: Re-verified the current GWT surface and documented the result in:
     - `docs/j2cl-gwt3-inventory.md`
     - `docs/j2cl-gwt3-decision-memo.md`
+  - 2026-04-18: Refreshed the J2CL docs after the merged Phase 0 cleanup so the
+    current baseline and follow-on tracker match the live repo:
+    - `docs/j2cl-gwt3-inventory.md`
+    - `docs/j2cl-gwt3-decision-memo.md`
+    - `docs/j2cl-preparatory-work.md`
+    - `docs/current-state.md`
 - Summary:
   - The repo is not ready for a full-app J2CL migration yet.
-  - The blocking surfaces are JSNI / `JavaScriptObject`, UiBinder and `GWT.create(...)`,
-    large `.gwt.xml` / deferred-binding usage, hosted GWT test harness debt, and
-    client dependency cleanup (especially `guava-gwt`).
-  - The recommended next move is prerequisite reduction, not a compiler/runtime switch.
-- Follow-on task titles proposed by the decision memo:
-  1) Module graph reduction for the web client
-  2) Client dependency cleanup
-  3) JsInterop / Elemental2 bridge pilot
-  4) JSNI / `JavaScriptObject` elimination in one vertical slice
-  5) GWT test harness replacement strategy
-  6) UiBinder replacement strategy
+  - The live blocker set is now the sidecar build gap, the transport / JSO stack,
+    UiBinder and `GWT.create(...)`, and remaining `GWTTestCase` debt.
+  - The earlier `guava-gwt`, gadget/htmltemplate, and `WaveContext` prerequisite
+    cleanups are already complete and should no longer be described as open.
+- Active follow-on issues:
+  1) `#904` staged GWT 2.x -> J2CL / GWT 3 tracker
+  2) `#900` isolated J2CL sidecar build and SBT entrypoints
+  3) `#903` pure-logic `wave/model` and `wave/concurrencycontrol`
+  4) `#902` transport / websocket / codec replacement
+  5) `#898` `GWTTestCase` verification split
+  6) `#901` search-panel first UI slice
 - Tests:
   - N/A; planning/documentation task.
 - AI Agent Guidance:

--- a/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
+++ b/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
@@ -46,7 +46,7 @@ Run these from `/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh`:
 ```bash
 find wave -name '*.gwt.xml' | wc -l
 rg -o 'GWT\.create\(' wave/src/main/java wave/src/test/java gen/messages | wc -l
-rg -l 'native .*?/\\*|extends JavaScriptObject|\\bJavaScriptObject\\b' wave/src/main/java gen/messages | wc -l
+rg -l 'native .*/\\*|extends JavaScriptObject|\\bJavaScriptObject\\b' wave/src/main/java gen/messages | wc -l
 rg -l 'GWTTestCase' wave/src/test/java wave/src/test/resources | wc -l
 find wave -name '*.ui.xml' | wc -l
 rg -l 'JsInterop|Elemental2|elemental2' wave/src/main/java gen/messages | wc -l

--- a/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
+++ b/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
@@ -46,7 +46,7 @@ Run these from `/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh`:
 ```bash
 find wave -name '*.gwt.xml' | wc -l
 rg -o 'GWT\.create\(' wave/src/main/java wave/src/test/java gen/messages | wc -l
-rg -l 'native .*/\\*|extends JavaScriptObject|\\bJavaScriptObject\\b' wave/src/main/java gen/messages | wc -l
+rg -l 'native .*/\*|extends JavaScriptObject|\bJavaScriptObject\b' wave/src/main/java gen/messages | wc -l
 rg -l 'GWTTestCase' wave/src/test/java wave/src/test/resources | wc -l
 find wave -name '*.ui.xml' | wc -l
 rg -l 'JsInterop|Elemental2|elemental2' wave/src/main/java gen/messages | wc -l

--- a/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
+++ b/docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md
@@ -1,0 +1,93 @@
+# Issue #899 J2CL Doc Baseline Refresh Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh the stale J2CL / GWT3 documentation so it reflects the post-Phase-0 cleanup baseline and the current follow-on issue map, without changing any implementation code.
+
+**Architecture:** Treat `docs/j2cl-gwt3-inventory.md` and `docs/j2cl-gwt3-decision-memo.md` as the measured baseline and decision record, then align `docs/j2cl-preparatory-work.md`, `docs/modernization-plan.md`, and `docs/current-state.md` to that same baseline. Use `docs/superpowers/plans/j2cl-full-migration-plan.md` only as the strategic source of truth for wording and sequencing; this issue is a documentation refresh, not a migration step.
+
+**Tech Stack:** Markdown docs, shell-based inventory verification, SBT/Wave local smoke verification, GitHub issue traceability.
+
+---
+
+## Goal / Root Cause
+The docs still describe an older pre-Phase-0 J2CL baseline. The repo now has a smaller, cleaned-up measured surface, and the docs need to agree on the same numbers and follow-on issue chain. The refresh is about eliminating stale facts, not about advancing the migration itself.
+
+## Scope and Non-Goals
+- Scope: update the five docs listed below to the current measured baseline; replace stale inventory counts and outdated claims with the post-cleanup numbers; align the docs with the current tracker chain (`#904` plus `#900`, `#903`, `#902`, `#898`, and `#901`); keep the strategic migration narrative pointed at `docs/superpowers/plans/j2cl-full-migration-plan.md`.
+- Non-goals: no Java, Scala, or build changes; no new migration decisions; no edits to the strategic J2CL full-migration plan; no changes to GitHub issues beyond recording execution evidence and links.
+
+## Exact Files to Update
+- `docs/j2cl-gwt3-inventory.md`
+- `docs/j2cl-gwt3-decision-memo.md`
+- `docs/j2cl-preparatory-work.md`
+- `docs/modernization-plan.md`
+- `docs/current-state.md`
+
+## Plan
+### Task 1: Refresh the measured baseline docs
+- [ ] Update `docs/j2cl-gwt3-inventory.md` to use the current counts: `.gwt.xml` files `129`, `GWT.create(...)` callsites `84`, JSNI / `JavaScriptObject` files `114`, JSNI native methods `238`, `GWTTestCase` files `24`, `.ui.xml` templates `23`, and JsInterop / Elemental2 usage `0`.
+- [ ] Update `docs/j2cl-gwt3-decision-memo.md` so the evidence basis and recommendation text match the refreshed inventory and the post-Phase-0 cleanup state.
+- [ ] Make sure both documents state the current dependency facts explicitly: `guava-gwt` is already gone from `build.sbt`; gadget/htmltemplate client trees are already gone; `WaveContext` already uses `org.waveprotocol.wave.model.document.BlipReadStateMonitor`.
+
+### Task 2: Reconcile the downstream planning docs
+- [ ] Update `docs/j2cl-preparatory-work.md` to reflect that the baseline cleanup is already past the earlier inventory stage and that the next work is issue-driven, not discovery-driven.
+- [ ] Update `docs/modernization-plan.md` so the Phase 8 / J2CL references point at the refreshed docs and the current follow-on issue map.
+- [ ] Update `docs/current-state.md` so the resume-point summary points at the refreshed J2CL docs and the live issue chain instead of stale pre-cleanup assumptions.
+
+### Task 3: Verify the refreshed baseline and record traceability
+- [ ] Re-run the inventory and stale-fact checks from the issue worktree.
+- [ ] Record the results in the linked issue comment with the worktree path, the plan path, and the exact commands used.
+- [ ] Keep the PR body concise and derived from the issue comment and refreshed docs.
+
+## Verification Commands
+Run these from `/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh`:
+
+```bash
+find wave -name '*.gwt.xml' | wc -l
+rg -o 'GWT\.create\(' wave/src/main/java wave/src/test/java gen/messages | wc -l
+rg -l 'native .*?/\\*|extends JavaScriptObject|\\bJavaScriptObject\\b' wave/src/main/java gen/messages | wc -l
+rg -l 'GWTTestCase' wave/src/test/java wave/src/test/resources | wc -l
+find wave -name '*.ui.xml' | wc -l
+rg -l 'JsInterop|Elemental2|elemental2' wave/src/main/java gen/messages | wc -l
+rg -n 'guava-gwt' build.sbt
+find wave/src/main/java \( -path '*gadget*' -o -path '*htmltemplate*' \) | wc -l
+rg -n 'BlipReadStateMonitor' wave/src/main/java/org/waveprotocol/wave/model/document/WaveContext.java
+```
+
+Expected results:
+- `.gwt.xml` count: `129`
+- `GWT.create(...)` callsites: `84`
+- JSNI / `JavaScriptObject` command above returns `114` on this worktree
+- `GWTTestCase` files: `24`
+- `.ui.xml` templates: `23`
+- JsInterop / Elemental2 usage: `0`
+- `guava-gwt` check: no matches
+- gadget/htmltemplate path check: `0`
+- `WaveContext` check: shows the shared `BlipReadStateMonitor` import or usage, not a client/state dependency
+
+## Required Local Verification Before PR
+Even though this issue is docs-only, the PR cannot go up until the worktree has been exercised end-to-end:
+
+- `sbt compile`
+- `sbt test`
+- `bash scripts/worktree-boot.sh --port 9900`  # use the next free port if 9900 is busy, and record the actual port
+- `PORT=9900 bash scripts/wave-smoke.sh start`
+- Open the staged app in a browser and sanity-check the live flow: register a fresh local user, log in, create a wave, and enter a short line of text in the wave editor.
+- `PORT=9900 bash scripts/wave-smoke.sh check`
+- `PORT=9900 bash scripts/wave-smoke.sh stop`
+
+Record the exact command outputs and the browser sanity path in the issue comment before opening the PR.
+
+## Acceptance Criteria
+- The five docs above all agree on the same refreshed baseline and no longer repeat the stale pre-Phase-0 counts.
+- The docs explicitly reflect the current cleanup facts listed in this plan.
+- The issue chain is clear: `#904` is the umbrella follow-on tracker, and `#900`, `#903`, `#902`, `#898`, and `#901` are the implementation slices.
+- Local compile, tests, and browser smoke verification have been completed and recorded.
+- No implementation code has been changed.
+
+## Issue / PR Traceability Notes
+- This issue should stay the live execution log for the docs refresh.
+- Record the worktree path, branch, plan path, verification commands, and results in the issue comment stream.
+- Link the PR back to issue `#899` and keep the PR summary short.
+- If any doc still names an old count or a retired dependency, fix the doc before marking the issue ready.


### PR DESCRIPTION
Closes #899

## Summary
- refresh the J2CL / GWT 3 inventory, decision memo, preparatory-work doc, modernization ledger summary, and current-state resume guide to the post-Phase-0 baseline
- replace stale pre-cleanup facts with the current measured counts and completed prerequisite status
- point the docs at the live GitHub issue chain `#904`, `#900`, `#903`, `#902`, `#898`, `#901`
- add the issue-specific plan doc used for this lane

## Verification
- inventory rerun in the issue worktree matched the refreshed docs:
  - `.gwt.xml`: `129`
  - `GWT.create(...)`: `84`
  - UiBinder-related Java files: `27`
  - `.ui.xml`: `23`
  - JSNI / `JavaScriptObject` files: `114`
  - JSNI native methods: `238`
  - `GWTTestCase`: `24`
  - active `<replace-with>` directives: `0`
  - JsInterop / Elemental2 matches: `0`
  - `guava-gwt` matches in `build.sbt`: `0`
- `sbt compile test`
  - first run failed because `wave/config/changelog.json` was missing
- `python3 scripts/assemble-changelog.py`
  - regenerated `wave/config/changelog.json`
- `sbt compile test`
  - passed: `Passed: Total 2289, Failed 0, Errors 0, Passed 2287, Skipped 2`
- `sbt compileGwt`
  - passed and linked `org.waveprotocol.box.webclient.WebClientProd`
- `bash scripts/worktree-boot.sh --port 9900`
  - completed successfully
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- `curl -I -sS http://localhost:9900/healthz`
  - `200 OK`
- `curl -I -sS http://localhost:9900/`
  - `200 OK`
- browser verification on `http://localhost:9900/`
  - registered local user `issue899doc@local.net`
  - signed in successfully
  - created a new wave from the live toolbar
  - entered `issue 899 docs verification text` into the live editor and confirmed it was present in `[editabledocmarker="true"]`
- `PORT=9900 bash scripts/wave-smoke.sh stop`
  - stopped cleanly

## Traceability
- Worktree: `/Users/vega/devroot/worktrees/issue-899-j2cl-doc-refresh`
- Plan: `docs/superpowers/plans/2026-04-18-issue-899-j2cl-doc-baseline-refresh.md`
- Local verification record: `journal/local-verification/2026-04-18-issue-899-j2cl-doc-refresh.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated J2CL/GWT3 baseline documentation to reflect post-Phase-0 cleanup state with refreshed measurements and current execution roadmap
* Mapped active follow-on work to specific GitHub issues in decision memo and planning documents
* Added comprehensive planning documentation with verification steps, acceptance criteria, and implementation guidance
* Consolidated modernization tracking across planning artifacts for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->