### PR TITLE
build: add isolated J2CL sidecar scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ war/org*
 wave/war/WEB-INF/
 wave/war/webclient/
 wave/war/org*
+### Build output — J2CL sidecar artifacts
+war/j2cl/
+war/j2cl-search/
+war/j2cl-debug/
 distributions/
 ### Reports
 reports/

--- a/build.sbt
+++ b/build.sbt
@@ -818,6 +818,10 @@ lazy val generatePstMessages = taskKey[Unit]("Generate PST DTO sources into gen/
 lazy val generateFlags = taskKey[Unit]("Generate ClientFlags and FlagConstants into gen/flags")
 lazy val prepareServerConfig = taskKey[Unit]("Generate server.config from server-config.example when missing")
 lazy val testBackend = taskKey[Unit]("Run backend unit tests via Ant (excludes GWT/large/mongodb)")
+lazy val j2clSandboxBuild = taskKey[Unit]("Build the isolated J2CL sandbox sidecar into war/j2cl-debug via the Maven wrapper")
+lazy val j2clSandboxTest = taskKey[Unit]("Run the isolated J2CL sandbox sidecar smoke test via the Maven wrapper")
+lazy val j2clSearchBuild = taskKey[Unit]("Build the isolated J2CL search-sidecar scaffold into war/j2cl-search via the Maven wrapper")
+lazy val j2clSearchTest = taskKey[Unit]("Run the isolated J2CL search-sidecar smoke test via the Maven wrapper")
 lazy val dataMigrate = inputKey[Unit]("Run DataMigrationTool: dataMigrate <sourceOpts> <targetOpts>")
 lazy val dataPrepare = inputKey[Unit]("Run DataPreparationTool: dataPrepare <waveId> [<options>]")
 
@@ -830,6 +834,19 @@ def runCmd(log: Logger)(cmd: Seq[String], cwd: File): Unit = {
   } else cmd
   val code = Process(fixedCmd, cwd).!(ProcessLogger(s => log.info(s), e => log.error(e)))
   if (code != 0) sys.error(s"Command failed: ${fixedCmd.mkString(" ")}")
+}
+
+def runJ2clWrapper(log: Logger, base: File, profile: String, goal: String): Unit = {
+  val isWindows = scala.util.Properties.isWin
+  val wrapper = if (isWindows) base / "j2cl" / "mvnw.cmd" else base / "j2cl" / "mvnw"
+  val cmd =
+    if (isWindows) {
+      Seq("cmd", "/c", wrapper.getAbsolutePath, "-f", (base / "j2cl" / "pom.xml").getAbsolutePath, s"-P$profile", "-q", goal)
+    } else {
+      Seq(wrapper.getAbsolutePath, "-f", (base / "j2cl" / "pom.xml").getAbsolutePath, s"-P$profile", "-q", goal)
+    }
+  val code = Process(cmd, base).!(ProcessLogger(s => log.info(s), e => log.error(e)))
+  if (code != 0) sys.error(s"[j2cl] ${profile}:${goal} failed with exit code $code")
 }
 
 ThisBuild / prepareProtosForPB := {
@@ -864,6 +881,30 @@ ThisBuild / prepareProtosForPB := {
     IO.write(dst, txt)
   }
   if (rawProtos.isEmpty && protodevels.isEmpty) log.warn("No .proto/.protodevel files found under src/")
+}
+
+ThisBuild / j2clSandboxBuild := {
+  val log = streams.value.log
+  val base = baseDirectory.value
+  runJ2clWrapper(log, base, "debug-single-project", "package")
+}
+
+ThisBuild / j2clSandboxTest := {
+  val log = streams.value.log
+  val base = baseDirectory.value
+  runJ2clWrapper(log, base, "debug-single-project", "test")
+}
+
+ThisBuild / j2clSearchBuild := {
+  val log = streams.value.log
+  val base = baseDirectory.value
+  runJ2clWrapper(log, base, "search-sidecar", "package")
+}
+
+ThisBuild / j2clSearchTest := {
+  val log = streams.value.log
+  val base = baseDirectory.value
+  runJ2clWrapper(log, base, "search-sidecar", "test")
 }
 
 // sbt-protoc: use embedded protoc to generate Java directly into proto_src
@@ -1309,3 +1350,6 @@ cleanFiles += baseDirectory.value / "war" / "webclient"
 cleanFiles += baseDirectory.value / "war" / "org"
 cleanFiles += baseDirectory.value / "war" / "WEB-INF"
 cleanFiles += baseDirectory.value / "war-dev"
+cleanFiles += baseDirectory.value / "war" / "j2cl-search"
+cleanFiles += baseDirectory.value / "war" / "j2cl-debug"
+cleanFiles += baseDirectory.value / "war" / "j2cl"

