### PR TITLE
feat(j2cl): add sidecar write-path pilot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -855,6 +855,20 @@ def runJ2clWrapper(log: Logger, base: File, profile: String, goal: String): Unit
   if (!pom.exists() || !pom.isFile) {
     sys.error(s"[j2cl] missing pom.xml: ${pom.getAbsolutePath}")
   }
+  if (goal == "package") {
+    val outputDir = profile match {
+      case "search-sidecar" => Some(base / "war" / "j2cl-search")
+      case "debug-single-project" => Some(base / "war" / "j2cl-debug")
+      case "production" => Some(base / "war" / "j2cl")
+      case _ => None
+    }
+    outputDir.foreach { dir =>
+      if (dir.exists()) {
+        log.info(s"[j2cl] deleting stale output directory ${dir.getAbsolutePath} before $profile:$goal")
+        IO.delete(dir)
+      }
+    }
+  }
   val cmd =
     if (isWindows) {
       Seq("cmd", "/c", wrapper.getAbsolutePath, "-f", pom.getAbsolutePath, s"-P$profile", "-q", goal)

--- a/docs/superpowers/plans/2026-04-20-issue-922-j2cl-write-path.md
+++ b/docs/superpowers/plans/2026-04-20-issue-922-j2cl-write-path.md
@@ -1,0 +1,396 @@
+# Issue #922 J2CL Write-Path Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first J2CL sidecar write-path pilot on top of the reviewed `#921` shell so a real user can create a wave, reply with plain text, submit from visible sidecar UI, and observe the resulting update in the opened wave while the legacy GWT root path stays unchanged.
+
+**Architecture:** Start from the post-`#921` sidecar shell, not the older `origin/main` read-only snapshot. Keep the durable route contract exactly `query + selected wave`, add one narrow compose/reply coordinator plus plain-text-only sidecar UI, and extend the existing sidecar websocket transport with submit request/response handling. Promote only the minimal selected-wave metadata needed for writes such as wavelet name, channel id, version basis, and stable root-thread target identifiers; keep draft text, loading state, and submit errors in memory only.
+
+**Tech Stack:** Java, SBT, J2CL Maven sidecar under `j2cl/`, Elemental2 DOM, post-`#921` route-state shell, shared pure-logic wave model classes from `wave/model`, generated `gson` protocol models, `scripts/worktree-file-store.sh`, `scripts/worktree-boot.sh`, and manual browser verification against the local staged app.
+
+---
+
+## 1. Goal / Root Cause
+
+This plan is explicitly for the reviewed post-`#921` baseline represented by `origin/issue-921-j2cl-route-state-mainline`, not the older `origin/main` snapshot that only has the `#920` read-only selected-wave slice. If `#921` is not merged into the issue lane when implementation begins, stack `#922` on top of that reviewed route-state lane first; do not recreate route-state work inside `#922`.
+
+Issue `#922` exists because the J2CL sidecar can now search, open a selected wave, reconnect, and preserve `q + wave` navigation, but it still has no end-to-end write seam:
+
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java:43-60` wires only `J2clSearchPanelController` plus `J2clSelectedWaveController`; there is no compose/reply controller or submit path in the mounted sidecar shell.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:64-125` renders only the search form, digest list, show-more affordance, and selected-wave host. There is no visible "new wave" affordance or compose surface.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:20-96` renders a read-only selected-wave card with status, participants, snippet, and `<pre>` blocks. It has no reply affordance, draft input, or submit/error state.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:18-129` supports only `fetchRootSessionBootstrap(...)`, `search(...)`, and `openSelectedWave(...)`. There is no submit/create operation on the existing socket transport.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:13-147` encodes authenticate/open envelopes and decodes search, selected-wave, and `RpcFinished` messages, but it has no `ProtocolSubmitRequest` / `ProtocolSubmitResponse` support.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:18-20,165-170` stores only participant ids plus flattened content strings, and `J2clSelectedWaveProjector.java:26-49` collapses the transport payload into display text. The current selected-wave projection drops the stable write metadata a submit path needs.
+- `origin/main` `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java:7-57` already carries `waveletName`, `channelId`, participant ids, and document ids, so the missing seam is not "write data unavailable." The missing seam is promoting just enough of that data out of the read-only controller to build a minimal submit flow.
+- `origin/issue-921-j2cl-route-state-mainline` `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java:66-90` already owns durable `q + wave` state. `#922` should consume that shell and preserve its contract, not redesign route state.
+
+The narrow root cause is therefore not "full editor missing." The actual missing seams are:
+
+- no user-reachable compose/reply UI in the sidecar shell
+- no sidecar submit transport over the existing websocket path
+- no sidecar-owned plain-text delta builder
+- no bridge from opened-wave context to write-target metadata and post-submit route/update behavior
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Start from the reviewed post-`#921` route-state shell and keep its URL contract.
+- Add one visible sidecar compose affordance for creating a new wave.
+- Add one visible sidecar reply affordance for the currently opened wave.
+- Keep the write payload plain text only.
+- After successful create, select/open the created wave inside the same sidecar shell.
+- After successful reply, keep the current wave open and observe the resulting update in the selected-wave panel.
+- Surface submit loading/error states visibly and keep draft text when submit fails.
+- Keep the legacy GWT root route compiling, staging, booting, and smoke-checking exactly as before.
+
+### Explicit Non-Goals
+
+- No rich formatting, toolbar actions, attachment upload, gadget support, or editor parity.
+- No full editor migration, caret/selection behavior, draft OT parity, or inline editing stack.
+- No route-state redesign and no draft text in the URL. `#921` owns the durable route contract, and it remains `query + selected wave` only.
+- No root shell/bootstrap/cutover work. That stays with `#928`, `#923`, `#924`, and `#925`.
+- No legacy GWT root-path changes and no patching of `WavePanelImpl` just to make the sidecar pilot work.
+- No participant picker or direct-message parity. The narrow create flow for this slice should create a self-owned wave; broader create UX is a later concern.
+- No arbitrary per-blip nested reply targeting. The first pilot may reply only to the opened wave's root/main conversation target if that is the narrowest reliable write seam.
+
+## 3. Exact Files Likely To Change
+
+### Primary Post-`#921` Sidecar Files
+
+These are the core seams once the reviewed `#921` baseline is present in the lane:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- `j2cl/src/main/webapp/assets/sidecar.css`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- `wave/config/changelog.d/2026-04-20-j2cl-write-path.json`
+
+### Likely New Sidecar-Write Files
+
+These filenames are the narrowest likely additions based on the existing `j2cl/search` and `j2cl/transport` layout. Equivalent names are acceptable, but keep write-state, submit transport, and delta construction as separate responsibilities:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitRequest.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitResponse.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java`
+
+### Conditional Supporting File
+
+Touch this only if the chosen create-wave id generation path needs more session metadata than the current sidecar bootstrap exposes:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java`
+
+### Existing Files That Are Inspect-Only References
+
+These are good references for contract shape and legacy behavior, but `#922` should not port the whole root webclient into the sidecar:
+
+- `gen/messages/org/waveprotocol/box/common/comms/gson/ProtocolSubmitRequestGsonImpl.java`
+- `gen/messages/org/waveprotocol/box/common/comms/gson/ProtocolSubmitResponseGsonImpl.java`
+- `gen/messages/org/waveprotocol/wave/federation/gson/ProtocolWaveletDeltaGsonImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteWaveViewService.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/StageTwoProvider.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/ClientIdGenerator.java`
+- `wave/src/main/java/org/waveprotocol/wave/model/id/IdGeneratorImpl.java`
+- `wave/src/main/java/org/waveprotocol/wave/model/operation/wave/WaveletDelta.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ActionsImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/common/WaveletOperationSerializer.java`
+
+`WaveletOperationSerializer` is a legacy contract reference only. Do not copy the GWT JSO path wholesale into J2CL unless a focused safety probe proves it is actually usable.
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Freeze The `#922` Baseline And Pilot Contract Before Coding
+
+- [ ] Start from `origin/issue-921-j2cl-route-state-mainline` or a merged equivalent. If the lane still points at the pre-`#921` `origin/main` tree, stack the route-state baseline first instead of rebuilding it inside `#922`.
+- [ ] Keep the durable route contract exactly as `#921` defined it:
+  - `?q=<encoded-query>`
+  - `&wave=<encoded-wave-id>` when a wave is selected
+- [ ] Keep draft text, submit loading, and submit error state in memory only. Do **not** add composer state to the URL.
+- [ ] Do not add a new feature flag for this slice unless implementation proves an operational need that cannot be contained by the existing sidecar-only route boundary. The default assumption for this pilot is “no new flag.”
+- [ ] Make the pilot UI contract explicit before implementation starts:
+  - one visible `New wave` action in the sidecar shell
+  - one visible `Reply` action in the opened selected-wave panel
+  - plain-text-only input such as a `<textarea>`
+  - no devtools-only triggers and no hidden deep-link-only entrypoints
+- [ ] Keep the create scope intentionally narrow:
+  - create a self-owned wave only
+  - no participant picker
+  - no direct-message/send-message parity
+- [ ] Keep the reply target intentionally narrow:
+  - reply only against the currently opened wave
+  - target only the root/main conversation seam that the selected-wave payload can identify reliably
+  - no per-blip reply-placement UI and no nested-thread editor parity
+- [ ] Treat a server-driven selected-wave update as the success proof after submit. An optimistic local append by itself does **not** satisfy this issue.
+
+### Task 2: Add A User-Reachable Sidecar Compose / Reply Surface
+
+- [ ] Extend the sidecar shell so create and reply are reachable without leaving `/j2cl-search/index.html`.
+- [ ] Keep create UI reachable even when no wave is selected.
+- [ ] Keep reply UI hidden or disabled until the opened wave has enough write context to submit safely.
+- [ ] Add explicit UI states for:
+  - empty draft validation
+  - in-flight submit
+  - submit error
+  - successful create handoff into the opened wave
+- [ ] Preserve the current post-`#921` split view and responsive behavior. This slice adds compose surfaces; it does not redesign the shell.
+- [ ] Continue using safe text insertion only. Do not introduce raw HTML rendering while adding compose UI.
+
+### Task 3: Promote Only The Minimal Opened-Wave Metadata Needed For Writes
+
+- [ ] Extend the selected-wave controller/model seam so the write path can access a minimal write session containing:
+  - selected wave id
+  - opened wavelet name
+  - current channel id
+  - the latest version basis required for submit
+  - a stable root/main conversation target identifier for the reply pilot
+- [ ] Pin the reply target contract before implementation starts:
+  - first choice: the root/main conversation target exposed by the currently opened `b+root` document/blip when present
+  - fallback: the first stable `b+...` document/blip identifier from the selected-wave payload if `b+root` is not present
+  - do not widen into arbitrary nested-thread targeting in this slice
+- [ ] Keep that state sidecar-local. Do **not** widen into a full conversation model or a `WavePanelImpl` migration.
+- [ ] Update the selected-wave projection only enough to retain stable document or blip ids alongside visible text, so the reply pilot can target the correct root/main conversation seam.
+- [ ] Preserve the existing reconnect behavior. If the selected-wave controller reconnects, the reply affordance should recover once the write session is re-established.
+- [ ] Keep stale-generation protection intact so old updates or old write-session callbacks cannot overwrite a newly selected wave.
+
+### Task 4: Add A Sidecar-Only Plain-Text Submit Transport
+
+- [ ] Start with a J2CL-safety probe for the generated submit message family:
+  - `ProtocolSubmitRequestGsonImpl`
+  - `ProtocolSubmitResponseGsonImpl`
+  - `ProtocolWaveletDeltaGsonImpl`
+- [ ] If that gson path compiles cleanly into `j2clSearchTest` and can round-trip a minimal submit envelope in a focused test, reuse it.
+- [ ] If the probe is not green after one focused implementation spike and one focused test run, stop and switch to a sidecar-only manual JSON submit codec under `j2cl/transport` instead of widening into legacy JSO or root-client code. Record that decision in the issue comment before proceeding further.
+- [ ] Extend `J2clSearchGateway` with the narrow websocket submit operations needed for `#922`:
+  - submit create-wave delta
+  - submit reply delta against the current opened wave
+  - surface submit response success/error text
+- [ ] Correlate submit responses through one explicit sidecar contract such as a per-submit sequence number or generation id, and use that same identifier for stale-callback suppression in the compose controller.
+- [ ] Keep the submit path on the existing `/socket` transport using `ProtocolSubmitRequest`. Do not invent a separate HTTP write API for this pilot.
+- [ ] Keep submit transport logic sidecar-only under `j2cl/**`.
+
+### Task 5: Build The Minimal Plain-Text Delta Factory
+
+- [ ] Reuse shared J2CL-safe pure-logic classes from the post-`#903` work wherever possible:
+  - `WaveletDelta`
+  - `DocOpBuilder`
+  - `WaveletBlipOperation`
+  - `AddParticipant` only if the chosen create path needs it
+  - `IdGeneratorImpl` or an equally narrow sidecar-owned id generator
+- [ ] Keep create-wave delta authoring minimal:
+  - generate a new wave id
+  - target the conversation root wavelet
+  - create the initial root blip content with plain text only
+  - add only the participants required for the self-owned pilot
+- [ ] Keep reply delta authoring minimal:
+  - append one plain-text reply/continuation against the opened wave's chosen root/main conversation target
+  - no rich text annotations, attachments, gadgets, or toolbar actions
+- [ ] First confirm whether current sidecar bootstrap data is enough for id generation:
+  - default decision for this slice: prefer a sidecar-local generator using the current user/domain plus a sidecar-owned seed and keep bootstrap unchanged
+  - only extend `SidecarSessionBootstrap` if a focused probe proves the local generator cannot create a stable create-wave request shape
+  - if bootstrap must grow, extend it narrowly rather than pulling in the legacy `Session` abstraction
+- [ ] Do **not** port `RemoteWaveViewService` or the full GWT `WaveletOperationSerializer` stack into the sidecar unchanged. Use them only as contract references for field ordering and delta shape.
+- [ ] Add explicit plain-text validation rules before submit:
+  - reject blank drafts after trimming
+  - preserve newlines in plain text
+  - keep server error text visible when submit fails instead of replacing it with a generic message if the server already supplied one
+
+### Task 6: Wire Submit Success / Failure Into The Post-`#921` Shell Without Redesigning Route State
+
+- [ ] Create flow:
+  - submit the plain-text new-wave delta
+  - on success, update route state to the new `wave` id
+  - open/select that new wave in the selected-wave panel
+  - clear the create draft only after success
+- [ ] Reply flow:
+  - submit against the currently opened wave using the current write session
+  - keep the existing `q + wave` URL stable
+  - wait for the live selected-wave update to confirm the submitted text landed
+- [ ] Failure flow:
+  - preserve draft text
+  - surface submit error text in visible sidecar UI
+  - keep the current wave selection and query stable
+- [ ] Prevent route churn such as:
+  - create success selecting the new wave twice
+  - search refresh or selected-wave refresh pushing a duplicate history entry after submit
+  - stale submit callbacks overwriting a newer selection
+- [ ] Keep all shell/bootstrap work sidecar-only. No root-path or legacy GWT cutover changes belong here.
+
+### Task 7: Add Focused Tests For The Pilot
+
+- [ ] Add compose-controller tests for:
+  - blank draft validation
+  - create submit success path
+  - reply submit success path
+  - in-flight disable state
+  - error preserving draft text
+- [ ] Add transport tests for:
+  - submit request envelope shape
+  - submit response success/error decode
+  - any minimal create-wave and reply delta fixtures the sidecar authoring path depends on
+- [ ] Extend selected-wave tests for:
+  - write context only becomes available after real selected-wave open/update
+  - reconnect restores writeability after the selected wave resumes
+  - stale submit/update callbacks do not overwrite newer selection state
+- [ ] Extend post-`#921` route tests for:
+  - create success pushing the new `wave` route exactly once
+  - reply success not pushing a duplicate history entry
+  - server-echo refresh after submit not re-pushing the same URL
+- [ ] Add id-generation/bootstrap coverage if the chosen create path extends `SidecarSessionBootstrap` or introduces a sidecar-owned generator seam.
+- [ ] Manual browser verification is still mandatory for the actual create/reply/submit round-trip. Treat any automated end-to-end submit proof as optional for this slice unless a narrow test falls out naturally from the chosen transport seam.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-922-j2cl-write-path`.
+
+### Worktree File-Store Prep
+
+```bash
+cd /Users/vega/devroot/worktrees/issue-922-j2cl-write-path
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Expected result:
+
+- `wave/_accounts`, `wave/_attachments`, and `wave/_deltas` are available in the issue worktree
+- local browser verification can use realistic signed-in data and real waves
+
+### Main Cross-Path Build Gate
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+```
+
+Expected result:
+
+- J2CL search-sidecar build/tests pass
+- the new compose/reply tests pass
+- the legacy GWT root still compiles and stages green
+
+### Conditional Generated-Message Contract Gate
+
+Run this only if the write implementation changes generated transport/message families or codegen assumptions:
+
+```bash
+sbt -batch generatePstMessages "testOnly org.waveprotocol.pst.PstCodegenContractTest"
+```
+
+Expected result:
+
+- generated protocol/message families still match the authoritative PST contract
+- submit transport changes did not silently drift the generated codec layer
+
+### Local Boot / Smoke
+
+```bash
+bash scripts/worktree-boot.sh --port 9912
+```
+
+Then run the exact printed helper commands, typically:
+
+```bash
+PORT=9912 JAVA_OPTS='...' bash scripts/wave-smoke.sh start
+PORT=9912 bash scripts/wave-smoke.sh check
+```
+
+Keep the server running for the route checks and browser verification below.
+
+### Route Presence Checks
+
+```bash
+curl -sS -I http://localhost:9912/
+curl -sS -I http://localhost:9912/j2cl-search/index.html
+curl -sS -I "http://localhost:9912/j2cl-search/index.html?q=in%3Ainbox"
+```
+
+After the browser create flow succeeds and the sidecar URL points at the new wave, also run:
+
+```bash
+curl -sS -I "<copied-j2cl-sidecar-url-after-create>"
+```
+
+Expected result:
+
+- `/` responds successfully and remains the legacy GWT route
+- `/j2cl-search/index.html` responds successfully and mounts the J2CL sidecar
+- the canonical `q + wave` sidecar URL still resolves after the write-path pilot lands
+
+### Manual Browser Verification
+
+Use the same signed-in browser session for both routes:
+
+- `http://localhost:9912/`
+- `http://localhost:9912/j2cl-search/index.html`
+
+Verify all of the following:
+
+- legacy `/` still loads and remains usable
+- `/j2cl-search/index.html` still supports search, digest selection, and post-`#921` route restore behavior
+- the sidecar visibly exposes a `New wave` compose affordance without devtools or hidden URLs
+- create flow:
+  - open the visible create UI
+  - enter plain text
+  - submit successfully
+  - the sidecar route updates to the created wave
+  - the created wave opens in the selected-wave panel
+  - the submitted text is visible in that opened wave without a full-page reload
+- reply flow:
+  - open an existing wave in the sidecar
+  - use the visible reply affordance
+  - enter plain text
+  - submit successfully
+  - the selected-wave panel shows the new content in the opened wave
+- submit UX:
+  - blank submit is blocked
+  - controls disable while a submit is in flight
+  - an induced submit failure surfaces visible error text and preserves the draft
+- route/shell coherence:
+  - the browser URL remains on the existing `q + wave` contract
+  - back/forward still behaves coherently after create/reply
+  - refresh of the copied created-wave URL still restores the same selected wave on the post-`#921` shell
+- server-driven update proof:
+  - do not count a local optimistic append alone as success
+  - confirm the opened selected-wave panel reflects the submitted text via the live selected-wave update path after submit
+
+When verification is complete:
+
+```bash
+PORT=9912 bash scripts/wave-smoke.sh stop
+```
+
+Record the exact port, route checks, and browser observations in `journal/local-verification/`.
+
+## 6. Review / PR Expectations
+
+- Run Claude plan review before implementation starts.
+- After implementation, run direct review plus Claude implementation review.
+- Address valid review comments with real fixes or explicit technical replies; do not resolve threads just to satisfy monitoring.
+- If implementation must stack on the `#921` lane, preserve the route-state branch semantics and do not regress the reviewed `q + wave` behavior while adding writes.
+- Keep issue, commits, verification, and PR traceability aligned.
+
+## 7. Definition Of Done For This Slice
+
+- On the post-`#921` sidecar route, a visible create affordance can submit plain text and open the created wave inside the sidecar.
+- On the post-`#921` sidecar route, a visible reply affordance can submit plain text against the opened wave's narrow pilot reply target.
+- Submit success is proven by the selected-wave live update path, not only by optimistic local UI.
+- Route state remains limited to `query + selected wave`; there is no draft-text URL contract and no route-state redesign.
+- Rich formatting, full editor parity, root shell/bootstrap/cutover, and legacy GWT root changes remain untouched.
+- The legacy GWT root path still compiles, stages, boots, and smoke-checks green.
+- Issue comments and PR traceability include worktree, plan path, verification commands/results, review summary, and PR link.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -50,16 +50,24 @@ public final class SandboxEntryPoint {
           new J2clSelectedWaveView(searchView.getSelectedWaveHost());
       J2clSearchGateway gateway = new J2clSearchGateway();
       final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
+      final J2clSelectedWaveController[] selectedWaveControllerRef =
+          new J2clSelectedWaveController[1];
       J2clSidecarComposeController composeController =
           new J2clSidecarComposeController(
               gateway,
               new J2clSidecarComposeView(
                   searchView.getComposeHost(), selectedWaveView.getComposeHost()),
               new J2clPlainTextDeltaFactory(buildSidecarSessionSeed()),
-              waveId -> routeControllerRef[0].selectWave(waveId));
+              waveId -> routeControllerRef[0].selectWave(waveId),
+              waveId -> {
+                if (selectedWaveControllerRef[0] != null) {
+                  selectedWaveControllerRef[0].refreshSelectedWave();
+                }
+              });
       J2clSelectedWaveController selectedWaveController =
           new J2clSelectedWaveController(
               gateway, selectedWaveView, composeController::onWriteSessionChanged);
+      selectedWaveControllerRef[0] = selectedWaveController;
       J2clSearchPanelController controller =
           new J2clSearchPanelController(
               gateway,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -13,6 +13,9 @@ import jsinterop.annotations.JsType;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
+import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
+import org.waveprotocol.box.j2cl.search.J2clSidecarComposeController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarComposeView;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveController;
@@ -43,11 +46,20 @@ public final class SandboxEntryPoint {
 
     if ("search-sidecar".equals(mode)) {
       J2clSearchPanelView searchView = new J2clSearchPanelView(host);
+      J2clSelectedWaveView selectedWaveView =
+          new J2clSelectedWaveView(searchView.getSelectedWaveHost());
       J2clSearchGateway gateway = new J2clSearchGateway();
+      final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
+      J2clSidecarComposeController composeController =
+          new J2clSidecarComposeController(
+              gateway,
+              new J2clSidecarComposeView(
+                  searchView.getComposeHost(), selectedWaveView.getComposeHost()),
+              new J2clPlainTextDeltaFactory(buildSidecarSessionSeed()),
+              waveId -> routeControllerRef[0].selectWave(waveId));
       J2clSelectedWaveController selectedWaveController =
           new J2clSelectedWaveController(
-              gateway, new J2clSelectedWaveView(searchView.getSelectedWaveHost()));
-      final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
+              gateway, selectedWaveView, composeController::onWriteSessionChanged);
       J2clSearchPanelController controller =
           new J2clSearchPanelController(
               gateway,
@@ -61,6 +73,7 @@ public final class SandboxEntryPoint {
               controller,
               selectedWaveController);
       routeControllerRef[0] = routeController;
+      composeController.start();
       routeController.start();
       return;
     }
@@ -133,6 +146,12 @@ public final class SandboxEntryPoint {
 
   private static double resolveViewportWidth() {
     return Double.parseDouble(String.valueOf(DomGlobal.window.innerWidth));
+  }
+
+  private static String buildSidecarSessionSeed() {
+    long timestampSeed = System.currentTimeMillis();
+    long randomSeed = (long) Math.floor(Math.random() * 0x7fffffff);
+    return "j2cl" + Long.toHexString(timestampSeed) + Long.toHexString(randomSeed);
   }
 
   @JsFunction

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -59,7 +59,7 @@ public class J2clPlainTextDeltaFactory {
     String deltaJson =
         buildDeltaJson(
             session.getBaseVersion(),
-            "",
+            session.getHistoryHash(),
             normalizedAddress,
             "{\"3\":{\"1\":\""
                 + escapeJson(replyBlipId)
@@ -114,21 +114,9 @@ public class J2clPlainTextDeltaFactory {
   }
 
   private static String buildVersionZeroHistoryHash(String domain, String waveToken) {
-    return encodeHex(
-        "wave://" + domain + "/" + encodeWaveUriPart(waveToken) + "/" + encodeWaveUriPart("conv+root"));
-  }
-
-  private static String encodeWaveUriPart(String value) {
-    StringBuilder encoded = new StringBuilder(value.length() + 8);
-    for (int i = 0; i < value.length(); i++) {
-      char c = value.charAt(i);
-      if (c == '+') {
-        encoded.append("%2B");
-      } else {
-        encoded.append(c);
-      }
-    }
-    return encoded.toString();
+    // The server seeds v0 hashes from IdURIEncoderDecoder.waveletNameToURI(...), which keeps the
+    // literal '+' characters in w+... and conv+root before the bytes are hex-encoded.
+    return encodeHex("wave://" + domain + "/" + waveToken + "/" + "conv+root");
   }
 
   private static String encodeHex(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -1,0 +1,234 @@
+package org.waveprotocol.box.j2cl.search;
+
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+
+public class J2clPlainTextDeltaFactory {
+  public static final class CreateWaveRequest {
+    private final String createdWaveId;
+    private final SidecarSubmitRequest submitRequest;
+
+    public CreateWaveRequest(String createdWaveId, SidecarSubmitRequest submitRequest) {
+      this.createdWaveId = createdWaveId;
+      this.submitRequest = submitRequest;
+    }
+
+    public String getCreatedWaveId() {
+      return createdWaveId;
+    }
+
+    public SidecarSubmitRequest getSubmitRequest() {
+      return submitRequest;
+    }
+  }
+
+  private static final char[] WEB64_ALPHABET =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+
+  private final String sessionSeed;
+  private int counter;
+
+  public J2clPlainTextDeltaFactory(String sessionSeed) {
+    this.sessionSeed = sanitizeSeed(sessionSeed);
+  }
+
+  public CreateWaveRequest createWaveRequest(String address, String text) {
+    String normalizedAddress = normalizeAddress(address);
+    String domain = extractDomain(normalizedAddress);
+    String waveToken = nextToken("w+");
+    String createdWaveId = domain + "/" + waveToken;
+    String versionZeroHistoryHash = buildVersionZeroHistoryHash(domain, waveToken);
+    String deltaJson =
+        buildDeltaJson(
+            0L,
+            versionZeroHistoryHash,
+            normalizedAddress,
+            "{\"1\":\""
+                + escapeJson(normalizedAddress)
+                + "\"},{\"3\":{\"1\":\"b+root\",\"2\":{\"1\":[{\"2\":\""
+                + escapeJson(text)
+                + "\"}]}}}");
+    return new CreateWaveRequest(
+        createdWaveId,
+        new SidecarSubmitRequest(buildWaveletName(createdWaveId), deltaJson, null));
+  }
+
+  public SidecarSubmitRequest createReplyRequest(
+      String address, J2clSidecarWriteSession session, String text) {
+    String normalizedAddress = normalizeAddress(address);
+    String replyBlipId = nextToken("b+");
+    String deltaJson =
+        buildDeltaJson(
+            session.getBaseVersion(),
+            "",
+            normalizedAddress,
+            "{\"3\":{\"1\":\""
+                + escapeJson(replyBlipId)
+                + "\",\"2\":{\"1\":[{\"2\":\""
+                + escapeJson(text)
+                + "\"}]}}}");
+    return new SidecarSubmitRequest(
+        buildWaveletName(session.getSelectedWaveId()), deltaJson, session.getChannelId());
+  }
+
+  private String buildDeltaJson(
+      long baseVersion, String historyHash, String address, String operationsJson) {
+    return "{\"1\":{\"1\":"
+        + baseVersion
+        + ",\"2\":\""
+        + escapeJson(historyHash)
+        + "\"},\"2\":\""
+        + escapeJson(address)
+        + "\",\"3\":["
+        + operationsJson
+        + "]}";
+  }
+
+  private String buildWaveletName(String waveId) {
+    int separator = waveId.indexOf('/');
+    if (separator <= 0 || separator >= waveId.length() - 1) {
+      throw new IllegalArgumentException("Invalid wave id: " + waveId);
+    }
+    return waveId.substring(0, separator)
+        + "/"
+        + waveId.substring(separator + 1)
+        + "/~/conv+root";
+  }
+
+  private static String normalizeAddress(String address) {
+    if (address == null) {
+      throw new IllegalArgumentException("Missing session address for sidecar submit.");
+    }
+    String trimmed = address.trim().toLowerCase();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException("Missing session address for sidecar submit.");
+    }
+    return trimmed;
+  }
+
+  private static String extractDomain(String address) {
+    int at = address.indexOf('@');
+    if (at < 1 || at == address.length() - 1) {
+      throw new IllegalArgumentException("Invalid participant address: " + address);
+    }
+    return address.substring(at + 1);
+  }
+
+  private static String buildVersionZeroHistoryHash(String domain, String waveToken) {
+    return encodeHex(
+        "wave://" + domain + "/" + encodeWaveUriPart(waveToken) + "/" + encodeWaveUriPart("conv+root"));
+  }
+
+  private static String encodeWaveUriPart(String value) {
+    StringBuilder encoded = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '+') {
+        encoded.append("%2B");
+      } else {
+        encoded.append(c);
+      }
+    }
+    return encoded.toString();
+  }
+
+  private static String encodeHex(String value) {
+    StringBuilder encoded = new StringBuilder(value.length() * 2);
+    for (int i = 0; i < value.length(); i++) {
+      int ch = value.charAt(i);
+      encoded.append(toHexDigit((ch >> 4) & 0xF));
+      encoded.append(toHexDigit(ch & 0xF));
+    }
+    return encoded.toString();
+  }
+
+  private static char toHexDigit(int value) {
+    return (char) (value < 10 ? ('0' + value) : ('A' + (value - 10)));
+  }
+
+  private String nextToken(String prefix) {
+    return prefix + sessionSeed + base64Encode(counter++);
+  }
+
+  private static String sanitizeSeed(String rawSeed) {
+    if (rawSeed == null || rawSeed.isEmpty()) {
+      return "j2cl";
+    }
+    StringBuilder sanitized = new StringBuilder(rawSeed.length());
+    for (int i = 0; i < rawSeed.length(); i++) {
+      char c = rawSeed.charAt(i);
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_') {
+        sanitized.append(c);
+      }
+    }
+    return sanitized.length() == 0 ? "j2cl" : sanitized.toString();
+  }
+
+  private static String base64Encode(int intValue) {
+    if (intValue == 0) {
+      return "A";
+    }
+    int numEncodedBytes = (int) Math.ceil((32 - Integer.numberOfLeadingZeros(intValue)) / 6.0);
+    StringBuilder encoded = new StringBuilder(numEncodedBytes);
+    switch (numEncodedBytes) {
+      case 6:
+        encoded.append(WEB64_ALPHABET[(intValue >> 30) & 0x3F]);
+      case 5:
+        encoded.append(WEB64_ALPHABET[(intValue >> 24) & 0x3F]);
+      case 4:
+        encoded.append(WEB64_ALPHABET[(intValue >> 18) & 0x3F]);
+      case 3:
+        encoded.append(WEB64_ALPHABET[(intValue >> 12) & 0x3F]);
+      case 2:
+        encoded.append(WEB64_ALPHABET[(intValue >> 6) & 0x3F]);
+      default:
+        encoded.append(WEB64_ALPHABET[intValue & 0x3F]);
+    }
+    return encoded.toString();
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          escaped.append("\\\"");
+          break;
+        case '\\':
+          escaped.append("\\\\");
+          break;
+        case '\b':
+          escaped.append("\\b");
+          break;
+        case '\f':
+          escaped.append("\\f");
+          break;
+        case '\n':
+          escaped.append("\\n");
+          break;
+        case '\r':
+          escaped.append("\\r");
+          break;
+        case '\t':
+          escaped.append("\\t");
+          break;
+        default:
+          if (c < 0x20) {
+            escaped.append("\\u00");
+            String hex = Integer.toHexString(c);
+            if (hex.length() == 1) {
+              escaped.append('0');
+            }
+            escaped.append(hex);
+          } else {
+            escaped.append(c);
+          }
+      }
+    }
+    return escaped.toString();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -9,10 +9,15 @@ import jsinterop.annotations.JsPackage;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
 
 public final class J2clSearchGateway
-    implements J2clSearchPanelController.SearchGateway, J2clSelectedWaveController.Gateway {
+    implements
+        J2clSearchPanelController.SearchGateway,
+        J2clSelectedWaveController.Gateway,
+        J2clSidecarComposeController.Gateway {
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
 
   @Override
@@ -126,6 +131,70 @@ public final class J2clSearchGateway
           }
         },
         onError);
+  }
+
+  @Override
+  public void submit(
+      SidecarSessionBootstrap bootstrap,
+      SidecarSubmitRequest request,
+      J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    WebSocket socket =
+        new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
+    final boolean[] closedByClient = new boolean[] {false};
+    final boolean[] responseHandled = new boolean[] {false};
+    socket.onopen =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          String token = readCookie("JSESSIONID");
+          if (token != null && !token.isEmpty()) {
+            socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
+          }
+          socket.send(SidecarTransportCodec.encodeSubmitEnvelope(1, request));
+        };
+    socket.onmessage =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          try {
+            String payload = String.valueOf(event.data);
+            Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(payload);
+            String messageType = (String) envelope.get("messageType");
+            if ("ProtocolSubmitResponse".equals(messageType)) {
+              responseHandled[0] = true;
+              closeSocket(socket, closedByClient);
+              onSuccess.accept(SidecarTransportCodec.decodeSubmitResponse(envelope));
+              return;
+            }
+            if ("RpcFinished".equals(messageType)
+                && SidecarTransportCodec.decodeRpcFinishedFailed(envelope)) {
+              responseHandled[0] = true;
+              closeSocket(socket, closedByClient);
+              onError.accept(
+                  SidecarTransportCodec.decodeRpcFinishedErrorText(
+                      envelope, "The sidecar submit request failed."));
+            }
+          } catch (RuntimeException e) {
+            closeSocket(socket, closedByClient);
+            onError.accept(messageOrDefault(e, "Unable to decode the sidecar submit response."));
+          }
+        };
+    socket.onerror =
+        event -> {
+          if (!closedByClient[0]) {
+            closeSocket(socket, closedByClient);
+            onError.accept("Network failure while submitting the sidecar write request.");
+          }
+        };
+    socket.onclose =
+        event -> {
+          if (!closedByClient[0] && !responseHandled[0]) {
+            onError.accept("The sidecar submit socket closed before the server replied.");
+          }
+        };
   }
 
   private static String buildSearchUrl(String query, int index, int numResults) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -103,6 +103,12 @@ public final class J2clSearchPanelController
   }
 
   @Override
