### PR TITLE
test(j2cl): split low-risk GWTTestCase suites

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,12 @@ Compile / unmanagedSources := (Compile / unmanagedSources).value.filterNot { f =
   val p = f.getPath.replace('\\', '/')
   val underMain    = p.contains("/wave/src/main/java/")
   val underJakarta = p.contains("/wave/src/jakarta-overrides/java/")
+  val isConvertedJvmClientSource =
+    p.endsWith("/wave/src/main/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistry.java") ||
+    p.endsWith("/wave/src/main/java/org/waveprotocol/wave/client/scheduler/Scheduler.java") ||
+    p.endsWith("/wave/src/main/java/org/waveprotocol/wave/client/scheduler/TaskInfo.java") ||
+    p.endsWith("/wave/src/main/java/org/waveprotocol/wave/client/util/TypedSource.java") ||
+    p.endsWith("/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java")
 
   // Same-path main/Jakarta duplicate classes were removed in issue #714.
   // Keep this empty set so build tooling and guard scripts can still parse the block.
@@ -84,6 +90,7 @@ Compile / unmanagedSources := (Compile / unmanagedSources).value.filterNot { f =
   val commonExcludes =
     (isSrc && p.contains("/org/waveprotocol/box/webclient/")) ||
     (isSrc && p.contains("/org/waveprotocol/wave/client/") &&
+      !isConvertedJvmClientSource &&
       !p.endsWith("/wave/client/state/BlipReadStateMonitor.java") &&
       !p.endsWith("/wave/client/state/ThreadReadStateMonitor.java") &&
       // SSR Phase 1: pure-model render interfaces needed by ServerHtmlRenderer (#216)
@@ -368,12 +375,15 @@ Test / unmanagedResourceDirectories += baseDirectory.value / "wave" / "src" / "t
 Test / unmanagedSources := (Test / unmanagedSources).value.filterNot { f =>
   val p = f.getPath.replace('\\', '/')
   val fn = f.getName
+  val isConvertedJvmClientTest =
+    p.endsWith("/wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryTest.java") ||
+    p.endsWith("/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java")
   // GWT test bases/cases
   fn.contains("GwtTest") || fn == "GwtTestCase.java" ||
   fn == "TestBase.java" || fn == "GenericGWTTestBase.java" ||
   fn == "ContentTestBase.java" || fn == "ContentTestCase.java" ||
   // Client and webclient trees
-  p.contains("/org/waveprotocol/wave/client/") ||
+  (p.contains("/org/waveprotocol/wave/client/") && !isConvertedJvmClientTest) ||
   p.contains("/org/waveprotocol/box/webclient/") ||
   // Legacy Jetty API tests that break on JDK17
   p.endsWith("/org/waveprotocol/box/server/rpc/FetchServletTest.java") ||

--- a/docs/j2cl-gwt3-decision-memo.md
+++ b/docs/j2cl-gwt3-decision-memo.md
@@ -1,9 +1,9 @@
 # J2CL / GWT 3 Decision Memo
 
 Status: Current
-Updated: 2026-04-18
+Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#899`
+Task: `#898`
 
 ## Decision Summary
 
@@ -14,7 +14,9 @@ Reason:
 - the current client still depends heavily on JSNI and `JavaScriptObject`
 - UiBinder and `GWT.create(...)` remain central to UI composition
 - the GWT client build is still an isolated legacy toolchain in `build.sbt`
-- the test harness still carries legacy `GWTTestCase` debt
+- the remaining browser-facing test harness still carries legacy
+  `GWTTestCase` debt even though `#898` now makes the JVM/browser split
+  explicit
 - there is still no existing JsInterop / Elemental2 bridge layer or J2CL sidecar
 
 The important update is not the decision itself; it is the baseline. The repo
@@ -34,12 +36,18 @@ Current short version:
 - `238` JSNI native methods
 - `27` UiBinder-related Java files
 - `23` `.ui.xml` templates
-- `24` `GWTTestCase` tests
+- `19` remaining direct `GWTTestCase` Java files after `#898`
+- `21` was the reconciled direct starting baseline for `#898`
+- `11` inherited editor/test-base descendants still need a browser-facing home
 - no JsInterop / Elemental2 bridge layer
 - no J2CL sidecar build yet
 - `guava-gwt` already removed
 - gadget/htmltemplate client cleanup already landed
 - `WaveContext` already uses the shared `BlipReadStateMonitor` contract
+
+See
+[docs/j2cl-gwttestcase-verification-matrix.md](./j2cl-gwttestcase-verification-matrix.md)
+for the suite-by-suite test-home map.
 
 ## Go / No-Go
 

--- a/docs/j2cl-gwt3-inventory.md
+++ b/docs/j2cl-gwt3-inventory.md
@@ -1,9 +1,9 @@
 # J2CL / GWT 3 Inventory
 
 Status: Current
-Updated: 2026-04-18
+Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#899`
+Task: `#898`
 
 This document records the current GWT-specific surface area in
 `incubator-wave` so future migration work starts from measured constraints
@@ -12,7 +12,7 @@ plan.
 
 ## Evidence Snapshot
 
-Re-verified on the `issue-899-j2cl-doc-refresh` worktree on 2026-04-18:
+Re-verified on the `issue-898-gwttest-split` worktree on 2026-04-19:
 
 - `.gwt.xml` files: `129`
 - `GWT.create(...)` callsites: `84`
@@ -20,7 +20,9 @@ Re-verified on the `issue-899-j2cl-doc-refresh` worktree on 2026-04-18:
 - `.ui.xml` templates: `23`
 - `JavaScriptObject` / JSNI-heavy files: `114`
 - JSNI native methods: `238`
-- `GWTTestCase` tests: `24`
+- remaining direct `GWTTestCase` Java files: `19`
+- reconciled pre-conversion direct `GWTTestCase` baseline for `#898`: `21`
+- inherited editor/test-base descendants still on the browser-era harness path: `11`
 - `<replace-with>` directives: `0`
 - custom `Generator` subclasses: `0`
 - JsInterop-annotated files: `0`
@@ -152,14 +154,22 @@ Blocker assessment:
 
 Measured surface:
 
-- `24` `GWTTestCase` tests
-- dedicated hosted/browser-era GWT validation paths still exist in the repo
+- `19` direct `GWTTestCase` Java files remain after the `#898` low-risk JVM
+  conversions
+- issue `#898` reconciled the actual starting direct baseline at `21`, not the
+  stale `24` previously copied forward in the docs
+- `11` editor/integration descendants still inherit the browser-era harness
+  through `EditorGwtTestCase`, `ContentTestBase`, `TestBase`, or
+  `ElementTestBase`
+- the canonical per-suite classification now lives in
+  [docs/j2cl-gwttestcase-verification-matrix.md](./j2cl-gwttestcase-verification-matrix.md)
 
 Implications:
 
 - the migration still requires a testing strategy, not just a source rewrite
-- some client tests can move to plain JVM tests
-- browser-semantics and widget tests still need an explicit post-GWT home
+- some client tests have now moved to plain JVM tests
+- browser-semantics and widget tests now have an explicit documented post-GWT
+  home even though they still need a future runner
 
 ## Dependency And Architecture Blockers
 

--- a/docs/j2cl-gwttestcase-verification-matrix.md
+++ b/docs/j2cl-gwttestcase-verification-matrix.md
@@ -26,7 +26,11 @@ and
 as the execution baseline. This issue records the classification, not a new
 browser runner.
 
-## Direct Suites
+## Direct Suites (Baseline Classification for This Lane)
+
+This baseline table is broader than the "19 remaining" metric above. It keeps
+the suites converted in `#898` alongside the retained browser-harness suites so
+the lane has one traceable classification record.
 
 | File | Current harness path | Category | Reason | Follow-on |
 | --- | --- | --- | --- | --- |

--- a/docs/j2cl-gwttestcase-verification-matrix.md
+++ b/docs/j2cl-gwttestcase-verification-matrix.md
@@ -1,0 +1,60 @@
+# GWTTestCase Verification Matrix
+
+Status: Current
+Updated: 2026-04-19
+Owner: Project Maintainers
+Task: `#898`
+
+This document is the canonical answer for where the remaining legacy
+`GWTTestCase` debt lives after issue `#898`.
+
+## Measured Baseline
+
+Measured on the `issue-898-gwttest-split` worktree on 2026-04-19:
+
+- direct `extends GWTTestCase` Java files before the lane conversions: `21`
+- direct `extends GWTTestCase` Java files remaining after this lane: `19`
+- inherited editor/test-base descendants still on the browser-era harness path: `11`
+- plain JVM conversions landed in this issue:
+  - `org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest`
+  - `org.waveprotocol.wave.client.util.UrlParametersTest`
+
+Browser verification for the retained browser-facing suites continues to use
+[docs/runbooks/browser-verification.md](./runbooks/browser-verification.md)
+and
+[docs/runbooks/change-type-verification-matrix.md](./runbooks/change-type-verification-matrix.md)
+as the execution baseline. This issue records the classification, not a new
+browser runner.
+
+## Direct Suites
+
+| File | Current harness path | Category | Reason | Follow-on |
+| --- | --- | --- | --- | --- |
+| `wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java` | direct `extends GWTTestCase` | temporary retain | The thing under test is still the `FastQueue` JSO-backed storage path (`IntMapJsoView`), so a plain JVM conversion would require changing the runtime seam instead of only the harness. | Later common-util/browser-interop cleanup in `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/content/EditorGwtTestCase.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Base harness for editor content suites; correctness depends on live DOM, browser selection, and widget/event semantics. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/content/img/ImgDoodadGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Exercises editor image doodad rendering and attachment behavior that depends on browser DOM/widget behavior. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Editor event routing is defined by browser event semantics, not plain JVM logic. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/PasteExtractorGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Paste extraction depends on browser DOM paste/input structure. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/PasteFormatRendererGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Paste-format rendering depends on browser-backed rich-text rendering semantics. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/RepairerGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | The repair flow is validated against browser DOM/editor mutation behavior. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/TypingExtractorGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Typing extraction is tied to browser input and mutation semantics. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/gwt/GwtRenderingMutationHandlerGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Validates GWT DOM rendering/mutation behavior directly. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/impl/NodeManagerGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Node-manager correctness is coupled to browser-backed editor node lifecycles. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/CleanupGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Integration cleanup assertions depend on browser DOM/editor state transitions. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/TestBase.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Base integration harness for focus, IME, paragraph, and operation suites that depend on browser behavior. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/keys/KeyBindingRegistryIntegrationGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Keyboard binding correctness depends on browser key event dispatch and editor focus behavior. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/selection/content/AggressiveSelectionHelperGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Selection helper behavior is defined by browser selection/range semantics. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/scheduler/BrowserBackedSchedulerGwtTest.java` | direct `extends GWTTestCase` | temporary retain | The scheduler seam is still coupled to browser timer/widget integration, so forcing a JVM conversion now would widen the lane. | Later scheduler/browser seam cleanup under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryGwtTest.java` | direct `extends GWTTestCase` | plain JVM now | Pure delayed-job registry logic no longer needs the hosted/browser harness. Converted in this issue to `DelayedJobRegistryTest`. | Completed in `#898` |
+| `wave/src/test/java/org/waveprotocol/wave/client/util/ExtendedJSObjectGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | JS overlay behavior is the thing under test; JVM execution would not prove the same contract. | Later JS overlay cleanup in `#902` / `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersGwtTest.java` | direct `extends GWTTestCase` | plain JVM now | The string-constructor/query-parser path and `buildQueryString(...)` can be verified without browser-global lookup. Converted in this issue to `UrlParametersTest`. | Completed in `#898` |
+| `wave/src/test/java/org/waveprotocol/wave/client/util/WrappedJSObjectGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | JS overlay/wrapper semantics are browser-runtime behavior, not plain JVM logic. | Later JS overlay cleanup in `#902` / `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/block/xml/XmlStructureGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Wavepanel XML structure assertions depend on live DOM structure/rendering behavior. | Later wavepanel migration under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/event/EventDispatcherPanelGwtTest.java` | direct `extends GWTTestCase` | browser/J2CL-facing later | Wavepanel event dispatch correctness depends on browser DOM event routing. | Later wavepanel migration under `#904` |
+
+## Editor Family Rows
+
+| Family | Current harness path | Category | Reason | Follow-on |
+| --- | --- | --- | --- | --- |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/content/ContentTestBase.java`, `LazyPersistentContentDocumentGwtTest.java`, `NodeEventRouterGwtTest.java`, `DomGwtTest.java`, `ContentElementGwtTest.java`, `ContentTextNodeGwtTest.java` | inherited through `EditorGwtTestCase` and `ContentTestBase` | browser/J2CL-facing later | These suites validate DOM-backed content documents, node routing, and editor content structure. Plain JVM execution would not prove the same browser/editor invariants. | Later editor DOM work under `#904` |
+| `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/ElementTestBase.java`, `OperationGwtTest.java`, `MobileWebkitFocusGwtTest.java`, `MobileImeFlushGwtTest.java`, `ParagraphGwtTest.java` | inherited through `TestBase` and `ElementTestBase` | browser/J2CL-facing later | These suites depend on browser focus, IME, paragraph layout, and editor integration behavior. | Later editor DOM work under `#904` |

--- a/docs/j2cl-preparatory-work.md
+++ b/docs/j2cl-preparatory-work.md
@@ -1,7 +1,7 @@
 # J2CL / GWT 3 Preparatory Work
 
 Status: Current
-Updated: 2026-04-18
+Updated: 2026-04-19
 Parent: [j2cl-gwt3-decision-memo.md](./j2cl-gwt3-decision-memo.md)
 
 This document originally tracked the first two recommended follow-on tasks from
@@ -43,6 +43,18 @@ The repo is also past several earlier preparatory blockers:
 - the remaining blocker story is now centered on sidecar build, transport,
   browser interop, UiBinder, and legacy GWT-only tests
 
+### Explicit `GWTTestCase` split now committed
+
+Issue `#898` has now turned the stale test-harness blocker into an explicit
+map:
+
+- the direct `GWTTestCase` baseline was reconciled to `21` in the live
+  worktree
+- `DelayedJobRegistry` and `UrlParameters` moved to plain JVM tests in `#898`
+- the remaining direct surface is now `19`
+- the browser-only/editor-family home is documented in
+  [docs/j2cl-gwttestcase-verification-matrix.md](./j2cl-gwttestcase-verification-matrix.md)
+
 ## Preparatory Work Still Open
 
 The following items remain open after the landed cleanup:
@@ -51,7 +63,8 @@ The following items remain open after the landed cleanup:
 - no JsInterop / Elemental2 bridge seam yet
 - the transport / websocket / generated JSO message stack is still GWT-specific
 - UiBinder and `GWT.create(...)` are still widespread in the client UI
-- `GWTTestCase` debt still needs an explicit JVM/browser split
+- the remaining browser-facing `GWTTestCase` suites still need a real post-GWT
+  browser runner even though the JVM/browser split is now documented
 
 ## Current Follow-On Issue Chain
 

--- a/docs/superpowers/plans/2026-04-19-issue-898-gwttest-split.md
+++ b/docs/superpowers/plans/2026-04-19-issue-898-gwttest-split.md
@@ -1,0 +1,389 @@
+# Issue #898 GWTTestCase Verification Split Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the remaining `GWTTestCase` debt with an explicit split between plain JVM tests and documented browser-only verification so later J2CL UI migration work has a defined test home.
+
+**Architecture:** Treat issue `#898` as test-harness triage, not a UI migration. First reconcile the live inventory in this worktree, then move only clearly non-DOM cases off `GWTTestCase`, and finally commit a dedicated browser-only verification matrix for the suites that still depend on DOM, JSNI, widgets, or browser event semantics.
+
+**Tech Stack:** Java, legacy GWT test harnesses, JUnit 3/4, SBT, `rg`, existing worktree boot/smoke scripts, manual browser verification runbooks, existing J2CL sidecar entrypoints.
+
+---
+
+## 1. Goal / Root Cause
+
+Issue `#898` exists because the repository still carries browser-era `GWTTestCase`
+coverage even though the staged J2CL plan now expects a deliberate JVM/browser
+split instead of a single legacy hosted-test bucket.
+
+Root cause:
+
+- the migration docs still describe `GWTTestCase` debt as a blocker, but do not
+  yet give each remaining suite an explicit target home
+- several direct `GWTTestCase` suites are pure or near-pure logic and should be
+  plain JVM tests instead of staying behind the legacy GWT harness
+- several editor, wavepanel, JS overlay, and widget suites still depend on DOM,
+  browser events, JSNI, or GWT widget behavior and therefore need a documented
+  browser-only home instead of an implied future cleanup
+- the current docs are already slightly stale: the live worktree has `21` Java
+  files with `GWTTestCase`, while `docs/j2cl-gwt3-decision-memo.md` and related
+  docs still describe `24`
+
+The narrow outcome for this issue is not “migrate the editor” or “finish J2CL.”
+It is “make the remaining test debt explicit and reduce the low-risk legacy
+surface now.”
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- inventory the live `GWTTestCase` surface in this worktree and reconcile doc
+  counts with the measured tree
+- classify each remaining direct `GWTTestCase` suite and each affected
+  base-class family into one of:
+  - convert to plain JVM tests now
+  - move to an explicit browser-runner / J2CL-facing verification bucket
+  - retain temporarily with a written reason
+- convert the low-risk, non-DOM cases off `GWTTestCase`
+- add a committed browser-only verification matrix document for the remaining
+  suites
+- update the J2CL migration docs so issue `#898` leaves a stable test-home map
+  for later issues
+
+### Explicit Non-Goals
+
+- no pure model or concurrency-control migration already tracked by `#903`
+- no full editor migration
+- no full wavepanel migration
+- no attempt to move every remaining browser-only suite into a real J2CL test
+  runner in this issue
+- no production app behavior change beyond any minimal test-only support code
+  needed to let low-risk suites run on the JVM
+
+## 3. Exact Files Likely To Change
+
+### Inventory And Migration Docs
+
+- `docs/j2cl-gwt3-inventory.md`
+- `docs/j2cl-gwt3-decision-memo.md`
+- `docs/j2cl-preparatory-work.md`
+- `docs/superpowers/plans/j2cl-full-migration-plan.md`
+- `docs/runbooks/browser-verification.md`
+- `docs/runbooks/change-type-verification-matrix.md`
+- `docs/j2cl-gwttestcase-verification-matrix.md` (new browser-only matrix output)
+
+### Direct `GWTTestCase` Suites To Classify
+
+- `wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/EditorGwtTestCase.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/img/ImgDoodadGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/PasteExtractorGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/PasteFormatRendererGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/RepairerGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/extract/TypingExtractorGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/gwt/GwtRenderingMutationHandlerGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/impl/NodeManagerGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/CleanupGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/TestBase.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/keys/KeyBindingRegistryIntegrationGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/selection/content/AggressiveSelectionHelperGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/scheduler/BrowserBackedSchedulerGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/util/ExtendedJSObjectGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/util/WrappedJSObjectGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/block/xml/XmlStructureGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/event/EventDispatcherPanelGwtTest.java`
+
+### Base-Class Families And Descendant Suites Likely To Move With The Classification
+
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/ContentTestBase.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/NodeEventRouterGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/LazyPersistentContentDocumentGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/DomGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/ContentElementGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/content/ContentTextNodeGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/ElementTestBase.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/OperationGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileWebkitFocusGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/MobileImeFlushGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/editor/integration/ParagraphGwtTest.java`
+
+### Legacy GWT Test Resource Modules Likely To Change
+
+- `wave/src/test/resources/org/waveprotocol/wave/client/common/util/tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/content/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/event/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/extract/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/gwt/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/impl/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/integration/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/keys/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/editor/selection/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/scheduler/tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/util/tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/wavepanel/block/Tests.gwt.xml`
+- `wave/src/test/resources/org/waveprotocol/wave/client/wavepanel/event/Tests.gwt.xml`
+
+### Most Likely Low-Risk JVM Conversion Targets
+
+- `wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryGwtTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersGwtTest.java` if the test stays on the constructor/query-parser path and any native browser lookup remains outside the JVM target
+
+### Likely Deferred Browser-Only Buckets
+
+- JS overlay / JSNI utilities:
+  - `wave/src/test/java/org/waveprotocol/wave/client/util/ExtendedJSObjectGwtTest.java`
+  - `wave/src/test/java/org/waveprotocol/wave/client/util/WrappedJSObjectGwtTest.java`
+- Wavepanel DOM structure / event routing:
+  - `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/block/xml/XmlStructureGwtTest.java`
+  - `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/event/EventDispatcherPanelGwtTest.java`
+- Editor DOM / selection / widget / IME families:
+  - all editor files listed above under the direct and descendant editor buckets
+
+### Likely Temporary Retain-With-Reason Bucket
+
+- `wave/src/test/java/org/waveprotocol/wave/client/scheduler/BrowserBackedSchedulerGwtTest.java`
+  because it is logic-heavy but still tied to the browser-backed scheduler seam
+  and should only move if the remaining GWT widget/timing assumptions can be
+  isolated without widening scope
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Reconcile The Live Inventory Before Any Conversion
+
+**Files:**
+- Inspect and update: `docs/j2cl-gwt3-inventory.md`
+- Inspect and update: `docs/j2cl-gwt3-decision-memo.md`
+- Inspect and update: `docs/j2cl-preparatory-work.md`
+
+- [ ] Measure the live direct `GWTTestCase` surface in this worktree instead of
+      relying on older counts copied forward from prior docs.
+- [ ] Record both:
+      - the direct `GWTTestCase` Java suites and abstract bases
+      - the descendant suites that inherit through `EditorGwtTestCase` or
+        `TestBase`
+- [ ] Update the J2CL inventory docs so `#898` starts from a reproducible
+      count and not a stale one.
+
+### Task 2: Publish The Classification Table
+
+**Files:**
+- Create: `docs/j2cl-gwttestcase-verification-matrix.md`
+- Update: `docs/j2cl-gwt3-inventory.md`
+- Update as needed: `docs/superpowers/plans/j2cl-full-migration-plan.md`
+
+- [ ] Build a flat classification table with one row per direct suite and one
+      explicit row for each editor base-chain family.
+- [ ] Each row must include:
+      - file path
+      - current harness path
+      - category: `plain JVM now`, `browser/J2CL-facing later`, or
+        `temporary retain`
+      - written reason
+      - expected follow-on issue or migration phase
+- [ ] Make the table the canonical answer for “where does this legacy test
+      live after `#898`?”
+
+### Task 3: Convert The Low-Risk Non-DOM Cases Off `GWTTestCase`
+
+**Files:**
+- Modify or replace: `wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java`
+- Modify or replace: `wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryGwtTest.java`
+- Modify or replace: `wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersGwtTest.java` if it stays narrow
+- Modify or delete matching `.gwt.xml` modules if those suites no longer need them:
+  - `wave/src/test/resources/org/waveprotocol/wave/client/common/util/tests.gwt.xml`
+  - `wave/src/test/resources/org/waveprotocol/wave/client/scheduler/tests.gwt.xml`
+  - `wave/src/test/resources/org/waveprotocol/wave/client/util/tests.gwt.xml`
+
+- [ ] Convert only cases that do not require real DOM nodes, JSNI execution,
+      GWT widget attachment, browser events, or browser-global query-string
+      access.
+- [ ] Keep the replacement narrow:
+      - same package
+      - same assertions
+      - plain JVM `TestCase` / JUnit execution
+      - no speculative cleanup in unrelated client code
+- [ ] If `UrlParametersGwtTest` requires touching production code to separate
+      constructor parsing from browser-global lookup, keep that refactor minimal
+      and leave JS overlay behavior out of scope.
+
+### Task 4: Document The Deferred Browser-Only Home
+
+**Files:**
+- Create: `docs/j2cl-gwttestcase-verification-matrix.md`
+- Update as needed: `docs/runbooks/browser-verification.md`
+- Update as needed: `docs/runbooks/change-type-verification-matrix.md`
+
+- [ ] Put all JS overlay, editor DOM, wavepanel DOM/event, widget-rendering,
+      popup, selection, IME, and browser-scheduler seams in the browser-only
+      bucket.
+- [ ] For each deferred bucket, document:
+      - why plain JVM execution is insufficient
+      - what narrow browser behavior must be proven
+      - the future home: browser-runner / J2CL-facing verification path
+      - the nearest follow-on issue or phase (`#901`, `#904`, later editor DOM
+        work, or later wavepanel migration)
+- [ ] Use the existing runbooks as the execution baseline rather than inventing
+      a new browser framework in this issue.
+
+### Task 5: Leave Temporary Retains Explicit, Small, And Auditable
+
+**Files:**
+- Update classification rows for any suite not converted yet, especially:
+  - `wave/src/test/java/org/waveprotocol/wave/client/scheduler/BrowserBackedSchedulerGwtTest.java`
+
+- [ ] Any suite that remains on `GWTTestCase` after this issue must have a
+      written reason in the committed matrix.
+- [ ] The allowed temporary reasons are narrow:
+      - browser timer / widget integration still leaks into the seam
+      - browser event semantics still define correctness
+      - JSNI / `JavaScriptObject` behavior is the thing under test
+- [ ] “Did not get to it” is not an acceptable retain reason.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-898-gwttest-split`.
+
+### Inventory And Count Gates
+
+```bash
+printf 'direct GWTTestCase java files: '
+rg -l 'extends GWTTestCase' wave/src/test/java | wc -l
+
+printf 'all Java files mentioning GWTTestCase: '
+rg -l 'GWTTestCase' wave/src/test/java | wc -l
+
+printf 'editor/test-base descendants: '
+rg -n 'extends (EditorGwtTestCase|ContentTestBase|ElementTestBase|TestBase)' \
+  wave/src/test/java/org/waveprotocol/wave/client | wc -l
+
+rg -l 'extends GWTTestCase' wave/src/test/java | sort
+
+find wave/src/test/resources -name '*.gwt.xml' | sort
+```
+
+Expected result:
+
+- the first command reflects the current direct-suite baseline before edits and
+  drops after low-risk conversions land
+- the second and third commands provide the classification input for direct
+  suites plus inherited editor harness debt
+- the sorted file lists are copied into the issue notes or matrix doc while
+  classification is being verified
+
+### Scope Guard For Low-Risk JVM Conversions
+
+```bash
+rg -n 'com\.google\.gwt\.dom|com\.google\.gwt\.user|JavaScriptObject|native .*/\*' \
+  wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java \
+  wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryGwtTest.java \
+  wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersGwtTest.java
+```
+
+Expected result:
+
+- `FastQueueGwtTest.java` and `DelayedJobRegistryGwtTest.java` should stay clear
+  of DOM/widget/JSNI dependencies
+- if `UrlParametersGwtTest.java` trips a browser-only dependency after the
+  planned narrow refactor is examined, move it out of the low-risk conversion
+  bucket and document the reason instead of forcing it
+
+### Targeted JVM Test Runs After Conversion
+
+```bash
+sbt -batch \
+  "testOnly org.waveprotocol.wave.client.common.util.FastQueueTest \
+  org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest"
+```
+
+If `UrlParametersGwtTest` is converted in-scope, rerun with:
+
+```bash
+sbt -batch \
+  "testOnly org.waveprotocol.wave.client.common.util.FastQueueTest \
+  org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest \
+  org.waveprotocol.wave.client.util.UrlParametersTest"
+```
+
+Expected result: the converted suites pass on the plain JVM without invoking
+`GWTTestCase`.
+
+### Compile Gates
+
+```bash
+sbt -batch compile
+sbt -batch Test/compile
+```
+
+If any `.gwt.xml` module wiring is removed or changed, also run:
+
+```bash
+sbt -batch Universal/stage
+```
+
+Expected result: compile succeeds, test compile succeeds, and staging still
+builds if test-module wiring changed.
+
+### Required Local Server / Browser Sanity Before PR
+
+Even though this issue is mostly test-harness and docs work, the repo rules
+still require a local lane sanity pass before PR. Use the worktree lifecycle
+runbook and record the exact commands printed by `worktree-boot.sh`.
+
+```bash
+bash scripts/worktree-boot.sh --port 9900
+PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+If the implementation touched any `.gwt.xml`, client packaging path, or GWT
+build wiring, add the narrow browser pass required by the packaging/build row
+of `docs/runbooks/change-type-verification-matrix.md`:
+
+```text
+Open http://localhost:9900/
+Confirm the staged home or sign-in page loads
+Confirm the served client asset path still resolves (for example the page loads
+its normal web client bootstrap without a missing-asset error)
+```
+
+Record whether the matrix required the browser pass and what exact route and
+result were checked.
+
+## 6. Acceptance Criteria
+
+- the repo has a committed issue-specific matrix document that names the
+  remaining legacy suites and assigns each one to `plain JVM now`,
+  `browser/J2CL-facing later`, or `temporary retain`
+- the J2CL inventory / decision docs no longer rely on stale `GWTTestCase`
+  counts for this worktree
+- at least the clearly low-risk non-DOM suites are no longer implemented as
+  `GWTTestCase`
+- any direct suite left on `GWTTestCase` has a written reason in the committed
+  matrix
+- editor, wavepanel, JS overlay, and widget-driven suites are explicitly marked
+  as browser-only and tied to a future verification home instead of vague
+  “later cleanup”
+- targeted JVM tests, compile gates, and required local smoke/browser sanity
+  are recorded in the issue traceability notes before PR
+
+## 7. Issue / PR Traceability Notes
+
+- Worktree: `/Users/vega/devroot/worktrees/issue-898-gwttest-split`
+- Branch: `issue-898-gwttest-split`
+- Plan path: `docs/superpowers/plans/2026-04-19-issue-898-gwttest-split.md`
+- Keep GitHub issue comments current with:
+  - the reconciled direct `GWTTestCase` count and the descendant-harness count
+  - the exact classification outputs or matrix path
+  - which suites were actually converted in this issue
+  - exact `sbt` and worktree smoke commands plus results
+  - whether browser verification was required by the matrix
+  - the PR URL once opened
+- Keep the PR body short and derived from the issue comment:
+  - reduced low-risk `GWTTestCase` surface
+  - committed browser-only matrix path
+  - remaining temporary retains and reasons

--- a/docs/superpowers/plans/j2cl-full-migration-plan.md
+++ b/docs/superpowers/plans/j2cl-full-migration-plan.md
@@ -42,7 +42,7 @@ All numbers below were re-verified on 2026-04-02 in this worktree.
 | JSNI / `JavaScriptObject` files | 97 | Runtime surface across `wave/src/main/java/**` plus PST-generated `gen/messages/**/jso/**`; the earlier figure counted only the hand-maintained runtime subset, not the generated JSO surface that Phases 3-4 must replace |
 | JSNI native methods | 297 | Dominated by selection, DOM, gadget, generated JSON message accessors, and JSON helper code |
 | JsInterop / Elemental2 usage | 0 | No `@JsType`, `@JsMethod`, `@JsProperty`, or `elemental2` imports found |
-| `GWTTestCase` files | 27 | Includes model and concurrency-control wrappers plus editor/browser suites |
+| `GWTTestCase` files | 19 direct suites plus 11 inherited editor-family descendants | See `docs/j2cl-gwttestcase-verification-matrix.md`; issue `#898` moved the clearly low-risk suites to plain JVM tests and left the browser families explicit |
 
 Important `GWT.create(...)` split:
 
@@ -91,7 +91,7 @@ The binder/resource majority is mechanically replaceable. The late-bound runtime
 | `CssResource` / `ClientBundle` / `DataResource` | Common in search, popups, editor resources, attachments, gadgets | Replace with static CSS files, host-page styles, or build-time CSS extraction; images become normal assets referenced by URL | Medium |
 | Deferred binding (`<replace-with>`) | `Popup.gwt.xml`, `Util.gwt.xml`, `useragents.gwt.xml`, `Logger.gwt.xml`, plus harness/property modules | Replace with runtime feature detection and ordinary Java factories | Medium |
 | GWT WebSocket wrapper | `com/google/gwt/websockets/client/WebSocket.java` and `WaveSocketFactory.java` | Replace with `elemental2.dom.WebSocket` adapter | Medium |
-| `GWTTestCase` | 27 files, including `GenericGWTTestBase`, model wrappers, concurrency-control wrappers, editor/browser suites | Convert logic tests to plain JUnit first; use browser runner only for DOM semantics after slice migration | Medium |
+| `GWTTestCase` | 19 direct suites plus 11 inherited editor-family descendants; see `docs/j2cl-gwttestcase-verification-matrix.md` | Convert logic tests to plain JUnit first; use browser runner only for DOM semantics after slice migration | Medium |
 | `guava-gwt` | Still present in the isolated `Gwt` config and many `.gwt.xml` inherits | Replace narrow Guava surface, remove `com.google.common.base.Base` / `Collect` inherits, then drop dependency | Low |
 
 ## 3. What Gets Dropped
@@ -419,6 +419,12 @@ Do not replace the `webclient` output path until Phase 5.
 ## 7. Testing Strategy
 
 ### 7.1 Replace `GWTTestCase` By Category
+
+The current suite-by-suite classification lives in
+`docs/j2cl-gwttestcase-verification-matrix.md`. Issue `#898` reconciled the
+direct baseline to `21`, converted two low-risk suites to plain JVM tests, and
+left `19` direct `GWTTestCase` suites plus `11` inherited editor-family
+descendants as the remaining browser-facing surface.
 
 | Test category | Current state | Target state | Phase |
 |---|---|---|---|

--- a/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
+++ b/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
@@ -36,3 +36,22 @@
 
 - PR: pending
 - Issue: #898
+
+## PR #914 Remediation
+
+### Commands
+
+- `sbt "testOnly org.waveprotocol.wave.client.util.UrlParametersTest"`
+- `sbt compile`
+- `sbt test`
+
+### Results
+
+- Added focused regression coverage for JVM query encoding parity, UTF-8 round-trips, and malformed UTF-8 rejection in `UrlParametersTest`.
+- `sbt "testOnly org.waveprotocol.wave.client.util.UrlParametersTest"` initially failed on three review-driven regressions:
+  - `testBuildQueryStringPreservesEncodeComponentSafeCharacters`
+  - `testTruncatedUtf8SequenceRejected`
+  - `testInvalidUtf8ContinuationRejected`
+- After fixing `UrlParameters`, the focused test suite passed with `11` tests run, `0` failed.
+- `sbt compile` succeeded.
+- `sbt test` succeeded with `2498` total tests, `0` failed, `0` errors, and `2` skipped.

--- a/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
+++ b/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
@@ -34,7 +34,7 @@
 
 ## Follow-up
 
-- PR: pending
+- PR: #914
 - Issue: #898
 
 ## PR #914 Remediation

--- a/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
+++ b/journal/local-verification/2026-04-19-issue-898-gwttest-split.md
@@ -1,0 +1,38 @@
+# Local Verification
+
+- Branch: issue-898-gwttest-split
+- Worktree: /Users/vega/devroot/worktrees/issue-898-gwttest-split
+- Date: 2026-04-19
+
+## Commands
+
+- `printf 'direct GWTTestCase java files: '; rg -l 'extends GWTTestCase' wave/src/test/java | wc -l`
+- `printf 'all Java files mentioning GWTTestCase: '; rg -l 'GWTTestCase' wave/src/test/java | wc -l`
+- `printf 'editor/test-base descendants: '; rg -n 'extends (EditorGwtTestCase|ContentTestBase|ElementTestBase|TestBase)' wave/src/test/java/org/waveprotocol/wave/client | wc -l`
+- `rg -n 'com\.google\.gwt\.dom|com\.google\.gwt\.user|JavaScriptObject|native .*/\*' wave/src/test/java/org/waveprotocol/wave/client/common/util/FastQueueGwtTest.java wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryTest.java wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java`
+- `python3 scripts/assemble-changelog.py`
+- `sbt -batch "wave / Test / testOnly org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest org.waveprotocol.wave.client.util.UrlParametersTest"`
+- `sbt -batch compile`
+- `sbt -batch Test/compile`
+- `bash scripts/worktree-boot.sh --port 9900`
+- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-898-gwttest-split/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-898-gwttest-split/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
+- `PORT=9900 bash scripts/wave-smoke.sh check`
+- `PORT=9900 bash scripts/wave-smoke.sh stop`
+
+## Results
+
+- Inventory before conversion was reconciled to `21` direct `GWTTestCase` Java files.
+- Current inventory after the lane is `19` direct `GWTTestCase` Java files and `11` inherited editor/test-base descendants.
+- Scope guard command returned no matches for DOM/widget/JSNI/native-browser patterns in `FastQueueGwtTest`, `DelayedJobRegistryTest`, or `UrlParametersTest`.
+- `python3 scripts/assemble-changelog.py` succeeded: `assembled 196 entries -> wave/config/changelog.json`.
+- `sbt -batch "wave / Test / testOnly org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest org.waveprotocol.wave.client.util.UrlParametersTest"` passed with `8` tests run, `0` failed.
+- `sbt -batch compile` succeeded.
+- `sbt -batch Test/compile` succeeded.
+- `bash scripts/worktree-boot.sh --port 9900` succeeded and produced the staged runtime config plus the standard smoke command sequence.
+- `PORT=9900 bash scripts/wave-smoke.sh check` returned `ROOT_STATUS=200`, `HEALTH_STATUS=200`, and `WEBCLIENT_STATUS=200`.
+- Browser verification was not required by `docs/runbooks/change-type-verification-matrix.md` because the lane changed JVM test coverage and documentation, not browser-visible packaging behavior; the staged asset check above confirmed the compiled web client still served correctly.
+
+## Follow-up
+
+- PR: pending
+- Issue: #898

--- a/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
@@ -147,11 +147,14 @@ public class UrlParameters implements TypedSource {
       try {
         decodeComponentNative("test");
         nativeCodecAvailable = Boolean.TRUE;
-      } catch (UnsatisfiedLinkError e) {
+      } catch (Error err) {
+        if (!isMissingNativeCodec(err)) {
+          throw err;
+        }
         nativeCodecAvailable = Boolean.FALSE;
       }
     }
-    return nativeCodecAvailable;
+    return nativeCodecAvailable.booleanValue();
   }
 
   private static String decodeComponent(String value) {
@@ -205,40 +208,22 @@ public class UrlParameters implements TypedSource {
       if ((b0 & 0x80) == 0) {
         codePoint = b0;
       } else if ((b0 & 0xE0) == 0xC0) {
-        if (i >= bytes.length()) {
-          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
-        }
-        int b1 = bytes.charAt(i++);
-        if ((b1 & 0xC0) != 0x80) {
-          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
-        }
-        codePoint = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+        int b1 = readContinuationByte(bytes, i++);
+        codePoint = ((b0 & 0x1F) << 6) | b1;
+        ensureValidDecodedCodePoint(codePoint, 0x80);
       } else if ((b0 & 0xF0) == 0xE0) {
-        if (i + 1 >= bytes.length()) {
-          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
-        }
-        int b1 = bytes.charAt(i++);
-        int b2 = bytes.charAt(i++);
-        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) {
-          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
-        }
-        codePoint = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+        int b1 = readContinuationByte(bytes, i++);
+        int b2 = readContinuationByte(bytes, i++);
+        codePoint = ((b0 & 0x0F) << 12) | (b1 << 6) | b2;
+        ensureValidDecodedCodePoint(codePoint, 0x800);
       } else if ((b0 & 0xF8) == 0xF0) {
-        if (i + 2 >= bytes.length()) {
-          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
-        }
-        int b1 = bytes.charAt(i++);
-        int b2 = bytes.charAt(i++);
-        int b3 = bytes.charAt(i++);
-        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) {
-          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
-        }
-        codePoint = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
+        int b1 = readContinuationByte(bytes, i++);
+        int b2 = readContinuationByte(bytes, i++);
+        int b3 = readContinuationByte(bytes, i++);
+        codePoint = ((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3;
+        ensureValidDecodedCodePoint(codePoint, 0x10000);
       } else {
         throw new IllegalArgumentException("Invalid UTF-8 lead byte in query string");
-      }
-      if (codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
-        throw new IllegalArgumentException("Invalid Unicode code point in query string: " + codePoint);
       }
       appendCodePoint(out, codePoint);
     }
@@ -307,6 +292,32 @@ public class UrlParameters implements TypedSource {
       throw new IllegalArgumentException("Invalid hex digit in query string: " + ch);
     }
     return value;
+  }
+
+  private static boolean isMissingNativeCodec(Error err) {
+    return "java.lang.UnsatisfiedLinkError".equals(err.getClass().getName());
+  }
+
+  private static int readContinuationByte(StringBuilder bytes, int index) {
+    if (index >= bytes.length()) {
+      throw malformedUtf8();
+    }
+    int b = bytes.charAt(index) & 0xFF;
+    if ((b & 0xC0) != 0x80) {
+      throw malformedUtf8();
+    }
+    return b & 0x3F;
+  }
+
+  private static void ensureValidDecodedCodePoint(int codePoint, int minimumValue) {
+    if (codePoint < minimumValue || codePoint > 0x10FFFF
+        || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+      throw malformedUtf8();
+    }
+  }
+
+  private static IllegalArgumentException malformedUtf8() {
+    return new IllegalArgumentException("Malformed UTF-8 in query string");
   }
 
   private static void appendCodePoint(StringBuilder out, int codePoint) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
@@ -140,20 +140,32 @@ public class UrlParameters implements TypedSource {
     return sb.toString();
   }
 
-  private static String decodeComponent(String value) {
-    try {
-      return decodeComponentNative(value);
-    } catch (Error err) {
-      return decodeComponentJvm(value);
+  private static volatile Boolean nativeCodecAvailable = null;
+
+  private static boolean isNativeCodecAvailable() {
+    if (nativeCodecAvailable == null) {
+      try {
+        decodeComponentNative("test");
+        nativeCodecAvailable = Boolean.TRUE;
+      } catch (UnsatisfiedLinkError e) {
+        nativeCodecAvailable = Boolean.FALSE;
+      }
     }
+    return nativeCodecAvailable;
+  }
+
+  private static String decodeComponent(String value) {
+    if (isNativeCodecAvailable()) {
+      return decodeComponentNative(value);
+    }
+    return decodeComponentJvm(value);
   }
 
   private static String encodeComponent(String value) {
-    try {
+    if (isNativeCodecAvailable()) {
       return encodeComponentNative(value);
-    } catch (Error err) {
-      return encodeComponentJvm(value);
     }
+    return encodeComponentJvm(value);
   }
 
   private static native String decodeComponentNative(String value) /*-{
@@ -193,19 +205,40 @@ public class UrlParameters implements TypedSource {
       if ((b0 & 0x80) == 0) {
         codePoint = b0;
       } else if ((b0 & 0xE0) == 0xC0) {
-        int b1 = bytes.charAt(i++) & 0x3F;
-        codePoint = ((b0 & 0x1F) << 6) | b1;
+        if (i >= bytes.length()) {
+          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
+        }
+        int b1 = bytes.charAt(i++);
+        if ((b1 & 0xC0) != 0x80) {
+          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
+        }
+        codePoint = ((b0 & 0x1F) << 6) | (b1 & 0x3F);
       } else if ((b0 & 0xF0) == 0xE0) {
-        int b1 = bytes.charAt(i++) & 0x3F;
-        int b2 = bytes.charAt(i++) & 0x3F;
-        codePoint = ((b0 & 0x0F) << 12) | (b1 << 6) | b2;
+        if (i + 1 >= bytes.length()) {
+          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
+        }
+        int b1 = bytes.charAt(i++);
+        int b2 = bytes.charAt(i++);
+        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80) {
+          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
+        }
+        codePoint = ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
       } else if ((b0 & 0xF8) == 0xF0) {
-        int b1 = bytes.charAt(i++) & 0x3F;
-        int b2 = bytes.charAt(i++) & 0x3F;
-        int b3 = bytes.charAt(i++) & 0x3F;
-        codePoint = ((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3;
+        if (i + 2 >= bytes.length()) {
+          throw new IllegalArgumentException("Truncated UTF-8 sequence in query string");
+        }
+        int b1 = bytes.charAt(i++);
+        int b2 = bytes.charAt(i++);
+        int b3 = bytes.charAt(i++);
+        if ((b1 & 0xC0) != 0x80 || (b2 & 0xC0) != 0x80 || (b3 & 0xC0) != 0x80) {
+          throw new IllegalArgumentException("Invalid UTF-8 continuation byte in query string");
+        }
+        codePoint = ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F);
       } else {
         throw new IllegalArgumentException("Invalid UTF-8 lead byte in query string");
+      }
+      if (codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+        throw new IllegalArgumentException("Invalid Unicode code point in query string: " + codePoint);
       }
       appendCodePoint(out, codePoint);
     }
@@ -228,6 +261,7 @@ public class UrlParameters implements TypedSource {
     return out.toString();
   }
 
+  // Matches characters left unescaped by GWT's URL.encodeComponent (JavaScript encodeURIComponent).
   private static boolean isUnescapedQueryCodePoint(int codePoint) {
     return (codePoint >= 'A' && codePoint <= 'Z')
         || (codePoint >= 'a' && codePoint <= 'z')
@@ -235,7 +269,12 @@ public class UrlParameters implements TypedSource {
         || codePoint == '-'
         || codePoint == '_'
         || codePoint == '.'
-        || codePoint == '*';
+        || codePoint == '!'
+        || codePoint == '~'
+        || codePoint == '*'
+        || codePoint == '\''
+        || codePoint == '('
+        || codePoint == ')';
   }
 
   private static void appendUtf8PercentEncoded(StringBuilder out, int codePoint) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
@@ -234,6 +234,10 @@ public class UrlParameters implements TypedSource {
     StringBuilder out = new StringBuilder();
     for (int i = 0; i < value.length();) {
       int codePoint = Character.codePointAt(value, i);
+      if (codePoint >= 0xD800 && codePoint <= 0xDFFF) {
+        throw new IllegalArgumentException(
+            "Lone surrogate in query string at index " + i + ": U+" + Integer.toHexString(codePoint).toUpperCase());
+      }
       if (isUnescapedQueryCodePoint(codePoint)) {
         appendCodePoint(out, codePoint);
       } else if (codePoint == ' ') {

--- a/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/util/UrlParameters.java
@@ -20,8 +20,6 @@
 
 package org.waveprotocol.wave.client.util;
 
-import com.google.gwt.http.client.URL;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -49,9 +47,9 @@ public class UrlParameters implements TypedSource {
         String[] keyval = pair.split("=");
         // Some basic error handling for invalid query params.
         if (keyval.length == 2) {
-          map.put(URL.decodeComponent(keyval[0]), URL.decodeComponent(keyval[1]));
+          map.put(decodeComponent(keyval[0]), decodeComponent(keyval[1]));
         } else if (keyval.length == 1) {
-          map.put(URL.decodeComponent(keyval[0]), "");
+          map.put(decodeComponent(keyval[0]), "");
         }
       }
     }
@@ -130,15 +128,155 @@ public class UrlParameters implements TypedSource {
       } else {
         sb.append('&');
       }
-      String encodedName = URL.encodeComponent(e.getKey());
+      String encodedName = encodeComponent(e.getKey());
       sb.append(encodedName);
 
       sb.append('=');
 
-      String encodedValue = URL.encodeComponent(e.getValue());
+      String encodedValue = encodeComponent(e.getValue());
       sb.append(encodedValue);
       firstIteration = false;
     }
     return sb.toString();
+  }
+
+  private static String decodeComponent(String value) {
+    try {
+      return decodeComponentNative(value);
+    } catch (Error err) {
+      return decodeComponentJvm(value);
+    }
+  }
+
+  private static String encodeComponent(String value) {
+    try {
+      return encodeComponentNative(value);
+    } catch (Error err) {
+      return encodeComponentJvm(value);
+    }
+  }
+
+  private static native String decodeComponentNative(String value) /*-{
+    return @com.google.gwt.http.client.URL::decodeComponent(Ljava/lang/String;)(value);
+  }-*/;
+
+  private static native String encodeComponentNative(String value) /*-{
+    return @com.google.gwt.http.client.URL::encodeComponent(Ljava/lang/String;)(value);
+  }-*/;
+
+  private static String decodeComponentJvm(String value) {
+    StringBuilder out = new StringBuilder();
+    StringBuilder bytes = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      if (ch == '%') {
+        if (i + 2 >= value.length()) {
+          throw new IllegalArgumentException("Invalid escape sequence in query string");
+        }
+        int high = hexValue(value.charAt(i + 1));
+        int low = hexValue(value.charAt(i + 2));
+        bytes.append((char) ((high << 4) | low));
+        i += 2;
+      } else {
+        flushDecodedBytes(bytes, out);
+        out.append(ch == '+' ? ' ' : ch);
+      }
+    }
+    flushDecodedBytes(bytes, out);
+    return out.toString();
+  }
+
+  private static void flushDecodedBytes(StringBuilder bytes, StringBuilder out) {
+    for (int i = 0; i < bytes.length();) {
+      int b0 = bytes.charAt(i++) & 0xFF;
+      int codePoint;
+      if ((b0 & 0x80) == 0) {
+        codePoint = b0;
+      } else if ((b0 & 0xE0) == 0xC0) {
+        int b1 = bytes.charAt(i++) & 0x3F;
+        codePoint = ((b0 & 0x1F) << 6) | b1;
+      } else if ((b0 & 0xF0) == 0xE0) {
+        int b1 = bytes.charAt(i++) & 0x3F;
+        int b2 = bytes.charAt(i++) & 0x3F;
+        codePoint = ((b0 & 0x0F) << 12) | (b1 << 6) | b2;
+      } else if ((b0 & 0xF8) == 0xF0) {
+        int b1 = bytes.charAt(i++) & 0x3F;
+        int b2 = bytes.charAt(i++) & 0x3F;
+        int b3 = bytes.charAt(i++) & 0x3F;
+        codePoint = ((b0 & 0x07) << 18) | (b1 << 12) | (b2 << 6) | b3;
+      } else {
+        throw new IllegalArgumentException("Invalid UTF-8 lead byte in query string");
+      }
+      appendCodePoint(out, codePoint);
+    }
+    bytes.setLength(0);
+  }
+
+  private static String encodeComponentJvm(String value) {
+    StringBuilder out = new StringBuilder();
+    for (int i = 0; i < value.length();) {
+      int codePoint = Character.codePointAt(value, i);
+      if (isUnescapedQueryCodePoint(codePoint)) {
+        appendCodePoint(out, codePoint);
+      } else if (codePoint == ' ') {
+        out.append('+');
+      } else {
+        appendUtf8PercentEncoded(out, codePoint);
+      }
+      i += Character.charCount(codePoint);
+    }
+    return out.toString();
+  }
+
+  private static boolean isUnescapedQueryCodePoint(int codePoint) {
+    return (codePoint >= 'A' && codePoint <= 'Z')
+        || (codePoint >= 'a' && codePoint <= 'z')
+        || (codePoint >= '0' && codePoint <= '9')
+        || codePoint == '-'
+        || codePoint == '_'
+        || codePoint == '.'
+        || codePoint == '*';
+  }
+
+  private static void appendUtf8PercentEncoded(StringBuilder out, int codePoint) {
+    if (codePoint <= 0x7F) {
+      appendEncodedByte(out, codePoint);
+    } else if (codePoint <= 0x7FF) {
+      appendEncodedByte(out, 0xC0 | (codePoint >> 6));
+      appendEncodedByte(out, 0x80 | (codePoint & 0x3F));
+    } else if (codePoint <= 0xFFFF) {
+      appendEncodedByte(out, 0xE0 | (codePoint >> 12));
+      appendEncodedByte(out, 0x80 | ((codePoint >> 6) & 0x3F));
+      appendEncodedByte(out, 0x80 | (codePoint & 0x3F));
+    } else {
+      appendEncodedByte(out, 0xF0 | (codePoint >> 18));
+      appendEncodedByte(out, 0x80 | ((codePoint >> 12) & 0x3F));
+      appendEncodedByte(out, 0x80 | ((codePoint >> 6) & 0x3F));
+      appendEncodedByte(out, 0x80 | (codePoint & 0x3F));
+    }
+  }
+
+  private static void appendEncodedByte(StringBuilder out, int value) {
+    out.append('%');
+    out.append(Character.toUpperCase(Character.forDigit((value >> 4) & 0xF, 16)));
+    out.append(Character.toUpperCase(Character.forDigit(value & 0xF, 16)));
+  }
+
+  private static int hexValue(char ch) {
+    int value = Character.digit(ch, 16);
+    if (value < 0) {
+      throw new IllegalArgumentException("Invalid hex digit in query string: " + ch);
+    }
+    return value;
+  }
+
+  private static void appendCodePoint(StringBuilder out, int codePoint) {
+    if (codePoint <= 0xFFFF) {
+      out.append((char) codePoint);
+    } else {
+      int adjusted = codePoint - 0x10000;
+      out.append((char) ((adjusted >> 10) + 0xD800));
+      out.append((char) ((adjusted & 0x3FF) + 0xDC00));
+    }
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/scheduler/DelayedJobRegistryTest.java
@@ -19,7 +19,7 @@
 
 package org.waveprotocol.wave.client.scheduler;
 
-import com.google.gwt.junit.client.GWTTestCase;
+import junit.framework.TestCase;
 
 import org.waveprotocol.wave.client.scheduler.Scheduler.Priority;
 import org.waveprotocol.wave.client.scheduler.Scheduler.Schedulable;
@@ -29,8 +29,7 @@ import org.waveprotocol.wave.client.scheduler.Scheduler.Schedulable;
  *
  * @author danilatos@google.com (Daniel Danilatos)
  */
-
-public class DelayedJobRegistryGwtTest extends GWTTestCase {
+public class DelayedJobRegistryTest extends TestCase {
 
   public void testDelayedJobRegistry() {
     DelayedJobRegistry r = new DelayedJobRegistry();
@@ -49,17 +48,15 @@ public class DelayedJobRegistryGwtTest extends GWTTestCase {
 
     String id1 = info[0].id;
     String id2 = info[1].id;
-    String id3 = info[2].id;
 
     assertTrue(r.debugIsClear());
     assertFalse(r.has(id1));
     assertFalse(r.has(id2));
-    assertEquals(-1, r.getNextDueDelayedJobTime(), 0.001);
-    assertEquals(null, r.getDueDelayedJob(0));
-    assertEquals(null, r.getDueDelayedJob(10000));
-    assertEquals(null, r.getDueDelayedJob(Double.MAX_VALUE));
-    r.removeDelayedJob(id1); // just check doesn't throw exception when id not
-                            // found
+    assertEquals(-1.0, r.getNextDueDelayedJobTime(), 0.001);
+    assertNull(r.getDueDelayedJob(0));
+    assertNull(r.getDueDelayedJob(10000));
+    assertNull(r.getDueDelayedJob(Double.MAX_VALUE));
+    r.removeDelayedJob(id1);
     r.removeDelayedJob(id2);
 
     r.addDelayedJob(info[0]);
@@ -67,11 +64,10 @@ public class DelayedJobRegistryGwtTest extends GWTTestCase {
     assertTrue(r.has(id1));
     assertTrue(r.has(id2));
     Schedulable j0 = r.getDueDelayedJob(0);
-    Schedulable j1 = r.getDueDelayedJob(0); // because it will be scheduled
-                                            // slightly later than 0
+    Schedulable j1 = r.getDueDelayedJob(0);
     assertTrue(j0 != j1);
-    assertTrue(j0 == tasks[0]);
-    assertTrue(j1 == tasks[1]);
+    assertSame(tasks[0], j0);
+    assertSame(tasks[1], j1);
 
     assertFalse(r.has(id1));
     info[1].calculateNextExecuteTime(0);
@@ -83,26 +79,18 @@ public class DelayedJobRegistryGwtTest extends GWTTestCase {
     assertNull(r.getDueDelayedJob(19));
     checkTimeAdvance(r, info[1], 20);
     checkTimeAdvance(r, info[1], 50);
-    assertNull(r.getDueDelayedJob(50)); // Won't get scheduled more times if
-                                        // time runs out
+    assertNull(r.getDueDelayedJob(50));
     assertTrue(r.has(id2));
     r.removeDelayedJob(id2);
     assertTrue(r.debugIsClear());
     assertFalse(r.has(id2));
     assertNull(r.getDueDelayedJob(100));
-
-    // TODO(danilatos): More?
   }
 
   private void checkTimeAdvance(DelayedJobRegistry r, TaskInfo info, double time) {
-    assertEquals(info.job, r.getDueDelayedJob(time));
+    assertSame(info.job, r.getDueDelayedJob(time));
     info.calculateNextExecuteTime(time);
     r.addDelayedJob(info);
     assertNull(r.getDueDelayedJob(time));
-  }
-
-  @Override
-  public String getModuleName() {
-    return "org.waveprotocol.wave.client.scheduler.tests";
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
@@ -94,4 +94,37 @@ public class UrlParametersTest extends TestCase {
     assertEquals("d", u.getParameter("c"));
     assertEquals("f", u.getParameter("e"));
   }
+
+  public void testBuildQueryStringPreservesEncodeComponentSafeCharacters() {
+    assertEquals("?!~*'()=!~*'()",
+        UrlParameters.buildQueryString(
+            Collections.<String, String>singletonMap("!~*'()", "!~*'()")));
+  }
+
+  public void testUtf8RoundTripInJvmCodec() {
+    String queryString =
+        UrlParameters.buildQueryString(
+            Collections.<String, String>singletonMap("こんにちは", "世界"));
+
+    UrlParameters u = new UrlParameters(queryString);
+    assertEquals("世界", u.getParameter("こんにちは"));
+  }
+
+  public void testTruncatedUtf8SequenceRejected() {
+    try {
+      new UrlParameters("?bad=%E2%82");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("UTF-8"));
+    }
+  }
+
+  public void testInvalidUtf8ContinuationRejected() {
+    try {
+      new UrlParameters("?bad=%E2%28%A1");
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("UTF-8"));
+    }
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
@@ -127,4 +127,14 @@ public class UrlParametersTest extends TestCase {
       assertTrue(expected.getMessage().contains("UTF-8"));
     }
   }
+
+  public void testLoneSurrogateInEncodeRejected() {
+    try {
+      UrlParameters.buildQueryString(
+          Collections.<String, String>singletonMap("k", "\uD800"));
+      fail("Expected IllegalArgumentException for lone surrogate");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("surrogate"));
+    }
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/util/UrlParametersTest.java
@@ -19,46 +19,38 @@
 
 package org.waveprotocol.wave.client.util;
 
-import com.google.gwt.junit.client.GWTTestCase;
+import junit.framework.TestCase;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- */
-
-public class UrlParametersGwtTest extends GWTTestCase {
-
-  @Override
-  public String getModuleName() {
-    return "org.waveprotocol.wave.client.util.ClientFlags";
-  }
+public class UrlParametersTest extends TestCase {
 
   public void testSomeQueries() {
     UrlParameters u = new UrlParameters("?act=new");
-    assertEquals("test1", "new", u.getParameter("act"));
-    assertEquals("test2", null, u.getParameter("cnv"));
+    assertEquals("new", u.getParameter("act"));
+    assertNull(u.getParameter("cnv"));
 
     u = new UrlParameters("?act=new&cnv=123");
-    assertEquals("test3", "new", u.getParameter("act"));
-    assertEquals("test4", "123", u.getParameter("cnv"));
+    assertEquals("new", u.getParameter("act"));
+    assertEquals("123", u.getParameter("cnv"));
   }
 
   public void testNonExistentQuery() {
     UrlParameters u = new UrlParameters("?");
-    assertEquals("test5", null, u.getParameter("act"));
-    assertEquals("test6", null, u.getParameter("cnv"));
+    assertNull(u.getParameter("act"));
+    assertNull(u.getParameter("cnv"));
 
     u = new UrlParameters("");
-    assertEquals("test7", null, u.getParameter("nonexistent_key"));
+    assertNull(u.getParameter("nonexistent_key"));
   }
 
   public void testSafeGetters() {
     UrlParameters u = new UrlParameters("?booleanValue=true&stringValue=hello");
-    assertEquals(Boolean.valueOf(true), u.getBoolean("booleanValue"));
+    assertEquals(Boolean.TRUE, u.getBoolean("booleanValue"));
     assertEquals("hello", u.getString("stringValue"));
-    assertEquals(null, u.getDouble("booleanValue"));
+    assertNull(u.getDouble("booleanValue"));
   }
 
   public void testInvalidQueryStrings() {
@@ -67,7 +59,6 @@ public class UrlParametersGwtTest extends GWTTestCase {
 
     u = new UrlParameters("?act==&");
     assertEquals("", u.getParameter("act"));
-
 
     u = new UrlParameters("?act=&cnv=3");
     assertEquals("", u.getParameter("act"));
@@ -81,22 +72,17 @@ public class UrlParametersGwtTest extends GWTTestCase {
 
   public void testNonExistent() {
     UrlParameters u = new UrlParameters("?booleanValue=true&stringValue=hello");
-    assertEquals(null, u.getBoolean("nonexistent"));
+    assertNull(u.getBoolean("nonexistent"));
   }
 
   public void testBuildQueryString() {
-    // Test empty map
-    assertEquals("", UrlParameters.buildQueryString(Collections.<String, String> emptyMap()));
+    assertEquals("", UrlParameters.buildQueryString(Collections.<String, String>emptyMap()));
+    assertEquals("?item=1",
+        UrlParameters.buildQueryString(Collections.<String, String>singletonMap("item", "1")));
+    assertEquals("?one+one=one+two",
+        UrlParameters.buildQueryString(
+            Collections.<String, String>singletonMap("one one", "one two")));
 
-    // Test one item
-    assertEquals("?item=1", UrlParameters.buildQueryString(Collections
-        .<String, String> singletonMap("item", "1")));
-
-    // Test that characters are urlencoded
-    assertEquals("?one+one=one+two", UrlParameters.buildQueryString(Collections
-        .<String, String> singletonMap("one one", "one two")));
-
-    // Test multiple items
     Map<String, String> queryMap = new HashMap<String, String>();
     queryMap.put("a", "b");
     queryMap.put("c", "d");


### PR DESCRIPTION
Closes #898

## Summary
- reconcile the live `GWTTestCase` inventory to the actual current baseline in this worktree
- convert the clearly low-risk JVM-safe suites off `GWTTestCase`
- add a committed browser-only verification matrix for the remaining suites
- update the J2CL inventory/memo/preparatory docs to reflect the verified counts and split

## What changed
- converted:
  - `DelayedJobRegistryGwtTest` -> `DelayedJobRegistryTest`
  - `UrlParametersGwtTest` -> `UrlParametersTest`
- added `docs/j2cl-gwttestcase-verification-matrix.md`
- updated the related J2CL migration docs to the live count and suite classification
- added a narrow cross-runtime helper path in `UrlParameters.java` so the JVM test path works without breaking GWT compile/runtime behavior
- added the issue-specific implementation plan doc for traceability

## Verification
Inventory and classification:
- direct `GWTTestCase` baseline before conversion: `21`
- direct `GWTTestCase` remaining after this lane: `19`
- inherited editor/test-base descendants still browser-only: `11`
- scope guard on the converted suites found no DOM/widget/JSNI dependency matches

Test/compile gates:
- `python3 scripts/assemble-changelog.py`
- `sbt -batch "wave / Test / testOnly org.waveprotocol.wave.client.scheduler.DelayedJobRegistryTest org.waveprotocol.wave.client.util.UrlParametersTest"`
  - passed: `8` tests run / `0` failed
- `sbt -batch compile`
  - passed
- `sbt -batch Test/compile`
  - passed

Local lane sanity:
- `bash scripts/worktree-boot.sh --port 9900`
  - passed
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-898-gwttest-split/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-898-gwttest-split/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- `PORT=9900 bash scripts/wave-smoke.sh stop`
  - passed

Browser verification:
- not required by the change-type matrix for this lane; the implementation is test-harness/docs/internal wiring, and the staged smoke confirmed the compiled client asset still served correctly

## Traceability
- Worktree: `/Users/vega/devroot/worktrees/issue-898-gwttest-split`
- Plan: `docs/superpowers/plans/2026-04-19-issue-898-gwttest-split.md`
- Local verification record: `journal/local-verification/2026-04-19-issue-898-gwttest-split.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical verification matrix, updated inventories, decision memo, migration plans, preparatory notes, and a local verification journal with dates and verification steps.

* **Tests**
  * Reclassified suites into JVM-run vs browser-facing groups and converted specific browser-dependent tests to plain JVM tests; updated assertions and added UTF‑8/encoding coverage.

* **Refactor**
  * Replaced query-parameter encoding/decoding with a unified JVM/browser-compatible implementation enforcing stricter validation.

* **Chores**
  * Adjusted build configuration so converted client sources and tests are included in JVM compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->