### PR TITLE
docs(j2cl): address Claude review findings on migration plan

### DIFF
--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -31,6 +31,7 @@ Review cadence: <value>
 <!-- One path per line. Lines starting with # or empty lines are ignored. -->
 
 docs/runbooks/README.md
+docs/runbooks/j2cl-sidecar-testing.md
 docs/runbooks/browser-verification.md
 docs/runbooks/change-type-verification-matrix.md
 docs/runbooks/mongo-migrations.md

--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -38,6 +38,7 @@ docs/runbooks/mongo-migrations.md
 docs/runbooks/worktree-diagnostics.md
 docs/runbooks/worktree-lane-lifecycle.md
 docs/runbooks/doc-guardrails.md
+docs/runbooks/j2cl-sidecar-testing.md
 docs/README.md
 docs/DEV_SETUP.md
 docs/BUILDING-sbt.md

--- a/docs/j2cl-gwt3-decision-memo.md
+++ b/docs/j2cl-gwt3-decision-memo.md
@@ -3,7 +3,7 @@
 Status: Current
 Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#919`
+Last refreshed by: `#919` (merged)
 
 ## Decision Summary
 
@@ -67,11 +67,12 @@ The next wave should still avoid trying to move the whole app.
 
 The narrowest viable sequence is now:
 
-1. refresh the stale tracker/docs to the post-`#901` baseline
+1. keep the tracker/docs refreshed to the post-`#901` baseline
 2. add a read-only selected-wave panel to the sidecar
 3. add route/history state for the J2CL sidecar shell
 4. prove the smallest write path on top of that shell
-5. add a reversible opt-in root bootstrap before any default cutover
+5. build a real J2CL root shell
+6. add a reversible opt-in root bootstrap before any default cutover
 
 Only after that should the project revisit a broader compiler/runtime switch.
 
@@ -80,10 +81,10 @@ Only after that should the project revisit a broader compiler/runtime switch.
 These are the current dependency-ordered follow-on issues:
 
 1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