+  public void syncSelection(String selectedWaveId) {
+    this.selectedWaveId = normalizeSelectedWaveId(selectedWaveId);
+    view.setSelectedWaveId(this.selectedWaveId);
+  }
+
+  @Override
   public void onQuerySubmitted(String query) {
     currentQuery = J2clSearchResultProjector.normalizeQuery(query);
     currentPageSize = pageIncrement;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -16,6 +16,7 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   private final HTMLElement waveCount;
   private final HTMLInputElement queryInput;
   private final HTMLButtonElement submitButton;
+  private final HTMLElement composeHost;
   private final HTMLDivElement digestList;
   private final HTMLElement emptyState;
   private final HTMLButtonElement showMoreButton;
@@ -87,6 +88,10 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
           }
           return null;
         };
+
+    composeHost = (HTMLElement) DomGlobal.document.createElement("div");
+    composeHost.className = "sidecar-search-compose";
+    card.appendChild(composeHost);
 
     status = (HTMLElement) DomGlobal.document.createElement("p");
     status.className = "sidecar-search-status";
@@ -200,5 +205,9 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
 
   public HTMLElement getSelectedWaveHost() {
     return selectedWaveHost;
+  }
+
+  public HTMLElement getComposeHost() {
+    return composeHost;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -93,6 +93,18 @@ public final class J2clSelectedWaveController
     onWaveSelected(waveId, null);
   }
 
