### PR TITLE
fix(ui): stack compact inline avatars above reply content

### DIFF
--- a/wave/config/changelog.d/2026-04-19-compact-inline-avatar-stack.json
+++ b/wave/config/changelog.d/2026-04-19-compact-inline-avatar-stack.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-19-compact-inline-avatar-stack",
+  "version": "PR pending",
+  "date": "2026-04-19",
+  "title": "Stack compact inline reply avatars above content",
+  "summary": "Updates the compact-inline-blips layout so new inline reply composers stack the author avatar above the metabar/content instead of reserving extra horizontal gutter width.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Depth 0-2 compact inline reply composers now render the avatar above the metadata row on desktop and mobile.",
+        "Compact inline reply width is no longer driven by a left avatar gutter, while depth 3+ slide-nav threads keep the baseline layout."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -453,14 +453,28 @@
 @external .compact-inline-blips;
 @external .compact-inline-blips-mobile;
 
-/* --- Depth 0 --- */
-.compact-inline-blips [data-depth="0"] .meta {
-  padding-left: 2.75em;
+/* Stack the avatar above the metabar/content so inline depth width does not
+   depend on the avatar gutter. */
+.compact-inline-blips [data-depth="0"] .meta,
+.compact-inline-blips [data-depth="1"] .meta,
+.compact-inline-blips [data-depth="2"] .meta {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0.75em;
 }
+.compact-inline-blips [data-depth="0"] .avatar,
+.compact-inline-blips [data-depth="1"] .avatar,
+.compact-inline-blips [data-depth="2"] .avatar {
+  float: none;
+  margin-left: 0;
+  margin-bottom: 0.35em;
+  align-self: flex-start;
+}
+
+/* --- Depth 0 --- */
 .compact-inline-blips [data-depth="0"] .avatar {
   width: 24px;
   height: 24px;
-  margin-left: -2.25em;
 }
 .compact-inline-blips [data-depth="0"] .replies,
 .compact-inline-blips [data-depth="0"] .privateReplies {
@@ -469,13 +483,9 @@
 }
 
 /* --- Depth 1 --- */
-.compact-inline-blips [data-depth="1"] .meta {
-  padding-left: 2.25em;
-}
 .compact-inline-blips [data-depth="1"] .avatar {
   width: 22px;
   height: 22px;
-  margin-left: -1.75em;
 }
 .compact-inline-blips [data-depth="1"] .replies,
 .compact-inline-blips [data-depth="1"] .privateReplies {
@@ -484,13 +494,9 @@
 }
 
 /* --- Depth 2 (last inline level before slide-nav) --- */
-.compact-inline-blips [data-depth="2"] .meta {
-  padding-left: 1.75em;
-}
 .compact-inline-blips [data-depth="2"] .avatar {
   width: 20px;
   height: 20px;
-  margin-left: -1.25em;
 }
 .compact-inline-blips [data-depth="2"] .replies,
 .compact-inline-blips [data-depth="2"] .privateReplies {
@@ -514,18 +520,28 @@
 }
 
 /* --- Mobile: more aggressive compaction via runtime class --- */
-.compact-inline-blips-mobile [data-depth="0"] .meta { padding-left: 2.25em; }
-.compact-inline-blips-mobile [data-depth="0"] .avatar {
-  width: 22px; height: 22px; margin-left: -1.75em;
+.compact-inline-blips-mobile [data-depth="0"] .meta,
+.compact-inline-blips-mobile [data-depth="1"] .meta,
+.compact-inline-blips-mobile [data-depth="2"] .meta {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0.5em;
 }
-.compact-inline-blips-mobile [data-depth="1"] .meta { padding-left: 1.75em; }
-.compact-inline-blips-mobile [data-depth="1"] .avatar {
-  width: 20px; height: 20px; margin-left: -1.25em;
-}
-.compact-inline-blips-mobile [data-depth="2"] .meta { padding-left: 1.25em; }
+.compact-inline-blips-mobile [data-depth="0"] .avatar,
+.compact-inline-blips-mobile [data-depth="1"] .avatar,
 .compact-inline-blips-mobile [data-depth="2"] .avatar {
-  width: 20px; height: 20px; margin-left: -1.25em;
+  float: none;
+  margin-left: 0;
+  margin-bottom: 0.25em;
+  align-self: flex-start;
 }
+.compact-inline-blips-mobile [data-depth="0"] .avatar {
+  width: 22px; height: 22px;
+}
+.compact-inline-blips-mobile [data-depth="1"] .avatar {
+  width: 20px; height: 20px;
+}
+.compact-inline-blips-mobile [data-depth="2"] .avatar { width: 20px; height: 20px; }
 .compact-inline-blips-mobile [data-depth="0"] .replies,
 .compact-inline-blips-mobile [data-depth="0"] .privateReplies {
   margin-left: 0.25em; padding-left: 2px;

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -506,12 +506,16 @@
 
 /* --- Depth 3+ reset (prevent cascade leak into slide-nav) --- */
 .compact-inline-blips [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .meta {
+  display: block;
   padding-left: 3.75em;
 }
 .compact-inline-blips [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .avatar {
+  float: left;
   width: 28px;
   height: 28px;
   margin-left: -3em;
+  margin-bottom: 0;
+  align-self: auto;
 }
 .compact-inline-blips [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .replies,
 .compact-inline-blips [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .privateReplies {
@@ -554,10 +558,12 @@
 }
 /* Depth 3+ reset inside the runtime mobile block prevents depth-2 rules from cascading into deeper threads. */
 .compact-inline-blips-mobile [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .meta {
+  display: block;
   padding-left: 3.75em;
 }
 .compact-inline-blips-mobile [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .avatar {
-  width: 28px; height: 28px; margin-left: -3em;
+  float: left;
+  width: 28px; height: 28px; margin-left: -3em; margin-bottom: 0; align-self: auto;
 }
 .compact-inline-blips-mobile [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .replies,
 .compact-inline-blips-mobile [data-depth]:not([data-depth="0"]):not([data-depth="1"]):not([data-depth="2"]) .privateReplies {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class CompactInlineBlipCssContractTest extends TestCase {
+
+  public void testDesktopCompactInlineBlipsStackAvatarAboveContent() throws Exception {
+    String css = readBlipCss();
+
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.meta,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.meta,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.meta \\{"
+            + "\\s*display: flex;"
+            + "\\s*flex-direction: column;"
+            + "\\s*padding-left: 0\\.75em;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.avatar \\{"
+            + "\\s*float: none;"
+            + "\\s*margin-left: 0;"
+            + "\\s*margin-bottom: 0\\.35em;"
+            + "\\s*align-self: flex-start;"
+            + "\\s*\\}.*");
+  }
+
+  public void testMobileCompactInlineBlipsKeepStackedAvatarLayout() throws Exception {
+    String css = readBlipCss();
+
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.meta,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.meta,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.meta \\{"
+            + "\\s*display: flex;"
+            + "\\s*flex-direction: column;"
+            + "\\s*padding-left: 0\\.5em;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.avatar \\{"
+            + "\\s*float: none;"
+            + "\\s*margin-left: 0;"
+            + "\\s*margin-bottom: 0\\.25em;"
+            + "\\s*align-self: flex-start;"
+            + "\\s*\\}.*");
+  }
+
+  private String readBlipCss() throws IOException {
+    return Files.readString(
+        Path.of(
+            "wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css"),
+        StandardCharsets.UTF_8);
+  }
+
+  private static void assertMatches(String text, String regex) {
+    assertTrue("Expected CSS to match regex: " + regex, text.matches(regex));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
@@ -22,9 +22,8 @@ package org.waveprotocol.box.server.util;
 import junit.framework.TestCase;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public final class CompactInlineBlipCssContractTest extends TestCase {
 
@@ -72,11 +71,49 @@ public final class CompactInlineBlipCssContractTest extends TestCase {
             + "\\s*\\}.*");
   }
 
+  public void testDepth3PlusResetRestoresBaselineLayout() throws Exception {
+    String css = readBlipCss();
+
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth\\]:not\\(\\[data-depth=\"0\"\\]\\)"
+            + ":not\\(\\[data-depth=\"1\"\\]\\):not\\(\\[data-depth=\"2\"\\]\\) \\.meta \\{"
+            + "\\s*display: block;"
+            + "\\s*padding-left: 3\\.75em;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth\\]:not\\(\\[data-depth=\"0\"\\]\\)"
+            + ":not\\(\\[data-depth=\"1\"\\]\\):not\\(\\[data-depth=\"2\"\\]\\) \\.avatar \\{"
+            + "\\s*float: left;"
+            + "\\s*width: 28px;"
+            + "\\s*height: 28px;"
+            + "\\s*margin-left: -3em;"
+            + "\\s*margin-bottom: 0;"
+            + "\\s*align-self: auto;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth\\]:not\\(\\[data-depth=\"0\"\\]\\)"
+            + ":not\\(\\[data-depth=\"1\"\\]\\):not\\(\\[data-depth=\"2\"\\]\\) \\.meta \\{"
+            + "\\s*display: block;"
+            + "\\s*padding-left: 3\\.75em;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth\\]:not\\(\\[data-depth=\"0\"\\]\\)"
+            + ":not\\(\\[data-depth=\"1\"\\]\\):not\\(\\[data-depth=\"2\"\\]\\) \\.avatar \\{"
+            + "\\s*float: left;"
+            + "\\s*width: 28px;"
+            + "\\s*height: 28px;"
+            + "\\s*margin-left: -3em;"
+            + "\\s*margin-bottom: 0;"
+            + "\\s*align-self: auto;"
+            + "\\s*\\}.*");
+  }
+
   private String readBlipCss() throws IOException {
-    return Files.readString(
-        Path.of(
-            "wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css"),
-        StandardCharsets.UTF_8);
+    String resourcePath = "org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css";
+    try (InputStream in = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+      assertNotNull("Missing resource: " + resourcePath, in);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
   }
 
   private static void assertMatches(String text, String regex) {


### PR DESCRIPTION
## Summary
This follow-up tightens the `compact-inline-blips` rollout so new inline reply composers no longer spend horizontal space on a left avatar gutter. The current compact CSS still shrank the avatar at inline depths 0-2, but it kept the old float-plus-negative-margin layout, so each new inline blip still paid width for the avatar lane.

This patch changes the compact depth-0/1/2 rules to stack the avatar above the metabar/content instead of floating it to the left. Depth 3+ slide-nav threads keep the baseline layout, and root blips remain unchanged because the compact rules are still scoped to the existing `[data-depth]` containers under `body.compact-inline-blips`.

The PR also adds a JVM-visible contract test that locks the compact CSS shape for both desktop and mobile, plus a changelog fragment for the user-facing layout fix.

## Verification
- `sbt "wave/testOnly org.waveprotocol.box.server.util.WavePanelCssCompatibilityTest org.waveprotocol.box.server.util.CompactInlineBlipCssContractTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- Local branch server prep: `bash scripts/worktree-boot.sh --port 9904 --shared-file-store`
- Local smoke helper note: `wave-smoke.sh start` reached `READY`, but the helper-managed detached server exited before the follow-up `wave-smoke.sh check`; I captured that with `PORT=9904 bash scripts/worktree-diagnostics.sh --port 9904`
- Stable local smoke: started the staged server directly from `target/universal/stage`, then verified `ROOT=200`, `HEALTH=200`, `WEBCLIENT=200` on `http://127.0.0.1:9904`
- Local flag-on browser check: registered/signed in a local owner user, enabled `compact-inline-blips` via `/admin/flags`, confirmed `document.body.className === "compact-inline-blips"`, and verified that clicking the blip `Reply` action opened a nested inline reply composer with the avatar stacked above the metadata row


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact inline reply composers at depths 0–2 now stack the author avatar above metadata/content on desktop and mobile; width is no longer determined by a left-avatar gutter. Depth 3+ retains the baseline layout.

* **Tests**
  * Added tests validating stacked layout and depth-3+ reset behavior across desktop and mobile.

* **Chores**
  * Added changelog entry documenting this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->