### PR TITLE
feat(j2cl): add search sidecar slice

### DIFF
--- a/docs/superpowers/plans/2026-04-19-issue-901-j2cl-search-slice.md
+++ b/docs/superpowers/plans/2026-04-19-issue-901-j2cl-search-slice.md
@@ -1,0 +1,271 @@
+# Issue #901 J2CL Search Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the search results panel as the first J2CL UI vertical slice, behind the isolated sidecar route, while preserving the existing search/query behavior and leaving the legacy root runtime active.
+
+**Architecture:** Keep the live GWT search path as the reference implementation and move only the view layer for the first slice into `j2cl/`. Reuse the existing search model and digest/query behavior where possible, consume the J2CL-safe search transport/codecs from the sidecar transport work, and render the sidecar panel with explicit DOM plus static CSS instead of UiBinder, `ClientBundle`, or `CssResource`.
+
+**Tech Stack:** Java, SBT, J2CL Maven sidecar under `j2cl/`, Elemental2 DOM, existing `Search`/`SimpleSearch` model, generated `impl`/`gson` search message families, worktree boot/smoke scripts, manual browser verification.
+
+---
+
+## 1. Goal / Root Cause
+
+Issue `#901` exists because the current search panel is still tied to GWT-only UI mechanisms:
+
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java`, `SearchPanelWidget.java`, and `DigestDomImpl.java` depend on UiBinder, `ClientBundle`, `CssResource`, and GWT DOM/widget APIs.
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelResourceLoader.java` synchronously injects bundled CSS with `StyleInjector`, which is explicitly called out as the wrong direction for the J2CL slice.
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/JsoSearchBuilderImpl.java` still uses `SearchRequestJsoImpl` / `SearchResponseJsoImpl`, which the sidecar path must not depend on.
+
+The narrow root cause is therefore not "search logic missing." The logic is already present in the legacy search stack. The blocker is that the current widget/rendering layer and JSO transport seam are not J2CL-safe.
+
+This plan assumes the prerequisite work from `#900` and `#902` is available in the lane baseline:
+
+- isolated sidecar route and build tasks under `j2cl/`
+- sidecar-safe search transport/codecs for `/search` and `/socket`
+- root-path proof that `/` and `/webclient/**` stay on the legacy GWT runtime
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Add the first search-results vertical slice under the isolated sidecar path, using explicit DOM construction in `j2cl/`.
+- Preserve existing query normalization, paging, digest/result semantics, and wave-count behavior where practical instead of redesigning search behavior.
+- Replace sidecar search-panel styling with static CSS or build-time CSS extraction; do not carry `ClientBundle`/`CssResource` into the sidecar slice.
+- Use the J2CL-safe search transport/codecs from the sidecar transport/codegen work instead of `SearchRequestJsoImpl` / `SearchResponseJsoImpl`.
+- Keep the first slice narrow enough to validate dual-run rendering: legacy root search panel remains available on `/`, sidecar search slice lives on `/j2cl-search/index.html`.
+
+### Explicit Non-Goals
+
+- No full app-shell migration.
+- No editor migration.
+- No root-route cutover from GWT to J2CL.
+- No rewrite of the active legacy `WebClient` search panel.
+- No saved-search editor rewrite; `SearchesEditorPopup` and `SearchesItemEditorPopup` may stay on the legacy path or remain unavailable from the first sidecar slice if that is the narrower safe boundary.
+- No transport protocol change beyond consuming the already-approved J2CL-safe search codecs.
+
+## 3. Exact Files Likely To Change
+
+### Primary Sidecar Files
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/SidecarSearchResponse.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- `j2cl/src/main/webapp/index.html`
+- `j2cl/src/main/webapp/assets/sidecar.css`
+- New files under `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/` for the actual slice, likely split by responsibility:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchBoxView.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+- New tests under `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/`
+
+### Shared Search Seams To Reuse Or Extract Narrow Helpers From
+
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/Search.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SimpleSearch.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchService.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelRenderer.java`
+- `gen/messages/org/waveprotocol/box/search/SearchRequest.java`
+- `gen/messages/org/waveprotocol/box/search/SearchResponse.java`
+- `gen/messages/org/waveprotocol/box/search/impl/SearchRequestImpl.java`
+- `gen/messages/org/waveprotocol/box/search/impl/SearchResponseImpl.java`
+- `gen/messages/org/waveprotocol/box/search/gson/SearchRequestGsonImpl.java`
+- `gen/messages/org/waveprotocol/box/search/gson/SearchResponseGsonImpl.java`
+
+### Legacy View-Layer Files That Should Be Inspect-Only Unless A Tiny Shared Helper Extraction Is Unavoidable
+
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchWidget.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelWidget.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/DigestDomImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPanelResourceLoader.java`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanelWidget.ui.xml`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/DigestDomImpl.ui.xml`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/Search.css`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchPanel.css`
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/mock/digest.css`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/JsoSearchBuilderImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/RemoteSearchService.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchServiceImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchesEditorPopup.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchesItemEditorPopup.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java`
+
+## 4. Concrete Task Breakdown For The First J2CL Search Slice
+
+### Task 1: Freeze The Slice Boundary Before Coding
+
+- [ ] Keep the runtime boundary explicit: `/` stays on the legacy GWT app; `/j2cl-search/index.html` is the only route for the J2CL search slice.
+- [ ] Treat the legacy GWT search panel as the parity reference, not the implementation target.
+- [ ] Confirm that the sidecar slice for `#901` depends on the sidecar scaffold and sidecar-safe transport/codecs from `#900` and `#902`; do not reopen those issues inside this slice.
+
+### Task 2: Reuse Search Logic, Not Legacy Widgets
+
+- [ ] Inventory the exact behavior that must remain aligned with the legacy path:
+  - query normalization (`SearchPresenter.normalizeSearchQuery(...)`)
+  - default query (`in:inbox`)
+  - page sizing / show-more behavior
+  - digest projection and wave-count summary behavior
+  - optimistic search-model updates from `SimpleSearch`
+- [ ] Extract only tiny compiler-safe helpers from `SearchPresenter.java` if the sidecar needs them; do not drag GWT widget, toolbar, popup, or binder code into the sidecar.
+- [ ] Keep the shared logic narrow enough that the legacy search panel behavior does not change just to support the sidecar view.
+
+### Task 3: Build A Sidecar-Only DOM View Layer
+
+- [ ] Create sidecar search-panel view classes under `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/` that construct the panel, query box, digest rows, and empty/loading states with explicit Elemental2 DOM calls.
+- [ ] Mirror the legacy search seams at the behavior level:
+  - search box input/query submit
+  - wave-count summary
+  - digest list insert/update/clear
+  - show-more affordance
+  - selection callback for a digest row
+- [ ] Keep saved-search editing outside this first slice unless a read-only affordance is trivial and does not widen scope.
+
+### Task 4: Remove Sidecar Dependence On GWT Search Assets And JSO Messages
+
+- [ ] Replace sidecar styling with static CSS in `j2cl/src/main/webapp/assets/sidecar.css` or another build-time-extracted sidecar stylesheet.
+- [ ] Do not use `SearchPanelResourceLoader`, `ClientBundle`, `CssResource`, `StyleInjector`, or `.ui.xml` files in the sidecar slice.
+- [ ] Route sidecar search requests and digest decoding through the J2CL-safe search message path from the transport/codegen work:
+  - prefer generated `impl` / `gson` families or the approved sidecar-safe wrappers
+  - do not introduce new `*JsoImpl` usage
+
+### Task 5: Wire The Search Slice Into The Existing Sidecar Host Page
+
+- [ ] Extend `SandboxEntryPoint` so the sidecar route renders the real search slice instead of only the current transport-proof card.
+- [ ] Keep the search slice sidecar-only; do not route the root shell or existing login bootstrap through the new UI.
+- [ ] Preserve the existing sidecar proof value: the page should still prove the sidecar can reuse the root session and sidecar transport stack while now rendering a real search panel.
+
+### Task 6: Add Narrow Sidecar Tests
+
+- [ ] Add J2CL-side tests for:
+  - search response to digest-row projection
+  - query submission and default-query behavior
+  - show-more visibility / total-count behavior
+  - selected digest / click callback wiring
+- [ ] If any shared helper is extracted from `SearchPresenter`, add or update legacy JVM tests so both paths stay aligned.
+
+### Task 7: Prove Dual-Run Rendering Without Broadening Scope
+
+- [ ] Verify that the legacy root search panel still renders from the GWT runtime on `/`.
+- [ ] Verify that the sidecar route renders the first J2CL search slice independently on `/j2cl-search/index.html`.
+- [ ] Keep the validation focused on parity of the search-results panel, not the rest of the app shell.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-901-j2cl-search-slice`.
+
+### Search Codec / Generation Gate
+
+```bash
+sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"
+```
+
+Expected result:
+
+- PST generation completes successfully
+- the contract test stays green
+- the `box/search` family still exposes `impl`, `gson`, `jso`, and `proto`
+
+### Sidecar Search Build/Test Proof
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+```
+
+Expected result:
+
+- the J2CL search-sidecar build and tests succeed
+- sidecar outputs remain isolated under `war/j2cl-search/**`
+- the search slice does not require rewriting `war/webclient/**`
+
+### Legacy-Root Compile / Stage Proof
+
+```bash
+sbt -batch compileGwt Universal/stage
+```
+
+Expected result:
+
+- `compileGwt` stays green
+- `Universal/stage` stays green
+- the staged app still serves the legacy root bootstrap assets
+
+### Local Boot / Smoke Proof
+
+```bash
+bash scripts/worktree-boot.sh --port 9900
+```
+
+Then run the exact printed commands from the helper. The expected shape remains:
+
+```bash
+PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+```
+
+### Root / Sidecar Route Presence Checks
+
+```bash
+curl -sS -I http://localhost:9900/
+curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
+curl -sS -I http://localhost:9900/j2cl-search/index.html
+```
+
+Expected result:
+
+- `/` responds successfully
+- `/webclient/webclient.nocache.js` is still present for the legacy root runtime
+- `/j2cl-search/index.html` is present for the sidecar search slice
+
+### Browser Checks For Both Root And Search Slice
+
+Browser verification is required by `docs/runbooks/change-type-verification-matrix.md` because this issue touches both `GWT client/UI` behavior and browser-visible sidecar assets.
+
+Open these in the same logged-in browser session:
+
+- `http://localhost:9900/`
+- `http://localhost:9900/j2cl-search/index.html`
+
+Confirm on the legacy root path:
+
+- `/` still boots the existing GWT app
+- the legacy search panel remains the runtime source of truth on the root page
+
+Confirm on the sidecar search slice:
+
+- the search panel is rendered by the J2CL sidecar route, not by the legacy root shell
+- the default `in:inbox` query loads a visible result list or explicit empty state
+- entering another narrow query such as `with:@` or `in:archive` re-renders the list without a page reload
+- wave-count text and show-more behavior update coherently with the returned result set
+
+Record the exact port, printed start/check/stop commands, route checks, and observed browser results in `journal/local-verification/<date>-issue-901-j2cl-search-slice.md`, then mirror the important outcomes into the issue comment and PR body.
+
+## 6. Acceptance Criteria
+
+- The first J2CL search slice is available only under the isolated sidecar route and does not take over `/` or `/webclient/**`.
+- The sidecar search slice renders the search results panel with explicit DOM construction and static/build-time CSS, with no sidecar dependence on UiBinder, `ClientBundle`, `CssResource`, or `StyleInjector`.
+- The sidecar search slice does not depend on `SearchRequestJsoImpl` or `SearchResponseJsoImpl`.
+- Existing search/query behavior is preserved closely enough that the default query, query entry, digest rendering, and show-more behavior match the legacy panel for the covered slice.
+- Saved-search editor popups remain on the legacy path or otherwise explicitly out of scope for this first slice.
+- `j2clSearchBuild`, `j2clSearchTest`, `compileGwt`, and `Universal/stage` all pass.
+- Manual browser verification proves dual-run rendering: legacy root path green, isolated J2CL search slice green.
+
+## 7. Issue / PR Traceability Notes
+
+- Use issue `#901` as the live execution log.
+- Record these exact identifiers in the issue comments:
+  - Worktree: `/Users/vega/devroot/worktrees/issue-901-j2cl-search-slice`
+  - Branch: `issue-901-j2cl-search-slice`
+  - Plan: `docs/superpowers/plans/2026-04-19-issue-901-j2cl-search-slice.md`
+- The implementation notes should explicitly call out the dependency chain on `#900` and `#902` and state whether those prerequisites were already present in the worktree baseline.
+- Commit summaries should make the slice boundary obvious, for example:
+  - sidecar search DOM view
+  - sidecar search codec wiring
+  - sidecar search verification/tests
+- The PR summary should explicitly state:
+  - legacy root path green
+  - isolated J2CL search slice green
+  - no app-shell or editor cutover performed

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -133,7 +133,7 @@ public final class SandboxEntryPoint {
           return DEFAULT_QUERY;
         }
         try {
-          return decodeUriComponentSafe(value);
+          return decodeUriComponentSafe(value.replace('+', ' '));
         } catch (RuntimeException e) {
           return DEFAULT_QUERY;
         }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -10,6 +10,9 @@ import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