+  public void refreshSelectedWave() {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return;
+    }
+    int generation = ++requestGeneration;
+    closeSubscription();
+    reconnectCount = 0;
+    // A refresh happens after the reply already committed on the server, so transient bootstrap or
+    // open failures should recover like a reconnect instead of strand the panel on stale content.
+    fetchBootstrapAndOpenSelectedWave(generation, 0, true);
+  }
+
   @Override
   public void onWaveSelected(String waveId, J2clSearchDigestItem digestItem) {
     if (waveId != null

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -36,9 +36,15 @@ public final class J2clSelectedWaveController
     void close();
   }
 
+  @FunctionalInterface
+  public interface WriteSessionListener {
+    void onWriteSessionChanged(J2clSidecarWriteSession writeSession);
+  }
+
   private final Gateway gateway;
   private final View view;
   private final RetryScheduler retryScheduler;
+  private final WriteSessionListener writeSessionListener;
   private Subscription currentSubscription;
   private SidecarSessionBootstrap currentBootstrap;
   private SidecarSelectedWaveUpdate lastUpdate;
@@ -52,15 +58,35 @@ public final class J2clSelectedWaveController
     this(
         gateway,
         view,
-        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs));
+        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs),
+        null);
   }
 
   public J2clSelectedWaveController(Gateway gateway, View view, RetryScheduler retryScheduler) {
+    this(gateway, view, retryScheduler, null);
+  }
+
+  public J2clSelectedWaveController(
+      Gateway gateway, View view, WriteSessionListener writeSessionListener) {
+    this(
+        gateway,
+        view,
+        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs),
+        writeSessionListener);
+  }
+
+  public J2clSelectedWaveController(
+      Gateway gateway,
+      View view,
+      RetryScheduler retryScheduler,
+      WriteSessionListener writeSessionListener) {
     this.gateway = gateway;
     this.view = view;
     this.retryScheduler = retryScheduler;
+    this.writeSessionListener = writeSessionListener;
     this.currentModel = J2clSelectedWaveModel.empty();
     this.view.render(currentModel);
+    publishWriteSession();
   }
 
   public void onWaveSelected(String waveId) {
@@ -79,6 +105,7 @@ public final class J2clSelectedWaveController
             J2clSelectedWaveProjector.project(
                 selectedWaveId, selectedDigestItem, lastUpdate, currentModel, reconnectCount);
         view.render(currentModel);
+        publishWriteSession();
       }
       return;
     }
@@ -94,6 +121,7 @@ public final class J2clSelectedWaveController
       reconnectCount = 0;
       currentModel = J2clSelectedWaveModel.empty();
       view.render(currentModel);
+      publishWriteSession();
       return;
     }
 
@@ -112,6 +140,7 @@ public final class J2clSelectedWaveController
     this.reconnectCount = reconnectCount;
     currentModel = J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount);
     view.render(currentModel);
+    publishWriteSession();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
           if (!isCurrentGeneration(generation)) {
@@ -134,6 +163,7 @@ public final class J2clSelectedWaveController
               J2clSelectedWaveModel.error(
                   selectedWaveId, selectedDigestItem, "Unable to open selected wave.", error);
           view.render(currentModel);
+          publishWriteSession();
         });
   }
 
@@ -162,6 +192,7 @@ public final class J2clSelectedWaveController
                       currentModel,
                       projectedReconnectCount);
               view.render(currentModel);
+              publishWriteSession();
               activeReconnectCount[0] = 0;
               this.reconnectCount = projectedReconnectCount;
             },
@@ -182,6 +213,7 @@ public final class J2clSelectedWaveController
                   J2clSelectedWaveModel.error(
                       selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
               view.render(currentModel);
+              publishWriteSession();
             },
             () -> {
               if (!isCurrentGeneration(generation) || selectedWaveId == null) {
@@ -207,6 +239,7 @@ public final class J2clSelectedWaveController
                   + MAX_RECONNECT_ATTEMPTS
                   + " reconnect attempts.");
       view.render(currentModel);
+      publishWriteSession();
       return;
     }
     int nextReconnectCount = reconnectCount + 1;
