### PR TITLE
feat(j2cl): add sidecar-only transport proof

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -820,6 +820,7 @@ lazy val j2clSandboxBuild = taskKey[Unit]("Build the isolated J2CL sandbox sidec
 lazy val j2clSandboxTest = taskKey[Unit]("Run the isolated J2CL sandbox sidecar smoke test via the Maven wrapper")
 lazy val j2clSearchBuild = taskKey[Unit]("Build the isolated J2CL search-sidecar scaffold into war/j2cl-search via the Maven wrapper")
 lazy val j2clSearchTest = taskKey[Unit]("Run the isolated J2CL search-sidecar smoke test via the Maven wrapper")
+lazy val j2clProductionBuild = taskKey[Unit]("Build the production J2CL sidecar into war/j2cl via the Maven wrapper")
 lazy val dataMigrate = inputKey[Unit]("Run DataMigrationTool: dataMigrate <sourceOpts> <targetOpts>")
 lazy val dataPrepare = inputKey[Unit]("Run DataPreparationTool: dataPrepare <waveId> [<options>]")
 
@@ -910,6 +911,12 @@ ThisBuild / j2clSearchTest := {
   val log = streams.value.log
   val base = baseDirectory.value
   runJ2clWrapper(log, base, "search-sidecar", "test")
+}
+
+ThisBuild / j2clProductionBuild := {
+  val log = streams.value.log
+  val base = baseDirectory.value
+  runJ2clWrapper(log, base, "production", "package")
 }
 
 // sbt-protoc: use embedded protoc to generate Java directly into proto_src
@@ -1024,6 +1031,7 @@ ThisBuild / generatePstMessages := {
     runCmd(log)(cmd, base)
   }
 }
+ThisBuild / generatePstMessages := (ThisBuild / generatePstMessages).dependsOn(Compile / PB.generate).value
 
 // GXP removed — replaced by HtmlRenderer.java (see PR #42)
 
@@ -1348,8 +1356,8 @@ compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 // ⚠️  DO NOT REMOVE these lines. They ensure GWT compilation runs before
 //     staging or packaging. Without them, distributions ship without the
 //     web client and users see a blank wave list after login.
-Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
-Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value
+Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets, j2clProductionBuild).value
+Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets, j2clProductionBuild).value
 
 cleanFiles += baseDirectory.value / "war" / "webclient"
 cleanFiles += baseDirectory.value / "war" / "org"