--- a/build.sbt
+++ b/build.sbt
@@ -839,11 +839,18 @@ def runCmd(log: Logger)(cmd: Seq[String], cwd: File): Unit = {
 def runJ2clWrapper(log: Logger, base: File, profile: String, goal: String): Unit = {
   val isWindows = scala.util.Properties.isWin
   val wrapper = if (isWindows) base / "j2cl" / "mvnw.cmd" else base / "j2cl" / "mvnw"
+  val pom = base / "j2cl" / "pom.xml"
+  if (!wrapper.exists() || !wrapper.isFile || (!isWindows && !wrapper.canExecute)) {
+    sys.error(s"[j2cl] missing or non-executable wrapper: ${wrapper.getAbsolutePath}")
+  }
+  if (!pom.exists() || !pom.isFile) {
+    sys.error(s"[j2cl] missing pom.xml: ${pom.getAbsolutePath}")
+  }
   val cmd =
     if (isWindows) {
-      Seq("cmd", "/c", wrapper.getAbsolutePath, "-f", (base / "j2cl" / "pom.xml").getAbsolutePath, s"-P$profile", "-q", goal)
+      Seq("cmd", "/c", wrapper.getAbsolutePath, "-f", pom.getAbsolutePath, s"-P$profile", "-q", goal)
     } else {
-      Seq(wrapper.getAbsolutePath, "-f", (base / "j2cl" / "pom.xml").getAbsolutePath, s"-P$profile", "-q", goal)
+      Seq(wrapper.getAbsolutePath, "-f", pom.getAbsolutePath, s"-P$profile", "-q", goal)
     }
   val code = Process(cmd, base).!(ProcessLogger(s => log.info(s), e => log.error(e)))
   if (code != 0) sys.error(s"[j2cl] ${profile}:${goal} failed with exit code $code")

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -52,6 +52,7 @@
         }
       }
 
+
       function mountWhenReady(attemptsRemaining) {
         if (window.WaveSandboxEntryPoint && window.WaveSandboxEntryPoint.mount) {
           window.WaveSandboxEntryPoint.mount("sidecar-root", detectMode(window.location.pathname));

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -39,8 +39,12 @@
 
       function renderFallback(mode) {
         var summary = document.querySelector("[data-sidecar-summary]");
+        var detail = document.querySelector(".sidecar-detail");
         if (summary) {
-          summary.textContent = "Profile " + mode + " writes isolated assets without changing the root runtime bootstrap.";
+          summary.textContent = "Waiting for the generated " + mode + " sidecar bundle to mount.";
+        }
+        if (detail) {
+          detail.textContent = "If this placeholder remains visible, the J2CL bundle did not load and this page is not a valid sidecar verification result.";
         }
       }
 

--- a/wave/config/changelog.d/2026-04-19-j2cl-sidecar-followups.json
+++ b/wave/config/changelog.d/2026-04-19-j2cl-sidecar-followups.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-19-j2cl-sidecar-followups",
+  "version": "Unreleased",
+  "date": "2026-04-19",
+  "title": "Harden the J2CL sidecar follow-up paths",
+  "summary": "Tightens the remaining sidecar scaffold behavior after the base scaffold landed on main by hardening wrapper execution, sidecar route serving, and generated artifact handling.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added explicit wrapper and pom preflight checks before running J2CL sidecar Maven tasks so missing wrapper assets fail with a clear build error",
+        "Stopped the Jakarta sidecar servlet routes from resolving repo source directories when generated sidecar assets have not been built",
+        "Ignored generated war/j2cl* sidecar outputs so local sidecar builds do not leave large untracked artifacts in git status"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #900

## Summary
- add an isolated `j2cl/` Maven sidecar project with wrapper-backed sandbox, search-sidecar, debug, and production build profiles
- add opt-in SBT entrypoints for the sidecar build/test flow without changing the legacy GWT runtime bootstrap
- serve isolated sidecar assets under `/j2cl-search/*`, `/j2cl-debug/*`, and `/j2cl/*` while keeping `/` and `/webclient/*` on the current GWT path
- add the issue-specific implementation plan and changelog fragment for the new sidecar scaffold

## Verification
- `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -q test`
- `./j2cl/mvnw -f j2cl/pom.xml -Pdebug-single-project -q package`
- `./j2cl/mvnw -f j2cl/pom.xml -Pproduction -q package`
- `sbt "j2clSandboxBuild" "j2clSandboxTest" "j2clSearchBuild" "j2clSearchTest"`
- `sbt compile test`
  - passed: `Passed: Total 2289, Failed 0, Errors 0, Passed 2287, Skipped 2`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt Universal/stage`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-900-j2cl-sidecar-build/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-900-j2cl-sidecar-build/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- `curl -sS -I http://127.0.0.1:9900/webclient/webclient.nocache.js`
  - `200 OK`
- `curl -sS -I http://127.0.0.1:9900/j2cl-search/index.html`
  - `200 OK`
- `curl -sS -I http://127.0.0.1:9900/j2cl/index.html`
  - `200 OK`
- browser verification on `http://127.0.0.1:9900/`, `http://127.0.0.1:9900/j2cl-search/index.html`, and `http://127.0.0.1:9900/j2cl/index.html`
  - root `/` still showed the legacy SupaWave landing/sign-in flow
  - `/j2cl-search/index.html` loaded the isolated sandbox page with the `search-sidecar` summary
  - `/j2cl/index.html` loaded the isolated sandbox page with the `production` summary
- `PORT=9900 bash scripts/wave-smoke.sh stop`

## Traceability
- Worktree: `/Users/vega/devroot/worktrees/issue-900-j2cl-sidecar-build`
- Plan: `docs/superpowers/plans/2026-04-18-issue-900-j2cl-sidecar-build.md`
- Local verification record: `journal/local-verification/2026-04-19-issue-900-j2cl-sidecar-build.md`

## Notes
The legacy GWT runtime remains the active root/bootstrap path in this PR. The new J2CL outputs are sidecar-only scaffolding for later issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in J2CL Maven sidecar that builds isolated browser artifacts and a lightweight sidecar UI served at /j2cl-search/, /j2cl-debug/, and /j2cl/.
  * New build and test tasks to produce and verify sidecar and search artifacts.
  * Lightweight sandbox entrypoint, host page and stylesheet for sidecar preview.

* **Chores**
  * Added implementation plan, changelog entry, Maven wrapper, .gitignore entries, cleanup of generated sidecar outputs, and a smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->