### PR TITLE
feat(j2cl): add root bootstrap seam

### DIFF
--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -198,7 +198,7 @@ Expected result:
 cp journal/runtime-config/issue-923-j2cl-root-bootstrap-port-9914.application.conf /tmp/j2cl-root-bootstrap.application.conf
 printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop
-PORT=9914 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf' bash scripts/wave-smoke.sh start
+PORT=9914 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf" bash scripts/wave-smoke.sh start
 curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 PORT=9914 bash scripts/wave-smoke.sh stop

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -196,7 +196,7 @@ Expected result:
 
 ```bash
 bash scripts/worktree-boot.sh --port 9914
-RUNTIME_CONFIG="$(find journal/runtime-config -name '*-port-9914.application.conf' | head -1)"
+RUNTIME_CONFIG="$(find journal/runtime-config -maxdepth 1 -name '*-port-9914.application.conf' | head -n1)"
 cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap.application.conf
 printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -195,7 +195,7 @@ Expected result:
 ### Mode B: J2CL Root Bootstrap Is Enabled Server-Side
 
 ```bash
-cp journal/runtime-config/issue-923-j2cl-root-bootstrap-port-9914.application.conf /tmp/j2cl-root-bootstrap.application.conf
+cp wave/config/reference.conf /tmp/j2cl-root-bootstrap.application.conf
 printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop
 PORT=9914 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf" bash scripts/wave-smoke.sh start

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -195,7 +195,9 @@ Expected result:
 ### Mode B: J2CL Root Bootstrap Is Enabled Server-Side
 
 ```bash
-cp wave/config/reference.conf /tmp/j2cl-root-bootstrap.application.conf
+bash scripts/worktree-boot.sh --port 9914
+RUNTIME_CONFIG="$(find journal/runtime-config -name '*-port-9914.application.conf' | head -1)"
+cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap.application.conf
 printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop
 PORT=9914 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf" bash scripts/wave-smoke.sh start
@@ -209,7 +211,7 @@ Expected result:
 - plain `/` serves the J2CL root shell when the server flag is on
 - the direct diagnostic route still serves the same shell
 - turning the config back to `false` restores the legacy GWT root without a code rollback
-- this server honors `-Dwave.server.config`, so the mode switch can be driven by a temp overlay built from the port-specific runtime config without editing the staged install directory directly
+- the mode switch is driven by a temp overlay built from the port-specific runtime config that `worktree-boot.sh` generated for the same smoke port, so the server and the probe port stay aligned
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -177,7 +177,7 @@ Run from the repo root unless the command says otherwise.
 ### Mode A: Legacy GWT Root Remains The Default
 
 ```bash
-sbt -batch "testOnly org.waveprotocol.box.server.persistence.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
 sbt -batch compileGwt Universal/stage
 bash scripts/worktree-boot.sh --port 9914
 PORT=9914 bash scripts/wave-smoke.sh start

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -21,8 +21,10 @@ As of 2026-04-19, the current J2CL browser surfaces are:
 - `/j2cl/index.html`
   - production-profile J2CL bundle used by packaging
 
-The root `/` route is still the legacy GWT application. Testing the J2CL path
-does not replace the obligation to keep the legacy path green.
+The root `/` route still defaults to the legacy GWT application. Issue #923
+adds a server-controlled bootstrap seam that can intentionally switch `/` to
+the J2CL root shell, but the J2CL path does not replace the obligation to keep
+the legacy path green.
 
 ## Fast J2CL-Only Checks
 
@@ -166,6 +168,48 @@ server:
 ```bash
 PORT=9900 bash scripts/wave-smoke.sh stop
 ```