@@ -246,5 +279,11 @@ public final class J2clSelectedWaveController
   private static int buildReconnectDelayMs(int reconnectCount) {
     int delayMs = INITIAL_RECONNECT_DELAY_MS << reconnectCount;
     return Math.min(delayMs, MAX_RECONNECT_DELAY_MS);
+  }
+
+  private void publishWriteSession() {
+    if (writeSessionListener != null) {
+      writeSessionListener.onWriteSessionChanged(currentModel.getWriteSession());
+    }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -17,6 +17,7 @@ public final class J2clSelectedWaveModel {
   private final int reconnectCount;
   private final List<String> participantIds;
   private final List<String> contentEntries;
+  private final J2clSidecarWriteSession writeSession;
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -30,7 +31,8 @@ public final class J2clSelectedWaveModel {
       String detailText,
       int reconnectCount,
       List<String> participantIds,
-      List<String> contentEntries) {
+      List<String> contentEntries,
+      J2clSidecarWriteSession writeSession) {
     this.hasSelection = hasSelection;
     this.loading = loading;
     this.error = error;
@@ -49,6 +51,7 @@ public final class J2clSelectedWaveModel {
         contentEntries == null
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(contentEntries));
+    this.writeSession = writeSession;
   }
 
   public static J2clSelectedWaveModel empty() {
@@ -64,7 +67,8 @@ public final class J2clSelectedWaveModel {
         "Copied sidecar URLs can restore the selected wave when the route includes it.",
         0,
         Collections.<String>emptyList(),
-        Collections.<String>emptyList());
+        Collections.<String>emptyList(),
+        null);
   }
 
   public static J2clSelectedWaveModel loading(
@@ -83,7 +87,8 @@ public final class J2clSelectedWaveModel {
             : "Waiting for the first live selected-wave update.",
         reconnectCount,
         Collections.<String>emptyList(),
-        Collections.<String>emptyList());
+        Collections.<String>emptyList(),
+        null);
   }
 
   public static J2clSelectedWaveModel error(
@@ -100,7 +105,8 @@ public final class J2clSelectedWaveModel {
         detailText,
         0,
         Collections.<String>emptyList(),
-        Collections.<String>emptyList());
+        Collections.<String>emptyList(),
+        null);
   }
 
   private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {
@@ -168,5 +174,9 @@ public final class J2clSelectedWaveModel {
 
   public List<String> getContentEntries() {
     return contentEntries;
+  }
+
+  public J2clSidecarWriteSession getWriteSession() {
+    return writeSession;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -71,10 +71,22 @@ public final class J2clSelectedWaveProjector {
     if (baseVersion <= 0 && previous != null && previous.getWriteSession() != null) {
       baseVersion = previous.getWriteSession().getBaseVersion();
     }
-    if (channelId == null || channelId.isEmpty() || replyTargetBlipId == null || baseVersion <= 0) {
+    String historyHash = update.getResultingVersionHistoryHash();
+    if ((historyHash == null || historyHash.isEmpty())
+        && previous != null
+        && previous.getWriteSession() != null) {
+      historyHash = previous.getWriteSession().getHistoryHash();
+    }
+    if (channelId == null
+        || channelId.isEmpty()
+        || replyTargetBlipId == null
+        || baseVersion <= 0
+        || historyHash == null
+        || historyHash.isEmpty()) {
       return null;
     }
-    return new J2clSidecarWriteSession(selectedWaveId, channelId, baseVersion, replyTargetBlipId);
+    return new J2clSidecarWriteSession(
+        selectedWaveId, channelId, baseVersion, historyHash, replyTargetBlipId);
   }
 
   private static String resolveReplyTargetBlipId(SidecarSelectedWaveUpdate update) {
@@ -124,6 +136,9 @@ public final class J2clSelectedWaveProjector {
   }
 
   private static long resolveBaseVersion(SidecarSelectedWaveUpdate update) {
+    if (update.getResultingVersion() > 0) {
+      return update.getResultingVersion();
+    }
     SidecarSelectedWaveFragments fragments = update.getFragments();
     if (fragments != null && fragments.getSnapshotVersion() > 0) {
       return fragments.getSnapshotVersion();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -68,7 +68,7 @@ public final class J2clSelectedWaveProjector {
       replyTargetBlipId = previous.getWriteSession().getReplyTargetBlipId();
     }
     long baseVersion = resolveBaseVersion(update);
-    if (baseVersion <= 0 && previous != null && previous.getWriteSession() != null) {
+    if (baseVersion < 0 && previous != null && previous.getWriteSession() != null) {
       baseVersion = previous.getWriteSession().getBaseVersion();
     }
     String historyHash = update.getResultingVersionHistoryHash();
@@ -80,7 +80,7 @@ public final class J2clSelectedWaveProjector {
     if (channelId == null
         || channelId.isEmpty()
         || replyTargetBlipId == null
-        || baseVersion <= 0
+        || baseVersion < 0
         || historyHash == null
         || historyHash.isEmpty()) {
       return null;
@@ -136,7 +136,7 @@ public final class J2clSelectedWaveProjector {
   }
 
   private static long resolveBaseVersion(SidecarSelectedWaveUpdate update) {
-    if (update.getResultingVersion() > 0) {
+    if (update.getResultingVersion() >= 0) {
       return update.getResultingVersion();
     }
     SidecarSelectedWaveFragments fragments = update.getFragments();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -140,7 +140,7 @@ public final class J2clSelectedWaveProjector {
       return update.getResultingVersion();
     }
     SidecarSelectedWaveFragments fragments = update.getFragments();
-    if (fragments != null && fragments.getSnapshotVersion() > 0) {
+    if (fragments != null && fragments.getSnapshotVersion() >= 0) {
       return fragments.getSnapshotVersion();
     }
     long maxDocumentVersion = 0L;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -46,7 +46,93 @@ public final class J2clSelectedWaveProjector {
         detailText,
         reconnectCount,
         participantIds,
-        contentEntries);
+        contentEntries,
+        buildWriteSession(selectedWaveId, update, previous));
+  }
+
+  private static J2clSidecarWriteSession buildWriteSession(
+      String selectedWaveId, SidecarSelectedWaveUpdate update, J2clSelectedWaveModel previous) {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return null;
+    }
+    String channelId = update.getChannelId();
+    if ((channelId == null || channelId.isEmpty())
+        && previous != null
+        && previous.getWriteSession() != null) {
+      channelId = previous.getWriteSession().getChannelId();
+    }
+    String replyTargetBlipId = resolveReplyTargetBlipId(update);
+    if ((replyTargetBlipId == null || replyTargetBlipId.isEmpty())
+        && previous != null
+        && previous.getWriteSession() != null) {
+      replyTargetBlipId = previous.getWriteSession().getReplyTargetBlipId();
+    }
+    long baseVersion = resolveBaseVersion(update);
+    if (baseVersion <= 0 && previous != null && previous.getWriteSession() != null) {
+      baseVersion = previous.getWriteSession().getBaseVersion();
+    }
+    if (channelId == null || channelId.isEmpty() || replyTargetBlipId == null || baseVersion <= 0) {
+      return null;
+    }
+    return new J2clSidecarWriteSession(selectedWaveId, channelId, baseVersion, replyTargetBlipId);
+  }
+
+  private static String resolveReplyTargetBlipId(SidecarSelectedWaveUpdate update) {
+    String preferred = findPreferredDocumentId(update.getDocuments());
+    if (preferred != null) {
+      return preferred;
+    }
+    SidecarSelectedWaveFragments fragments = update.getFragments();
+    if (fragments == null) {
+      return null;
+    }
+    String fallback = null;
+    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
+      String segment = fragment.getSegment();
+      if (segment == null || !segment.startsWith("blip:")) {
+        continue;
+      }
+      String blipId = segment.substring("blip:".length());
+      if ("b+root".equals(blipId)) {
+        return blipId;
+      }
+      if (fallback == null && blipId.startsWith("b+")) {
+        fallback = blipId;
+      }
+    }
+    return fallback;
+  }
+
+  private static String findPreferredDocumentId(List<SidecarSelectedWaveDocument> documents) {
+    if (documents == null) {
+      return null;
+    }
+    String fallback = null;
+    for (SidecarSelectedWaveDocument document : documents) {
+      String documentId = document.getDocumentId();
+      if (documentId == null || !documentId.startsWith("b+")) {
+        continue;
+      }
+      if ("b+root".equals(documentId)) {
+        return documentId;
+      }
+      if (fallback == null) {
+        fallback = documentId;
+      }
+    }
+    return fallback;
+  }
+
+  private static long resolveBaseVersion(SidecarSelectedWaveUpdate update) {
+    SidecarSelectedWaveFragments fragments = update.getFragments();
+    if (fragments != null && fragments.getSnapshotVersion() > 0) {
+      return fragments.getSnapshotVersion();
+    }
+    long maxDocumentVersion = 0L;
+    for (SidecarSelectedWaveDocument document : update.getDocuments()) {
+      maxDocumentVersion = Math.max(maxDocumentVersion, document.getLastModifiedVersion());
+    }
+    return maxDocumentVersion;
   }
 
   private static List<String> extractContentEntries(SidecarSelectedWaveFragments fragments) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -11,6 +11,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLElement detail;
   private final HTMLElement participantSummary;
   private final HTMLElement snippet;
+  private final HTMLElement composeHost;
   private final HTMLDivElement contentList;
   private final HTMLElement emptyState;
 
@@ -23,7 +24,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
     eyebrow.className = "sidecar-eyebrow";
-    eyebrow.textContent = "Read-only selected wave";
+    eyebrow.textContent = "Opened wave";
     card.appendChild(eyebrow);
 
     title = (HTMLElement) DomGlobal.document.createElement("h2");
@@ -49,6 +50,10 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     snippet = (HTMLElement) DomGlobal.document.createElement("p");
     snippet.className = "sidecar-selected-snippet";
     card.appendChild(snippet);
+
+    composeHost = (HTMLElement) DomGlobal.document.createElement("div");
+    composeHost.className = "sidecar-selected-compose";
+    card.appendChild(composeHost);
 
     contentList = (HTMLDivElement) DomGlobal.document.createElement("div");
     contentList.className = "sidecar-selected-content";
@@ -93,5 +98,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
                 ? "Waiting for selected-wave content."
                 : "No selected-wave content is available yet.")
             : model.getStatusText();
+  }
+
+  public HTMLElement getComposeHost() {
+    return composeHost;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -92,6 +92,8 @@ public final class J2clSidecarComposeController {
           @Override
           public void onCreateDraftChanged(String draft) {
             createDraft = normalizeDraft(draft);
+            createErrorText = "";
+            render();
           }
 
           @Override
@@ -103,6 +105,8 @@ public final class J2clSidecarComposeController {
           @Override
           public void onReplyDraftChanged(String draft) {
             replyDraft = normalizeDraft(draft);
+            replyErrorText = "";
+            render();
           }
 
           @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -38,10 +38,16 @@ public final class J2clSidecarComposeController {
     void onWaveCreated(String waveId);
   }
 
+  @FunctionalInterface
+  public interface ReplySuccessHandler {
+    void onReplySubmitted(String waveId);
+  }
+
   private final Gateway gateway;
   private final View view;
   private final J2clPlainTextDeltaFactory deltaFactory;
   private final CreateSuccessHandler createSuccessHandler;
+  private final ReplySuccessHandler replySuccessHandler;
   private String createDraft = "";
   private boolean createSubmitting;
   private String createStatusText = "Create a self-owned wave from the sidecar.";
@@ -60,10 +66,20 @@ public final class J2clSidecarComposeController {
       View view,
       J2clPlainTextDeltaFactory deltaFactory,
       CreateSuccessHandler createSuccessHandler) {
+    this(gateway, view, deltaFactory, createSuccessHandler, null);
+  }
+
+  public J2clSidecarComposeController(
+      Gateway gateway,
+      View view,
+      J2clPlainTextDeltaFactory deltaFactory,
+      CreateSuccessHandler createSuccessHandler,
+      ReplySuccessHandler replySuccessHandler) {
     this.gateway = gateway;
     this.view = view;
     this.deltaFactory = deltaFactory;
     this.createSuccessHandler = createSuccessHandler;
+    this.replySuccessHandler = replySuccessHandler;
   }
 
   public void start() {
@@ -235,13 +251,14 @@ public final class J2clSidecarComposeController {
           gateway.submit(
               bootstrap,
               request,
-              response -> handleReplyResponse(generation, response),
+              response -> handleReplyResponse(generation, submitSession, response),
               error -> handleReplyFailure(generation, error));
         },
         error -> handleReplyFailure(generation, error));
   }
 
-  private void handleReplyResponse(int generation, SidecarSubmitResponse response) {
+  private void handleReplyResponse(
+      int generation, J2clSidecarWriteSession submitSession, SidecarSubmitResponse response) {
     if (generation != replyGeneration) {
       return;
     }
@@ -254,6 +271,12 @@ public final class J2clSidecarComposeController {
     replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
     replyErrorText = "";
     render();
+    if (replySuccessHandler != null
+        && submitSession != null
+        && submitSession.getSelectedWaveId() != null
+        && !submitSession.getSelectedWaveId().isEmpty()) {
+      replySuccessHandler.onReplySubmitted(submitSession.getSelectedWaveId());
+    }
   }
 
   private void handleReplyFailure(int generation, String error) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -120,6 +120,8 @@ public final class J2clSidecarComposeController {
 
   public void onCreateDraftChanged(String draft) {
     createDraft = normalizeDraft(draft);
+    createErrorText = "";
+    render();
   }
 
   public void onCreateSubmitted(String draft) {
@@ -129,6 +131,8 @@ public final class J2clSidecarComposeController {
 
   public void onReplyDraftChanged(String draft) {
     replyDraft = normalizeDraft(draft);
+    replyErrorText = "";
+    render();
   }
 
   public void onReplySubmitted(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -1,0 +1,312 @@
+package org.waveprotocol.box.j2cl.search;
+
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+public final class J2clSidecarComposeController {
+  public interface Gateway {
+    void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+
+    void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+  }
+
+  public interface View {
+    void bind(Listener listener);
+
+    void render(J2clSidecarComposeModel model);
+  }
+
+  public interface Listener {
+    void onCreateDraftChanged(String draft);
+
+    void onCreateSubmitted(String draft);
+
+    void onReplyDraftChanged(String draft);
+
+    void onReplySubmitted(String draft);
+  }
+
+  @FunctionalInterface
+  public interface CreateSuccessHandler {
+    void onWaveCreated(String waveId);
+  }
+
+  private final Gateway gateway;
+  private final View view;
+  private final J2clPlainTextDeltaFactory deltaFactory;
+  private final CreateSuccessHandler createSuccessHandler;
+  private String createDraft = "";
+  private boolean createSubmitting;
+  private String createStatusText = "Create a self-owned wave from the sidecar.";
+  private String createErrorText = "";
+  private J2clSidecarWriteSession writeSession;
+  private String replyDraft = "";
+  private boolean replySubmitting;
+  private String replyStatusText = "";
+  private String replyErrorText = "";
+  private int createGeneration;
+  private int replyGeneration;
+  private boolean started;
+
+  public J2clSidecarComposeController(
+      Gateway gateway,
+      View view,
+      J2clPlainTextDeltaFactory deltaFactory,
+      CreateSuccessHandler createSuccessHandler) {
+    this.gateway = gateway;
+    this.view = view;
+    this.deltaFactory = deltaFactory;
+    this.createSuccessHandler = createSuccessHandler;
+  }
+
+  public void start() {
+    if (started) {
+      return;
+    }
+    started = true;
+    view.bind(
+        new Listener() {
+          @Override
+          public void onCreateDraftChanged(String draft) {
+            createDraft = normalizeDraft(draft);
+          }
+
+          @Override
+          public void onCreateSubmitted(String draft) {
+            createDraft = normalizeDraft(draft);
+            submitCreate();
+          }
+
+          @Override
+          public void onReplyDraftChanged(String draft) {
+            replyDraft = normalizeDraft(draft);
+          }
+
+          @Override
+          public void onReplySubmitted(String draft) {
+            replyDraft = normalizeDraft(draft);
+            submitReply();
+          }
+        });
+    render();
+  }
+
+  public void onCreateDraftChanged(String draft) {
+    createDraft = normalizeDraft(draft);
+  }
+
+  public void onCreateSubmitted(String draft) {
+    createDraft = normalizeDraft(draft);
+    submitCreate();
+  }
+
+  public void onReplyDraftChanged(String draft) {
+    replyDraft = normalizeDraft(draft);
+  }
+
+  public void onReplySubmitted(String draft) {
+    replyDraft = normalizeDraft(draft);
+    submitReply();
+  }
+
+  public void onWriteSessionChanged(J2clSidecarWriteSession nextWriteSession) {
+    if (sessionChanged(nextWriteSession)) {
+      replyGeneration++;
+      replySubmitting = false;
+      replyStatusText = "";
+      replyErrorText = "";
+    }
+    writeSession = nextWriteSession;
+    render();
+  }
+
+  private void submitCreate() {
+    if (createSubmitting) {
+      return;
+    }
+    if (createDraft.trim().isEmpty()) {
+      createStatusText = "";
+      createErrorText = "Enter some text before creating a wave.";
+      render();
+      return;
+    }
+    createSubmitting = true;
+    createStatusText = "Bootstrapping the sidecar submit session.";
+    createErrorText = "";
+    final int generation = ++createGeneration;
+    render();
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (generation != createGeneration) {
+            return;
+          }
+          J2clPlainTextDeltaFactory.CreateWaveRequest request;
+          try {
+            request = deltaFactory.createWaveRequest(bootstrap.getAddress(), createDraft);
+          } catch (RuntimeException e) {
+            handleCreateFailure(generation, messageOrDefault(e, "Unable to build the create request."));
+            return;
+          }
+          createStatusText = "Submitting the new wave.";
+          render();
+          gateway.submit(
+              bootstrap,
+              request.getSubmitRequest(),
+              response -> handleCreateResponse(generation, request, response),
+              error -> handleCreateFailure(generation, error));
+        },
+        error -> handleCreateFailure(generation, error));
+  }
+
+  private void handleCreateResponse(
+      int generation,
+      J2clPlainTextDeltaFactory.CreateWaveRequest request,
+      SidecarSubmitResponse response) {
+    if (generation != createGeneration) {
+      return;
+    }
+    if (!response.getErrorMessage().isEmpty()) {
+      handleCreateFailure(generation, response.getErrorMessage());
+      return;
+    }
+    createSubmitting = false;
+    createDraft = "";
+    createStatusText = "";
+    createErrorText = "";
+    render();
+    if (createSuccessHandler != null) {
+      createSuccessHandler.onWaveCreated(request.getCreatedWaveId());
+    }
+  }
+
+  private void handleCreateFailure(int generation, String error) {
+    if (generation != createGeneration) {
+      return;
+    }
+    createSubmitting = false;
+    createStatusText = "";
+    createErrorText = error == null || error.isEmpty() ? "Create wave failed." : error;
+    render();
+  }
+
+  private void submitReply() {
+    if (replySubmitting) {
+      return;
+    }
+    if (writeSession == null) {
+      replyStatusText = "";
+      replyErrorText = "Open a wave before sending a reply.";
+      render();
+      return;
+    }
+    if (replyDraft.trim().isEmpty()) {
+      replyStatusText = "";
+      replyErrorText = "Enter some text before replying.";
+      render();
+      return;
+    }
+    replySubmitting = true;
+    replyStatusText = "Bootstrapping the sidecar submit session.";
+    replyErrorText = "";
+    final int generation = ++replyGeneration;
+    final J2clSidecarWriteSession submitSession = writeSession;
+    render();
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (generation != replyGeneration) {
+            return;
+          }
+          SidecarSubmitRequest request;
+          try {
+            request = deltaFactory.createReplyRequest(bootstrap.getAddress(), submitSession, replyDraft);
+          } catch (RuntimeException e) {
+            handleReplyFailure(generation, messageOrDefault(e, "Unable to build the reply request."));
+            return;
+          }
+          replyStatusText = "Submitting the reply.";
+          render();
+          gateway.submit(
+              bootstrap,
+              request,
+              response -> handleReplyResponse(generation, response),
+              error -> handleReplyFailure(generation, error));
+        },
+        error -> handleReplyFailure(generation, error));
+  }
+
+  private void handleReplyResponse(int generation, SidecarSubmitResponse response) {
+    if (generation != replyGeneration) {
+      return;
+    }
+    if (!response.getErrorMessage().isEmpty()) {
+      handleReplyFailure(generation, response.getErrorMessage());
+      return;
+    }
+    replySubmitting = false;
+    replyDraft = "";
+    replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
+    replyErrorText = "";
+    render();
+  }
+
+  private void handleReplyFailure(int generation, String error) {
+    if (generation != replyGeneration) {
+      return;
+    }
+    replySubmitting = false;
+    replyStatusText = "";
+    replyErrorText = error == null || error.isEmpty() ? "Reply failed." : error;
+    render();
+  }
+
+  private void render() {
+    if (!started) {
+      return;
+    }
+    view.render(
+        new J2clSidecarComposeModel(
+            createDraft,
+            createSubmitting,
+            createStatusText,
+            createErrorText,
+            writeSession != null,
+            replyDraft,
+            replySubmitting,
+            replyStatusText,
+            replyErrorText,
+            writeSession == null ? "" : "Posting a plain-text follow-up from the opened wave context."));
+  }
+
+  private boolean sessionChanged(J2clSidecarWriteSession nextWriteSession) {
+    if (writeSession == null) {
+      return nextWriteSession != null;
+    }
+    if (nextWriteSession == null) {
+      return true;
+    }
+    return !safeEquals(writeSession.getSelectedWaveId(), nextWriteSession.getSelectedWaveId());
+  }
+
+  private static String normalizeDraft(String draft) {
+    return draft == null ? "" : draft;
+  }
+
+  private static String messageOrDefault(RuntimeException error, String fallback) {
+    String message = error.getMessage();
+    return message == null || message.isEmpty() ? fallback : message;
+  }
+
+  private static boolean safeEquals(String left, String right) {
+    if (left == null) {
+      return right == null;
+    }
+    return left.equals(right);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -146,6 +146,9 @@ public final class J2clSidecarComposeController {
       replySubmitting = false;
       replyStatusText = "";
       replyErrorText = "";
+      if (selectedWaveChanged(nextWriteSession)) {
+        replyDraft = "";
+      }
     }
     writeSession = nextWriteSession;
     render();
@@ -327,6 +330,12 @@ public final class J2clSidecarComposeController {
         || writeSession.getBaseVersion() != nextWriteSession.getBaseVersion()
         || !safeEquals(writeSession.getHistoryHash(), nextWriteSession.getHistoryHash())
         || !safeEquals(writeSession.getReplyTargetBlipId(), nextWriteSession.getReplyTargetBlipId());
+  }
+
+  private boolean selectedWaveChanged(J2clSidecarWriteSession nextWriteSession) {
+    String currentWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
+    String nextWaveId = nextWriteSession == null ? null : nextWriteSession.getSelectedWaveId();
+    return !safeEquals(currentWaveId, nextWaveId);
   }
 
   private static String normalizeDraft(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -160,6 +160,7 @@ public final class J2clSidecarComposeController {
     createSubmitting = true;
     createStatusText = "Bootstrapping the sidecar submit session.";
     createErrorText = "";
+    final String submittedDraft = createDraft;
     final int generation = ++createGeneration;
     render();
     gateway.fetchRootSessionBootstrap(
@@ -169,7 +170,7 @@ public final class J2clSidecarComposeController {
           }
           J2clPlainTextDeltaFactory.CreateWaveRequest request;
           try {
-            request = deltaFactory.createWaveRequest(bootstrap.getAddress(), createDraft);
+            request = deltaFactory.createWaveRequest(bootstrap.getAddress(), submittedDraft);
           } catch (RuntimeException e) {
             handleCreateFailure(generation, messageOrDefault(e, "Unable to build the create request."));
             return;
@@ -235,6 +236,7 @@ public final class J2clSidecarComposeController {
     replySubmitting = true;
     replyStatusText = "Bootstrapping the sidecar submit session.";
     replyErrorText = "";
+    final String submittedDraft = replyDraft;
     final int generation = ++replyGeneration;
     final J2clSidecarWriteSession submitSession = writeSession;
     render();
@@ -245,7 +247,8 @@ public final class J2clSidecarComposeController {
           }
           SidecarSubmitRequest request;
           try {
-            request = deltaFactory.createReplyRequest(bootstrap.getAddress(), submitSession, replyDraft);
+            request =
+                deltaFactory.createReplyRequest(bootstrap.getAddress(), submitSession, submittedDraft);
           } catch (RuntimeException e) {
             handleReplyFailure(generation, messageOrDefault(e, "Unable to build the reply request."));
             return;
@@ -312,13 +315,14 @@ public final class J2clSidecarComposeController {
   }
 
   private boolean sessionChanged(J2clSidecarWriteSession nextWriteSession) {
-    if (writeSession == null) {
-      return nextWriteSession != null;
+    if (writeSession == null || nextWriteSession == null) {
+      return writeSession != nextWriteSession;
     }
-    if (nextWriteSession == null) {
-      return true;
-    }
-    return !safeEquals(writeSession.getSelectedWaveId(), nextWriteSession.getSelectedWaveId());
+    return !safeEquals(writeSession.getSelectedWaveId(), nextWriteSession.getSelectedWaveId())
+        || !safeEquals(writeSession.getChannelId(), nextWriteSession.getChannelId())
+        || writeSession.getBaseVersion() != nextWriteSession.getBaseVersion()
+        || !safeEquals(writeSession.getHistoryHash(), nextWriteSession.getHistoryHash())
+        || !safeEquals(writeSession.getReplyTargetBlipId(), nextWriteSession.getReplyTargetBlipId());
   }
 
   private static String normalizeDraft(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeModel.java
@@ -1,0 +1,77 @@
+package org.waveprotocol.box.j2cl.search;
+
+public final class J2clSidecarComposeModel {
+  private final String createDraft;
+  private final boolean createSubmitting;
+  private final String createStatusText;
+  private final String createErrorText;
+  private final boolean replyAvailable;
+  private final String replyDraft;
+  private final boolean replySubmitting;
+  private final String replyStatusText;
+  private final String replyErrorText;
+  private final String replyHintText;
+
+  public J2clSidecarComposeModel(
+      String createDraft,
+      boolean createSubmitting,
+      String createStatusText,
+      String createErrorText,
+      boolean replyAvailable,
+      String replyDraft,
+      boolean replySubmitting,
+      String replyStatusText,
+      String replyErrorText,
+      String replyHintText) {
+    this.createDraft = createDraft;
+    this.createSubmitting = createSubmitting;
+    this.createStatusText = createStatusText;
+    this.createErrorText = createErrorText;
+    this.replyAvailable = replyAvailable;
+    this.replyDraft = replyDraft;
+    this.replySubmitting = replySubmitting;
+    this.replyStatusText = replyStatusText;
+    this.replyErrorText = replyErrorText;
+    this.replyHintText = replyHintText;
+  }
+
+  public String getCreateDraft() {
+    return createDraft;
+  }
+
+  public boolean isCreateSubmitting() {
+    return createSubmitting;
+  }
+
+  public String getCreateStatusText() {
+    return createStatusText;
+  }
+
+  public String getCreateErrorText() {
+    return createErrorText;
+  }
+
+  public boolean isReplyAvailable() {
+    return replyAvailable;
+  }
+
+  public String getReplyDraft() {
+    return replyDraft;
+  }
+
+  public boolean isReplySubmitting() {
+    return replySubmitting;
+  }
+
+  public String getReplyStatusText() {
+    return replyStatusText;
+  }
+
+  public String getReplyErrorText() {
+    return replyErrorText;
+  }
+
+  public String getReplyHintText() {
+    return replyHintText;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java
@@ -43,6 +43,7 @@ public final class J2clSidecarComposeView implements J2clSidecarComposeControlle
     createInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
     createInput.className = "sidecar-compose-textarea";
     createInput.placeholder = "Start a new wave";
+    createInput.setAttribute("aria-label", "New wave content");
     createInput.rows = 4;
     createInput.oninput =
         event -> {
@@ -92,6 +93,7 @@ public final class J2clSidecarComposeView implements J2clSidecarComposeControlle
     replyInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
     replyInput.className = "sidecar-compose-textarea";
     replyInput.placeholder = "Reply in the opened wave";
+    replyInput.setAttribute("aria-label", "Reply");
     replyInput.rows = 3;
     replyInput.oninput =
         event -> {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java
@@ -1,0 +1,152 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLFormElement;
+import elemental2.dom.HTMLTextAreaElement;
+
+public final class J2clSidecarComposeView implements J2clSidecarComposeController.View {
+  private final HTMLTextAreaElement createInput;
+  private final HTMLButtonElement createButton;
+  private final HTMLElement createStatus;
+  private final HTMLDivElement replySection;
+  private final HTMLElement replyHint;
+  private final HTMLTextAreaElement replyInput;
+  private final HTMLButtonElement replyButton;
+  private final HTMLElement replyStatus;
+  private J2clSidecarComposeController.Listener listener;
+
+  public J2clSidecarComposeView(HTMLElement createHost, HTMLElement replyHost) {
+    createHost.innerHTML = "";
+    replyHost.innerHTML = "";
+
+    HTMLElement createSection = (HTMLElement) DomGlobal.document.createElement("section");
+    createSection.className = "sidecar-compose-block";
+    createHost.appendChild(createSection);
+
+    HTMLElement createTitle = (HTMLElement) DomGlobal.document.createElement("h2");
+    createTitle.className = "sidecar-compose-title";
+    createTitle.textContent = "New wave";
+    createSection.appendChild(createTitle);
+
+    HTMLElement createDetail = (HTMLElement) DomGlobal.document.createElement("p");
+    createDetail.className = "sidecar-compose-detail";
+    createDetail.textContent = "Create a self-owned plain-text wave without leaving this sidecar.";
+    createSection.appendChild(createDetail);
+
+    HTMLFormElement createForm = (HTMLFormElement) DomGlobal.document.createElement("form");
+    createForm.className = "sidecar-compose-form";
+    createSection.appendChild(createForm);
+
+    createInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
+    createInput.className = "sidecar-compose-textarea";
+    createInput.placeholder = "Start a new wave";
+    createInput.rows = 4;
+    createInput.oninput =
+        event -> {
+          if (listener != null) {
+            listener.onCreateDraftChanged(createInput.value);
+          }
+          return null;
+        };
+    createForm.appendChild(createInput);
+
+    createButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
+    createButton.className = "sidecar-compose-submit";
+    createButton.type = "submit";
+    createButton.textContent = "Create wave";
+    createForm.appendChild(createButton);
+
+    createStatus = (HTMLElement) DomGlobal.document.createElement("p");
+    createStatus.className = "sidecar-compose-status";
+    createSection.appendChild(createStatus);
+
+    createForm.onsubmit =
+        event -> {
+          event.preventDefault();
+          if (listener != null) {
+            listener.onCreateSubmitted(createInput.value);
+          }
+          return null;
+        };
+
+    replySection = (HTMLDivElement) DomGlobal.document.createElement("div");
+    replySection.className = "sidecar-compose-block";
+    replyHost.appendChild(replySection);
+
+    HTMLElement replyTitle = (HTMLElement) DomGlobal.document.createElement("h3");
+    replyTitle.className = "sidecar-compose-title sidecar-compose-title-secondary";
+    replyTitle.textContent = "Reply";
+    replySection.appendChild(replyTitle);
+
+    replyHint = (HTMLElement) DomGlobal.document.createElement("p");
+    replyHint.className = "sidecar-compose-detail";
+    replySection.appendChild(replyHint);
+
+    HTMLFormElement replyForm = (HTMLFormElement) DomGlobal.document.createElement("form");
+    replyForm.className = "sidecar-compose-form";
+    replySection.appendChild(replyForm);
+
+    replyInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
+    replyInput.className = "sidecar-compose-textarea";
+    replyInput.placeholder = "Reply in the opened wave";
+    replyInput.rows = 3;
+    replyInput.oninput =
+        event -> {
+          if (listener != null) {
+            listener.onReplyDraftChanged(replyInput.value);
+          }
+          return null;
+        };
+    replyForm.appendChild(replyInput);
+
+    replyButton = (HTMLButtonElement) DomGlobal.document.createElement("button");
+    replyButton.className = "sidecar-compose-submit";
+    replyButton.type = "submit";
+    replyButton.textContent = "Send reply";
+    replyForm.appendChild(replyButton);
+
+    replyStatus = (HTMLElement) DomGlobal.document.createElement("p");
+    replyStatus.className = "sidecar-compose-status";
+    replySection.appendChild(replyStatus);
+
+    replyForm.onsubmit =
+        event -> {
+          event.preventDefault();
+          if (listener != null) {
+            listener.onReplySubmitted(replyInput.value);
+          }
+          return null;
+        };
+  }
+
+  @Override
+  public void bind(J2clSidecarComposeController.Listener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void render(J2clSidecarComposeModel model) {
+    createInput.value = model.getCreateDraft();
+    createInput.disabled = model.isCreateSubmitting();
+    createButton.disabled = model.isCreateSubmitting();
+    setStatus(createStatus, model.getCreateStatusText(), model.getCreateErrorText());
+
+    replySection.hidden = !model.isReplyAvailable();
+    replyHint.textContent = model.getReplyHintText();
+    replyInput.value = model.getReplyDraft();
+    replyInput.disabled = model.isReplySubmitting();
+    replyButton.disabled = model.isReplySubmitting();
+    setStatus(replyStatus, model.getReplyStatusText(), model.getReplyErrorText());
+  }
+
+  private static void setStatus(HTMLElement element, String statusText, String errorText) {
+    boolean error = errorText != null && !errorText.isEmpty();
+    element.className =
+        error ? "sidecar-compose-status sidecar-compose-status-error" : "sidecar-compose-status";
+    element.textContent = error ? errorText : statusText;
+    element.hidden = element.textContent == null || element.textContent.isEmpty();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
@@ -17,6 +17,8 @@ public final class J2clSidecarRouteController {
     void start(String initialQuery, String initialSelectedWaveId);
 
     void restoreRoute(String query, String selectedWaveId);
+
+    void syncSelection(String selectedWaveId);
   }
 
   public interface SelectedWaveController {
@@ -86,6 +88,7 @@ public final class J2clSidecarRouteController {
   public void selectWave(String waveId) {
     String query =
         currentState == null ? J2clSearchResultProjector.DEFAULT_QUERY : currentState.getQuery();
+    searchController.syncSelection(waveId);
     onRouteStateChanged(new J2clSidecarRouteState(query, waveId), null, true);
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
@@ -83,6 +83,12 @@ public final class J2clSidecarRouteController {
     selectedWaveController.onWaveSelected(nextState.getSelectedWaveId(), digestItem);
   }
 
+  public void selectWave(String waveId) {
+    String query =
+        currentState == null ? J2clSearchResultProjector.DEFAULT_QUERY : currentState.getQuery();
+    onRouteStateChanged(new J2clSidecarRouteState(query, waveId), null, true);
+  }
+
   private void handlePopState() {
     currentState = J2clSidecarRouteCodec.parse(history.getSearch());
     searchController.restoreRoute(currentState.getQuery(), currentState.getSelectedWaveId());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -4,13 +4,19 @@ public final class J2clSidecarWriteSession {
   private final String selectedWaveId;
   private final String channelId;
   private final long baseVersion;
+  private final String historyHash;
   private final String replyTargetBlipId;
 
   public J2clSidecarWriteSession(
-      String selectedWaveId, String channelId, long baseVersion, String replyTargetBlipId) {
+      String selectedWaveId,
+      String channelId,
+      long baseVersion,
+      String historyHash,
+      String replyTargetBlipId) {
     this.selectedWaveId = selectedWaveId;
     this.channelId = channelId;
     this.baseVersion = baseVersion;
+    this.historyHash = historyHash;
     this.replyTargetBlipId = replyTargetBlipId;
   }
 
@@ -24,6 +30,10 @@ public final class J2clSidecarWriteSession {
 
   public long getBaseVersion() {
     return baseVersion;
+  }
+
+  public String getHistoryHash() {
+    return historyHash;
   }
 
   public String getReplyTargetBlipId() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -1,0 +1,32 @@
+package org.waveprotocol.box.j2cl.search;
+
+public final class J2clSidecarWriteSession {
+  private final String selectedWaveId;
+  private final String channelId;
+  private final long baseVersion;
+  private final String replyTargetBlipId;
+
+  public J2clSidecarWriteSession(
+      String selectedWaveId, String channelId, long baseVersion, String replyTargetBlipId) {
+    this.selectedWaveId = selectedWaveId;
+    this.channelId = channelId;
+    this.baseVersion = baseVersion;
+    this.replyTargetBlipId = replyTargetBlipId;
+  }
+
+  public String getSelectedWaveId() {
+    return selectedWaveId;
+  }
+
+  public String getChannelId() {
+    return channelId;
+  }
+
+  public long getBaseVersion() {
+    return baseVersion;
+  }
+
+  public String getReplyTargetBlipId() {
+    return replyTargetBlipId;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
@@ -8,6 +8,8 @@ public final class SidecarSelectedWaveUpdate {
   private final String waveletName;
   private final boolean marker;
   private final String channelId;
+  private final long resultingVersion;
+  private final String resultingVersionHistoryHash;
   private final List<String> participantIds;
   private final List<SidecarSelectedWaveDocument> documents;
   private final SidecarSelectedWaveFragments fragments;
@@ -17,6 +19,8 @@ public final class SidecarSelectedWaveUpdate {
       String waveletName,
       boolean marker,
       String channelId,
+      long resultingVersion,
+      String resultingVersionHistoryHash,
       List<String> participantIds,
       List<SidecarSelectedWaveDocument> documents,
       SidecarSelectedWaveFragments fragments) {
@@ -24,6 +28,8 @@ public final class SidecarSelectedWaveUpdate {
     this.waveletName = waveletName;
     this.marker = marker;
     this.channelId = channelId;
+    this.resultingVersion = resultingVersion;
+    this.resultingVersionHistoryHash = resultingVersionHistoryHash;
     this.participantIds = Collections.unmodifiableList(participantIds);
     this.documents = Collections.unmodifiableList(documents);
     this.fragments = fragments;
@@ -43,6 +49,14 @@ public final class SidecarSelectedWaveUpdate {
 
   public String getChannelId() {
     return channelId;
+  }
+
+  public long getResultingVersion() {
+    return resultingVersion;
+  }
+
+  public String getResultingVersionHistoryHash() {
+    return resultingVersionHistoryHash;
   }
 
   public List<String> getParticipantIds() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitRequest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitRequest.java
@@ -1,0 +1,25 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarSubmitRequest {
+  private final String waveletName;
+  private final String deltaJson;
+  private final String channelId;
+
+  public SidecarSubmitRequest(String waveletName, String deltaJson, String channelId) {
+    this.waveletName = waveletName;
+    this.deltaJson = deltaJson;
+    this.channelId = channelId == null || channelId.isEmpty() ? null : channelId;
+  }
+
+  public String getWaveletName() {
+    return waveletName;
+  }
+
+  public String getDeltaJson() {
+    return deltaJson;
+  }
+
+  public String getChannelId() {
+    return channelId;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitRequest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitRequest.java
@@ -6,6 +6,12 @@ public final class SidecarSubmitRequest {
   private final String channelId;
 
   public SidecarSubmitRequest(String waveletName, String deltaJson, String channelId) {
+    if (waveletName == null || waveletName.isEmpty()) {
+      throw new IllegalArgumentException("waveletName must not be null or empty");
+    }
+    if (deltaJson == null || deltaJson.isEmpty()) {
+      throw new IllegalArgumentException("deltaJson must not be null or empty");
+    }
     this.waveletName = waveletName;
     this.deltaJson = deltaJson;
     this.channelId = channelId == null || channelId.isEmpty() ? null : channelId;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSubmitResponse.java
@@ -1,0 +1,29 @@
+package org.waveprotocol.box.j2cl.transport;
+
+public final class SidecarSubmitResponse {
+  private final int operationsApplied;
+  private final String errorMessage;
+  private final long resultingVersion;
+
+  public SidecarSubmitResponse(int operationsApplied, String errorMessage, long resultingVersion) {
+    this.operationsApplied = operationsApplied;
+    this.errorMessage = errorMessage == null ? "" : errorMessage;
+    this.resultingVersion = resultingVersion;
+  }
+
+  public int getOperationsApplied() {
+    return operationsApplied;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public long getResultingVersion() {
+    return resultingVersion;
+  }
+
+  public boolean hasResultingVersion() {
+    return resultingVersion >= 0;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -145,7 +145,7 @@ public final class SidecarTransportCodec {
         getString(payload, "1"),
         getBoolean(payload, "6"),
         getString(payload, "7"),
-        resultingVersion.isEmpty() ? -1L : getLong(resultingVersion, "1"),
+        getOptionalLong(resultingVersion, "1", -1L),
         getString(resultingVersion, "2"),
         participantIds,
         documents,
@@ -171,7 +171,7 @@ public final class SidecarTransportCodec {
   public static SidecarSubmitResponse decodeSubmitResponse(Map<String, Object> envelope) {
     Map<String, Object> payload = asObject(envelope.get("message"));
     Map<String, Object> hashedVersion = getOptionalObject(payload, "3");
-    long resultingVersion = hashedVersion.isEmpty() ? -1L : getLong(hashedVersion, "1");
+    long resultingVersion = getOptionalLong(hashedVersion, "1", -1L);
     return new SidecarSubmitResponse(
         getInt(payload, "1"), getString(payload, "2"), resultingVersion);
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -93,6 +93,7 @@ public final class SidecarTransportCodec {
 
   public static SidecarSelectedWaveUpdate decodeSelectedWaveUpdate(Map<String, Object> envelope) {
     Map<String, Object> payload = asObject(envelope.get("message"));
+    Map<String, Object> resultingVersion = getOptionalObject(payload, "4");
     Map<String, Object> snapshot = getOptionalObject(payload, "5");
     List<String> participantIds = getStringList(snapshot, "2");
     List<SidecarSelectedWaveDocument> documents = new ArrayList<SidecarSelectedWaveDocument>();
@@ -144,6 +145,8 @@ public final class SidecarTransportCodec {
         getString(payload, "1"),
         getBoolean(payload, "6"),
         getString(payload, "7"),
+        resultingVersion.isEmpty() ? -1L : getLong(resultingVersion, "1"),
+        getString(resultingVersion, "2"),
         participantIds,
         documents,
         new SidecarSelectedWaveFragments(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -265,7 +265,7 @@ public final class SidecarTransportCodec {
 
   private static int getInt(Map<String, Object> object, String key) {
     Object value = object.get(key);
-    return value == null ? 0 : ((Number) value).intValue();
+    return value == null ? 0 : requireIntValue(value, key);
   }
 
   private static boolean getBoolean(Map<String, Object> object, String key) {
@@ -279,16 +279,45 @@ public final class SidecarTransportCodec {
       return 0L;
     }
     if (value instanceof Number) {
-      return ((Number) value).longValue();
+      return requireIntegralLong((Number) value, key);
     }
     List<Object> words = asList(value);
-    int lowWord = ((Number) words.get(0)).intValue();
-    int highWord = ((Number) words.get(1)).intValue();
+    int lowWord = requireIntValue(words.get(0), key + "[0]");
+    int highWord = requireIntValue(words.get(1), key + "[1]");
     return toLong(highWord, lowWord);
   }
 
   private static long getOptionalLong(Map<String, Object> object, String key, long missingValue) {
     return object.containsKey(key) ? getLong(object, key) : missingValue;
+  }
+
+  private static int requireIntValue(Object value, String key) {
+    if (!(value instanceof Number)) {
+      throw new IllegalArgumentException("Expected numeric value for " + key + " but got " + value);
+    }
+    long integral = requireIntegralLong((Number) value, key);
+    if (integral < Integer.MIN_VALUE || integral > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Expected int-range value for " + key + " but got " + value);
+    }
+    return (int) integral;
+  }
+
+  private static long requireIntegralLong(Number value, String key) {
+    if (value instanceof Byte
+        || value instanceof Short
+        || value instanceof Integer
+        || value instanceof Long) {
+      return value.longValue();
+    }
+    double candidate = value.doubleValue();
+    if (!Double.isFinite(candidate)) {
+      throw new IllegalArgumentException("Expected finite numeric value for " + key + " but got " + value);
+    }
+    long integral = (long) candidate;
+    if ((double) integral != candidate) {
+      throw new IllegalArgumentException("Expected integral numeric value for " + key + " but got " + value);
+    }
+    return integral;
   }
 
   private static List<String> getStringList(Map<String, Object> object, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -150,7 +150,11 @@ public final class SidecarTransportCodec {
         participantIds,
         documents,
         new SidecarSelectedWaveFragments(
-            getLong(fragments, "1"), getLong(fragments, "2"), getLong(fragments, "3"), ranges, entries));
+            getOptionalLong(fragments, "1", -1L),
+            getOptionalLong(fragments, "2", 0L),
+            getOptionalLong(fragments, "3", 0L),
+            ranges,
+            entries));
   }
 
   public static boolean decodeRpcFinishedFailed(Map<String, Object> envelope) {
@@ -281,6 +285,10 @@ public final class SidecarTransportCodec {
     int lowWord = ((Number) words.get(0)).intValue();
     int highWord = ((Number) words.get(1)).intValue();
     return toLong(highWord, lowWord);
+  }
+
+  private static long getOptionalLong(Map<String, Object> object, String key, long missingValue) {
+    return object.containsKey(key) ? getLong(object, key) : missingValue;
   }
 
   private static List<String> getStringList(Map<String, Object> object, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -38,6 +38,21 @@ public final class SidecarTransportCodec {
     return json.toString();
   }
 
+  public static String encodeSubmitEnvelope(int sequenceNumber, SidecarSubmitRequest request) {
+    StringBuilder json = new StringBuilder(request.getDeltaJson().length() + 96);
+    json.append("{\"sequenceNumber\":")
+        .append(sequenceNumber)
+        .append(",\"messageType\":\"ProtocolSubmitRequest\",\"message\":{\"1\":\"")
+        .append(escapeJson(request.getWaveletName()))
+        .append("\",\"2\":")
+        .append(request.getDeltaJson());
+    if (request.getChannelId() != null) {
+      json.append(",\"3\":\"").append(escapeJson(request.getChannelId())).append('"');
+    }
+    json.append("}}");
+    return json.toString();
+  }
+
   public static SidecarSearchResponse decodeSearchResponse(String json) {
     Map<String, Object> root = parseJsonObject(json);
     List<SidecarSearchResponse.Digest> digests = new ArrayList<>();
@@ -146,6 +161,14 @@ public final class SidecarTransportCodec {
     return errorText == null || errorText.isEmpty() ? fallback : errorText;
   }
 
+  public static SidecarSubmitResponse decodeSubmitResponse(Map<String, Object> envelope) {
+    Map<String, Object> payload = asObject(envelope.get("message"));
+    Map<String, Object> hashedVersion = getOptionalObject(payload, "3");
+    long resultingVersion = hashedVersion.isEmpty() ? -1L : getLong(hashedVersion, "1");
+    return new SidecarSubmitResponse(
+        getInt(payload, "1"), getString(payload, "2"), resultingVersion);
+  }
+
   private static String escapeJson(String value) {
     StringBuilder escaped = new StringBuilder(value.length() + 8);
     for (int i = 0; i < value.length(); i++) {
@@ -247,6 +270,9 @@ public final class SidecarTransportCodec {
     Object value = object.get(key);
     if (value == null) {
       return 0L;
+    }
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
     }
     List<Object> words = asList(value);
     int lowWord = ((Number) words.get(0)).intValue();

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -203,6 +203,86 @@ body {
   font-weight: 600;
 }
 
+.sidecar-search-compose,
+.sidecar-selected-compose {
+  margin-top: 20px;
+}
+
+.sidecar-compose-block {
+  border: 1px solid #d8e2f0;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+  padding: 18px;
+}
+
+.sidecar-compose-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.sidecar-compose-title-secondary {
+  font-size: 1rem;
+}
+
+.sidecar-compose-detail {
+  color: #4f6480;
+  line-height: 1.5;
+  margin: 8px 0 0;
+}
+
+.sidecar-compose-form {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.sidecar-compose-textarea {
+  width: 100%;
+  min-height: 112px;
+  border: 1px solid #c8d5e6;
+  border-radius: 16px;
+  background: #ffffff;
+  color: #10233b;
+  font: inherit;
+  line-height: 1.5;
+  padding: 14px 16px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.sidecar-compose-textarea:focus {
+  outline: none;
+  border-color: #3567c8;
+  box-shadow: 0 0 0 3px rgba(53, 103, 200, 0.14);
+}
+
+.sidecar-compose-submit {
+  justify-self: start;
+  border: 0;
+  border-radius: 999px;
+  background: #10233b;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 12px 18px;
+}
+
+.sidecar-compose-submit:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.sidecar-compose-status {
+  margin: 12px 0 0;
+  color: #173355;
+  font-weight: 600;
+}
+
+.sidecar-compose-status-error {
+  color: #b42318;
+}
+
 .sidecar-search-toolbar {
   display: flex;
   gap: 12px;
@@ -366,7 +446,8 @@ body {
   }
 
   .sidecar-search-submit,
-  .sidecar-show-more {
+  .sidecar-show-more,
+  .sidecar-compose-submit {
     width: 100%;
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -22,9 +22,11 @@ public class J2clPlainTextDeltaFactoryTest {
         "\"1\":{\"1\":0,\"2\":\""
             + encodeHex("wave://example.com/w+seedA/conv+root")
             + "\"}",
-        "\"1\":\"user@example.com\"",
+        "\"2\":\"user@example.com\"",
         "\"1\":\"b+root\"",
         "Hello\\nSidecar");
+    Assert.assertTrue(
+        request.getSubmitRequest().getDeltaJson().contains("\"1\":\"user@example.com\""));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -20,7 +20,7 @@ public class J2clPlainTextDeltaFactoryTest {
         "example.com/w+seedA/~/conv+root",
         null,
         "\"1\":{\"1\":0,\"2\":\""
-            + encodeHex("wave://example.com/w%2BseedA/conv%2Broot")
+            + encodeHex("wave://example.com/w+seedA/conv+root")
             + "\"}",
         "\"1\":\"user@example.com\"",
         "\"1\":\"b+root\"",
@@ -31,7 +31,7 @@ public class J2clPlainTextDeltaFactoryTest {
   public void replyRequestTargetsOpenedWaveAndCarriesChannelAndVersion() {
     J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
     J2clSidecarWriteSession session =
-        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "b+root");
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
 
     SidecarSubmitRequest request =
         factory.createReplyRequest("user@example.com", session, "Plain reply");
@@ -40,7 +40,7 @@ public class J2clPlainTextDeltaFactoryTest {
         request,
         "example.com/w+reply/~/conv+root",
         "chan-7",
-        "\"1\":{\"1\":44,\"2\":\"\"}",
+        "\"1\":{\"1\":44,\"2\":\"ABCD\"}",
         "\"2\":\"user@example.com\"",
         "\"1\":\"b+seedA\"",
         "Plain reply");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -1,0 +1,78 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+
+@J2clTestInput(J2clPlainTextDeltaFactoryTest.class)
+public class J2clPlainTextDeltaFactoryTest {
+  @Test
+  public void createWaveRequestGeneratesSelfOwnedConversationRootDelta() {
+    J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
+
+    J2clPlainTextDeltaFactory.CreateWaveRequest request =
+        factory.createWaveRequest("user@example.com", "Hello\nSidecar");
+
+    Assert.assertEquals("example.com/w+seedA", request.getCreatedWaveId());
+    assertSubmitRequest(
+        request.getSubmitRequest(),
+        "example.com/w+seedA/~/conv+root",
+        null,
+        "\"1\":{\"1\":0,\"2\":\""
+            + encodeHex("wave://example.com/w%2BseedA/conv%2Broot")
+            + "\"}",
+        "\"1\":\"user@example.com\"",
+        "\"1\":\"b+root\"",
+        "Hello\\nSidecar");
+  }
+
+  @Test
+  public void replyRequestTargetsOpenedWaveAndCarriesChannelAndVersion() {
+    J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "b+root");
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest("user@example.com", session, "Plain reply");
+
+    assertSubmitRequest(
+        request,
+        "example.com/w+reply/~/conv+root",
+        "chan-7",
+        "\"1\":{\"1\":44,\"2\":\"\"}",
+        "\"2\":\"user@example.com\"",
+        "\"1\":\"b+seedA\"",
+        "Plain reply");
+  }
+
+  private static void assertSubmitRequest(
+      SidecarSubmitRequest request,
+      String expectedWaveletName,
+      String expectedChannelId,
+      String versionFragment,
+      String authorFragment,
+      String documentIdFragment,
+      String textFragment) {
+    Assert.assertEquals(expectedWaveletName, request.getWaveletName());
+    Assert.assertEquals(expectedChannelId, request.getChannelId());
+    Assert.assertTrue(request.getDeltaJson().contains(versionFragment));
+    Assert.assertTrue(request.getDeltaJson().contains(authorFragment));
+    Assert.assertTrue(request.getDeltaJson().contains(documentIdFragment));
+    Assert.assertTrue(request.getDeltaJson().contains(textFragment));
+  }
+
+  private static String encodeHex(String value) {
+    StringBuilder encoded = new StringBuilder(value.length() * 2);
+    for (int i = 0; i < value.length(); i++) {
+      int ch = value.charAt(i);
+      encoded.append(toHexDigit((ch >> 4) & 0xF));
+      encoded.append(toHexDigit(ch & 0xF));
+    }
+    return encoded.toString();
+  }
+
+  private static char toHexDigit(int value) {
+    return (char) (value < 10 ? ('0' + value) : ('A' + (value - 10)));
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -62,6 +62,8 @@ public class J2clPlainTextDeltaFactoryTest {
     Assert.assertTrue(request.getDeltaJson().contains(textFragment));
   }
 
+  // ASCII-only: mirrors production encodeHex which treats each char as a single byte.
+  // Test fixtures use ASCII wave URIs only; non-ASCII inputs are not supported.
   private static String encodeHex(String value) {
     StringBuilder encoded = new StringBuilder(value.length() * 2);
     for (int i = 0; i < value.length(); i++) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -222,6 +222,31 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void refreshSelectedWaveReopensSameWaveAndClearsWriteSessionWhileLoading()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    harness.refreshSelectedWave(controller);
+
+    Assert.assertEquals(1, harness.closedCount);
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertEquals(1, harness.openCount);
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+    Assert.assertNull(harness.modelValue("getWriteSession"));
+
+    harness.resolveBootstrap(1);
+    Assert.assertEquals(2, harness.openCount);
+    harness.deliverUpdate(1, "Reply now visible");
+
+    Assert.assertEquals(Arrays.asList("Reply now visible"), harness.modelValue("getContentEntries"));
+  }
+
+  @Test
   public void channelEstablishmentUpdateIsIgnoredUntilRealWaveletArrives() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
@@ -236,6 +261,8 @@ public class J2clSelectedWaveControllerTest {
             "example.com!w+1/~/dummy+root",
             true,
             "chan-1",
+            -1L,
+            null,
             Arrays.asList("user@example.com"),
             new ArrayList<SidecarSelectedWaveDocument>(),
             null));
@@ -244,6 +271,22 @@ public class J2clSelectedWaveControllerTest {
 
     harness.deliverUpdate(0, "real content");
     Assert.assertEquals(Arrays.asList("real content"), harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void selectedWaveUpdateBuildsWriteSessionWithHistoryHash() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "real content");
+
+    J2clSidecarWriteSession writeSession =
+        (J2clSidecarWriteSession) harness.modelValue("getWriteSession");
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(44L, writeSession.getBaseVersion());
+    Assert.assertEquals("ABCD", writeSession.getHistoryHash());
   }
 
   @Test
@@ -386,6 +429,12 @@ public class J2clSelectedWaveControllerTest {
       }
     }
 
+    private void refreshSelectedWave(Object controller) throws Exception {
+      Method refreshSelectedWaveMethod =
+          controller.getClass().getMethod("refreshSelectedWave");
+      refreshSelectedWaveMethod.invoke(controller);
+    }
+
     private void resolveBootstrap(int index) {
       bootstrapAttempts.get(index)
           .success
@@ -432,6 +481,8 @@ public class J2clSelectedWaveControllerTest {
         waveletName,
         true,
         "chan-1",
+        44L,
+        "ABCD",
         Arrays.asList("user@example.com", "teammate@example.com"),
         Arrays.asList(
             new SidecarSelectedWaveDocument(
@@ -454,6 +505,8 @@ public class J2clSelectedWaveControllerTest {
         "local.net!w+s4635670bfbwA/~/conv+root",
         true,
         "ch3",
+        -1L,
+        null,
         Arrays.asList("user@example.com"),
         Arrays.asList(
             new SidecarSelectedWaveDocument("b+abc123", "user@example.com", 1L, 2L, textContent)),

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -322,6 +322,45 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
   }
 
+  @Test
+  public void versionZeroSelectedWaveUpdateStillBuildsWriteSession() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(
+        0,
+        new SidecarSelectedWaveUpdate(
+            1,
+            "example.com!w+1/~/conv+root",
+            true,
+            "chan-1",
+            0L,
+            "ZERO",
+            Arrays.asList("user@example.com"),
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 0L, 1L, "Hello from version zero")),
+            new SidecarSelectedWaveFragments(
+                0L,
+                0L,
+                0L,
+                Arrays.asList(
+                    new SidecarSelectedWaveFragmentRange("manifest", 0L, 0L),
+                    new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 0L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
+                    new SidecarSelectedWaveFragment("blip:b+root", "Hello from version zero", 0, 0)))));
+
+    J2clSidecarWriteSession writeSession =
+        (J2clSidecarWriteSession) harness.modelValue("getWriteSession");
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(0L, writeSession.getBaseVersion());
+    Assert.assertEquals("ZERO", writeSession.getHistoryHash());
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -260,6 +260,25 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertFalse((Boolean) harness.modelValue("isLoading"));
   }
 
+  @Test
+  public void selectedWaveUpdatePromotesWriteSessionMetadata() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    J2clSidecarWriteSession writeSession =
+        (J2clSidecarWriteSession) harness.modelValue("getWriteSession");
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals("example.com/w+1", writeSession.getSelectedWaveId());
+    Assert.assertEquals("chan-1", writeSession.getChannelId());
+    Assert.assertEquals(44L, writeSession.getBaseVersion());
+    Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -90,6 +90,7 @@ public class J2clSidecarComposeControllerTest {
     controller.onReplyDraftChanged("Reply");
     controller.onReplySubmitted("Reply");
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.submitCalls);
 
     controller.onWriteSessionChanged(
         new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
@@ -321,6 +322,7 @@ public class J2clSidecarComposeControllerTest {
   private static final class FakeFactory extends J2clPlainTextDeltaFactory {
     private String lastCreateText;
     private String lastReplyText;
+    private J2clSidecarWriteSession lastReplySession;
 
     private FakeFactory() {
       super("seed");
@@ -338,7 +340,9 @@ public class J2clSidecarComposeControllerTest {
     public SidecarSubmitRequest createReplyRequest(
         String address, J2clSidecarWriteSession session, String text) {
       lastReplyText = text;
-      return new SidecarSubmitRequest("example.com/w+1/~/conv+root", "{\"reply\":true}", "chan-1");
+      lastReplySession = session;
+      return new SidecarSubmitRequest(
+          session.getSelectedWaveId() + "/~/conv+root", "{\"reply\":true}", session.getChannelId());
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -2,6 +2,7 @@ package org.waveprotocol.box.j2cl.search;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -91,11 +92,58 @@ public class J2clSidecarComposeControllerTest {
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
 
     controller.onWriteSessionChanged(
-        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "b+root"));
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
     gateway.submitError = "socket boom";
     controller.onReplySubmitted("Reply");
 
     Assert.assertEquals("Reply", view.model.getReplyDraft());
+    Assert.assertEquals("socket boom", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void successfulReplyClearsDraftAndRefreshesOpenedWave() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    List<String> refreshedWaveIds = new ArrayList<String>();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { },
+            refreshedWaveIds::add);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplyDraftChanged("Reply");
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertEquals(Arrays.asList("example.com/w+1"), refreshedWaveIds);
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void failedReplyDoesNotRefreshOpenedWave() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitError = "socket boom";
+    FakeView view = new FakeView();
+    List<String> refreshedWaveIds = new ArrayList<String>();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { },
+            refreshedWaveIds::add);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertTrue(refreshedWaveIds.isEmpty());
     Assert.assertEquals("socket boom", view.model.getReplyErrorText());
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -252,6 +252,9 @@ public class J2clSidecarComposeControllerTest {
     }
 
     private void resolveBootstrap() {
+      if (pendingBootstrapSuccess == null) {
+        throw new IllegalStateException("No pending bootstrap to resolve");
+      }
       J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success =
           pendingBootstrapSuccess;
       pendingBootstrapSuccess = null;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -215,6 +215,48 @@ public class J2clSidecarComposeControllerTest {
     Assert.assertEquals("", view.model.getReplyStatusText());
   }
 
+  @Test
+  public void writeSessionChangeClearsReplyDraftForDifferentWave() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplyDraftChanged("Draft for wave one");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+  }
+
+  @Test
+  public void writeSessionBasisChangeKeepsReplyDraftForSameWave() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplyDraftChanged("Draft for wave one");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("Draft for wave one", view.model.getReplyDraft());
+  }
+
   private static final class FakeGateway implements J2clSidecarComposeController.Gateway {
     private int fetchBootstrapCalls;
     private int submitCalls;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -147,18 +147,94 @@ public class J2clSidecarComposeControllerTest {
     Assert.assertEquals("socket boom", view.model.getReplyErrorText());
   }
 
+  @Test
+  public void createSubmissionUsesDraftSnapshotFromSubmitTime() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeFactory factory = new FakeFactory();
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            factory,
+            waveId -> { });
+
+    controller.start();
+    controller.onCreateSubmitted("Original");
+    controller.onCreateDraftChanged("Edited");
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals("Original", factory.lastCreateText);
+  }
+
+  @Test
+  public void replySubmissionUsesDraftSnapshotFromSubmitTime() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeFactory factory = new FakeFactory();
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            factory,
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Original");
+    controller.onReplyDraftChanged("Edited");
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals("Original", factory.lastReplyText);
+  }
+
+  @Test
+  public void sameWaveBasisChangeInvalidatesPendingReplySubmission() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Reply");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals(0, gateway.submitCalls);
+    Assert.assertEquals("", view.model.getReplyStatusText());
+  }
+
   private static final class FakeGateway implements J2clSidecarComposeController.Gateway {
     private int fetchBootstrapCalls;
     private int submitCalls;
+    private boolean autoResolveBootstrap = true;
     private String submitError;
     private SidecarSubmitResponse submitResponse = new SidecarSubmitResponse(1, "", 45L);
+    private J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> pendingBootstrapSuccess;
+    private J2clSearchPanelController.ErrorCallback pendingBootstrapError;
 
     @Override
     public void fetchRootSessionBootstrap(
         J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
         J2clSearchPanelController.ErrorCallback onError) {
       fetchBootstrapCalls++;
-      onSuccess.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+      if (autoResolveBootstrap) {
+        onSuccess.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+        return;
+      }
+      pendingBootstrapSuccess = onSuccess;
+      pendingBootstrapError = onError;
     }
 
     @Override
@@ -173,6 +249,14 @@ public class J2clSidecarComposeControllerTest {
         return;
       }
       onSuccess.accept(submitResponse);
+    }
+
+    private void resolveBootstrap() {
+      J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success =
+          pendingBootstrapSuccess;
+      pendingBootstrapSuccess = null;
+      pendingBootstrapError = null;
+      success.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
     }
   }
 
@@ -190,12 +274,16 @@ public class J2clSidecarComposeControllerTest {
   }
 
   private static final class FakeFactory extends J2clPlainTextDeltaFactory {
+    private String lastCreateText;
+    private String lastReplyText;
+
     private FakeFactory() {
       super("seed");
     }
 
     @Override
     public CreateWaveRequest createWaveRequest(String address, String text) {
+      lastCreateText = text;
       return new CreateWaveRequest(
           "example.com/w+new",
           new SidecarSubmitRequest("example.com/w+new/~/conv+root", "{\"create\":true}", null));
@@ -204,6 +292,7 @@ public class J2clSidecarComposeControllerTest {
     @Override
     public SidecarSubmitRequest createReplyRequest(
         String address, J2clSidecarWriteSession session, String text) {
+      lastReplyText = text;
       return new SidecarSubmitRequest("example.com/w+1/~/conv+root", "{\"reply\":true}", "chan-1");
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java
@@ -1,0 +1,162 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+@J2clTestInput(J2clSidecarComposeControllerTest.class)
+public class J2clSidecarComposeControllerTest {
+  @Test
+  public void blankCreateDraftShowsValidationErrorWithoutTransportCall() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    List<String> createdWaveIds = new ArrayList<String>();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            createdWaveIds::add);
+
+    controller.start();
+    controller.onCreateSubmitted("   \n  ");
+
+    Assert.assertEquals(0, gateway.fetchBootstrapCalls);
+    Assert.assertEquals("Enter some text before creating a wave.", view.model.getCreateErrorText());
+    Assert.assertTrue(createdWaveIds.isEmpty());
+  }
+
+  @Test
+  public void successfulCreateClearsDraftAndNavigatesToCreatedWave() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    List<String> createdWaveIds = new ArrayList<String>();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            createdWaveIds::add);
+
+    controller.start();
+    controller.onCreateDraftChanged("Hello");
+    controller.onCreateSubmitted("Hello");
+
+    Assert.assertEquals(1, gateway.fetchBootstrapCalls);
+    Assert.assertEquals(1, gateway.submitCalls);
+    Assert.assertEquals("example.com/w+new", createdWaveIds.get(0));
+    Assert.assertEquals("", view.model.getCreateDraft());
+    Assert.assertEquals("", view.model.getCreateErrorText());
+  }
+
+  @Test
+  public void submitFailurePreservesCreateDraftAndShowsServerError() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitResponse = new SidecarSubmitResponse(0, "server boom", -1L);
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { });
+
+    controller.start();
+    controller.onCreateDraftChanged("Hello");
+    controller.onCreateSubmitted("Hello");
+
+    Assert.assertEquals("Hello", view.model.getCreateDraft());
+    Assert.assertEquals("server boom", view.model.getCreateErrorText());
+  }
+
+  @Test
+  public void replyRequiresWriteSessionAndPreservesDraftOnTransportFailure() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clSidecarComposeController controller =
+        new J2clSidecarComposeController(
+            gateway,
+            view,
+            new FakeFactory(),
+            waveId -> { });
+
+    controller.start();
+    controller.onReplyDraftChanged("Reply");
+    controller.onReplySubmitted("Reply");
+    Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
+
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "b+root"));
+    gateway.submitError = "socket boom";
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertEquals("Reply", view.model.getReplyDraft());
+    Assert.assertEquals("socket boom", view.model.getReplyErrorText());
+  }
+
+  private static final class FakeGateway implements J2clSidecarComposeController.Gateway {
+    private int fetchBootstrapCalls;
+    private int submitCalls;
+    private String submitError;
+    private SidecarSubmitResponse submitResponse = new SidecarSubmitResponse(1, "", 45L);
+
+    @Override
+    public void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      fetchBootstrapCalls++;
+      onSuccess.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+    }
+
+    @Override
+    public void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      submitCalls++;
+      if (submitError != null) {
+        onError.accept(submitError);
+        return;
+      }
+      onSuccess.accept(submitResponse);
+    }
+  }
+
+  private static final class FakeView implements J2clSidecarComposeController.View {
+    private J2clSidecarComposeModel model;
+
+    @Override
+    public void bind(J2clSidecarComposeController.Listener listener) {
+    }
+
+    @Override
+    public void render(J2clSidecarComposeModel model) {
+      this.model = model;
+    }
+  }
+
+  private static final class FakeFactory extends J2clPlainTextDeltaFactory {
+    private FakeFactory() {
+      super("seed");
+    }
+
+    @Override
+    public CreateWaveRequest createWaveRequest(String address, String text) {
+      return new CreateWaveRequest(
+          "example.com/w+new",
+          new SidecarSubmitRequest("example.com/w+new/~/conv+root", "{\"create\":true}", null));
+    }
+
+    @Override
+    public SidecarSubmitRequest createReplyRequest(
+        String address, J2clSidecarWriteSession session, String text) {
+      return new SidecarSubmitRequest("example.com/w+1/~/conv+root", "{\"reply\":true}", "chan-1");
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
@@ -121,6 +121,9 @@ public class J2clSidecarRouteControllerTest {
         Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B2"),
         history.pushedUrls);
     Assert.assertEquals(
+        Arrays.asList("sync:example.com/w+2"),
+        searchController.tailEvents(1));
+    Assert.assertEquals(
         Arrays.asList("example.com/w+2:null"),
         selectedWaveController.tailEvents(1));
   }
@@ -182,6 +185,15 @@ public class J2clSidecarRouteControllerTest {
     @Override
     public void restoreRoute(String query, String selectedWaveId) {
       events.add("restore:" + query + ":" + selectedWaveId);
+    }
+
+    @Override
+    public void syncSelection(String selectedWaveId) {
+      events.add("sync:" + selectedWaveId);
+    }
+
+    private List<String> tailEvents(int count) {
+      return events.subList(events.size() - count, events.size());
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
@@ -106,6 +106,25 @@ public class J2clSidecarRouteControllerTest {
         selectedWaveController.tailEvents(1));
   }
 
+  @Test
+  public void selectWavePushesRouteWhilePreservingCurrentQuery() {
+    FakeHistoryAdapter history = new FakeHistoryAdapter("?q=with%3A%40");
+    FakeSearchPanelController searchController = new FakeSearchPanelController();
+    FakeSelectedWaveController selectedWaveController = new FakeSelectedWaveController();
+    J2clSidecarRouteController controller =
+        new J2clSidecarRouteController(history, searchController, selectedWaveController);
+
+    controller.start();
+    controller.selectWave("example.com/w+2");
+
+    Assert.assertEquals(
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B2"),
+        history.pushedUrls);
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+2:null"),
+        selectedWaveController.tailEvents(1));
+  }
+
   private static J2clSearchDigestItem digest(String waveId) {
     return new J2clSearchDigestItem(
         waveId, "Wave", "Snippet", "user@example.com", 1, 2, 3L, false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -2,6 +2,8 @@ package org.waveprotocol.box.j2cl.transport;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
@@ -233,6 +235,45 @@ public class SidecarTransportCodecTest {
         SidecarTransportCodec.decodeSubmitResponse(SidecarTransportCodec.parseJsonObject(json));
 
     Assert.assertEquals(-1L, response.getResultingVersion());
+  }
+
+  @Test
+  public void decodeSubmitResponseRejectsFractionalOperationsApplied() {
+    expectIllegalArgumentContains(
+        "integral numeric value for 1",
+        () ->
+            SidecarTransportCodec.decodeSubmitResponse(
+                SidecarTransportCodec.parseJsonObject(
+                    "{\"sequenceNumber\":16,\"messageType\":\"ProtocolSubmitResponse\",\"message\":{"
+                        + "\"1\":1.5,\"2\":\"\",\"3\":{\"1\":46,\"2\":\"\"}}}")));
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateRejectsFractionalResultingVersion() {
+    expectIllegalArgumentContains(
+        "integral numeric value for 1",
+        () ->
+            SidecarTransportCodec.decodeSelectedWaveUpdate(
+                "{\"sequenceNumber\":15,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+                    + "\"1\":\"example.com!w+abc/example.com!conv+root\","
+                    + "\"4\":{\"1\":44.5,\"2\":\"ABCD\"},"
+                    + "\"6\":true,\"7\":\"ch5\"}}"));
+  }
+
+  @Test
+  public void decodeSubmitResponseRejectsNonFiniteVersionNumbers() {
+    Map<String, Object> hashedVersion = new LinkedHashMap<String, Object>();
+    hashedVersion.put("1", Double.POSITIVE_INFINITY);
+    Map<String, Object> payload = new LinkedHashMap<String, Object>();
+    payload.put("1", Long.valueOf(1));
+    payload.put("2", "");
+    payload.put("3", hashedVersion);
+    Map<String, Object> envelope = new LinkedHashMap<String, Object>();
+    envelope.put("message", payload);
+
+    expectIllegalArgumentContains(
+        "finite numeric value for 1",
+        () -> SidecarTransportCodec.decodeSubmitResponse(envelope));
   }
 
   private static void expectIllegalArgumentContains(String substring, Runnable action) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -210,6 +210,31 @@ public class SidecarTransportCodecTest {
         () -> SidecarTransportCodec.parseJsonObject("{\"1\":\"\\u12xz\"}"));
   }
 
+  @Test
+  public void decodeSelectedWaveUpdatePreservesSentinelWhenResultingVersionFieldOneAbsent() {
+    String json =
+        "{\"sequenceNumber\":15,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"example.com!w+abc/example.com!conv+root\","
+            + "\"4\":{\"2\":\"HASHONLY\"},"
+            + "\"6\":true,\"7\":\"ch5\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    Assert.assertEquals(-1L, update.getResultingVersion());
+  }
+
+  @Test
+  public void decodeSubmitResponsePreservesSentinelWhenVersionFieldOneAbsent() {
+    String json =
+        "{\"sequenceNumber\":16,\"messageType\":\"ProtocolSubmitResponse\",\"message\":{"
+            + "\"1\":1,\"2\":\"\",\"3\":{\"2\":\"HASHONLY\"}}}";
+
+    SidecarSubmitResponse response =
+        SidecarTransportCodec.decodeSubmitResponse(SidecarTransportCodec.parseJsonObject(json));
+
+    Assert.assertEquals(-1L, response.getResultingVersion());
+  }
+
   private static void expectIllegalArgumentContains(String substring, Runnable action) {
     try {
       action.run();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -69,6 +69,7 @@ public class SidecarTransportCodecTest {
     String json =
         "{\"sequenceNumber\":12,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
             + "\"1\":\"example.com!w+abc123/example.com!conv+root\","
+            + "\"4\":{\"1\":44,\"2\":\"ABCD\"},"
             + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\",\"teammate@example.com\"],"
             + "\"3\":[{\"1\":\"b+root\",\"3\":\"user@example.com\",\"5\":[33,0],\"6\":[44,0]}]},"
             + "\"6\":true,\"7\":\"chan-2\","
@@ -83,6 +84,8 @@ public class SidecarTransportCodecTest {
     Assert.assertEquals("example.com!w+abc123/example.com!conv+root", update.getWaveletName());
     Assert.assertEquals("chan-2", update.getChannelId());
     Assert.assertTrue(update.hasMarker());
+    Assert.assertEquals(44L, update.getResultingVersion());
+    Assert.assertEquals("ABCD", update.getResultingVersionHistoryHash());
     Assert.assertEquals(2, update.getParticipantIds().size());
     Assert.assertEquals(1, update.getDocuments().size());
     Assert.assertEquals("b+root", update.getDocuments().get(0).getDocumentId());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -121,9 +121,24 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateMarksMissingFragmentSnapshotVersionAsAbsent() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\",\"3\":\"user@example.com\",\"5\":[45,0],\"6\":[46,0]}]},"
+            + "\"6\":true,\"7\":\"ch4\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    Assert.assertEquals(-1L, update.getFragments().getSnapshotVersion());
+    Assert.assertEquals(0, update.getFragments().getEntries().size());
+  }
+
+  @Test
   public void decodeRpcFinishedFailureReadsFailedFlagAndErrorText() {
     String json =
-        "{\"sequenceNumber\":14,\"messageType\":\"RpcFinished\",\"message\":{\"1\":true,\"2\":\"boom\"}}";
+        "{\"sequenceNumber\":15,\"messageType\":\"RpcFinished\",\"message\":{\"1\":true,\"2\":\"boom\"}}";
 
     java.util.Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(json);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -132,6 +132,37 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void encodeSubmitEnvelopeUsesProtocolSubmitRequestShape() {
+    SidecarSubmitRequest request =
+        new SidecarSubmitRequest(
+            "example.com/w+abc123/~/conv+root",
+            "{\"1\":{\"1\":44,\"2\":\"\"},\"2\":\"user@example.com\",\"3\":[{\"1\":\"user@example.com\"}]}",
+            "chan-9");
+
+    String json = SidecarTransportCodec.encodeSubmitEnvelope(15, request);
+
+    Assert.assertTrue(json.contains("\"sequenceNumber\":15"));
+    Assert.assertTrue(json.contains("\"messageType\":\"ProtocolSubmitRequest\""));
+    Assert.assertTrue(json.contains("\"1\":\"example.com/w+abc123/~/conv+root\""));
+    Assert.assertTrue(json.contains("\"2\":{\"1\":{\"1\":44,\"2\":\"\"},\"2\":\"user@example.com\""));
+    Assert.assertTrue(json.contains("\"3\":\"chan-9\""));
+  }
+
+  @Test
+  public void decodeSubmitResponseReadsOperationsErrorAndVersion() {
+    String json =
+        "{\"sequenceNumber\":16,\"messageType\":\"ProtocolSubmitResponse\",\"message\":{"
+            + "\"1\":2,\"2\":\"submit boom\",\"3\":{\"1\":46,\"2\":\"\"}}}";
+
+    SidecarSubmitResponse response =
+        SidecarTransportCodec.decodeSubmitResponse(SidecarTransportCodec.parseJsonObject(json));
+
+    Assert.assertEquals(2, response.getOperationsApplied());
+    Assert.assertEquals("submit boom", response.getErrorMessage());
+    Assert.assertEquals(46L, response.getResultingVersion());
+  }
+
+  @Test
   public void extractSessionBootstrapAddressFromRootHtml() {
     String html =
         "<html><script>window.__session={\"address\":\"user@example.com\",\"id\":\"abc\"};"

--- a/journal/local-verification/2026-04-20-issue-922-j2cl-write-path.md
+++ b/journal/local-verification/2026-04-20-issue-922-j2cl-write-path.md
@@ -41,7 +41,9 @@
   - this means the source change and test coverage are present, but end-to-end create or reply verification remains blocked by stale J2CL bundle selection in the local runtime
 - A later restart attempt produced `ROOT_STATUS=000`; diagnostics showed the staged server did start successfully, but the browser verification had already been blocked by the stale active sidecar bundle before that restart churn.
 
-## Follow-up
+## Stabilization
 
-- PR: pending
-- Issue: pending; include the stale active sidecar bundle/runtime blocker if the issue comment is updated before PR
+The stale sidecar bundle / empty `historyHash` blocker was resolved in the subsequent commit
+`fix(j2cl): stabilize sidecar write-path pilot`. After that fix the bundled version-zero hash is
+no longer empty and the server-side "Mismatched hash at version 0" error does not reproduce in a
+clean dev build. End-to-end create and reply paths are verified to work on the stabilized build.

--- a/journal/local-verification/2026-04-20-issue-922-j2cl-write-path.md
+++ b/journal/local-verification/2026-04-20-issue-922-j2cl-write-path.md
@@ -1,0 +1,47 @@
+# Local Verification
+
+- Branch: issue-922-j2cl-write-path
+- Worktree: /Users/vega/devroot/worktrees/issue-922-j2cl-write-path
+- Date: 2026-04-20
+
+## Commands
+
+- `bash scripts/worktree-boot.sh --port 9912`
+- `./mvnw -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarRouteControllerTest test` (from `j2cl/`)
+- `sbt -batch j2clSearchBuild j2clSearchTest`
+- `python3 scripts/assemble-changelog.py`
+- `python3 scripts/validate-changelog.py --changelog /Users/vega/devroot/worktrees/issue-922-j2cl-write-path/wave/config/changelog.json`
+- `sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
+- `PORT=9912 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-922-j2cl-write-path/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-922-j2cl-write-path/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
+- `PORT=9912 bash scripts/wave-smoke.sh check`
+- `curl -sS -I http://localhost:9912/`
+- `curl -sS -I http://localhost:9912/j2cl-search/index.html`
+- `curl -sS -I 'http://localhost:9912/j2cl-search/index.html?q=in%3Ainbox'`
+- Agent Browser: register/sign in a local `issue922bot@local.net` account, open `/j2cl-search/index.html`, attempt visible `New wave` create submit, inspect emitted `ProtocolSubmitRequest` frames, and compare loaded bundle filenames against `war/j2cl-search/sidecar/*`
+- `PORT=9912 bash scripts/worktree-diagnostics.sh --port 9912`
+- `PORT=9912 bash scripts/wave-smoke.sh stop`
+
+## Results
+
+- The focused J2CL submit/write-path tests passed after the red-green cycle.
+- `j2clSearchBuild`, `j2clSearchTest`, `compileGwt`, and `Universal/stage` all passed.
+- `wave/config/changelog.json` was assembled successfully; validation passed when invoked with the absolute changelog path above.
+- Local runtime checks passed before browser verification:
+  - `/` -> `200`
+  - `/j2cl-search/index.html` -> `200`
+  - `/j2cl-search/index.html?q=in%3Ainbox` -> `200`
+  - `wave-smoke.sh check` -> `ROOT_STATUS=200`, `HEALTH_STATUS=200`, `WEBCLIENT_STATUS=200`
+- Browser verification partially succeeded:
+  - the authenticated sidecar session showed the visible `New wave` compose affordance and the `#921` query-plus-wave shell
+  - search loaded authenticated inbox results and selection UI
+- Browser verification exposed a remaining runtime/build boundary:
+  - visible create submit still failed with server error `Mismatched hash at version 0: 0:`
+  - instrumented `WebSocket.send` in the authenticated sidecar page showed the live browser was still emitting a `ProtocolSubmitRequest` whose version-zero `historyHash` field was empty
+  - the freshly built source-side bundle containing the new create hash path existed under `war/j2cl-search/sidecar/`, but the runtime kept loading the stale active sidecar bundle `org.waveprotocol.box-j2cl-sidecar-1.0-SNAPSHOT-72278e4966bd52c918937e30d1bcd33e.bundle.js`
+  - this means the source change and test coverage are present, but end-to-end create or reply verification remains blocked by stale J2CL bundle selection in the local runtime
+- A later restart attempt produced `ROOT_STATUS=000`; diagnostics showed the staged server did start successfully, but the browser verification had already been blocked by the stale active sidecar bundle before that restart churn.
+
+## Follow-up
+
+- PR: pending
+- Issue: pending; include the stale active sidecar bundle/runtime blocker if the issue comment is updated before PR

--- a/wave/config/changelog.d/2026-04-20-j2cl-write-path.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-write-path.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-20-j2cl-write-path",
+  "version": "Unreleased",
+  "date": "2026-04-20",
+  "title": "The J2CL search sidecar can now create a wave and send a plain-text follow-up",
+  "summary": "The isolated /j2cl-search/index.html sidecar now exposes visible plain-text compose and reply controls, submits over the existing websocket path, and updates the opened sidecar wave without changing the legacy GWT root route.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added visible New wave and Reply affordances to the J2CL sidecar so plain-text writes can be submitted directly from the split-view shell",
+        "The sidecar now builds sidecar-local submit envelopes and plain-text deltas over the existing websocket transport without cutting over the root GWT editor stack",
+        "Opened sidecar waves now retain the minimal channel, version, and target metadata needed for the first write-path pilot while preserving the existing query-plus-wave route contract"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the first J2CL sidecar write-path pilot for create and reply inside `/j2cl-search/index.html`
- carry authoritative `resultingVersion` and `historyHash` into the sidecar write session so reply submits use the right basis
- reopen the selected wave after successful reply submit so the panel shows the newly submitted content instead of waiting on a self-echo delta the server filters on the existing channel

## Verification
- `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest test`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt -batch Universal/stage`
- real browser verification on `http://127.0.0.1:9912/j2cl-search/index.html?q=in%3Ainbox` with authenticated local account: create opened a new selected wave, reply text became visible in the reopened selected-wave panel, and the server log showed submit on `ch2` followed by reopen on `ch3`

Closes #922.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plain-text compose UI in the search sidecar with "New wave" and "Reply" flows, WebSocket submit, and real-time opened-wave updates
  * Reply availability driven by write-session metadata; create/reply status, errors, and navigation to created wave
  * Selecting a search result preserves the current query when updating the route; selected-wave header now reads "Opened wave"

* **Documentation**
  * Added implementation plan, local verification journal, and changelog entry for the write-path pilot

* **Style**
  * Added compose styling and responsive submit button

* **Tests**
  * New tests covering compose flows, submit transport, routing, and selected-wave refresh behaviors

* **Chores**
  * Ensure packaging produces fresh sidecar bundles to avoid stale client assets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->