### PR TITLE
docs(j2cl): add post-search continuation plan and test runbook

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,7 +2,7 @@
 
 Status: Canonical
 Owner: Project Maintainers
-Updated: 2026-04-10
+Updated: 2026-04-19
 Review cadence: quarterly
 
 Use this map for procedures you are expected to follow step by step: local

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,8 @@ setup, smoke checks, deployment, and operational routines.
   - Standard browser-verification path built on the existing smoke baseline.
 - [`change-type-verification-matrix.md`](change-type-verification-matrix.md)
   - Quick reference for when smoke is enough versus when browser verification is required.
+- [`j2cl-sidecar-testing.md`](j2cl-sidecar-testing.md)
+  - Local build, smoke, and browser-verification flow for the merged J2CL sidecar routes.
 - [`worktree-diagnostics.md`](worktree-diagnostics.md)
   - One-command diagnostics bundle for failed or detail-heavy worktree verification.
 - [`../DEV_SETUP.md`](../DEV_SETUP.md)

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -62,6 +62,9 @@ python3 scripts/assemble-changelog.py
 python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
 ```
 
+`wave/config/changelog.json` is gitignored — do not commit it. Only commit
+changelog fragments under `wave/config/changelog.d/`.
+
 ### 2. Run The Cross-Path Build Gate
 
 ```bash
@@ -87,6 +90,12 @@ Then run the exact printed commands. The normal shape is:
 ```bash
 PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.login.config=...' bash scripts/wave-smoke.sh start
 PORT=9900 bash scripts/wave-smoke.sh check
+```
+
+Keep the server running through steps 4 and manual browser verification, then
+stop it when done:
+
+```bash
 PORT=9900 bash scripts/wave-smoke.sh stop
 ```
 
@@ -98,6 +107,8 @@ While the server is running:
 curl -sS -I http://localhost:9900/
 curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
 curl -sS -I http://localhost:9900/j2cl-search/index.html