+
+## Dual Bootstrap Matrix
+
+Use this matrix when you are validating the issue #923 root-bootstrap seam.
+Run from the repo root unless the command says otherwise.
+
+### Mode A: Legacy GWT Root Remains The Default
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch compileGwt Universal/stage
+bash scripts/worktree-boot.sh --port 9914
+PORT=9914 bash scripts/wave-smoke.sh start
+curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
+curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
+PORT=9914 bash scripts/wave-smoke.sh stop
+```
+
+Expected result:
+
+- `/` still serves the legacy GWT root HTML when the bootstrap flag is off
+- `/?view=j2cl-root` still serves the J2CL root shell as the direct diagnostic route
+- `compileGwt` and `Universal/stage` stay green
+
+### Mode B: J2CL Root Bootstrap Is Enabled Server-Side
+
+```bash
+cp journal/runtime-config/issue-923-j2cl-root-bootstrap-port-9914.application.conf /tmp/j2cl-root-bootstrap.application.conf
+printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
+PORT=9914 bash scripts/wave-smoke.sh stop
+PORT=9914 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf' bash scripts/wave-smoke.sh start
+curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
+PORT=9914 bash scripts/wave-smoke.sh stop
+```
+
+Expected result:
+
+- plain `/` serves the J2CL root shell when the server flag is on
+- the direct diagnostic route still serves the same shell
+- turning the config back to `false` restores the legacy GWT root without a code rollback
+- this server honors `-Dwave.server.config`, so the mode switch can be driven by a temp overlay built from the port-specific runtime config without editing the staged install directory directly
 
 ## When To Use Direct Maven Instead Of SBT
 

--- a/docs/superpowers/plans/2026-04-20-issue-923-j2cl-root-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-20-issue-923-j2cl-root-bootstrap.md
@@ -1,0 +1,196 @@
+# Issue #923 J2CL Root Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reversible, server-controlled bootstrap seam so plain `/` can intentionally boot the J2CL-owned root shell while legacy GWT remains the default fallback.
+
+**Architecture:** Build on the post-`#928/#937` baseline already on `main`: the J2CL root shell HTML exists, `WaveClientServlet` is already the root decision point, and `FeatureFlagService` can evaluate global and per-user rollout state. `#923` should make the server-side feature flag the authoritative bootstrap control plane for `/`, keep `/?view=j2cl-root` as a direct diagnostic route, and let `getSessionJson()` mirror enabled flags only for visibility/debugging.
+
+**Tech Stack:** Java, Jakarta servlets, SBT, existing server feature-flag store/service, `HtmlRenderer`, `WaveClientServlet`, J2CL sidecar/root-shell assets under `j2cl/`, worktree boot/smoke scripts, and local browser verification.
+
+---
+
+## Problem Framing
+
+The J2CL root shell is already in place from the `#928/#937` work on `main`, but the bootstrap control plane is still missing. Right now, the request path can either show legacy GWT or an explicit J2CL shell route; `#923` needs a server-owned switch that decides which root shell HTML to render before the client loads.
+
+That switch must be reversible without deploying code, must work for signed-out traffic, and must not depend on client flags as the primary control. Client-flag plumbing happens after HTML render, so it is the wrong authority for the root bootstrap decision.
+
+The intended control plane is:
+
+- a known feature flag named `j2cl-root-bootstrap`, default `false`
+- `FeatureFlagService.isEnabled("j2cl-root-bootstrap", participantId)` as the server-side decision point
+- `participantId == null` as the signed-out/global path
+- `WaveClientServlet#doGet` as the actual place where `/` chooses GWT or J2CL root shell HTML
+- `getSessionJson()` as a secondary mirror of enabled flags for page/debug visibility only
+
+`/?view=j2cl-root` should remain available as a direct diagnostic path from `#928`, but it should not be the primary rollout mechanism.
+
+## Exact Seams / Files
+
+### Primary server-control-plane files
+
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+
+### Root-shell rendering and visibility
+
+- Inspect first, modify only if a tiny helper is needed: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+- Inspect first, likely no change needed: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/FeatureFlagServlet.java`
+
+### Tests
+
+- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/FeatureFlagSeederJ2clBootstrapTest.java`
+- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java`
+- Extend if needed: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+
+### Release note
+
+- Add: `wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json`
+- Regenerate only: `wave/config/changelog.json`
+
+### Committed verification matrix artifact
+
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+
+## Minimal Acceptance Slices
+
+### Slice 1: Server-known flag exists and defaults off
+
+- Add `j2cl-root-bootstrap` to `KnownFeatureFlags` so it appears in admin flag listings and cannot be deleted as an unknown free-form toggle.
+- Seed the flag from server config or startup seeding code so the default is reproducibly `false`.
+- Keep `FeatureFlagService` as the evaluation layer; do not add client-flag plumbing as the authoritative switch.
+
+### Slice 2: `/` chooses the shell from the server flag
+
+- `WaveClientServlet#doGet` should render legacy GWT for `/` when `j2cl-root-bootstrap` is off.
+- The same method should render the J2CL root shell for `/` when `j2cl-root-bootstrap` is on.
+- Preserve `/?view=j2cl-root` as a direct root-shell diagnostic route from `#928`, but do not make it the rollout control plane.
+- `getSessionJson()` may continue to include enabled feature names for visibility; that is secondary to the HTML decision.
+
+### Slice 3: Signed-out bootstrap is supported
+
+- Global evaluation via `FeatureFlagService.isEnabled("j2cl-root-bootstrap", null)` must work.
+- When the global flag is on, unsigned requests to `/` should intentionally receive the J2CL root shell HTML before login.
+- Signed-out proof must stay deterministic and not rely on a client-side flag after page load.
+
+### Slice 4: Rollback is immediate and boring
+
+- Turning the flag off should restore the legacy GWT root on `/` without a code rollback.
+- The J2CL shell route from `#928` remains available as a direct diagnostic path, but the production bootstrap decision for `/` returns to GWT when the flag is disabled.
+- If flag refresh lags, the plan should use `refreshCache()` or a restart path in verification rather than assuming the first request proves the new state.
+
+## Implementation Tasks
+
+### Task 1: Add the server-side bootstrap flag
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+
+- [ ] Register `j2cl-root-bootstrap` in the known-flag list with a concise rollout description and a default `false` state.
+- [ ] Add a config-seeded startup path for the new flag so local dev and staged environments can flip the root bootstrap without editing client code.
+- [ ] Make the seeding path preserve admin overrides if the flag already exists in the store.
+- [ ] Ensure the startup path refreshes `FeatureFlagService` after seeding so the root decision sees the new value immediately.
+
+### Task 2: Route plain `/` from the server flag
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+- Inspect first, modify only if a tiny helper is needed: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+
+- [ ] Add an explicit server-side branch for `/` that checks `FeatureFlagService.isEnabled("j2cl-root-bootstrap", participantId)`.
+- [ ] Keep the existing `/?view=j2cl-root` direct path working as a diagnostic escape hatch for local verification.
+- [ ] Preserve the legacy landing-page behavior for unauthenticated users when the flag is off and the request is not explicitly selecting the J2CL root shell.
+- [ ] Leave client flags as a visibility mirror only; do not use them to decide which shell HTML gets rendered.
+- [ ] Keep the J2CL root shell page HTML itself anchored in the already-committed `HtmlRenderer.renderJ2clRootShellPage(...)` baseline rather than reworking the shell layout.
+
+### Task 3: Cover the control plane with focused tests
+
+**Files:**
+- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/FeatureFlagSeederJ2clBootstrapTest.java`
+- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java`
+- Extend if needed: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+
+- [ ] Add a test that proves `j2cl-root-bootstrap` is discoverable through the known-flag registry and defaults to off.
+- [ ] Add a test that proves the seeder path turns the flag on from config without breaking admin-owned persisted values.
+- [ ] Add a test matrix for `WaveClientServlet` that covers legacy `/` with the flag off, `/` with the flag on, signed-out `/` with the global flag on, and `/?view=j2cl-root` as the direct diagnostic path.
+- [ ] Add a test that proves the root-shell HTML does not regress the existing `/#928` marker behavior while the server-side decision changes.
+
+### Task 4: Record the rollout contract
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json`
+- Regenerate only: `wave/config/changelog.json`
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+
+- [ ] Add a changelog fragment that says the J2CL root shell is now selectable by a server-side feature flag while legacy GWT remains the default fallback.
+- [ ] Keep the changelog focused on the bootstrap control plane; do not describe the later client migration work.
+- [ ] Add a committed dual-bootstrap verification matrix section to `docs/runbooks/j2cl-sidecar-testing.md` (or an adjacent J2CL runbook if implementation proves that file is the wrong home) so the bootstrap-off vs bootstrap-on checks are no longer only in issue text or the plan file.
+
+## Verification Matrix
+
+### Mode A: Legacy GWT root remains the default
+
+Run from `/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap`:
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch compileGwt Universal/stage
+bash scripts/worktree-boot.sh --port 9914
+PORT=9914 bash scripts/wave-smoke.sh start
+curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
+curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
+PORT=9914 bash scripts/wave-smoke.sh stop
+```
+
+Expected result:
+
+- `/` still serves the legacy GWT root HTML
+- the explicit `/?view=j2cl-root` diagnostic route still serves the J2CL root shell
+- `compileGwt` and `Universal/stage` stay green
+
+### Mode B: J2CL root bootstrap is enabled server-side
+
+Run from `/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap`:
+
+```bash
+cp wave/config/application.conf /tmp/issue-923-j2cl-root-bootstrap.application.conf
+printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/issue-923-j2cl-root-bootstrap.application.conf
+JAVA_OPTS='-Dwave.server.config=/tmp/issue-923-j2cl-root-bootstrap.application.conf' bash scripts/worktree-boot.sh --port 9914
+PORT=9914 bash scripts/wave-smoke.sh start
+curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
+PORT=9914 bash scripts/wave-smoke.sh stop
+```
+
+Expected result:
+
+- plain `/` now serves the J2CL root shell because the server flag is on
+- the J2CL shell still works through the direct diagnostic route
+- toggling the config back to false restores the legacy GWT root without a code rollback
+
+## Rollback / Fallback
+
+- The rollback path is to disable `j2cl-root-bootstrap` in the feature-flag store or config seed, then refresh the cache or restart the server.
+- If `FeatureFlagService` caching makes the switch look sticky, the plan should treat that as a refresh problem, not a new bootstrap branch.
+- Keep `/?view=j2cl-root` as a diagnostic route, but do not widen it into the authoritative rollout knob.
+- Client-flag mirrors in `getSessionJson()` are informational only; they must never become the bootstrap source of truth.
+
+## Risks
+
+- A per-user-only rollout would fail the signed-out bootstrap proof, so the plan must support the global `participantId == null` path.
+- If `WaveClientServlet` keeps consulting client flags for the root decision, the bootstrap control plane will be in the wrong layer.
+- If the known flag is not added to `KnownFeatureFlags`, the admin UI and delete guardrails will not treat it as a first-class rollout toggle.
+- If the seeding path is omitted, local verification will be hard to reproduce and rollback will require manual DB edits.
+- If the root-shell diagnostic route is accidentally coupled to the rollout flag, debugging the baseline from `#928` becomes harder, not easier.
+
+## Self-Check
+
+- Coverage check: every acceptance slice maps to at least one task.
+- Scope check: this plan changes only the server bootstrap control plane and its tests; it does not reopen the J2CL root shell implementation from `#928/#937`.
+- Fallback check: disabling the flag returns `/` to legacy GWT without code rollback.
+- Verification check: both bootstrap modes have explicit commands, and both are testable in the worktree.