@@ -34,6 +37,18 @@ public final class SandboxEntryPoint {
 
     String mode = normalizeMode(requestedMode);
     host.innerHTML = "";
+
+    if ("search-sidecar".equals(mode)) {
+      J2clSearchPanelView searchView = new J2clSearchPanelView(host);
+      J2clSearchPanelController controller =
+          new J2clSearchPanelController(
+              new J2clSearchGateway(),
+              searchView,
+              waveId -> { },
+              resolveViewportWidth());
+      controller.start(readRequestedQuery(DomGlobal.location.search));
+      return;
+    }
 
     HTMLDivElement card = (HTMLDivElement) DomGlobal.document.createElement("div");
     card.className = "sidecar-card";
@@ -99,6 +114,25 @@ public final class SandboxEntryPoint {
     }
     String trimmed = requestedMode.trim();
     return trimmed.isEmpty() ? DEFAULT_MODE : trimmed;
+  }
+
+  private static double resolveViewportWidth() {
+    return Double.parseDouble(String.valueOf(DomGlobal.window.innerWidth));
+  }
+
+  static String readRequestedQuery(String search) {
+    if (search == null || search.isEmpty()) {
+      return DEFAULT_QUERY;
+    }
+    String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
+    String[] parts = trimmed.split("&");
+    for (String part : parts) {
+      if (part.startsWith("q=")) {
+        String value = part.substring(2);
+        return value.isEmpty() ? DEFAULT_QUERY : decodeUriComponent(value);
+      }
+    }
+    return DEFAULT_QUERY;
   }
 
   @JsFunction
