### PR TITLE
feat(j2cl): add durable sidecar route state

### DIFF
--- a/docs/superpowers/plans/2026-04-20-issue-921-j2cl-route-state.md
+++ b/docs/superpowers/plans/2026-04-20-issue-921-j2cl-route-state.md
@@ -1,0 +1,316 @@
+# Issue #921 J2CL Route-State Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add durable route state to the post-`#920` J2CL search sidecar so the active query and selected wave survive reload, copied URLs, and browser back/forward behavior, while preserving the sidecar-only route and leaving the legacy GWT root bootstrap unchanged.
+
+**Architecture:** Start from the reviewed `#920` split-view baseline, not the earlier search-only slice. Add a small sidecar route-state model plus a shell-level coordinator that owns URL parse/serialize, `history.pushState` / `popstate` handling, and restore ordering across the existing `J2clSearchPanelController` and `J2clSelectedWaveController`. Keep the durable contract intentionally narrow: only `query` and `selected wave` belong in the URL; page size, reconnect counters, and future write-path state remain in-memory.
+
+**Tech Stack:** Java, SBT, J2CL Maven sidecar under `j2cl/`, Elemental2 DOM, browser `History` / `Location` APIs, existing `J2clSearchPanelController` + `J2clSelectedWaveController`, Jakarta static-resource serving, `scripts/worktree-file-store.sh`, `scripts/worktree-boot.sh`, manual browser verification.
+
+---
+
+## 1. Goal / Root Cause
+
+This plan is explicitly for the current post-`#920` baseline represented by worktree `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave` and PR `#932`, not the older `origin/main` search-only snapshot. If `#920` is still unmerged when implementation starts, stack `#921` on top of that reviewed lane first; do not implement route state against the pre-selected-wave tree.
+
+Issue `#921` exists because the selected-wave sidecar already has a real split layout and reconnecting read-only panel, but all navigation state is still transient:
+
+- `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java:43-60` wires `J2clSearchPanelController` and `J2clSelectedWaveController`, but only restores `q` from `location.search`; it does not parse a selected wave, listen for browser history changes, or write route state back to the URL.
+- `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java:69-170` keeps `currentQuery` and `selectedWaveId` in memory only. It can clear or re-emit the selected wave after a search refresh, but it has no route-aware API and no protection against turning internal selection refreshes into duplicate browser-history entries.
+- `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:69-209` already supports open, clear, reconnect, and stale-update protection, but it likewise has no durable route contract; it only knows about the current in-memory selection.
+- `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:31-125` and `/Users/vega/devroot/worktrees/issue-920-j2cl-selected-wave/j2cl/src/main/webapp/assets/sidecar.css` already provide the split-view shell from `#920`, but that shell is still just controller composition, not a route-owning application shell.
+- `j2cl/src/main/webapp/index.html:7-8` currently uses relative asset paths (`./assets/sidecar.css`, `./sidecar/j2cl-sidecar.js`), so arbitrary nested client-side path segments under `/j2cl-search/...` would break asset loading unless the route shape or host page is chosen deliberately.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java:608-610` and `:849-879` currently mount `/j2cl-search/*` as a plain `ResourceServlet`. That serves built files, but it does not provide SPA-style fallback for arbitrary deep-link paths.
+
+The narrow root cause is therefore not “selected-wave rendering missing.” `#920` already proved that seam. The missing piece is a durable sidecar route contract plus shell coordination that can restore and replay the current query/selection state without widening into `#922` write-path or root-shell work.
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Define the durable sidecar route contract for `query` plus `selected wave`.
+- Restore the same query and selected wave from a copied sidecar URL under `/j2cl-search/...`.
+- Make browser back/forward behave coherently inside the sidecar route.
+- Reuse the existing post-`#920` split-view shell and stabilize it as the base for later `#922` work.
+- Keep selection restore working even when selected-wave metadata is temporarily missing from the current digest model.
+- Add only the narrow sidecar-serving adjustment needed if the chosen canonical `/j2cl-search/...` URL shape cannot reload directly with the current static servlet.
+
+### Explicit Non-Goals
+
+- No create/reply/editor/write-path work. That belongs to `#922`.
+- No J2CL-owned root shell work. That belongs to `#928`.
+- No root bootstrap flag, default-root cutover, or legacy GWT retirement work. That belongs to `#923`, `#924`, and `#925`.
+- No legacy GWT root-path behavior changes; `/` must remain on the current GWT app.
+- No pagination, show-more window size, reconnect counters, or other transient UI state in the durable URL. `#921` only owns `query` + `selected wave`.
+- No broad Jakarta routing rewrite; any server-side change must stay limited to the sidecar route under `/j2cl-search/*`.
+
+## 3. Exact Files Likely To Change
+
+### Primary Post-`#920` Sidecar Files
+
+These paths are the likely ownership seams once the `#920` baseline is present in the lane:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+- `j2cl/src/main/webapp/index.html`
+- `j2cl/src/main/webapp/assets/sidecar.css`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+
+### Recommended New Sidecar Route Files
+
+These filenames are the narrowest likely additions. Equivalent names are acceptable, but keep route state separate from view rendering:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java`
+
+### Existing Files That Are Likely Inspect-Only
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+
+### Conditional Sidecar-Serving Seam
+
+Only touch this file if browser verification shows the chosen canonical sidecar URL cannot reload directly with the current static resource mapping:
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java`
+
+That change must stay limited to sidecar delivery under `/j2cl-search/*`; do not mix it with root-shell or legacy-bootstrap changes.
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Freeze The Baseline And Canonical Route Contract Before Coding
+
+- [ ] Start from the reviewed `#920` selected-wave lane or a merged equivalent. If `origin/main` still lacks the `J2clSelectedWave*` files and split layout, stack that baseline first instead of re-deriving it inside `#921`.
+- [ ] Keep the durable route contract intentionally narrow:
+  - `q=<encoded-query>`
+  - `wave=<encoded-wave-id>` when a wave is selected
+- [ ] Recommend the canonical URL shape as:
+  - `/j2cl-search/index.html?q=<encoded-query>`
+  - `/j2cl-search/index.html?q=<encoded-query>&wave=<encoded-wave-id>`
+- [ ] Pin the route encoding contract explicitly:
+  - both `q` and `wave` are serialized with `encodeURIComponent`
+  - parse uses the inverse decode and treats decode failures as invalid route input
+  - wave-id serialization must round-trip stable even when the value contains `!`, `/`, or other reserved characters
+  - all route serialization/deserialization must go through one helper seam in `J2clSidecarRouteCodec` (for example `encodeQuery(...)`, `encodeWaveId(...)`, `decodeWaveId(...)`) so controller logic and tests cannot drift onto ad hoc encoders
+- [ ] Treat `/j2cl-search/index.html?...` as the single canonical form for this slice and use initial `replaceState` to normalize any `/j2cl-search/` or equivalent variant to that exact document path before normal route listening begins.
+- [ ] Do **not** introduce page-size, reconnect state, or write-path parameters.
+- [ ] Treat explicit user actions as the only history-pushing events:
+  - query submit pushes `q`
+  - digest selection pushes `q + wave`
+  - query change clears `wave`
+  - re-submitting the same query should not create duplicate history entries; use `replaceState` for idempotent submits instead of `pushState`
+  - internal search refresh, reconnect, and show-more do **not** push history entries
+
+Why this route shape is recommended:
+
+- it already fits the existing `readRequestedQuery(location.search)` seam
+- it keeps asset loading on the fixed sidecar document path
+- it avoids widening into arbitrary nested-path fallback unless verification proves that a cleaner `/j2cl-search/...` path is required
+
+### Task 2: Add A Dedicated Sidecar Route Model And Codec
+
+- [ ] Add a small route-state type with exactly these durable fields:
+  - normalized query
+  - nullable selected wave id
+- [ ] Add parse/serialize helpers that:
+  - default blank or missing `q` to `in:inbox`
+  - decode malformed `q` / `wave` defensively instead of crashing the sidecar
+  - validate decoded `wave` input before handing it to restore/open logic
+  - omit `wave` entirely when there is no selection
+  - produce one canonical query-string ordering so copied URLs are stable
+- [ ] Keep the default-query constant sourced from one place only. If `in:inbox` is still owned by the current `SandboxEntryPoint` / search controller seam, reference that constant from the route codec instead of duplicating it.
+- [ ] Replace `SandboxEntryPoint.readRequestedQuery(...)` with route-state parsing that can read both the initial query and the optional selected wave.
+- [ ] Add a thin browser-history adapter around `window.history` / `window.onpopstate` so route changes are not spread across ad hoc DOM code.
+- [ ] Use `replaceState` for initial route normalization and `pushState` only for real user navigation, not for restore or replay.
+- [ ] Perform the initial `replaceState` normalization before installing any `popstate` listener or route-write observer so the app does not treat its own normalization pass as navigation.
+
+### Task 3: Add A Shell-Level Route Coordinator Instead Of Teaching Every Controller About The URL
+
+- [ ] Introduce a sidecar route controller (or equivalent shell coordinator) that owns:
+  - initial route load
+  - URL writes
+  - `popstate` replay
+  - suppressing history feedback loops during restore
+- [ ] Keep `SandboxEntryPoint` as the mount/bootstrap seam only; do not turn it into a long-lived routing controller full of state transitions.
+- [ ] Extend `J2clSearchPanelController` just enough for route-aware orchestration. The key missing seam is that it currently re-emits `selectionHandler.onWaveSelected(selectedWaveId)` after a search refresh, which is correct for digest-metadata refresh but must **not** create duplicate history entries. Add a narrow distinction between:
+  - user-initiated query/selection changes
+  - internal re-selection used to refresh digest metadata after search results re-render
+- [ ] On initial load or `popstate`, let the route coordinator:
+  - start the search controller with the route query
+  - restore the selected wave from route state without treating that restore as new user navigation
+  - allow the selected-wave panel to open even if the current digest model does not yet contain metadata for that wave
+- [ ] Treat the latest route as authoritative when async work completes:
+  - stale in-flight search results after a later `popstate` or query restore must be ignored
+  - stale selected-wave restore callbacks must not overwrite newer route state
+- [ ] Preserve the useful `#920` behavior where a later search refresh can enrich the selected-wave panel with digest metadata if the selected wave is present in the result model.
+- [ ] During initial route restore, suppress the normal “query change clears wave” behavior until the restored query + selected-wave pair has been replayed; otherwise the first search refresh can clobber the URL-selected wave before restore finishes.
+- [ ] Make sure route replay does not create loops such as:
+  - `popstate` -> controller update -> `pushState` again
+  - search refresh -> selection callback -> duplicate history entry for the same `wave`
+
+### Task 4: Keep The Post-`#920` Split-View Shell Stable And Future-Proof
+
+- [ ] Treat the existing split layout from `J2clSearchPanelView` + `sidecar.css` as the stable shell for future work, not as a temporary render artifact that gets rebuilt on every route change.
+- [ ] Keep the right-hand selected-wave host mounted while route state changes; controller render passes should update contents, not destroy and recreate the whole shell.
+- [ ] Ensure the shell remains stable in these transitions:
+  - query-only route -> query + selected-wave route
+  - selected-wave route -> query-only route via Back
+  - reload of a selected-wave URL
+  - reconnect after the selected-wave route is already open
+- [ ] Preserve a true two-pane desktop layout and a clean stacked narrow/mobile fallback. `#921` is not a styling redesign, but it does need a shell that will not fight later `#922` compose work.
+
+### Task 5: Prove Direct Reload / Deep-Link Behavior On The Chosen `/j2cl-search/...` URL
+
+- [ ] First implement the canonical fixed-document route under `/j2cl-search/index.html?...`.
+- [ ] Verify that a copied selected-wave URL can:
+  - load in a fresh tab
+  - restore the same query
+  - reopen the same selected wave
+  - keep the legacy root `/` route unchanged
+- [ ] Only if browser proof shows the desired canonical URL must be a cleaner nested `/j2cl-search/...` path, add the narrowest possible sidecar-serving seam in `ServerRpcProvider`:
+  - keep static assets such as `/j2cl-search/assets/**` and `/j2cl-search/sidecar/**` working as real files
+  - serve the sidecar host page for non-asset sidecar deep links
+  - do not touch `/`, `/webclient/**`, or legacy GWT bootstrap wiring
+- [ ] If a nested path is chosen after all, update `j2cl/src/main/webapp/index.html` so asset loading is absolute or otherwise canonicalized. Do not leave `./assets/...` and `./sidecar/...` relative to arbitrary nested route segments.
+
+### Task 6: Add Focused Tests For Route Semantics And Restore Order
+
+- [ ] Add route-codec tests for:
+  - blank query -> default `in:inbox`
+  - query-only route
+  - query + selected-wave route
+  - malformed or partially missing parameters
+  - canonical serialization ordering
+- [ ] Add route-controller tests for:
+  - initial load with query-only state
+  - initial load with query + selected-wave state
+  - user query submit pushes a new route and clears `wave`
+  - user digest selection pushes a new route with `wave`
+  - `popstate` replays old route state without echoing another `pushState`
+  - internal digest-metadata refresh after search re-render does not create duplicate history entries
+- [ ] Update `J2clSearchPanelControllerTest` only as needed to cover any new route-facing callback or restore API.
+- [ ] Update `J2clSelectedWaveControllerTest` for the route-driven restore case where the selected wave is reopened from URL state before digest metadata is available.
+- [ ] If a sidecar-only `ServerRpcProvider` fallback is added, add a focused test only if an existing Jakarta resource-serving test seam already exists; otherwise rely on explicit `curl -I` plus browser deep-link proof and document that choice.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-921-j2cl-route-state`.
+
+### Worktree File-Store Prep
+
+```bash
+cd /Users/vega/devroot/worktrees/issue-921-j2cl-route-state
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Expected result:
+
+- `wave/_accounts`, `wave/_attachments`, and `wave/_deltas` are available in the worktree
+- local browser verification can use realistic signed-in data and real waves
+
+### Sidecar + Legacy Compile Gates
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+```
+
+Expected result:
+
+- J2CL search-sidecar build/tests pass
+- any new route-state tests pass
+- the legacy GWT root still compiles and stages green
+
+### Local Boot / Smoke
+
+```bash
+bash scripts/worktree-boot.sh --port 9911
+```
+
+Then run the exact printed helper commands, typically:
+
+```bash
+PORT=9911 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9911 bash scripts/wave-smoke.sh check
+```
+
+### Route Presence Checks
+
+```bash
+curl -sS -I http://localhost:9911/
+curl -sS -I http://localhost:9911/j2cl-search/index.html
+curl -sS -I "http://localhost:9911/j2cl-search/index.html?q=with%3A%40"
+```
+
+After selecting a real wave in the browser and copying the exact canonical sidecar URL, also run:
+
+```bash
+curl -sS -I "<copied-j2cl-sidecar-url>"
+```
+
+Expected result:
+
+- `/` remains available and still serves the legacy GWT runtime
+- the sidecar route responds directly at the canonical copied URL
+- copied selected-wave URLs reload without falling back to the wrong app shell
+- the canonical copied URL stays on `/j2cl-search/index.html?...` rather than drifting between equivalent variants
+
+## 6. Local Browser Verification Expectations
+
+Browser verification is required for this slice because the acceptance criteria are route/history/layout behaviors, not just unit tests.
+
+Verify all of the following against the local booted app:
+
+- open `http://localhost:9911/` and confirm the legacy GWT root still boots normally
+- open `http://localhost:9911/j2cl-search/index.html` and confirm the post-`#920` split-view sidecar loads
+- submit a non-default query such as `with:@`
+- select a real wave from the results and confirm the right-hand selected-wave panel opens
+- copy the resulting selected-wave sidecar URL into a fresh tab and confirm it restores both the query and the selected wave
+- use browser Back and Forward to move between query-only and query+wave states without duplicate-history churn
+- try a malformed `wave=` parameter and confirm the sidecar degrades safely instead of crashing
+- try an inaccessible or invalid wave id and confirm the sidecar keeps the query while clearing or safely rejecting the selection, rather than wedging the shell in an error loop
+- confirm the browser tab title remains coherent with the restored sidecar state (or, if intentionally unchanged in this slice, record that as an explicit observed non-goal)
+- copy the resulting canonical sidecar URL
+- open that copied URL in a fresh tab and confirm both the query and selected wave restore after reload
+- use browser Back once and confirm the selected-wave panel clears while the query remains
+- use browser Back again and confirm the prior query state restores
+- use browser Forward to return to the query-only state, then Forward again to restore the selected-wave state
+- refresh while the selected-wave URL is open and confirm the same selected wave reopens without manual reselection
+
+Layout-specific expectations:
+
+- on a desktop-width window, the sidecar remains a stable two-pane shell with search rail on the left and selected wave on the right
+- on a narrow/mobile-width viewport, the shell stacks cleanly without losing either the search rail or the selected-wave panel
+- route changes and reloads do not cause obvious shell collapse, duplicate mounts, or selected-wave-card flicker
+
+Record the exact copied URL shape, Back/Forward behavior, reload outcome, and desktop/narrow layout observations in:
+
+- `journal/local-verification/2026-04-20-issue-921-j2cl-route-state.md`
+
+Then mirror the important results into the issue comment and PR body.
+
+## 7. Review / PR Expectations
+
+- Run Claude plan review before implementation begins.
+- Keep `#921` stacked on the actual `#920` selected-wave baseline until `#920` is merged, rather than duplicating or partially re-implementing that slice.
+- After implementation, run direct review plus Claude implementation review.
+- If a rebase is needed while `#920` is still open, inspect both sides carefully; do not let a rebase silently drop the selected-wave files that `#921` assumes.
+- Resolve review threads only after replying with the fix commit or technical reasoning.
+
+## 8. Definition Of Done For This Slice
+
+- The copied sidecar URL restores the same query and selected wave.
+- Browser back/forward behaves coherently inside the J2CL sidecar route.
+- The post-`#920` split-view shell remains stable enough to extend in `#922`.
+- The durable route contract includes only `query` and `selected wave`; write-path state, root-shell work, and legacy GWT root changes remain out of scope.
+- `j2clSearchBuild`, `j2clSearchTest`, `compileGwt`, and `Universal/stage` all pass.
+- Local browser verification covers reload, copied URL restore, back/forward, and desktop + narrow layout behavior.
+- The implementation record for `#921` includes worktree path, plan path, verification commands/results, review summary, and PR link.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -13,6 +13,8 @@ import jsinterop.annotations.JsType;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveView;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
@@ -24,7 +26,6 @@ import org.waveprotocol.box.j2cl.transport.SidecarWaveletUpdateSummary;
 @JsType(namespace = JsPackage.GLOBAL, name = "WaveSandboxEntryPoint")
 public final class SandboxEntryPoint {
   private static final String DEFAULT_MODE = "sidecar";
-  private static final String DEFAULT_QUERY = "in:inbox";
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
 
   private SandboxEntryPoint() {
@@ -46,18 +47,21 @@ public final class SandboxEntryPoint {
       J2clSelectedWaveController selectedWaveController =
           new J2clSelectedWaveController(
               gateway, new J2clSelectedWaveView(searchView.getSelectedWaveHost()));
-      final J2clSearchPanelController[] controllerRef = new J2clSearchPanelController[1];
+      final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
       J2clSearchPanelController controller =
           new J2clSearchPanelController(
               gateway,
               searchView,
-              waveId ->
-                  selectedWaveController.onWaveSelected(
-                      waveId,
-                      controllerRef[0] == null ? null : controllerRef[0].findDigestItem(waveId)),
+              (state, digestItem, userNavigation) ->
+                  routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation),
               resolveViewportWidth());
-      controllerRef[0] = controller;
-      controller.start(readRequestedQuery(DomGlobal.location.search));
+      J2clSidecarRouteController routeController =
+          new J2clSidecarRouteController(
+              new J2clSidecarRouteController.BrowserHistoryAdapter(),
+              controller,
+              selectedWaveController);
+      routeControllerRef[0] = routeController;
+      routeController.start();
       return;
     }
 
@@ -129,28 +133,6 @@ public final class SandboxEntryPoint {
 
   private static double resolveViewportWidth() {
     return Double.parseDouble(String.valueOf(DomGlobal.window.innerWidth));
-  }
-
-  static String readRequestedQuery(String search) {
-    if (search == null || search.isEmpty()) {
-      return DEFAULT_QUERY;
-    }
-    String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
-    String[] parts = trimmed.split("&");
-    for (String part : parts) {
-      if (part.startsWith("q=")) {
-        String value = part.substring(2);
-        if (value.isEmpty()) {
-          return DEFAULT_QUERY;
-        }
-        try {
-          return decodeUriComponentSafe(value.replace('+', ' '));
-        } catch (RuntimeException e) {
-          return DEFAULT_QUERY;
-        }
-      }
-    }
-    return DEFAULT_QUERY;
   }
 
   @JsFunction
@@ -396,7 +378,7 @@ public final class SandboxEntryPoint {
 
     private String buildSearchUrl() {
       return "/search/?query="
-          + encodeUriComponent(readRequestedQuery(DomGlobal.location.search))
+          + encodeUriComponent(J2clSidecarRouteCodec.parse(DomGlobal.location.search).getQuery())
           + "&index=0&numResults=1";
     }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -2,7 +2,8 @@ package org.waveprotocol.box.j2cl.search;
 
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
-public final class J2clSearchPanelController implements J2clSearchViewListener {
+public final class J2clSearchPanelController
+    implements J2clSearchViewListener, J2clSidecarRouteController.SearchPanelController {
   @FunctionalInterface
   public interface ErrorCallback {
     void accept(String error);
@@ -41,13 +42,14 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
     void setSelectedWaveId(String waveId);
   }
 
-  public interface WaveSelectionHandler {
-    void onWaveSelected(String waveId);
+  public interface RouteStateHandler {
+    void onRouteStateChanged(
+        J2clSidecarRouteState state, J2clSearchDigestItem digestItem, boolean userNavigation);
   }
 
   private final SearchGateway gateway;
   private final View view;
-  private final WaveSelectionHandler selectionHandler;
+  private final RouteStateHandler routeStateHandler;
   private final int pageIncrement;
   private String currentQuery;
   private String selectedWaveId;
@@ -58,21 +60,22 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
   public J2clSearchPanelController(
       SearchGateway gateway,
       View view,
-      WaveSelectionHandler selectionHandler,
+      RouteStateHandler routeStateHandler,
       double viewportWidth) {
     this.gateway = gateway;
     this.view = view;
-    this.selectionHandler = selectionHandler;
+    this.routeStateHandler = routeStateHandler;
     this.pageIncrement = J2clSearchResultProjector.getPageSizeForViewport(viewportWidth);
   }
 
-  public void start(String initialQuery) {
+  @Override
+  public void start(String initialQuery, String initialSelectedWaveId) {
     view.bind(this);
     currentQuery = J2clSearchResultProjector.normalizeQuery(initialQuery);
     currentPageSize = pageIncrement;
-    selectedWaveId = null;
+    selectedWaveId = normalizeSelectedWaveId(initialSelectedWaveId);
     view.setQuery(currentQuery);
-    view.setSelectedWaveId(null);
+    view.setSelectedWaveId(selectedWaveId);
     view.setLoading(true);
     view.setStatus("Bootstrapping the root session.", false);
     gateway.fetchRootSessionBootstrap(
@@ -90,10 +93,20 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
   }
 
   @Override
+  public void restoreRoute(String query, String selectedWaveId) {
+    currentQuery = J2clSearchResultProjector.normalizeQuery(query);
+    this.selectedWaveId = normalizeSelectedWaveId(selectedWaveId);
+    currentPageSize = pageIncrement;
+    view.setQuery(currentQuery);
+    view.setSelectedWaveId(this.selectedWaveId);
+    requestSearch();
+  }
+
+  @Override
   public void onQuerySubmitted(String query) {
     currentQuery = J2clSearchResultProjector.normalizeQuery(query);
     currentPageSize = pageIncrement;
-    clearSelection();
+    clearSelection(true);
     requestSearch();
   }
 
@@ -105,11 +118,9 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
 
   @Override
   public void onDigestSelected(String waveId) {
-    selectedWaveId = waveId;
-    view.setSelectedWaveId(waveId);
-    if (selectionHandler != null) {
-      selectionHandler.onWaveSelected(waveId);
-    }
+    selectedWaveId = normalizeSelectedWaveId(waveId);
+    view.setSelectedWaveId(selectedWaveId);
+    publishRouteState(true);
   }
 
   private void requestSearch() {
@@ -128,13 +139,10 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
             return;
           }
           lastModel = J2clSearchResultProjector.project(response, numResults);
-          if (selectedWaveId != null && !lastModel.containsWave(selectedWaveId)) {
-            clearSelection();
-          }
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
-          if (selectedWaveId != null && selectionHandler != null) {
-            selectionHandler.onWaveSelected(selectedWaveId);
+          if (selectedWaveId != null) {
+            publishRouteState(false);
           }
           view.setStatus(buildStatusText(query, lastModel), false);
           view.setLoading(false);
@@ -143,20 +151,18 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
           if (generation != requestGeneration) {
             return;
           }
-          clearSelection();
           lastModel = J2clSearchResultModel.empty("Unable to load search results.");
           view.render(lastModel);
+          view.setSelectedWaveId(selectedWaveId);
           view.setStatus("Search request failed: " + error, true);
           view.setLoading(false);
         });
   }
 
-  private void clearSelection() {
+  private void clearSelection(boolean userNavigation) {
     selectedWaveId = null;
     view.setSelectedWaveId(null);
-    if (selectionHandler != null) {
-      selectionHandler.onWaveSelected(null);
-    }
+    publishRouteState(userNavigation);
   }
 
   private static String buildStatusText(String query, J2clSearchResultModel model) {
@@ -168,5 +174,23 @@ public final class J2clSearchPanelController implements J2clSearchViewListener {
 
   public J2clSearchDigestItem findDigestItem(String waveId) {
     return lastModel.findDigestItem(waveId);
+  }
+
+  private void publishRouteState(boolean userNavigation) {
+    if (routeStateHandler == null) {
+      return;
+    }
+    J2clSearchDigestItem digestItem = lastModel.findDigestItem(selectedWaveId);
+    if (!userNavigation && selectedWaveId != null && digestItem == null) {
+      return;
+    }
+    routeStateHandler.onRouteStateChanged(
+        new J2clSidecarRouteState(currentQuery, selectedWaveId),
+        digestItem,
+        userNavigation);
+  }
+
+  private static String normalizeSelectedWaveId(String waveId) {
+    return waveId == null || waveId.isEmpty() ? null : waveId;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -4,7 +4,8 @@ import elemental2.dom.DomGlobal;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
-public final class J2clSelectedWaveController {
+public final class J2clSelectedWaveController
+    implements J2clSidecarRouteController.SelectedWaveController {
   private static final int INITIAL_RECONNECT_DELAY_MS = 250;
   // Keep retries bounded, but leave enough budget for a local WIAB restart on the same port.
   private static final int MAX_RECONNECT_DELAY_MS = 2000;
@@ -66,6 +67,7 @@ public final class J2clSelectedWaveController {
     onWaveSelected(waveId, null);
   }
 
+  @Override
   public void onWaveSelected(String waveId, J2clSearchDigestItem digestItem) {
     if (waveId != null
         && waveId.equals(selectedWaveId)

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -61,7 +61,7 @@ public final class J2clSelectedWaveModel {
         "",
         "",
         "Choose a digest from the search results to open a read-only selected-wave panel.",
-        "Selection stays in memory only for this sidecar slice.",
+        "Copied sidecar URLs can restore the selected wave when the route includes it.",
         0,
         Collections.<String>emptyList(),
         Collections.<String>emptyList());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -4,7 +4,6 @@ import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 
 public final class J2clSidecarRouteCodec {
-  private static final String CANONICAL_PATH = "/j2cl-search/index.html";
   private static final char[] HEX_DIGITS = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
   };
@@ -35,7 +34,7 @@ public final class J2clSidecarRouteCodec {
   }
 
   public static String toUrl(J2clSidecarRouteState state) {
-    StringBuilder url = new StringBuilder(CANONICAL_PATH);
+    StringBuilder url = new StringBuilder();
     url.append("?q=").append(encodeUriComponentSafe(state.getQuery()));
     if (state.getSelectedWaveId() != null) {
       url.append("&wave=").append(encodeUriComponentSafe(state.getSelectedWaveId()));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -1,0 +1,216 @@
+package org.waveprotocol.box.j2cl.search;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsPackage;
+
+public final class J2clSidecarRouteCodec {
+  private static final String CANONICAL_PATH = "/j2cl-search/index.html";
+
+  private J2clSidecarRouteCodec() {
+  }
+
+  public static J2clSidecarRouteState parse(String search) {
+    String query = null;
+    String selectedWaveId = null;
+    if (search != null && !search.isEmpty()) {
+      String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
+      if (!trimmed.isEmpty()) {
+        String[] parts = trimmed.split("&");
+        for (String part : parts) {
+          int separator = part.indexOf('=');
+          String key = separator >= 0 ? part.substring(0, separator) : part;
+          String value = separator >= 0 ? part.substring(separator + 1) : "";
+          if ("q".equals(key)) {
+            query = decodeQueryValue(value);
+          } else if ("wave".equals(key)) {
+            selectedWaveId = decodeWaveValue(value);
+          }
+        }
+      }
+    }
+    return new J2clSidecarRouteState(query, selectedWaveId);
+  }
+
+  public static String toUrl(J2clSidecarRouteState state) {
+    StringBuilder url = new StringBuilder(CANONICAL_PATH);
+    url.append("?q=").append(encodeUriComponentSafe(state.getQuery()));
+    if (state.getSelectedWaveId() != null) {
+      url.append("&wave=").append(encodeUriComponentSafe(state.getSelectedWaveId()));
+    }
+    return url.toString();
+  }
+
+  private static String decodeQueryValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return J2clSearchResultProjector.DEFAULT_QUERY;
+    }
+    try {
+      String decoded = decodeUriComponentSafe(value.replace('+', ' '));
+      return J2clSearchResultProjector.normalizeQuery(decoded);
+    } catch (RuntimeException e) {
+      return J2clSearchResultProjector.DEFAULT_QUERY;
+    }
+  }
+
+  private static String decodeWaveValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    try {
+      String decoded = decodeUriComponentSafe(value.replace('+', ' '));
+      return isValidWaveId(decoded) ? decoded : null;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static boolean isValidWaveId(String waveId) {
+    if (waveId == null || waveId.isEmpty() || waveId.indexOf(' ') >= 0) {
+      return false;
+    }
+    int separator = waveId.indexOf("/w+");
+    return separator > 0 && separator == waveId.lastIndexOf("/w+");
+  }
+
+  @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")
+  private static native String encodeUriComponent(String value);
+
+  @JsMethod(namespace = JsPackage.GLOBAL, name = "decodeURIComponent")
+  private static native String decodeUriComponentNative(String value);
+
+  private static String decodeUriComponentSafe(String value) {
+    try {
+      return decodeUriComponentNative(value);
+    } catch (Error err) {
+      return decodeUriComponentFallback(value);
+    }
+  }
+
+  private static String encodeUriComponentSafe(String value) {
+    try {
+      return encodeUriComponent(value);
+    } catch (Error err) {
+      return encodeUriComponentFallback(value);
+    }
+  }
+
+  private static String encodeUriComponentFallback(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    StringBuilder encoded = new StringBuilder(value.length());
+    for (int index = 0; index < value.length(); index++) {
+      char ch = value.charAt(index);
+      if (isUnreserved(ch)) {
+        encoded.append(ch);
+        continue;
+      }
+      if (ch <= 0x7F) {
+        appendEncodedByte(encoded, ch);
+        continue;
+      }
+      if (ch <= 0x7FF) {
+        appendEncodedByte(encoded, 0xC0 | (ch >> 6));
+        appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
+        continue;
+      }
+      appendEncodedByte(encoded, 0xE0 | (ch >> 12));
+      appendEncodedByte(encoded, 0x80 | ((ch >> 6) & 0x3F));
+      appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
+    }
+    return encoded.toString();
+  }
+
+  private static String decodeUriComponentFallback(String value) {
+    if (value == null || value.indexOf('%') < 0) {
+      return value;
+    }
+    StringBuilder decoded = new StringBuilder(value.length());
+    byte[] bytes = new byte[value.length()];
+    int index = 0;
+    while (index < value.length()) {
+      char ch = value.charAt(index);
+      if (ch != '%') {
+        decoded.append(ch);
+        index++;
+        continue;
+      }
+      int byteCount = 0;
+      while (index + 2 < value.length() && value.charAt(index) == '%') {
+        int hi = decodeHexDigit(value.charAt(index + 1));
+        int lo = decodeHexDigit(value.charAt(index + 2));
+        if (hi < 0 || lo < 0) {
+          throw new RuntimeException("Malformed percent-encoded value.");
+        }
+        bytes[byteCount++] = (byte) ((hi << 4) | lo);
+        index += 3;
+      }
+      if (byteCount == 0) {
+        throw new RuntimeException("Malformed percent-encoded value.");
+      }
+      decoded.append(decodeUtf8(bytes, byteCount));
+    }
+    return decoded.toString();
+  }
+
+  private static String decodeUtf8(byte[] bytes, int byteCount) {
+    StringBuilder decoded = new StringBuilder(byteCount);
+    int index = 0;
+    while (index < byteCount) {
+      int first = bytes[index] & 0xFF;
+      if ((first & 0x80) == 0) {
+        decoded.append((char) first);
+        index++;
+        continue;
+      }
+      if ((first & 0xE0) == 0xC0 && index + 1 < byteCount) {
+        int second = bytes[index + 1] & 0x3F;
+        decoded.append((char) (((first & 0x1F) << 6) | second));
+        index += 2;
+        continue;
+      }
+      if ((first & 0xF0) == 0xE0 && index + 2 < byteCount) {
+        int second = bytes[index + 1] & 0x3F;
+        int third = bytes[index + 2] & 0x3F;
+        decoded.append((char) (((first & 0x0F) << 12) | (second << 6) | third));
+        index += 3;
+        continue;
+      }
+      throw new RuntimeException("Malformed UTF-8 sequence.");
+    }
+    return decoded.toString();
+  }
+
+  private static int decodeHexDigit(char ch) {
+    if (ch >= '0' && ch <= '9') {
+      return ch - '0';
+    }
+    if (ch >= 'A' && ch <= 'F') {
+      return ch - 'A' + 10;
+    }
+    if (ch >= 'a' && ch <= 'f') {
+      return ch - 'a' + 10;
+    }
+    return -1;
+  }
+
+  private static boolean isUnreserved(char ch) {
+    if (ch >= 'A' && ch <= 'Z') {
+      return true;
+    }
+    if (ch >= 'a' && ch <= 'z') {
+      return true;
+    }
+    if (ch >= '0' && ch <= '9') {
+      return true;
+    }
+    return ch == '-' || ch == '_' || ch == '.' || ch == '~';
+  }
+
+  private static void appendEncodedByte(StringBuilder encoded, int value) {
+    final char[] digits = "0123456789ABCDEF".toCharArray();
+    encoded.append('%');
+    encoded.append(digits[(value >> 4) & 0x0F]);
+    encoded.append(digits[value & 0x0F]);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -235,7 +235,15 @@ public final class J2clSidecarRouteCodec {
     if (ch >= '0' && ch <= '9') {
       return true;
     }
-    return ch == '-' || ch == '_' || ch == '.' || ch == '~';
+    return ch == '-'
+        || ch == '_'
+        || ch == '.'
+        || ch == '!'
+        || ch == '~'
+        || ch == '*'
+        || ch == '\''
+        || ch == '('
+        || ch == ')';
   }
 
   private static boolean isHighSurrogate(char ch) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -57,7 +57,7 @@ public final class J2clSidecarRouteCodec {
       return null;
     }
     try {
-      String decoded = decodeUriComponentSafe(value.replace('+', ' '));
+      String decoded = decodeUriComponentSafe(value);
       return isValidWaveId(decoded) ? decoded : null;
     } catch (RuntimeException e) {
       return null;
@@ -81,7 +81,7 @@ public final class J2clSidecarRouteCodec {
   private static String decodeUriComponentSafe(String value) {
     try {
       return decodeUriComponentNative(value);
-    } catch (Error err) {
+    } catch (RuntimeException | Error err) {
       return decodeUriComponentFallback(value);
     }
   }
@@ -89,7 +89,7 @@ public final class J2clSidecarRouteCodec {
   private static String encodeUriComponentSafe(String value) {
     try {
       return encodeUriComponent(value);
-    } catch (Error err) {
+    } catch (RuntimeException | Error err) {
       return encodeUriComponentFallback(value);
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -114,6 +114,18 @@ public final class J2clSidecarRouteCodec {
         appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
         continue;
       }
+      if (ch >= 0xD800 && ch <= 0xDBFF && index + 1 < value.length()) {
+        char low = value.charAt(index + 1);
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          int codePoint = 0x10000 + ((ch - 0xD800) << 10) + (low - 0xDC00);
+          appendEncodedByte(encoded, 0xF0 | (codePoint >> 18));
+          appendEncodedByte(encoded, 0x80 | ((codePoint >> 12) & 0x3F));
+          appendEncodedByte(encoded, 0x80 | ((codePoint >> 6) & 0x3F));
+          appendEncodedByte(encoded, 0x80 | (codePoint & 0x3F));
+          index++;
+          continue;
+        }
+      }
       appendEncodedByte(encoded, 0xE0 | (ch >> 12));
       appendEncodedByte(encoded, 0x80 | ((ch >> 6) & 0x3F));
       appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
@@ -164,21 +176,55 @@ public final class J2clSidecarRouteCodec {
         continue;
       }
       if ((first & 0xE0) == 0xC0 && index + 1 < byteCount) {
-        int second = bytes[index + 1] & 0x3F;
-        decoded.append((char) (((first & 0x1F) << 6) | second));
+        int second = requireContinuationByte(bytes[index + 1]);
+        int codePoint = ((first & 0x1F) << 6) | second;
+        if (codePoint < 0x80) {
+          throw malformedUtf8Sequence();
+        }
+        decoded.append((char) codePoint);
         index += 2;
         continue;
       }
       if ((first & 0xF0) == 0xE0 && index + 2 < byteCount) {
-        int second = bytes[index + 1] & 0x3F;
-        int third = bytes[index + 2] & 0x3F;
-        decoded.append((char) (((first & 0x0F) << 12) | (second << 6) | third));
+        int second = requireContinuationByte(bytes[index + 1]);
+        int third = requireContinuationByte(bytes[index + 2]);
+        int codePoint = ((first & 0x0F) << 12) | (second << 6) | third;
+        if (codePoint < 0x800 || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+          throw malformedUtf8Sequence();
+        }
+        decoded.append((char) codePoint);
         index += 3;
         continue;
       }
-      throw new RuntimeException("Malformed UTF-8 sequence.");
+      if ((first & 0xF8) == 0xF0 && index + 3 < byteCount) {
+        int second = requireContinuationByte(bytes[index + 1]);
+        int third = requireContinuationByte(bytes[index + 2]);
+        int fourth = requireContinuationByte(bytes[index + 3]);
+        int codePoint = ((first & 0x07) << 18) | (second << 12) | (third << 6) | fourth;
+        if (codePoint < 0x10000 || codePoint > 0x10FFFF) {
+          throw malformedUtf8Sequence();
+        }
+        codePoint -= 0x10000;
+        decoded.append((char) (0xD800 | (codePoint >> 10)));
+        decoded.append((char) (0xDC00 | (codePoint & 0x3FF)));
+        index += 4;
+        continue;
+      }
+      throw malformedUtf8Sequence();
     }
     return decoded.toString();
+  }
+
+  private static int requireContinuationByte(byte value) {
+    int intValue = value & 0xFF;
+    if ((intValue & 0xC0) != 0x80) {
+      throw malformedUtf8Sequence();
+    }
+    return intValue & 0x3F;
+  }
+
+  private static RuntimeException malformedUtf8Sequence() {
+    return new RuntimeException("Malformed UTF-8 sequence.");
   }
 
   private static int decodeHexDigit(char ch) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -5,6 +5,9 @@ import jsinterop.annotations.JsPackage;
 
 public final class J2clSidecarRouteCodec {
   private static final String CANONICAL_PATH = "/j2cl-search/index.html";
+  private static final char[] HEX_DIGITS = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+  };
 
   private J2clSidecarRouteCodec() {
   }
@@ -291,9 +294,8 @@ public final class J2clSidecarRouteCodec {
   }
 
   private static void appendEncodedByte(StringBuilder encoded, int value) {
-    final char[] digits = "0123456789ABCDEF".toCharArray();
     encoded.append('%');
-    encoded.append(digits[(value >> 4) & 0x0F]);
-    encoded.append(digits[value & 0x0F]);
+    encoded.append(HEX_DIGITS[(value >> 4) & 0x0F]);
+    encoded.append(HEX_DIGITS[value & 0x0F]);
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -105,30 +105,17 @@ public final class J2clSidecarRouteCodec {
         encoded.append(ch);
         continue;
       }
-      if (ch <= 0x7F) {
-        appendEncodedByte(encoded, ch);
-        continue;
-      }
-      if (ch <= 0x7FF) {
-        appendEncodedByte(encoded, 0xC0 | (ch >> 6));
-        appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
-        continue;
-      }
-      if (ch >= 0xD800 && ch <= 0xDBFF && index + 1 < value.length()) {
-        char low = value.charAt(index + 1);
-        if (low >= 0xDC00 && low <= 0xDFFF) {
-          int codePoint = 0x10000 + ((ch - 0xD800) << 10) + (low - 0xDC00);
-          appendEncodedByte(encoded, 0xF0 | (codePoint >> 18));
-          appendEncodedByte(encoded, 0x80 | ((codePoint >> 12) & 0x3F));
-          appendEncodedByte(encoded, 0x80 | ((codePoint >> 6) & 0x3F));
-          appendEncodedByte(encoded, 0x80 | (codePoint & 0x3F));
-          index++;
-          continue;
+      int codePoint = ch;
+      if (isHighSurrogate(ch)) {
+        if (index + 1 >= value.length() || !isLowSurrogate(value.charAt(index + 1))) {
+          throw new RuntimeException("Malformed UTF-16 surrogate pair.");
         }
+        codePoint = toCodePoint(ch, value.charAt(index + 1));
+        index++;
+      } else if (isLowSurrogate(ch)) {
+        throw new RuntimeException("Malformed UTF-16 surrogate pair.");
       }
-      appendEncodedByte(encoded, 0xE0 | (ch >> 12));
-      appendEncodedByte(encoded, 0x80 | ((ch >> 6) & 0x3F));
-      appendEncodedByte(encoded, 0x80 | (ch & 0x3F));
+      appendUtf8CodePoint(encoded, codePoint);
     }
     return encoded.toString();
   }
@@ -189,7 +176,7 @@ public final class J2clSidecarRouteCodec {
         int second = requireContinuationByte(bytes[index + 1]);
         int third = requireContinuationByte(bytes[index + 2]);
         int codePoint = ((first & 0x0F) << 12) | (second << 6) | third;
-        if (codePoint < 0x800 || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
+        if (codePoint < 0x800 || isSurrogate((char) codePoint)) {
           throw malformedUtf8Sequence();
         }
         decoded.append((char) codePoint);
@@ -204,9 +191,7 @@ public final class J2clSidecarRouteCodec {
         if (codePoint < 0x10000 || codePoint > 0x10FFFF) {
           throw malformedUtf8Sequence();
         }
-        codePoint -= 0x10000;
-        decoded.append((char) (0xD800 | (codePoint >> 10)));
-        decoded.append((char) (0xDC00 | (codePoint & 0x3FF)));
+        appendCodePoint(decoded, codePoint);
         index += 4;
         continue;
       }
@@ -251,6 +236,50 @@ public final class J2clSidecarRouteCodec {
       return true;
     }
     return ch == '-' || ch == '_' || ch == '.' || ch == '~';
+  }
+
+  private static boolean isHighSurrogate(char ch) {
+    return ch >= 0xD800 && ch <= 0xDBFF;
+  }
+
+  private static boolean isLowSurrogate(char ch) {
+    return ch >= 0xDC00 && ch <= 0xDFFF;
+  }
+
+  private static boolean isSurrogate(char ch) {
+    return isHighSurrogate(ch) || isLowSurrogate(ch);
+  }
+
+  private static int toCodePoint(char high, char low) {
+    return 0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00);
+  }
+
+  private static void appendUtf8CodePoint(StringBuilder encoded, int codePoint) {
+    if (codePoint <= 0x7F) {
+      appendEncodedByte(encoded, codePoint);
+      return;
+    }
+    if (codePoint <= 0x7FF) {
+      appendEncodedByte(encoded, 0xC0 | (codePoint >> 6));
+      appendEncodedByte(encoded, 0x80 | (codePoint & 0x3F));
+      return;
+    }
+    if (codePoint <= 0xFFFF) {
+      appendEncodedByte(encoded, 0xE0 | (codePoint >> 12));
+      appendEncodedByte(encoded, 0x80 | ((codePoint >> 6) & 0x3F));
+      appendEncodedByte(encoded, 0x80 | (codePoint & 0x3F));
+      return;
+    }
+    appendEncodedByte(encoded, 0xF0 | (codePoint >> 18));
+    appendEncodedByte(encoded, 0x80 | ((codePoint >> 12) & 0x3F));
+    appendEncodedByte(encoded, 0x80 | ((codePoint >> 6) & 0x3F));
+    appendEncodedByte(encoded, 0x80 | (codePoint & 0x3F));
+  }
+
+  private static void appendCodePoint(StringBuilder decoded, int codePoint) {
+    int adjusted = codePoint - 0x10000;
+    decoded.append((char) (0xD800 | (adjusted >> 10)));
+    decoded.append((char) (0xDC00 | (adjusted & 0x3FF)));
   }
 
   private static void appendEncodedByte(StringBuilder encoded, int value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
@@ -1,0 +1,91 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.DomGlobal;
+
+public final class J2clSidecarRouteController {
+  public interface HistoryAdapter {
+    String getSearch();
+
+    void pushUrl(String url);
+
+    void replaceUrl(String url);
+
+    void setPopStateListener(Runnable listener);
+  }
+
+  public interface SearchPanelController {
+    void start(String initialQuery, String initialSelectedWaveId);
+
+    void restoreRoute(String query, String selectedWaveId);
+  }
+
+  public interface SelectedWaveController {
+    void onWaveSelected(String waveId, J2clSearchDigestItem digestItem);
+  }
+
+  public static final class BrowserHistoryAdapter implements HistoryAdapter {
+    @Override
+    public String getSearch() {
+      return DomGlobal.location.search;
+    }
+
+    @Override
+    public void pushUrl(String url) {
+      DomGlobal.window.history.pushState(null, "", url);
+    }
+
+    @Override
+    public void replaceUrl(String url) {
+      DomGlobal.window.history.replaceState(null, "", url);
+    }
+
+    @Override
+    public void setPopStateListener(Runnable listener) {
+      DomGlobal.window.onpopstate =
+          event -> {
+            listener.run();
+            return null;
+          };
+    }
+  }
+
+  private final HistoryAdapter history;
+  private final SearchPanelController searchController;
+  private final SelectedWaveController selectedWaveController;
+  private J2clSidecarRouteState currentState;
+
+  public J2clSidecarRouteController(
+      HistoryAdapter history,
+      SearchPanelController searchController,
+      SelectedWaveController selectedWaveController) {
+    this.history = history;
+    this.searchController = searchController;
+    this.selectedWaveController = selectedWaveController;
+  }
+
+  public void start() {
+    currentState = J2clSidecarRouteCodec.parse(history.getSearch());
+    history.replaceUrl(J2clSidecarRouteCodec.toUrl(currentState));
+    searchController.start(currentState.getQuery(), currentState.getSelectedWaveId());
+    selectedWaveController.onWaveSelected(currentState.getSelectedWaveId(), null);
+    history.setPopStateListener(this::handlePopState);
+  }
+
+  public void onRouteStateChanged(
+      J2clSidecarRouteState nextState, J2clSearchDigestItem digestItem, boolean userNavigation) {
+    if (nextState == null) {
+      return;
+    }
+    if (userNavigation && !nextState.equals(currentState)) {
+      history.pushUrl(J2clSidecarRouteCodec.toUrl(nextState));
+    }
+    currentState = nextState;
+    selectedWaveController.onWaveSelected(nextState.getSelectedWaveId(), digestItem);
+  }
+
+  private void handlePopState() {
+    currentState = J2clSidecarRouteCodec.parse(history.getSearch());
+    searchController.restoreRoute(currentState.getQuery(), currentState.getSelectedWaveId());
+    selectedWaveController.onWaveSelected(currentState.getSelectedWaveId(), null);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java
@@ -1,0 +1,43 @@
+package org.waveprotocol.box.j2cl.search;
+
+public final class J2clSidecarRouteState {
+  private final String query;
+  private final String selectedWaveId;
+
+  public J2clSidecarRouteState(String query, String selectedWaveId) {
+    this.query = J2clSearchResultProjector.normalizeQuery(query);
+    this.selectedWaveId =
+        selectedWaveId == null || selectedWaveId.isEmpty() ? null : selectedWaveId;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public String getSelectedWaveId() {
+    return selectedWaveId;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof J2clSidecarRouteState)) {
+      return false;
+    }
+    J2clSidecarRouteState that = (J2clSidecarRouteState) other;
+    return safeEquals(query, that.query) && safeEquals(selectedWaveId, that.selectedWaveId);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = query == null ? 0 : query.hashCode();
+    result = 31 * result + (selectedWaveId == null ? 0 : selectedWaveId.hashCode());
+    return result;
+  }
+
+  private static boolean safeEquals(String left, String right) {
+    if (left == null) {
+      return right == null;
+    }
+    return left.equals(right);
+  }
+}

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SupaWave J2CL Sidecar Sandbox</title>
-  <link rel="stylesheet" href="./assets/sidecar.css">
-  <script src="./sidecar/j2cl-sidecar.js"></script>
+  <link rel="stylesheet" href="/j2cl-search/assets/sidecar.css">
+  <script src="/j2cl-search/sidecar/j2cl-sidecar.js"></script>
 </head>
 <body>
   <main class="sidecar-shell">

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SupaWave J2CL Sidecar Sandbox</title>
-  <link rel="stylesheet" href="/j2cl-search/assets/sidecar.css">
-  <script src="/j2cl-search/sidecar/j2cl-sidecar.js"></script>
+  <link rel="stylesheet" href="./assets/sidecar.css">
+  <script src="./sidecar/j2cl-sidecar.js"></script>
 </head>
 <body>
   <main class="sidecar-shell">

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.sandbox;
 import com.google.j2cl.junit.apt.J2clTestInput;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
 
 @J2clTestInput(SandboxBuildSmokeTest.class)
 public class SandboxBuildSmokeTest {
@@ -65,19 +66,19 @@ public class SandboxBuildSmokeTest {
 
   @Test
   public void malformedQueryFallsBackToDefaultSearch() {
-    Assert.assertEquals("in:inbox", SandboxEntryPoint.readRequestedQuery("?q=%"));
+    Assert.assertEquals("in:inbox", J2clSidecarRouteCodec.parse("?q=%").getQuery());
   }
 
   @Test
   public void encodedQueryDecodesPercentEscapes() {
-    Assert.assertEquals("with:@", SandboxEntryPoint.readRequestedQuery("?q=with%3A%40"));
+    Assert.assertEquals("with:@", J2clSidecarRouteCodec.parse("?q=with%3A%40").getQuery());
   }
 
   @Test
   public void encodedQueryTreatsPlusAsSpace() {
     Assert.assertEquals(
         "mentions:me unread:true",
-        SandboxEntryPoint.readRequestedQuery("?q=mentions%3Ame+unread%3Atrue"));
+        J2clSidecarRouteCodec.parse("?q=mentions%3Ame+unread%3Atrue").getQuery());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxHostPageAssetPathTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxHostPageAssetPathTest.java
@@ -1,0 +1,22 @@
+package org.waveprotocol.box.j2cl.sandbox;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SandboxHostPageAssetPathTest {
+  @Test
+  public void hostPageUsesProfileRelativeAssetUrls() throws Exception {
+    String html =
+        new String(
+            Files.readAllBytes(Paths.get("src/main/webapp/index.html")),
+            StandardCharsets.UTF_8);
+
+    Assert.assertTrue(html.contains("href=\"./assets/sidecar.css\""));
+    Assert.assertTrue(html.contains("src=\"./sidecar/j2cl-sidecar.js\""));
+    Assert.assertFalse(html.contains("href=\"/j2cl-search/assets/sidecar.css\""));
+    Assert.assertFalse(html.contains("src=\"/j2cl-search/sidecar/j2cl-sidecar.js\""));
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -31,9 +31,9 @@ public class J2clSearchPanelControllerTest {
                         false))));
     FakeView view = new FakeView();
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, waveId -> { }, 1200);
+        new J2clSearchPanelController(gateway, view, (state, digestItem, userNavigation) -> { }, 1200);
 
-    controller.start("   ");
+    controller.start("   ", null);
 
     Assert.assertEquals("in:inbox", gateway.lastQuery);
     Assert.assertEquals(0, gateway.lastIndex);
@@ -74,9 +74,9 @@ public class J2clSearchPanelControllerTest {
                         false))));
     FakeView view = new FakeView();
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, waveId -> { }, 1200);
+        new J2clSearchPanelController(gateway, view, (state, digestItem, userNavigation) -> { }, 1200);
 
-    controller.start(null);
+    controller.start(null, null);
     controller.onQuerySubmitted("with:@");
     Assert.assertEquals("with:@", gateway.lastQuery);
     Assert.assertEquals(30, gateway.lastNumResults);
@@ -102,20 +102,27 @@ public class J2clSearchPanelControllerTest {
                     "person@example.com",
                     false)));
     FakeView view = new FakeView();
-    List<String> selectionEvents = new ArrayList<String>();
+    List<String> routeEvents = new ArrayList<String>();
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+        new J2clSearchPanelController(
+            gateway,
+            view,
+            (state, digestItem, userNavigation) ->
+                routeEvents.add(state.getQuery() + "|" + state.getSelectedWaveId() + "|" + userNavigation),
+            1200);
 
-    controller.start(null);
+    controller.start(null, null);
     controller.onDigestSelected("example.com/w+1");
     controller.onQuerySubmitted("with:@");
 
     Assert.assertNull(view.selectedWaveId);
-    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+    Assert.assertEquals(
+        Arrays.asList("in:inbox|example.com/w+1|true", "with:@|null|true"),
+        routeEvents);
   }
 
   @Test
-  public void missingSelectedWaveClearsSelectionAndNotifiesHandler() {
+  public void missingSelectedWaveDoesNotClearRestoredRouteSelection() {
     FakeGateway gateway =
         new FakeGateway(
             responseWithDigests(
@@ -130,12 +137,16 @@ public class J2clSearchPanelControllerTest {
                     "person@example.com",
                     false)));
     FakeView view = new FakeView();
-    List<String> selectionEvents = new ArrayList<String>();
+    List<String> routeEvents = new ArrayList<String>();
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+        new J2clSearchPanelController(
+            gateway,
+            view,
+            (state, digestItem, userNavigation) ->
+                routeEvents.add(state.getQuery() + "|" + state.getSelectedWaveId() + "|" + userNavigation),
+            1200);
 
-    controller.start(null);
-    controller.onDigestSelected("example.com/w+1");
+    controller.start("with:@", "example.com/w+1");
     gateway.response =
         responseWithDigests(
             new SidecarSearchResponse.Digest(
@@ -151,12 +162,14 @@ public class J2clSearchPanelControllerTest {
 
     controller.onShowMoreRequested();
 
-    Assert.assertNull(view.selectedWaveId);
-    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+    Assert.assertEquals("example.com/w+1", view.selectedWaveId);
+    Assert.assertEquals(
+        Arrays.asList("with:@|example.com/w+1|false"),
+        routeEvents);
   }
 
   @Test
-  public void searchErrorClearsSelectionAndNotifiesHandler() {
+  public void searchErrorKeepsCurrentSelectionRouteState() {
     FakeGateway gateway =
         new FakeGateway(
             responseWithDigests(
@@ -171,34 +184,48 @@ public class J2clSearchPanelControllerTest {
                     "person@example.com",
                     false)));
     FakeView view = new FakeView();
-    List<String> selectionEvents = new ArrayList<String>();
+    List<String> routeEvents = new ArrayList<String>();
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, selectionEvents::add, 1200);
+        new J2clSearchPanelController(
+            gateway,
+            view,
+            (state, digestItem, userNavigation) ->
+                routeEvents.add(state.getQuery() + "|" + state.getSelectedWaveId() + "|" + userNavigation),
+            1200);
 
-    controller.start(null);
+    controller.start(null, null);
     controller.onDigestSelected("example.com/w+1");
     gateway.error = "boom";
 
     controller.onShowMoreRequested();
 
-    Assert.assertNull(view.selectedWaveId);
+    Assert.assertEquals("example.com/w+1", view.selectedWaveId);
     Assert.assertEquals("Search request failed: boom", view.status);
     Assert.assertTrue(view.error);
-    Assert.assertEquals(Arrays.asList("example.com/w+1", null), selectionEvents);
+    Assert.assertEquals(Arrays.asList("in:inbox|example.com/w+1|true"), routeEvents);
   }
 
   @Test
-  public void digestSelectionUpdatesViewAndInvokesCallback() {
+  public void digestSelectionPublishesRouteStateAsUserNavigation() {
     FakeGateway gateway = new FakeGateway(new SidecarSearchResponse("in:inbox", 0, null));
     FakeView view = new FakeView();
-    String[] selectedWaveId = new String[1];
+    J2clSidecarRouteState[] selectedState = new J2clSidecarRouteState[1];
+    boolean[] userNavigation = new boolean[1];
     J2clSearchPanelController controller =
-        new J2clSearchPanelController(gateway, view, waveId -> selectedWaveId[0] = waveId, 1200);
+        new J2clSearchPanelController(
+            gateway,
+            view,
+            (state, digestItem, isUserNavigation) -> {
+              selectedState[0] = state;
+              userNavigation[0] = isUserNavigation;
+            },
+            1200);
 
     controller.onDigestSelected("example.com/w+abc123");
 
     Assert.assertEquals("example.com/w+abc123", view.selectedWaveId);
-    Assert.assertEquals("example.com/w+abc123", selectedWaveId[0]);
+    Assert.assertEquals("example.com/w+abc123", selectedState[0].getSelectedWaveId());
+    Assert.assertTrue(userNavigation[0]);
   }
 
   private static final class FakeGateway implements J2clSearchPanelController.SearchGateway {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
@@ -1,0 +1,39 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class J2clSidecarRouteCodecFallbackJvmTest {
+  @Test
+  public void fallbackEncoderEmitsSupplementaryCodePointsAsUtf8() throws Exception {
+    Assert.assertEquals(
+        "%F0%9F%9A%80",
+        invokePrivateStringMethod("encodeUriComponentFallback", "\uD83D\uDE80"));
+  }
+
+  @Test
+  public void fallbackDecoderAcceptsFourByteUtf8Sequences() throws Exception {
+    Assert.assertEquals(
+        "\uD83D\uDE80",
+        invokePrivateStringMethod("decodeUriComponentFallback", "%F0%9F%9A%80"));
+  }
+
+  private static String invokePrivateStringMethod(String methodName, String value) throws Exception {
+    Method method = J2clSidecarRouteCodec.class.getDeclaredMethod(methodName, String.class);
+    method.setAccessible(true);
+    try {
+      return (String) method.invoke(null, value);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      }
+      throw e;
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
@@ -25,6 +25,9 @@ public class J2clSidecarRouteCodecFallbackJvmTest {
     Assert.assertEquals(
         "!*'()~",
         invokePrivateStringMethod("encodeUriComponentFallback", "!*'()~"));
+    Assert.assertEquals(
+        "!%20*'()",
+        invokePrivateStringMethod("encodeUriComponentFallback", "! *'()"));
   }
 
   private static String invokePrivateStringMethod(String methodName, String value) throws Exception {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecFallbackJvmTest.java
@@ -20,6 +20,13 @@ public class J2clSidecarRouteCodecFallbackJvmTest {
         invokePrivateStringMethod("decodeUriComponentFallback", "%F0%9F%9A%80"));
   }
 
+  @Test
+  public void fallbackEncoderMatchesEncodeUriComponentAllowList() throws Exception {
+    Assert.assertEquals(
+        "!*'()~",
+        invokePrivateStringMethod("encodeUriComponentFallback", "!*'()~"));
+  }
+
   private static String invokePrivateStringMethod(String methodName, String value) throws Exception {
     Method method = J2clSidecarRouteCodec.class.getDeclaredMethod(methodName, String.class);
     method.setAccessible(true);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
@@ -1,0 +1,58 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clSidecarRouteCodecTest.class)
+public class J2clSidecarRouteCodecTest {
+  @Test
+  public void blankOrMissingQueryFallsBackToDefault() {
+    Assert.assertEquals(
+        J2clSearchResultProjector.DEFAULT_QUERY,
+        J2clSidecarRouteCodec.parse("").getQuery());
+    Assert.assertEquals(
+        J2clSearchResultProjector.DEFAULT_QUERY,
+        J2clSidecarRouteCodec.parse("?q=").getQuery());
+    Assert.assertEquals(
+        J2clSearchResultProjector.DEFAULT_QUERY,
+        J2clSidecarRouteCodec.parse("?q=%").getQuery());
+  }
+
+  @Test
+  public void queryOnlyRouteRoundTripsToCanonicalUrl() {
+    J2clSidecarRouteState state = J2clSidecarRouteCodec.parse("?q=with%3A%40");
+
+    Assert.assertEquals("with:@", state.getQuery());
+    Assert.assertNull(state.getSelectedWaveId());
+    Assert.assertEquals(
+        "/j2cl-search/index.html?q=with%3A%40",
+        J2clSidecarRouteCodec.toUrl(state));
+  }
+
+  @Test
+  public void queryAndSelectedWaveRouteRoundTripsToCanonicalUrl() {
+    J2clSidecarRouteState state =
+        J2clSidecarRouteCodec.parse("?wave=example.com%2Fw%2Babc123&q=with%3A%40");
+
+    Assert.assertEquals("with:@", state.getQuery());
+    Assert.assertEquals("example.com/w+abc123", state.getSelectedWaveId());
+    Assert.assertEquals(
+        "/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2Babc123",
+        J2clSidecarRouteCodec.toUrl(state));
+  }
+
+  @Test
+  public void malformedOrIncompleteWaveParameterIsDroppedSafely() {
+    Assert.assertNull(J2clSidecarRouteCodec.parse("?wave=").getSelectedWaveId());
+    Assert.assertNull(J2clSidecarRouteCodec.parse("?wave=not-a-wave-id").getSelectedWaveId());
+    Assert.assertNull(J2clSidecarRouteCodec.parse("?wave=bad%20value").getSelectedWaveId());
+  }
+
+  @Test
+  public void queryDecodingTreatsPlusAsSpace() {
+    Assert.assertEquals(
+        "mentions:me unread:true",
+        J2clSidecarRouteCodec.parse("?q=mentions%3Ame+unread%3Atrue").getQuery());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
@@ -26,7 +26,7 @@ public class J2clSidecarRouteCodecTest {
     Assert.assertEquals("with:@", state.getQuery());
     Assert.assertNull(state.getSelectedWaveId());
     Assert.assertEquals(
-        "/j2cl-search/index.html?q=with%3A%40",
+        "?q=with%3A%40",
         J2clSidecarRouteCodec.toUrl(state));
   }
 
@@ -38,7 +38,7 @@ public class J2clSidecarRouteCodecTest {
     Assert.assertEquals("with:@", state.getQuery());
     Assert.assertEquals("example.com/w+abc123", state.getSelectedWaveId());
     Assert.assertEquals(
-        "/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2Babc123",
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123",
         J2clSidecarRouteCodec.toUrl(state));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
@@ -50,6 +50,13 @@ public class J2clSidecarRouteCodecTest {
   }
 
   @Test
+  public void waveParameterPreservesLiteralPlusInWaveId() {
+    Assert.assertEquals(
+        "example.com/w+abc123",
+        J2clSidecarRouteCodec.parse("?wave=example.com/w+abc123").getSelectedWaveId());
+  }
+
+  @Test
   public void queryDecodingTreatsPlusAsSpace() {
     Assert.assertEquals(
         "mentions:me unread:true",

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
@@ -21,7 +21,7 @@ public class J2clSidecarRouteControllerTest {
     controller.start();
 
     Assert.assertEquals(
-        Arrays.asList("/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1"),
         history.replacedUrls);
     Assert.assertEquals(
         Arrays.asList("start:with:@:example.com/w+1"),
@@ -44,7 +44,7 @@ public class J2clSidecarRouteControllerTest {
     controller.onRouteStateChanged(new J2clSidecarRouteState("with:@", null), null, true);
 
     Assert.assertEquals(
-        Arrays.asList("/j2cl-search/index.html?q=with%3A%40"),
+        Arrays.asList("?q=with%3A%40"),
         history.pushedUrls);
     Assert.assertEquals(Arrays.asList("null:null"), selectedWaveController.tailEvents(1));
   }
@@ -62,7 +62,7 @@ public class J2clSidecarRouteControllerTest {
         new J2clSidecarRouteState("with:@", "example.com/w+1"), digest("example.com/w+1"), true);
 
     Assert.assertEquals(
-        Arrays.asList("/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1"),
         history.pushedUrls);
     Assert.assertEquals(
         Arrays.asList("example.com/w+1:example.com/w+1"),

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
@@ -1,0 +1,182 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clSidecarRouteControllerTest.class)
+public class J2clSidecarRouteControllerTest {
+  @Test
+  public void startNormalizesUrlAndRestoresQueryAndSelectedWave() {
+    FakeHistoryAdapter history =
+        new FakeHistoryAdapter("?wave=example.com%2Fw%2B1&q=with%3A%40");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+
+    Assert.assertEquals(
+        Arrays.asList("/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        history.replacedUrls);
+    Assert.assertEquals(
+        Arrays.asList("start:with:@:example.com/w+1"),
+        searchController.events);
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+1:null"),
+        selectedWaveController.events);
+    Assert.assertEquals(0, history.pushedUrls.size());
+  }
+
+  @Test
+  public void userQueryChangePushesQueryOnlyRouteAndClearsSelectedWave() {
+    FakeHistoryAdapter history = new FakeHistoryAdapter("");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+    controller.onRouteStateChanged(new J2clSidecarRouteState("with:@", null), null, true);
+
+    Assert.assertEquals(
+        Arrays.asList("/j2cl-search/index.html?q=with%3A%40"),
+        history.pushedUrls);
+    Assert.assertEquals(Arrays.asList("null:null"), selectedWaveController.tailEvents(1));
+  }
+
+  @Test
+  public void userSelectionPushesRouteWithWave() {
+    FakeHistoryAdapter history = new FakeHistoryAdapter("?q=with%3A%40");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+    controller.onRouteStateChanged(
+        new J2clSidecarRouteState("with:@", "example.com/w+1"), digest("example.com/w+1"), true);
+
+    Assert.assertEquals(
+        Arrays.asList("/j2cl-search/index.html?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        history.pushedUrls);
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+1:example.com/w+1"),
+        selectedWaveController.tailEvents(1));
+  }
+
+  @Test
+  public void popStateRestoresEarlierRouteWithoutEchoingPushState() {
+    FakeHistoryAdapter history = new FakeHistoryAdapter("?q=with%3A%40&wave=example.com%2Fw%2B1");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+    history.setSearch("?q=in%3Ainbox");
+    history.firePopState();
+
+    Assert.assertEquals(
+        Arrays.asList("start:with:@:example.com/w+1", "restore:in:inbox:null"),
+        searchController.events);
+    Assert.assertEquals(0, history.pushedUrls.size());
+    Assert.assertEquals(Arrays.asList("null:null"), selectedWaveController.tailEvents(1));
+  }
+
+  @Test
+  public void internalMetadataRefreshDoesNotPushDuplicateHistoryEntry() {
+    FakeHistoryAdapter history = new FakeHistoryAdapter("?q=with%3A%40&wave=example.com%2Fw%2B1");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+    controller.onRouteStateChanged(
+        new J2clSidecarRouteState("with:@", "example.com/w+1"), digest("example.com/w+1"), false);
+
+    Assert.assertEquals(0, history.pushedUrls.size());
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+1:example.com/w+1"),
+        selectedWaveController.tailEvents(1));
+  }
+
+  private static J2clSearchDigestItem digest(String waveId) {
+    return new J2clSearchDigestItem(
+        waveId, "Wave", "Snippet", "user@example.com", 1, 2, 3L, false);
+  }
+
+  private static final class FakeHistoryAdapter
+      implements J2clSidecarRouteController.HistoryAdapter {
+    private final List<String> pushedUrls = new ArrayList<String>();
+    private final List<String> replacedUrls = new ArrayList<String>();
+    private String search;
+    private Runnable popStateListener;
+
+    private FakeHistoryAdapter(String search) {
+      this.search = search;
+    }
+
+    @Override
+    public String getSearch() {
+      return search;
+    }
+
+    @Override
+    public void pushUrl(String url) {
+      pushedUrls.add(url);
+    }
+
+    @Override
+    public void replaceUrl(String url) {
+      replacedUrls.add(url);
+    }
+
+    @Override
+    public void setPopStateListener(Runnable listener) {
+      this.popStateListener = listener;
+    }
+
+    private void setSearch(String search) {
+      this.search = search;
+    }
+
+    private void firePopState() {
+      popStateListener.run();
+    }
+  }
+
+  private static final class FakeSearchPanelController
+      implements J2clSidecarRouteController.SearchPanelController {
+    private final List<String> events = new ArrayList<String>();
+
+    @Override
+    public void start(String initialQuery, String initialSelectedWaveId) {
+      events.add("start:" + initialQuery + ":" + initialSelectedWaveId);
+    }
+
+    @Override
+    public void restoreRoute(String query, String selectedWaveId) {
+      events.add("restore:" + query + ":" + selectedWaveId);
+    }
+  }
+
+  private static final class FakeSelectedWaveController
+      implements J2clSidecarRouteController.SelectedWaveController {
+    private final List<String> events = new ArrayList<String>();
+
+    @Override
+    public void onWaveSelected(String waveId, J2clSearchDigestItem digestItem) {
+      events.add(waveId + ":" + (digestItem == null ? null : digestItem.getWaveId()));
+    }
+
+    private List<String> tailEvents(int count) {
+      return events.subList(events.size() - count, events.size());
+    }
+  }
+}

--- a/wave/config/changelog.d/2026-04-20-j2cl-route-state.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-route-state.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-20-j2cl-route-state",
+  "version": "Unreleased",
+  "date": "2026-04-20",
+  "title": "The J2CL search sidecar now restores query and selected-wave route state",
+  "summary": "The isolated /j2cl-search/index.html sidecar now keeps the active query and selected wave in the URL so reload, copied links, and browser back or forward restore the same split-view state without changing the legacy GWT root route.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added durable J2CL sidecar route state for the search query and selected wave under /j2cl-search/index.html",
+        "Reloaded or copied sidecar URLs now reopen the same selected wave and preserve back or forward navigation between query-only and query-plus-wave states",
+        "Sidecar route restore now keeps the selected-wave panel stable even when the latest search refresh cannot currently rehydrate digest metadata"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add durable J2CL sidecar route state for query plus selected wave
- restore copied selected-wave URLs and browser back/forward behavior on the split-view sidecar
- keep the legacy GWT root untouched while stabilizing the sidecar shell for later #922 work

## Verification
- `./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -Dtest=J2clSidecarRouteCodecTest,J2clSidecarRouteControllerTest,J2clSearchPanelControllerTest,SandboxBuildSmokeTest test`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
- local browser verification on `9911`
  - copied selected-wave URL restored both query and selected wave in a fresh tab
  - Back returned to query-only state
  - Forward restored query+wave state with the selected-wave panel reopened
  - malformed `wave=%25` normalized back to query-only URL
  - invalid but well-formed `wave=example.com/w+missing` kept the split shell mounted and rendered a controlled selected-wave error

## Scope note
- This PR intentionally stays inside #921 durable route state and split-view navigation.
- Write-path work remains in #922.
- Root shell/bootstrap work remains in #928 / #923+.

Closes #921


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search query and selected wave are persisted in shareable URLs; reloads, back/forward navigation, and copied links restore split-view state.

* **Documentation**
  * Added a detailed implementation plan, verification steps, and definition-of-done for route-state behavior.

* **UI**
  * Clarified selected-wave help text to note that copied sidecar URLs can restore the selected wave when present.

* **Tests**
  * Added and updated tests for route parsing, URL canonicalization, history behavior, and codec encoding/decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->