--- a/docs/superpowers/plans/2026-04-20-issue-923-j2cl-root-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-20-issue-923-j2cl-root-bootstrap.md
@@ -42,7 +42,7 @@ The intended control plane is:
 
 ### Tests
 
-- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/FeatureFlagSeederJ2clBootstrapTest.java`
+- Modify or add: `wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java`
 - Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java`
 - Extend if needed: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
 
@@ -111,7 +111,7 @@ The intended control plane is:
 ### Task 3: Cover the control plane with focused tests
 
 **Files:**
-- Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/persistence/FeatureFlagSeederJ2clBootstrapTest.java`
+- Modify or add: `wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java`
 - Modify or add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java`
 - Extend if needed: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
 
@@ -138,7 +138,7 @@ The intended control plane is:
 Run from `/Users/vega/devroot/worktrees/issue-923-j2cl-root-bootstrap`:
 
 ```bash
-sbt -batch "testOnly org.waveprotocol.box.server.persistence.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
 sbt -batch compileGwt Universal/stage
 bash scripts/worktree-boot.sh --port 9914
 PORT=9914 bash scripts/wave-smoke.sh start

--- a/journal/local-verification/2026-04-20-issue-923-j2cl-root-bootstrap.md
+++ b/journal/local-verification/2026-04-20-issue-923-j2cl-root-bootstrap.md
@@ -15,6 +15,7 @@ sbt -batch test
 
 ## Results
 
+- Follow-up runbook remediation: updated Mode B to copy the `scripts/worktree-boot.sh --port 9914` runtime config from `journal/runtime-config/*-port-9914.application.conf` before enabling `ui.j2cl_root_bootstrap_enabled`, so the documented override keeps the staged server on port 9914.
 - Focused regression checks passed after adding:
   - coverage that explicit override config can still reconcile `j2cl-root-bootstrap`
   - coverage that omitting the key from override config preserves the stored flag value
@@ -24,3 +25,6 @@ sbt -batch test
   - First run had one unrelated failure in `org.waveprotocol.box.server.waveletstate.segment.SegmentWaveletStateRegistryConcurrencyTest.concurrentGetsAndPutsDoNotThrow` (`LRU size should be <= maxEntries`).
   - Immediate isolated rerun of that test passed.
   - Full `sbt -batch test` retry passed with `Passed: Total 2538, Failed 0, Errors 0, Passed 2536, Skipped 2`.
+- Fresh post-remediation reruns also passed:
+  - `sbt -batch compile`
+  - `sbt -batch test` with `Passed: Total 2538, Failed 0, Errors 0, Passed 2536, Skipped 2`

--- a/journal/local-verification/2026-04-20-issue-923-j2cl-root-bootstrap.md
+++ b/journal/local-verification/2026-04-20-issue-923-j2cl-root-bootstrap.md
@@ -1,0 +1,26 @@
+# Issue 923 / PR 939 remediation verification
+
+- Date: 2026-04-20
+- Worktree: `/Users/vega/devroot/worktrees/vega113-incubator-wave-pr-939-monitor`
+- Branch: `monitor/vega113-incubator-wave/pr-939`
+- PR: `#939`
+
+## Commands
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest" "jakartaTest:testOnly org.waveprotocol.box.server.ServerMainConfigOverrideTest"
+sbt -batch compile
+sbt -batch test
+```
+
+## Results
+
+- Focused regression checks passed after adding:
+  - coverage that explicit override config can still reconcile `j2cl-root-bootstrap`
+  - coverage that omitting the key from override config preserves the stored flag value
+  - coverage that `loadCoreConfig()` rejects a missing `-Dwave.server.config` path
+- `sbt -batch compile` passed.
+- `sbt -batch test` passed on retry.
+  - First run had one unrelated failure in `org.waveprotocol.box.server.waveletstate.segment.SegmentWaveletStateRegistryConcurrencyTest.concurrentGetsAndPutsDoNotThrow` (`LRU size should be <= maxEntries`).
+  - Immediate isolated rerun of that test passed.
+  - Full `sbt -batch test` retry passed with `Passed: Total 2538, Failed 0, Errors 0, Passed 2536, Skipped 2`.

--- a/wave/config/application.conf
+++ b/wave/config/application.conf
@@ -56,6 +56,3 @@ core.enable_profiling = false
 
 # Enable OT search (real-time search wavelets) for local testing
 search.ot_search_enabled = true
-
-# Opt in to the J2CL root-shell bootstrap only when explicitly enabled.
-ui.j2cl_root_bootstrap_enabled = false

--- a/wave/config/application.conf
+++ b/wave/config/application.conf
@@ -56,3 +56,6 @@ core.enable_profiling = false
 
 # Enable OT search (real-time search wavelets) for local testing
 search.ot_search_enabled = true
+
+# Opt in to the J2CL root-shell bootstrap only when explicitly enabled.
+ui.j2cl_root_bootstrap_enabled = false

--- a/wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json
@@ -6,7 +6,7 @@
   "summary": "The root / route can now opt into the J2CL shell through a server-side feature flag while legacy GWT remains the default fallback and the explicit /?view=j2cl-root diagnostic route stays available.",
   "sections": [
     {
-      "type": "fix",
+      "type": "feature",
       "items": [
         "Added the j2cl-root-bootstrap known feature flag and seeded it from ui.j2cl_root_bootstrap_enabled",
         "The / route now checks the server feature flag before choosing the J2CL root shell, while /?view=j2cl-root remains a direct diagnostic route",

--- a/wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-root-bootstrap.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-20-j2cl-root-bootstrap",
+  "version": "Unreleased",
+  "date": "2026-04-20",
+  "title": "Allow the J2CL root shell to bootstrap from a server feature flag",
+  "summary": "The root / route can now opt into the J2CL shell through a server-side feature flag while legacy GWT remains the default fallback and the explicit /?view=j2cl-root diagnostic route stays available.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added the j2cl-root-bootstrap known feature flag and seeded it from ui.j2cl_root_bootstrap_enabled",
+        "The / route now checks the server feature flag before choosing the J2CL root shell, while /?view=j2cl-root remains a direct diagnostic route",
+        "Fresh deployments keep legacy GWT as the default unless the bootstrap flag is explicitly enabled"
+      ]
+    }
+  ]
+}

--- a/wave/config/reference.conf
+++ b/wave/config/reference.conf
@@ -492,6 +492,8 @@ wave.fragments.applier.impl = "noop"
 # polling mechanism. Disabled by default until Phase 4 (client integration)
 # is complete.
 search.ot_search_enabled = false
+# Bootstrap the J2CL root shell on / only when explicitly enabled.
+ui.j2cl_root_bootstrap_enabled = false
 # Controls the synchronous startup warmup in ServerMain that pre-builds either
 # the owner wave view or the entire wave map. Default false because eager
 # warmup can block startup on a full wave scan; leaving it off preserves the

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -13,6 +13,7 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigParseOptions;
 import org.waveprotocol.box.server.authentication.AccountStoreHolder;
 import org.waveprotocol.box.server.executor.ExecutorsModule;
 import org.waveprotocol.box.server.frontend.ClientFrontend;
@@ -149,16 +150,45 @@ public class ServerMain {
   }
 
   static Config loadCoreConfig() {
-    String serverConfigPath = System.getProperty("wave.server.config");
-    File applicationConfig =
-        (serverConfigPath != null && !serverConfigPath.isBlank())
-            ? new File(serverConfigPath)
-            : new File("config/application.conf");
+    File applicationConfig = resolveApplicationConfigFile();
+    boolean hasExplicitOverride = hasExplicitConfigOverride();
+    ConfigParseOptions parseOptions =
+        hasExplicitOverride
+            ? ConfigParseOptions.defaults().setAllowMissing(false)
+            : ConfigParseOptions.defaults();
 
     return ConfigFactory.defaultOverrides()
-        .withFallback(ConfigFactory.parseFile(applicationConfig))
+        .withFallback(ConfigFactory.parseFile(applicationConfig, parseOptions))
         .withFallback(ConfigFactory.parseFile(new File("config/reference.conf")))
         .resolve();
+  }
+
+  static Config loadApplicationOverrideConfig() {
+    File applicationConfig = resolveApplicationConfigFile();
+    boolean hasExplicitOverride = hasExplicitConfigOverride();
+    ConfigParseOptions parseOptions =
+        hasExplicitOverride
+            ? ConfigParseOptions.defaults().setAllowMissing(false)
+            : ConfigParseOptions.defaults();
+    return ConfigFactory.parseFile(applicationConfig, parseOptions).resolve();
+  }
+
+  private static boolean hasExplicitConfigOverride() {
+    String serverConfigPath = System.getProperty("wave.server.config");
+    return serverConfigPath != null && !serverConfigPath.isBlank();
+  }
+
+  private static File resolveApplicationConfigFile() {
+    String serverConfigPath = System.getProperty("wave.server.config");
+    if (serverConfigPath != null && !serverConfigPath.isBlank()) {
+      File applicationConfig = new File(serverConfigPath);
+      if (!applicationConfig.exists() || !applicationConfig.isFile()) {
+        throw new IllegalArgumentException(
+            "wave.server.config does not point to a readable config file: " + serverConfigPath);
+      }
+      return applicationConfig;
+    }
+    return new File("config/application.conf");
   }
 
   private static Module buildFederationModule(Injector settingsInjector) {
@@ -188,10 +218,12 @@ public class ServerMain {
   private static void initializeFeatureFlags(Injector injector) {
     try {
       Config config = injector.getInstance(Config.class);
+      Config applicationOverrideConfig = loadApplicationOverrideConfig();
       FeatureFlagStore featureFlagStore = injector.getInstance(FeatureFlagStore.class);
       FeatureFlagSeeder.seedSearchFeatureFlags(featureFlagStore, config);
       FeatureFlagSeeder.seedJ2clRootBootstrapFeatureFlags(featureFlagStore, config);
-      FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(featureFlagStore, config);
+      FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
+          featureFlagStore, applicationOverrideConfig);
       injector.getInstance(FeatureFlagService.class).refreshCache();
     } catch (PersistenceException e) {
       LOG.log(java.util.logging.Level.WARNING,

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -170,7 +170,7 @@ public class ServerMain {
         hasExplicitOverride
             ? ConfigParseOptions.defaults().setAllowMissing(false)
             : ConfigParseOptions.defaults();
-    return ConfigFactory.parseFile(applicationConfig, parseOptions).resolve();
+    return ConfigFactory.parseFile(applicationConfig, parseOptions);
   }
 
   private static boolean hasExplicitConfigOverride() {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -89,10 +89,7 @@ public class ServerMain {
 
       Module coreSettings = new AbstractModule() {
         @Override protected void configure() {
-          Config config = ConfigFactory.defaultOverrides()
-              .withFallback(ConfigFactory.parseFile(new File("config/application.conf")))
-              .withFallback(ConfigFactory.parseFile(new File("config/reference.conf")))
-              .resolve();
+          Config config = loadCoreConfig();
           bind(Config.class).toInstance(config);
           bind(Key.get(String.class, Names.named(CoreSettingsNames.WAVE_SERVER_DOMAIN)))
               .toInstance(config.getString("core.wave_server_domain"));
@@ -151,6 +148,19 @@ public class ServerMain {
     server.startWebSocketServer(injector);
   }
 
+  static Config loadCoreConfig() {
+    String serverConfigPath = System.getProperty("wave.server.config");
+    File applicationConfig =
+        (serverConfigPath != null && !serverConfigPath.isBlank())
+            ? new File(serverConfigPath)
+            : new File("config/application.conf");
+
+    return ConfigFactory.defaultOverrides()
+        .withFallback(ConfigFactory.parseFile(applicationConfig))
+        .withFallback(ConfigFactory.parseFile(new File("config/reference.conf")))
+        .resolve();
+  }
+
   private static Module buildFederationModule(Injector settingsInjector) {
     return settingsInjector.getInstance(NoOpFederationModule.class);
   }
@@ -180,10 +190,12 @@ public class ServerMain {
       Config config = injector.getInstance(Config.class);
       FeatureFlagStore featureFlagStore = injector.getInstance(FeatureFlagStore.class);
       FeatureFlagSeeder.seedSearchFeatureFlags(featureFlagStore, config);
+      FeatureFlagSeeder.seedJ2clRootBootstrapFeatureFlags(featureFlagStore, config);
+      FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(featureFlagStore, config);
       injector.getInstance(FeatureFlagService.class).refreshCache();
     } catch (PersistenceException e) {
       LOG.log(java.util.logging.Level.WARNING,
-          "Failed to seed ot-search feature flag; search updates stay off", e);
+          "Failed to seed feature flags; rollout defaults stay unchanged", e);
     }
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -130,8 +130,11 @@ public class WaveClientServlet extends HttpServlet {
     WebSession session = WebSessions.from(request, false);
     ParticipantId id = sessionManager.getLoggedInUser(session);
     String requestedView = resolveRequestedView(request);
+    boolean j2clRootBootstrapEnabled =
+        featureFlagService.isEnabled("j2cl-root-bootstrap", id != null ? id.getAddress() : null);
 
-    if (VIEW_J2CL_ROOT.equals(requestedView)) {
+    if (VIEW_J2CL_ROOT.equals(requestedView)
+        || (StringUtils.isEmpty(requestedView) && j2clRootBootstrapEnabled)) {
       String rootShellReturnTarget = buildJ2clRootShellReturnTarget(request);
       response.setContentType("text/html");
       response.setCharacterEncoding("UTF-8");

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
@@ -50,4 +50,19 @@ public final class ServerMainConfigOverrideTest {
       }
     }
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void loadCoreConfigFailsFastWhenWaveServerConfigIsMissing() {
+    String previousConfigPath = System.getProperty("wave.server.config");
+    System.setProperty("wave.server.config", "/tmp/does-not-exist-issue-923.application.conf");
+    try {
+      ServerMain.loadCoreConfig();
+    } finally {
+      if (previousConfigPath == null) {
+        System.clearProperty("wave.server.config");
+      } else {
+        System.setProperty("wave.server.config", previousConfigPath);
+      }
+    }
+  }
 }

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server;
+
+import static org.junit.Assert.assertTrue;
+
+import com.typesafe.config.Config;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Test;
+
+public final class ServerMainConfigOverrideTest {
+  @Test
+  public void loadCoreConfigHonorsWaveServerConfigOverride() throws Exception {
+    Path tempDir = Files.createTempDirectory("server-main-config-override");
+    Path applicationConfig = tempDir.resolve("application.conf");
+    Files.writeString(
+        applicationConfig,
+        "ui.j2cl_root_bootstrap_enabled = true\n",
+        StandardCharsets.UTF_8);
+
+    String previousConfigPath = System.getProperty("wave.server.config");
+    System.setProperty("wave.server.config", applicationConfig.toString());
+    try {
+      Config config = ServerMain.loadCoreConfig();
+
+      assertTrue(config.getBoolean("ui.j2cl_root_bootstrap_enabled"));
+    } finally {
+      if (previousConfigPath == null) {
+        System.clearProperty("wave.server.config");
+      } else {
+        System.setProperty("wave.server.config", previousConfigPath);
+      }
+    }
+  }
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
@@ -19,6 +19,7 @@
 package org.waveprotocol.box.server;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.typesafe.config.Config;
 import java.nio.charset.StandardCharsets;
@@ -51,12 +52,20 @@ public final class ServerMainConfigOverrideTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void loadCoreConfigFailsFastWhenWaveServerConfigIsMissing() {
+  @Test
+  public void loadCoreConfigRejectsMissingWaveServerConfigOverride() {
+    Path missingConfig =
+        Path.of(System.getProperty("java.io.tmpdir"), "missing-server-main-config-" + System.nanoTime());
+
     String previousConfigPath = System.getProperty("wave.server.config");
-    System.setProperty("wave.server.config", "/tmp/does-not-exist-issue-923.application.conf");
+    System.setProperty("wave.server.config", missingConfig.toString());
     try {
-      ServerMain.loadCoreConfig();
+      try {
+        ServerMain.loadCoreConfig();
+        fail("Expected loadCoreConfig to reject a missing override file");
+      } catch (RuntimeException e) {
+        assertTrue(e.getMessage().contains(missingConfig.toString()));
+      }
     } finally {
       if (previousConfigPath == null) {
         System.clearProperty("wave.server.config");

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
@@ -82,6 +82,8 @@ public final class FeatureFlagSeeder {
 
   public static void reconcileJ2clRootBootstrapFeatureFlag(
       FeatureFlagStore store, Config config) throws PersistenceException {
+    // Reconcile only from the operator-provided application/override config, not from
+    // the fully-resolved effective config (which always contains the reference default).
     if (store == null || config == null || !config.hasPath(J2CL_ROOT_BOOTSTRAP_CONFIG_KEY)) {
       return;
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
@@ -30,6 +30,10 @@ public final class FeatureFlagSeeder {
   private static final String OT_SEARCH_DESCRIPTION =
       "OT/Lucene search (real-time wavelets + full-text indexing)";
   private static final String OT_SEARCH_CONFIG_KEY = "search.ot_search_enabled";
+  private static final String J2CL_ROOT_BOOTSTRAP_FLAG_NAME = "j2cl-root-bootstrap";
+  private static final String J2CL_ROOT_BOOTSTRAP_DESCRIPTION =
+      "Bootstrap the J2CL root shell on /";
+  private static final String J2CL_ROOT_BOOTSTRAP_CONFIG_KEY = "ui.j2cl_root_bootstrap_enabled";
 
   private FeatureFlagSeeder() {
   }
@@ -52,6 +56,59 @@ public final class FeatureFlagSeeder {
       LOG.info("Seeded ot-search feature flag: enabled=" + enabled);
     } else {
       LOG.info("ot-search feature flag already present in store — preserving existing value");
+    }
+  }
+
+  public static void seedJ2clRootBootstrapFeatureFlags(FeatureFlagStore store, Config config)
+      throws PersistenceException {
+    if (store == null || config == null || !config.hasPath(J2CL_ROOT_BOOTSTRAP_CONFIG_KEY)) {
+      return;
+    }
+    if (store.get(J2CL_ROOT_BOOTSTRAP_FLAG_NAME) == null) {
+      // Flag not yet in DB — initialize from config so fresh deploys start with the right default.
+      // If a flag already exists (admin set it via the API), leave it untouched.
+      boolean enabled = config.getBoolean(J2CL_ROOT_BOOTSTRAP_CONFIG_KEY);
+      store.save(
+          new FeatureFlag(
+              J2CL_ROOT_BOOTSTRAP_FLAG_NAME,
+              J2CL_ROOT_BOOTSTRAP_DESCRIPTION,
+              enabled,
+              Collections.emptyMap()));
+      LOG.info("Seeded j2cl-root-bootstrap feature flag: enabled=" + enabled);
+    } else {
+      LOG.info("j2cl-root-bootstrap feature flag already present in store — preserving existing value");
+    }
+  }
+
+  public static void reconcileJ2clRootBootstrapFeatureFlag(
+      FeatureFlagStore store, Config config) throws PersistenceException {
+    if (store == null || config == null || !config.hasPath(J2CL_ROOT_BOOTSTRAP_CONFIG_KEY)) {
+      return;
+    }
+
+    boolean enabled = config.getBoolean(J2CL_ROOT_BOOTSTRAP_CONFIG_KEY);
+    FeatureFlag existing = store.get(J2CL_ROOT_BOOTSTRAP_FLAG_NAME);
+    if (existing == null) {
+      store.save(
+          new FeatureFlag(
+              J2CL_ROOT_BOOTSTRAP_FLAG_NAME,
+              J2CL_ROOT_BOOTSTRAP_DESCRIPTION,
+              enabled,
+              Collections.emptyMap()));
+      LOG.info("Reconciled j2cl-root-bootstrap feature flag from startup config: enabled=" + enabled);
+      return;
+    }
+
+    if (existing.isEnabled() != enabled) {
+      store.save(
+          new FeatureFlag(
+              J2CL_ROOT_BOOTSTRAP_FLAG_NAME,
+              existing.getDescription().isEmpty()
+                  ? J2CL_ROOT_BOOTSTRAP_DESCRIPTION
+                  : existing.getDescription(),
+              enabled,
+              existing.getAllowedUsers()));
+      LOG.info("Reconciled j2cl-root-bootstrap feature flag from startup config: enabled=" + enabled);
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -42,6 +42,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("task-search", "Enable tasks:me search filter and Tasks toolbar button", true, Collections.emptyMap()));
     defaults.add(new FeatureFlag("mentions-search", "Enable @mention search filter and Mentions toolbar button", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on /", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.persistence.memory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.typesafe.config.ConfigFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.waveprotocol.box.server.persistence.FeatureFlagSeeder;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.KnownFeatureFlags;
+
+public final class FeatureFlagSeederJ2clBootstrapTest {
+  @Test
+  public void knownBootstrapFlagIsRegisteredAndDefaultsOff() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    FeatureFlagService service = new FeatureFlagService(store);
+    try {
+      assertTrue(KnownFeatureFlags.isKnownFlag("j2cl-root-bootstrap"));
+      assertFalse(service.getEnabledFlagNames(null).contains("j2cl-root-bootstrap"));
+    } finally {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  public void seedsJ2clRootBootstrapFlagFromConfigWhenAbsent() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+
+    FeatureFlagSeeder.seedJ2clRootBootstrapFeatureFlags(
+        store, ConfigFactory.parseString("ui.j2cl_root_bootstrap_enabled = true"));
+
+    FeatureFlag flag = store.get("j2cl-root-bootstrap");
+
+    assertTrue(flag != null);
+    assertTrue(flag.isEnabled());
+    assertTrue(flag.getAllowedUsers().isEmpty());
+  }
+
+  @Test
+  public void preservesExistingJ2clRootBootstrapFlagWhenSeeding() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    Map<String, Boolean> allowedUsers = new LinkedHashMap<>();
+    allowedUsers.put("admin@example.com", true);
+    store.save(
+        new FeatureFlag(
+            "j2cl-root-bootstrap",
+            "Bootstrap the J2CL root shell on /",
+            true,
+            allowedUsers));
+
+    FeatureFlagSeeder.seedJ2clRootBootstrapFeatureFlags(
+        store, ConfigFactory.parseString("ui.j2cl_root_bootstrap_enabled = false"));
+
+    FeatureFlag flag = store.get("j2cl-root-bootstrap");
+
+    assertTrue(flag.isEnabled());
+    assertTrue(flag.getAllowedUsers().containsKey("admin@example.com"));
+    assertTrue(flag.getAllowedUsers().get("admin@example.com"));
+  }
+
+  @Test
+  public void reconcilesJ2clRootBootstrapFlagFromStartupConfig() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    Map<String, Boolean> allowedUsers = new LinkedHashMap<>();
+    allowedUsers.put("admin@example.com", true);
+    store.save(
+        new FeatureFlag(
+            "j2cl-root-bootstrap",
+            "Bootstrap the J2CL root shell on /",
+            false,
+            allowedUsers));
+
+    FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
+        store, ConfigFactory.parseString("ui.j2cl_root_bootstrap_enabled = true"));
+
+    FeatureFlag flag = store.get("j2cl-root-bootstrap");
+
+    assertTrue(flag.isEnabled());
+    assertTrue(flag.getAllowedUsers().containsKey("admin@example.com"));
+    assertTrue(flag.getAllowedUsers().get("admin@example.com"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
@@ -80,7 +80,8 @@ public final class FeatureFlagSeederJ2clBootstrapTest {
   }
 
   @Test
-  public void reconcilesJ2clRootBootstrapFlagFromStartupConfig() throws Exception {
+  public void reconcilePreservesExistingJ2clRootBootstrapFlagWhenOverrideConfigOmitsValue()
+      throws Exception {
     MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
     Map<String, Boolean> allowedUsers = new LinkedHashMap<>();
     allowedUsers.put("admin@example.com", true);
@@ -88,8 +89,28 @@ public final class FeatureFlagSeederJ2clBootstrapTest {
         new FeatureFlag(
             "j2cl-root-bootstrap",
             "Bootstrap the J2CL root shell on /",
-            false,
+            true,
             allowedUsers));
+
+    FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
+        store, ConfigFactory.parseString("core.http_frontend_addresses=[\"127.0.0.1:9898\"]"));
+
+    FeatureFlag flag = store.get("j2cl-root-bootstrap");
+
+    assertTrue(flag.isEnabled());
+    assertTrue(flag.getAllowedUsers().containsKey("admin@example.com"));
+    assertTrue(flag.getAllowedUsers().get("admin@example.com"));
+  }
+
+  @Test
+  public void reconcileAppliesExplicitJ2clRootBootstrapOverride() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(
+        new FeatureFlag(
+            "j2cl-root-bootstrap",
+            "Bootstrap the J2CL root shell on /",
+            false,
+            new LinkedHashMap<>()));
 
     FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
         store, ConfigFactory.parseString("ui.j2cl_root_bootstrap_enabled = true"));
@@ -97,7 +118,5 @@ public final class FeatureFlagSeederJ2clBootstrapTest {
     FeatureFlag flag = store.get("j2cl-root-bootstrap");
 
     assertTrue(flag.isEnabled());
-    assertTrue(flag.getAllowedUsers().containsKey("admin@example.com"));
-    assertTrue(flag.getAllowedUsers().get("admin@example.com"));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.junit.After;
 import org.junit.Test;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
@@ -43,6 +44,16 @@ import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
 public final class WaveClientServletJ2clBootstrapTest {
+  private FeatureFlagService featureFlagService;
+
+  @After
+  public void tearDown() {
+    if (featureFlagService != null) {
+      featureFlagService.shutdown();
+      featureFlagService = null;
+    }
+  }
+
   @Test
   public void plainRootFallsBackToLegacyGwtWhenBootstrapFlagIsOff() throws Exception {
     WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), false);
@@ -115,7 +126,7 @@ public final class WaveClientServletJ2clBootstrapTest {
     assertTrue(html.contains("/auth/signin?r=/%3Fview%3Dj2cl-root"));
   }
 
-  private static WaveClientServlet createServlet(ParticipantId user, boolean bootstrapEnabled)
+  private WaveClientServlet createServlet(ParticipantId user, boolean bootstrapEnabled)
       throws Exception {
     Config config = ConfigFactory.parseString(
         "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
@@ -134,7 +145,7 @@ public final class WaveClientServletJ2clBootstrapTest {
             "Bootstrap the J2CL root shell on /",
             bootstrapEnabled,
             java.util.Collections.emptyMap()));
-    FeatureFlagService featureFlagService = new FeatureFlagService(featureFlagStore);
+    featureFlagService = new FeatureFlagService(featureFlagStore);
 
     return new WaveClientServlet(
         "example.com",

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.Test;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class WaveClientServletJ2clBootstrapTest {
+  @Test
+  public void plainRootFallsBackToLegacyGwtWhenBootstrapFlagIsOff() throws Exception {
+    WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("webclient/webclient.nocache.js"));
+    assertFalse(html.contains("data-j2cl-root-shell"));
+  }
+
+  @Test
+  public void plainRootBootsIntoJ2clShellWhenBootstrapFlagIsOn() throws Exception {
+    WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), true);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("data-j2cl-root-shell"));
+    assertTrue(html.contains("/j2cl/assets/sidecar.css"));
+    assertFalse(html.contains("webclient/webclient.nocache.js"));
+  }
+
+  @Test
+  public void signedOutRootUsesGlobalBootstrapFlag() throws Exception {
+    WaveClientServlet servlet = createServlet(null, true);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getSession(false)).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("data-j2cl-root-shell"));
+    assertTrue(html.contains("Signed out"));
+    assertTrue(html.contains("data-j2cl-root-signin=\"true\""));
+  }
+
+  @Test
+  public void explicitDiagnosticRootRouteStillWorksWithoutBootstrapFlag() throws Exception {
+    WaveClientServlet servlet = createServlet(null, false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn("j2cl-root");
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(null);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("data-j2cl-root-shell"));
+    assertTrue(html.contains("data-j2cl-root-return-target=\"/?view=j2cl-root\""));
+    assertTrue(html.contains("/auth/signin?r=/%3Fview%3Dj2cl-root"));
+  }
+
+  private static WaveClientServlet createServlet(ParticipantId user, boolean bootstrapEnabled)
+      throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+
+    MemoryFeatureFlagStore featureFlagStore = new MemoryFeatureFlagStore();
+    featureFlagStore.save(
+        new FeatureFlag(
+            "j2cl-root-bootstrap",
+            "Bootstrap the J2CL root shell on /",
+            bootstrapEnabled,
+            java.util.Collections.emptyMap()));
+    FeatureFlagService featureFlagService = new FeatureFlagService(featureFlagStore);
+
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        mock(AccountStore.class),
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        featureFlagService);
+  }
+}


### PR DESCRIPTION
## Summary
- add a server-controlled `j2cl-root-bootstrap` feature-flag seam so plain `/` can intentionally boot the J2CL root shell while legacy GWT remains the default fallback
- seed and reconcile the bootstrap flag from server config, and teach `ServerMain` to honor `-Dwave.server.config` so reversible config-based verification works
- keep `/?view=j2cl-root` as the direct diagnostic route and add focused bootstrap tests plus a committed dual-bootstrap runbook matrix
- add the changelog fragment for the opt-in root bootstrap seam

## Verification
- `sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"`
- `sbt -batch compileGwt Universal/stage`
- bootstrap OFF mode on port `9914`:
  - `PORT=9914 bash scripts/wave-smoke.sh check`
  - `curl -fsS http://localhost:9914/` -> legacy signed-out landing page
  - `curl -fsS 'http://localhost:9914/?view=j2cl-root'` -> J2CL root shell
- bootstrap ON mode on port `9914` using a temp overlay built from the port-specific runtime config:
  - `PORT=9914 bash scripts/wave-smoke.sh check`
  - `curl -fsS http://localhost:9914/` -> J2CL root shell
  - `curl -fsS 'http://localhost:9914/?view=j2cl-root'` -> J2CL root shell

Closes #923.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-controlled feature flag to optionally bootstrap the J2CL root shell at /; legacy GWT remains the default and diagnostic route /?view=j2cl-root is preserved.

* **Configuration**
  * New config ui.j2cl_root_bootstrap_enabled (default: false) and support for loading an explicit server config override.

* **Documentation**
  * Added runbook, implementation plan, and changelog entry with dual validation modes.

* **Tests**
  * New tests covering config override handling, flag seeding/reconciliation, and servlet rendering for signed-in/signed-out and diagnostic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->