-2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
-3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
-4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
-5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+2. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+3. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+4. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+5. [#928](https://github.com/vega113/supawave/issues/928) Build the first J2CL-owned root app shell
 6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
 7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
 8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps

--- a/docs/j2cl-gwt3-decision-memo.md
+++ b/docs/j2cl-gwt3-decision-memo.md
@@ -3,7 +3,7 @@
 Status: Current
 Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#898`
+Task: `#919`
 
 ## Decision Summary
 
@@ -17,7 +17,8 @@ Reason:
 - the remaining browser-facing test harness still carries legacy
   `GWTTestCase` debt even though `#898` now makes the JVM/browser split
   explicit
-- there is still no existing JsInterop / Elemental2 bridge layer or J2CL sidecar
+- there is still no broad existing JsInterop / Elemental2 bridge layer
+- the J2CL sidecar now exists, but it is still only a partial parallel client
 
 The important update is not the decision itself; it is the baseline. The repo
 is now better prepared than the March snapshot implied because several
@@ -39,8 +40,9 @@ Current short version:
 - `19` remaining direct `GWTTestCase` Java files after `#898`
 - `21` was the reconciled direct starting baseline for `#898`
 - `11` inherited editor/test-base descendants still need a browser-facing home
-- no JsInterop / Elemental2 bridge layer
-- no J2CL sidecar build yet
+- no broad JsInterop / Elemental2 bridge layer
+- the J2CL sidecar build now exists
+- the first J2CL UI slice now exists on `/j2cl-search/index.html`
 - `guava-gwt` already removed
 - gadget/htmltemplate client cleanup already landed
 - `WaveContext` already uses the shared `BlipReadStateMonitor` contract
@@ -52,10 +54,12 @@ for the suite-by-suite test-home map.
 ## Go / No-Go
 
 - Full-app migration now: `No-go`
-- Staged migration preparation: `Go`
-- Isolated J2CL build scaffold: `Go`
-- Narrow transport replacement path: `Go`
-- First UI vertical slice after scaffold and transport: `Go`
+- Staged migration continuation: `Go`
+- Isolated J2CL build scaffold: `Complete`
+- Narrow transport replacement path: `Complete`
+- First UI vertical slice after scaffold and transport: `Complete`
+- Read-only selected-wave sidecar slice: `Go`
+- Route-state / write-path / root-bootstrap follow-on work: `Go`
 
 ## Narrowest Viable Next Wave
 
@@ -63,10 +67,11 @@ The next wave should still avoid trying to move the whole app.
 
 The narrowest viable sequence is now:
 
-1. stand up the isolated J2CL sidecar build
-2. keep shrinking pure-logic and test debt
-3. replace one transport / websocket / JSON seam end-to-end
-4. prove one first UI vertical slice on top of that stack
+1. refresh the stale tracker/docs to the post-`#901` baseline
+2. add a read-only selected-wave panel to the sidecar
+3. add route/history state for the J2CL sidecar shell
+4. prove the smallest write path on top of that shell
+5. add a reversible opt-in root bootstrap before any default cutover
 
 Only after that should the project revisit a broader compiler/runtime switch.
 
@@ -74,12 +79,14 @@ Only after that should the project revisit a broader compiler/runtime switch.
 
 These are the current dependency-ordered follow-on issues:
 
-1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
-2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
-3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
-4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
-5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
-6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
+2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
+3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
+7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
+8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps
 
 ## Explicit Non-Starter Moves
 
@@ -97,12 +104,12 @@ These are still not recommended as the next step:
 
 The decision can be revisited after these conditions are met:
 
-- the J2CL sidecar build exists and produces a usable bundle
-- one JsInterop / Elemental2 seam exists in production code
-- the transport / websocket / generated-JSON stack has one successful
-  replacement path
-- the remaining GWT-only test debt has an explicit post-GWT home
-- one real UI slice has shipped behind the staged migration path
+- the sidecar can render a selected wave, not only a search list
+- sidecar route/history state is durable enough for real navigation
+- the first write path has shipped behind the staged migration path
+- an opt-in J2CL root bootstrap exists and is locally verified
+- the remaining GWT-only test debt keeps an explicit post-GWT home through the
+  cutover
 
 ## Recommended Status
 

--- a/docs/j2cl-gwt3-inventory.md
+++ b/docs/j2cl-gwt3-inventory.md
@@ -3,7 +3,7 @@
 Status: Current
 Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#919`
+Last refreshed by: `#919` (merged)
 
 This document records the current GWT-specific surface area in
 `incubator-wave` so future migration work starts from measured constraints
@@ -206,14 +206,15 @@ Completed staged foundation:
 4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
 5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
 6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
+7. [#919](https://github.com/vega113/supawave/issues/919) Refresh the tracker/docs to the post-search baseline
 
 Current pending sequence:
 
 1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
-2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
-3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
-4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
-5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+2. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+3. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+4. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+5. [#928](https://github.com/vega113/supawave/issues/928) Build the first J2CL-owned root app shell
 6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
 7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
 8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps

--- a/docs/j2cl-gwt3-inventory.md
+++ b/docs/j2cl-gwt3-inventory.md
@@ -3,7 +3,7 @@
 Status: Current
 Updated: 2026-04-19
 Owner: Project Maintainers
-Task: `#898`
+Task: `#919`
 
 This document records the current GWT-specific surface area in
 `incubator-wave` so future migration work starts from measured constraints
@@ -56,7 +56,11 @@ The client build is still explicitly GWT-centric in [build.sbt](../build.sbt):
 What changed since the earlier inventory:
 
 - `guava-gwt` is no longer present in `build.sbt`
-- the repo still has no `j2cl/` sidecar
+- the repo now has an isolated `j2cl/` sidecar subtree
+- `build.sbt` now exposes `j2clSandboxBuild`, `j2clSandboxTest`,
+  `j2clSearchBuild`, `j2clSearchTest`, and `j2clProductionBuild`
+- packaging now invokes `j2clProductionBuild` alongside the legacy
+  `compileGwt` path
 - the browser client still depends on the dedicated GWT compile/runtime path
 
 The current toolchain picture means a J2CL move is still not just a compiler
@@ -120,7 +124,7 @@ What changed since the earlier inventory:
 
 Blocker assessment:
 
-- the codebase still has no existing JsInterop / Elemental2 bridge seam
+- the codebase still has no broad existing JsInterop / Elemental2 bridge seam
 - browser interop is still embedded in the main runtime instead of isolated
   behind one thin compatibility layer
 - the transport / websocket / generated-JSON stack is now the clearest
@@ -194,14 +198,25 @@ closed rather than still open.
 
 ## Active Follow-On Issue Chain
 
-The current GitHub-native follow-on sequence is:
+Completed staged foundation:
 
-1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
+1. [#899](https://github.com/vega113/supawave/issues/899) Refresh the J2CL / GWT 3 baseline docs after the merged Phase 0 cleanup
 2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
 3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
 4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
 5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
 6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
+
+Current pending sequence:
+
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
+2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
+3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
+7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
+8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps
 
 ## Bottom Line
 
@@ -212,8 +227,10 @@ The measured blocker pattern is now:
 - too much JSNI / browser interop concentrated in transport and editor helpers
 - too much UiBinder / GWT widget composition still in the live UI
 - too much legacy GWT-only test infrastructure
-- no existing modern browser-interop seam or J2CL sidecar build
+- no broad modern browser-interop seam yet
+- no J2CL-selected-wave flow or J2CL-owned root shell yet
 
 That does not rule out a future J2CL path. It means the repo should now be
-described as “post-prerequisite cleanup but pre-sidecar / pre-transport
-replacement,” not as if it were still at the original pre-cleanup baseline.
+described as “post-sidecar / post-first-slice, but still pre-selected-wave and
+pre-root-cutover,” not as if it were still at the original pre-cleanup
+baseline.

--- a/docs/j2cl-preparatory-work.md
+++ b/docs/j2cl-preparatory-work.md
@@ -59,27 +59,42 @@ map:
 
 The following items remain open after the landed cleanup:
 
-- no J2CL sidecar build or `j2cl/` subtree yet
-- no JsInterop / Elemental2 bridge seam yet
+- no broad JsInterop / Elemental2 bridge seam yet
 - the transport / websocket / generated JSO message stack is still GWT-specific
 - UiBinder and `GWT.create(...)` are still widespread in the client UI
 - the remaining browser-facing `GWTTestCase` suites still need a real post-GWT
   browser runner even though the JVM/browser split is now documented
+- the sidecar still needs selected-wave rendering, route state, and a write
+  path before root cutover is realistic
 
 ## Current Follow-On Issue Chain
 
-The active GitHub-native sequence is:
+The active GitHub-native sequence is now:
 
-1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged GWT 2.x -> J2CL / GWT 3 migration after Phase 0
+Completed staged foundation:
+
+1. [#899](https://github.com/vega113/supawave/issues/899) Refresh the J2CL / GWT 3 baseline docs after the merged Phase 0 cleanup
 2. [#900](https://github.com/vega113/supawave/issues/900) Stand up the isolated J2CL sidecar build and SBT entrypoints
 3. [#903](https://github.com/vega113/supawave/issues/903) Make `wave/model` and `wave/concurrencycontrol` J2CL-safe pure logic
 4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
 5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
 6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
 
+Current pending sequence:
+
+1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
+2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
+3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
+7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
+8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps
+
 ## Summary
 
-The preparatory phase should now be described as “partially completed and
-re-baselined,” not as if the repo were still waiting on `guava-gwt` removal or
-duplicate-module cleanup. The next execution work is issue-driven, not
+The preparatory phase should now be described as “completed enough to enable
+the first staged sidecar client, but not yet ready for root cutover,” not as if
+the repo were still waiting on `guava-gwt` removal, duplicate-module cleanup,
+or the first J2CL slice itself. The next execution work is issue-driven, not
 discovery-driven.

--- a/docs/j2cl-preparatory-work.md
+++ b/docs/j2cl-preparatory-work.md
@@ -79,14 +79,15 @@ Completed staged foundation:
 4. [#902](https://github.com/vega113/supawave/issues/902) Replace the JSO transport stack and GWT WebSocket shim with J2CL-friendly codecs
 5. [#898](https://github.com/vega113/supawave/issues/898) Replace the remaining GWTTestCase debt with an explicit JVM/browser verification split
 6. [#901](https://github.com/vega113/supawave/issues/901) Migrate the search results panel as the first J2CL UI vertical slice
+7. [#919](https://github.com/vega113/supawave/issues/919) Refresh the tracker/docs to the post-search baseline
 
 Current pending sequence:
 
 1. [#904](https://github.com/vega113/supawave/issues/904) Track the staged J2CL / GWT 3 migration from the merged sidecar/search baseline
-2. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
-3. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
-4. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
-5. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+2. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+3. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+4. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+5. [#928](https://github.com/vega113/supawave/issues/928) Build the first J2CL-owned root app shell
 6. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
 7. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
 8. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -3,7 +3,7 @@
 Status: Canonical
 Owner: Project Maintainers
 Updated: 2026-04-19
-Review cadence: Quarterly
+Review cadence: quarterly
 
 This runbook covers the local verification path for the merged J2CL sidecar
 work. It is the right procedure when a change touches `j2cl/`, the sidecar
@@ -115,7 +115,7 @@ curl -fsS -o /dev/null http://localhost:9900/webclient/webclient.nocache.js
 curl -fsS -o /dev/null http://localhost:9900/j2cl-search/index.html
 curl -fsS -o /dev/null http://localhost:9900/j2cl/index.html
 curl -fsS http://localhost:9900/j2cl-search/sidecar/j2cl-sidecar.js | grep -E "WaveSandboxEntryPoint|j2cl"
-# Optional — only present when j2clSandboxBuild was also run
+# Optional — run this only when j2clSandboxBuild was also run
 curl -fsS -o /dev/null http://localhost:9900/j2cl-debug/index.html
 ```
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -3,6 +3,7 @@
 Status: Canonical
 Owner: Project Maintainers
 Updated: 2026-04-19
+Review cadence: Quarterly
 
 This runbook covers the local verification path for the merged J2CL sidecar
 work. It is the right procedure when a change touches `j2cl/`, the sidecar
@@ -109,13 +110,13 @@ below.
 While the server is running:
 
 ```bash
-curl -sS -I http://localhost:9900/
-curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
-curl -sS -I http://localhost:9900/j2cl-search/index.html
-curl -sS -I http://localhost:9900/j2cl/index.html
-curl -fsS http://localhost:9900/j2cl-search/sidecar/j2cl-sidecar.js | rg "WaveSandboxEntryPoint|j2cl"
+curl -fsS -o /dev/null http://localhost:9900/
+curl -fsS -o /dev/null http://localhost:9900/webclient/webclient.nocache.js
+curl -fsS -o /dev/null http://localhost:9900/j2cl-search/index.html
+curl -fsS -o /dev/null http://localhost:9900/j2cl/index.html
+curl -fsS http://localhost:9900/j2cl-search/sidecar/j2cl-sidecar.js | grep -E "WaveSandboxEntryPoint|j2cl"
 # Optional — only present when j2clSandboxBuild was also run
-curl -sS -I http://localhost:9900/j2cl-debug/index.html
+curl -fsS -o /dev/null http://localhost:9900/j2cl-debug/index.html
 ```
 
 Expected result:

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -65,6 +65,7 @@ python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
 `wave/config/changelog.json` is generated and gitignored. Do not commit it;
 commit only changelog fragments under `wave/config/changelog.d/`.
 
+
 ### 2. Run The Cross-Path Build Gate
 
 ```bash
@@ -94,6 +95,7 @@ PORT=9900 bash scripts/wave-smoke.sh check
 
 Keep the server running through the route checks and browser verification
 below.
+
 
 ### 4. Route Presence Checks
 
@@ -154,6 +156,7 @@ server:
 ```bash
 PORT=9900 bash scripts/wave-smoke.sh stop
 ```
+
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -113,6 +113,7 @@ curl -sS -I http://localhost:9900/
 curl -sS -I http://localhost:9900/webclient/webclient.nocache.js
 curl -sS -I http://localhost:9900/j2cl-search/index.html
 curl -sS -I http://localhost:9900/j2cl/index.html
+curl -fsS http://localhost:9900/j2cl-search/sidecar/j2cl-sidecar.js | rg "WaveSandboxEntryPoint|j2cl"
 # Optional — only present when j2clSandboxBuild was also run
 curl -sS -I http://localhost:9900/j2cl-debug/index.html
 ```
@@ -123,6 +124,7 @@ Expected result:
 - `/webclient/webclient.nocache.js` is present
 - `/j2cl-search/index.html` is present
 - `/j2cl/index.html` is present (production sidecar artifact from `Universal/stage`)
+- the J2CL search bundle itself is present and non-placeholder
 - `/j2cl-debug/index.html` is present only if `j2clSandboxBuild` was run; not required by the standard gate
 
 ## Manual Browser Verification

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -62,9 +62,8 @@ python3 scripts/assemble-changelog.py
 python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
 ```
 
-`wave/config/changelog.json` is generated and gitignored. Do not commit it;
-commit only changelog fragments under `wave/config/changelog.d/`.
-
+`wave/config/changelog.json` is gitignored — do not commit it. Only commit
+changelog fragments under `wave/config/changelog.d/`.
 
 ### 2. Run The Cross-Path Build Gate
 
@@ -93,9 +92,12 @@ PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.lo
 PORT=9900 bash scripts/wave-smoke.sh check
 ```
 
-Keep the server running through the route checks and browser verification
-below.
+Keep the server running through steps 4 and manual browser verification, then
+stop it when done:
 
+```bash
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
 
 ### 4. Route Presence Checks
 
@@ -149,14 +151,6 @@ For stronger manual proof:
 - create extra waves from the normal app first
 - refresh `/j2cl-search/index.html`
 - confirm the wave count and `Show more waves` behavior change coherently
-
-When the route checks and browser verification are finished, stop the local
-server:
-
-```bash
-PORT=9900 bash scripts/wave-smoke.sh stop
-```
-
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -34,12 +34,21 @@ sbt -batch j2clSandboxBuild j2clSandboxTest
 sbt -batch j2clSearchBuild j2clSearchTest
 ```
 
+If the change touches generated transport/message families, also run:
+
+```bash
+sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"
+```
+
 Use these expectations:
 
 - `j2clSandboxBuild` / `j2clSandboxTest`
   - proves the base sidecar sandbox still packages and its smoke tests pass
 - `j2clSearchBuild` / `j2clSearchTest`
   - proves the merged J2CL search slice still packages and its unit tests pass
+- `generatePstMessages` + `PstCodegenContractTest`
+  - proves the sidecar-safe generated codec families still match the repo's
+    authoritative PST contract when transport/search schemas change
 
 For production-profile output only:
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -62,8 +62,8 @@ python3 scripts/assemble-changelog.py
 python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
 ```
 
-`wave/config/changelog.json` is gitignored — do not commit it. Only commit
-changelog fragments under `wave/config/changelog.d/`.
+`wave/config/changelog.json` is generated and gitignored. Do not commit it;
+commit only changelog fragments under `wave/config/changelog.d/`.
 
 ### 2. Run The Cross-Path Build Gate
 
@@ -92,12 +92,8 @@ PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.lo
 PORT=9900 bash scripts/wave-smoke.sh check
 ```
 
-Keep the server running through steps 4 and manual browser verification, then
-stop it when done:
-
-```bash
-PORT=9900 bash scripts/wave-smoke.sh stop
-```
+Keep the server running through the route checks and browser verification
+below.
 
 ### 4. Route Presence Checks
 
@@ -151,6 +147,13 @@ For stronger manual proof:
 - create extra waves from the normal app first
 - refresh `/j2cl-search/index.html`
 - confirm the wave count and `Show more waves` behavior change coherently
+
+When the route checks and browser verification are finished, stop the local
+server:
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
+++ b/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
@@ -41,7 +41,7 @@ The current J2CL tree is still only a thin slice:
 - no sidecar route that opens and renders a selected wave in context
 - no read-only conversation view
 - no compose/reply/edit path
-- no J2CL-owned root app shell yet
+- no J2CL-owned editor route on the real app path
 - no feature-flagged root bootstrap that can swap between a real GWT shell and
   a real J2CL shell
 - no production parity checklist that proves “J2CL can replace GWT” rather than

--- a/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
+++ b/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
@@ -41,7 +41,9 @@ The current J2CL tree is still only a thin slice:
 - no sidecar route that opens and renders a selected wave in context
 - no read-only conversation view
 - no compose/reply/edit path
-- no feature-flagged root bootstrap that can swap between GWT and J2CL
+- no J2CL-owned root app shell yet
+- no feature-flagged root bootstrap that can swap between a real GWT shell and
+  a real J2CL shell
 - no production parity checklist that proves “J2CL can replace GWT” rather than
   “J2CL can coexist beside GWT”
 
@@ -106,6 +108,10 @@ Exit criteria:
 
 - `/j2cl-search/index.html` supports inbox/search + open selected wave
 - live updates still arrive on the opened wave
+- opening a selected wave proves unread/read-state behavior, not only static
+  rendering
+- one forced disconnect/recovery cycle proves the selected wave can resume the
+  live sidecar session without a full page reset
 - `/` remains GWT and still passes the normal compile/stage/smoke gates
 - reload/deep-link persistence is still explicitly out of scope here
 
@@ -137,6 +143,8 @@ Recommended scope:
 - create a new wave
 - reply with plain text
 - submit and observe the update in the opened wave
+- provide a user-reachable compose/reply affordance in the sidecar shell; this
+  slice must not rely on devtools-only triggers or hidden URLs
 
 Non-goals for this slice:
 
@@ -150,26 +158,54 @@ Exit criteria:
 - the J2CL sidecar can perform a simple end-to-end write flow against the live
   local server
 - the transport/update path stays coherent after write operations
+- the compose/reply path is reachable through the sidecar UI, not only through
+  a developer-only seam
 
-### Slice 4: Opt-In Root Bootstrap
+### Slice 4: J2CL Root App Shell
 
-Only after the sidecar supports a useful read/write flow should the repo add a
-root-bootstrap seam that can choose between GWT and J2CL.
+Only after the sidecar supports a useful read/write flow should the repo build a
+real J2CL-owned root shell. The bootstrap selector belongs to the next slice.
+
+Deliverables:
+
+- build a real J2CL-owned root shell for `/`, including the minimum app chrome
+  needed for later cutover work
+- make the shell capable of hosting the sidecar read/write workflows without
+  depending on the legacy GWT shell
+- include the signed-out login entry/redirect seam that the next bootstrap
+  slice will verify through the real J2CL root mode
+- do not make J2CL the default bootstrap in this slice
+
+Exit criteria:
+
+- there is a real J2CL root shell, not just the search sidecar remounted at `/`
+- local verification can intentionally boot the J2CL shell behind a non-default
+  seam
+- the legacy GWT bootstrap is still the default after this slice lands
+
+### Slice 5: Opt-In Root Bootstrap
+
+Only after the J2CL root shell exists should the repo add a bootstrap selector
+that can choose between the legacy GWT shell and the new J2CL shell.
 
 Deliverables:
 
 - feature flag or explicit opt-in route for J2CL root bootstrap
 - production-safe fallback to the legacy GWT bootstrap
-- one dual-run verification matrix for both bootstrap modes
-- keep GWT as the default bootstrap in this slice; default cutover belongs to the
-  next slice
+- one concrete dual-bootstrap verification matrix as a committed docs artifact
+- keep GWT as the default bootstrap in this slice; default cutover belongs to
+  the next slice
 
 Exit criteria:
 
-- selected users or local verification can boot a J2CL-owned root shell
+- local verification can boot the J2CL root shell intentionally through the
+  bootstrap seam
+- first-time signed-out login through the J2CL root mode is explicitly verified
 - switching back to GWT is still one configuration change, not a rollback patch
+- the verification matrix exists as a committed file or committed runbook
+  section, not only issue text
 
-### Slice 5: Default Cutover
+### Slice 6: Default Cutover
 
 This is the first slice that should actually “switch to J2CL.”
 
@@ -191,7 +227,7 @@ Required proof before this slice is approved:
 - reconnect/reload behavior
 - browser sanity on the real staged app
 
-### Slice 6: GWT Retirement
+### Slice 7: GWT Retirement
 
 Only after a stable default cutover should the repo remove the old GWT path.
 
@@ -203,15 +239,17 @@ Deliverables:
   client
 - only start this slice after the J2CL root path has already been the proven
   default route, not in parallel with the first cutover
+- explicitly account for the remaining browser-harness descendants before GWT
+  packaging/runtime pieces are removed; no suite is silently dropped
 
 ## Suggested Next GitHub Issues
 
 If the work continues in the same issue-driven sequence, the next issues are:
 
-1. [#919](https://github.com/vega113/supawave/issues/919) Refresh the J2CL tracker/docs after the merged search-sidecar slice
-2. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
-3. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
-4. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+1. [#920](https://github.com/vega113/supawave/issues/920) Add a read-only selected-wave panel to the J2CL search sidecar
+2. [#921](https://github.com/vega113/supawave/issues/921) Add sidecar route state and split-view navigation for the J2CL shell
+3. [#922](https://github.com/vega113/supawave/issues/922) Add the first J2CL write-path pilot for create/reply/plain-text submit
+4. [#928](https://github.com/vega113/supawave/issues/928) Build the first J2CL-owned root app shell
 5. [#923](https://github.com/vega113/supawave/issues/923) Add an opt-in root bootstrap flag for the J2CL client
 6. [#924](https://github.com/vega113/supawave/issues/924) Cut over the default root route from GWT to J2CL
 7. [#925](https://github.com/vega113/supawave/issues/925) Retire the legacy GWT client path and packaging steps
@@ -224,6 +262,7 @@ the J2CL path:
 - it boots from the root route, not only a sidecar route
 - it can search, open, and navigate waves without relying on the legacy shell
 - it can create a wave and enter text
+- it has already proven a signed-out login flow through the J2CL root mode
 - it survives reload/reconnect and preserves route state
 - the legacy fallback still exists until the J2CL root path passes staged
   rollout

--- a/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
+++ b/docs/superpowers/plans/2026-04-19-j2cl-post-search-cutover-plan.md
@@ -70,10 +70,12 @@ docs and tracker so future work starts from the real baseline.
 
 Deliverables:
 
-- refresh `#904` or replace it with a new post-`#901` tracker issue
+- refresh `#904` in place or replace it with a new post-`#901` tracker issue
 - update the stale J2CL inventory/decision/preparatory docs so they stop saying
   there is no `j2cl/` tree or no sidecar build
 - keep one canonical list of remaining migration slices
+- mark the completed `#899` / `#900` / `#903` / `#902` / `#898` / `#901`
+  sequence clearly so the tracker no longer reads like current pending work
 
 Exit criteria:
 
@@ -88,9 +90,11 @@ the J2CL sidecar, not a root cutover.
 Deliverables:
 
 - add a J2CL-owned content panel beside the search results
-- clicking a digest opens the selected wave in the sidecar route
+- clicking a digest opens the selected wave in the current sidecar session
 - reuse the sidecar transport stack to keep the selected wave live
 - keep the scope read-only: rendering, unread state, and updates, but no edit
+- keep selection in-memory only for this slice; durable URL/history state belongs
+  to the next slice
 
 Why this next:
 
@@ -103,6 +107,7 @@ Exit criteria:
 - `/j2cl-search/index.html` supports inbox/search + open selected wave
 - live updates still arrive on the opened wave
 - `/` remains GWT and still passes the normal compile/stage/smoke gates
+- reload/deep-link persistence is still explicitly out of scope here
 
 ### Slice 2: J2CL Split-View Shell And Route State
 
@@ -115,6 +120,7 @@ Deliverables:
 - support reload/deep-link behavior inside the J2CL route
 - preserve the existing root bootstrap and session reuse model
 - establish the sidecar shell layout that future slices will extend
+- do not widen this slice into editor/write-path work
 
 Exit criteria:
 
@@ -155,6 +161,8 @@ Deliverables:
 - feature flag or explicit opt-in route for J2CL root bootstrap
 - production-safe fallback to the legacy GWT bootstrap
 - one dual-run verification matrix for both bootstrap modes
+- keep GWT as the default bootstrap in this slice; default cutover belongs to the
+  next slice
 
 Exit criteria:
 
@@ -193,6 +201,8 @@ Deliverables:
 - retire `compileGwt` from the packaging-critical path
 - remove legacy module/deferred-binding paths that only existed for the old
   client
+- only start this slice after the J2CL root path has already been the proven
+  default route, not in parallel with the first cutover
 
 ## Suggested Next GitHub Issues
 


### PR DESCRIPTION
## Summary
- apply Claude-driven adversarial review fixes to the post-search J2CL migration plan and sidecar testing runbook
- update the stale current-state J2CL docs and tracker ordering to include the missing root-shell slice
- tighten the live GitHub issue chain around reconnect, unread/read, user-reachable compose UI, signed-out login, and browser-harness retirement criteria

## Key corrections
- add the missing root-shell step as #928 before the bootstrap/cutover issues
- stop #920 from overlapping #921 by keeping state in-memory only in the read-only wave slice
- make #923 require a committed dual-bootstrap verification matrix and signed-out login proof
- make #924 verify reconnect/reload on the J2CL root path during cutover instead of implying it was already proven
- make #925 explicitly account for the remaining browser-harness descendants before retiring `compileGwt`

## Verification
- `git diff --check`
- Claude adversarial review via `/Users/vega/.codex/skills/public/claude-review/scripts/claude_review.sh` on the docs plus live issue bodies
- second Claude pass reported no blocker-level defects in the revised state

## Follow-up issues
- #920
- #921
- #922
- #928
- #923
- #924
- #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated decision memos, inventory, and planning documents to reflect current J2CL migration milestones and project status.
  * Refreshed baseline documentation including completed sidecar build and first UI slice availability.
  * Enhanced testing runbook with additional verification steps for J2CL builds.
  * Clarified staged migration sequencing and exit criteria for upcoming phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->