+curl -sS -I http://localhost:9900/j2cl/index.html
+curl -sS -I http://localhost:9900/j2cl-debug/index.html
 ```
 
 Expected result:
@@ -105,6 +116,8 @@ Expected result:
 - `/` returns success
 - `/webclient/webclient.nocache.js` is present
 - `/j2cl-search/index.html` is present
+- `/j2cl/index.html` is present (production sidecar artifact from `Universal/stage`)
+- `/j2cl-debug/index.html` is present
 
 ## Manual Browser Verification
 
@@ -128,7 +141,7 @@ On `/j2cl-search/index.html`:
 - the placeholder card disappears and the J2CL search UI mounts
 - the page does not show `WaveSandboxEntryPoint not defined`
 - the default query `in:inbox` loads results or an explicit empty state
-- entering another query such as `with:@` re-renders without a full page reload
+- entering another query such as `with:@` re-renders without a full-page reload
 - `Show more waves` appears only when more server-side results exist
 - clicking a digest updates the selected row styling
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -1,0 +1,224 @@
+# J2CL Sidecar Testing
+
+Status: Canonical
+Owner: Project Maintainers
+Updated: 2026-04-19
+
+This runbook covers the local verification path for the merged J2CL sidecar
+work. It is the right procedure when a change touches `j2cl/`, the sidecar
+transport/codec seam, or a J2CL-backed UI slice such as
+`/j2cl-search/index.html`.
+
+## What Exists Today
+
+As of 2026-04-19, the current J2CL browser surfaces are:
+
+- `/j2cl-search/index.html`
+  - the first real J2CL search/results slice
+- `/j2cl-debug/index.html`
+  - debug-oriented single-project J2CL bundle
+- `/j2cl/index.html`
+  - production-profile J2CL bundle used by packaging
+
+The root `/` route is still the legacy GWT application. Testing the J2CL path
+does not replace the obligation to keep the legacy path green.
+
+## Fast J2CL-Only Checks
+
+Run these first when you want a narrow sidecar signal before the full app gate.
+
+From the repo root:
+
+```bash
+sbt -batch j2clSandboxBuild j2clSandboxTest
+sbt -batch j2clSearchBuild j2clSearchTest
+```
+
+Use these expectations:
+
+- `j2clSandboxBuild` / `j2clSandboxTest`
+  - proves the base sidecar sandbox still packages and its smoke tests pass
+- `j2clSearchBuild` / `j2clSearchTest`
+  - proves the merged J2CL search slice still packages and its unit tests pass
+
+For production-profile output only:
+
+```bash
+sbt -batch j2clProductionBuild
+```
+
+Use that when you need to verify the `war/j2cl/**` output specifically.
+
+## Full PR Gate For J2CL Work
+
+Use this sequence before claiming a J2CL-affecting branch is ready.
+
+### 1. Regenerate The Changelog If Needed
+
+If `wave/config/changelog.json` is missing or stale:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
+```
+
+### 2. Run The Cross-Path Build Gate
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+```
+
+This is the minimum trustworthy gate for the current migration phase because it
+proves both of these at once:
+
+- the J2CL sidecar slice still builds/tests
+- the legacy GWT root app still compiles and stages
+
+### 3. Prepare Local Runtime Assets
+
+```bash
+bash scripts/worktree-boot.sh --port 9900
+```
+
+If `9900` is occupied, pick another free port and rerun the command.
+
+Then run the exact printed commands. The normal shape is:
+
+```bash
+PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.login.config=...' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+### 4. Route Presence Checks
+
+While the server is running:
+
+```bash
+curl -sS -I http://localhost:9900/
+curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
+curl -sS -I http://localhost:9900/j2cl-search/index.html
+```
+
+Expected result:
+
+- `/` returns success
+- `/webclient/webclient.nocache.js` is present
+- `/j2cl-search/index.html` is present
+
+## Manual Browser Verification
+
+Open these in the same signed-in browser session:
+
+- `http://localhost:9900/`
+- `http://localhost:9900/j2cl-search/index.html`
+
+### Legacy Root Expectations
+
+On `/`:
+
+- the legacy GWT app still boots
+- login still works
+- the root app remains usable
+
+### J2CL Search Slice Expectations
+
+On `/j2cl-search/index.html`:
+
+- the placeholder card disappears and the J2CL search UI mounts
+- the page does not show `WaveSandboxEntryPoint not defined`
+- the default query `in:inbox` loads results or an explicit empty state
+- entering another query such as `with:@` re-renders without a full page reload
+- `Show more waves` appears only when more server-side results exist
+- clicking a digest updates the selected row styling
+
+For stronger manual proof:
+
+- create extra waves from the normal app first
+- refresh `/j2cl-search/index.html`
+- confirm the wave count and `Show more waves` behavior change coherently
+
+## When To Use Direct Maven Instead Of SBT
+
+Prefer the SBT tasks above for normal repo work. Use the Maven wrapper only
+when you need to debug the J2CL sidecar in isolation.
+
+From `j2cl/`:
+
+```bash
+./mvnw -Psearch-sidecar test
+./mvnw -Psearch-sidecar package
+./mvnw -Pdebug-single-project package
+./mvnw -Pproduction package
+```
+
+Use those only for deep sidecar debugging; the repo-standard verification path
+should still go through SBT.
+
+## Common Failure Signals
+
+### Placeholder Never Replaced
+
+Symptom:
+
+- `/j2cl-search/index.html` only shows the fallback card text
+
+Meaning:
+
+- the host page loaded, but the generated J2CL bundle did not mount
+
+Check:
+
+- rerun `sbt -batch j2clSearchBuild j2clSearchTest`
+- confirm the built assets exist under `war/j2cl-search/**`
+
+### `WaveSandboxEntryPoint not defined`
+
+Symptom:
+
+- the page reports a sidecar load error
+
+Meaning:
+
+- the host page is present, but `sidecar/j2cl-sidecar.js` failed to load or was
+  not generated for the current profile
+
+Check:
+
+- rerun the matching J2CL build task
+- verify the asset path under the correct `war/j2cl*` directory
+
+### J2CL Build Green, `compileGwt` Red
+
+Meaning:
+
+- the change is not safe for the current migration phase
+- the sidecar work has leaked into the active legacy root path
+
+Do not wave that through. Fix the branch until both paths are green.
+
+### Missing `wave/config/changelog.json`
+
+Symptom:
+
+- stage or compile tasks fail before the real verification even begins
+
+Fix:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
+```
+
+## Required Evidence To Record
+
+For issue/PR closeout, record:
+
+- the exact build command(s) you ran
+- the port used for local boot
+- the `wave-smoke.sh check` result
+- the route checks for `/` and `/j2cl-search/index.html`
+- the browser-observed J2CL behavior
+
+That evidence is what distinguishes a real J2CL verification from “the code
+looked plausible.”

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -104,6 +104,7 @@ curl -sS -I http://localhost:9900/
 curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
 curl -sS -I http://localhost:9900/j2cl-search/index.html
 curl -sS -I http://localhost:9900/j2cl/index.html
+# Optional — only present when j2clSandboxBuild was also run
 curl -sS -I http://localhost:9900/j2cl-debug/index.html
 ```
 
@@ -113,7 +114,7 @@ Expected result:
 - `/webclient/webclient.nocache.js` is present
 - `/j2cl-search/index.html` is present
 - `/j2cl/index.html` is present (production sidecar artifact from `Universal/stage`)
-- `/j2cl-debug/index.html` is present
+- `/j2cl-debug/index.html` is present only if `j2clSandboxBuild` was run; not required by the standard gate
 
 ## Manual Browser Verification
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -62,8 +62,8 @@ python3 scripts/assemble-changelog.py
 python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
 ```
 
-`wave/config/changelog.json` is gitignored — do not commit it. Only commit
-changelog fragments under `wave/config/changelog.d/`.
+`wave/config/changelog.json` is generated and gitignored. Do not commit it;
+commit only changelog fragments under `wave/config/changelog.d/`.
 
 ### 2. Run The Cross-Path Build Gate
 
@@ -92,12 +92,8 @@ PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.lo
 PORT=9900 bash scripts/wave-smoke.sh check
 ```
 
-Keep the server running through steps 4 and manual browser verification, then
-stop it when done:
-
-```bash
-PORT=9900 bash scripts/wave-smoke.sh stop
-```
+Keep the server running through the route checks and browser verification
+below.
 
 ### 4. Route Presence Checks
 
@@ -150,6 +146,13 @@ For stronger manual proof:
 - create extra waves from the normal app first
 - refresh `/j2cl-search/index.html`
 - confirm the wave count and `Show more waves` behavior change coherently
+
+When the route checks and browser verification are finished, stop the local
+server:
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
+++ b/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
@@ -1,0 +1,229 @@
+# Post-#901 J2CL Continuation And Cutover Plan
+
+Status: Draft
+Owner: Project Maintainers
+Updated: 2026-04-19
+
+## Goal
+
+Continue from the merged J2CL foundation work through a safe staged cutover from
+the legacy GWT client to J2CL, without losing the ability to compile, boot, and
+verify the current app at each step.
+
+This plan starts from the actual post-`#901` baseline:
+
+- the isolated J2CL sidecar build exists under `j2cl/`
+- SBT can run `j2clSandboxBuild`, `j2clSandboxTest`, `j2clSearchBuild`,
+  `j2clSearchTest`, and `j2clProductionBuild`
+- the transport/codec bridge is J2CL-safe
+- the remaining `GWTTestCase` debt has an explicit JVM/browser split
+- the first J2CL UI slice is merged at `/j2cl-search/index.html`
+- the root `/` route is still the legacy GWT application
+
+## Current Baseline
+
+As of 2026-04-19, the repo has proven only the first dual-run milestone:
+
+1. The legacy GWT app still owns the real root app shell and editor path.
+2. The J2CL sidecar can build, mount, reuse the live session bootstrap, query
+   `/search`, and render the first search/results slice on its own route.
+3. Packaging already depends on `j2clProductionBuild`, so the J2CL output is no
+   longer hypothetical; it is part of the staged application build.
+
+That is enough to prove the migration path is real. It is not enough to switch
+the app to J2CL yet.
+
+## What Still Blocks Cutover
+
+The current J2CL tree is still only a thin slice:
+
+- no J2CL-owned root app shell
+- no sidecar route that opens and renders a selected wave in context
+- no read-only conversation view
+- no compose/reply/edit path
+- no feature-flagged root bootstrap that can swap between GWT and J2CL
+- no production parity checklist that proves “J2CL can replace GWT” rather than
+  “J2CL can coexist beside GWT”
+
+The next work should therefore move from “isolated proof” to “usable parallel
+client,” then only after that to “root-route cutover.”
+
+## Migration Strategy
+
+Do not jump directly from the search slice to full cutover.
+
+The safe sequence is:
+
+1. Keep the legacy root path green at all times.
+2. Grow the J2CL sidecar into a real read-only workflow first.
+3. Add the write path only after read-only navigation is stable.
+4. Cut over `/` only when the sidecar can replace the core daily path, not just
+   render one widget.
+
+## Ordered Next Slices
+
+### Slice 0: Refresh The Tracker And Docs
+
+The existing tracker and several older J2CL docs still describe a pre-sidecar
+or pre-search-slice world. Before opening more migration issues, refresh the
+docs and tracker so future work starts from the real baseline.
+
+Deliverables:
+
+- refresh `#904` or replace it with a new post-`#901` tracker issue
+- update the stale J2CL inventory/decision/preparatory docs so they stop saying
+  there is no `j2cl/` tree or no sidecar build
+- keep one canonical list of remaining migration slices
+
+Exit criteria:
+
+- the docs describe the merged sidecar/search reality accurately
+- the next issues are opened against the actual current baseline
+
+### Slice 1: Read-Only Wave Panel In The Sidecar
+
+The next technical milestone should be “search result -> selected wave” inside
+the J2CL sidecar, not a root cutover.
+
+Deliverables:
+
+- add a J2CL-owned content panel beside the search results
+- clicking a digest opens the selected wave in the sidecar route
+- reuse the sidecar transport stack to keep the selected wave live
+- keep the scope read-only: rendering, unread state, and updates, but no edit
+
+Why this next:
+
+- it validates the hardest missing seam between the list and the actual wave
+- it proves the transport work is sufficient for a real user flow
+- it is still narrow enough to keep the legacy root path untouched
+
+Exit criteria:
+
+- `/j2cl-search/index.html` supports inbox/search + open selected wave
+- live updates still arrive on the opened wave
+- `/` remains GWT and still passes the normal compile/stage/smoke gates
+
+### Slice 2: J2CL Split-View Shell And Route State
+
+Once read-only wave rendering exists, add a minimal sidecar-owned shell that
+tracks query, selected wave, and browser history in a durable way.
+
+Deliverables:
+
+- define sidecar route state for query + selected wave
+- support reload/deep-link behavior inside the J2CL route
+- preserve the existing root bootstrap and session reuse model
+- establish the sidecar shell layout that future slices will extend
+
+Exit criteria:
+
+- a copied `/j2cl-search/...` URL restores the same sidecar state
+- browser back/forward behaves coherently inside the sidecar route
+
+### Slice 3: Write-Path Pilot
+
+Do not attempt full editor migration immediately. First prove the smallest
+useful write path in J2CL.
+
+Recommended scope:
+
+- create a new wave
+- reply with plain text
+- submit and observe the update in the opened wave
+
+Non-goals for this slice:
+
+- full editor parity
+- rich formatting
+- every toolbar action
+- gadget support
+
+Exit criteria:
+
+- the J2CL sidecar can perform a simple end-to-end write flow against the live
+  local server
+- the transport/update path stays coherent after write operations
+
+### Slice 4: Opt-In Root Bootstrap
+
+Only after the sidecar supports a useful read/write flow should the repo add a
+root-bootstrap seam that can choose between GWT and J2CL.
+
+Deliverables:
+
+- feature flag or explicit opt-in route for J2CL root bootstrap
+- production-safe fallback to the legacy GWT bootstrap
+- one dual-run verification matrix for both bootstrap modes
+
+Exit criteria:
+
+- selected users or local verification can boot a J2CL-owned root shell
+- switching back to GWT is still one configuration change, not a rollback patch
+
+### Slice 5: Default Cutover
+
+This is the first slice that should actually “switch to J2CL.”
+
+Deliverables:
+
+- `/` boots the J2CL client by default
+- packaging serves the J2CL-owned app shell as the default browser runtime
+- the legacy GWT client remains available only as a temporary fallback during
+  rollout
+
+Required proof before this slice is approved:
+
+- login
+- inbox/search
+- open wave
+- unread/read updates
+- create wave
+- enter and submit text
+- reconnect/reload behavior
+- browser sanity on the real staged app
+
+### Slice 6: GWT Retirement
+
+Only after a stable default cutover should the repo remove the old GWT path.
+
+Deliverables:
+
+- delete obsolete GWT-only shell/bootstrap code
+- retire `compileGwt` from the packaging-critical path
+- remove legacy module/deferred-binding paths that only existed for the old
+  client
+
+## Suggested Next GitHub Issues
+
+If the work continues in the same issue-driven sequence, the next issues are:
+
+1. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
+2. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+3. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+4. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+5. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
+6. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
+7. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps
+
+## Cutover Gate
+
+Do not call the app “ready to switch” until all of the following are true on
+the J2CL path:
+
+- it boots from the root route, not only a sidecar route
+- it can search, open, and navigate waves without relying on the legacy shell
+- it can create a wave and enter text
+- it survives reload/reconnect and preserves route state
+- the legacy fallback still exists until the J2CL root path passes staged
+  rollout
+
+## Testing Rule
+
+Every follow-on J2CL slice should keep using a two-path verification rule:
+
+1. J2CL path must prove the new behavior is real.
+2. Legacy GWT root path must still compile, boot, and smoke cleanly until the
+   actual cutover slice.
+
+That rule is what keeps the migration incremental instead of speculative.


### PR DESCRIPTION
## Summary
- add a post-#901 continuation plan from the merged search sidecar baseline toward full J2CL cutover
- add a canonical J2CL sidecar testing runbook covering the SBT tasks, local boot flow, route checks, browser verification, and the PST/codegen contract gate when transport schemas change
- refresh the stale current-state J2CL docs so they no longer describe a pre-sidecar or pre-search-slice repo
- link the new runbook from the runbooks index

## Issue
Closes #919

## Follow-on implementation issues
- #920 read-only selected-wave panel in the J2CL sidecar
- #921 sidecar route state and split-view navigation
- #922 first J2CL write-path pilot
- #923 opt-in J2CL root bootstrap flag
- #924 default root cutover to J2CL
- #925 retire the legacy GWT client path and packaging steps

## Verification
- `git diff --check`
- docs-only change; no runtime verification required for this PR