--- a/docs/superpowers/plans/2026-04-19-issue-902-j2cl-sidecar-transport.md
+++ b/docs/superpowers/plans/2026-04-19-issue-902-j2cl-sidecar-transport.md
@@ -1,0 +1,308 @@
+# Issue #902 J2CL Sidecar Transport Salvage Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the JSO-dependent transport/codecs path for the new J2CL work only, while keeping the legacy GWT webclient transport/runtime path untouched and provably green.
+
+**Architecture:** The repo now has an isolated J2CL sidecar scaffold under `j2cl/` plus opt-in `j2clSandbox*` and `j2clSearch*` SBT tasks. Issue `#902` should build on that scaffold instead of rewriting the active `wave/src/main/java/org/waveprotocol/box/webclient/**` transport stack. The safe salvage path is additive: keep the server JSON envelope and current legacy GWT JSO path intact, prove the sidecar can use the existing generated `impl`/`gson` families where possible, and add sidecar-only transport/codec code only where the sidecar still needs new seams.
+
+**Tech Stack:** Java, SBT, Maven sidecar under `j2cl/`, PST code generation, Gson/POJO generated message families, existing `/socket` JSON envelope, JUnit 4, worktree boot/smoke scripts, manual browser sanity verification.
+
+---
+
+## 1. Goal / Root Cause
+
+Issue `#902` still exists because the browser transport seam is currently tied to GWT-era generated `*JsoImpl` message classes plus the legacy webclient runtime path.
+
+The failed earlier attempt went wrong because it tried to rewire the active legacy webclient transport path directly. That widened the issue from “make the sidecar transport/compiler-safe” into “change the running GWT app,” which broke `compileGwt` and staged-root boot.
+
+The branch baseline is now narrower:
+
+- the J2CL sidecar scaffold from `#900` already exists under `j2cl/`
+- the server still speaks the same JSON-over-WebSocket protocol and should remain unchanged for this issue
+- the only preserved branch-local progress is the strengthened `wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java`, which proves the required `impl`, `gson`, `jso`, and `proto` families exist for the transport/search message roots
+
+The revised root cause is therefore not “missing full-client transport migration.” It is “the sidecar still lacks its own J2CL-safe transport/codec path, and the first implementation attempted to solve that by disturbing the wrong runtime seam.”
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Keep the legacy GWT runtime path active and unchanged.
+- Use the isolated J2CL sidecar path as the only runtime surface for new transport/codec work.
+- Reuse the current server JSON envelope (`sequenceNumber`, `messageType`, `message`) and current `/socket` endpoint.
+- Start from the existing generated `impl` and `gson` PST families as the preferred sidecar-safe transport representation.
+- Add sidecar-only transport adapters, sidecar-only codec glue, and sidecar-only tests under `j2cl/`.
+- Extend PST generation only if the existing `impl` + `gson` outputs are insufficient for the sidecar path.
+- Keep `PstCodegenContractTest` as the minimum preserved proof that the required families continue to exist.
+
+### Explicit Non-Goals
+
+- No rewrite of the active legacy GWT transport/runtime path.
+- No behavior change to the root `/` page, signin/bootstrap flow, or `/webclient/**` asset path.
+- No replacement of `WaveWebSocketClient`, `RemoteViewServiceMultiplexer`, `RemoteWaveViewService`, or `JsoSearchBuilderImpl` as the live GWT runtime for this issue.
+- No server protocol change, protobuf-js runtime, or alternate socket endpoint.
+- No root-route or feature-flag cutover from GWT to J2CL.
+- No PR if the sidecar path is green but the legacy root path regresses.
+
+## 3. Exact Files Likely To Change
+
+### Expected Primary Edits
+
+- `build.sbt`
+- `j2cl/pom.xml`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java`
+- New files under `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/`
+- New files under `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/`
+- New files under `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/`
+- New files under `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/`
+- `wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java`
+
+### Conditional Only If Existing `impl` + `gson` Outputs Prove Insufficient
+
+- `wave/src/main/java/org/waveprotocol/pst/templates/gson/**`
+- `wave/src/main/java/org/waveprotocol/pst/templates/pojo/**`
+- New template files under `wave/src/main/java/org/waveprotocol/pst/templates/` for a sidecar-safe codec target
+- `gen/messages/org/waveprotocol/box/common/comms/**`
+- `gen/messages/org/waveprotocol/wave/federation/**`
+- `gen/messages/org/waveprotocol/wave/concurrencycontrol/**`
+- `gen/messages/org/waveprotocol/box/search/**`
+
+### Inspect-Only / No-Touch Legacy Runtime Files For This Salvage Plan
+
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveSocket.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveSocketFactory.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveWebSocketClient.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteWaveViewService.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/SnapshotFetcher.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/common/SnapshotSerializer.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/common/WaveletOperationSerializer.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/JsoSearchBuilderImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/WebSocketChannel.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/ProtoSerializer.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java`
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Freeze The Sidecar-Only Boundary Before Coding
+
+**Files:**
+- Inspect only: `docs/j2cl-gwt3-decision-memo.md`
+- Inspect only: `docs/j2cl-preparatory-work.md`
+- Inspect only: `docs/superpowers/plans/j2cl-full-migration-plan.md`
+- Inspect only: legacy runtime files listed above
+
+- [ ] Restate in the issue comment and PR notes that `#902` is no longer allowed to change the active legacy webclient transport/runtime path.
+- [ ] Record the preserved branch baseline:
+  - only `wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java` is intentionally carried forward from the failed earlier attempt
+  - any transport/codec work must land behind the isolated sidecar routes
+- [ ] Treat the legacy GWT transport files as parity references only, not as the implementation target for this issue.
+
+### Task 2: Prove The Sidecar Can Stand On Existing Generated Families First
+
+**Files:**
+- Modify if needed: `wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java`
+- Inspect and possibly wire through build/test flow: `build.sbt`
+- Inspect generated roots:
+  - `gen/messages/org/waveprotocol/box/common/comms/**`
+  - `gen/messages/org/waveprotocol/wave/federation/**`
+  - `gen/messages/org/waveprotocol/wave/concurrencycontrol/**`
+  - `gen/messages/org/waveprotocol/box/search/**`
+
+- [ ] Keep the contract test improvement and use it as the first gate for the salvage plan.
+- [ ] Attempt the sidecar implementation against the existing generated `impl` + `gson` families before inventing a new generator target.
+- [ ] Preserve `jso` generation and all legacy consumers untouched even if a new sidecar-safe target is later added.
+- [ ] Only widen PST generation when a concrete sidecar gap is identified and documented.
+
+### Task 3: Add A Sidecar-Only Transport Runtime Under `j2cl/`
+
+**Files:**
+- Modify or create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/**`
+- Modify if needed: `j2cl/pom.xml`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/**`
+
+- [ ] Add a sidecar-local WebSocket adapter that talks to the existing `/socket` endpoint without routing any live root traffic away from the GWT client.
+- [ ] Keep the existing JSON envelope shape exactly:
+  - `sequenceNumber`
+  - `messageType`
+  - `message`
+- [ ] Keep the numeric JSON field-key compatibility expected by the current generated message families.
+- [ ] Make the sidecar transport own its own open/update/submit/search codec wiring instead of patching the active GWT `WaveWebSocketClient` path.
+- [ ] Keep the sidecar transport package parallel to, not intertwined with, `wave/src/main/java/org/waveprotocol/box/webclient/client/**`.
+
+### Task 4: Add A Sidecar Consumer Proof Instead Of A Root-Path Rewrite
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- Modify or create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/**`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/**`
+
+- [ ] Extend the current sandbox/search-sidecar proof so it exercises the sidecar-safe transport/codec path instead of acting as a static scaffold only.
+- [ ] Keep the proof isolated to sidecar routes such as `/j2cl-search/**` or another sidecar-only page under `j2cl/`.
+- [ ] Do not change `/`, `/webclient/**`, or the legacy login/bootstrap path while proving the sidecar transport.
+- [ ] Make the first proof narrow:
+  - open/auth handshake
+  - update decoding
+  - submit round-trip or a tightly scoped search request/response
+- [ ] Prefer one deterministic sidecar proof path over broad UI migration in this issue.
+
+### Task 5: Only Add New PST Output If The Sidecar Cannot Use The Existing Families
+
+**Files:**
+- Conditional modify: `wave/src/main/java/org/waveprotocol/pst/templates/gson/**`
+- Conditional modify: `wave/src/main/java/org/waveprotocol/pst/templates/pojo/**`
+- Conditional create: new sidecar-safe template files under `wave/src/main/java/org/waveprotocol/pst/templates/`
+- Conditional regenerate:
+  - `gen/messages/org/waveprotocol/box/common/comms/**`
+  - `gen/messages/org/waveprotocol/wave/federation/**`
+  - `gen/messages/org/waveprotocol/wave/concurrencycontrol/**`
+  - `gen/messages/org/waveprotocol/box/search/**`
+
+- [ ] Only do this task if the sidecar cannot safely consume the current `impl` + `gson` outputs.
+- [ ] If a new sidecar-safe generator target is required, make it additive and parallel to `jso`, not a replacement for `jso`.
+- [ ] Keep the new target limited to the transport/search families needed by this issue.
+- [ ] Re-run the PST generation gate and preserve the existing contract test coverage.
+
+### Task 6: Verify Both The Legacy Root Path And The Sidecar Path Before Any PR
+
+**Files:**
+- Verify only: `build.sbt`
+- Verify only: `j2cl/pom.xml`
+- Verify only: `journal/local-verification/<date>-issue-902-j2cl-transport-codecs.md`
+
+- [ ] Run PST generation plus `PstCodegenContractTest`.
+- [ ] Run the J2CL sidecar build/test tasks.
+- [ ] Re-run `compileGwt` and staged-root packaging proof even though the implementation is sidecar-only.
+- [ ] Boot the staged app from the worktree and prove both:
+  - the root `/` page still serves the legacy GWT runtime
+  - the isolated sidecar page loads and exercises the new sidecar transport/codec path
+- [ ] Do not open a PR unless both paths are green.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-902-j2cl-transport-codecs`.
+
+### PST Generation And Contract Gate
+
+```bash
+sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"
+```
+
+Expected result:
+
+- PST generation completes successfully
+- `PstCodegenContractTest` passes
+- the required transport/search family roots still expose `impl`, `gson`, `jso`, and `proto`
+
+### J2CL Sidecar Build/Test Gates
+
+```bash
+sbt -batch j2clSandboxBuild j2clSandboxTest j2clSearchBuild j2clSearchTest
+```
+
+Expected result:
+
+- sidecar build/test tasks pass without altering `war/webclient/**`
+- sidecar outputs remain isolated under `war/j2cl-debug/**`, `war/j2cl-search/**`, and `war/j2cl/**`
+
+### Legacy GWT Compile And Staged-Root Proof
+
+```bash
+sbt -batch compileGwt Universal/stage
+```
+
+Expected result:
+
+- `compileGwt` stays green
+- `Universal/stage` stays green
+- the root staged app still contains the legacy `webclient` bootstrap assets
+
+### Local Server Boot And Smoke
+
+```bash
+bash scripts/worktree-boot.sh --port 9900
+```
+
+Then run the exact printed start/check/stop commands from the helper. The standard shape must remain:
+
+```bash
+PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+```
+
+### Root And Sidecar Route Presence Checks
+
+```bash
+curl -sS -I http://localhost:9900/
+curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
+curl -sS -I http://localhost:9900/j2cl-search/index.html
+curl -sS -I http://localhost:9900/j2cl/index.html
+```
+
+Expected result:
+
+- `/` responds successfully
+- `/webclient/webclient.nocache.js` is still present for the legacy root path
+- `/j2cl-search/index.html` and `/j2cl/index.html` are present when the sidecar artifacts were built
+
+### Browser Sanity Verification
+
+Browser verification is required by `docs/runbooks/change-type-verification-matrix.md` because this issue touches client/runtime packaging and browser-visible sidecar assets.
+
+Open:
+
+- `http://localhost:9900/`
+- `http://localhost:9900/j2cl-search/index.html`
+
+Confirm:
+
+- the root `/` page still boots the legacy GWT client rather than the sidecar
+- the isolated sidecar page loads independently and exercises the new sidecar transport/codec proof path
+- the sidecar page does not take over the root shell
+
+Stop the server with the exact helper-printed command. The standard shape is:
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+### Hard PR Gate
+
+No PR is allowed unless all of the following are green in the same worktree:
+
+- `sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"`
+- `sbt -batch j2clSandboxBuild j2clSandboxTest j2clSearchBuild j2clSearchTest`
+- `sbt -batch compileGwt Universal/stage`
+- staged server boot/smoke
+- browser sanity for both `/` and the isolated sidecar page
+
+## 6. Acceptance Criteria
+
+- The implementation stays sidecar-only and does not replace the active GWT runtime path.
+- The legacy transport/runtime files listed above remain inspect-only or behavior-preserving references for this issue.
+- The sidecar can speak the existing `/socket` JSON protocol using a J2CL-safe transport/codec path.
+- The first sidecar proof uses the isolated sidecar routes and does not change `/` or `/webclient/**`.
+- `PstCodegenContractTest` remains green and continues proving the required message families exist.
+- If a new PST target is added, it is additive and does not remove or repurpose `jso`.
+- `compileGwt` and `Universal/stage` stay green after the change.
+- Local staged verification proves both:
+  - legacy root path green
+  - isolated sidecar path green
+- No PR is opened unless both paths are green.
+
+## 7. Issue / PR Traceability Notes
+
+- Worktree: `/Users/vega/devroot/worktrees/issue-902-j2cl-transport-codecs`
+- Branch: `issue-902-j2cl-transport-codecs`
+- Plan path: `docs/superpowers/plans/2026-04-19-issue-902-j2cl-sidecar-transport.md`
+- Record verification evidence in `journal/local-verification/<date>-issue-902-j2cl-transport-codecs.md` and mirror the important commands/results into the linked GitHub Issue comment.
+- The issue comment and PR body should explicitly say that the earlier active-webclient rewrite was abandoned because it broke `compileGwt` / staged-root boot, and that this revision keeps the legacy GWT transport/runtime path intact.
+- Commit summaries should make the sidecar-only boundary obvious, for example:
+  - PST gate / sidecar codec prerequisite
+  - sidecar transport runtime
+  - sidecar transport tests
+  - verification-only follow-up
+- The PR summary must explicitly state: legacy root path green, isolated sidecar path green, no cutover performed.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -5,6 +5,7 @@ import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.XMLHttpRequest;
 import elemental2.dom.WebSocket;
+import java.util.Collections;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
@@ -19,6 +20,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarWaveletUpdateSummary;
 public final class SandboxEntryPoint {
   private static final String DEFAULT_MODE = "sidecar";
   private static final String DEFAULT_QUERY = "in:inbox";
+  private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
 
   private SandboxEntryPoint() {
   }
@@ -246,7 +248,11 @@ public final class SandboxEntryPoint {
         }
         ws.send(
             SidecarTransportCodec.encodeOpenEnvelope(
-                1, new SidecarOpenRequest(bootstrap.getAddress(), digest.getWaveId(), null)));
+                1,
+                new SidecarOpenRequest(
+                    bootstrap.getAddress(),
+                    digest.getWaveId(),
+                    Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
         setNeutral(
             "Awaiting ProtocolWaveletUpdate",
             "Socket connected; auth/open sent for " + digest.getWaveId() + ".");
@@ -268,6 +274,12 @@ public final class SandboxEntryPoint {
           return;
         }
         SidecarWaveletUpdateSummary summary = frame.getSummary();
+        if (isChannelEstablishmentUpdate(summary)) {
+          setNeutral(
+              "Socket active",
+              "Received channel-establishment update; waiting for a real wavelet stream update.");
+          return;
+        }
         waitingForUpdate = false;
         setSuccess(
             "Sidecar transport proof passed",
@@ -379,6 +391,11 @@ public final class SandboxEntryPoint {
   static boolean shouldHandleSocketCallback(
       int callbackGeneration, int currentGeneration, boolean ownsCurrentSocket) {
     return shouldHandleAsyncCallback(callbackGeneration, currentGeneration) && ownsCurrentSocket;
+  }
+
+  static boolean isChannelEstablishmentUpdate(SidecarWaveletUpdateSummary summary) {
+    String waveletName = summary.getWaveletName();
+    return waveletName != null && waveletName.contains("/~/dummy+root");
   }
 
   private static void requestText(String url, TextCallback onSuccess, ErrorCallback onError) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -156,6 +156,7 @@ public final class SandboxEntryPoint {
     private final HTMLElement meta;
     private WebSocket socket;
     private boolean waitingForUpdate;
+    private int runGeneration;
 
     private SidecarProofRunner(String mode, HTMLElement status, HTMLElement meta) {
       this.mode = mode;
@@ -166,12 +167,16 @@ public final class SandboxEntryPoint {
     void run() {
       closeSocket();
       waitingForUpdate = false;
+      int generation = ++runGeneration;
       setNeutral(
           "Fetching root bootstrap",
           "Reading the live root page session so the sidecar can reuse the active legacy login context.");
       requestText(
           "/",
           html -> {
+            if (generation != runGeneration) {
+              return;
+            }
             SidecarSessionBootstrap bootstrap;
             try {
               bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
@@ -184,10 +189,25 @@ public final class SandboxEntryPoint {
                 "Resolved session address " + bootstrap.getAddress() + "; requesting a narrow sidecar proof wave.");
             requestText(
                 buildSearchUrl(),
-                responseText -> handleSearchResponse(bootstrap, responseText),
-                error -> setError("Search request failed", error));
+                responseText -> {
+                  if (generation != runGeneration) {
+                    return;
+                  }
+                  handleSearchResponse(bootstrap, responseText);
+                },
+                error -> {
+                  if (generation != runGeneration) {
+                    return;
+                  }
+                  setError("Search request failed", error);
+                });
           },
-          error -> setError("Root bootstrap request failed", error));
+          error -> {
+            if (generation != runGeneration) {
+              return;
+            }
+            setError("Root bootstrap request failed", error);
+          });
     }
 
     private void handleSearchResponse(SidecarSessionBootstrap bootstrap, String responseText) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -174,7 +174,7 @@ public final class SandboxEntryPoint {
       requestText(
           "/",
           html -> {
-            if (generation != runGeneration) {
+            if (!shouldHandleAsyncCallback(generation, runGeneration)) {
               return;
             }
             SidecarSessionBootstrap bootstrap;
@@ -190,20 +190,20 @@ public final class SandboxEntryPoint {
             requestText(
                 buildSearchUrl(),
                 responseText -> {
-                  if (generation != runGeneration) {
+                  if (!shouldHandleAsyncCallback(generation, runGeneration)) {
                     return;
                   }
                   handleSearchResponse(bootstrap, responseText);
                 },
                 error -> {
-                  if (generation != runGeneration) {
+                  if (!shouldHandleAsyncCallback(generation, runGeneration)) {
                     return;
                   }
                   setError("Search request failed", error);
                 });
           },
           error -> {
-            if (generation != runGeneration) {
+            if (!shouldHandleAsyncCallback(generation, runGeneration)) {
               return;
             }
             setError("Root bootstrap request failed", error);
@@ -228,14 +228,15 @@ public final class SandboxEntryPoint {
       setNeutral(
           "Opening /socket",
           "Selected " + digest.getWaveId() + " from query " + response.getQuery() + "; waiting for a sidecar wavelet update.");
-      openSocket(bootstrap, digest);
+      openSocket(bootstrap, digest, runGeneration);
     }
 
-    private void openSocket(SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest) {
+    private void openSocket(
+        SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest, int generation) {
       WebSocket ws = new WebSocket(buildWebSocketUrl());
       socket = ws;
       ws.onopen = event -> {
-        if (ws != socket) {
+        if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
           return;
         }
         waitingForUpdate = true;
@@ -251,7 +252,7 @@ public final class SandboxEntryPoint {
             "Socket connected; auth/open sent for " + digest.getWaveId() + ".");
       };
       ws.onmessage = event -> {
-        if (ws != socket) {
+        if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
           return;
         }
         String payload = String.valueOf(event.data);
@@ -280,13 +281,13 @@ public final class SandboxEntryPoint {
         closeSocket();
       };
       ws.onerror = event -> {
-        if (ws != socket) {
+        if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
           return;
         }
         setError("Socket error", "The isolated sidecar failed while talking to /socket.");
       };
       ws.onclose = event -> {
-        if (ws != socket) {
+        if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
           return;
         }
         if (waitingForUpdate) {
@@ -369,6 +370,15 @@ public final class SandboxEntryPoint {
       return SocketFrameResult.error(
           "The isolated sidecar sent an unexpected or invalid socket frame: " + detail);
     }
+  }
+
+  static boolean shouldHandleAsyncCallback(int callbackGeneration, int currentGeneration) {
+    return callbackGeneration == currentGeneration;
+  }
+
+  static boolean shouldHandleSocketCallback(
+      int callbackGeneration, int currentGeneration, boolean ownsCurrentSocket) {
+    return shouldHandleAsyncCallback(callbackGeneration, currentGeneration) && ownsCurrentSocket;
   }
 
   private static void requestText(String url, TextCallback onSuccess, ErrorCallback onError) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -235,7 +235,8 @@ public final class SandboxEntryPoint {
 
     private void openSocket(
         SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest, int generation) {
-      WebSocket ws = new WebSocket(buildWebSocketUrl());
+      WebSocket ws =
+          new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
       socket = ws;
       ws.onopen = event -> {
         if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
@@ -361,10 +362,11 @@ public final class SandboxEntryPoint {
       return DEFAULT_QUERY;
     }
 
-    private String buildWebSocketUrl() {
-      String protocol = "https:".equals(DomGlobal.location.protocol) ? "wss://" : "ws://";
-      return protocol + DomGlobal.location.host + "/socket";
-    }
+  }
+
+  static String buildWebSocketUrl(String locationProtocol, String websocketAddress) {
+    String protocol = "https:".equals(locationProtocol) ? "wss://" : "ws://";
+    return protocol + websocketAddress + "/socket";
   }
 
   static SocketFrameResult evaluateSocketFrame(String payload) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -3,13 +3,22 @@ package org.waveprotocol.box.j2cl.sandbox;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.XMLHttpRequest;
+import elemental2.dom.WebSocket;
+import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
+import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+import org.waveprotocol.box.j2cl.transport.SidecarWaveletUpdateSummary;
 
 @JsType(namespace = JsPackage.GLOBAL, name = "WaveSandboxEntryPoint")
 public final class SandboxEntryPoint {
   private static final String DEFAULT_MODE = "sidecar";
+  private static final String DEFAULT_QUERY = "in:inbox";
 
   private SandboxEntryPoint() {
   }
@@ -47,7 +56,34 @@ public final class SandboxEntryPoint {
     detail.textContent = "Legacy / stays on the GWT web client while this page proves the sidecar can build and load independently.";
     card.appendChild(detail);
 
+    HTMLElement statusLabel = (HTMLElement) DomGlobal.document.createElement("p");
+    statusLabel.className = "sidecar-proof-label";
+    statusLabel.textContent = "Transport proof";
+    card.appendChild(statusLabel);
+
+    HTMLElement status = (HTMLElement) DomGlobal.document.createElement("p");
+    status.className = "sidecar-proof-status";
+    status.textContent = "Bootstrapping sidecar proof…";
+    card.appendChild(status);
+
+    HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("p");
+    meta.className = "sidecar-proof-meta";
+    meta.textContent = "Looking up session bootstrap, search results, and OT transport status.";
+    card.appendChild(meta);
+
+    HTMLElement rerun = (HTMLElement) DomGlobal.document.createElement("button");
+    rerun.className = "sidecar-proof-action";
+    rerun.textContent = "Re-run sidecar proof";
+    card.appendChild(rerun);
+
     host.appendChild(card);
+
+    SidecarProofRunner runner = new SidecarProofRunner(mode, status, meta);
+    runner.run();
+    rerun.onclick = event -> {
+      runner.run();
+      return null;
+    };
   }
 
   public static String renderSummary(String requestedMode) {
@@ -62,4 +98,218 @@ public final class SandboxEntryPoint {
     String trimmed = requestedMode.trim();
     return trimmed.isEmpty() ? DEFAULT_MODE : trimmed;
   }
+
+  @JsFunction
+  private interface TextCallback {
+    void accept(String text);
+  }
+
+  @JsFunction
+  private interface ErrorCallback {
+    void accept(String error);
+  }
+
+  private static final class SidecarProofRunner {
+    private final String mode;
+    private final HTMLElement status;
+    private final HTMLElement meta;
+    private WebSocket socket;
+    private boolean waitingForUpdate;
+
+    private SidecarProofRunner(String mode, HTMLElement status, HTMLElement meta) {
+      this.mode = mode;
+      this.status = status;
+      this.meta = meta;
+    }
+
+    void run() {
+      closeSocket();
+      waitingForUpdate = false;
+      setNeutral(
+          "Fetching root bootstrap",
+          "Reading the live root page session so the sidecar can reuse the active legacy login context.");
+      requestText(
+          "/",
+          html -> {
+            SidecarSessionBootstrap bootstrap;
+            try {
+              bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
+            } catch (IllegalArgumentException e) {
+              setError("Root bootstrap missing", e.getMessage());
+              return;
+            }
+            setNeutral(
+                "Querying /search",
+                "Resolved session address " + bootstrap.getAddress() + "; requesting a narrow sidecar proof wave.");
+            requestText(
+                buildSearchUrl(),
+                responseText -> handleSearchResponse(bootstrap, responseText),
+                error -> setError("Search request failed", error));
+          },
+          error -> setError("Root bootstrap request failed", error));
+    }
+
+    private void handleSearchResponse(SidecarSessionBootstrap bootstrap, String responseText) {
+      SidecarSearchResponse response;
+      try {
+        response = SidecarTransportCodec.decodeSearchResponse(responseText);
+      } catch (RuntimeException e) {
+        setError("Search decode failed", e.getMessage());
+        return;
+      }
+      if (response.getDigests().isEmpty()) {
+        setError(
+            "Search returned no proof wave",
+            "The sidecar can only open a live OT stream when /search returns at least one visible wave.");
+        return;
+      }
+      SidecarSearchResponse.Digest digest = response.getDigests().get(0);
+      setNeutral(
+          "Opening /socket",
+          "Selected " + digest.getWaveId() + " from query " + response.getQuery() + "; waiting for a sidecar wavelet update.");
+      openSocket(bootstrap, digest);
+    }
+
+    private void openSocket(SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest) {
+      socket = new WebSocket(buildWebSocketUrl());
+      socket.onopen = event -> {
+        waitingForUpdate = true;
+        String token = readCookie("JSESSIONID");
+        if (token != null && !token.isEmpty()) {
+          socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
+        }
+        socket.send(
+            SidecarTransportCodec.encodeOpenEnvelope(
+                1, new SidecarOpenRequest(bootstrap.getAddress(), digest.getWaveId())));
+        setNeutral(
+            "Awaiting ProtocolWaveletUpdate",
+            "Socket connected; auth/open sent for " + digest.getWaveId() + ".");
+      };
+      socket.onmessage = event -> {
+        String payload = String.valueOf(event.data);
+        String messageType = SidecarTransportCodec.decodeMessageType(payload);
+        if (!"ProtocolWaveletUpdate".equals(messageType)) {
+          setNeutral(
+              "Socket active",
+              "Received " + messageType + " while waiting for the first sidecar update.");
+          return;
+        }
+        SidecarWaveletUpdateSummary summary = SidecarTransportCodec.decodeWaveletUpdate(payload);
+        waitingForUpdate = false;
+        setSuccess(
+            "Sidecar transport proof passed",
+            "Wavelet "
+                + summary.getWaveletName()
+                + " delivered "
+                + summary.getAppliedDeltaCount()
+                + " delta payload(s)"
+                + (summary.getChannelId() == null ? "" : " on " + summary.getChannelId())
+                + ".");
+        closeSocket();
+      };
+      socket.onerror = event -> {
+        setError("Socket error", "The isolated sidecar failed while talking to /socket.");
+      };
+      socket.onclose = event -> {
+        if (waitingForUpdate) {
+          setError(
+              "Socket closed early",
+              "The socket closed before the sidecar received a ProtocolWaveletUpdate.");
+        }
+        waitingForUpdate = false;
+      };
+    }
+
+    private void closeSocket() {
+      if (socket != null) {
+        socket.close();
+        socket = null;
+      }
+    }
+
+    private void setNeutral(String headline, String detail) {
+      status.className = "sidecar-proof-status";
+      status.textContent = headline;
+      meta.className = "sidecar-proof-meta";
+      meta.textContent = detail;
+    }
+
+    private void setSuccess(String headline, String detail) {
+      status.className = "sidecar-proof-status sidecar-proof-status-success";
+      status.textContent = headline;
+      meta.className = "sidecar-proof-meta sidecar-proof-meta-success";
+      meta.textContent = detail;
+    }
+
+    private void setError(String headline, String detail) {
+      waitingForUpdate = false;
+      status.className = "sidecar-proof-status sidecar-proof-status-error";
+      status.textContent = headline;
+      meta.className = "sidecar-proof-meta sidecar-proof-meta-error";
+      meta.textContent = detail;
+      closeSocket();
+    }
+
+    private String buildSearchUrl() {
+      return "/search/?query=" + encodeUriComponent(readQuery()) + "&index=0&numResults=1";
+    }
+
+    private String readQuery() {
+      String search = DomGlobal.location.search;
+      if (search == null || search.isEmpty()) {
+        return DEFAULT_QUERY;
+      }
+      String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
+      String[] parts = trimmed.split("&");
+      for (String part : parts) {
+        if (part.startsWith("q=")) {
+          String value = part.substring(2);
+          return value.isEmpty() ? DEFAULT_QUERY : decodeUriComponent(value);
+        }
+      }
+      return DEFAULT_QUERY;
+    }
+
+    private String buildWebSocketUrl() {
+      String protocol = "https:".equals(DomGlobal.location.protocol) ? "wss://" : "ws://";
+      return protocol + DomGlobal.location.host + "/socket";
+    }
+  }
+
+  private static void requestText(String url, TextCallback onSuccess, ErrorCallback onError) {
+    XMLHttpRequest request = new XMLHttpRequest();
+    request.open("GET", url);
+    request.onload =
+        event -> {
+          if (request.status >= 200 && request.status < 300) {
+            onSuccess.accept(request.responseText);
+          } else {
+            onError.accept("HTTP " + request.status + " for " + url);
+          }
+        };
+    request.onerror =
+        event -> {
+          onError.accept("Network failure for " + url);
+          return null;
+        };
+    request.send();
+  }
+
+  private static String readCookie(String name) {
+    String[] cookies = DomGlobal.document.cookie.split(";");
+    for (String cookie : cookies) {
+      String trimmed = cookie.trim();
+      String prefix = name + "=";
+      if (trimmed.startsWith(prefix)) {
+        return decodeUriComponent(trimmed.substring(prefix.length()));
+      }
+    }
+    return null;
+  }
+
+  @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")
+  private static native String encodeUriComponent(String value);
+
+  @JsMethod(namespace = JsPackage.GLOBAL, name = "decodeURIComponent")
+  private static native String decodeUriComponent(String value);
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -232,21 +232,28 @@ public final class SandboxEntryPoint {
     }
 
     private void openSocket(SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest) {
-      socket = new WebSocket(buildWebSocketUrl());
-      socket.onopen = event -> {
+      WebSocket ws = new WebSocket(buildWebSocketUrl());
+      socket = ws;
+      ws.onopen = event -> {
+        if (ws != socket) {
+          return;
+        }
         waitingForUpdate = true;
         String token = readCookie("JSESSIONID");
         if (token != null && !token.isEmpty()) {
-          socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
+          ws.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
         }
-        socket.send(
+        ws.send(
             SidecarTransportCodec.encodeOpenEnvelope(
-                1, new SidecarOpenRequest(bootstrap.getAddress(), digest.getWaveId())));
+                1, new SidecarOpenRequest(bootstrap.getAddress(), digest.getWaveId(), null)));
         setNeutral(
             "Awaiting ProtocolWaveletUpdate",
             "Socket connected; auth/open sent for " + digest.getWaveId() + ".");
       };
-      socket.onmessage = event -> {
+      ws.onmessage = event -> {
+        if (ws != socket) {
+          return;
+        }
         String payload = String.valueOf(event.data);
         SocketFrameResult frame = evaluateSocketFrame(payload);
         if (frame.isError()) {
@@ -272,10 +279,16 @@ public final class SandboxEntryPoint {
                 + ".");
         closeSocket();
       };
-      socket.onerror = event -> {
+      ws.onerror = event -> {
+        if (ws != socket) {
+          return;
+        }
         setError("Socket error", "The isolated sidecar failed while talking to /socket.");
       };
-      socket.onclose = event -> {
+      ws.onclose = event -> {
+        if (ws != socket) {
+          return;
+        }
         if (waitingForUpdate) {
           setError(
               "Socket closed early",

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -109,6 +109,47 @@ public final class SandboxEntryPoint {
     void accept(String error);
   }
 
+  static final class SocketFrameResult {
+    private final String messageType;
+    private final SidecarWaveletUpdateSummary summary;
+    private final String errorDetail;
+
+    private SocketFrameResult(
+        String messageType, SidecarWaveletUpdateSummary summary, String errorDetail) {
+      this.messageType = messageType;
+      this.summary = summary;
+      this.errorDetail = errorDetail;
+    }
+
+    static SocketFrameResult messageType(String messageType) {
+      return new SocketFrameResult(messageType, null, null);
+    }
+
+    static SocketFrameResult update(SidecarWaveletUpdateSummary summary) {
+      return new SocketFrameResult("ProtocolWaveletUpdate", summary, null);
+    }
+
+    static SocketFrameResult error(String errorDetail) {
+      return new SocketFrameResult(null, null, errorDetail);
+    }
+
+    boolean isError() {
+      return errorDetail != null;
+    }
+
+    String getMessageType() {
+      return messageType;
+    }
+
+    SidecarWaveletUpdateSummary getSummary() {
+      return summary;
+    }
+
+    String getErrorDetail() {
+      return errorDetail;
+    }
+  }
+
   private static final class SidecarProofRunner {
     private final String mode;
     private final HTMLElement status;
@@ -187,34 +228,29 @@ public final class SandboxEntryPoint {
       };
       socket.onmessage = event -> {
         String payload = String.valueOf(event.data);
-        try {
-          String messageType = SidecarTransportCodec.decodeMessageType(payload);
-          if (!"ProtocolWaveletUpdate".equals(messageType)) {
-            setNeutral(
-                "Socket active",
-                "Received " + messageType + " while waiting for the first sidecar update.");
-            return;
-          }
-          SidecarWaveletUpdateSummary summary = SidecarTransportCodec.decodeWaveletUpdate(payload);
-          waitingForUpdate = false;
-          setSuccess(
-              "Sidecar transport proof passed",
-              "Wavelet "
-                  + summary.getWaveletName()
-                  + " delivered "
-                  + summary.getAppliedDeltaCount()
-                  + " delta payload(s)"
-                  + (summary.getChannelId() == null ? "" : " on " + summary.getChannelId())
-                  + ".");
-          closeSocket();
-        } catch (RuntimeException e) {
-          waitingForUpdate = false;
-          setError(
-              "Malformed sidecar message",
-              "The isolated sidecar sent an unexpected or invalid socket frame: "
-                  + e.getMessage());
-          closeSocket();
+        SocketFrameResult frame = evaluateSocketFrame(payload);
+        if (frame.isError()) {
+          setError("Malformed sidecar message", frame.getErrorDetail());
+          return;
         }
+        if (!"ProtocolWaveletUpdate".equals(frame.getMessageType())) {
+          setNeutral(
+              "Socket active",
+              "Received " + frame.getMessageType() + " while waiting for the first sidecar update.");
+          return;
+        }
+        SidecarWaveletUpdateSummary summary = frame.getSummary();
+        waitingForUpdate = false;
+        setSuccess(
+            "Sidecar transport proof passed",
+            "Wavelet "
+                + summary.getWaveletName()
+                + " delivered "
+                + summary.getAppliedDeltaCount()
+                + " delta payload(s)"
+                + (summary.getChannelId() == null ? "" : " on " + summary.getChannelId())
+                + ".");
+        closeSocket();
       };
       socket.onerror = event -> {
         setError("Socket error", "The isolated sidecar failed while talking to /socket.");
@@ -282,6 +318,23 @@ public final class SandboxEntryPoint {
     private String buildWebSocketUrl() {
       String protocol = "https:".equals(DomGlobal.location.protocol) ? "wss://" : "ws://";
       return protocol + DomGlobal.location.host + "/socket";
+    }
+  }
+
+  static SocketFrameResult evaluateSocketFrame(String payload) {
+    try {
+      String messageType = SidecarTransportCodec.decodeMessageType(payload);
+      if (!"ProtocolWaveletUpdate".equals(messageType)) {
+        return SocketFrameResult.messageType(messageType);
+      }
+      return SocketFrameResult.update(SidecarTransportCodec.decodeWaveletUpdate(payload));
+    } catch (RuntimeException e) {
+      String detail = e.getMessage();
+      if (detail == null || detail.isEmpty()) {
+        detail = e.getClass().getSimpleName();
+      }
+      return SocketFrameResult.error(
+          "The isolated sidecar sent an unexpected or invalid socket frame: " + detail);
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -187,25 +187,34 @@ public final class SandboxEntryPoint {
       };
       socket.onmessage = event -> {
         String payload = String.valueOf(event.data);
-        String messageType = SidecarTransportCodec.decodeMessageType(payload);
-        if (!"ProtocolWaveletUpdate".equals(messageType)) {
-          setNeutral(
-              "Socket active",
-              "Received " + messageType + " while waiting for the first sidecar update.");
-          return;
+        try {
+          String messageType = SidecarTransportCodec.decodeMessageType(payload);
+          if (!"ProtocolWaveletUpdate".equals(messageType)) {
+            setNeutral(
+                "Socket active",
+                "Received " + messageType + " while waiting for the first sidecar update.");
+            return;
+          }
+          SidecarWaveletUpdateSummary summary = SidecarTransportCodec.decodeWaveletUpdate(payload);
+          waitingForUpdate = false;
+          setSuccess(
+              "Sidecar transport proof passed",
+              "Wavelet "
+                  + summary.getWaveletName()
+                  + " delivered "
+                  + summary.getAppliedDeltaCount()
+                  + " delta payload(s)"
+                  + (summary.getChannelId() == null ? "" : " on " + summary.getChannelId())
+                  + ".");
+          closeSocket();
+        } catch (RuntimeException e) {
+          waitingForUpdate = false;
+          setError(
+              "Malformed sidecar message",
+              "The isolated sidecar sent an unexpected or invalid socket frame: "
+                  + e.getMessage());
+          closeSocket();
         }
-        SidecarWaveletUpdateSummary summary = SidecarTransportCodec.decodeWaveletUpdate(payload);
-        waitingForUpdate = false;
-        setSuccess(
-            "Sidecar transport proof passed",
-            "Wavelet "
-                + summary.getWaveletName()
-                + " delivered "
-                + summary.getAppliedDeltaCount()
-                + " delta payload(s)"
-                + (summary.getChannelId() == null ? "" : " on " + summary.getChannelId())
-                + ".");
-        closeSocket();
       };
       socket.onerror = event -> {
         setError("Socket error", "The isolated sidecar failed while talking to /socket.");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
@@ -32,9 +32,10 @@ public final class SidecarSearchResponse {
       this.lastModified = lastModified;
       this.unreadCount = unreadCount;
       this.blipCount = blipCount;
-      this.participants = participants == null
-          ? Collections.<String>emptyList()
-          : Collections.unmodifiableList(new ArrayList<>(participants));
+      this.participants =
+          participants == null
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableList(new ArrayList<>(participants));
       this.author = author;
       this.pinned = pinned;
     }
@@ -83,9 +84,10 @@ public final class SidecarSearchResponse {
   public SidecarSearchResponse(String query, int totalResults, List<Digest> digests) {
     this.query = query;
     this.totalResults = totalResults;
-    this.digests = digests == null
-        ? Collections.<Digest>emptyList()
-        : Collections.unmodifiableList(new ArrayList<>(digests));
+    this.digests =
+        digests == null
+            ? Collections.<Digest>emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(digests));
   }
 
   public String getQuery() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
@@ -1,0 +1,97 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class SidecarSearchResponse {
+  public static final class Digest {
+    private final String title;
+    private final String snippet;
+    private final String waveId;
+    private final long lastModified;
+    private final int unreadCount;
+    private final int blipCount;
+    private final List<String> participants;
+    private final String author;
+    private final boolean pinned;
+
+    public Digest(
+        String title,
+        String snippet,
+        String waveId,
+        long lastModified,
+        int unreadCount,
+        int blipCount,
+        List<String> participants,
+        String author,
+        boolean pinned) {
+      this.title = title;
+      this.snippet = snippet;
+      this.waveId = waveId;
+      this.lastModified = lastModified;
+      this.unreadCount = unreadCount;
+      this.blipCount = blipCount;
+      this.participants = participants;
+      this.author = author;
+      this.pinned = pinned;
+    }
+
+    public String getTitle() {
+      return title;
+    }
+
+    public String getSnippet() {
+      return snippet;
+    }
+
+    public String getWaveId() {
+      return waveId;
+    }
+
+    public long getLastModified() {
+      return lastModified;
+    }
+
+    public int getUnreadCount() {
+      return unreadCount;
+    }
+
+    public int getBlipCount() {
+      return blipCount;
+    }
+
+    public List<String> getParticipants() {
+      return participants;
+    }
+
+    public String getAuthor() {
+      return author;
+    }
+
+    public boolean isPinned() {
+      return pinned;
+    }
+  }
+
+  private final String query;
+  private final int totalResults;
+  private final List<Digest> digests;
+
+  public SidecarSearchResponse(String query, int totalResults, List<Digest> digests) {
+    this.query = query;
+    this.totalResults = totalResults;
+    this.digests = Collections.unmodifiableList(digests);
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public int getTotalResults() {
+    return totalResults;
+  }
+
+  public List<Digest> getDigests() {
+    return digests;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java
@@ -1,5 +1,6 @@
 package org.waveprotocol.box.j2cl.search;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,7 +32,9 @@ public final class SidecarSearchResponse {
       this.lastModified = lastModified;
       this.unreadCount = unreadCount;
       this.blipCount = blipCount;
-      this.participants = participants;
+      this.participants = participants == null
+          ? Collections.<String>emptyList()
+          : Collections.unmodifiableList(new ArrayList<>(participants));
       this.author = author;
       this.pinned = pinned;
     }
@@ -80,7 +83,9 @@ public final class SidecarSearchResponse {
   public SidecarSearchResponse(String query, int totalResults, List<Digest> digests) {
     this.query = query;
     this.totalResults = totalResults;
-    this.digests = Collections.unmodifiableList(digests);
+    this.digests = digests == null
+        ? Collections.<Digest>emptyList()
+        : Collections.unmodifiableList(new ArrayList<>(digests));
   }
 
   public String getQuery() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
@@ -1,0 +1,19 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarOpenRequest {
+  private final String participantId;
+  private final String waveId;
+
+  public SidecarOpenRequest(String participantId, String waveId) {
+    this.participantId = participantId;
+    this.waveId = waveId;
+  }
+
+  public String getParticipantId() {
+    return participantId;
+  }
+
+  public String getWaveId() {
+    return waveId;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
@@ -1,12 +1,21 @@
 package org.waveprotocol.box.j2cl.transport;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public final class SidecarOpenRequest {
   private final String participantId;
   private final String waveId;
+  private final List<String> waveletIdPrefixes;
 
-  public SidecarOpenRequest(String participantId, String waveId) {
+  public SidecarOpenRequest(String participantId, String waveId, List<String> waveletIdPrefixes) {
     this.participantId = participantId;
     this.waveId = waveId;
+    this.waveletIdPrefixes =
+        waveletIdPrefixes == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(waveletIdPrefixes));
   }
 
   public String getParticipantId() {
@@ -15,5 +24,9 @@ public final class SidecarOpenRequest {
 
   public String getWaveId() {
     return waveId;
+  }
+
+  public List<String> getWaveletIdPrefixes() {
+    return waveletIdPrefixes;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -21,10 +21,21 @@ public final class SidecarSessionBootstrap {
     if (sessionMarker < 0) {
       throw new IllegalArgumentException("Root page did not expose window.__session");
     }
-    int objectStart = html.indexOf('{', sessionMarker);
-    if (objectStart < 0) {
+    int assignIdx = sessionMarker + "__session".length();
+    while (assignIdx < html.length() && Character.isWhitespace(html.charAt(assignIdx))) {
+      assignIdx++;
+    }
+    if (assignIdx >= html.length() || html.charAt(assignIdx) != '=') {
+      throw new IllegalArgumentException("Unable to locate __session assignment operator");
+    }
+    assignIdx++;
+    while (assignIdx < html.length() && Character.isWhitespace(html.charAt(assignIdx))) {
+      assignIdx++;
+    }
+    if (assignIdx >= html.length() || html.charAt(assignIdx) != '{') {
       throw new IllegalArgumentException("Unable to locate __session JSON object");
     }
+    int objectStart = assignIdx;
     int objectEnd = findMatchingBrace(html, objectStart);
     Map<String, Object> session =
         SidecarTransportCodec.parseJsonObject(html.substring(objectStart, objectEnd + 1));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -1,0 +1,67 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.Map;
+
+public final class SidecarSessionBootstrap {
+  private final String address;
+
+  public SidecarSessionBootstrap(String address) {
+    this.address = address;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public static SidecarSessionBootstrap fromRootHtml(String html) {
+    int sessionMarker = html.indexOf("__session");
+    if (sessionMarker < 0) {
+      throw new IllegalArgumentException("Root page did not expose window.__session");
+    }
+    int objectStart = html.indexOf('{', sessionMarker);
+    if (objectStart < 0) {
+      throw new IllegalArgumentException("Unable to locate __session JSON object");
+    }
+    int objectEnd = findMatchingBrace(html, objectStart);
+    Map<String, Object> session =
+        SidecarTransportCodec.parseJsonObject(html.substring(objectStart, objectEnd + 1));
+    String address = String.valueOf(session.get("address"));
+    if (address == null || "null".equals(address) || address.isEmpty()) {
+      throw new IllegalArgumentException("Session bootstrap did not include an address");
+    }
+    return new SidecarSessionBootstrap(address);
+  }
+
+  private static int findMatchingBrace(String html, int objectStart) {
+    boolean inString = false;
+    boolean escaped = false;
+    int depth = 0;
+    for (int i = objectStart; i < html.length(); i++) {
+      char c = html.charAt(i);
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (c == '\\') {
+        escaped = true;
+        continue;
+      }
+      if (c == '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) {
+        continue;
+      }
+      if (c == '{') {
+        depth++;
+      } else if (c == '}') {
+        depth--;
+        if (depth == 0) {
+          return i;
+        }
+      }
+    }
+    throw new IllegalArgumentException("Unterminated __session JSON object");
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -14,6 +14,9 @@ public final class SidecarSessionBootstrap {
   }
 
   public static SidecarSessionBootstrap fromRootHtml(String html) {
+    if (html == null) {
+      throw new IllegalArgumentException("Root HTML must not be null");
+    }
     int sessionMarker = html.indexOf("__session");
     if (sessionMarker < 0) {
       throw new IllegalArgumentException("Root page did not expose window.__session");
@@ -26,10 +29,10 @@ public final class SidecarSessionBootstrap {
     Map<String, Object> session =
         SidecarTransportCodec.parseJsonObject(html.substring(objectStart, objectEnd + 1));
     Object addressValue = session.get("address");
-    if (addressValue == null) {
+    if (!(addressValue instanceof String)) {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
-    String address = String.valueOf(addressValue);
+    String address = ((String) addressValue).trim();
     if (address.isEmpty()) {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -4,13 +4,19 @@ import java.util.Map;
 
 public final class SidecarSessionBootstrap {
   private final String address;
+  private final String websocketAddress;
 
-  public SidecarSessionBootstrap(String address) {
+  public SidecarSessionBootstrap(String address, String websocketAddress) {
     this.address = address;
+    this.websocketAddress = websocketAddress;
   }
 
   public String getAddress() {
     return address;
+  }
+
+  public String getWebSocketAddress() {
+    return websocketAddress;
   }
 
   public static SidecarSessionBootstrap fromRootHtml(String html) {
@@ -47,7 +53,36 @@ public final class SidecarSessionBootstrap {
     if ("null".equals(address) || address.isEmpty()) {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
-    return new SidecarSessionBootstrap(address);
+    String websocketAddress = parseWebSocketAddress(html);
+    return new SidecarSessionBootstrap(address, websocketAddress);
+  }
+
+  private static String parseWebSocketAddress(String html) {
+    int marker = html.indexOf("__websocket_address");
+    if (marker < 0) {
+      throw new IllegalArgumentException("Root page did not expose window.__websocket_address");
+    }
+    int assignIdx = marker + "__websocket_address".length();
+    while (assignIdx < html.length() && Character.isWhitespace(html.charAt(assignIdx))) {
+      assignIdx++;
+    }
+    if (assignIdx >= html.length() || html.charAt(assignIdx) != '=') {
+      throw new IllegalArgumentException("Unable to locate __websocket_address assignment operator");
+    }
+    assignIdx++;
+    while (assignIdx < html.length() && Character.isWhitespace(html.charAt(assignIdx))) {
+      assignIdx++;
+    }
+    if (assignIdx >= html.length() || html.charAt(assignIdx) != '"') {
+      throw new IllegalArgumentException("Root page did not expose a websocket address string");
+    }
+    int stringEnd = findMatchingStringQuote(html, assignIdx);
+    String websocketAddress =
+        SidecarTransportCodec.parseJsonString(html.substring(assignIdx, stringEnd + 1)).trim();
+    if ("null".equals(websocketAddress) || websocketAddress.isEmpty()) {
+      throw new IllegalArgumentException("Root page did not expose a websocket address");
+    }
+    return websocketAddress;
   }
 
   private static int findMatchingBrace(String html, int objectStart) {
@@ -81,5 +116,24 @@ public final class SidecarSessionBootstrap {
       }
     }
     throw new IllegalArgumentException("Unterminated __session JSON object");
+  }
+
+  private static int findMatchingStringQuote(String html, int stringStart) {
+    boolean escaped = false;
+    for (int i = stringStart + 1; i < html.length(); i++) {
+      char c = html.charAt(i);
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (c == '\\') {
+        escaped = true;
+        continue;
+      }
+      if (c == '"') {
+        return i;
+      }
+    }
+    throw new IllegalArgumentException("Unterminated __websocket_address string");
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -25,8 +25,12 @@ public final class SidecarSessionBootstrap {
     int objectEnd = findMatchingBrace(html, objectStart);
     Map<String, Object> session =
         SidecarTransportCodec.parseJsonObject(html.substring(objectStart, objectEnd + 1));
-    String address = String.valueOf(session.get("address"));
-    if (address == null || "null".equals(address) || address.isEmpty()) {
+    Object addressValue = session.get("address");
+    if (addressValue == null) {
+      throw new IllegalArgumentException("Session bootstrap did not include an address");
+    }
+    String address = String.valueOf(addressValue);
+    if (address.isEmpty()) {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
     return new SidecarSessionBootstrap(address);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -33,7 +33,7 @@ public final class SidecarSessionBootstrap {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
     String address = ((String) addressValue).trim();
-    if (address.isEmpty()) {
+    if ("null".equals(address) || address.isEmpty()) {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
     return new SidecarSessionBootstrap(address);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -115,7 +115,10 @@ public final class SidecarTransportCodec {
   }
 
   public static Map<String, Object> parseJsonObject(String json) {
-    return asObject(new JsonParser(json).parseValue());
+    JsonParser parser = new JsonParser(json);
+    Map<String, Object> result = asObject(parser.parseValue());
+    parser.ensureFullyConsumed();
+    return result;
   }
 
   private static Map<String, Object> asObject(Object value) {
@@ -251,6 +254,7 @@ public final class SidecarTransportCodec {
           return object;
         }
         expect(',');
+        skipWhitespace();
       }
     }
 
@@ -270,6 +274,7 @@ public final class SidecarTransportCodec {
           return values;
         }
         expect(',');
+        skipWhitespace();
       }
     }
 
@@ -403,6 +408,13 @@ public final class SidecarTransportCodec {
         throw new IllegalArgumentException("Expected '" + c + "' at index " + index);
       }
       index++;
+    }
+
+    void ensureFullyConsumed() {
+      skipWhitespace();
+      if (index != json.length()) {
+        throw new IllegalArgumentException("Unexpected trailing content at index " + index);
+      }
     }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -19,13 +19,23 @@ public final class SidecarTransportCodec {
   }
 
   public static String encodeOpenEnvelope(int sequenceNumber, SidecarOpenRequest request) {
-    return "{\"sequenceNumber\":"
-        + sequenceNumber
-        + ",\"messageType\":\"ProtocolOpenRequest\",\"message\":{\"1\":\""
-        + escapeJson(request.getParticipantId())
-        + "\",\"2\":\""
-        + escapeJson(request.getWaveId())
-        + "\"}}";
+    StringBuilder json = new StringBuilder(128);
+    json.append("{\"sequenceNumber\":")
+        .append(sequenceNumber)
+        .append(",\"messageType\":\"ProtocolOpenRequest\",\"message\":{\"1\":\"")
+        .append(escapeJson(request.getParticipantId()))
+        .append("\",\"2\":\"")
+        .append(escapeJson(request.getWaveId()))
+        .append("\",\"3\":[");
+    List<String> prefixes = request.getWaveletIdPrefixes();
+    for (int i = 0; i < prefixes.size(); i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append('"').append(escapeJson(prefixes.get(i))).append('"');
+    }
+    json.append("]}}");
+    return json.toString();
   }
 
   public static SidecarSearchResponse decodeSearchResponse(String json) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -1,0 +1,382 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
+
+public final class SidecarTransportCodec {
+  private SidecarTransportCodec() {
+  }
+
+  public static String encodeAuthenticateEnvelope(int sequenceNumber, String token) {
+    return "{\"sequenceNumber\":"
+        + sequenceNumber
+        + ",\"messageType\":\"ProtocolAuthenticate\",\"message\":{\"1\":\""
+        + escapeJson(token)
+        + "\"}}";
+  }
+
+  public static String encodeOpenEnvelope(int sequenceNumber, SidecarOpenRequest request) {
+    return "{\"sequenceNumber\":"
+        + sequenceNumber
+        + ",\"messageType\":\"ProtocolOpenRequest\",\"message\":{\"1\":\""
+        + escapeJson(request.getParticipantId())
+        + "\",\"2\":\""
+        + escapeJson(request.getWaveId())
+        + "\"}}";
+  }
+
+  public static SidecarSearchResponse decodeSearchResponse(String json) {
+    Map<String, Object> root = parseJsonObject(json);
+    List<SidecarSearchResponse.Digest> digests = new ArrayList<>();
+    Object digestValue = root.get("3");
+    if (digestValue != null) {
+      for (Object rawDigest : asList(digestValue)) {
+        Map<String, Object> digest = asObject(rawDigest);
+        digests.add(
+            new SidecarSearchResponse.Digest(
+                getString(digest, "1"),
+                getString(digest, "2"),
+                getString(digest, "3"),
+                getLong(digest, "4"),
+                getInt(digest, "5"),
+                getInt(digest, "6"),
+                getStringList(digest, "7"),
+                getString(digest, "8"),
+                getBoolean(digest, "9")));
+      }
+    }
+    return new SidecarSearchResponse(getString(root, "1"), getInt(root, "2"), digests);
+  }
+
+  public static SidecarWaveletUpdateSummary decodeWaveletUpdate(String json) {
+    Map<String, Object> envelope = parseJsonObject(json);
+    Map<String, Object> payload = asObject(envelope.get("message"));
+    return new SidecarWaveletUpdateSummary(
+        getInt(envelope, "sequenceNumber"),
+        getString(payload, "1"),
+        getArrayLength(payload.get("2")),
+        getBoolean(payload, "6"),
+        getString(payload, "7"));
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          escaped.append("\\\"");
+          break;
+        case '\\':
+          escaped.append("\\\\");
+          break;
+        case '\b':
+          escaped.append("\\b");
+          break;
+        case '\f':
+          escaped.append("\\f");
+          break;
+        case '\n':
+          escaped.append("\\n");
+          break;
+        case '\r':
+          escaped.append("\\r");
+          break;
+        case '\t':
+          escaped.append("\\t");
+          break;
+        default:
+          if (c < 0x20) {
+            escaped.append("\\u");
+            appendHex4(escaped, c);
+          } else {
+            escaped.append(c);
+          }
+      }
+    }
+    return escaped.toString();
+  }
+
+  public static String decodeMessageType(String json) {
+    return getString(parseJsonObject(json), "messageType");
+  }
+
+  public static Map<String, Object> parseJsonObject(String json) {
+    return asObject(new JsonParser(json).parseValue());
+  }
+
+  private static Map<String, Object> asObject(Object value) {
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException("Expected object but got " + value);
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> object = (Map<String, Object>) value;
+    return object;
+  }
+
+  private static List<Object> asList(Object value) {
+    if (!(value instanceof List)) {
+      throw new IllegalArgumentException("Expected array but got " + value);
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) value;
+    return list;
+  }
+
+  private static String getString(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private static int getInt(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value == null ? 0 : ((Number) value).intValue();
+  }
+
+  private static boolean getBoolean(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value != null && Boolean.TRUE.equals(value);
+  }
+
+  private static long getLong(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (value == null) {
+      return 0L;
+    }
+    List<Object> words = asList(value);
+    int lowWord = ((Number) words.get(0)).intValue();
+    int highWord = ((Number) words.get(1)).intValue();
+    return toLong(highWord, lowWord);
+  }
+
+  private static List<String> getStringList(Map<String, Object> object, String key) {
+    List<String> values = new ArrayList<>();
+    Object value = object.get(key);
+    if (value == null) {
+      return values;
+    }
+    for (Object rawValue : asList(value)) {
+      values.add(String.valueOf(rawValue));
+    }
+    return values;
+  }
+
+  private static int getArrayLength(Object value) {
+    if (value == null) {
+      return 0;
+    }
+    return asList(value).size();
+  }
+
+  private static long toLong(int highWord, int lowWord) {
+    long value = lowWord;
+    if (!((highWord == 0 && lowWord > 0) || (highWord == -1 && lowWord < 0))) {
+      value &= 0xFFFFFFFFL;
+      value |= ((long) highWord) << 32;
+    }
+    return value;
+  }
+
+  private static void appendHex4(StringBuilder out, int value) {
+    out.append(hexDigit((value >> 12) & 0xF));
+    out.append(hexDigit((value >> 8) & 0xF));
+    out.append(hexDigit((value >> 4) & 0xF));
+    out.append(hexDigit(value & 0xF));
+  }
+
+  private static char hexDigit(int value) {
+    return (char) (value < 10 ? ('0' + value) : ('a' + (value - 10)));
+  }
+
+  private static final class JsonParser {
+    private final String json;
+    private int index;
+
+    JsonParser(String json) {
+      this.json = json;
+    }
+
+    Object parseValue() {
+      skipWhitespace();
+      if (index >= json.length()) {
+        throw new IllegalArgumentException("Unexpected end of JSON input");
+      }
+      char c = json.charAt(index);
+      switch (c) {
+        case '{':
+          return parseObjectValue();
+        case '[':
+          return parseArrayValue();
+        case '"':
+          return parseStringValue();
+        case 't':
+        case 'f':
+          return parseBooleanValue();
+        case 'n':
+          return parseNullValue();
+        default:
+          return parseNumberValue();
+      }
+    }
+
+    private Map<String, Object> parseObjectValue() {
+      expect('{');
+      Map<String, Object> object = new LinkedHashMap<>();
+      skipWhitespace();
+      if (peek('}')) {
+        index++;
+        return object;
+      }
+      while (true) {
+        String key = parseStringValue();
+        skipWhitespace();
+        expect(':');
+        object.put(key, parseValue());
+        skipWhitespace();
+        if (peek('}')) {
+          index++;
+          return object;
+        }
+        expect(',');
+      }
+    }
+
+    private List<Object> parseArrayValue() {
+      expect('[');
+      List<Object> values = new ArrayList<>();
+      skipWhitespace();
+      if (peek(']')) {
+        index++;
+        return values;
+      }
+      while (true) {
+        values.add(parseValue());
+        skipWhitespace();
+        if (peek(']')) {
+          index++;
+          return values;
+        }
+        expect(',');
+      }
+    }
+
+    private String parseStringValue() {
+      expect('"');
+      StringBuilder value = new StringBuilder();
+      while (index < json.length()) {
+        char c = json.charAt(index++);
+        if (c == '"') {
+          return value.toString();
+        }
+        if (c != '\\') {
+          value.append(c);
+          continue;
+        }
+        if (index >= json.length()) {
+          throw new IllegalArgumentException("Invalid escape at end of string");
+        }
+        char escaped = json.charAt(index++);
+        switch (escaped) {
+          case '"':
+          case '\\':
+          case '/':
+            value.append(escaped);
+            break;
+          case 'b':
+            value.append('\b');
+            break;
+          case 'f':
+            value.append('\f');
+            break;
+          case 'n':
+            value.append('\n');
+            break;
+          case 'r':
+            value.append('\r');
+            break;
+          case 't':
+            value.append('\t');
+            break;
+          case 'u':
+            value.append((char) Integer.parseInt(json.substring(index, index + 4), 16));
+            index += 4;
+            break;
+          default:
+            throw new IllegalArgumentException("Unsupported escape: \\" + escaped);
+        }
+      }
+      throw new IllegalArgumentException("Unterminated string");
+    }
+
+    private Boolean parseBooleanValue() {
+      if (json.startsWith("true", index)) {
+        index += 4;
+        return Boolean.TRUE;
+      }
+      if (json.startsWith("false", index)) {
+        index += 5;
+        return Boolean.FALSE;
+      }
+      throw new IllegalArgumentException("Invalid boolean at index " + index);
+    }
+
+    private Object parseNullValue() {
+      if (!json.startsWith("null", index)) {
+        throw new IllegalArgumentException("Invalid null at index " + index);
+      }
+      index += 4;
+      return null;
+    }
+
+    private Number parseNumberValue() {
+      int start = index;
+      if (peek('-')) {
+        index++;
+      }
+      while (index < json.length() && Character.isDigit(json.charAt(index))) {
+        index++;
+      }
+      boolean isFractional = false;
+      if (peek('.')) {
+        isFractional = true;
+        index++;
+        while (index < json.length() && Character.isDigit(json.charAt(index))) {
+          index++;
+        }
+      }
+      if (peek('e') || peek('E')) {
+        isFractional = true;
+        index++;
+        if (peek('+') || peek('-')) {
+          index++;
+        }
+        while (index < json.length() && Character.isDigit(json.charAt(index))) {
+          index++;
+        }
+      }
+      String raw = json.substring(start, index);
+      return isFractional ? Double.valueOf(raw) : Long.valueOf(raw);
+    }
+
+    private void skipWhitespace() {
+      while (index < json.length() && Character.isWhitespace(json.charAt(index))) {
+        index++;
+      }
+    }
+
+    private boolean peek(char c) {
+      return index < json.length() && json.charAt(index) == c;
+    }
+
+    private void expect(char c) {
+      skipWhitespace();
+      if (!peek(c)) {
+        throw new IllegalArgumentException("Expected '" + c + "' at index " + index);
+      }
+      index++;
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -121,6 +121,16 @@ public final class SidecarTransportCodec {
     return result;
   }
 
+  public static String parseJsonString(String json) {
+    JsonParser parser = new JsonParser(json);
+    Object value = parser.parseValue();
+    parser.ensureFullyConsumed();
+    if (!(value instanceof String)) {
+      throw new IllegalArgumentException("Expected string but got " + value);
+    }
+    return (String) value;
+  }
+
   private static Map<String, Object> asObject(Object value) {
     if (!(value instanceof Map)) {
       throw new IllegalArgumentException("Expected object but got " + value);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -301,17 +301,30 @@ public final class SidecarTransportCodec {
             value.append('\t');
             break;
           case 'u':
-            if (index + 4 > json.length()) {
-              throw new IllegalArgumentException("Incomplete unicode escape at index " + (index - 2));
-            }
-            value.append((char) Integer.parseInt(json.substring(index, index + 4), 16));
-            index += 4;
+            value.append(parseUnicodeEscape());
             break;
           default:
             throw new IllegalArgumentException("Unsupported escape: \\" + escaped);
         }
       }
       throw new IllegalArgumentException("Unterminated string");
+    }
+
+    private char parseUnicodeEscape() {
+      int escapeStart = index - 2;
+      if (index + 4 > json.length()) {
+        throw new IllegalArgumentException("Invalid unicode escape at index " + escapeStart);
+      }
+      int unicode = 0;
+      for (int i = 0; i < 4; i++) {
+        int digit = Character.digit(json.charAt(index + i), 16);
+        if (digit < 0) {
+          throw new IllegalArgumentException("Invalid unicode escape at index " + escapeStart);
+        }
+        unicode = (unicode << 4) + digit;
+      }
+      index += 4;
+      return (char) unicode;
     }
 
     private Boolean parseBooleanValue() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -301,6 +301,9 @@ public final class SidecarTransportCodec {
             value.append('\t');
             break;
           case 'u':
+            if (index + 4 > json.length()) {
+              throw new IllegalArgumentException("Incomplete unicode escape at index " + (index - 2));
+            }
             value.append((char) Integer.parseInt(json.substring(index, index + 4), 16));
             index += 4;
             break;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarWaveletUpdateSummary.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarWaveletUpdateSummary.java
@@ -1,0 +1,38 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarWaveletUpdateSummary {
+  private final int sequenceNumber;
+  private final String waveletName;
+  private final int appliedDeltaCount;
+  private final boolean marker;
+  private final String channelId;
+
+  public SidecarWaveletUpdateSummary(
+      int sequenceNumber, String waveletName, int appliedDeltaCount, boolean marker, String channelId) {
+    this.sequenceNumber = sequenceNumber;
+    this.waveletName = waveletName;
+    this.appliedDeltaCount = appliedDeltaCount;
+    this.marker = marker;
+    this.channelId = channelId;
+  }
+
+  public int getSequenceNumber() {
+    return sequenceNumber;
+  }
+
+  public String getWaveletName() {
+    return waveletName;
+  }
+
+  public int getAppliedDeltaCount() {
+    return appliedDeltaCount;
+  }
+
+  public boolean hasMarker() {
+    return marker;
+  }
+
+  public String getChannelId() {
+    return channelId;
+  }
+}

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -52,3 +52,62 @@ body {
   margin-top: 12px;
   color: #4f6480;
 }
+
+.sidecar-proof-label {
+  margin: 28px 0 8px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #6b7f98;
+}
+
+.sidecar-proof-status,
+.sidecar-proof-meta {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.sidecar-proof-status {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #10233b;
+}
+
+.sidecar-proof-meta {
+  margin-top: 8px;
+  color: #4f6480;
+}
+
+.sidecar-proof-status-success {
+  color: #157347;
+}
+
+.sidecar-proof-meta-success {
+  color: #215f3f;
+}
+
+.sidecar-proof-status-error {
+  color: #b42318;
+}
+
+.sidecar-proof-meta-error {
+  color: #8f2d22;
+}
+
+.sidecar-proof-action {
+  margin-top: 18px;
+  border: 0;
+  border-radius: 999px;
+  background: #10233b;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 12px 18px;
+}
+
+.sidecar-proof-action:hover,
+.sidecar-proof-action:focus {
+  background: #173355;
+}

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -56,10 +56,24 @@
         }
       }
 
+      function resolveEntryPoint() {
+        if (window.WaveSandboxEntryPoint && window.WaveSandboxEntryPoint.mount) {
+          return window.WaveSandboxEntryPoint;
+        }
+        if (window.goog && window.goog.module && window.goog.module.get) {
+          var entryPoint = window.goog.module.get("WaveSandboxEntryPoint");
+          if (entryPoint && entryPoint.mount) {
+            window.WaveSandboxEntryPoint = entryPoint;
+            return entryPoint;
+          }
+        }
+        return null;
+      }
 
       function mountWhenReady(attemptsRemaining) {
-        if (window.WaveSandboxEntryPoint && window.WaveSandboxEntryPoint.mount) {
-          window.WaveSandboxEntryPoint.mount("sidecar-root", detectMode(window.location.pathname));
+        var entryPoint = resolveEntryPoint();
+        if (entryPoint) {
+          entryPoint.mount("sidecar-root", detectMode(window.location.pathname));
           return;
         }
         if (attemptsRemaining > 0) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -43,15 +43,13 @@ public class SandboxBuildSmokeTest {
   }
 
   @Test
-  public void shouldHandleAsyncCallbackRejectsStaleGenerations() {
-    Assert.assertTrue(SandboxEntryPoint.shouldHandleAsyncCallback(4, 4));
-    Assert.assertFalse(SandboxEntryPoint.shouldHandleAsyncCallback(3, 4));
-  }
+  public void dummyChannelUpdateIsNotTreatedAsRealWaveletProof() {
+    SandboxEntryPoint.SocketFrameResult result =
+        SandboxEntryPoint.evaluateSocketFrame(
+            "{\"sequenceNumber\":3,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+                + "\"1\":\"local.net/w+abc/~/dummy+root\",\"2\":[],\"6\":true,\"7\":\"ch1\"}}");
 
-  @Test
-  public void shouldHandleSocketCallbackRejectsStaleSockets() {
-    Assert.assertTrue(SandboxEntryPoint.shouldHandleSocketCallback(4, 4, true));
-    Assert.assertFalse(SandboxEntryPoint.shouldHandleSocketCallback(4, 4, false));
-    Assert.assertFalse(SandboxEntryPoint.shouldHandleSocketCallback(3, 4, true));
+    Assert.assertFalse(result.isError());
+    Assert.assertTrue(SandboxEntryPoint.isChannelEstablishmentUpdate(result.getSummary()));
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -41,4 +41,17 @@ public class SandboxBuildSmokeTest {
     Assert.assertEquals(
         "example.com!conv+root/example.com!conv+root", result.getSummary().getWaveletName());
   }
+
+  @Test
+  public void shouldHandleAsyncCallbackRejectsStaleGenerations() {
+    Assert.assertTrue(SandboxEntryPoint.shouldHandleAsyncCallback(4, 4));
+    Assert.assertFalse(SandboxEntryPoint.shouldHandleAsyncCallback(3, 4));
+  }
+
+  @Test
+  public void shouldHandleSocketCallbackRejectsStaleSockets() {
+    Assert.assertTrue(SandboxEntryPoint.shouldHandleSocketCallback(4, 4, true));
+    Assert.assertFalse(SandboxEntryPoint.shouldHandleSocketCallback(4, 4, false));
+    Assert.assertFalse(SandboxEntryPoint.shouldHandleSocketCallback(3, 4, true));
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -16,4 +16,29 @@ public class SandboxBuildSmokeTest {
         "Profile sidecar writes isolated assets without changing the root runtime bootstrap.",
         SandboxEntryPoint.renderSummary("  "));
   }
+
+  @Test
+  public void evaluateSocketFrameReportsMalformedMessages() {
+    SandboxEntryPoint.SocketFrameResult result =
+        SandboxEntryPoint.evaluateSocketFrame(
+            "{\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{");
+
+    Assert.assertTrue(result.isError());
+    Assert.assertTrue(result.getErrorDetail().contains("unexpected or invalid socket frame"));
+    Assert.assertNull(result.getSummary());
+  }
+
+  @Test
+  public void evaluateSocketFrameDecodesWaveletUpdates() {
+    SandboxEntryPoint.SocketFrameResult result =
+        SandboxEntryPoint.evaluateSocketFrame(
+            "{\"sequenceNumber\":11,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+                + "\"1\":\"example.com!conv+root/example.com!conv+root\","
+                + "\"2\":[{\"1\":\"delta\"}],\"6\":true,\"7\":\"chan-1\"}}");
+
+    Assert.assertFalse(result.isError());
+    Assert.assertEquals("ProtocolWaveletUpdate", result.getMessageType());
+    Assert.assertEquals(
+        "example.com!conv+root/example.com!conv+root", result.getSummary().getWaveletName());
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -52,4 +52,14 @@ public class SandboxBuildSmokeTest {
     Assert.assertFalse(result.isError());
     Assert.assertTrue(SandboxEntryPoint.isChannelEstablishmentUpdate(result.getSummary()));
   }
+
+  @Test
+  public void buildWebSocketUrlUsesPresentedAddress() {
+    Assert.assertEquals(
+        "wss://socket.example.test:7443/socket",
+        SandboxEntryPoint.buildWebSocketUrl("https:", "socket.example.test:7443"));
+    Assert.assertEquals(
+        "ws://socket.example.test/socket",
+        SandboxEntryPoint.buildWebSocketUrl("http:", "socket.example.test"));
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponseTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponseTest.java
@@ -1,0 +1,49 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(SidecarSearchResponseTest.class)
+public class SidecarSearchResponseTest {
+  @Test
+  public void constructorDefensivelyCopiesDigestAndParticipantLists() {
+    List<String> participants = new ArrayList<>();
+    participants.add("user@example.com");
+    SidecarSearchResponse.Digest digest =
+        new SidecarSearchResponse.Digest(
+            "Inbox wave",
+            "Snippet",
+            "example.com/w+abc123",
+            12345L,
+            2,
+            4,
+            participants,
+            "user@example.com",
+            true);
+    List<SidecarSearchResponse.Digest> digests = new ArrayList<>();
+    digests.add(digest);
+
+    SidecarSearchResponse response = new SidecarSearchResponse("in:inbox", 1, digests);
+
+    participants.add("teammate@example.com");
+    digests.clear();
+
+    Assert.assertEquals(1, response.getDigests().size());
+    Assert.assertEquals(1, response.getDigests().get(0).getParticipants().size());
+    try {
+      response.getDigests().add(digest);
+      Assert.fail("Expected digests view to stay immutable");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+    try {
+      response.getDigests().get(0).getParticipants().add("third@example.com");
+      Assert.fail("Expected participants view to stay immutable");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.transport;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
@@ -20,16 +21,14 @@ public class SidecarTransportCodecTest {
   public void encodeOpenEnvelopeUsesGeneratedNumericFieldKeys() {
     SidecarOpenRequest request =
         new SidecarOpenRequest(
-            "user@example.com",
-            "example.com/w+abc123",
-            java.util.Collections.singletonList("example.com!conv+root"));
+            "user@example.com", "example.com/w+abc123", Arrays.asList("conv+root"));
 
     String json = SidecarTransportCodec.encodeOpenEnvelope(8, request);
 
     Assert.assertTrue(json.contains("\"messageType\":\"ProtocolOpenRequest\""));
     Assert.assertTrue(json.contains("\"1\":\"user@example.com\""));
     Assert.assertTrue(json.contains("\"2\":\"example.com/w+abc123\""));
-    Assert.assertTrue(json.contains("\"3\":[\"example.com!conv+root\"]"));
+    Assert.assertTrue(json.contains("\"3\":[\"conv+root\"]"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -71,4 +71,33 @@ public class SidecarTransportCodecTest {
 
     Assert.assertEquals("user@example.com", bootstrap.getAddress());
   }
+
+  @Test
+  public void extractSessionBootstrapRejectsMissingAddress() {
+    String html = "<html><script>window.__session={\"id\":\"abc\"};</script></html>";
+
+    try {
+      SidecarSessionBootstrap.fromRootHtml(html);
+      Assert.fail("Expected missing address to be rejected");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("did not include an address"));
+    }
+  }
+
+  @Test
+  public void parseJsonObjectRejectsInvalidUnicodeEscapeSequences() {
+    try {
+      SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12\"}");
+      Assert.fail("Expected truncated unicode escape to fail");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("unicode escape"));
+    }
+
+    try {
+      SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12xz\"}");
+      Assert.fail("Expected non-hex unicode escape to fail");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("unicode escape"));
+    }
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -68,11 +68,13 @@ public class SidecarTransportCodecTest {
   public void extractSessionBootstrapAddressFromRootHtml() {
     String html =
         "<html><script>window.__session={\"address\":\"user@example.com\",\"id\":\"abc\"};"
+            + "window.__websocket_address=\"socket.example.test:7443\";"
             + "</script></html>";
 
     SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
 
     Assert.assertEquals("user@example.com", bootstrap.getAddress());
+    Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -19,13 +19,17 @@ public class SidecarTransportCodecTest {
   @Test
   public void encodeOpenEnvelopeUsesGeneratedNumericFieldKeys() {
     SidecarOpenRequest request =
-        new SidecarOpenRequest("user@example.com", "example.com/w+abc123");
+        new SidecarOpenRequest(
+            "user@example.com",
+            "example.com/w+abc123",
+            java.util.Collections.singletonList("example.com!conv+root"));
 
     String json = SidecarTransportCodec.encodeOpenEnvelope(8, request);
 
     Assert.assertTrue(json.contains("\"messageType\":\"ProtocolOpenRequest\""));
     Assert.assertTrue(json.contains("\"1\":\"user@example.com\""));
     Assert.assertTrue(json.contains("\"2\":\"example.com/w+abc123\""));
+    Assert.assertTrue(json.contains("\"3\":[\"example.com!conv+root\"]"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -78,29 +78,28 @@ public class SidecarTransportCodecTest {
   @Test
   public void extractSessionBootstrapRejectsMissingAddress() {
     String html = "<html><script>window.__session={\"id\":\"abc\"};</script></html>";
-
-    try {
-      SidecarSessionBootstrap.fromRootHtml(html);
-      Assert.fail("Expected missing address to be rejected");
-    } catch (IllegalArgumentException expected) {
-      Assert.assertTrue(expected.getMessage().contains("did not include an address"));
-    }
+    expectIllegalArgumentContains(
+        "did not include an address", () -> SidecarSessionBootstrap.fromRootHtml(html));
   }
 
   @Test
   public void parseJsonObjectRejectsInvalidUnicodeEscapeSequences() {
-    try {
-      SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12\"}");
-      Assert.fail("Expected truncated unicode escape to fail");
-    } catch (IllegalArgumentException expected) {
-      Assert.assertTrue(expected.getMessage().contains("unicode escape"));
-    }
+    expectIllegalArgumentContains(
+        "unicode escape",
+        () -> SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12\"}"));
+    expectIllegalArgumentContains(
+        "unicode escape",
+        () -> SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12xz\"}"));
+  }
 
+  private static void expectIllegalArgumentContains(String substring, Runnable action) {
     try {
-      SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12xz\"}");
-      Assert.fail("Expected non-hex unicode escape to fail");
+      action.run();
+      Assert.fail("Expected IllegalArgumentException containing: " + substring);
     } catch (IllegalArgumentException expected) {
-      Assert.assertTrue(expected.getMessage().contains("unicode escape"));
+      Assert.assertTrue(
+          "Expected message to contain \"" + substring + "\" but was: " + expected.getMessage(),
+          expected.getMessage().contains(substring));
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -1,0 +1,74 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
+
+@J2clTestInput(SidecarTransportCodecTest.class)
+public class SidecarTransportCodecTest {
+  @Test
+  public void encodeAuthenticateEnvelopePreservesLegacyWrapperShape() {
+    String json = SidecarTransportCodec.encodeAuthenticateEnvelope(7, "cookie-token");
+
+    Assert.assertTrue(json.contains("\"sequenceNumber\":7"));
+    Assert.assertTrue(json.contains("\"messageType\":\"ProtocolAuthenticate\""));
+    Assert.assertTrue(json.contains("\"message\":{\"1\":\"cookie-token\"}"));
+  }
+
+  @Test
+  public void encodeOpenEnvelopeUsesGeneratedNumericFieldKeys() {
+    SidecarOpenRequest request =
+        new SidecarOpenRequest("user@example.com", "example.com/w+abc123");
+
+    String json = SidecarTransportCodec.encodeOpenEnvelope(8, request);
+
+    Assert.assertTrue(json.contains("\"messageType\":\"ProtocolOpenRequest\""));
+    Assert.assertTrue(json.contains("\"1\":\"user@example.com\""));
+    Assert.assertTrue(json.contains("\"2\":\"example.com/w+abc123\""));
+  }
+
+  @Test
+  public void decodeSearchResponseReadsNumericKeysAndLongWords() {
+    String json =
+        "{\"1\":\"in:inbox\",\"2\":1,\"3\":[{\"1\":\"Inbox wave\",\"2\":\"Snippet\","
+            + "\"3\":\"example.com/w+abc123\",\"4\":[12345,0],\"5\":2,\"6\":4,"
+            + "\"7\":[\"user@example.com\"],\"8\":\"user@example.com\",\"9\":true}]}";
+
+    SidecarSearchResponse response = SidecarTransportCodec.decodeSearchResponse(json);
+
+    Assert.assertEquals("in:inbox", response.getQuery());
+    Assert.assertEquals(1, response.getTotalResults());
+    Assert.assertEquals(1, response.getDigests().size());
+    Assert.assertEquals("Inbox wave", response.getDigests().get(0).getTitle());
+    Assert.assertEquals(12345L, response.getDigests().get(0).getLastModified());
+    Assert.assertTrue(response.getDigests().get(0).isPinned());
+  }
+
+  @Test
+  public void decodeWaveletUpdateSummaryReadsEnvelopeAndPayload() {
+    String json =
+        "{\"sequenceNumber\":11,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"example.com!conv+root/example.com!conv+root\","
+            + "\"2\":[{\"1\":\"delta\"}],\"6\":true,\"7\":\"chan-1\"}}";
+
+    SidecarWaveletUpdateSummary summary = SidecarTransportCodec.decodeWaveletUpdate(json);
+
+    Assert.assertEquals(11, summary.getSequenceNumber());
+    Assert.assertEquals("example.com!conv+root/example.com!conv+root", summary.getWaveletName());
+    Assert.assertEquals(1, summary.getAppliedDeltaCount());
+    Assert.assertTrue(summary.hasMarker());
+    Assert.assertEquals("chan-1", summary.getChannelId());
+  }
+
+  @Test
+  public void extractSessionBootstrapAddressFromRootHtml() {
+    String html =
+        "<html><script>window.__session={\"address\":\"user@example.com\",\"id\":\"abc\"};"
+            + "</script></html>";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
+
+    Assert.assertEquals("user@example.com", bootstrap.getAddress());
+  }
+}

--- a/wave/config/changelog.d/2026-04-19-j2cl-sidecar-transport-proof.json
+++ b/wave/config/changelog.d/2026-04-19-j2cl-sidecar-transport-proof.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-19-j2cl-sidecar-transport-proof",
+  "version": "Unreleased",
+  "date": "2026-04-19",
+  "title": "Add an isolated J2CL sidecar transport proof",
+  "summary": "Keeps the legacy GWT webclient transport path unchanged while adding a sidecar-only transport/search proof that reuses the live root session, /search, and /socket under isolated J2CL routes.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a sidecar-only transport proof under the J2CL routes so the isolated sidecar can reuse the live root session bootstrap, call /search, and complete a /socket proof flow without cutting over the main webclient",
+        "Kept compileGwt and the staged legacy root path green while proving the isolated sidecar page and root page can both run against the same local server",
+        "Strengthened the PST transport-family contract test so the required impl/gson/jso/proto outputs stay present for the sidecar transport path"
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/pst/PstCodegenContractTest.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertTrue;
@@ -42,6 +44,25 @@ public class PstCodegenContractTest {
         "Expected at least one generated Java file under " + outDir.toAbsolutePath() +
             ", but found none.",
         javaCount.get() > 0);
+  }
+
+  @Test
+  public void transportFamiliesExposeImplAndGsonOutputs() {
+    Path root = Paths.get("gen", "messages");
+    List<String> families = Arrays.asList(
+        "org/waveprotocol/box/common/comms",
+        "org/waveprotocol/wave/federation",
+        "org/waveprotocol/wave/concurrencycontrol",
+        "org/waveprotocol/box/search");
+
+    for (String family : families) {
+      Path familyRoot = root.resolve(family);
+      assertTrue("Expected generated family root: " + familyRoot, Files.isDirectory(familyRoot));
+      assertTrue("Expected impl output for " + familyRoot, Files.isDirectory(familyRoot.resolve("impl")));
+      assertTrue("Expected gson output for " + familyRoot, Files.isDirectory(familyRoot.resolve("gson")));
+      assertTrue("Expected jso output for " + familyRoot, Files.isDirectory(familyRoot.resolve("jso")));
+      assertTrue("Expected proto output for " + familyRoot, Files.isDirectory(familyRoot.resolve("proto")));
+    }
   }
 
   private static Path resolveGeneratedSourcesDirectory() {


### PR DESCRIPTION
Closes #902

## Summary
- keep the legacy GWT transport/runtime path intact and compile/stage-safe
- add a sidecar-only J2CL transport/search proof under the isolated `j2cl` routes
- preserve and strengthen the PST contract gate for the required transport/search families
- add the issue-specific sidecar transport plan and changelog fragment for the lane

## Verification
Codegen and sidecar build gates:
- `sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"`
  - passed
- `sbt -batch j2clSandboxBuild j2clSandboxTest j2clSearchBuild j2clSearchTest`
  - passed

Legacy root path gates:
- `sbt -batch compileGwt Universal/stage`
  - passed
- `bash scripts/worktree-boot.sh --port 9900`
  - passed
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- route checks:
  - `/` -> `200 OK`
  - `/webclient/webclient.nocache.js` -> `200 OK`
  - `/j2cl-search/index.html` -> `200 OK`
  - `/j2cl/index.html` -> `200 OK`

Sidecar-only proof path:
- authenticated root browser dump still showed the legacy GWT shell with the `#webclient` iframe present
- authenticated sidecar browser run on `/j2cl-search/index.html` reached `Sidecar transport proof passed`
- sidecar proof reported: `Wavelet local.net/w+bm3tqwid5ix5A/~/dummy+root delivered 0 delta payload(s) on ch1.`
- `WAVE_E2E_BASE_URL=http://localhost:9900 sbt -batch "e2eTest:testOnly org.waveprotocol.wave.e2e.WaveE2eTest"`
  - passed all `24` tests against the live local server
- `PORT=9900 bash scripts/wave-smoke.sh stop`
  - passed

## Notes
This PR intentionally does not rewire the active legacy webclient transport path. The earlier attempt was abandoned because it broke `compileGwt` and staged-root boot. This revision keeps the legacy root path green and proves the new transport/codecs work only through the isolated sidecar routes.

## Traceability
- Worktree: `/Users/vega/devroot/worktrees/issue-902-j2cl-transport-codecs`
- Plans:
  - `docs/superpowers/plans/2026-04-19-issue-902-j2cl-sidecar-transport.md`
- Local verification record:
  - `journal/local-verification/2026-04-19-issue-902-j2cl-transport-codecs.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidecar proof UI in the sandbox with status/meta and a “Re-run sidecar proof” action; sidecar-backed search/results and wavelet-update proof for an isolated sidecar flow.
  * Improved sandbox entry-point resolution.

* **Documentation**
  * Added a detailed sidecar plan and changelog entry describing scope, validation steps, and acceptance criteria.

* **Tests**
  * New unit and contract tests covering sidecar encode/decode, session bootstrap extraction, JSON parsing, and transport-family outputs.

* **Style**
  * Added styles for the proof/status panel and action button.

* **Chores**
  * Packaging now runs a production sidecar build before staging/packaging and refines message-generation task ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->