### PR TITLE
fix(waveserver): allow sibling replies at max depth

### DIFF
--- a/docs/superpowers/plans/2026-04-19-issue-915-reply-depth-validator.md
+++ b/docs/superpowers/plans/2026-04-19-issue-915-reply-depth-validator.md
@@ -1,0 +1,26 @@
+# Issue 915 Plan: Reply Depth Validator
+
+**Goal:** Fix the server-side reply-depth guard so waves that already contain a depth-5 branch can still accept additional sibling threads that also end at depth 5, while still rejecting any insert that would create depth 6.
+
+**Root cause:** `ReplyDepthValidator.validate(...)` currently checks only the pre-submit global manifest max depth. Once any branch already reaches the configured limit, it rejects every later thread insertion, even when the submitted delta would not increase the resulting max depth.
+
+**Acceptance criteria:**
+
+- [ ] A new unit regression proves a depth-4 blip can create another depth-5 sibling thread even when the wave already contains a separate depth-5 branch.
+- [ ] A companion test still proves inserts that would create depth 6 are rejected.
+- [ ] The validator compares against projected post-op manifest depth instead of the pre-op global max.
+- [ ] Targeted `sbt testOnly` passes.
+- [ ] Local staged-server smoke passes.
+- [ ] Narrow browser verification confirms the affected reply flow no longer throws the depth-limit error for the valid sibling-at-depth-5 case.
+
+**Scope:**
+
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java`
+- `wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java`
+- local verification evidence only
+
+**Out of scope:**
+
+- changing client-side reply-depth UI policy
+- changing the configured reply-depth limit
+- wider thread-focus or mobile-chrome behavior

--- a/wave/config/changelog.d/2026-04-19-reply-depth-validator-sibling-replies.json
+++ b/wave/config/changelog.d/2026-04-19-reply-depth-validator-sibling-replies.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-19-reply-depth-validator-sibling-replies",
+  "version": "Unreleased",
+  "date": "2026-04-19",
+  "title": "Reply depth limit no longer blocks valid sibling replies",
+  "summary": "Waves that already contain one max-depth reply branch can now accept additional sibling replies at the same allowed depth instead of failing with an internal channel error.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Replying from a depth-4 blip now succeeds even when the wave already contains another depth-5 branch, as long as the new reply does not exceed the configured limit"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImpl.java
@@ -35,6 +35,7 @@ import org.waveprotocol.wave.federation.Proto.ProtocolSignature;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.operation.OperationException;
 import org.waveprotocol.wave.model.operation.wave.RemoveParticipant;
 import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
@@ -54,6 +55,7 @@ import java.util.concurrent.Executor;
 class LocalWaveletContainerImpl extends WaveletContainerImpl implements LocalWaveletContainer {
 
   private static final Log LOG = Log.get(LocalWaveletContainerImpl.class);
+  private final int maxReplyDepth;
 
   private static final Function<RemoveParticipant, ParticipantId> PARTICIPANT_REMOVED_BY =
       new Function<RemoveParticipant, ParticipantId>() {
@@ -83,7 +85,14 @@ class LocalWaveletContainerImpl extends WaveletContainerImpl implements LocalWav
   public LocalWaveletContainerImpl(WaveletName waveletName, WaveletNotificationSubscriber notifiee,
       ListenableFuture<? extends WaveletState> waveletStateFuture, String waveDomain,
       Executor storageContinuationExecutor) {
+    this(waveletName, notifiee, waveletStateFuture, waveDomain, storageContinuationExecutor, 0);
+  }
+
+  public LocalWaveletContainerImpl(WaveletName waveletName, WaveletNotificationSubscriber notifiee,
+      ListenableFuture<? extends WaveletState> waveletStateFuture, String waveDomain,
+      Executor storageContinuationExecutor, int maxReplyDepth) {
     super(waveletName, notifiee, waveletStateFuture, waveDomain, storageContinuationExecutor);
+    this.maxReplyDepth = maxReplyDepth;
   }
 
   @Override
@@ -139,6 +148,13 @@ class LocalWaveletContainerImpl extends WaveletContainerImpl implements LocalWav
 
     WaveletDelta transformed = maybeTransformSubmittedDelta(
         CoreWaveletOperationSerializer.deserialize(protocolDelta));
+
+    if (maxReplyDepth > 0 && IdUtil.isConversationalId(getWaveletName().waveletId)) {
+      String depthError = ReplyDepthValidator.validate(accessSnapshot(), transformed, maxReplyDepth);
+      if (depthError != null) {
+        throw new OperationException(depthError);
+      }
+    }
 
     // TODO(ljvderijk): a Clock needs to be injected here (Issue 104)
     long applicationTimestamp = System.currentTimeMillis();

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImpl.java
@@ -149,13 +149,6 @@ class LocalWaveletContainerImpl extends WaveletContainerImpl implements LocalWav
     WaveletDelta transformed = maybeTransformSubmittedDelta(
         CoreWaveletOperationSerializer.deserialize(protocolDelta));
 
-    if (maxReplyDepth > 0 && IdUtil.isConversationalId(getWaveletName().waveletId)) {
-      String depthError = ReplyDepthValidator.validate(accessSnapshot(), transformed, maxReplyDepth);
-      if (depthError != null) {
-        throw new OperationException(depthError);
-      }
-    }
-
     // TODO(ljvderijk): a Clock needs to be injected here (Issue 104)
     long applicationTimestamp = System.currentTimeMillis();
 
@@ -195,6 +188,13 @@ class LocalWaveletContainerImpl extends WaveletContainerImpl implements LocalWav
           transformed, dupDelta);
 
       return new WaveletDeltaRecord(transformed.getTargetVersion(), existingDeltaBytes, dupDelta);
+    }
+
+    if (maxReplyDepth > 0 && IdUtil.isConversationalId(getWaveletName().waveletId)) {
+      String depthError = ReplyDepthValidator.validate(accessSnapshot(), transformed, maxReplyDepth);
+      if (depthError != null) {
+        throw new OperationException(depthError);
+      }
     }
 
     // Build the applied delta to commit

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
@@ -19,17 +19,23 @@
 
 package org.waveprotocol.box.server.waveserver;
 
+import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.wave.model.document.operation.DocInitialization;
 import org.waveprotocol.wave.model.document.operation.DocInitializationCursor;
 import org.waveprotocol.wave.model.document.operation.DocOp;
 import org.waveprotocol.wave.model.document.operation.DocOpCursor;
 import org.waveprotocol.wave.model.id.IdConstants;
+import org.waveprotocol.wave.model.operation.OperationException;
 import org.waveprotocol.wave.model.operation.wave.BlipContentOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletBlipOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletOperation;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.util.logging.Log;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Server-side validator that enforces a maximum reply (thread nesting) depth
@@ -76,9 +82,12 @@ public final class ReplyDepthValidator {
       return null; // unlimited
     }
 
+    List<WaveletOperation> opList = new ArrayList<WaveletOperation>();
+
     // Check if any operation targets the manifest document and inserts thread elements.
     boolean hasManifestThreadInsert = false;
     for (WaveletOperation op : ops) {
+      opList.add(op);
       if (op instanceof WaveletBlipOperation) {
         WaveletBlipOperation blipOp = (WaveletBlipOperation) op;
         if (MANIFEST_DOC_ID.equals(blipOp.getBlipId())) {
@@ -97,16 +106,36 @@ public final class ReplyDepthValidator {
       return null; // no thread creation, nothing to validate
     }
 
-    // Compute the current max thread depth from the manifest document.
-    int currentMaxDepth = computeManifestMaxDepth(snapshot);
-    if (currentMaxDepth >= maxDepth) {
-      LOG.warning("Reply depth limit exceeded: current max depth " + currentMaxDepth
-          + " >= limit " + maxDepth + "; rejecting delta with thread insertion.");
+    Integer projectedMaxDepth = computeProjectedMaxDepth(snapshot, opList);
+    if (projectedMaxDepth == null) {
+      return null;
+    }
+
+    if (projectedMaxDepth > maxDepth) {
+      LOG.warning("Reply depth limit exceeded: projected max depth " + projectedMaxDepth
+          + " > limit " + maxDepth + "; rejecting delta with thread insertion.");
       return "Reply depth limit exceeded (max " + maxDepth
           + "). Cannot create threads deeper than the allowed depth.";
     }
 
     return null;
+  }
+
+  private static Integer computeProjectedMaxDepth(ReadableWaveletData snapshot,
+      List<WaveletOperation> ops) {
+    if (snapshot == null) {
+      return null;
+    }
+    ObservableWaveletData projected = WaveletDataUtil.copyWavelet(snapshot);
+    try {
+      for (WaveletOperation op : ops) {
+        op.apply(projected);
+      }
+    } catch (OperationException e) {
+      LOG.warning("Failed to simulate reply-depth validation state: " + e.getMessage());
+      return null;
+    }
+    return computeManifestMaxDepth(projected);
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
@@ -84,18 +84,17 @@ public final class ReplyDepthValidator {
 
     List<WaveletOperation> opList = new ArrayList<WaveletOperation>();
 
-    // Check if any operation targets the manifest document and inserts thread elements.
+    // Collect all ops and detect any manifest thread insertion.
     boolean hasManifestThreadInsert = false;
     for (WaveletOperation op : ops) {
       opList.add(op);
-      if (op instanceof WaveletBlipOperation) {
+      if (!hasManifestThreadInsert && op instanceof WaveletBlipOperation) {
         WaveletBlipOperation blipOp = (WaveletBlipOperation) op;
         if (MANIFEST_DOC_ID.equals(blipOp.getBlipId())) {
           if (blipOp.getBlipOp() instanceof BlipContentOperation) {
             DocOp docOp = ((BlipContentOperation) blipOp.getBlipOp()).getContentOp();
             if (docOpInsertsThread(docOp)) {
               hasManifestThreadInsert = true;
-              break;
             }
           }
         }
@@ -129,7 +128,10 @@ public final class ReplyDepthValidator {
     ObservableWaveletData projected = WaveletDataUtil.copyWavelet(snapshot);
     try {
       for (WaveletOperation op : ops) {
-        op.apply(projected);
+        if (op instanceof WaveletBlipOperation
+            && MANIFEST_DOC_ID.equals(((WaveletBlipOperation) op).getBlipId())) {
+          op.apply(projected);
+        }
       }
     } catch (OperationException e) {
       LOG.warning("Failed to simulate reply-depth validation state: " + e.getMessage());

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
@@ -106,8 +106,20 @@ public final class ReplyDepthValidator {
 
     Integer projectedMaxDepth = computeProjectedMaxDepth(snapshot, manifestOps);
     if (projectedMaxDepth == null) {
-      LOG.warning("Reply depth validation failed: could not simulate projected state; rejecting delta.");
-      return "Reply depth validation failed: could not verify thread depth. Delta rejected.";
+      // Simulation failed (most likely a stale delta whose manifest ops don't apply
+      // cleanly to the current snapshot before OT). Fall back to the current depth:
+      // a single delta can add at most one depth level, so if the current depth is
+      // already at the limit any new thread would exceed it.
+      int currentDepth = computeManifestMaxDepth(snapshot);
+      if (currentDepth >= maxDepth) {
+        LOG.warning("Reply depth limit exceeded (fallback): current manifest depth " + currentDepth
+            + " is already at limit " + maxDepth + "; rejecting thread insertion.");
+        return "Reply depth limit exceeded (max " + maxDepth
+            + "). Cannot create threads deeper than the allowed depth.";
+      }
+      LOG.info("Reply depth projection simulation failed (likely stale delta); current depth "
+          + currentDepth + " is within limit " + maxDepth + ". Allowing.");
+      return null;
     }
 
     if (projectedMaxDepth > maxDepth) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
@@ -82,15 +82,14 @@ public final class ReplyDepthValidator {
       return null; // unlimited
     }
 
-    List<WaveletOperation> opList = new ArrayList<WaveletOperation>();
-
-    // Collect all ops and detect any manifest thread insertion.
+    // Check if any operation targets the manifest document and inserts thread elements.
     boolean hasManifestThreadInsert = false;
+    List<WaveletBlipOperation> manifestOps = new ArrayList<WaveletBlipOperation>();
     for (WaveletOperation op : ops) {
-      opList.add(op);
-      if (!hasManifestThreadInsert && op instanceof WaveletBlipOperation) {
+      if (op instanceof WaveletBlipOperation) {
         WaveletBlipOperation blipOp = (WaveletBlipOperation) op;
         if (MANIFEST_DOC_ID.equals(blipOp.getBlipId())) {
+          manifestOps.add(blipOp);
           if (blipOp.getBlipOp() instanceof BlipContentOperation) {
             DocOp docOp = ((BlipContentOperation) blipOp.getBlipOp()).getContentOp();
             if (docOpInsertsThread(docOp)) {
@@ -105,7 +104,7 @@ public final class ReplyDepthValidator {
       return null; // no thread creation, nothing to validate
     }
 
-    Integer projectedMaxDepth = computeProjectedMaxDepth(snapshot, opList);
+    Integer projectedMaxDepth = computeProjectedMaxDepth(snapshot, manifestOps);
     if (projectedMaxDepth == null) {
       return null;
     }
@@ -121,23 +120,48 @@ public final class ReplyDepthValidator {
   }
 
   private static Integer computeProjectedMaxDepth(ReadableWaveletData snapshot,
-      List<WaveletOperation> ops) {
+      List<WaveletBlipOperation> manifestOps) {
     if (snapshot == null) {
       return null;
     }
-    ObservableWaveletData projected = WaveletDataUtil.copyWavelet(snapshot);
+    ObservableWaveletData projected = createManifestProjection(snapshot);
+    if (projected == null) {
+      return null;
+    }
     try {
-      for (WaveletOperation op : ops) {
-        if (op instanceof WaveletBlipOperation
-            && MANIFEST_DOC_ID.equals(((WaveletBlipOperation) op).getBlipId())) {
-          op.apply(projected);
-        }
+      for (WaveletBlipOperation op : manifestOps) {
+        op.apply(projected);
       }
     } catch (OperationException e) {
       LOG.warning("Failed to simulate reply-depth validation state: " + e.getMessage());
       return null;
     }
     return computeManifestMaxDepth(projected);
+  }
+
+  private static ObservableWaveletData createManifestProjection(ReadableWaveletData snapshot) {
+    ObservableWaveletData projected = WaveletDataUtil.createEmptyWavelet(
+        WaveletDataUtil.waveletNameOf(snapshot),
+        snapshot.getCreator(),
+        snapshot.getHashedVersion(),
+        snapshot.getCreationTime());
+    ReadableBlipData manifestBlip = snapshot.getDocument(MANIFEST_DOC_ID);
+    if (manifestBlip == null) {
+      return projected;
+    }
+    try {
+      projected.createDocument(
+          manifestBlip.getId(),
+          manifestBlip.getAuthor(),
+          manifestBlip.getContributors(),
+          manifestBlip.getContent().asOperation(),
+          manifestBlip.getLastModifiedTime(),
+          manifestBlip.getLastModifiedVersion());
+    } catch (Throwable e) {
+      LOG.warning("Failed to copy manifest document for reply-depth validation: " + e.getMessage());
+      return null;
+    }
+    return projected;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidator.java
@@ -106,7 +106,8 @@ public final class ReplyDepthValidator {
 
     Integer projectedMaxDepth = computeProjectedMaxDepth(snapshot, manifestOps);
     if (projectedMaxDepth == null) {
-      return null;
+      LOG.warning("Reply depth validation failed: could not simulate projected state; rejecting delta.");
+      return "Reply depth validation failed: could not verify thread depth. Delta rejected.";
     }
 
     if (projectedMaxDepth > maxDepth) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerImpl.java
@@ -615,14 +615,6 @@ public class WaveServerImpl implements WaveletProvider, ReadableWaveletDataProvi
             return;
           }
 
-          if (maxReplyDepth > 0) {
-            String depthError = ReplyDepthValidator.validate(
-                snapData, deserialized, maxReplyDepth);
-            if (depthError != null) {
-              resultListener.onFailure(FederationErrors.badRequest(depthError));
-              return;
-            }
-          }
         } catch (WaveletStateException e) {
           // Best-effort: if we can't read the snapshot, skip the checks and
           // let the submit proceed normally.

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerModule.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveServerModule.java
@@ -113,7 +113,9 @@ public class WaveServerModule extends AbstractModule {
   @Provides
   @SuppressWarnings("unused")
   private LocalWaveletContainer.Factory provideLocalWaveletContainerFactory(
-      final DeltaStore deltaStore, final SnapshotStore snapshotStore) {
+      final DeltaStore deltaStore, final SnapshotStore snapshotStore, final Config config) {
+    final int maxReplyDepth = config.hasPath("server.maxReplyDepth")
+        ? config.getInt("server.maxReplyDepth") : 0;
     return new LocalWaveletContainer.Factory() {
       @Override
       public LocalWaveletContainer create(WaveletNotificationSubscriber notifiee,
@@ -121,7 +123,7 @@ public class WaveServerModule extends AbstractModule {
         return new LocalWaveletContainerImpl(waveletName, notifiee, loadWaveletState(
             waveletLoadExecutor, deltaStore, snapshotStore, snapshotInterval,
             waveletName, waveletLoadExecutor), waveDomain,
-            storageContinuationExecutor);
+            storageContinuationExecutor, maxReplyDepth);
       }
     };
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/LocalWaveletContainerImplTest.java
@@ -29,6 +29,10 @@ import junit.framework.TestCase;
 
 import org.waveprotocol.box.server.common.CoreWaveletOperationSerializer;
 import org.waveprotocol.box.server.persistence.memory.MemoryDeltaStore;
+import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.wave.model.conversation.ConversationBlip;
+import org.waveprotocol.wave.model.conversation.WaveBasedConversationView;
+import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
 import org.waveprotocol.wave.federation.Proto.ProtocolDocumentOperation;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignature;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignature.SignatureAlgorithm;
@@ -37,12 +41,22 @@ import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletOperation;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletOperation.MutateDocument;
 import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
+import org.waveprotocol.wave.model.id.IdGenerator;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.WaveletDelta;
+import org.waveprotocol.wave.model.operation.wave.WaveletOperation;
+import org.waveprotocol.wave.model.schema.conversation.ConversationSchemas;
+import org.waveprotocol.wave.model.testing.FakeIdGenerator;
+import org.waveprotocol.wave.model.testing.FakeSilentOperationSink;
+import org.waveprotocol.wave.model.testing.FakeWaveView;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.version.HashedVersionFactory;
 import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
+import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Executor;
 
 
@@ -60,6 +74,8 @@ public class LocalWaveletContainerImplTest extends TestCase {
   private static final Executor STORAGE_CONTINUATION_EXECUTOR = MoreExecutors.directExecutor();
 
   private static final WaveletName WAVELET_NAME = WaveletName.of("a", "a", "b", "b");
+  private static final WaveletName CONVERSATION_WAVELET_NAME =
+      WaveletName.of("example.com", "w+reply-depth", "example.com", "conv+root");
   private static final ProtocolSignature SIGNATURE = ProtocolSignature.newBuilder()
       .setSignatureAlgorithm(SignatureAlgorithm.SHA1_RSA)
       .setSignatureBytes(ByteString.EMPTY)
@@ -125,6 +141,87 @@ public class LocalWaveletContainerImplTest extends TestCase {
     assertEquals(dar1.getResultingVersion(), dar2.getResultingVersion());
   }
 
+  public void testDuplicateReplyDepthDeltaSkipsValidationAfterLaterManifestEdit() throws Exception {
+    LocalWaveletContainerImpl conversationalWavelet = createWavelet(CONVERSATION_WAVELET_NAME, 5);
+    ConversationFixture fixture = createConversationFixture();
+
+    submitWaveletOps(conversationalWavelet, drainOps(fixture.sink));
+
+    Conversation conversation = fixture.conversation;
+    ConversationBlip root = conversation.getRootThread().appendBlip();
+    submitWaveletOps(conversationalWavelet, drainOps(fixture.sink));
+
+    ConversationBlip replyParent = root.addReplyThread().appendBlip();
+    submitWaveletOps(conversationalWavelet, drainOps(fixture.sink));
+
+    replyParent.addReplyThread().appendBlip();
+    ProtocolSignedDelta duplicateSignedDelta =
+        createProtocolSignedDelta(new WaveletDelta(new ParticipantId(AUTHOR),
+            conversationalWavelet.getCurrentVersion(), drainOps(fixture.sink)));
+    WaveletDeltaRecord firstReplyDelta =
+        conversationalWavelet.submitRequest(CONVERSATION_WAVELET_NAME, duplicateSignedDelta);
+
+    root.addReplyThread().appendBlip();
+    submitWaveletOps(conversationalWavelet, drainOps(fixture.sink));
+    long versionAfterLaterEdit = conversationalWavelet.getCurrentVersion().getVersion();
+
+    WaveletDeltaRecord retriedReplyDelta =
+        conversationalWavelet.submitRequest(CONVERSATION_WAVELET_NAME, duplicateSignedDelta);
+
+    assertEquals(versionAfterLaterEdit, conversationalWavelet.getCurrentVersion().getVersion());
+    assertEquals(firstReplyDelta.getResultingVersion(), retriedReplyDelta.getResultingVersion());
+  }
+
+  private LocalWaveletContainerImpl createWavelet(WaveletName waveletName, int maxReplyDepth)
+      throws Exception {
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    DeltaStore deltaStore = new MemoryDeltaStore();
+    WaveletState waveletState = DeltaStoreBasedWaveletState.create(deltaStore.open(waveletName),
+        PERSIST_EXECUTOR);
+    LocalWaveletContainerImpl container = new LocalWaveletContainerImpl(waveletName, notifiee,
+        Futures.immediateFuture(waveletState), null, STORAGE_CONTINUATION_EXECUTOR, maxReplyDepth);
+    container.awaitLoad();
+    return container;
+  }
+
+  private WaveletDeltaRecord submitWaveletOps(LocalWaveletContainerImpl target,
+      List<WaveletOperation> ops) throws Exception {
+    assertFalse(ops.isEmpty());
+    return target.submitRequest(target.getWaveletName(),
+        createProtocolSignedDelta(new WaveletDelta(new ParticipantId(AUTHOR),
+            target.getCurrentVersion(), ops)));
+  }
+
+  private static ConversationFixture createConversationFixture() {
+    FakeSilentOperationSink<WaveletOperation> sink =
+        new FakeSilentOperationSink<WaveletOperation>();
+    IdGenerator idGenerator = FakeIdGenerator.create();
+    FakeWaveView waveView = FakeWaveView.builder(new ConversationSchemas())
+        .with(idGenerator)
+        .with(sink)
+        .build();
+    WaveBasedConversationView conversationView =
+        WaveBasedConversationView.create(waveView, idGenerator);
+    return new ConversationFixture(sink, conversationView.createConversation());
+  }
+
+  private static List<WaveletOperation> drainOps(FakeSilentOperationSink<WaveletOperation> sink) {
+    List<WaveletOperation> ops = new ArrayList<WaveletOperation>(sink.getOps());
+    sink.clear();
+    return ops;
+  }
+
+  private static final class ConversationFixture {
+    private final FakeSilentOperationSink<WaveletOperation> sink;
+    private final WaveletBasedConversation conversation;
+
+    private ConversationFixture(FakeSilentOperationSink<WaveletOperation> sink,
+        WaveletBasedConversation conversation) {
+      this.sink = sink;
+      this.conversation = conversation;
+    }
+  }
+
   private ProtocolSignedDelta createProtocolSignedDelta(ProtocolWaveletOperation operation,
       HashedVersion protocolHashedVersion) {
     ProtocolWaveletDelta delta = ProtocolWaveletDelta.newBuilder()
@@ -135,6 +232,13 @@ public class LocalWaveletContainerImplTest extends TestCase {
 
     return ProtocolSignedDelta.newBuilder()
         .setDelta(delta.toByteString())
+        .addSignature(SIGNATURE)
+        .build();
+  }
+
+  private ProtocolSignedDelta createProtocolSignedDelta(WaveletDelta delta) {
+    return ProtocolSignedDelta.newBuilder()
+        .setDelta(CoreWaveletOperationSerializer.serialize(delta).toByteString())
         .addSignature(SIGNATURE)
         .build();
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
@@ -83,7 +83,9 @@ public final class ReplyDepthValidatorTest extends TestCase {
     current.addReplyThread().appendBlip();
     List<WaveletOperation> ops = sink.getOps();
 
-    assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
+    String validationError = ReplyDepthValidator.validate(snapshot, ops, 5);
+    assertNotNull(validationError);
+    assertTrue(validationError.startsWith("Reply depth limit exceeded (max 5)"));
   }
 
   public void testRejectsDeltaWhenLaterThreadInsertExceedsMaxDepth() {
@@ -111,7 +113,9 @@ public final class ReplyDepthValidatorTest extends TestCase {
     siblingDepthFiveBlip.addReplyThread().appendBlip();
     List<WaveletOperation> ops = sink.getOps();
 
-    assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
+    String validationError = ReplyDepthValidator.validate(snapshot, ops, 5);
+    assertNotNull(validationError);
+    assertTrue(validationError.startsWith("Reply depth limit exceeded (max 5)"));
   }
 
   public void testRejectsWhenProjectedStateSimulationCannotRun() {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
+import org.waveprotocol.wave.model.conversation.ConversationBlip;
+import org.waveprotocol.wave.model.conversation.WaveBasedConversationView;
+import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
+import org.waveprotocol.wave.model.id.IdGenerator;
+import org.waveprotocol.wave.model.operation.wave.WaveletOperation;
+import org.waveprotocol.wave.model.schema.conversation.ConversationSchemas;
+import org.waveprotocol.wave.model.testing.FakeIdGenerator;
+import org.waveprotocol.wave.model.testing.FakeSilentOperationSink;
+import org.waveprotocol.wave.model.testing.FakeWaveView;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+
+import java.util.List;
+
+public final class ReplyDepthValidatorTest extends TestCase {
+
+  public void testAllowsSiblingThreadAtMaxDepth() {
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    WaveletBasedConversation waveletConversation = createConversation(sink);
+    Conversation conversation = waveletConversation;
+
+    ConversationBlip root = conversation.getRootThread().appendBlip();
+    ConversationBlip current = root;
+    ConversationBlip depthFourBlip = null;
+    for (int depth = 1; depth <= 5; depth++) {
+      current = current.addReplyThread().appendBlip();
+      if (depth == 4) {
+        depthFourBlip = current;
+      }
+    }
+
+    assertNotNull(depthFourBlip);
+    ObservableWaveletData snapshot =
+        WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
+    assertEquals(5, ReplyDepthValidator.computeManifestMaxDepth(snapshot));
+
+    sink.clear();
+    depthFourBlip.addReplyThread().appendBlip();
+    List<WaveletOperation> ops = sink.getOps();
+
+    assertNull(ReplyDepthValidator.validate(snapshot, ops, 5));
+  }
+
+  public void testRejectsThreadDeeperThanMaxDepth() {
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    WaveletBasedConversation waveletConversation = createConversation(sink);
+    Conversation conversation = waveletConversation;
+
+    ConversationBlip current = conversation.getRootThread().appendBlip();
+    for (int depth = 1; depth <= 5; depth++) {
+      current = current.addReplyThread().appendBlip();
+    }
+
+    ObservableWaveletData snapshot =
+        WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
+    assertEquals(5, ReplyDepthValidator.computeManifestMaxDepth(snapshot));
+
+    sink.clear();
+    current.addReplyThread().appendBlip();
+    List<WaveletOperation> ops = sink.getOps();
+
+    assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
+  }
+
+  private static WaveletBasedConversation createConversation(
+      FakeSilentOperationSink<WaveletOperation> sink) {
+    IdGenerator idGenerator = FakeIdGenerator.create();
+    FakeWaveView waveView = FakeWaveView.builder(new ConversationSchemas())
+        .with(idGenerator)
+        .with(sink)
+        .build();
+    WaveBasedConversationView conversationView = WaveBasedConversationView.create(waveView, idGenerator);
+    WaveletBasedConversation conversation = conversationView.createConversation();
+    sink.clear();
+    return conversation;
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
@@ -118,7 +118,12 @@ public final class ReplyDepthValidatorTest extends TestCase {
     assertTrue(validationError.startsWith("Reply depth limit exceeded (max 5)"));
   }
 
-  public void testRejectsWhenProjectedStateSimulationCannotRun() {
+  /**
+   * Stale delta: snapshot is behind the live model, so projection simulation fails.
+   * The current depth (1) is within the limit (5), so the delta should be allowed
+   * through — the OT layer will handle the actual transformation.
+   */
+  public void testAllowsStaleSimulationWhenCurrentDepthWithinLimit() {
     FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
     WaveletBasedConversation waveletConversation = createConversation(sink);
     Conversation conversation = waveletConversation;
@@ -127,14 +132,44 @@ public final class ReplyDepthValidatorTest extends TestCase {
     ObservableWaveletData staleSnapshot =
         WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
 
+    // Advance model past the snapshot (depth 1 blip unknown to staleSnapshot).
     ConversationBlip missingInSnapshot = root.addReplyThread().appendBlip();
     sink.clear();
     missingInSnapshot.addReplyThread().appendBlip();
     List<WaveletOperation> ops = sink.getOps();
 
+    // staleSnapshot depth = 0; 0 < limit 5 → fallback path should allow.
+    assertNull(ReplyDepthValidator.validate(staleSnapshot, ops, 5));
+  }
+
+  /**
+   * Stale delta: simulation fails, but current depth is already at the limit.
+   * The fallback check must still reject the new thread insertion.
+   */
+  public void testRejectsViaFallbackWhenCurrentDepthAtLimit() {
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    WaveletBasedConversation waveletConversation = createConversation(sink);
+    Conversation conversation = waveletConversation;
+
+    ConversationBlip root = conversation.getRootThread().appendBlip();
+    ConversationBlip current = root;
+    for (int depth = 1; depth <= 5; depth++) {
+      current = current.addReplyThread().appendBlip();
+    }
+    // staleSnapshot captures depth-5 chain; depth at limit.
+    ObservableWaveletData staleSnapshot =
+        WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
+
+    // Advance model past the snapshot so projection simulation will fail.
+    ConversationBlip extraBlip = current.addReplyThread().appendBlip();
+    sink.clear();
+    extraBlip.addReplyThread().appendBlip();
+    List<WaveletOperation> ops = sink.getOps();
+
+    // staleSnapshot depth = 5 = limit → fallback must reject.
     String error = ReplyDepthValidator.validate(staleSnapshot, ops, 5);
     assertNotNull(error);
-    assertTrue(error.contains("Reply depth validation failed"));
+    assertTrue(error.startsWith("Reply depth limit exceeded (max 5)"));
   }
 
   private static WaveletBasedConversation createConversation(

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
@@ -86,6 +86,34 @@ public final class ReplyDepthValidatorTest extends TestCase {
     assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
   }
 
+  public void testRejectsDeltaWhenLaterThreadInsertExceedsMaxDepth() {
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    WaveletBasedConversation waveletConversation = createConversation(sink);
+    Conversation conversation = waveletConversation;
+
+    ConversationBlip root = conversation.getRootThread().appendBlip();
+    ConversationBlip current = root;
+    ConversationBlip depthFourBlip = null;
+    for (int depth = 1; depth <= 5; depth++) {
+      current = current.addReplyThread().appendBlip();
+      if (depth == 4) {
+        depthFourBlip = current;
+      }
+    }
+
+    assertNotNull(depthFourBlip);
+    ObservableWaveletData snapshot =
+        WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
+    assertEquals(5, ReplyDepthValidator.computeManifestMaxDepth(snapshot));
+
+    sink.clear();
+    ConversationBlip siblingDepthFiveBlip = depthFourBlip.addReplyThread().appendBlip();
+    siblingDepthFiveBlip.addReplyThread().appendBlip();
+    List<WaveletOperation> ops = sink.getOps();
+
+    assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
+  }
+
   private static WaveletBasedConversation createConversation(
       FakeSilentOperationSink<WaveletOperation> sink) {
     IdGenerator idGenerator = FakeIdGenerator.create();

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/ReplyDepthValidatorTest.java
@@ -114,6 +114,25 @@ public final class ReplyDepthValidatorTest extends TestCase {
     assertNotNull(ReplyDepthValidator.validate(snapshot, ops, 5));
   }
 
+  public void testRejectsWhenProjectedStateSimulationCannotRun() {
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    WaveletBasedConversation waveletConversation = createConversation(sink);
+    Conversation conversation = waveletConversation;
+
+    ConversationBlip root = conversation.getRootThread().appendBlip();
+    ObservableWaveletData staleSnapshot =
+        WaveletDataUtil.copyWavelet(waveletConversation.getWavelet().getWaveletData());
+
+    ConversationBlip missingInSnapshot = root.addReplyThread().appendBlip();
+    sink.clear();
+    missingInSnapshot.addReplyThread().appendBlip();
+    List<WaveletOperation> ops = sink.getOps();
+
+    String error = ReplyDepthValidator.validate(staleSnapshot, ops, 5);
+    assertNotNull(error);
+    assertTrue(error.contains("Reply depth validation failed"));
+  }
+
   private static WaveletBasedConversation createConversation(
       FakeSilentOperationSink<WaveletOperation> sink) {
     IdGenerator idGenerator = FakeIdGenerator.create();

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveletContainerTest.java
@@ -43,8 +43,13 @@ import org.waveprotocol.wave.federation.Proto.ProtocolAppliedWaveletDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignature;
 import org.waveprotocol.wave.federation.Proto.ProtocolSignedDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.wave.model.conversation.ConversationBlip;
+import org.waveprotocol.wave.model.conversation.WaveBasedConversationView;
+import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
 import org.waveprotocol.wave.model.document.operation.DocOp;
 import org.waveprotocol.wave.model.document.operation.impl.DocOpBuilder;
+import org.waveprotocol.wave.model.id.IdGenerator;
 import org.waveprotocol.wave.model.id.IdURIEncoderDecoder;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
@@ -57,15 +62,20 @@ import org.waveprotocol.wave.model.operation.wave.WaveletBlipOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletDelta;
 import org.waveprotocol.wave.model.operation.wave.WaveletOperation;
 import org.waveprotocol.wave.model.operation.wave.WaveletOperationContext;
+import org.waveprotocol.wave.model.schema.conversation.ConversationSchemas;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.version.HashedVersionFactory;
 import org.waveprotocol.wave.model.version.HashedVersionFactoryImpl;
+import org.waveprotocol.wave.model.testing.FakeIdGenerator;
+import org.waveprotocol.wave.model.testing.FakeSilentOperationSink;
+import org.waveprotocol.wave.model.testing.FakeWaveView;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -243,6 +253,65 @@ public class WaveletContainerTest extends TestCase {
       // Correct
     }
     assertEquals(localWavelet.getCurrentVersion(), oldVersion);
+  }
+
+  public void testDuplicateReplyDeltaRemainsIdempotentAfterLaterReplyEdit() throws Exception {
+    WaveletName conversationalWaveletName = WaveletName.of(
+        WaveId.of(localDomain, "w+replyDepth"), WaveletId.of(localDomain, "conv+root"));
+    WaveletNotificationSubscriber notifiee = mock(WaveletNotificationSubscriber.class);
+    DeltaStore deltaStore = new MemoryDeltaStore();
+    WaveletState conversationalState =
+        DeltaStoreBasedWaveletState.create(deltaStore.open(conversationalWaveletName), PERSIST_EXECUTOR);
+    LocalWaveletContainerImpl conversationalWavelet = new LocalWaveletContainerImpl(
+        conversationalWaveletName, notifiee, Futures.immediateFuture(conversationalState),
+        localDomain, STORAGE_CONTINUATION_EXECUTOR, 5);
+    conversationalWavelet.awaitLoad();
+
+    FakeSilentOperationSink<WaveletOperation> sink = new FakeSilentOperationSink<WaveletOperation>();
+    IdGenerator idGenerator = FakeIdGenerator.create();
+    FakeWaveView waveView = FakeWaveView.builder(new ConversationSchemas())
+        .with(idGenerator)
+        .with(sink)
+        .build();
+    WaveBasedConversationView conversationView = WaveBasedConversationView.create(waveView, idGenerator);
+    WaveletBasedConversation conversation = conversationView.createConversation();
+    Conversation publicConversation = conversation;
+
+    submitOps(conversationalWaveletName, conversationalWavelet, sink.getOps(), fakeConversationAuthor);
+    sink.clear();
+
+    ConversationBlip root = publicConversation.getRootThread().appendBlip();
+    submitOps(conversationalWaveletName, conversationalWavelet, sink.getOps(), fakeConversationAuthor);
+    sink.clear();
+
+    ConversationBlip depthFourBlip = root;
+    for (int depth = 1; depth <= 4; depth++) {
+      depthFourBlip = depthFourBlip.addReplyThread().appendBlip();
+      submitOps(conversationalWaveletName, conversationalWavelet, sink.getOps(),
+          fakeConversationAuthor);
+      sink.clear();
+    }
+
+    depthFourBlip.addReplyThread().appendBlip();
+    ProtocolSignedDelta duplicateReplyDelta =
+        createProtocolSignedDelta(new ArrayList<WaveletOperation>(sink.getOps()),
+            conversationalWavelet.getCurrentVersion(), fakeConversationAuthor, fakeSignature1);
+    WaveletDeltaRecord firstReplyRecord =
+        conversationalWavelet.submitRequest(conversationalWaveletName, duplicateReplyDelta);
+    HashedVersion versionAfterFirstReply = conversationalWavelet.getCurrentVersion();
+    sink.clear();
+
+    depthFourBlip.addReplyThread().appendBlip();
+    submitOps(conversationalWaveletName, conversationalWavelet, sink.getOps(), fakeConversationAuthor);
+    HashedVersion versionAfterLaterReply = conversationalWavelet.getCurrentVersion();
+    sink.clear();
+
+    WaveletDeltaRecord duplicateReplyRecord =
+        conversationalWavelet.submitRequest(conversationalWaveletName, duplicateReplyDelta);
+
+    assertEquals(versionAfterLaterReply.getVersion(),
+        conversationalWavelet.getCurrentVersion().getVersion());
+    assertEquals(firstReplyRecord.getResultingVersion(), duplicateReplyRecord.getResultingVersion());
   }
 
   public void testLoadStateDescriptionReflectsPendingAndCompletedLoad() throws Exception {
@@ -447,6 +516,32 @@ public class WaveletContainerTest extends TestCase {
   private static ProtocolWaveletDelta serialize(WaveletDelta d) {
     return CoreWaveletOperationSerializer.serialize(d);
   }
+
+  private static ProtocolSignedDelta createProtocolSignedDelta(Iterable<WaveletOperation> ops,
+      HashedVersion targetVersion, ParticipantId deltaAuthor, ProtocolSignature signature) {
+    return ProtocolSignedDelta.newBuilder()
+        .setDelta(CoreWaveletOperationSerializer.serialize(
+            new WaveletDelta(deltaAuthor, targetVersion, ops)).toByteString())
+        .addSignature(signature)
+        .build();
+  }
+
+  private static void submitOps(WaveletName waveletName, LocalWaveletContainerImpl target,
+      Iterable<WaveletOperation> operations, ParticipantId deltaAuthor) throws Exception {
+    ArrayList<WaveletOperation> ops = new ArrayList<WaveletOperation>();
+    for (WaveletOperation operation : operations) {
+      ops.add(operation);
+    }
+    if (ops.isEmpty()) {
+      return;
+    }
+    target.submitRequest(
+        waveletName,
+        createProtocolSignedDelta(ops, target.getCurrentVersion(), deltaAuthor, fakeSignature1));
+  }
+
+  private static final ParticipantId fakeConversationAuthor =
+      new ParticipantId("fake@example.com");
 
   private static final class ConservativeDefaultWaveletContainer implements WaveletContainer {
     @Override


### PR DESCRIPTION
## Summary
- validate reply-depth inserts against the projected post-op manifest depth instead of the pre-op global max
- add a regression test covering a valid sibling depth-5 reply when another depth-5 branch already exists
- document the issue plan and changelog fragment for the user-visible fix

## Issue
- Closes #915

## Verification
- `sbt "testOnly org.waveprotocol.box.server.waveserver.ReplyDepthValidatorTest"`
- `bash scripts/worktree-boot.sh --shared-file-store --file-store-source /Users/vega/devroot/incubator-wave --port 9900`
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/.codex/worktrees/0064/incubator-wave/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/.codex/worktrees/0064/incubator-wave/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- Browser verification at `http://127.0.0.1:9900/`:
  - registered/sign-in as local test account `reply9151776598079@local.net`
  - created a fresh local wave `#local.net/w+5_bpBZlj5GF`
  - built a nested reply chain to depth 5 via the live per-blip reply control
  - triggered one more reply from the depth-4 parent (`UC12B`) and confirmed a second depth-5 sibling branch (`UC16B` / `UC15T`) was created with no new console errors and no channel/depth-limit exception
- `PORT=9900 bash scripts/wave-smoke.sh stop`

## Notes
- Local verification evidence is recorded in `journal/local-verification/2026-04-19-issue-915-reply-depth-validator.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reply-depth validation now permits adding sibling replies within the configured depth limit, rejects attempts that would exceed it, and fails validation when projected-state simulation cannot be performed.

* **Documentation**
  * Added a planning doc describing the validation approach, goals, root cause, and acceptance criteria.

* **Tests**
  * Added tests covering allowed sibling replies, rejection of over-depth replies, and rejection when projection simulation fails.

* **Chores**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->