@@ -343,23 +377,9 @@ public final class SandboxEntryPoint {
     }
 
     private String buildSearchUrl() {
-      return "/search/?query=" + encodeUriComponent(readQuery()) + "&index=0&numResults=1";
-    }
-
-    private String readQuery() {
-      String search = DomGlobal.location.search;
-      if (search == null || search.isEmpty()) {
-        return DEFAULT_QUERY;
-      }
-      String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
-      String[] parts = trimmed.split("&");
-      for (String part : parts) {
-        if (part.startsWith("q=")) {
-          String value = part.substring(2);
-          return value.isEmpty() ? DEFAULT_QUERY : decodeUriComponent(value);
-        }
-      }
-      return DEFAULT_QUERY;
+      return "/search/?query="
+          + encodeUriComponent(readRequestedQuery(DomGlobal.location.search))
+          + "&index=0&numResults=1";
     }
 
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -478,7 +478,10 @@ public final class SandboxEntryPoint {
   private static String decodeUriComponentSafe(String value) {
     try {
       return decodeUriComponentNative(value);
-    } catch (UnsatisfiedLinkError e) {
+    } catch (Error err) {
+      if (!isMissingNativeUriCodec(err)) {
+        throw err;
+      }
       return decodeUriComponentFallback(value);
     }
   }
@@ -580,5 +583,9 @@ public final class SandboxEntryPoint {
       return ch - 'a' + 10;
     }
     throw new IllegalArgumentException("Invalid hex digit");
+  }
+
+  private static boolean isMissingNativeUriCodec(Error err) {
+    return "java.lang.UnsatisfiedLinkError".equals(err.getClass().getName());
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -447,7 +447,14 @@ public final class SandboxEntryPoint {
   }
 
   private static String readCookie(String name) {
-    String[] cookies = DomGlobal.document.cookie.split(";");
+    return readCookieFromHeader(DomGlobal.document.cookie, name);
+  }
+
+  static String readCookieFromHeader(String cookieHeader, String name) {
+    if (cookieHeader == null || cookieHeader.isEmpty()) {
+      return null;
+    }
+    String[] cookies = cookieHeader.split(";");
     for (String cookie : cookies) {
       String trimmed = cookie.trim();
       String prefix = name + "=";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -133,7 +133,7 @@ public final class SandboxEntryPoint {
           return DEFAULT_QUERY;
         }
         try {
-          return decodeUriComponent(value);
+          return decodeUriComponentSafe(value);
         } catch (RuntimeException e) {
           return DEFAULT_QUERY;
         }
@@ -460,7 +460,7 @@ public final class SandboxEntryPoint {
       String prefix = name + "=";
       if (trimmed.startsWith(prefix)) {
         try {
-          return decodeUriComponent(trimmed.substring(prefix.length()));
+          return decodeUriComponentSafe(trimmed.substring(prefix.length()));
         } catch (RuntimeException e) {
           return null;
         }
@@ -473,5 +473,112 @@ public final class SandboxEntryPoint {
   private static native String encodeUriComponent(String value);
 
   @JsMethod(namespace = JsPackage.GLOBAL, name = "decodeURIComponent")
-  private static native String decodeUriComponent(String value);
+  private static native String decodeUriComponentNative(String value);
+
+  private static String decodeUriComponentSafe(String value) {
+    try {
+      return decodeUriComponentNative(value);
+    } catch (UnsatisfiedLinkError e) {
+      return decodeUriComponentFallback(value);
+    }
+  }
+
+  private static String decodeUriComponentFallback(String value) {
+    if (value == null || value.indexOf('%') < 0) {
+      return value;
+    }
+    StringBuilder decoded = new StringBuilder(value.length());
+    byte[] bytes = new byte[value.length()];
+    int index = 0;
+    while (index < value.length()) {
+      char ch = value.charAt(index);
+      if (ch != '%') {
+        decoded.append(ch);
+        index++;
+        continue;
+      }
+      int byteCount = 0;
+      while (index < value.length() && value.charAt(index) == '%') {
+        if (index + 2 >= value.length()) {
+          throw new IllegalArgumentException("Incomplete percent escape");
+        }
+        bytes[byteCount++] =
+            (byte) ((hexValue(value.charAt(index + 1)) << 4) | hexValue(value.charAt(index + 2)));
+        index += 3;
+      }
+      appendUtf8Bytes(decoded, bytes, byteCount);
+    }
+    return decoded.toString();
+  }
+
+  private static void appendUtf8Bytes(StringBuilder decoded, byte[] bytes, int length) {
+    int index = 0;
+    while (index < length) {
+      int first = bytes[index] & 0xFF;
+      if ((first & 0x80) == 0) {
+        decoded.append((char) first);
+        index++;
+        continue;
+      }
+
+      int additionalBytes;
+      int codePoint;
+      int minCodePoint;
+      if ((first & 0xE0) == 0xC0) {
+        additionalBytes = 1;
+        codePoint = first & 0x1F;
+        minCodePoint = 0x80;
+      } else if ((first & 0xF0) == 0xE0) {
+        additionalBytes = 2;
+        codePoint = first & 0x0F;
+        minCodePoint = 0x800;
+      } else if ((first & 0xF8) == 0xF0) {
+        additionalBytes = 3;
+        codePoint = first & 0x07;
+        minCodePoint = 0x10000;
+      } else {
+        throw new IllegalArgumentException("Invalid UTF-8 leading byte");
+      }
+
+      if (index + additionalBytes >= length) {
+        throw new IllegalArgumentException("Incomplete UTF-8 sequence");
+      }
+
+      for (int i = 0; i < additionalBytes; i++) {
+        int continuation = bytes[++index] & 0xFF;
+        if ((continuation & 0xC0) != 0x80) {
+          throw new IllegalArgumentException("Invalid UTF-8 continuation byte");
+        }
+        codePoint = (codePoint << 6) | (continuation & 0x3F);
+      }
+
+      if (codePoint < minCodePoint
+          || codePoint > 0x10FFFF
+          || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+        throw new IllegalArgumentException("Invalid UTF-8 code point");
+      }
+
+      if (codePoint <= 0xFFFF) {
+        decoded.append((char) codePoint);
+      } else {
+        int supplementary = codePoint - 0x10000;
+        decoded.append((char) ((supplementary >> 10) + 0xD800));
+        decoded.append((char) ((supplementary & 0x3FF) + 0xDC00));
+      }
+      index++;
+    }
+  }
+
+  private static int hexValue(char ch) {
+    if (ch >= '0' && ch <= '9') {
+      return ch - '0';
+    }
+    if (ch >= 'A' && ch <= 'F') {
+      return ch - 'A' + 10;
+    }
+    if (ch >= 'a' && ch <= 'f') {
+      return ch - 'a' + 10;
+    }
+    throw new IllegalArgumentException("Invalid hex digit");
+  }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -129,7 +129,14 @@ public final class SandboxEntryPoint {
     for (String part : parts) {
       if (part.startsWith("q=")) {
         String value = part.substring(2);
-        return value.isEmpty() ? DEFAULT_QUERY : decodeUriComponent(value);
+        if (value.isEmpty()) {
+          return DEFAULT_QUERY;
+        }
+        try {
+          return decodeUriComponent(value);
+        } catch (RuntimeException e) {
+          return DEFAULT_QUERY;
+        }
       }
     }
     return DEFAULT_QUERY;
@@ -445,7 +452,11 @@ public final class SandboxEntryPoint {
       String trimmed = cookie.trim();
       String prefix = name + "=";
       if (trimmed.startsWith(prefix)) {
-        return decodeUriComponent(trimmed.substring(prefix.length()));
+        try {
+          return decodeUriComponent(trimmed.substring(prefix.length()));
+        } catch (RuntimeException e) {
+          return null;
+        }
       }
     }
     return null;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
@@ -1,0 +1,80 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLElement;
+
+public final class J2clDigestView {
+  @FunctionalInterface
+  public interface SelectionHandler {
+    void onSelected(String waveId);
+  }
+
+  private final String waveId;
+  private final HTMLButtonElement root;
+
+  public J2clDigestView(J2clSearchDigestItem item, SelectionHandler selectionHandler) {
+    this.waveId = item.getWaveId();
+    this.root = (HTMLButtonElement) DomGlobal.document.createElement("button");
+    root.type = "button";
+    root.className = "sidecar-digest";
+
+    HTMLElement header = (HTMLElement) DomGlobal.document.createElement("div");
+    header.className = "sidecar-digest-header";
+    root.appendChild(header);
+
+    HTMLElement title = (HTMLElement) DomGlobal.document.createElement("strong");
+    title.className = "sidecar-digest-title";
+    title.textContent = item.getTitle();
+    header.appendChild(title);
+
+    if (item.isPinned()) {
+      HTMLElement pin = (HTMLElement) DomGlobal.document.createElement("span");
+      pin.className = "sidecar-digest-pin";
+      pin.textContent = "Pinned";
+      header.appendChild(pin);
+    }
+
+    HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
+    meta.className = "sidecar-digest-meta";
+    meta.textContent = item.getAuthor();
+    root.appendChild(meta);
+
+    HTMLElement snippet = (HTMLElement) DomGlobal.document.createElement("p");
+    snippet.className = "sidecar-digest-snippet";
+    snippet.textContent = item.getSnippet().isEmpty() ? "No snippet available." : item.getSnippet();
+    root.appendChild(snippet);
+
+    HTMLElement stats = (HTMLElement) DomGlobal.document.createElement("div");
+    stats.className = "sidecar-digest-stats";
+    stats.textContent = buildStatsText(item);
+    root.appendChild(stats);
+
+    root.onclick =
+        event -> {
+          selectionHandler.onSelected(item.getWaveId());
+          return null;
+        };
+  }
+
+  public HTMLElement element() {
+    return root;
+  }
+
+  public String getWaveId() {
+    return waveId;
+  }
+
+  public void setSelected(boolean selected) {
+    root.className = selected ? "sidecar-digest sidecar-digest-selected" : "sidecar-digest";
+  }
+
+  private static String buildStatsText(J2clSearchDigestItem item) {
+    StringBuilder text = new StringBuilder();
+    if (item.getUnreadCount() > 0) {
+      text.append(item.getUnreadCount()).append(" unread \u00b7 ");
+    }
+    text.append(item.getBlipCount()).append(item.getBlipCount() == 1 ? " message" : " messages");
+    return text.toString();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchDigestItem.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchDigestItem.java
@@ -1,0 +1,63 @@
+package org.waveprotocol.box.j2cl.search;
+
+public final class J2clSearchDigestItem {
+  private final String waveId;
+  private final String title;
+  private final String snippet;
+  private final String author;
+  private final int unreadCount;
+  private final int blipCount;
+  private final long lastModified;
+  private final boolean pinned;
+
+  public J2clSearchDigestItem(
+      String waveId,
+      String title,
+      String snippet,
+      String author,
+      int unreadCount,
+      int blipCount,
+      long lastModified,
+      boolean pinned) {
+    this.waveId = waveId;
+    this.title = title;
+    this.snippet = snippet;
+    this.author = author;
+    this.unreadCount = unreadCount;
+    this.blipCount = blipCount;
+    this.lastModified = lastModified;
+    this.pinned = pinned;
+  }
+
+  public String getWaveId() {
+    return waveId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getSnippet() {
+    return snippet;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public int getUnreadCount() {
+    return unreadCount;
+  }
+
+  public int getBlipCount() {
+    return blipCount;
+  }
+
+  public long getLastModified() {
+    return lastModified;
+  }
+
+  public boolean isPinned() {
+    return pinned;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -1,0 +1,83 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.XMLHttpRequest;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsPackage;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+
+public final class J2clSearchGateway implements J2clSearchPanelController.SearchGateway {
+  @Override
+  public void fetchRootSessionBootstrap(
+      J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    requestText(
+        "/",
+        html -> {
+          try {
+            onSuccess.accept(SidecarSessionBootstrap.fromRootHtml(html));
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to read the root session bootstrap."));
+          }
+        },
+        onError);
+  }
+
+  @Override
+  public void search(
+      String query,
+      int index,
+      int numResults,
+      J2clSearchPanelController.SuccessCallback<SidecarSearchResponse> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    requestText(
+        buildSearchUrl(query, index, numResults),
+        text -> {
+          try {
+            onSuccess.accept(SidecarTransportCodec.decodeSearchResponse(text));
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to decode the sidecar search response."));
+          }
+        },
+        onError);
+  }
+
+  private static String buildSearchUrl(String query, int index, int numResults) {
+    return "/search/?query="
+        + encodeUriComponent(query)
+        + "&index="
+        + index
+        + "&numResults="
+        + numResults;
+  }
+
+  private static void requestText(
+      String url,
+      J2clSearchPanelController.SuccessCallback<String> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    XMLHttpRequest request = new XMLHttpRequest();
+    request.open("GET", url);
+    request.onload =
+        event -> {
+          if (request.status >= 200 && request.status < 300) {
+            onSuccess.accept(request.responseText);
+          } else {
+            onError.accept("HTTP " + request.status + " for " + url);
+          }
+        };
+    request.onerror =
+        event -> {
+          onError.accept("Network failure for " + url);
+          return null;
+        };
+    request.send();
+  }
+
+  private static String messageOrDefault(RuntimeException error, String fallback) {
+    String message = error.getMessage();
+    return message == null || message.isEmpty() ? fallback : message;
+  }
+
+  @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")
+  private static native String encodeUriComponent(String value);
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -48,7 +48,6 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
   private final SearchGateway gateway;
   private final View view;
   private final WaveSelectionHandler selectionHandler;
-  private final double viewportWidth;
   private final int pageIncrement;
   private String currentQuery;
   private String selectedWaveId;
@@ -64,7 +63,6 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
     this.gateway = gateway;
     this.view = view;
     this.selectionHandler = selectionHandler;
-    this.viewportWidth = viewportWidth;
     this.pageIncrement = J2clSearchResultProjector.getPageSizeForViewport(viewportWidth);
   }
 
@@ -85,7 +83,7 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
         error -> {
           view.setSessionSummary("Using the current browser session.");
           view.setStatus(
-              "Root bootstrap lookup failed; continuing with the current browser session.",
+              "Continuing with the current browser session.",
               false);
           requestSearch();
         });

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -1,0 +1,161 @@
+package org.waveprotocol.box.j2cl.search;
+
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+
+public final class J2clSearchPanelController implements J2clSearchViewListener {
+  @FunctionalInterface
+  public interface ErrorCallback {
+    void accept(String error);
+  }
+
+  @FunctionalInterface
+  public interface SuccessCallback<T> {
+    void accept(T value);
+  }
+
+  public interface SearchGateway {
+    void fetchRootSessionBootstrap(
+        SuccessCallback<SidecarSessionBootstrap> onSuccess, ErrorCallback onError);
+
+    void search(
+        String query,
+        int index,
+        int numResults,
+        SuccessCallback<SidecarSearchResponse> onSuccess,
+        ErrorCallback onError);
+  }
+
+  public interface View {
+    void bind(J2clSearchViewListener listener);
+
+    void setQuery(String query);
+
+    void setLoading(boolean loading);
+
+    void setSessionSummary(String summary);
+
+    void setStatus(String status, boolean error);
+
+    void render(J2clSearchResultModel model);
+
+    void setSelectedWaveId(String waveId);
+  }
+
+  public interface WaveSelectionHandler {
+    void onWaveSelected(String waveId);
+  }
+
+  private final SearchGateway gateway;
+  private final View view;
+  private final WaveSelectionHandler selectionHandler;
+  private final double viewportWidth;
+  private final int pageIncrement;
+  private String currentQuery;
+  private String selectedWaveId;
+  private int currentPageSize;
+  private int requestGeneration;
+  private J2clSearchResultModel lastModel = J2clSearchResultModel.empty("Search results will appear here.");
+
+  public J2clSearchPanelController(
+      SearchGateway gateway,
+      View view,
+      WaveSelectionHandler selectionHandler,
+      double viewportWidth) {
+    this.gateway = gateway;
+    this.view = view;
+    this.selectionHandler = selectionHandler;
+    this.viewportWidth = viewportWidth;
+    this.pageIncrement = J2clSearchResultProjector.getPageSizeForViewport(viewportWidth);
+  }
+
+  public void start(String initialQuery) {
+    view.bind(this);
+    currentQuery = J2clSearchResultProjector.normalizeQuery(initialQuery);
+    currentPageSize = pageIncrement;
+    selectedWaveId = null;
+    view.setQuery(currentQuery);
+    view.setSelectedWaveId(null);
+    view.setLoading(true);
+    view.setStatus("Bootstrapping the root session.", false);
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          view.setSessionSummary(bootstrap.getAddress());
+          requestSearch();
+        },
+        error -> {
+          view.setSessionSummary("Using the current browser session.");
+          view.setStatus(
+              "Root bootstrap lookup failed; continuing with the current browser session.",
+              false);
+          requestSearch();
+        });
+  }
+
+  @Override
+  public void onQuerySubmitted(String query) {
+    currentQuery = J2clSearchResultProjector.normalizeQuery(query);
+    currentPageSize = pageIncrement;
+    selectedWaveId = null;
+    view.setSelectedWaveId(null);
+    requestSearch();
+  }
+
+  @Override
+  public void onShowMoreRequested() {
+    currentPageSize += pageIncrement;
+    requestSearch();
+  }
+
+  @Override
+  public void onDigestSelected(String waveId) {
+    selectedWaveId = waveId;
+    view.setSelectedWaveId(waveId);
+    if (selectionHandler != null) {
+      selectionHandler.onWaveSelected(waveId);
+    }
+  }
+
+  private void requestSearch() {
+    final int generation = ++requestGeneration;
+    final String query = currentQuery;
+    final int numResults = currentPageSize;
+    view.setQuery(query);
+    view.setLoading(true);
+    view.setStatus("Loading results for " + query + ".", false);
+    gateway.search(
+        query,
+        0,
+        numResults,
+        response -> {
+          if (generation != requestGeneration) {
+            return;
+          }
+          lastModel = J2clSearchResultProjector.project(response, numResults);
+          if (selectedWaveId != null && !lastModel.containsWave(selectedWaveId)) {
+            selectedWaveId = null;
+          }
+          view.render(lastModel);
+          view.setSelectedWaveId(selectedWaveId);
+          view.setStatus(buildStatusText(query, lastModel), false);
+          view.setLoading(false);
+        },
+        error -> {
+          if (generation != requestGeneration) {
+            return;
+          }
+          selectedWaveId = null;
+          lastModel = J2clSearchResultModel.empty("Unable to load search results.");
+          view.render(lastModel);
+          view.setSelectedWaveId(null);
+          view.setStatus("Search request failed: " + error, true);
+          view.setLoading(false);
+        });
+  }
+
+  private static String buildStatusText(String query, J2clSearchResultModel model) {
+    if (model.isEmpty()) {
+      return "No results for " + query + ".";
+    }
+    return "Showing " + model.getDigestItems().size() + " result(s) for " + query + ".";
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -143,7 +143,6 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
           clearSelection();
           lastModel = J2clSearchResultModel.empty("Unable to load search results.");
           view.render(lastModel);
-          view.setSelectedWaveId(null);
           view.setStatus("Search request failed: " + error, true);
           view.setLoading(false);
         });

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -93,8 +93,7 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
   public void onQuerySubmitted(String query) {
     currentQuery = J2clSearchResultProjector.normalizeQuery(query);
     currentPageSize = pageIncrement;
-    selectedWaveId = null;
-    view.setSelectedWaveId(null);
+    clearSelection();
     requestSearch();
   }
 
@@ -130,7 +129,7 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
           }
           lastModel = J2clSearchResultProjector.project(response, numResults);
           if (selectedWaveId != null && !lastModel.containsWave(selectedWaveId)) {
-            selectedWaveId = null;
+            clearSelection();
           }
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
@@ -141,13 +140,21 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
           if (generation != requestGeneration) {
             return;
           }
-          selectedWaveId = null;
+          clearSelection();
           lastModel = J2clSearchResultModel.empty("Unable to load search results.");
           view.render(lastModel);
           view.setSelectedWaveId(null);
           view.setStatus("Search request failed: " + error, true);
           view.setLoading(false);
         });
+  }
+
+  private void clearSelection() {
+    selectedWaveId = null;
+    view.setSelectedWaveId(null);
+    if (selectionHandler != null) {
+      selectionHandler.onWaveSelected(null);
+    }
   }
 
   private static String buildStatusText(String query, J2clSearchResultModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -161,6 +161,9 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     } else {
       emptyState.hidden = true;
       for (J2clSearchDigestItem item : model.getDigestItems()) {
+        if (item.getWaveId() == null) {
+          continue;
+        }
         J2clDigestView digestView =
             new J2clDigestView(
                 item,
@@ -180,7 +183,7 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   @Override
   public void setSelectedWaveId(String waveId) {
     for (Map.Entry<String, J2clDigestView> entry : digestViews.entrySet()) {
-      entry.getValue().setSelected(entry.getKey().equals(waveId));
+      entry.getValue().setSelected(entry.getKey() != null && entry.getKey().equals(waveId));
     }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -1,0 +1,186 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLFormElement;
+import elemental2.dom.HTMLInputElement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class J2clSearchPanelView implements J2clSearchPanelController.View {
+  private final HTMLElement host;
+  private final HTMLElement sessionSummary;
+  private final HTMLElement status;
+  private final HTMLElement waveCount;
+  private final HTMLInputElement queryInput;
+  private final HTMLButtonElement submitButton;
+  private final HTMLDivElement digestList;
+  private final HTMLElement emptyState;
+  private final HTMLButtonElement showMoreButton;
+  private final Map<String, J2clDigestView> digestViews = new LinkedHashMap<String, J2clDigestView>();
+  private J2clSearchViewListener listener;
+
+  public J2clSearchPanelView(HTMLElement host) {
+    this.host = host;
+    host.innerHTML = "";
+
+    HTMLElement shell = (HTMLElement) DomGlobal.document.createElement("section");
+    shell.className = "sidecar-search-shell";
+    host.appendChild(shell);
+
+    HTMLElement card = (HTMLElement) DomGlobal.document.createElement("div");
+    card.className = "sidecar-search-card";
+    shell.appendChild(card);
+
+    HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
+    eyebrow.className = "sidecar-eyebrow";
+    eyebrow.textContent = "Isolated J2CL search slice";
+    card.appendChild(eyebrow);
+
+    HTMLElement title = (HTMLElement) DomGlobal.document.createElement("h1");
+    title.className = "sidecar-title";
+    title.textContent = "First real search/results vertical slice";
+    card.appendChild(title);
+
+    HTMLElement detail = (HTMLElement) DomGlobal.document.createElement("p");
+    detail.className = "sidecar-detail";
+    detail.textContent =
+        "The root / route still runs the legacy GWT app. This sidecar route only mounts the first J2CL search panel slice.";
+    card.appendChild(detail);
+
+    sessionSummary = (HTMLElement) DomGlobal.document.createElement("p");
+    sessionSummary.className = "sidecar-search-session";
+    sessionSummary.textContent = "Inspecting the active root session.";
+    card.appendChild(sessionSummary);
+
+    HTMLFormElement form = (HTMLFormElement) DomGlobal.document.createElement("form");
+    form.className = "sidecar-search-toolbar";
+    card.appendChild(form);
+
+    queryInput = (HTMLInputElement) DomGlobal.document.createElement("input");
+    queryInput.className = "sidecar-search-input";
+    queryInput.type = "search";
+    queryInput.placeholder = "Search waves";
+    queryInput.autocomplete = "off";
+    form.appendChild(queryInput);
+
+    submitButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
+    submitButton.className = "sidecar-search-submit";
+    submitButton.type = "submit";
+    submitButton.textContent = "Search";
+    form.appendChild(submitButton);
+
+    form.onsubmit =
+        event -> {
+          event.preventDefault();
+          if (listener != null) {
+            listener.onQuerySubmitted(queryInput.value);
+          }
+          return null;
+        };
+
+    status = (HTMLElement) DomGlobal.document.createElement("p");
+    status.className = "sidecar-search-status";
+    status.textContent = "Waiting for the first sidecar search response.";
+    card.appendChild(status);
+
+    waveCount = (HTMLElement) DomGlobal.document.createElement("p");
+    waveCount.className = "sidecar-wave-count";
+    card.appendChild(waveCount);
+
+    digestList = (HTMLDivElement) DomGlobal.document.createElement("div");
+    digestList.className = "sidecar-digests";
+    card.appendChild(digestList);
+
+    emptyState = (HTMLElement) DomGlobal.document.createElement("div");
+    emptyState.className = "sidecar-empty-state";
+    emptyState.textContent = "Search results will appear here.";
+    card.appendChild(emptyState);
+
+    showMoreButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
+    showMoreButton.className = "sidecar-show-more";
+    showMoreButton.type = "button";
+    showMoreButton.textContent = "Show more waves";
+    showMoreButton.hidden = true;
+    showMoreButton.onclick =
+        event -> {
+          if (listener != null) {
+            listener.onShowMoreRequested();
+          }
+          return null;
+        };
+    card.appendChild(showMoreButton);
+  }
+
+  @Override
+  public void bind(J2clSearchViewListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void setQuery(String query) {
+    if (query == null) {
+      queryInput.value = "";
+      return;
+    }
+    queryInput.value = query;
+  }
+
+  @Override
+  public void setLoading(boolean loading) {
+    queryInput.disabled = loading;
+    submitButton.disabled = loading;
+    showMoreButton.disabled = loading;
+    host.className = loading ? "sidecar-root sidecar-root-loading" : "sidecar-root";
+  }
+
+  @Override
+  public void setSessionSummary(String summary) {
+    sessionSummary.textContent = summary;
+  }
+
+  @Override
+  public void setStatus(String statusText, boolean error) {
+    status.className = error ? "sidecar-search-status sidecar-search-status-error" : "sidecar-search-status";
+    status.textContent = statusText;
+  }
+
+  @Override
+  public void render(J2clSearchResultModel model) {
+    waveCount.textContent = model.getWaveCountText();
+    digestList.innerHTML = "";
+    digestViews.clear();
+
+    if (model.isEmpty()) {
+      emptyState.hidden = false;
+      emptyState.textContent = model.getEmptyMessage().isEmpty()
+          ? "No waves matched this query."
+          : model.getEmptyMessage();
+    } else {
+      emptyState.hidden = true;
+      for (J2clSearchDigestItem item : model.getDigestItems()) {
+        J2clDigestView digestView =
+            new J2clDigestView(
+                item,
+                waveId -> {
+                  if (listener != null) {
+                    listener.onDigestSelected(waveId);
+                  }
+                });
+        digestViews.put(item.getWaveId(), digestView);
+        digestList.appendChild(digestView.element());
+      }
+    }
+
+    showMoreButton.hidden = !model.isShowMoreVisible();
+  }
+
+  @Override
+  public void setSelectedWaveId(String waveId) {
+    for (Map.Entry<String, J2clDigestView> entry : digestViews.entrySet()) {
+      entry.getValue().setSelected(entry.getKey().equals(waveId));
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -63,6 +63,7 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     queryInput.className = "sidecar-search-input";
     queryInput.type = "search";
     queryInput.placeholder = "Search waves";
+    queryInput.setAttribute("aria-label", "Search waves");
     queryInput.autocomplete = "off";
     form.appendChild(queryInput);
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -1,0 +1,59 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clSearchResultModel {
+  private final List<J2clSearchDigestItem> digestItems;
+  private final String waveCountText;
+  private final boolean showMoreVisible;
+  private final String emptyMessage;
+
+  public J2clSearchResultModel(
+      List<J2clSearchDigestItem> digestItems,
+      String waveCountText,
+      boolean showMoreVisible,
+      String emptyMessage) {
+    this.digestItems =
+        digestItems == null
+            ? Collections.<J2clSearchDigestItem>emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(digestItems));
+    this.waveCountText = waveCountText == null ? "" : waveCountText;
+    this.showMoreVisible = showMoreVisible;
+    this.emptyMessage = emptyMessage == null ? "" : emptyMessage;
+  }
+
+  public static J2clSearchResultModel empty(String emptyMessage) {
+    return new J2clSearchResultModel(Collections.<J2clSearchDigestItem>emptyList(), "", false, emptyMessage);
+  }
+
+  public List<J2clSearchDigestItem> getDigestItems() {
+    return digestItems;
+  }
+
+  public String getWaveCountText() {
+    return waveCountText;
+  }
+
+  public boolean isShowMoreVisible() {
+    return showMoreVisible;
+  }
+
+  public String getEmptyMessage() {
+    return emptyMessage;
+  }
+
+  public boolean isEmpty() {
+    return digestItems.isEmpty();
+  }
+
+  public boolean containsWave(String waveId) {
+    for (J2clSearchDigestItem item : digestItems) {
+      if (item.getWaveId() != null && item.getWaveId().equals(waveId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
@@ -1,7 +1,6 @@
 package org.waveprotocol.box.j2cl.search;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public final class J2clSearchResultProjector {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
@@ -71,8 +71,7 @@ public final class J2clSearchResultProjector {
       waveCountText += " \u00b7 " + unreadWaveCount + " unread";
     }
 
-    boolean showMoreVisible =
-        totalKnown ? loaded < total : (requestedSize > 0 && loaded >= requestedSize);
+    boolean showMoreVisible = !totalKnown || loaded < total;
     return new J2clSearchResultModel(items, waveCountText, showMoreVisible, "");
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
@@ -1,0 +1,89 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clSearchResultProjector {
+  static final String DEFAULT_QUERY = "in:inbox";
+  static final int DESKTOP_PAGE_SIZE = 30;
+  static final int MOBILE_PAGE_SIZE = 15;
+  static final int MOBILE_BREAKPOINT_PX = 768;
+
+  private J2clSearchResultProjector() {
+  }
+
+  public static String normalizeQuery(String rawQuery) {
+    if (rawQuery == null || rawQuery.trim().isEmpty()) {
+      return DEFAULT_QUERY;
+    }
+    return rawQuery;
+  }
+
+  public static int getPageSizeForViewport(double viewportWidth) {
+    if (viewportWidth <= MOBILE_BREAKPOINT_PX) {
+      return MOBILE_PAGE_SIZE;
+    }
+    return DESKTOP_PAGE_SIZE;
+  }
+
+  public static J2clSearchResultModel project(SidecarSearchResponse response, int requestedSize) {
+    if (response == null || response.getDigests().isEmpty()) {
+      return J2clSearchResultModel.empty("No waves matched this query.");
+    }
+
+    List<J2clSearchDigestItem> items = new ArrayList<J2clSearchDigestItem>();
+    int unreadWaveCount = 0;
+    for (SidecarSearchResponse.Digest digest : response.getDigests()) {
+      if (digest.getUnreadCount() > 0) {
+        unreadWaveCount++;
+      }
+      items.add(
+          new J2clSearchDigestItem(
+              digest.getWaveId(),
+              normalizeTitle(digest.getTitle()),
+              defaultString(digest.getSnippet()),
+              resolveAuthor(digest),
+              digest.getUnreadCount(),
+              digest.getBlipCount(),
+              digest.getLastModified(),
+              digest.isPinned()));
+    }
+
+    int total = response.getTotalResults();
+    boolean totalKnown = total >= 0;
+    int loaded = items.size();
+    String waveCountText;
+    if (!totalKnown) {
+      waveCountText = loaded + " waves";
+    } else if (loaded < total) {
+      waveCountText = loaded + " of " + total + " waves";
+    } else {
+      waveCountText = total + " waves";
+    }
+    if (unreadWaveCount > 0) {
+      waveCountText += " \u00b7 " + unreadWaveCount + " unread";
+    }
+
+    boolean showMoreVisible =
+        totalKnown ? loaded < total : (requestedSize > 0 && loaded >= requestedSize);
+    return new J2clSearchResultModel(items, waveCountText, showMoreVisible, "");
+  }
+
+  private static String normalizeTitle(String title) {
+    return title == null || title.trim().isEmpty() ? "(untitled wave)" : title;
+  }
+
+  private static String defaultString(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static String resolveAuthor(SidecarSearchResponse.Digest digest) {
+    String author = digest.getAuthor();
+    if (author != null && !author.trim().isEmpty()) {
+      return author;
+    }
+    List<String> participants = digest.getParticipants();
+    return participants.isEmpty() ? "" : participants.get(0);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
@@ -34,6 +34,9 @@ public final class J2clSearchResultProjector {
     List<J2clSearchDigestItem> items = new ArrayList<J2clSearchDigestItem>();
     int unreadWaveCount = 0;
     for (SidecarSearchResponse.Digest digest : response.getDigests()) {
+      if (digest.getWaveId() == null) {
+        continue;
+      }
       if (digest.getUnreadCount() > 0) {
         unreadWaveCount++;
       }
@@ -47,6 +50,10 @@ public final class J2clSearchResultProjector {
               digest.getBlipCount(),
               digest.getLastModified(),
               digest.isPinned()));
+    }
+
+    if (items.isEmpty()) {
+      return J2clSearchResultModel.empty("No waves matched this query.");
     }
 
     int total = response.getTotalResults();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjector.java
@@ -34,7 +34,7 @@ public final class J2clSearchResultProjector {
     List<J2clSearchDigestItem> items = new ArrayList<J2clSearchDigestItem>();
     int unreadWaveCount = 0;
     for (SidecarSearchResponse.Digest digest : response.getDigests()) {
-      if (digest.getWaveId() == null) {
+      if (digest == null || digest.getWaveId() == null) {
         continue;
       }
       if (digest.getUnreadCount() > 0) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
@@ -1,0 +1,9 @@
+package org.waveprotocol.box.j2cl.search;
+
+public interface J2clSearchViewListener {
+  void onQuerySubmitted(String query);
+
+  void onShowMoreRequested();
+
+  void onDigestSelected(String waveId);
+}

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -9,13 +9,13 @@ body {
 
 .sidecar-shell {
   min-height: 100vh;
-  display: grid;
-  place-items: center;
+  display: flex;
+  justify-content: center;
   padding: 24px;
 }
 
 .sidecar-root {
-  width: min(100%, 720px);
+  width: min(100%, 960px);
 }
 
 .sidecar-card {
@@ -110,4 +110,190 @@ body {
 .sidecar-proof-action:hover,
 .sidecar-proof-action:focus {
   background: #173355;
+}
+
+.sidecar-root-loading .sidecar-search-card {
+  opacity: 0.92;
+}
+
+.sidecar-search-shell {
+  width: 100%;
+}
+
+.sidecar-search-card {
+  background: rgba(255, 255, 255, 0.97);
+  border: 1px solid #d8e2f0;
+  border-radius: 24px;
+  box-shadow: 0 22px 50px rgba(16, 35, 59, 0.08);
+  padding: 32px;
+}
+
+.sidecar-search-session {
+  margin: 16px 0 0;
+  color: #3567c8;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.sidecar-search-toolbar {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.sidecar-search-input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #c8d5e6;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #10233b;
+  font: inherit;
+  padding: 14px 18px;
+}
+
+.sidecar-search-input:focus {
+  outline: none;
+  border-color: #3567c8;
+  box-shadow: 0 0 0 3px rgba(53, 103, 200, 0.14);
+}
+
+.sidecar-search-submit,
+.sidecar-show-more {
+  border: 0;
+  border-radius: 999px;
+  background: #10233b;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 13px 18px;
+}
+
+.sidecar-search-submit:disabled,
+.sidecar-show-more:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.sidecar-search-status {
+  margin: 18px 0 0;
+  color: #173355;
+  font-weight: 600;
+}
+
+.sidecar-search-status-error {
+  color: #b42318;
+}
+
+.sidecar-wave-count {
+  margin: 10px 0 0;
+  color: #5b6f89;
+  font-size: 0.95rem;
+}
+
+.sidecar-digests {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.sidecar-digest {
+  display: block;
+  width: 100%;
+  border: 1px solid #d8e2f0;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  color: #10233b;
+  cursor: pointer;
+  font: inherit;
+  padding: 18px;
+  text-align: left;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+}
+
+.sidecar-digest:hover,
+.sidecar-digest:focus {
+  border-color: #8aaee6;
+  box-shadow: 0 10px 22px rgba(16, 35, 59, 0.08);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.sidecar-digest-selected {
+  border-color: #3567c8;
+  box-shadow: 0 14px 26px rgba(53, 103, 200, 0.16);
+}
+
+.sidecar-digest-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.sidecar-digest-title {
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.sidecar-digest-pin {
+  background: #e9f1ff;
+  border-radius: 999px;
+  color: #3567c8;
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 4px 10px;
+}
+
+.sidecar-digest-meta {
+  color: #3567c8;
+  font-size: 0.88rem;
+  margin-top: 8px;
+}
+
+.sidecar-digest-snippet {
+  color: #30465f;
+  line-height: 1.5;
+  margin: 10px 0 0;
+}
+
+.sidecar-digest-stats {
+  color: #6b7f98;
+  font-size: 0.88rem;
+  margin-top: 12px;
+}
+
+.sidecar-empty-state {
+  border: 1px dashed #c8d5e6;
+  border-radius: 18px;
+  color: #5b6f89;
+  margin-top: 18px;
+  padding: 28px 20px;
+  text-align: center;
+}
+
+.sidecar-show-more {
+  margin-top: 18px;
+}
+
+@media (max-width: 768px) {
+  .sidecar-shell {
+    padding: 16px;
+  }
+
+  .sidecar-search-card,
+  .sidecar-card {
+    border-radius: 20px;
+    padding: 24px;
+  }
+
+  .sidecar-search-toolbar {
+    flex-direction: column;
+  }
+
+  .sidecar-search-submit,
+  .sidecar-show-more {
+    width: 100%;
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -62,4 +62,15 @@ public class SandboxBuildSmokeTest {
         "ws://socket.example.test/socket",
         SandboxEntryPoint.buildWebSocketUrl("http:", "socket.example.test"));
   }
+
+  @Test
+  public void malformedQueryFallsBackToDefaultSearch() {
+    Assert.assertEquals("in:inbox", SandboxEntryPoint.readRequestedQuery("?q=%"));
+  }
+
+  @Test
+  public void malformedCookieValueReturnsNull() {
+    Assert.assertNull(
+        SandboxEntryPoint.readCookieFromHeader("JSESSIONID=%; theme=dark", "JSESSIONID"));
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -74,6 +74,13 @@ public class SandboxBuildSmokeTest {
   }
 
   @Test
+  public void encodedQueryTreatsPlusAsSpace() {
+    Assert.assertEquals(
+        "mentions:me unread:true",
+        SandboxEntryPoint.readRequestedQuery("?q=mentions%3Ame+unread%3Atrue"));
+  }
+
+  @Test
   public void malformedCookieValueReturnsNull() {
     Assert.assertNull(
         SandboxEntryPoint.readCookieFromHeader("JSESSIONID=%; theme=dark", "JSESSIONID"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -69,6 +69,11 @@ public class SandboxBuildSmokeTest {
   }
 
   @Test
+  public void encodedQueryDecodesPercentEscapes() {
+    Assert.assertEquals("with:@", SandboxEntryPoint.readRequestedQuery("?q=with%3A%40"));
+  }
+
+  @Test
   public void malformedCookieValueReturnsNull() {
     Assert.assertNull(
         SandboxEntryPoint.readCookieFromHeader("JSESSIONID=%; theme=dark", "JSESSIONID"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -1,8 +1,10 @@
 package org.waveprotocol.box.j2cl.search;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.junit.Assert;
 import org.junit.Test;
@@ -85,6 +87,107 @@ public class J2clSearchPanelControllerTest {
   }
 
   @Test
+  public void submittingQueryClearsSelectionAndNotifiesHandler() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Wave 1",
+                    "Snippet",
+                    "example.com/w+1",
+                    1L,
+                    0,
+                    2,
+                    Collections.singletonList("person@example.com"),
+                    "person@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    List<String> selectionEvents = new ArrayList<String>();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+
+    controller.start(null);
+    controller.onDigestSelected("example.com/w+1");
+    controller.onQuerySubmitted("with:@");
+
+    Assert.assertNull(view.selectedWaveId);
+    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+  }
+
+  @Test
+  public void missingSelectedWaveClearsSelectionAndNotifiesHandler() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Wave 1",
+                    "Snippet",
+                    "example.com/w+1",
+                    1L,
+                    0,
+                    2,
+                    Collections.singletonList("person@example.com"),
+                    "person@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    List<String> selectionEvents = new ArrayList<String>();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+
+    controller.start(null);
+    controller.onDigestSelected("example.com/w+1");
+    gateway.response =
+        responseWithDigests(
+            new SidecarSearchResponse.Digest(
+                "Wave 2",
+                "Snippet",
+                "example.com/w+2",
+                2L,
+                0,
+                2,
+                Collections.singletonList("person@example.com"),
+                "person@example.com",
+                false));
+
+    controller.onShowMoreRequested();
+
+    Assert.assertNull(view.selectedWaveId);
+    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+  }
+
+  @Test
+  public void searchErrorClearsSelectionAndNotifiesHandler() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Wave 1",
+                    "Snippet",
+                    "example.com/w+1",
+                    1L,
+                    0,
+                    2,
+                    Collections.singletonList("person@example.com"),
+                    "person@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    List<String> selectionEvents = new ArrayList<String>();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+
+    controller.start(null);
+    controller.onDigestSelected("example.com/w+1");
+    gateway.error = "boom";
+
+    controller.onShowMoreRequested();
+
+    Assert.assertNull(view.selectedWaveId);
+    Assert.assertEquals("Search request failed: boom", view.status);
+    Assert.assertTrue(view.error);
+    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+  }
+
+  @Test
   public void digestSelectionUpdatesViewAndInvokesCallback() {
     FakeGateway gateway = new FakeGateway(new SidecarSearchResponse("in:inbox", 0, null));
     FakeView view = new FakeView();
@@ -99,7 +202,8 @@ public class J2clSearchPanelControllerTest {
   }
 
   private static final class FakeGateway implements J2clSearchPanelController.SearchGateway {
-    private final SidecarSearchResponse response;
+    private SidecarSearchResponse response;
+    private String error;
     private String lastQuery;
     private int lastIndex = -1;
     private int lastNumResults = -1;
@@ -125,6 +229,10 @@ public class J2clSearchPanelControllerTest {
       lastQuery = query;
       lastIndex = index;
       lastNumResults = numResults;
+      if (error != null) {
+        onError.accept(error);
+        return;
+      }
       onSuccess.accept(response);
     }
   }
@@ -174,5 +282,9 @@ public class J2clSearchPanelControllerTest {
     public void setSelectedWaveId(String waveId) {
       this.selectedWaveId = waveId;
     }
+  }
+
+  private static SidecarSearchResponse responseWithDigests(SidecarSearchResponse.Digest... digests) {
+    return new SidecarSearchResponse("in:inbox", digests.length, Arrays.asList(digests));
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -1,0 +1,178 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
+import java.util.Collections;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clSearchPanelControllerTest.class)
+public class J2clSearchPanelControllerTest {
+  @Test
+  public void startLoadsDefaultQueryAndRendersInitialResponse() {
+    FakeGateway gateway =
+        new FakeGateway(
+            new SidecarSearchResponse(
+                "in:inbox",
+                1,
+                Collections.singletonList(
+                    new SidecarSearchResponse.Digest(
+                        "Inbox wave",
+                        "Snippet",
+                        "example.com/w+abc123",
+                        12345L,
+                        1,
+                        3,
+                        Collections.singletonList("teammate@example.com"),
+                        "user@example.com",
+                        false))));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, waveId -> { }, 1200);
+
+    controller.start("   ");
+
+    Assert.assertEquals("in:inbox", gateway.lastQuery);
+    Assert.assertEquals(0, gateway.lastIndex);
+    Assert.assertEquals(30, gateway.lastNumResults);
+    Assert.assertEquals("in:inbox", view.query);
+    Assert.assertEquals("user@example.com", view.sessionSummary);
+    Assert.assertEquals("1 waves · 1 unread", view.lastModel.getWaveCountText());
+    Assert.assertFalse(view.loading);
+  }
+
+  @Test
+  public void submittingQueryResetsWindowAndShowMoreUsesNextPage() {
+    FakeGateway gateway =
+        new FakeGateway(
+            new SidecarSearchResponse(
+                "with:@",
+                45,
+                Arrays.asList(
+                    new SidecarSearchResponse.Digest(
+                        "Wave 1",
+                        "Snippet",
+                        "example.com/w+1",
+                        1L,
+                        0,
+                        2,
+                        Collections.singletonList("person@example.com"),
+                        "person@example.com",
+                        false),
+                    new SidecarSearchResponse.Digest(
+                        "Wave 2",
+                        "Snippet",
+                        "example.com/w+2",
+                        2L,
+                        0,
+                        2,
+                        Collections.singletonList("person@example.com"),
+                        "person@example.com",
+                        false))));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, waveId -> { }, 1200);
+
+    controller.start(null);
+    controller.onQuerySubmitted("with:@");
+    Assert.assertEquals("with:@", gateway.lastQuery);
+    Assert.assertEquals(30, gateway.lastNumResults);
+
+    controller.onShowMoreRequested();
+    Assert.assertEquals("with:@", gateway.lastQuery);
+    Assert.assertEquals(60, gateway.lastNumResults);
+  }
+
+  @Test
+  public void digestSelectionUpdatesViewAndInvokesCallback() {
+    FakeGateway gateway = new FakeGateway(new SidecarSearchResponse("in:inbox", 0, null));
+    FakeView view = new FakeView();
+    String[] selectedWaveId = new String[1];
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, waveId -> selectedWaveId[0] = waveId, 1200);
+
+    controller.onDigestSelected("example.com/w+abc123");
+
+    Assert.assertEquals("example.com/w+abc123", view.selectedWaveId);
+    Assert.assertEquals("example.com/w+abc123", selectedWaveId[0]);
+  }
+
+  private static final class FakeGateway implements J2clSearchPanelController.SearchGateway {
+    private final SidecarSearchResponse response;
+    private String lastQuery;
+    private int lastIndex = -1;
+    private int lastNumResults = -1;
+
+    private FakeGateway(SidecarSearchResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      onSuccess.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+    }
+
+    @Override
+    public void search(
+        String query,
+        int index,
+        int numResults,
+        J2clSearchPanelController.SuccessCallback<SidecarSearchResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      lastQuery = query;
+      lastIndex = index;
+      lastNumResults = numResults;
+      onSuccess.accept(response);
+    }
+  }
+
+  private static final class FakeView implements J2clSearchPanelController.View {
+    private J2clSearchViewListener listener;
+    private String query;
+    private boolean loading;
+    private String sessionSummary;
+    private String status;
+    private boolean error;
+    private J2clSearchResultModel lastModel = J2clSearchResultModel.empty("");
+    private String selectedWaveId;
+
+    @Override
+    public void bind(J2clSearchViewListener listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    public void setQuery(String query) {
+      this.query = query;
+    }
+
+    @Override
+    public void setLoading(boolean loading) {
+      this.loading = loading;
+    }
+
+    @Override
+    public void setSessionSummary(String summary) {
+      this.sessionSummary = summary;
+    }
+
+    @Override
+    public void setStatus(String status, boolean error) {
+      this.status = status;
+      this.error = error;
+    }
+
+    @Override
+    public void render(J2clSearchResultModel model) {
+      this.lastModel = model;
+    }
+
+    @Override
+    public void setSelectedWaveId(String waveId) {
+      this.selectedWaveId = waveId;
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
@@ -96,4 +96,38 @@ public class J2clSearchResultProjectorTest {
     Assert.assertEquals("No waves matched this query.", model.getEmptyMessage());
     Assert.assertFalse(model.isShowMoreVisible());
   }
+
+  @Test
+  public void projectKeepsShowMoreVisibleWhenTotalIsUnknown() {
+    SidecarSearchResponse response =
+        new SidecarSearchResponse(
+            "in:archive",
+            -1,
+            Arrays.asList(
+                new SidecarSearchResponse.Digest(
+                    "Alpha",
+                    "Snippet A",
+                    "example.com/w+alpha",
+                    111L,
+                    0,
+                    4,
+                    Collections.singletonList("teammate@example.com"),
+                    "author@example.com",
+                    false),
+                new SidecarSearchResponse.Digest(
+                    "Beta",
+                    "Snippet B",
+                    "example.com/w+beta",
+                    222L,
+                    0,
+                    7,
+                    Collections.singletonList("friend@example.com"),
+                    "other@example.com",
+                    true)));
+
+    J2clSearchResultModel model = J2clSearchResultProjector.project(response, 30);
+
+    Assert.assertEquals("2 waves", model.getWaveCountText());
+    Assert.assertTrue(model.isShowMoreVisible());
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
@@ -1,0 +1,73 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clSearchResultProjectorTest.class)
+public class J2clSearchResultProjectorTest {
+  @Test
+  public void normalizeQueryFallsBackToInboxForBlankValues() {
+    Assert.assertEquals("in:inbox", J2clSearchResultProjector.normalizeQuery(null));
+    Assert.assertEquals("in:inbox", J2clSearchResultProjector.normalizeQuery("   "));
+    Assert.assertEquals("with:@", J2clSearchResultProjector.normalizeQuery("with:@"));
+  }
+
+  @Test
+  public void pageSizeMatchesLegacyDesktopAndMobileBreakpoints() {
+    Assert.assertEquals(15, J2clSearchResultProjector.getPageSizeForViewport(768));
+    Assert.assertEquals(15, J2clSearchResultProjector.getPageSizeForViewport(420));
+    Assert.assertEquals(30, J2clSearchResultProjector.getPageSizeForViewport(1280));
+  }
+
+  @Test
+  public void projectBuildsWaveCountAndShowMoreStateFromResponse() {
+    SidecarSearchResponse response =
+        new SidecarSearchResponse(
+            "in:archive",
+            28,
+            Arrays.asList(
+                new SidecarSearchResponse.Digest(
+                    "Alpha",
+                    "Snippet A",
+                    "example.com/w+alpha",
+                    111L,
+                    2,
+                    4,
+                    Collections.singletonList("teammate@example.com"),
+                    "author@example.com",
+                    false),
+                new SidecarSearchResponse.Digest(
+                    "Beta",
+                    "Snippet B",
+                    "example.com/w+beta",
+                    222L,
+                    0,
+                    7,
+                    Collections.singletonList("friend@example.com"),
+                    "other@example.com",
+                    true)));
+
+    J2clSearchResultModel model = J2clSearchResultProjector.project(response, 30);
+
+    Assert.assertEquals("2 of 28 waves · 1 unread", model.getWaveCountText());
+    Assert.assertTrue(model.isShowMoreVisible());
+    Assert.assertFalse(model.isEmpty());
+    Assert.assertEquals(2, model.getDigestItems().size());
+    Assert.assertEquals("example.com/w+alpha", model.getDigestItems().get(0).getWaveId());
+    Assert.assertEquals("author@example.com", model.getDigestItems().get(0).getAuthor());
+    Assert.assertTrue(model.getDigestItems().get(1).isPinned());
+  }
+
+  @Test
+  public void projectUsesExplicitEmptyStateWhenNoDigestsAreReturned() {
+    J2clSearchResultModel model =
+        J2clSearchResultProjector.project(new SidecarSearchResponse("in:inbox", 0, null), 30);
+
+    Assert.assertTrue(model.isEmpty());
+    Assert.assertEquals("No waves matched this query.", model.getEmptyMessage());
+    Assert.assertFalse(model.isShowMoreVisible());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchResultProjectorTest.java
@@ -70,4 +70,30 @@ public class J2clSearchResultProjectorTest {
     Assert.assertEquals("No waves matched this query.", model.getEmptyMessage());
     Assert.assertFalse(model.isShowMoreVisible());
   }
+
+  @Test
+  public void projectReturnsEmptyWhenOnlyInvalidDigestsRemain() {
+    J2clSearchResultModel model =
+        J2clSearchResultProjector.project(
+            new SidecarSearchResponse(
+                "in:inbox",
+                2,
+                Arrays.asList(
+                    null,
+                    new SidecarSearchResponse.Digest(
+                        "Broken digest",
+                        "Snippet",
+                        null,
+                        111L,
+                        1,
+                        2,
+                        Collections.singletonList("teammate@example.com"),
+                        "author@example.com",
+                        false))),
+            30);
+
+    Assert.assertTrue(model.isEmpty());
+    Assert.assertEquals("No waves matched this query.", model.getEmptyMessage());
+    Assert.assertFalse(model.isShowMoreVisible());
+  }
 }

--- a/wave/config/changelog.d/2026-04-19-j2cl-search-slice.json
+++ b/wave/config/changelog.d/2026-04-19-j2cl-search-slice.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-19-j2cl-search-slice",
+  "version": "Unreleased",
+  "date": "2026-04-19",
+  "title": "A first J2CL search slice now runs on the isolated sidecar route",
+  "summary": "The legacy root app stays on / while /j2cl-search/index.html now renders the first real J2CL search results panel against the existing search backend.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added an isolated J2CL search/results slice under /j2cl-search/index.html without cutting over the legacy root runtime",
+        "The sidecar search slice now loads the default inbox query, reruns narrow searches without a full page reload, and expands the result window with show-more behavior",
+        "The first slice uses static sidecar CSS and the J2CL-safe search response path instead of GWT UiBinder or JSO-only search widgets"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #901

## Summary
- add the first real J2CL search results slice under `/j2cl-search/index.html`
- keep the legacy root app and legacy search path intact on `/`
- render the sidecar search panel with explicit DOM and static CSS instead of UiBinder/ClientBundle/CssResource
- consume the sidecar-safe search transport/codecs path and prove dual-run rendering against the same local server

## What changed
- extended the sidecar sandbox entrypoint to mount a real search/results panel
- added sidecar search controller/view/gateway/result projection classes under `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/`
- added J2CL tests for query defaulting, result projection, show-more paging, and digest selection wiring
- added the issue-specific plan doc and changelog fragment for the search slice lane

## Verification
- `sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"`
  - passed
- `sbt -batch j2clSearchBuild j2clSearchTest`
  - passed
- `python3 scripts/assemble-changelog.py`
  - regenerated `wave/config/changelog.json`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
  - passed
- `sbt -batch compileGwt Universal/stage`
  - passed
- `bash scripts/worktree-boot.sh --port 9900`
  - passed
- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-901-j2cl-search-slice/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-901-j2cl-search-slice/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
- `PORT=9900 bash scripts/wave-smoke.sh check`
  - `ROOT_STATUS=200`
  - `HEALTH_STATUS=200`
  - `WEBCLIENT_STATUS=200`
- route checks:
  - `/` -> `200 OK`
  - `/webclient/webclient.nocache.js` -> `200 OK`
  - `/j2cl-search/index.html` -> `200 OK`
- browser verification in one authenticated session:
  - `/` still loaded the legacy signed-in GWT app
  - `/j2cl-search/index.html` rendered the J2CL slice
  - default `in:inbox` rendered results
  - `with:@` rerendered to an explicit empty state without leaving the route
  - after seeding additional inbox waves for the same test account, the sidecar showed `30 of 54 waves · 30 unread`, exposed `Show more waves`, then expanded to `54 waves · 54 unread`
- `PORT=9900 bash scripts/wave-smoke.sh stop`
  - passed

## Notes
This PR intentionally does not cut over the root app shell or editor. The legacy root path remains the runtime source of truth on `/`; the J2CL search slice is isolated to `/j2cl-search/index.html`.

## Traceability
- Worktree: `/Users/vega/devroot/worktrees/issue-901-j2cl-search-slice`
- Plan: `docs/superpowers/plans/2026-04-19-issue-901-j2cl-search-slice.md`
- Local verification record: `journal/local-verification/2026-04-19-issue-901-j2cl-search-slice.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Isolated J2CL search-results sidecar served separately with query submission, live results, pagination/show-more, wave counts, unread/pinned indicators, selectable digests, and responsive mobile layout.

* **Documentation**
  * Added implementation plan and changelog entry for the J2CL search vertical slice and verification steps.

* **Tests**
  * New unit tests covering controller behavior, result projection, and sandbox parsing edge cases.

* **Style**
  * Updated sidecar CSS for search UI, loading states, and responsiveness.

* **Bug Fixes**
  * Hardened query and cookie decoding; improved transport/error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->