### PR TITLE
feat(j2cl): add selected-wave sidecar panel

### DIFF
--- a/docs/superpowers/plans/2026-04-19-issue-920-j2cl-selected-wave.md
+++ b/docs/superpowers/plans/2026-04-19-issue-920-j2cl-selected-wave.md
@@ -1,0 +1,255 @@
+# Issue #920 J2CL Selected-Wave Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the existing J2CL search sidecar so selecting a digest opens a read-only selected-wave panel with live updates and one reconnect proof, while keeping route state in-memory only and leaving the legacy GWT root path untouched.
+
+**Architecture:** Keep the current J2CL search slice as the left-hand search rail and add a sidecar-only selected-wave panel beside it. Reuse the existing root-session bootstrap fetch and `/search` query path, then add a sidecar-only open/reconnect flow that turns `ProtocolWaveletUpdate` payloads into a read-only view model for the selected wave. Preserve the current isolated `/j2cl-search/**` route, keep selection state in memory only, and treat deeper route/history persistence as explicitly deferred to `#921`.
+
+**Tech Stack:** Java, SBT, J2CL Maven sidecar under `j2cl/`, Elemental2 DOM, sidecar transport codec helpers, generated `gen/messages/org/waveprotocol/box/common/comms/**` protocol models, `scripts/worktree-file-store.sh`, `scripts/worktree-boot.sh`, manual browser verification.
+
+---
+
+## 1. Goal / Root Cause
+
+Issue `#920` exists because the current sidecar search slice stops at list selection instead of opening or rendering the chosen wave:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java:41-50` mounts the search-sidecar mode, but passes a no-op selection callback into `J2clSearchPanelController`, so the selected digest cannot trigger any follow-on wave load.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java:44-113` tracks `selectedWaveId`, highlights the selected digest, and notifies a selection handler, but it has no selected-wave fetch, reconnect, or render path.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:29-115` builds only the search card, search form, digest list, empty state, and show-more button, and `:152-189` only re-renders digests plus selection highlight. There is no DOM seam for a selected-wave panel.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:9-43` only supports `fetchRootSessionBootstrap(...)` and `search(...)`. It has no wave-open or wave-refresh operation.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:64-73` currently reduces `ProtocolWaveletUpdate` to `SidecarWaveletUpdateSummary`, dropping the richer payload even though `gen/messages/org/waveprotocol/box/common/comms/ProtocolWaveletUpdate.java:219-322` exposes `snapshot` and `fragments`.
+
+The narrow root cause is therefore not “selection missing.” Selection already exists. The missing seam is that the sidecar still lacks a selected-wave read model and a sidecar-owned open/update/reconnect flow that can feed a read-only panel.
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Add a selected-wave panel inside the J2CL search sidecar route.
+- Reuse the current browser session bootstrap from `/` for the selected-wave flow.
+- Add a sidecar-only wave-open/update seam for read-only rendering and live updates.
+- Keep the selected-wave state in memory only for this issue.
+- Prove one disconnect/recovery cycle without full-page reset.
+- Keep the legacy root GWT route compiling, staging, and booting exactly as before.
+
+### Explicit Non-Goals
+
+- No durable route state or deep-link persistence. That belongs to `#921`.
+- No create/reply/editor/write flow. That belongs to `#922`.
+- No root shell work. That belongs to `#928`.
+- No root bootstrap flag or cutover work. That belongs to `#923` and `#924`.
+- No retirement of the GWT root client or `compileGwt`. That belongs to `#925`.
+- No silent widening into full `WavePanelImpl` migration.
+
+## 3. Exact Files Likely To Change
+
+### Primary Sidecar Files
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarWaveletUpdateSummary.java`
+- `j2cl/src/main/webapp/assets/sidecar.css`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+
+### Likely New Sidecar-Only Files
+
+These filenames are an inference based on the existing `j2cl/search` structure and may shift slightly during implementation, but the responsibilities should remain separate:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+
+### Shared / Generated Inspect-Only References
+
+- `gen/messages/org/waveprotocol/box/common/comms/ProtocolWaveletUpdate.java`
+- `gen/messages/org/waveprotocol/box/common/comms/gson/ProtocolWaveletUpdateGsonImpl.java`
+- `gen/messages/org/waveprotocol/box/common/comms/WaveletSnapshot.java`
+- `gen/messages/org/waveprotocol/box/common/comms/ProtocolFragments.java`
+- `build.sbt:831-920`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java:816-843`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteWaveViewService.java:337-339`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/HistoryChangeListener.java:74`
+- `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java:155-251`
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/WavePanelImpl.java`
+
+Those legacy files are parity references only. `#920` should not patch the live GWT runtime to make the sidecar work.
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Freeze The Issue Boundary Before Coding
+
+- [ ] Keep `/j2cl-search/index.html` as the only runtime surface for this issue.
+- [ ] Preserve the current tracker order from `#904`: `#920 -> #921 -> #922 -> #928 -> #923 -> #924 -> #925`.
+- [ ] Record in the issue comments that `#920` owns read-only selected-wave rendering only, with route persistence explicitly deferred to `#921`.
+- [ ] Treat the GWT root client as a parity reference, not an implementation target.
+
+### Task 2: Add A Sidecar Shell Layout That Can Host A Selected Wave
+
+- [ ] Extend `J2clSearchPanelView` so the sidecar route can render a split layout: search rail plus selected-wave panel.
+- [ ] Keep the new layout responsive in `j2cl/src/main/webapp/assets/sidecar.css`, with a stacked mobile fallback.
+- [ ] Preserve the existing digest-selection highlight, wave count, empty states, and show-more affordance while adding the selected-wave panel.
+- [ ] Add explicit empty/loading/error states for the selected-wave panel so selection and recovery failures are visible without falling back to devtools.
+
+### Task 3: Turn Digest Selection Into A Real Sidecar Wave-Open Flow
+
+- [ ] Replace the no-op `waveId -> { }` hook in `SandboxEntryPoint` with a sidecar-owned selection controller.
+- [ ] Extend `J2clSearchGateway` with the narrow operations needed for `#920`:
+  - reuse root bootstrap/session resolution
+  - open the selected wave over the existing sidecar socket path
+  - reconnect or re-open the selected wave after a forced disconnect
+- [ ] Keep selection state in memory only. Do not add URL/history state in this issue.
+- [ ] Ensure re-running a search clears the selected wave when the selected digest falls out of the result set, matching the current controller behavior.
+- [ ] Add explicit error behavior for at least:
+  - unauthorized or failed selected-wave open
+  - selected wave disappearing or becoming inaccessible
+  - updates arriving after the user has switched to a different wave
+
+### Task 4: Extend The Sidecar Transport Decode Beyond Summary-Only Updates
+
+- [ ] Start with a go/no-go J2CL-safety probe for `ProtocolWaveletUpdateGsonImpl`:
+  - if it compiles cleanly into the sidecar and can decode a representative selected-wave payload in a focused test, prefer reusing it
+  - if it fails the probe, stop and commit to the fallback path below instead of widening scope ad hoc mid-implementation
+- [ ] If it is J2CL-safe, reuse it to decode the selected-wave payload into sidecar-friendly projections.
+- [ ] If it is not J2CL-safe, extend `SidecarTransportCodec` narrowly so it can decode the `snapshot` and/or `fragments` fields needed for read-only rendering without disturbing the legacy transport path.
+- [ ] Preserve the current summary-only test coverage while adding richer decode coverage for the selected-wave path.
+- [ ] Keep all transport changes sidecar-only under `j2cl/**`.
+
+### Task 5: Add A Read-Only Selected-Wave Projection And View
+
+- [ ] Build a sidecar-owned read-only wave model that is intentionally smaller than the legacy `WavePanelImpl` stack.
+- [ ] Prefer a narrow rendering target for `#920`:
+  - wave title / identity
+  - participant / unread metadata needed for visible read-state proof
+  - a read-only conversation content projection good enough to prove the selected wave is really opened and kept live
+- [ ] Treat read-state proof as a first-class seam:
+  - first confirm whether the selected-wave payload already surfaces enough data to prove read/unread movement
+  - if it does not, add the smallest sidecar-visible status projection needed for `#920` rather than widening into legacy wavepanel parity
+- [ ] Do not attempt editor parity, toolbar parity, or write affordances here.
+- [ ] Keep the selected-wave rendering code independent from route persistence so `#921` can layer on URL/history later without redoing the read-only panel.
+- [ ] Build all visible text with DOM `textContent` / equivalent safe text insertion, not raw HTML interpolation.
+
+### Task 6: Prove Live Update And One Disconnect / Recovery Cycle
+
+- [ ] Add a deterministic controller-level test for selected-wave open + state transitions.
+- [ ] Add transport tests that cover at least one update payload carrying the fields the new read-only projector needs.
+- [ ] Add at least one deterministic reopen-path test that exercises the selected-wave recovery flow after a simulated disconnect or close event.
+- [ ] In local browser verification, intentionally force one socket disconnect and prove the selected wave resumes without a full page reload.
+- [ ] Verify that the opened wave demonstrates live unread/read movement, not only a static initial snapshot.
+
+### Task 7: Preserve The Legacy Root Path And Record Traceability
+
+- [ ] Re-run the legacy root compile/stage gates even though the implementation is sidecar-only.
+- [ ] Boot the app from the issue worktree, with shared file-store state prepared via:
+
+```bash
+cd /Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+- [ ] Record the exact local verification commands and observed results in `journal/local-verification/`.
+- [ ] Mirror the important verification and review results into the GitHub issue comment and PR body.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave`.
+
+### Targeted Sidecar Unit / Integration Gates
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+```
+
+Expected result:
+
+- the sidecar search build remains green
+- the new selected-wave panel tests pass
+- the sidecar output remains isolated under `war/j2cl-search/**`
+- `build.sbt:831-920` remains the authoritative definition of `j2clSearchBuild` / `j2clSearchTest`
+
+### Legacy Root Compile / Stage Gate
+
+```bash
+sbt -batch compileGwt Universal/stage
+```
+
+Expected result:
+
+- the legacy GWT root client still compiles
+- staged packaging remains green
+- the root `/` path remains served by the legacy runtime
+
+### Fresh Worktree File-Store Prep
+
+```bash
+cd /Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Expected result:
+
+- `wave/_accounts`, `wave/_attachments`, and `wave/_deltas` are linked into the issue worktree
+- local browser verification can use realistic current-user wave data
+
+### Local Boot / Smoke
+
+```bash
+bash scripts/worktree-boot.sh --port 9910
+```
+
+Then run the exact printed helper commands, typically:
+
+```bash
+PORT=9910 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9910 bash scripts/wave-smoke.sh check
+```
+
+### Route Presence Checks
+
+```bash
+curl -sS -I http://localhost:9910/
+curl -sS -I http://localhost:9910/j2cl-search/index.html
+```
+
+Expected result:
+
+- `/` responds successfully and remains the legacy GWT route
+- `/j2cl-search/index.html` responds successfully and mounts the J2CL sidecar
+
+### Manual Browser Verification
+
+Verify all of the following against the local booted app:
+
+- legacy `/` still loads and remains usable
+- `/j2cl-search/index.html` still supports search and digest selection
+- selecting a digest opens a read-only selected-wave panel beside the search results
+- the opened wave continues receiving live updates
+- unread/read state changes are visibly proven on the selected wave path
+- one forced disconnect/recovery cycle resumes the selected wave without a full page reset
+- reload/deep-link persistence is still out of scope and therefore not claimed here
+
+Use browser devtools offline/network disable as the canonical disconnect method for this issue unless implementation constraints force a different approach, and record the exact method used plus the observed recovery behavior in `journal/local-verification/<date>-issue-920-j2cl-selected-wave.md`.
+
+## 6. Review / PR Expectations
+
+- Run Claude plan review before implementation starts.
+- After implementation, run direct review plus Claude implementation review.
+- Address all review comments that make technical sense, including nitpicks and out-of-diff feedback when they are valid.
+- Resolve review threads only after replying with the fix commit or technical reasoning.
+- If a later rebase or conflict occurs, inspect both sides carefully and do not overwrite newer behavior with older code.
+
+## 7. Definition Of Done For This Slice
+
+- `/j2cl-search/index.html` supports search plus a read-only selected-wave panel.
+- The selected wave stays live after open and through one disconnect/recovery proof.
+- Selection state remains in-memory only; no deep-link persistence is claimed.
+- The legacy root GWT path still compiles, stages, boots, and smokes green.
+- Claude plan review and Claude implementation review outcomes are recorded in the issue or PR traceability.
+- Issue comments contain worktree, plan path, verification commands/results, review summary, and PR link.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -13,6 +13,8 @@ import jsinterop.annotations.JsType;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
+import org.waveprotocol.box.j2cl.search.J2clSelectedWaveController;
+import org.waveprotocol.box.j2cl.search.J2clSelectedWaveView;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
@@ -40,12 +42,21 @@ public final class SandboxEntryPoint {
 
     if ("search-sidecar".equals(mode)) {
       J2clSearchPanelView searchView = new J2clSearchPanelView(host);
+      J2clSearchGateway gateway = new J2clSearchGateway();
+      J2clSelectedWaveController selectedWaveController =
+          new J2clSelectedWaveController(
+              gateway, new J2clSelectedWaveView(searchView.getSelectedWaveHost()));
+      final J2clSearchPanelController[] controllerRef = new J2clSearchPanelController[1];
       J2clSearchPanelController controller =
           new J2clSearchPanelController(
-              new J2clSearchGateway(),
+              gateway,
               searchView,
-              waveId -> { },
+              waveId ->
+                  selectedWaveController.onWaveSelected(
+                      waveId,
+                      controllerRef[0] == null ? null : controllerRef[0].findDigestItem(waveId)),
               resolveViewportWidth());
+      controllerRef[0] = controller;
       controller.start(readRequestedQuery(DomGlobal.location.search));
       return;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -1,12 +1,19 @@
 package org.waveprotocol.box.j2cl.search;
 
+import elemental2.dom.DomGlobal;
+import elemental2.dom.WebSocket;
 import elemental2.dom.XMLHttpRequest;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
+import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
 
-public final class J2clSearchGateway implements J2clSearchPanelController.SearchGateway {
+public final class J2clSearchGateway
+    implements J2clSearchPanelController.SearchGateway, J2clSelectedWaveController.Gateway {
+  private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
+
   @Override
   public void fetchRootSessionBootstrap(
       J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
@@ -21,6 +28,72 @@ public final class J2clSearchGateway implements J2clSearchPanelController.Search
           }
         },
         onError);
+  }
+
+  @Override
+  public J2clSelectedWaveController.Subscription openSelectedWave(
+      SidecarSessionBootstrap bootstrap,
+      String waveId,
+      J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
+      J2clSearchPanelController.ErrorCallback onError,
+      Runnable onDisconnect) {
+    WebSocket socket =
+        new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
+    final boolean[] closedByClient = new boolean[] {false};
+    socket.onopen =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          String token = readCookie("JSESSIONID");
+          if (token != null && !token.isEmpty()) {
+            socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
+          }
+          socket.send(
+              SidecarTransportCodec.encodeOpenEnvelope(
+                  1,
+                  new SidecarOpenRequest(
+                      bootstrap.getAddress(),
+                      waveId,
+                      java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
+        };
+    socket.onmessage =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          try {
+            String payload = String.valueOf(event.data);
+            if (!"ProtocolWaveletUpdate".equals(SidecarTransportCodec.decodeMessageType(payload))) {
+              return;
+            }
+            onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(payload));
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to decode the selected wave update."));
+          }
+        };
+    socket.onerror =
+        event -> {
+          if (!closedByClient[0]) {
+            onError.accept("Network failure while opening the selected wave.");
+          }
+        };
+    socket.onclose =
+        event -> {
+          if (!closedByClient[0]) {
+            onDisconnect.run();
+          }
+        };
+    return new J2clSelectedWaveController.Subscription() {
+      @Override
+      public void close() {
+        if (closedByClient[0]) {
+          return;
+        }
+        closedByClient[0] = true;
+        socket.close();
+      }
+    };
   }
 
   @Override
@@ -76,6 +149,27 @@ public final class J2clSearchGateway implements J2clSearchPanelController.Search
   private static String messageOrDefault(RuntimeException error, String fallback) {
     String message = error.getMessage();
     return message == null || message.isEmpty() ? fallback : message;
+  }
+
+  private static String buildWebSocketUrl(String locationProtocol, String websocketAddress) {
+    String protocol = "https:".equals(locationProtocol) ? "wss://" : "ws://";
+    return protocol + websocketAddress + "/socket";
+  }
+
+  private static String readCookie(String name) {
+    String cookieHeader = DomGlobal.document.cookie;
+    if (cookieHeader == null || cookieHeader.isEmpty()) {
+      return null;
+    }
+    String[] cookies = cookieHeader.split(";");
+    for (String cookie : cookies) {
+      String trimmed = cookie.trim();
+      String prefix = name + "=";
+      if (trimmed.startsWith(prefix)) {
+        return trimmed.substring(prefix.length());
+      }
+    }
+    return null;
   }
 
   @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -71,8 +71,7 @@ public final class J2clSearchGateway
             }
             onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(envelope));
           } catch (RuntimeException e) {
-            closedByClient[0] = true;
-            socket.close();
+            closeSocket(socket, closedByClient);
             onError.accept(messageOrDefault(e, "Unable to decode the selected wave update."));
           }
         };
@@ -158,6 +157,14 @@ public final class J2clSearchGateway
   private static String buildWebSocketUrl(String locationProtocol, String websocketAddress) {
     String protocol = "https:".equals(locationProtocol) ? "wss://" : "ws://";
     return protocol + websocketAddress + "/socket";
+  }
+
+  private static void closeSocket(WebSocket socket, boolean[] closedByClient) {
+    if (closedByClient[0]) {
+      return;
+    }
+    closedByClient[0] = true;
+    socket.close();
   }
 
   private static String readCookie(String name) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -66,7 +66,21 @@ public final class J2clSearchGateway
           try {
             String payload = String.valueOf(event.data);
             Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(payload);
-            if (!"ProtocolWaveletUpdate".equals(envelope.get("messageType"))) {
+            String messageType = (String) envelope.get("messageType");
+            if ("RpcFinished".equals(messageType)) {
+              @SuppressWarnings("unchecked")
+              Map<String, Object> msg = (Map<String, Object>) envelope.get("message");
+              if (msg != null && Boolean.TRUE.equals(msg.get("1"))) {
+                Object errorText = msg.get("2");
+                closeSocket(socket, closedByClient);
+                onError.accept(
+                    errorText != null && !String.valueOf(errorText).isEmpty()
+                        ? String.valueOf(errorText)
+                        : "The selected wave request failed.");
+              }
+              return;
+            }
+            if (!"ProtocolWaveletUpdate".equals(messageType)) {
               return;
             }
             onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(envelope));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.search;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.WebSocket;
 import elemental2.dom.XMLHttpRequest;
+import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
@@ -64,10 +65,11 @@ public final class J2clSearchGateway
           }
           try {
             String payload = String.valueOf(event.data);
-            if (!"ProtocolWaveletUpdate".equals(SidecarTransportCodec.decodeMessageType(payload))) {
+            Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(payload);
+            if (!"ProtocolWaveletUpdate".equals(envelope.get("messageType"))) {
               return;
             }
-            onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(payload));
+            onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(envelope));
           } catch (RuntimeException e) {
             onError.accept(messageOrDefault(e, "Unable to decode the selected wave update."));
           }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -68,15 +68,11 @@ public final class J2clSearchGateway
             Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(payload);
             String messageType = (String) envelope.get("messageType");
             if ("RpcFinished".equals(messageType)) {
-              @SuppressWarnings("unchecked")
-              Map<String, Object> msg = (Map<String, Object>) envelope.get("message");
-              if (msg != null && Boolean.TRUE.equals(msg.get("1"))) {
-                Object errorText = msg.get("2");
+              if (SidecarTransportCodec.decodeRpcFinishedFailed(envelope)) {
                 closeSocket(socket, closedByClient);
                 onError.accept(
-                    errorText != null && !String.valueOf(errorText).isEmpty()
-                        ? String.valueOf(errorText)
-                        : "The selected wave request failed.");
+                    SidecarTransportCodec.decodeRpcFinishedErrorText(
+                        envelope, "The selected wave request failed."));
               }
               return;
             }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -71,6 +71,8 @@ public final class J2clSearchGateway
             }
             onUpdate.accept(SidecarTransportCodec.decodeSelectedWaveUpdate(envelope));
           } catch (RuntimeException e) {
+            closedByClient[0] = true;
+            socket.close();
             onError.accept(messageOrDefault(e, "Unable to decode the selected wave update."));
           }
         };

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -133,6 +133,9 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
           }
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
+          if (selectedWaveId != null && selectionHandler != null) {
+            selectionHandler.onWaveSelected(selectedWaveId);
+          }
           view.setStatus(buildStatusText(query, lastModel), false);
           view.setLoading(false);
         },
@@ -161,5 +164,9 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
       return "No results for " + query + ".";
     }
     return "Showing " + model.getDigestItems().size() + " result(s) for " + query + ".";
+  }
+
+  public J2clSearchDigestItem findDigestItem(String waveId) {
+    return lastModel.findDigestItem(waveId);
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -19,20 +19,26 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   private final HTMLDivElement digestList;
   private final HTMLElement emptyState;
   private final HTMLButtonElement showMoreButton;
+  private final HTMLElement selectedWaveHost;
   private final Map<String, J2clDigestView> digestViews = new LinkedHashMap<String, J2clDigestView>();
   private J2clSearchViewListener listener;
 
   public J2clSearchPanelView(HTMLElement host) {
     this.host = host;
     host.innerHTML = "";
+    host.className = "sidecar-root";
 
     HTMLElement shell = (HTMLElement) DomGlobal.document.createElement("section");
     shell.className = "sidecar-search-shell";
     host.appendChild(shell);
 
+    HTMLElement layout = (HTMLElement) DomGlobal.document.createElement("div");
+    layout.className = "sidecar-split-layout";
+    shell.appendChild(layout);
+
     HTMLElement card = (HTMLElement) DomGlobal.document.createElement("div");
     card.className = "sidecar-search-card";
-    shell.appendChild(card);
+    layout.appendChild(card);
 
     HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
     eyebrow.className = "sidecar-eyebrow";
@@ -113,6 +119,10 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
           return null;
         };
     card.appendChild(showMoreButton);
+
+    selectedWaveHost = (HTMLElement) DomGlobal.document.createElement("div");
+    selectedWaveHost.className = "sidecar-selected-host";
+    layout.appendChild(selectedWaveHost);
   }
 
   @Override
@@ -186,5 +196,9 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     for (Map.Entry<String, J2clDigestView> entry : digestViews.entrySet()) {
       entry.getValue().setSelected(entry.getKey() != null && entry.getKey().equals(waveId));
     }
+  }
+
+  public HTMLElement getSelectedWaveHost() {
+    return selectedWaveHost;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -56,4 +56,16 @@ public final class J2clSearchResultModel {
     }
     return false;
   }
+
+  public J2clSearchDigestItem findDigestItem(String waveId) {
+    if (waveId == null) {
+      return null;
+    }
+    for (J2clSearchDigestItem item : digestItems) {
+      if (waveId.equals(item.getWaveId())) {
+        return item;
+      }
+    }
+    return null;
+  }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,0 +1,158 @@
+package org.waveprotocol.box.j2cl.search;
+
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+
+public final class J2clSelectedWaveController {
+  public interface Gateway {
+    void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+
+    Subscription openSelectedWave(
+        SidecarSessionBootstrap bootstrap,
+        String waveId,
+        J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
+        J2clSearchPanelController.ErrorCallback onError,
+        Runnable onDisconnect);
+  }
+
+  public interface View {
+    void render(J2clSelectedWaveModel model);
+  }
+
+  public interface Subscription {
+    void close();
+  }
+
+  private final Gateway gateway;
+  private final View view;
+  private Subscription currentSubscription;
+  private SidecarSessionBootstrap currentBootstrap;
+  private SidecarSelectedWaveUpdate lastUpdate;
+  private String selectedWaveId;
+  private J2clSearchDigestItem selectedDigestItem;
+  private J2clSelectedWaveModel currentModel;
+  private int reconnectCount;
+  private int requestGeneration;
+
+  public J2clSelectedWaveController(Gateway gateway, View view) {
+    this.gateway = gateway;
+    this.view = view;
+    this.currentModel = J2clSelectedWaveModel.empty();
+    this.view.render(currentModel);
+  }
+
+  public void onWaveSelected(String waveId) {
+    onWaveSelected(waveId, null);
+  }
+
+  public void onWaveSelected(String waveId, J2clSearchDigestItem digestItem) {
+    if (waveId != null
+        && waveId.equals(selectedWaveId)
+        && currentSubscription != null
+        && requestGeneration > 0) {
+      selectedDigestItem = digestItem;
+      if (lastUpdate != null) {
+        currentModel =
+            J2clSelectedWaveProjector.project(
+                selectedWaveId, selectedDigestItem, lastUpdate, currentModel, reconnectCount);
+        view.render(currentModel);
+      }
+      return;
+    }
+
+    int generation = ++requestGeneration;
+    closeSubscription();
+
+    if (waveId == null || waveId.isEmpty()) {
+      selectedWaveId = null;
+      selectedDigestItem = null;
+      currentBootstrap = null;
+      lastUpdate = null;
+      reconnectCount = 0;
+      currentModel = J2clSelectedWaveModel.empty();
+      view.render(currentModel);
+      return;
+    }
+
+    selectedWaveId = waveId;
+    selectedDigestItem = digestItem;
+    lastUpdate = null;
+    reconnectCount = 0;
+    currentModel = J2clSelectedWaveModel.loading(waveId, digestItem, reconnectCount);
+    view.render(currentModel);
+
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (!isCurrentGeneration(generation)) {
+            return;
+          }
+          currentBootstrap = bootstrap;
+          openSelectedWave(generation, 0);
+        },
+        error -> {
+          if (!isCurrentGeneration(generation)) {
+            return;
+          }
+          currentModel =
+              J2clSelectedWaveModel.error(
+                  selectedWaveId, selectedDigestItem, "Unable to open selected wave.", error);
+          view.render(currentModel);
+        });
+  }
+
+  private void openSelectedWave(int generation, int reconnectCount) {
+    if (selectedWaveId == null || currentBootstrap == null) {
+      return;
+    }
+    this.reconnectCount = reconnectCount;
+    currentModel = J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount);
+    view.render(currentModel);
+    currentSubscription =
+        gateway.openSelectedWave(
+            currentBootstrap,
+            selectedWaveId,
+            update -> {
+              if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
+                return;
+              }
+              lastUpdate = update;
+              currentModel =
+                  J2clSelectedWaveProjector.project(
+                      selectedWaveId, selectedDigestItem, update, currentModel, reconnectCount);
+              view.render(currentModel);
+            },
+            error -> {
+              if (!isCurrentGeneration(generation)) {
+                return;
+              }
+              currentModel =
+                  J2clSelectedWaveModel.error(
+                      selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
+              view.render(currentModel);
+            },
+            () -> {
+              if (!isCurrentGeneration(generation) || selectedWaveId == null) {
+                return;
+              }
+              openSelectedWave(generation, reconnectCount + 1);
+            });
+  }
+
+  private boolean isCurrentGeneration(int generation) {
+    return generation == requestGeneration;
+  }
+
+  private static boolean isChannelEstablishmentUpdate(SidecarSelectedWaveUpdate update) {
+    String waveletName = update.getWaveletName();
+    return waveletName != null && waveletName.contains("/~/dummy+root");
+  }
+
+  private void closeSubscription() {
+    if (currentSubscription != null) {
+      currentSubscription.close();
+      currentSubscription = null;
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -163,7 +163,14 @@ public final class J2clSelectedWaveController {
               }
               terminalStateHandled[0] = true;
               closeSubscription();
-              scheduleReconnectOrFail(generation, reconnectCount);
+              if (retryOnFailure || lastUpdate != null) {
+                scheduleReconnectOrFail(generation, reconnectCount);
+                return;
+              }
+              currentModel =
+                  J2clSelectedWaveModel.error(
+                      selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
+              view.render(currentModel);
             },
             () -> {
               if (!isCurrentGeneration(generation) || selectedWaveId == null) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -150,13 +150,18 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
                 return;
               }
-              activeReconnectCount[0] = 0;
+              int projectedReconnectCount = activeReconnectCount[0];
               lastUpdate = update;
-              this.reconnectCount = 0;
               currentModel =
                   J2clSelectedWaveProjector.project(
-                      selectedWaveId, selectedDigestItem, update, currentModel, activeReconnectCount[0]);
+                      selectedWaveId,
+                      selectedDigestItem,
+                      update,
+                      currentModel,
+                      projectedReconnectCount);
               view.render(currentModel);
+              activeReconnectCount[0] = 0;
+              this.reconnectCount = projectedReconnectCount;
             },
             error -> {
               if (!isCurrentGeneration(generation)) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -140,6 +140,8 @@ public final class J2clSelectedWaveController {
       return;
     }
     final boolean[] terminalStateHandled = new boolean[] {false};
+    // Mutable so successful updates reset the budget, keeping MAX_RECONNECT_ATTEMPTS per outage.
+    final int[] activeReconnectCount = {reconnectCount};
     currentSubscription =
         gateway.openSelectedWave(
             currentBootstrap,
@@ -148,16 +150,12 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
                 return;
               }
-              int displayReconnectCount = reconnectCount;
+              activeReconnectCount[0] = 0;
               lastUpdate = update;
               this.reconnectCount = 0;
               currentModel =
                   J2clSelectedWaveProjector.project(
-                      selectedWaveId,
-                      selectedDigestItem,
-                      update,
-                      currentModel,
-                      displayReconnectCount);
+                      selectedWaveId, selectedDigestItem, update, currentModel, activeReconnectCount[0]);
               view.render(currentModel);
             },
             error -> {
@@ -170,7 +168,7 @@ public final class J2clSelectedWaveController {
               terminalStateHandled[0] = true;
               closeSubscription();
               if (retryOnFailure || lastUpdate != null) {
-                scheduleReconnectOrFail(generation, this.reconnectCount);
+                scheduleReconnectOrFail(generation, activeReconnectCount[0]);
                 return;
               }
               currentModel =
@@ -187,7 +185,7 @@ public final class J2clSelectedWaveController {
               }
               terminalStateHandled[0] = true;
               clearActiveSubscription();
-              scheduleReconnectOrFail(generation, this.reconnectCount);
+              scheduleReconnectOrFail(generation, activeReconnectCount[0]);
             });
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,9 +1,14 @@
 package org.waveprotocol.box.j2cl.search;
 
+import elemental2.dom.DomGlobal;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
 public final class J2clSelectedWaveController {
+  private static final int INITIAL_RECONNECT_DELAY_MS = 250;
+  private static final int MAX_RECONNECT_DELAY_MS = 1000;
+  private static final int MAX_RECONNECT_ATTEMPTS = 3;
+
   public interface Gateway {
     void fetchRootSessionBootstrap(
         J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
@@ -21,12 +26,17 @@ public final class J2clSelectedWaveController {
     void render(J2clSelectedWaveModel model);
   }
 
+  public interface RetryScheduler {
+    void scheduleRetry(int delayMs, Runnable action);
+  }
+
   public interface Subscription {
     void close();
   }
 
   private final Gateway gateway;
   private final View view;
+  private final RetryScheduler retryScheduler;
   private Subscription currentSubscription;
   private SidecarSessionBootstrap currentBootstrap;
   private SidecarSelectedWaveUpdate lastUpdate;
@@ -37,8 +47,16 @@ public final class J2clSelectedWaveController {
   private int requestGeneration;
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
+    this(
+        gateway,
+        view,
+        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs));
+  }
+
+  public J2clSelectedWaveController(Gateway gateway, View view, RetryScheduler retryScheduler) {
     this.gateway = gateway;
     this.view = view;
+    this.retryScheduler = retryScheduler;
     this.currentModel = J2clSelectedWaveModel.empty();
     this.view.render(currentModel);
   }
@@ -95,6 +113,7 @@ public final class J2clSelectedWaveController {
           if (!isCurrentGeneration(generation)) {
             return;
           }
+          clearActiveSubscription();
           currentModel =
               J2clSelectedWaveModel.error(
                   selectedWaveId, selectedDigestItem, "Unable to open selected wave.", error);
@@ -127,6 +146,7 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation)) {
                 return;
               }
+              clearActiveSubscription();
               currentModel =
                   J2clSelectedWaveModel.error(
                       selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
@@ -136,7 +156,28 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation) || selectedWaveId == null) {
                 return;
               }
-              openSelectedWave(generation, reconnectCount + 1);
+              clearActiveSubscription();
+              if (reconnectCount >= MAX_RECONNECT_ATTEMPTS) {
+                currentModel =
+                    J2clSelectedWaveModel.error(
+                        selectedWaveId,
+                        selectedDigestItem,
+                        "Selected wave disconnected.",
+                        "The selected-wave sidecar stopped retrying after "
+                            + MAX_RECONNECT_ATTEMPTS
+                            + " reconnect attempts.");
+                view.render(currentModel);
+                return;
+              }
+              int nextReconnectCount = reconnectCount + 1;
+              retryScheduler.scheduleRetry(
+                  buildReconnectDelayMs(reconnectCount),
+                  () -> {
+                    if (!isCurrentGeneration(generation) || selectedWaveId == null) {
+                      return;
+                    }
+                    openSelectedWave(generation, nextReconnectCount);
+                  });
             });
   }
 
@@ -144,9 +185,12 @@ public final class J2clSelectedWaveController {
     return generation == requestGeneration;
   }
 
-  private static boolean isChannelEstablishmentUpdate(SidecarSelectedWaveUpdate update) {
+  static boolean isChannelEstablishmentUpdate(SidecarSelectedWaveUpdate update) {
     String waveletName = update.getWaveletName();
-    return waveletName != null && waveletName.contains("/~/dummy+root");
+    // The socket open handshake reuses ProtocolWaveletUpdate to deliver the initial channel id
+    // before any real wavelet data is streamed. Those synthetic frames target ~/dummy+root and
+    // must not overwrite the selected-wave panel or they would flash a fake wavelet into view.
+    return waveletName != null && waveletName.endsWith("/~/dummy+root");
   }
 
   private void closeSubscription() {
@@ -154,5 +198,14 @@ public final class J2clSelectedWaveController {
       currentSubscription.close();
       currentSubscription = null;
     }
+  }
+
+  private void clearActiveSubscription() {
+    currentSubscription = null;
+  }
+
+  private static int buildReconnectDelayMs(int reconnectCount) {
+    int delayMs = INITIAL_RECONNECT_DELAY_MS << reconnectCount;
+    return Math.min(delayMs, MAX_RECONNECT_DELAY_MS);
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -6,8 +6,9 @@ import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
 public final class J2clSelectedWaveController {
   private static final int INITIAL_RECONNECT_DELAY_MS = 250;
-  private static final int MAX_RECONNECT_DELAY_MS = 1000;
-  private static final int MAX_RECONNECT_ATTEMPTS = 3;
+  // Keep retries bounded, but leave enough budget for a local WIAB restart on the same port.
+  private static final int MAX_RECONNECT_DELAY_MS = 2000;
+  private static final int MAX_RECONNECT_ATTEMPTS = 8;
 
   public interface Gateway {
     void fetchRootSessionBootstrap(
@@ -98,22 +99,35 @@ public final class J2clSelectedWaveController {
     selectedDigestItem = digestItem;
     lastUpdate = null;
     reconnectCount = 0;
-    currentModel = J2clSelectedWaveModel.loading(waveId, digestItem, reconnectCount);
-    view.render(currentModel);
+    fetchBootstrapAndOpenSelectedWave(generation, 0, false);
+  }
 
+  private void fetchBootstrapAndOpenSelectedWave(
+      int generation, int reconnectCount, boolean retryOnFailure) {
+    if (selectedWaveId == null) {
+      return;
+    }
+    this.reconnectCount = reconnectCount;
+    currentModel = J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount);
+    view.render(currentModel);
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
           if (!isCurrentGeneration(generation)) {
             return;
           }
           currentBootstrap = bootstrap;
-          openSelectedWave(generation, 0);
+          openSelectedWave(generation, reconnectCount, retryOnFailure);
         },
         error -> {
           if (!isCurrentGeneration(generation)) {
             return;
           }
           clearActiveSubscription();
+          currentBootstrap = null;
+          if (retryOnFailure) {
+            scheduleReconnectOrFail(generation, reconnectCount);
+            return;
+          }
           currentModel =
               J2clSelectedWaveModel.error(
                   selectedWaveId, selectedDigestItem, "Unable to open selected wave.", error);
@@ -121,13 +135,11 @@ public final class J2clSelectedWaveController {
         });
   }
 
-  private void openSelectedWave(int generation, int reconnectCount) {
+  private void openSelectedWave(int generation, int reconnectCount, boolean retryOnFailure) {
     if (selectedWaveId == null || currentBootstrap == null) {
       return;
     }
-    this.reconnectCount = reconnectCount;
-    currentModel = J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount);
-    view.render(currentModel);
+    final boolean[] terminalStateHandled = new boolean[] {false};
     currentSubscription =
         gateway.openSelectedWave(
             currentBootstrap,
@@ -146,7 +158,15 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation)) {
                 return;
               }
+              if (terminalStateHandled[0]) {
+                return;
+              }
+              terminalStateHandled[0] = true;
               clearActiveSubscription();
+              if (retryOnFailure) {
+                scheduleReconnectOrFail(generation, reconnectCount);
+                return;
+              }
               currentModel =
                   J2clSelectedWaveModel.error(
                       selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
@@ -156,29 +176,37 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation) || selectedWaveId == null) {
                 return;
               }
-              clearActiveSubscription();
-              if (reconnectCount >= MAX_RECONNECT_ATTEMPTS) {
-                currentModel =
-                    J2clSelectedWaveModel.error(
-                        selectedWaveId,
-                        selectedDigestItem,
-                        "Selected wave disconnected.",
-                        "The selected-wave sidecar stopped retrying after "
-                            + MAX_RECONNECT_ATTEMPTS
-                            + " reconnect attempts.");
-                view.render(currentModel);
+              if (terminalStateHandled[0]) {
                 return;
               }
-              int nextReconnectCount = reconnectCount + 1;
-              retryScheduler.scheduleRetry(
-                  buildReconnectDelayMs(reconnectCount),
-                  () -> {
-                    if (!isCurrentGeneration(generation) || selectedWaveId == null) {
-                      return;
-                    }
-                    openSelectedWave(generation, nextReconnectCount);
-                  });
+              terminalStateHandled[0] = true;
+              clearActiveSubscription();
+              scheduleReconnectOrFail(generation, reconnectCount);
             });
+  }
+
+  private void scheduleReconnectOrFail(int generation, int reconnectCount) {
+    if (reconnectCount >= MAX_RECONNECT_ATTEMPTS) {
+      currentModel =
+          J2clSelectedWaveModel.error(
+              selectedWaveId,
+              selectedDigestItem,
+              "Selected wave disconnected.",
+              "The selected-wave sidecar stopped retrying after "
+                  + MAX_RECONNECT_ATTEMPTS
+                  + " reconnect attempts.");
+      view.render(currentModel);
+      return;
+    }
+    int nextReconnectCount = reconnectCount + 1;
+    retryScheduler.scheduleRetry(
+        buildReconnectDelayMs(reconnectCount),
+        () -> {
+          if (!isCurrentGeneration(generation) || selectedWaveId == null) {
+            return;
+          }
+          fetchBootstrapAndOpenSelectedWave(generation, nextReconnectCount, true);
+        });
   }
 
   private boolean isCurrentGeneration(int generation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -163,14 +163,7 @@ public final class J2clSelectedWaveController {
               }
               terminalStateHandled[0] = true;
               clearActiveSubscription();
-              if (retryOnFailure) {
-                scheduleReconnectOrFail(generation, reconnectCount);
-                return;
-              }
-              currentModel =
-                  J2clSelectedWaveModel.error(
-                      selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
-              view.render(currentModel);
+              scheduleReconnectOrFail(generation, reconnectCount);
             },
             () -> {
               if (!isCurrentGeneration(generation) || selectedWaveId == null) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -162,7 +162,7 @@ public final class J2clSelectedWaveController {
                 return;
               }
               terminalStateHandled[0] = true;
-              clearActiveSubscription();
+              closeSubscription();
               scheduleReconnectOrFail(generation, reconnectCount);
             },
             () -> {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -148,10 +148,16 @@ public final class J2clSelectedWaveController {
               if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
                 return;
               }
+              int displayReconnectCount = reconnectCount;
               lastUpdate = update;
+              this.reconnectCount = 0;
               currentModel =
                   J2clSelectedWaveProjector.project(
-                      selectedWaveId, selectedDigestItem, update, currentModel, reconnectCount);
+                      selectedWaveId,
+                      selectedDigestItem,
+                      update,
+                      currentModel,
+                      displayReconnectCount);
               view.render(currentModel);
             },
             error -> {
@@ -164,7 +170,7 @@ public final class J2clSelectedWaveController {
               terminalStateHandled[0] = true;
               closeSubscription();
               if (retryOnFailure || lastUpdate != null) {
-                scheduleReconnectOrFail(generation, reconnectCount);
+                scheduleReconnectOrFail(generation, this.reconnectCount);
                 return;
               }
               currentModel =
@@ -181,7 +187,7 @@ public final class J2clSelectedWaveController {
               }
               terminalStateHandled[0] = true;
               clearActiveSubscription();
-              scheduleReconnectOrFail(generation, reconnectCount);
+              scheduleReconnectOrFail(generation, this.reconnectCount);
             });
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -1,0 +1,172 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clSelectedWaveModel {
+  private final boolean hasSelection;
+  private final boolean loading;
+  private final boolean error;
+  private final String selectedWaveId;
+  private final String titleText;
+  private final String snippetText;
+  private final String unreadText;
+  private final String statusText;
+  private final String detailText;
+  private final int reconnectCount;
+  private final List<String> participantIds;
+  private final List<String> contentEntries;
+
+  J2clSelectedWaveModel(
+      boolean hasSelection,
+      boolean loading,
+      boolean error,
+      String selectedWaveId,
+      String titleText,
+      String snippetText,
+      String unreadText,
+      String statusText,
+      String detailText,
+      int reconnectCount,
+      List<String> participantIds,
+      List<String> contentEntries) {
+    this.hasSelection = hasSelection;
+    this.loading = loading;
+    this.error = error;
+    this.selectedWaveId = selectedWaveId;
+    this.titleText = titleText == null ? "" : titleText;
+    this.snippetText = snippetText == null ? "" : snippetText;
+    this.unreadText = unreadText == null ? "" : unreadText;
+    this.statusText = statusText == null ? "" : statusText;
+    this.detailText = detailText == null ? "" : detailText;
+    this.reconnectCount = reconnectCount;
+    this.participantIds =
+        participantIds == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(participantIds));
+    this.contentEntries =
+        contentEntries == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(contentEntries));
+  }
+
+  public static J2clSelectedWaveModel empty() {
+    return new J2clSelectedWaveModel(
+        false,
+        false,
+        false,
+        null,
+        "Select a wave",
+        "",
+        "",
+        "Choose a digest from the search results to open a read-only selected-wave panel.",
+        "Selection stays in memory only for this sidecar slice.",
+        0,
+        Collections.<String>emptyList(),
+        Collections.<String>emptyList());
+  }
+
+  public static J2clSelectedWaveModel loading(
+      String selectedWaveId, J2clSearchDigestItem digestItem, int reconnectCount) {
+    return new J2clSelectedWaveModel(
+        true,
+        true,
+        false,
+        selectedWaveId,
+        resolveTitle(selectedWaveId, digestItem),
+        resolveSnippet(digestItem),
+        resolveUnreadText(digestItem),
+        reconnectCount > 0 ? "Reconnecting selected wave." : "Opening selected wave.",
+        reconnectCount > 0
+            ? "Reusing the current sidecar session after a disconnect."
+            : "Waiting for the first live selected-wave update.",
+        reconnectCount,
+        Collections.<String>emptyList(),
+        Collections.<String>emptyList());
+  }
+
+  public static J2clSelectedWaveModel error(
+      String selectedWaveId, J2clSearchDigestItem digestItem, String statusText, String detailText) {
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        true,
+        selectedWaveId,
+        resolveTitle(selectedWaveId, digestItem),
+        resolveSnippet(digestItem),
+        resolveUnreadText(digestItem),
+        statusText,
+        detailText,
+        0,
+        Collections.<String>emptyList(),
+        Collections.<String>emptyList());
+  }
+
+  private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {
+    if (digestItem != null && digestItem.getTitle() != null && !digestItem.getTitle().isEmpty()) {
+      return digestItem.getTitle();
+    }
+    return selectedWaveId == null ? "Selected wave" : selectedWaveId;
+  }
+
+  private static String resolveSnippet(J2clSearchDigestItem digestItem) {
+    return digestItem == null ? "" : digestItem.getSnippet();
+  }
+
+  private static String resolveUnreadText(J2clSearchDigestItem digestItem) {
+    if (digestItem == null) {
+      return "";
+    }
+    int unreadCount = digestItem.getUnreadCount();
+    return unreadCount <= 0 ? "Selected digest is read." : unreadCount + " unread in the selected digest.";
+  }
+
+  public boolean hasSelection() {
+    return hasSelection;
+  }
+
+  public boolean isLoading() {
+    return loading;
+  }
+
+  public boolean isError() {
+    return error;
+  }
+
+  public String getSelectedWaveId() {
+    return selectedWaveId;
+  }
+
+  public String getTitleText() {
+    return titleText;
+  }
+
+  public String getSnippetText() {
+    return snippetText;
+  }
+
+  public String getUnreadText() {
+    return unreadText;
+  }
+
+  public String getStatusText() {
+    return statusText;
+  }
+
+  public String getDetailText() {
+    return detailText;
+  }
+
+  public int getReconnectCount() {
+    return reconnectCount;
+  }
+
+  public List<String> getParticipantIds() {
+    return participantIds;
+  }
+
+  public List<String> getContentEntries() {
+    return contentEntries;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.search;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
@@ -23,6 +24,9 @@ public final class J2clSelectedWaveProjector {
     }
 
     List<String> contentEntries = extractContentEntries(update.getFragments());
+    if (contentEntries.isEmpty()) {
+      contentEntries = extractDocumentEntries(update.getDocuments());
+    }
     if (contentEntries.isEmpty() && previous != null && !previous.getContentEntries().isEmpty()) {
       contentEntries = previous.getContentEntries();
     }
@@ -63,6 +67,26 @@ public final class J2clSelectedWaveProjector {
       }
     }
     return blipSnapshots.isEmpty() ? fallbackSnapshots : blipSnapshots;
+  }
+
+  private static List<String> extractDocumentEntries(List<SidecarSelectedWaveDocument> documents) {
+    if (documents == null || documents.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> blipEntries = new ArrayList<String>();
+    List<String> fallbackEntries = new ArrayList<String>();
+    for (SidecarSelectedWaveDocument document : documents) {
+      String textContent = document.getTextContent();
+      if (textContent == null || textContent.isEmpty()) {
+        continue;
+      }
+      if (document.getDocumentId() != null && document.getDocumentId().startsWith("b+")) {
+        blipEntries.add(textContent);
+      } else {
+        fallbackEntries.add(textContent);
+      }
+    }
+    return blipEntries.isEmpty() ? fallbackEntries : blipEntries;
   }
 
   private static String buildDetailText(SidecarSelectedWaveUpdate update) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -1,0 +1,109 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
+
+public final class J2clSelectedWaveProjector {
+  private J2clSelectedWaveProjector() {
+  }
+
+  public static J2clSelectedWaveModel project(
+      String selectedWaveId,
+      J2clSearchDigestItem digestItem,
+      SidecarSelectedWaveUpdate update,
+      J2clSelectedWaveModel previous,
+      int reconnectCount) {
+    List<String> participantIds = update.getParticipantIds();
+    if (participantIds.isEmpty() && previous != null) {
+      participantIds = previous.getParticipantIds();
+    }
+
+    List<String> contentEntries = extractContentEntries(update.getFragments());
+    if (contentEntries.isEmpty() && previous != null && !previous.getContentEntries().isEmpty()) {
+      contentEntries = previous.getContentEntries();
+    }
+
+    String detailText = buildDetailText(update);
+    String statusText = reconnectCount > 0 ? "Live updates reconnected." : "Live updates connected.";
+
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        selectedWaveId,
+        resolveTitle(selectedWaveId, digestItem),
+        resolveSnippet(digestItem, contentEntries),
+        resolveUnreadText(digestItem),
+        statusText,
+        detailText,
+        reconnectCount,
+        participantIds,
+        contentEntries);
+  }
+
+  private static List<String> extractContentEntries(SidecarSelectedWaveFragments fragments) {
+    if (fragments == null) {
+      return Collections.emptyList();
+    }
+    List<String> blipSnapshots = new ArrayList<String>();
+    List<String> fallbackSnapshots = new ArrayList<String>();
+    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
+      String rawSnapshot = fragment.getRawSnapshot();
+      if (rawSnapshot == null || rawSnapshot.isEmpty()) {
+        continue;
+      }
+      if (fragment.getSegment() != null && fragment.getSegment().startsWith("blip:")) {
+        blipSnapshots.add(rawSnapshot);
+      } else {
+        fallbackSnapshots.add(rawSnapshot);
+      }
+    }
+    return blipSnapshots.isEmpty() ? fallbackSnapshots : blipSnapshots;
+  }
+
+  private static String buildDetailText(SidecarSelectedWaveUpdate update) {
+    StringBuilder detail = new StringBuilder();
+    if (update.getWaveletName() != null && !update.getWaveletName().isEmpty()) {
+      detail.append(update.getWaveletName());
+    }
+    if (update.getChannelId() != null && !update.getChannelId().isEmpty()) {
+      if (detail.length() > 0) {
+        detail.append(" · ");
+      }
+      detail.append("channel ").append(update.getChannelId());
+    }
+    if (update.getFragments() != null && update.getFragments().getSnapshotVersion() > 0) {
+      if (detail.length() > 0) {
+        detail.append(" · ");
+      }
+      detail.append("snapshot v").append(update.getFragments().getSnapshotVersion());
+    }
+    return detail.toString();
+  }
+
+  private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {
+    if (digestItem != null && digestItem.getTitle() != null && !digestItem.getTitle().isEmpty()) {
+      return digestItem.getTitle();
+    }
+    return selectedWaveId == null ? "Selected wave" : selectedWaveId;
+  }
+
+  private static String resolveSnippet(J2clSearchDigestItem digestItem, List<String> contentEntries) {
+    if (digestItem != null && digestItem.getSnippet() != null && !digestItem.getSnippet().isEmpty()) {
+      return digestItem.getSnippet();
+    }
+    return contentEntries.isEmpty() ? "" : contentEntries.get(0);
+  }
+
+  private static String resolveUnreadText(J2clSearchDigestItem digestItem) {
+    if (digestItem == null) {
+      return "";
+    }
+    int unreadCount = digestItem.getUnreadCount();
+    return unreadCount <= 0 ? "Selected digest is read." : unreadCount + " unread in the selected digest.";
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -100,6 +100,8 @@ public final class J2clSelectedWaveProjector {
   }
 
   private static String resolveUnreadText(J2clSearchDigestItem digestItem) {
+    // #920 does not add a dedicated read-state transport field. The selected-wave panel can only
+    // surface unread status from the latest search digest metadata that selected this wave.
     if (digestItem == null) {
       return "";
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -1,0 +1,97 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+
+public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
+  private final HTMLElement title;
+  private final HTMLElement unread;
+  private final HTMLElement status;
+  private final HTMLElement detail;
+  private final HTMLElement participantSummary;
+  private final HTMLElement snippet;
+  private final HTMLDivElement contentList;
+  private final HTMLElement emptyState;
+
+  public J2clSelectedWaveView(HTMLElement host) {
+    host.innerHTML = "";
+
+    HTMLElement card = (HTMLElement) DomGlobal.document.createElement("section");
+    card.className = "sidecar-selected-card";
+    host.appendChild(card);
+
+    HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
+    eyebrow.className = "sidecar-eyebrow";
+    eyebrow.textContent = "Read-only selected wave";
+    card.appendChild(eyebrow);
+
+    title = (HTMLElement) DomGlobal.document.createElement("h2");
+    title.className = "sidecar-selected-title";
+    card.appendChild(title);
+
+    unread = (HTMLElement) DomGlobal.document.createElement("p");
+    unread.className = "sidecar-selected-unread";
+    card.appendChild(unread);
+
+    status = (HTMLElement) DomGlobal.document.createElement("p");
+    status.className = "sidecar-selected-status";
+    card.appendChild(status);
+
+    detail = (HTMLElement) DomGlobal.document.createElement("p");
+    detail.className = "sidecar-selected-detail";
+    card.appendChild(detail);
+
+    participantSummary = (HTMLElement) DomGlobal.document.createElement("p");
+    participantSummary.className = "sidecar-selected-participants";
+    card.appendChild(participantSummary);
+
+    snippet = (HTMLElement) DomGlobal.document.createElement("p");
+    snippet.className = "sidecar-selected-snippet";
+    card.appendChild(snippet);
+
+    contentList = (HTMLDivElement) DomGlobal.document.createElement("div");
+    contentList.className = "sidecar-selected-content";
+    card.appendChild(contentList);
+
+    emptyState = (HTMLElement) DomGlobal.document.createElement("div");
+    emptyState.className = "sidecar-empty-state";
+    card.appendChild(emptyState);
+  }
+
+  @Override
+  public void render(J2clSelectedWaveModel model) {
+    title.textContent = model.getTitleText();
+    unread.textContent = model.getUnreadText();
+    unread.hidden = model.getUnreadText().isEmpty();
+    status.className =
+        model.isError()
+            ? "sidecar-selected-status sidecar-selected-status-error"
+            : "sidecar-selected-status";
+    status.textContent = model.getStatusText();
+    detail.textContent = model.getDetailText();
+    participantSummary.textContent =
+        model.getParticipantIds().isEmpty()
+            ? ""
+            : "Participants: " + String.join(", ", model.getParticipantIds());
+    participantSummary.hidden = model.getParticipantIds().isEmpty();
+    snippet.textContent = model.getSnippetText();
+    snippet.hidden = model.getSnippetText().isEmpty();
+
+    contentList.innerHTML = "";
+    for (String entry : model.getContentEntries()) {
+      HTMLElement block = (HTMLElement) DomGlobal.document.createElement("pre");
+      block.className = "sidecar-selected-entry";
+      block.textContent = entry;
+      contentList.appendChild(block);
+    }
+
+    emptyState.hidden = model.hasSelection() && !model.getContentEntries().isEmpty();
+    emptyState.textContent =
+        model.hasSelection()
+            ? (model.isLoading()
+                ? "Waiting for selected-wave content."
+                : "No selected-wave content is available yet.")
+            : model.getStatusText();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -86,7 +86,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       contentList.appendChild(block);
     }
 
-    emptyState.hidden = model.hasSelection() && !model.getContentEntries().isEmpty();
+    emptyState.hidden = model.isError() || (model.hasSelection() && !model.getContentEntries().isEmpty());
     emptyState.textContent =
         model.hasSelection()
             ? (model.isLoading()

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
@@ -1,0 +1,32 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarSelectedWaveDocument {
+  private final String documentId;
+  private final String author;
+  private final long lastModifiedVersion;
+  private final long lastModifiedTime;
+
+  public SidecarSelectedWaveDocument(
+      String documentId, String author, long lastModifiedVersion, long lastModifiedTime) {
+    this.documentId = documentId;
+    this.author = author;
+    this.lastModifiedVersion = lastModifiedVersion;
+    this.lastModifiedTime = lastModifiedTime;
+  }
+
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
+  public long getLastModifiedVersion() {
+    return lastModifiedVersion;
+  }
+
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
@@ -5,13 +5,19 @@ public final class SidecarSelectedWaveDocument {
   private final String author;
   private final long lastModifiedVersion;
   private final long lastModifiedTime;
+  private final String textContent;
 
   public SidecarSelectedWaveDocument(
-      String documentId, String author, long lastModifiedVersion, long lastModifiedTime) {
+      String documentId,
+      String author,
+      long lastModifiedVersion,
+      long lastModifiedTime,
+      String textContent) {
     this.documentId = documentId;
     this.author = author;
     this.lastModifiedVersion = lastModifiedVersion;
     this.lastModifiedTime = lastModifiedTime;
+    this.textContent = textContent;
   }
 
   public String getDocumentId() {
@@ -28,5 +34,9 @@ public final class SidecarSelectedWaveDocument {
 
   public long getLastModifiedTime() {
     return lastModifiedTime;
+  }
+
+  public String getTextContent() {
+    return textContent;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragment.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragment.java
@@ -1,0 +1,32 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarSelectedWaveFragment {
+  private final String segment;
+  private final String rawSnapshot;
+  private final int adjustOperationCount;
+  private final int diffOperationCount;
+
+  public SidecarSelectedWaveFragment(
+      String segment, String rawSnapshot, int adjustOperationCount, int diffOperationCount) {
+    this.segment = segment;
+    this.rawSnapshot = rawSnapshot;
+    this.adjustOperationCount = adjustOperationCount;
+    this.diffOperationCount = diffOperationCount;
+  }
+
+  public String getSegment() {
+    return segment;
+  }
+
+  public String getRawSnapshot() {
+    return rawSnapshot;
+  }
+
+  public int getAdjustOperationCount() {
+    return adjustOperationCount;
+  }
+
+  public int getDiffOperationCount() {
+    return diffOperationCount;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragmentRange.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragmentRange.java
@@ -1,0 +1,25 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarSelectedWaveFragmentRange {
+  private final String segment;
+  private final long fromVersion;
+  private final long toVersion;
+
+  public SidecarSelectedWaveFragmentRange(String segment, long fromVersion, long toVersion) {
+    this.segment = segment;
+    this.fromVersion = fromVersion;
+    this.toVersion = toVersion;
+  }
+
+  public String getSegment() {
+    return segment;
+  }
+
+  public long getFromVersion() {
+    return fromVersion;
+  }
+
+  public long getToVersion() {
+    return toVersion;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragments.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragments.java
@@ -1,0 +1,45 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class SidecarSelectedWaveFragments {
+  private final long snapshotVersion;
+  private final long startVersion;
+  private final long endVersion;
+  private final List<SidecarSelectedWaveFragmentRange> ranges;
+  private final List<SidecarSelectedWaveFragment> entries;
+
+  public SidecarSelectedWaveFragments(
+      long snapshotVersion,
+      long startVersion,
+      long endVersion,
+      List<SidecarSelectedWaveFragmentRange> ranges,
+      List<SidecarSelectedWaveFragment> entries) {
+    this.snapshotVersion = snapshotVersion;
+    this.startVersion = startVersion;
+    this.endVersion = endVersion;
+    this.ranges = Collections.unmodifiableList(ranges);
+    this.entries = Collections.unmodifiableList(entries);
+  }
+
+  public long getSnapshotVersion() {
+    return snapshotVersion;
+  }
+
+  public long getStartVersion() {
+    return startVersion;
+  }
+
+  public long getEndVersion() {
+    return endVersion;
+  }
+
+  public List<SidecarSelectedWaveFragmentRange> getRanges() {
+    return ranges;
+  }
+
+  public List<SidecarSelectedWaveFragment> getEntries() {
+    return entries;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
@@ -1,0 +1,59 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class SidecarSelectedWaveUpdate {
+  private final int sequenceNumber;
+  private final String waveletName;
+  private final boolean marker;
+  private final String channelId;
+  private final List<String> participantIds;
+  private final List<SidecarSelectedWaveDocument> documents;
+  private final SidecarSelectedWaveFragments fragments;
+
+  public SidecarSelectedWaveUpdate(
+      int sequenceNumber,
+      String waveletName,
+      boolean marker,
+      String channelId,
+      List<String> participantIds,
+      List<SidecarSelectedWaveDocument> documents,
+      SidecarSelectedWaveFragments fragments) {
+    this.sequenceNumber = sequenceNumber;
+    this.waveletName = waveletName;
+    this.marker = marker;
+    this.channelId = channelId;
+    this.participantIds = Collections.unmodifiableList(participantIds);
+    this.documents = Collections.unmodifiableList(documents);
+    this.fragments = fragments;
+  }
+
+  public int getSequenceNumber() {
+    return sequenceNumber;
+  }
+
+  public String getWaveletName() {
+    return waveletName;
+  }
+
+  public boolean hasMarker() {
+    return marker;
+  }
+
+  public String getChannelId() {
+    return channelId;
+  }
+
+  public List<String> getParticipantIds() {
+    return participantIds;
+  }
+
+  public List<SidecarSelectedWaveDocument> getDocuments() {
+    return documents;
+  }
+
+  public SidecarSelectedWaveFragments getFragments() {
+    return fragments;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -87,7 +87,8 @@ public final class SidecarTransportCodec {
                 getString(document, "1"),
                 getString(document, "3"),
                 getLong(document, "5"),
-                getLong(document, "6")));
+                getLong(document, "6"),
+                extractDocumentText(getOptionalObject(document, "2"))));
       }
     }
 
@@ -256,6 +257,29 @@ public final class SidecarTransportCodec {
       return 0;
     }
     return asList(value).size();
+  }
+
+  private static String extractDocumentText(Map<String, Object> documentOperation) {
+    Object rawComponents = documentOperation.get("1");
+    if (rawComponents == null) {
+      return "";
+    }
+    StringBuilder text = new StringBuilder();
+    for (Object rawComponent : asList(rawComponents)) {
+      Map<String, Object> component = asObject(rawComponent);
+      if (component.containsKey("2")) {
+        text.append(getString(component, "2"));
+        continue;
+      }
+      if (component.containsKey("3")) {
+        Map<String, Object> elementStart = getOptionalObject(component, "3");
+        String type = getString(elementStart, "1");
+        if ("line".equals(type) && text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
+          text.append('\n');
+        }
+      }
+    }
+    return text.toString().trim();
   }
 
   private static long toLong(int highWord, int lowWord) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -72,6 +72,65 @@ public final class SidecarTransportCodec {
         getString(payload, "7"));
   }
 
+  public static SidecarSelectedWaveUpdate decodeSelectedWaveUpdate(String json) {
+    Map<String, Object> envelope = parseJsonObject(json);
+    Map<String, Object> payload = asObject(envelope.get("message"));
+    Map<String, Object> snapshot = getOptionalObject(payload, "5");
+    List<String> participantIds = getStringList(snapshot, "2");
+    List<SidecarSelectedWaveDocument> documents = new ArrayList<SidecarSelectedWaveDocument>();
+    Object rawDocuments = snapshot.get("3");
+    if (rawDocuments != null) {
+      for (Object rawDocument : asList(rawDocuments)) {
+        Map<String, Object> document = asObject(rawDocument);
+        documents.add(
+            new SidecarSelectedWaveDocument(
+                getString(document, "1"),
+                getString(document, "3"),
+                getLong(document, "5"),
+                getLong(document, "6")));
+      }
+    }
+
+    Map<String, Object> fragments = getOptionalObject(payload, "8");
+    List<SidecarSelectedWaveFragmentRange> ranges =
+        new ArrayList<SidecarSelectedWaveFragmentRange>();
+    Object rawRanges = fragments.get("4");
+    if (rawRanges != null) {
+      for (Object rawRange : asList(rawRanges)) {
+        Map<String, Object> range = asObject(rawRange);
+        ranges.add(
+            new SidecarSelectedWaveFragmentRange(
+                getString(range, "1"), getLong(range, "2"), getLong(range, "3")));
+      }
+    }
+
+    List<SidecarSelectedWaveFragment> entries =
+        new ArrayList<SidecarSelectedWaveFragment>();
+    Object rawEntries = fragments.get("5");
+    if (rawEntries != null) {
+      for (Object rawEntry : asList(rawEntries)) {
+        Map<String, Object> entry = asObject(rawEntry);
+        Map<String, Object> entrySnapshot = getOptionalObject(entry, "2");
+        entries.add(
+            new SidecarSelectedWaveFragment(
+                getString(entry, "1"),
+                getString(entrySnapshot, "1"),
+                getArrayLength(entry.get("3")),
+                getArrayLength(entry.get("4"))));
+      }
+    }
+
+    return new SidecarSelectedWaveUpdate(
+        getInt(envelope, "sequenceNumber"),
+        getString(payload, "1"),
+        getBoolean(payload, "6"),
+        getString(payload, "7"),
+        participantIds,
+        documents,
+        new SidecarSelectedWaveFragments(
+            getLong(fragments, "1"), getLong(fragments, "2"), getLong(fragments, "3"), ranges, entries));
+  }
+
   private static String escapeJson(String value) {
     StringBuilder escaped = new StringBuilder(value.length() + 8);
     for (int i = 0; i < value.length(); i++) {
@@ -152,6 +211,11 @@ public final class SidecarTransportCodec {
   private static String getString(Map<String, Object> object, String key) {
     Object value = object.get(key);
     return value == null ? null : String.valueOf(value);
+  }
+
+  private static Map<String, Object> getOptionalObject(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value == null ? new LinkedHashMap<String, Object>() : asObject(value);
   }
 
   private static int getInt(Map<String, Object> object, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -135,6 +135,17 @@ public final class SidecarTransportCodec {
             getLong(fragments, "1"), getLong(fragments, "2"), getLong(fragments, "3"), ranges, entries));
   }
 
+  public static boolean decodeRpcFinishedFailed(Map<String, Object> envelope) {
+    Map<String, Object> payload = asObject(envelope.get("message"));
+    return getBoolean(payload, "1");
+  }
+
+  public static String decodeRpcFinishedErrorText(Map<String, Object> envelope, String fallback) {
+    Map<String, Object> payload = asObject(envelope.get("message"));
+    String errorText = getString(payload, "2");
+    return errorText == null || errorText.isEmpty() ? fallback : errorText;
+  }
+
   private static String escapeJson(String value) {
     StringBuilder escaped = new StringBuilder(value.length() + 8);
     for (int i = 0; i < value.length(); i++) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -282,7 +282,7 @@ public final class SidecarTransportCodec {
         }
       }
     }
-    return text.toString().trim();
+    return text.toString();
   }
 
   private static long toLong(int highWord, int lowWord) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -73,7 +73,10 @@ public final class SidecarTransportCodec {
   }
 
   public static SidecarSelectedWaveUpdate decodeSelectedWaveUpdate(String json) {
-    Map<String, Object> envelope = parseJsonObject(json);
+    return decodeSelectedWaveUpdate(parseJsonObject(json));
+  }
+
+  public static SidecarSelectedWaveUpdate decodeSelectedWaveUpdate(Map<String, Object> envelope) {
     Map<String, Object> payload = asObject(envelope.get("message"));
     Map<String, Object> snapshot = getOptionalObject(payload, "5");
     List<String> participantIds = getStringList(snapshot, "2");

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -120,6 +120,13 @@ body {
   width: 100%;
 }
 
+.sidecar-split-layout {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+  align-items: start;
+}
+
 .sidecar-search-card {
   background: rgba(255, 255, 255, 0.97);
   border: 1px solid #d8e2f0;
@@ -127,6 +134,67 @@ body {
   box-shadow: 0 22px 50px rgba(16, 35, 59, 0.08);
   padding: 32px;
 }
+
+.sidecar-selected-host {
+  min-width: 0;
+}
+
+.sidecar-selected-card {
+  background: rgba(255, 255, 255, 0.97);
+  border: 1px solid #d8e2f0;
+  border-radius: 24px;
+  box-shadow: 0 22px 50px rgba(16, 35, 59, 0.08);
+  padding: 32px;
+}
+
+.sidecar-selected-title {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.sidecar-selected-unread {
+  color: #3567c8;
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 14px 0 0;
+}
+
+.sidecar-selected-status {
+  color: #173355;
+  font-weight: 700;
+  margin: 16px 0 0;
+}
+
+.sidecar-selected-status-error {
+  color: #b42318;
+}
+
+.sidecar-selected-detail,
+.sidecar-selected-participants,
+.sidecar-selected-snippet {
+  color: #4f6480;
+  line-height: 1.6;
+  margin: 10px 0 0;
+}
+
+.sidecar-selected-content {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.sidecar-selected-entry {
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+  border: 1px solid #d8e2f0;
+  border-radius: 18px;
+  color: #173355;
+  font: inherit;
+  margin: 0;
+  overflow-x: auto;
+  padding: 16px;
+  white-space: pre-wrap;
+ }
 
 .sidecar-search-session {
   margin: 16px 0 0;
@@ -282,8 +350,13 @@ body {
     padding: 16px;
   }
 
+  .sidecar-split-layout {
+    grid-template-columns: 1fr;
+  }
+
   .sidecar-search-card,
-  .sidecar-card {
+  .sidecar-card,
+  .sidecar-selected-card {
     border-radius: 20px;
     padding: 24px;
   }

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -194,7 +194,7 @@ body {
   overflow-x: auto;
   padding: 16px;
   white-space: pre-wrap;
- }
+}
 
 .sidecar-search-session {
   margin: 16px 0 0;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -155,6 +155,20 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(Arrays.asList("real content"), harness.modelValue("getContentEntries"));
   }
 
+  @Test
+  public void snapshotOnlyUpdateRendersDocumentTextWhenFragmentsAreMissing() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", digest("Wave A", "Digest snippet", 3));
+    harness.resolveBootstrap(0);
+    harness.deliverSnapshotOnlyUpdate(0, "Welcome to SupaWave");
+
+    Assert.assertEquals(Arrays.asList("Welcome to SupaWave"), harness.modelValue("getContentEntries"));
+    Assert.assertEquals("Digest snippet", harness.modelValue("getSnippetText"));
+    Assert.assertFalse((Boolean) harness.modelValue("isLoading"));
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
@@ -288,6 +302,10 @@ public class J2clSelectedWaveControllerTest {
       deliverRawUpdate(index, update("example.com!w+1/example.com!conv+root", rawSnapshot));
     }
 
+    private void deliverSnapshotOnlyUpdate(int index, String textContent) {
+      deliverRawUpdate(index, snapshotOnlyUpdate(textContent));
+    }
+
     private void deliverRawUpdate(int index, SidecarSelectedWaveUpdate update) {
       openAttempts.get(index).success.accept(update);
     }
@@ -305,7 +323,9 @@ public class J2clSelectedWaveControllerTest {
         true,
         "chan-1",
         Arrays.asList("user@example.com", "teammate@example.com"),
-        Arrays.asList(new SidecarSelectedWaveDocument("b+root", "user@example.com", 33L, 44L)),
+        Arrays.asList(
+            new SidecarSelectedWaveDocument(
+                "b+root", "user@example.com", 33L, 44L, rawSnapshot)),
         new SidecarSelectedWaveFragments(
             44L,
             40L,
@@ -316,6 +336,23 @@ public class J2clSelectedWaveControllerTest {
             Arrays.asList(
                 new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
                 new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
+  }
+
+  private static SidecarSelectedWaveUpdate snapshotOnlyUpdate(String textContent) {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        "local.net!w+s4635670bfbwA/~/conv+root",
+        true,
+        "ch3",
+        Arrays.asList("user@example.com"),
+        Arrays.asList(
+            new SidecarSelectedWaveDocument("b+abc123", "user@example.com", 1L, 2L, textContent)),
+        new SidecarSelectedWaveFragments(
+            0L,
+            0L,
+            0L,
+            new ArrayList<SidecarSelectedWaveFragmentRange>(),
+            new ArrayList<SidecarSelectedWaveFragment>()));
   }
 
   private static final class BootstrapAttempt {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -416,12 +416,7 @@ public class J2clSelectedWaveControllerTest {
         Arrays.asList("user@example.com"),
         Arrays.asList(
             new SidecarSelectedWaveDocument("b+abc123", "user@example.com", 1L, 2L, textContent)),
-        new SidecarSelectedWaveFragments(
-            0L,
-            0L,
-            0L,
-            new ArrayList<SidecarSelectedWaveFragmentRange>(),
-            new ArrayList<SidecarSelectedWaveFragment>()));
+        null);
   }
 
   private static final class BootstrapAttempt {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1,0 +1,157 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+
+@J2clTestInput(J2clSelectedWaveControllerTest.class)
+public class J2clSelectedWaveControllerTest {
+  @Test
+  public void selectingWaveRendersLiveUpdateAndReconnectsAfterDisconnect() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController();
+
+    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, "example.com/w+1");
+
+    Assert.assertEquals("example.com/w+1", harness.modelValue("getSelectedWaveId"));
+    Assert.assertEquals(Boolean.TRUE, harness.modelValue("isLoading"));
+    Assert.assertEquals(1, harness.openCount);
+
+    harness.deliverUpdate("Hello from the sidecar");
+
+    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isLoading"));
+    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isError"));
+    Assert.assertEquals(1, ((List<?>) harness.modelValue("getContentEntries")).size());
+    Assert.assertEquals("Hello from the sidecar", ((List<?>) harness.modelValue("getContentEntries")).get(0));
+
+    harness.fireDisconnect();
+    Assert.assertEquals(2, harness.openCount);
+
+    harness.deliverUpdate("After reconnect");
+
+    Assert.assertEquals(1, harness.modelValue("getReconnectCount"));
+    Assert.assertEquals("After reconnect", ((List<?>) harness.modelValue("getContentEntries")).get(0));
+  }
+
+  @Test
+  public void clearingSelectionClosesSubscriptionAndReturnsToEmptyState() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController();
+
+    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, "example.com/w+1");
+    harness.deliverUpdate("Hello from the sidecar");
+
+    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, new Object[] {null});
+
+    Assert.assertEquals(1, harness.closedCount);
+    Assert.assertEquals(Boolean.FALSE, harness.modelValue("hasSelection"));
+    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isLoading"));
+  }
+
+  private static final class Harness {
+    private int openCount;
+    private int closedCount;
+    private J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> updateCallback;
+    private Runnable disconnectCallback;
+    private Object lastModel;
+
+    private Object createController() throws Exception {
+      Class<?> controllerClass =
+          Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController");
+      Class<?> gatewayClass =
+          Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$Gateway");
+      Class<?> viewClass =
+          Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$View");
+      Class<?> subscriptionClass =
+          Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$Subscription");
+
+      Object gateway =
+          Proxy.newProxyInstance(
+              gatewayClass.getClassLoader(),
+              new Class<?>[] {gatewayClass},
+              (proxy, method, args) -> {
+                if ("fetchRootSessionBootstrap".equals(method.getName())) {
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success =
+                      (J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap>) args[0];
+                  success.accept(
+                      new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+                  return null;
+                }
+                if ("openSelectedWave".equals(method.getName())) {
+                  openCount++;
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success =
+                      (J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate>) args[2];
+                  updateCallback = success;
+                  disconnectCallback = (Runnable) args[4];
+                  return Proxy.newProxyInstance(
+                      subscriptionClass.getClassLoader(),
+                      new Class<?>[] {subscriptionClass},
+                      (subscriptionProxy, subscriptionMethod, subscriptionArgs) -> {
+                        if ("close".equals(subscriptionMethod.getName())) {
+                          closedCount++;
+                        }
+                        return null;
+                      });
+                }
+                return null;
+              });
+
+      Object view =
+          Proxy.newProxyInstance(
+              viewClass.getClassLoader(),
+              new Class<?>[] {viewClass},
+              (proxy, method, args) -> {
+                if ("render".equals(method.getName())) {
+                  lastModel = args[0];
+                }
+                return null;
+              });
+
+      Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass);
+      return constructor.newInstance(gateway, view);
+    }
+
+    private void deliverUpdate(String rawSnapshot) {
+      updateCallback.accept(
+          new SidecarSelectedWaveUpdate(
+              1,
+              "example.com!w+1/example.com!conv+root",
+              true,
+              "chan-1",
+              java.util.Arrays.asList("user@example.com", "teammate@example.com"),
+              java.util.Collections.singletonList(
+                  new SidecarSelectedWaveDocument("b+root", "user@example.com", 33L, 44L)),
+              new SidecarSelectedWaveFragments(
+                  44L,
+                  40L,
+                  44L,
+                  java.util.Arrays.asList(
+                      new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
+                      new SidecarSelectedWaveFragmentRange("blip:b+root", 41L, 44L)),
+                  java.util.Arrays.asList(
+                      new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
+                      new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0)))));
+    }
+
+    private void fireDisconnect() {
+      disconnectCallback.run();
+    }
+
+    private Object modelValue(String methodName) throws Exception {
+      Method method = lastModel.getClass().getMethod(methodName);
+      return method.invoke(lastModel);
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -108,16 +108,33 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
-  public void transportOpenErrorRetriesSelectedWave() throws Exception {
+  public void transportOpenErrorRendersSelectedWaveError() throws Exception {
     Harness harness = new Harness();
-    Object controller = harness.createController(true);
+    Object controller = harness.createController(false);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
     harness.failOpen(0, "socket boom");
 
+    Assert.assertTrue((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals("Selected wave stream failed.", harness.modelValue("getStatusText"));
+    Assert.assertEquals("socket boom", harness.modelValue("getDetailText"));
+    Assert.assertEquals(1, harness.closedCount);
+  }
+
+  @Test
+  public void transportStreamErrorRetriesSelectedWave() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+    harness.failOpen(0, "socket boom");
+
     Assert.assertFalse((Boolean) harness.modelValue("isError"));
     Assert.assertEquals(Arrays.asList(250), harness.scheduledDelays);
+    Assert.assertEquals(1, harness.closedCount);
 
     harness.runScheduledRetry(0);
     harness.resolveBootstrap(1);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -108,17 +108,24 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
-  public void transportOpenErrorRendersSelectedWaveError() throws Exception {
+  public void transportOpenErrorRetriesSelectedWave() throws Exception {
     Harness harness = new Harness();
-    Object controller = harness.createController(false);
+    Object controller = harness.createController(true);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
     harness.failOpen(0, "socket boom");
 
-    Assert.assertTrue((Boolean) harness.modelValue("isError"));
-    Assert.assertEquals("Selected wave stream failed.", harness.modelValue("getStatusText"));
-    Assert.assertEquals("socket boom", harness.modelValue("getDetailText"));
+    Assert.assertFalse((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals(Arrays.asList(250), harness.scheduledDelays);
+
+    harness.runScheduledRetry(0);
+    harness.resolveBootstrap(1);
+    harness.deliverUpdate(1, "Recovered after socket error");
+
+    Assert.assertEquals("Live updates reconnected.", harness.modelValue("getStatusText"));
+    Assert.assertEquals(
+        Arrays.asList("Recovered after socket error"), harness.modelValue("getContentEntries"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -171,6 +171,7 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(1, harness.openCount);
 
     harness.selectWave(controller, "example.com/w+b", null);
+    Assert.assertEquals(1, harness.closedCount);
     harness.resolveBootstrap(1);
     Assert.assertEquals(2, harness.openCount);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -19,7 +19,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 @J2clTestInput(J2clSelectedWaveControllerTest.class)
 public class J2clSelectedWaveControllerTest {
   @Test
-  public void selectingWaveSchedulesBoundedReconnectInsteadOfImmediateLoop() throws Exception {
+  public void selectingWaveRetriesLongEnoughToRecoverAfterServerRestart() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(true);
 
@@ -32,21 +32,66 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(Arrays.asList(250), harness.scheduledDelays);
 
     harness.runScheduledRetry(0);
-    Assert.assertEquals(2, harness.openCount);
-    harness.fireDisconnect(1);
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertEquals(1, harness.openCount);
+    harness.rejectBootstrap(1, "Network failure for /");
     Assert.assertEquals(Arrays.asList(250, 500), harness.scheduledDelays);
 
     harness.runScheduledRetry(1);
-    Assert.assertEquals(3, harness.openCount);
-    harness.fireDisconnect(2);
+    Assert.assertEquals(3, harness.bootstrapAttempts.size());
+    Assert.assertEquals(1, harness.openCount);
+    harness.rejectBootstrap(2, "Network failure for /");
     Assert.assertEquals(Arrays.asList(250, 500, 1000), harness.scheduledDelays);
 
     harness.runScheduledRetry(2);
-    Assert.assertEquals(4, harness.openCount);
-    harness.fireDisconnect(3);
+    Assert.assertEquals(4, harness.bootstrapAttempts.size());
+    Assert.assertEquals(1, harness.openCount);
+    harness.rejectBootstrap(3, "Network failure for /");
+    Assert.assertEquals(Arrays.asList(250, 500, 1000, 2000), harness.scheduledDelays);
+
+    harness.runScheduledRetry(3);
+    Assert.assertEquals(5, harness.bootstrapAttempts.size());
+    Assert.assertEquals(1, harness.openCount);
+    harness.rejectBootstrap(4, "Network failure for /");
+    Assert.assertEquals(Arrays.asList(250, 500, 1000, 2000, 2000), harness.scheduledDelays);
+
+    harness.runScheduledRetry(4);
+    Assert.assertEquals(6, harness.bootstrapAttempts.size());
+    harness.resolveBootstrap(5);
+    Assert.assertEquals(2, harness.openCount);
+    harness.deliverUpdate(1, "Recovered after restart");
+
+    Assert.assertFalse((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals("Live updates reconnected.", harness.modelValue("getStatusText"));
+    Assert.assertEquals(Arrays.asList("Recovered after restart"), harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void selectingWaveStillStopsAfterBoundedReconnectBudget() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    harness.fireDisconnect(0);
+
+    for (int attempt = 1; attempt <= 8; attempt++) {
+      Assert.assertFalse((Boolean) harness.modelValue("isError"));
+      harness.runScheduledRetry(attempt - 1);
+      Assert.assertEquals(attempt + 1, harness.bootstrapAttempts.size());
+      Assert.assertEquals(1, harness.openCount);
+      harness.rejectBootstrap(attempt, "Network failure for /");
+    }
+
     Assert.assertTrue((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals(
+        Arrays.asList(250, 500, 1000, 2000, 2000, 2000, 2000, 2000), harness.scheduledDelays);
     Assert.assertTrue(
         String.valueOf(harness.modelValue("getStatusText")).contains("Selected wave disconnected"));
+    Assert.assertTrue(
+        String.valueOf(harness.modelValue("getDetailText")).contains("8 reconnect attempts"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -146,6 +146,27 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void recoveredStreamResetsReconnectBudgetForNextOutage() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    harness.fireDisconnect(0);
+    Assert.assertEquals(Arrays.asList(250), harness.scheduledDelays);
+
+    harness.runScheduledRetry(0);
+    harness.resolveBootstrap(1);
+    harness.deliverUpdate(1, "Recovered after restart");
+    Assert.assertEquals("Live updates reconnected.", harness.modelValue("getStatusText"));
+
+    harness.fireDisconnect(1);
+    Assert.assertEquals(Arrays.asList(250, 250), harness.scheduledDelays);
+  }
+
+  @Test
   public void staleBootstrapSuccessIsIgnoredAfterRapidReselection() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -4,6 +4,8 @@ import com.google.j2cl.junit.apt.J2clTestInput;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -17,55 +19,159 @@ import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 @J2clTestInput(J2clSelectedWaveControllerTest.class)
 public class J2clSelectedWaveControllerTest {
   @Test
-  public void selectingWaveRendersLiveUpdateAndReconnectsAfterDisconnect() throws Exception {
+  public void selectingWaveSchedulesBoundedReconnectInsteadOfImmediateLoop() throws Exception {
     Harness harness = new Harness();
-    Object controller = harness.createController();
+    Object controller = harness.createController(true);
 
-    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, "example.com/w+1");
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
 
-    Assert.assertEquals("example.com/w+1", harness.modelValue("getSelectedWaveId"));
-    Assert.assertEquals(Boolean.TRUE, harness.modelValue("isLoading"));
+    harness.fireDisconnect(0);
     Assert.assertEquals(1, harness.openCount);
+    Assert.assertEquals(Arrays.asList(250), harness.scheduledDelays);
 
-    harness.deliverUpdate("Hello from the sidecar");
-
-    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isLoading"));
-    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isError"));
-    Assert.assertEquals(1, ((List<?>) harness.modelValue("getContentEntries")).size());
-    Assert.assertEquals("Hello from the sidecar", ((List<?>) harness.modelValue("getContentEntries")).get(0));
-
-    harness.fireDisconnect();
+    harness.runScheduledRetry(0);
     Assert.assertEquals(2, harness.openCount);
+    harness.fireDisconnect(1);
+    Assert.assertEquals(Arrays.asList(250, 500), harness.scheduledDelays);
 
-    harness.deliverUpdate("After reconnect");
+    harness.runScheduledRetry(1);
+    Assert.assertEquals(3, harness.openCount);
+    harness.fireDisconnect(2);
+    Assert.assertEquals(Arrays.asList(250, 500, 1000), harness.scheduledDelays);
 
-    Assert.assertEquals(1, harness.modelValue("getReconnectCount"));
-    Assert.assertEquals("After reconnect", ((List<?>) harness.modelValue("getContentEntries")).get(0));
+    harness.runScheduledRetry(2);
+    Assert.assertEquals(4, harness.openCount);
+    harness.fireDisconnect(3);
+    Assert.assertTrue((Boolean) harness.modelValue("isError"));
+    Assert.assertTrue(
+        String.valueOf(harness.modelValue("getStatusText")).contains("Selected wave disconnected"));
   }
 
   @Test
-  public void clearingSelectionClosesSubscriptionAndReturnsToEmptyState() throws Exception {
+  public void bootstrapErrorRendersSelectedWaveError() throws Exception {
     Harness harness = new Harness();
-    Object controller = harness.createController();
+    Object controller = harness.createController(false);
 
-    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, "example.com/w+1");
-    harness.deliverUpdate("Hello from the sidecar");
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.rejectBootstrap(0, "bootstrap boom");
 
-    controller.getClass().getMethod("onWaveSelected", String.class).invoke(controller, new Object[] {null});
+    Assert.assertTrue((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals("Unable to open selected wave.", harness.modelValue("getStatusText"));
+    Assert.assertEquals("bootstrap boom", harness.modelValue("getDetailText"));
+  }
 
-    Assert.assertEquals(1, harness.closedCount);
-    Assert.assertEquals(Boolean.FALSE, harness.modelValue("hasSelection"));
-    Assert.assertEquals(Boolean.FALSE, harness.modelValue("isLoading"));
+  @Test
+  public void transportOpenErrorRendersSelectedWaveError() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.failOpen(0, "socket boom");
+
+    Assert.assertTrue((Boolean) harness.modelValue("isError"));
+    Assert.assertEquals("Selected wave stream failed.", harness.modelValue("getStatusText"));
+    Assert.assertEquals("socket boom", harness.modelValue("getDetailText"));
+  }
+
+  @Test
+  public void staleBootstrapSuccessIsIgnoredAfterRapidReselection() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+a", null);
+    harness.selectWave(controller, "example.com/w+b", null);
+
+    harness.resolveBootstrap(0);
+    Assert.assertEquals(0, harness.openCount);
+
+    harness.resolveBootstrap(1);
+    Assert.assertEquals(1, harness.openCount);
+    Assert.assertEquals("example.com/w+b", harness.openAttempts.get(0).waveId);
+  }
+
+  @Test
+  public void staleOpenUpdateIsIgnoredAfterSwitchingToDifferentWave() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+a", null);
+    harness.resolveBootstrap(0);
+    Assert.assertEquals(1, harness.openCount);
+
+    harness.selectWave(controller, "example.com/w+b", null);
+    harness.resolveBootstrap(1);
+    Assert.assertEquals(2, harness.openCount);
+
+    harness.deliverUpdate(0, "stale A");
+    Assert.assertEquals("Opening selected wave.", harness.modelValue("getStatusText"));
+
+    harness.deliverUpdate(1, "fresh B");
+    Assert.assertEquals(Arrays.asList("fresh B"), harness.modelValue("getContentEntries"));
+    Assert.assertEquals("example.com/w+b", harness.modelValue("getSelectedWaveId"));
+  }
+
+  @Test
+  public void sameWaveReselectRefreshesDigestMetadataWithoutReopeningSocket() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", digest("Wave A", "Old snippet", 3));
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    harness.selectWave(controller, "example.com/w+1", digest("Wave A updated", "New snippet", 0));
+
+    Assert.assertEquals(1, harness.openCount);
+    Assert.assertEquals("Wave A updated", harness.modelValue("getTitleText"));
+    Assert.assertEquals("Selected digest is read.", harness.modelValue("getUnreadText"));
+    Assert.assertEquals("New snippet", harness.modelValue("getSnippetText"));
+  }
+
+  @Test
+  public void channelEstablishmentUpdateIsIgnoredUntilRealWaveletArrives() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    harness.deliverRawUpdate(
+        0,
+        new SidecarSelectedWaveUpdate(
+            1,
+            "example.com!w+1/~/dummy+root",
+            true,
+            "chan-1",
+            Arrays.asList("user@example.com"),
+            new ArrayList<SidecarSelectedWaveDocument>(),
+            null));
+
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+
+    harness.deliverUpdate(0, "real content");
+    Assert.assertEquals(Arrays.asList("real content"), harness.modelValue("getContentEntries"));
+  }
+
+  private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
+    return new J2clSearchDigestItem(
+        "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
   }
 
   private static final class Harness {
     private int openCount;
     private int closedCount;
-    private J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> updateCallback;
-    private Runnable disconnectCallback;
+    private final List<Integer> scheduledDelays = new ArrayList<Integer>();
+    private final List<Runnable> scheduledRetries = new ArrayList<Runnable>();
+    private final List<BootstrapAttempt> bootstrapAttempts = new ArrayList<BootstrapAttempt>();
+    private final List<OpenAttempt> openAttempts = new ArrayList<OpenAttempt>();
     private Object lastModel;
+    private Method onWaveSelectedMethod;
+    private Method onWaveSelectedWithDigestMethod;
 
-    private Object createController() throws Exception {
+    private Object createController(boolean withScheduler) throws Exception {
       Class<?> controllerClass =
           Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController");
       Class<?> gatewayClass =
@@ -84,8 +190,9 @@ public class J2clSelectedWaveControllerTest {
                   @SuppressWarnings("unchecked")
                   J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success =
                       (J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap>) args[0];
-                  success.accept(
-                      new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+                  J2clSearchPanelController.ErrorCallback error =
+                      (J2clSearchPanelController.ErrorCallback) args[1];
+                  bootstrapAttempts.add(new BootstrapAttempt(success, error));
                   return null;
                 }
                 if ("openSelectedWave".equals(method.getName())) {
@@ -93,8 +200,11 @@ public class J2clSelectedWaveControllerTest {
                   @SuppressWarnings("unchecked")
                   J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success =
                       (J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate>) args[2];
-                  updateCallback = success;
-                  disconnectCallback = (Runnable) args[4];
+                  J2clSearchPanelController.ErrorCallback error =
+                      (J2clSearchPanelController.ErrorCallback) args[3];
+                  Runnable disconnect = (Runnable) args[4];
+                  OpenAttempt attempt = new OpenAttempt((String) args[1], success, error, disconnect);
+                  openAttempts.add(attempt);
                   return Proxy.newProxyInstance(
                       subscriptionClass.getClassLoader(),
                       new Class<?>[] {subscriptionClass},
@@ -119,39 +229,122 @@ public class J2clSelectedWaveControllerTest {
                 return null;
               });
 
-      Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass);
-      return constructor.newInstance(gateway, view);
+      Object controller;
+      if (withScheduler) {
+        Class<?> schedulerClass =
+            Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$RetryScheduler");
+        Object scheduler =
+            Proxy.newProxyInstance(
+                schedulerClass.getClassLoader(),
+                new Class<?>[] {schedulerClass},
+                (proxy, method, args) -> {
+                  scheduledDelays.add(((Number) args[0]).intValue());
+                  scheduledRetries.add((Runnable) args[1]);
+                  return null;
+                });
+        Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass, schedulerClass);
+        controller = constructor.newInstance(gateway, view, scheduler);
+      } else {
+        Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass);
+        controller = constructor.newInstance(gateway, view);
+      }
+      onWaveSelectedMethod = controllerClass.getMethod("onWaveSelected", String.class);
+      onWaveSelectedWithDigestMethod =
+          controllerClass.getMethod("onWaveSelected", String.class, J2clSearchDigestItem.class);
+      return controller;
     }
 
-    private void deliverUpdate(String rawSnapshot) {
-      updateCallback.accept(
-          new SidecarSelectedWaveUpdate(
-              1,
-              "example.com!w+1/example.com!conv+root",
-              true,
-              "chan-1",
-              java.util.Arrays.asList("user@example.com", "teammate@example.com"),
-              java.util.Collections.singletonList(
-                  new SidecarSelectedWaveDocument("b+root", "user@example.com", 33L, 44L)),
-              new SidecarSelectedWaveFragments(
-                  44L,
-                  40L,
-                  44L,
-                  java.util.Arrays.asList(
-                      new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
-                      new SidecarSelectedWaveFragmentRange("blip:b+root", 41L, 44L)),
-                  java.util.Arrays.asList(
-                      new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
-                      new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0)))));
+    private void selectWave(Object controller, String waveId, J2clSearchDigestItem digestItem) throws Exception {
+      if (digestItem == null) {
+        onWaveSelectedMethod.invoke(controller, waveId);
+      } else {
+        onWaveSelectedWithDigestMethod.invoke(controller, waveId, digestItem);
+      }
     }
 
-    private void fireDisconnect() {
-      disconnectCallback.run();
+    private void resolveBootstrap(int index) {
+      bootstrapAttempts.get(index)
+          .success
+          .accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+    }
+
+    private void rejectBootstrap(int index, String message) {
+      bootstrapAttempts.get(index).error.accept(message);
+    }
+
+    private void failOpen(int index, String message) {
+      openAttempts.get(index).error.accept(message);
+    }
+
+    private void fireDisconnect(int index) {
+      openAttempts.get(index).disconnect.run();
+    }
+
+    private void runScheduledRetry(int index) {
+      scheduledRetries.get(index).run();
+    }
+
+    private void deliverUpdate(int index, String rawSnapshot) {
+      deliverRawUpdate(index, update("example.com!w+1/example.com!conv+root", rawSnapshot));
+    }
+
+    private void deliverRawUpdate(int index, SidecarSelectedWaveUpdate update) {
+      openAttempts.get(index).success.accept(update);
     }
 
     private Object modelValue(String methodName) throws Exception {
       Method method = lastModel.getClass().getMethod(methodName);
       return method.invoke(lastModel);
+    }
+  }
+
+  private static SidecarSelectedWaveUpdate update(String waveletName, String rawSnapshot) {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        waveletName,
+        true,
+        "chan-1",
+        Arrays.asList("user@example.com", "teammate@example.com"),
+        Arrays.asList(new SidecarSelectedWaveDocument("b+root", "user@example.com", 33L, 44L)),
+        new SidecarSelectedWaveFragments(
+            44L,
+            40L,
+            44L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
+                new SidecarSelectedWaveFragmentRange("blip:b+root", 41L, 44L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
+                new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
+  }
+
+  private static final class BootstrapAttempt {
+    private final J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success;
+    private final J2clSearchPanelController.ErrorCallback error;
+
+    private BootstrapAttempt(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success,
+        J2clSearchPanelController.ErrorCallback error) {
+      this.success = success;
+      this.error = error;
+    }
+  }
+
+  private static final class OpenAttempt {
+    private final String waveId;
+    private final J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success;
+    private final J2clSearchPanelController.ErrorCallback error;
+    private final Runnable disconnect;
+
+    private OpenAttempt(
+        String waveId,
+        J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success,
+        J2clSearchPanelController.ErrorCallback error,
+        Runnable disconnect) {
+      this.waveId = waveId;
+      this.success = success;
+      this.error = error;
+      this.disconnect = disconnect;
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -104,7 +104,7 @@ public class SidecarTransportCodecTest {
             + "\"3\":[{\"1\":\"b+abc123\","
             + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
             + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
-            + "{\"2\":\"Welcome to SupaWave\"},"
+            + "{\"2\":\"  Welcome to SupaWave  \"},"
             + "{\"4\":true},{\"4\":true}]},"
             + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
             + "\"6\":true,\"7\":\"ch3\"}}";
@@ -113,7 +113,7 @@ public class SidecarTransportCodecTest {
 
     Assert.assertEquals(1, update.getDocuments().size());
     Assert.assertEquals("b+abc123", update.getDocuments().get(0).getDocumentId());
-    Assert.assertEquals("Welcome to SupaWave", update.getDocuments().get(0).getTextContent());
+    Assert.assertEquals("  Welcome to SupaWave  ", update.getDocuments().get(0).getTextContent());
     Assert.assertEquals(0, update.getFragments().getEntries().size());
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -109,6 +109,29 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateReadsSnapshotDocumentTextWhenFragmentsAreAbsent()
+      throws Exception {
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"2\":\"Welcome to SupaWave\"},"
+            + "{\"4\":true},{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    Assert.assertEquals(1, update.getDocuments().size());
+    Assert.assertEquals("b+abc123", update.getDocuments().get(0).getDocumentId());
+    Assert.assertEquals("Welcome to SupaWave", update.getDocuments().get(0).getTextContent());
+    Assert.assertEquals(0, update.getFragments().getEntries().size());
+  }
+
+  @Test
   public void extractSessionBootstrapAddressFromRootHtml() {
     String html =
         "<html><script>window.__session={\"address\":\"user@example.com\",\"id\":\"abc\"};"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.transport;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
@@ -62,6 +63,49 @@ public class SidecarTransportCodecTest {
     Assert.assertEquals(1, summary.getAppliedDeltaCount());
     Assert.assertTrue(summary.hasMarker());
     Assert.assertEquals("chan-1", summary.getChannelId());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateReadsSnapshotAndFragmentsForSidecarProjection()
+      throws Exception {
+    String json =
+        "{\"sequenceNumber\":12,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"example.com!w+abc123/example.com!conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\",\"teammate@example.com\"],"
+            + "\"3\":[{\"1\":\"b+root\",\"3\":\"user@example.com\",\"5\":[33,0],\"6\":[44,0]}]},"
+            + "\"6\":true,\"7\":\"chan-2\","
+            + "\"8\":{\"1\":[44,0],\"2\":[40,0],\"3\":[44,0],"
+            + "\"4\":[{\"1\":\"manifest\",\"2\":[40,0],\"3\":[44,0]},"
+            + "{\"1\":\"blip:b+root\",\"2\":[41,0],\"3\":[44,0]}],"
+            + "\"5\":[{\"1\":\"manifest\",\"2\":{\"1\":\"conversation: Inbox wave\"}},"
+            + "{\"1\":\"blip:b+root\",\"2\":{\"1\":\"Hello from the sidecar\"},\"3\":[],\"4\":[]}]}}}";
+
+    Method decoder =
+        SidecarTransportCodec.class.getMethod("decodeSelectedWaveUpdate", String.class);
+    Object update = decoder.invoke(null, json);
+
+    Assert.assertEquals(
+        "example.com!w+abc123/example.com!conv+root",
+        update.getClass().getMethod("getWaveletName").invoke(update));
+    Assert.assertEquals("chan-2", update.getClass().getMethod("getChannelId").invoke(update));
+    Assert.assertEquals(Boolean.TRUE, update.getClass().getMethod("hasMarker").invoke(update));
+
+    Object participants = update.getClass().getMethod("getParticipantIds").invoke(update);
+    Assert.assertEquals(2, ((java.util.List<?>) participants).size());
+
+    Object documents = update.getClass().getMethod("getDocuments").invoke(update);
+    Assert.assertEquals(1, ((java.util.List<?>) documents).size());
+    Object document = ((java.util.List<?>) documents).get(0);
+    Assert.assertEquals("b+root", document.getClass().getMethod("getDocumentId").invoke(document));
+
+    Object fragments = update.getClass().getMethod("getFragments").invoke(update);
+    Assert.assertEquals(44L, fragments.getClass().getMethod("getSnapshotVersion").invoke(fragments));
+    Assert.assertEquals(2, ((java.util.List<?>) fragments.getClass().getMethod("getRanges").invoke(fragments)).size());
+    Object fragment = ((java.util.List<?>) fragments.getClass().getMethod("getEntries").invoke(fragments)).get(1);
+    Assert.assertEquals("blip:b+root", fragment.getClass().getMethod("getSegment").invoke(fragment));
+    Assert.assertEquals(
+        "Hello from the sidecar",
+        fragment.getClass().getMethod("getRawSnapshot").invoke(fragment));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -118,6 +118,20 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeRpcFinishedFailureReadsFailedFlagAndErrorText() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"RpcFinished\",\"message\":{\"1\":true,\"2\":\"boom\"}}";
+
+    java.util.Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(json);
+
+    Assert.assertTrue(SidecarTransportCodec.decodeRpcFinishedFailed(envelope));
+    Assert.assertEquals(
+        "boom",
+        SidecarTransportCodec.decodeRpcFinishedErrorText(
+            envelope, "The selected wave request failed."));
+  }
+
+  @Test
   public void extractSessionBootstrapAddressFromRootHtml() {
     String html =
         "<html><script>window.__session={\"address\":\"user@example.com\",\"id\":\"abc\"};"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -1,7 +1,6 @@
 package org.waveprotocol.box.j2cl.transport;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
@@ -66,8 +65,7 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
-  public void decodeSelectedWaveUpdateReadsSnapshotAndFragmentsForSidecarProjection()
-      throws Exception {
+  public void decodeSelectedWaveUpdateReadsSnapshotAndFragmentsForSidecarProjection() {
     String json =
         "{\"sequenceNumber\":12,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
             + "\"1\":\"example.com!w+abc123/example.com!conv+root\","
@@ -80,37 +78,25 @@ public class SidecarTransportCodecTest {
             + "\"5\":[{\"1\":\"manifest\",\"2\":{\"1\":\"conversation: Inbox wave\"}},"
             + "{\"1\":\"blip:b+root\",\"2\":{\"1\":\"Hello from the sidecar\"},\"3\":[],\"4\":[]}]}}}";
 
-    Method decoder =
-        SidecarTransportCodec.class.getMethod("decodeSelectedWaveUpdate", String.class);
-    Object update = decoder.invoke(null, json);
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
 
-    Assert.assertEquals(
-        "example.com!w+abc123/example.com!conv+root",
-        update.getClass().getMethod("getWaveletName").invoke(update));
-    Assert.assertEquals("chan-2", update.getClass().getMethod("getChannelId").invoke(update));
-    Assert.assertEquals(Boolean.TRUE, update.getClass().getMethod("hasMarker").invoke(update));
+    Assert.assertEquals("example.com!w+abc123/example.com!conv+root", update.getWaveletName());
+    Assert.assertEquals("chan-2", update.getChannelId());
+    Assert.assertTrue(update.hasMarker());
+    Assert.assertEquals(2, update.getParticipantIds().size());
+    Assert.assertEquals(1, update.getDocuments().size());
+    Assert.assertEquals("b+root", update.getDocuments().get(0).getDocumentId());
 
-    Object participants = update.getClass().getMethod("getParticipantIds").invoke(update);
-    Assert.assertEquals(2, ((java.util.List<?>) participants).size());
-
-    Object documents = update.getClass().getMethod("getDocuments").invoke(update);
-    Assert.assertEquals(1, ((java.util.List<?>) documents).size());
-    Object document = ((java.util.List<?>) documents).get(0);
-    Assert.assertEquals("b+root", document.getClass().getMethod("getDocumentId").invoke(document));
-
-    Object fragments = update.getClass().getMethod("getFragments").invoke(update);
-    Assert.assertEquals(44L, fragments.getClass().getMethod("getSnapshotVersion").invoke(fragments));
-    Assert.assertEquals(2, ((java.util.List<?>) fragments.getClass().getMethod("getRanges").invoke(fragments)).size());
-    Object fragment = ((java.util.List<?>) fragments.getClass().getMethod("getEntries").invoke(fragments)).get(1);
-    Assert.assertEquals("blip:b+root", fragment.getClass().getMethod("getSegment").invoke(fragment));
-    Assert.assertEquals(
-        "Hello from the sidecar",
-        fragment.getClass().getMethod("getRawSnapshot").invoke(fragment));
+    SidecarSelectedWaveFragments fragments = update.getFragments();
+    Assert.assertEquals(44L, fragments.getSnapshotVersion());
+    Assert.assertEquals(2, fragments.getRanges().size());
+    SidecarSelectedWaveFragment fragment = fragments.getEntries().get(1);
+    Assert.assertEquals("blip:b+root", fragment.getSegment());
+    Assert.assertEquals("Hello from the sidecar", fragment.getRawSnapshot());
   }
 
   @Test
-  public void decodeSelectedWaveUpdateReadsSnapshotDocumentTextWhenFragmentsAreAbsent()
-      throws Exception {
+  public void decodeSelectedWaveUpdateReadsSnapshotDocumentTextWhenFragmentsAreAbsent() {
     String json =
         "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
             + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","

--- a/wave/config/changelog.d/2026-04-19-j2cl-selected-wave.json
+++ b/wave/config/changelog.d/2026-04-19-j2cl-selected-wave.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-19-j2cl-selected-wave",
+  "version": "Unreleased",
+  "date": "2026-04-19",
+  "title": "The J2CL sidecar can now open a read-only selected wave beside search results",
+  "summary": "The isolated /j2cl-search/index.html route now keeps the existing search rail and opens the selected wave in a live read-only panel with sidecar-owned reconnect handling, while the legacy root path stays on GWT.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a split-view J2CL sidecar shell that keeps search results on the left and renders a read-only selected-wave panel on the right",
+        "Digest selection now opens the selected wave over the existing sidecar socket path, decodes snapshot plus fragment payloads, and renders live read-only content without route persistence",
+        "The selected-wave sidecar flow now retries once through the existing session bootstrap after a disconnect instead of requiring a full page reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a read-only selected-wave panel to the J2CL search sidecar
- render selected-wave content from both fragment and snapshot-only payload shapes
- harden the reconnect path so the selected-wave panel can recover after a local server bounce

## Verification
- `./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q -Dtest=J2clSelectedWaveControllerTest,SidecarTransportCodecTest test`
- `sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
- local browser verification on `/` and `/j2cl-search/index.html`
  - authenticated search results rendered in the sidecar
  - selected-wave panel rendered real content for `Welcome to SupaWave`
  - reconnect/recovery re-check passed on the latest bundle after a no-reload local server bounce

## Scope note
Live unread/read state was explicitly split into follow-up issue #931 so this PR closes the selected-wave rendering and reconnect milestone without widening the slice.

Closes #920


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split-view search: left search rail plus a read-only selected-wave panel with live updates, participants, content list, status, and reconnect indicator.

* **Bug Fixes**
  * More robust handling of auth/open failures, disconnects, unavailable selections, and stale or out-of-order updates.

* **Documentation**
  * Added implementation plan and changelog entry describing the new selected-wave sidecar flow.

* **Tests**
  * New tests for connection lifecycle, retry behavior, decoding, selection, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->