### PR TITLE
feat(j2cl): cut over default root

### DIFF
--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -171,46 +171,50 @@ PORT=9900 bash scripts/wave-smoke.sh stop
 
 ## Dual Bootstrap Matrix
 
-Use this matrix when you are validating the issue #923 root-bootstrap seam.
+Use this matrix when you are validating the issue #924 default-root cutover.
 Run from the repo root unless the command says otherwise.
 
-### Mode A: Legacy GWT Root Remains The Default
+### Mode A: J2CL Root Is The Default
 
 ```bash
-sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest org.waveprotocol.box.server.ServerMainConfigOverrideTest"
 sbt -batch compileGwt Universal/stage
 bash scripts/worktree-boot.sh --port 9914
 PORT=9914 bash scripts/wave-smoke.sh start
-curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
+curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/?view=landing | grep -F 'Sign In'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 PORT=9914 bash scripts/wave-smoke.sh stop
 ```
 
 Expected result:
 
-- `/` still serves the legacy GWT root HTML when the bootstrap flag is off
-- `/?view=j2cl-root` still serves the J2CL root shell as the direct diagnostic route
+- `/` serves the J2CL root shell when the bootstrap flag defaults on
+- `?view=landing` still reaches the explicit legacy landing page
+- `/?view=j2cl-root` still serves the same J2CL root shell as the direct diagnostic route
 - `compileGwt` and `Universal/stage` stay green
 
-### Mode B: J2CL Root Bootstrap Is Enabled Server-Side
+### Mode B: Legacy GWT Rollback Restores The Old Root
 
 ```bash
 bash scripts/worktree-boot.sh --port 9914
 RUNTIME_CONFIG="$(find journal/runtime-config -maxdepth 1 -name '*-port-9914.application.conf' | head -n1)"
 cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap.application.conf
-printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap.application.conf
+printf '\nui.j2cl_root_bootstrap_enabled=false\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop
 PORT=9914 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf" bash scripts/wave-smoke.sh start
-curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/ | grep -F 'SupaWave - Real-time Collaborative Communication'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/?view=landing | grep -F 'SupaWave - Real-time Collaborative Communication'
 PORT=9914 bash scripts/wave-smoke.sh stop
 ```
 
 Expected result:
 
-- plain `/` serves the J2CL root shell when the server flag is on
-- the direct diagnostic route still serves the same shell
-- turning the config back to `false` restores the legacy GWT root without a code rollback
+- plain `/` falls back to the legacy landing/GWT root when the server flag is rolled back to `false`
+- the direct diagnostic route still serves the J2CL root shell
+- `?view=landing` remains the explicit legacy landing-page escape hatch
+- turning the config back to `true` restores the J2CL default without a code rollback
 - the mode switch is driven by a temp overlay built from the port-specific runtime config that `worktree-boot.sh` generated for the same smoke port, so the server and the probe port stay aligned
 
 ## When To Use Direct Maven Instead Of SBT

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -204,17 +204,19 @@ cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap.application.conf
 printf '\nui.j2cl_root_bootstrap_enabled=false\n' >> /tmp/j2cl-root-bootstrap.application.conf
 PORT=9914 bash scripts/wave-smoke.sh stop
 PORT=9914 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap.application.conf" bash scripts/wave-smoke.sh start
-curl -fsS http://localhost:9914/ | grep -F 'SupaWave - Real-time Collaborative Communication'
+curl -fsS http://localhost:9914/ | grep -F 'nav-link-signin'
+! curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
-curl -fsS http://localhost:9914/?view=landing | grep -F 'SupaWave - Real-time Collaborative Communication'
+curl -fsS http://localhost:9914/?view=landing | grep -F 'nav-link-signin'
+! curl -fsS http://localhost:9914/?view=landing | grep -F 'data-j2cl-root-shell'
 PORT=9914 bash scripts/wave-smoke.sh stop
 ```
 
 Expected result:
 
-- plain `/` falls back to the legacy landing/GWT root when the server flag is rolled back to `false`
+- plain `/` renders legacy markers and does not include `data-j2cl-root-shell` when rolled back to `false`
 - the direct diagnostic route still serves the J2CL root shell
-- `?view=landing` remains the explicit legacy landing-page escape hatch
+- `/?view=landing` renders legacy markers and does not include `data-j2cl-root-shell`
 - turning the config back to `true` restores the J2CL default without a code rollback
 - the mode switch is driven by a temp overlay built from the port-specific runtime config that `worktree-boot.sh` generated for the same smoke port, so the server and the probe port stay aligned
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -21,10 +21,11 @@ As of 2026-04-19, the current J2CL browser surfaces are:
 - `/j2cl/index.html`
   - production-profile J2CL bundle used by packaging
 
-The root `/` route still defaults to the legacy GWT application. Issue #923
-adds a server-controlled bootstrap seam that can intentionally switch `/` to
-the J2CL root shell, but the J2CL path does not replace the obligation to keep
-the legacy path green.
+The root `/` route now boots the J2CL root shell by default (issue #924).
+Issue #923 added the server-controlled bootstrap seam; issue #924 flipped its
+default to enabled for fresh deployments. The legacy GWT root path remains
+reachable through the rollback config and the `/?view=landing` escape hatch,
+but the J2CL path is now the production default.
 
 ## Fast J2CL-Only Checks
 
@@ -190,7 +191,7 @@ PORT=9914 bash scripts/wave-smoke.sh stop
 Expected result:
 
 - `/` serves the J2CL root shell when the bootstrap flag defaults on
-- `?view=landing` still reaches the explicit legacy landing page
+- `/?view=landing` still reaches the explicit legacy landing page
 - `/?view=j2cl-root` still serves the same J2CL root shell as the direct diagnostic route
 - `compileGwt` and `Universal/stage` stay green
 

--- a/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
+++ b/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
@@ -1,0 +1,139 @@
+# Issue #924 Default Root Cutover Implementation Plan
+
+> **For agentic workers:** implement this plan task-by-task in the issue-924 lane only. Do not widen scope into root-shell redesign, route-state changes, or write-path work.
+
+**Goal:** cut over `/` so the J2CL root shell boots by default, while keeping a temporary rollback path that can restore the legacy GWT root without reverting code. This plan starts from the post-`#923` state on `main`: the reversible bootstrap seam already exists and the explicit `/?view=j2cl-root` J2CL root-shell route is already the diagnostic entry point.
+
+**Architecture:** treat this as a server control-plane change, not a new client feature. The key seam is the root decision in `WaveClientServlet#doGet(...)`. When the root-bootstrap control flag says J2CL, `/` should render the same J2CL root shell that `/?view=j2cl-root` already uses, for both signed-in and signed-out requests. Keep the legacy landing/GWT path reachable through the existing rollback control path and keep the explicit J2CL root-shell URL intact for local proof. Fresh deploys should default to J2CL; existing stored/admin overrides must still win so rollback is a config change, not a patch rollback.
+
+## 1. Baseline And Problem
+
+The current repo already has:
+
+- a real J2CL root shell behind `/?view=j2cl-root`
+- a server-side root-bootstrap seam introduced by `#923`
+- the legacy GWT root path still acting as the default `/` experience
+
+The remaining issue is that the root dispatch still short-circuits through the legacy signed-out/landing branch before the J2CL shell can win by default. The cutover needs to move that decision point, not rebuild the shell.
+
+## 2. Exact Control-Plane And Seam Changes
+
+### Server root dispatch
+
+- Update `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java` so the root-bootstrap decision is made before the legacy signed-out landing-page branch.
+- Keep `/?view=j2cl-root` as the explicit diagnostic route, but make `/` follow the J2CL default when the bootstrap flag is enabled.
+- Preserve `?view=landing` as the explicit landing-page escape hatch so the current public landing page is still reachable without being the default root.
+- Ensure the signed-out root path can still render the J2CL shell login entry instead of falling through to the landing page when J2CL is the default.
+
+### Bootstrap control plane
+
+- Use the same server-side bootstrap flag introduced by `#923` as the rollback switch.
+- Make the fresh-deploy default `true` in the flag seeding/config path, but preserve stored/admin overrides so an operator can force legacy GWT back on without a code change.
+- Keep the source of truth in the server control plane:
+  - `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+  - `wave/config/application.conf`
+  - `wave/config/reference.conf`
+
+### J2CL shell preservation
+
+- Keep `HtmlRenderer.renderJ2clRootShellPage(...)` and the J2CL mount path unchanged unless a small copy/return-target adjustment is required to make default-root vs explicit-fallback behavior obvious.
+- Do not rework `J2clRootShellController`, `J2clRootShellView`, or the `SandboxEntryPoint` mount contract unless a test proves the root shell needs a tiny adapter for `/` vs `/?view=j2cl-root`.
+
+### Test seam
+
+- Extend the existing servlet coverage in `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java` or the nearest root-bootstrap test seam.
+- Add one server-level assertion for each root mode: default-on `/`, rollback-off `/`, and explicit `/?view=j2cl-root`.
+
+## 3. Fallback And Rollback Mechanics
+
+- Primary rollback path: disable the root-bootstrap flag and restart/reload the staged config. That must restore the legacy root behavior without a code rollback.
+- Secondary rollback proof: keep `/?view=j2cl-root` working even when `/` is rolled back, so the J2CL shell remains available for targeted diagnosis during the rollout window.
+- Keep `/?view=landing` available as the explicit legacy landing-page route. Do not rely on it as the hidden default once the cutover lands.
+- If the flag lives in persistent storage, the rollout must verify both fresh-deploy seeding and stored-flag precedence so a rollback does not get masked by a stale DB value.
+- Document the rollback command path in the runbook and issue comments, not only in the plan.
+
+## 4. Acceptance Slices
+
+### Slice A: Control-plane flip
+
+- The root-bootstrap flag defaults to J2CL for fresh deploys.
+- Existing stored/admin overrides still beat the fresh default.
+- The server decision point chooses J2CL for `/` before the legacy landing-page fallback can win.
+
+### Slice B: Default `/` cutover
+
+- Signed-out `/` renders the J2CL root shell, not the landing page.
+- Signed-in `/` renders the same J2CL root shell and preserves the existing auth chrome.
+- The J2CL shell still mounts the current search/read/write workflow that `#928` introduced.
+
+### Slice C: Explicit fallback and rollback
+
+- `/?view=j2cl-root` still renders the J2CL shell in both bootstrap modes.
+- A rollback to legacy GWT is possible by config/flag only.
+- `?view=landing` still reaches the legacy landing page explicitly.
+
+### Slice D: Proof and traceability
+
+- The local verification journal records both bootstrap modes.
+- The changelog fragment reflects the user-facing default-root behavior change.
+- Issue comments record the worktree, branch, verification commands, and the final rollback decision.
+
+## 5. Likely Files To Change
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+- `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+- `wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java`
+- `wave/config/application.conf`
+- `wave/config/reference.conf`
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletTest.java` or the nearest root-bootstrap server test seam
+- `docs/runbooks/j2cl-sidecar-testing.md`
+- `wave/config/changelog.d/2026-04-20-j2cl-default-root.json`
+
+## 6. Verification Matrix
+
+| Mode | Route | Expected result | Proof |
+| --- | --- | --- | --- |
+| Default J2CL | `GET /` signed out | J2CL root shell loads with login entry and the J2CL mount host | `WaveClientServletJ2clRootShellTest` plus browser smoke |
+| Default J2CL | `GET /` signed in | Same J2CL root shell loads with authenticated chrome and the hosted workflow | browser smoke in a signed-in session |
+| Default J2CL | `GET /?view=j2cl-root` | Same J2CL shell as `/`, including return-target preservation | server test plus `curl -I`/page-content check |
+| Rollback off | `GET /` signed out | Legacy root behavior returns, not the J2CL shell | server test plus browser smoke |
+| Rollback off | `GET /` signed in | Legacy GWT root remains the default app | `compileGwt Universal/stage` plus browser smoke |
+| Rollback off | `GET /?view=j2cl-root` | The explicit J2CL diagnostic route still works | server test and local browser check |
+| Explicit legacy landing | `GET /?view=landing` | The landing page remains reachable on demand | server test or direct curl |
+
+Recommended local gate:
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+bash scripts/worktree-boot.sh --port 9912
+PORT=9912 bash scripts/wave-smoke.sh start
+PORT=9912 bash scripts/wave-smoke.sh check
+```
+
+Use the browser against both:
+
+- `http://localhost:9912/`
+- `http://localhost:9912/?view=j2cl-root`
+
+## 7. Concrete Risks
+
+- Signed-out `/` can still fall through to the landing-page branch if the root dispatch is not reordered before the `id == null` check.
+- Fresh-deploy defaults can drift from stored/admin overrides if `KnownFeatureFlags`, `FeatureFlagSeeder`, `ServerMain`, and the config files are not kept in sync.
+- A rollback that only changes tests or docs is not enough; the control-plane switch must be genuinely config-only at runtime.
+- It is easy to accidentally make `/?view=j2cl-root` the only working path and forget to prove `/` itself in the browser.
+- The root-shell chrome can look correct in unit tests while the J2CL bundle mount or auth redirect target is wrong in a live browser session, so browser proof remains mandatory.
+
+## 8. Ordering
+
+Recommended order:
+
+1. Confirm the current `#923` bootstrap seam still exists and identify the exact flag/config source of truth.
+2. Flip the server decision point so `/` can choose J2CL before the legacy landing-page fallback.
+3. Make the fresh-deploy default J2CL while preserving rollback to legacy GWT.
+4. Run the default-on and rollback-off verification matrix in the local staged app.
+5. Record the result in the linked GitHub issue and add the changelog fragment if user-facing behavior changed.
+

--- a/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
+++ b/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
@@ -4,7 +4,15 @@
 
 **Goal:** cut over `/` so the J2CL root shell boots by default, while keeping a temporary rollback path that can restore the legacy GWT root without reverting code. This plan starts from the post-`#923` state on `main`: the reversible bootstrap seam already exists and the explicit `/?view=j2cl-root` J2CL root-shell route is already the diagnostic entry point.
 
-**Architecture:** treat this as a server control-plane change, not a new client feature. The key seam is the root decision in `WaveClientServlet#doGet(...)`. When the root-bootstrap control flag says J2CL, `/` should render the same J2CL root shell that `/?view=j2cl-root` already uses, for both signed-in and signed-out requests. Keep the legacy landing/GWT path reachable through the existing rollback control path and keep the explicit J2CL root-shell URL intact for local proof. Fresh deploys should default to J2CL; existing stored/admin overrides must still win so rollback is a config change, not a patch rollback.
+**Architecture:** treat this as a server control-plane change, not a new client feature. The key seam is the root decision in `WaveClientServlet#doGet(...)`. When the root-bootstrap control plane says J2CL, `/` should render the same J2CL root shell that `/?view=j2cl-root` already uses, for both signed-in and signed-out requests. Keep the legacy landing/GWT path reachable through the existing rollback control path and keep the explicit J2CL root-shell URL intact for local proof.
+
+Precedence model for this slice must be explicit:
+
+- operator-provided application config override is authoritative for rollback/cutover
+- when no operator override is present, the persisted/store-backed flag remains the source of truth
+- `reference.conf` only supplies the fresh-deploy default
+
+That means rollback remains a config change, while stored/admin overrides are still durable when no operator override is set.
 
 ## 1. Baseline And Problem
 
@@ -28,7 +36,9 @@ The remaining issue is that the root dispatch still short-circuits through the l
 ### Bootstrap control plane
 
 - Use the same server-side bootstrap flag introduced by `#923` as the rollback switch.
-- Make the fresh-deploy default `true` in the flag seeding/config path, but preserve stored/admin overrides so an operator can force legacy GWT back on without a code change.
+- Make the fresh-deploy default `true` in the flag seeding/config path.
+- Preserve stored/admin overrides only when the operator has not explicitly set an application override value.
+- Make the operator-provided application config override authoritative so an operator can force legacy GWT back on without a code change.
 - Keep the source of truth in the server control plane:
   - `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
   - `wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java`
@@ -59,7 +69,8 @@ The remaining issue is that the root dispatch still short-circuits through the l
 ### Slice A: Control-plane flip
 
 - The root-bootstrap flag defaults to J2CL for fresh deploys.
-- Existing stored/admin overrides still beat the fresh default.
+- Existing stored/admin overrides still beat the fresh default when no operator override is set.
+- An explicit operator override value in application config beats the stored/admin value and serves as the rollback switch.
 - The server decision point chooses J2CL for `/` before the legacy landing-page fallback can win.
 
 ### Slice B: Default `/` cutover
@@ -105,24 +116,37 @@ The remaining issue is that the root dispatch still short-circuits through the l
 | Rollback off | `GET /?view=j2cl-root` | The explicit J2CL diagnostic route still works | server test and local browser check |
 | Explicit legacy landing | `GET /?view=landing` | The landing page remains reachable on demand | server test or direct curl |
 
-Recommended local gate:
+Required local matrix:
 
 ```bash
 sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
 bash scripts/worktree-boot.sh --port 9912
 PORT=9912 bash scripts/wave-smoke.sh start
 PORT=9912 bash scripts/wave-smoke.sh check
+curl -fsS http://localhost:9912/ | grep -F 'data-j2cl-root-shell'
+curl -fsS 'http://localhost:9912/?view=landing' | grep -F 'Sign In'
+curl -fsS 'http://localhost:9912/?view=j2cl-root' | grep -F 'data-j2cl-root-shell'
+PORT=9912 bash scripts/wave-smoke.sh stop
+
+cp journal/runtime-config/issue-924-j2cl-default-root-port-9912.application.conf /tmp/j2cl-default-root.application.conf
+perl -0pi -e 's/ui\\.j2cl_root_bootstrap_enabled = false/ui.j2cl_root_bootstrap_enabled = true/' /tmp/j2cl-default-root.application.conf
+PORT=9912 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-default-root.application.conf" bash scripts/wave-smoke.sh start
+PORT=9912 bash scripts/wave-smoke.sh check
+curl -fsS http://localhost:9912/ | grep -F 'data-j2cl-root-shell'
+curl -fsS 'http://localhost:9912/?view=landing' | grep -F 'Sign In'
+curl -fsS 'http://localhost:9912/?view=j2cl-root' | grep -F 'data-j2cl-root-shell'
 ```
 
-Use the browser against both:
+Use the browser against all of:
 
 - `http://localhost:9912/`
+- `http://localhost:9912/?view=landing`
 - `http://localhost:9912/?view=j2cl-root`
 
 ## 7. Concrete Risks
 
 - Signed-out `/` can still fall through to the landing-page branch if the root dispatch is not reordered before the `id == null` check.
-- Fresh-deploy defaults can drift from stored/admin overrides if `KnownFeatureFlags`, `FeatureFlagSeeder`, `ServerMain`, and the config files are not kept in sync.
+- Fresh-deploy defaults can drift from stored/admin overrides if `KnownFeatureFlags`, `FeatureFlagSeeder`, `ServerMain`, and the config files are not kept in sync or if operator override precedence is not made explicit.
 - A rollback that only changes tests or docs is not enough; the control-plane switch must be genuinely config-only at runtime.
 - It is easy to accidentally make `/?view=j2cl-root` the only working path and forget to prove `/` itself in the browser.
 - The root-shell chrome can look correct in unit tests while the J2CL bundle mount or auth redirect target is wrong in a live browser session, so browser proof remains mandatory.
@@ -133,7 +157,6 @@ Recommended order:
 
 1. Confirm the current `#923` bootstrap seam still exists and identify the exact flag/config source of truth.
 2. Flip the server decision point so `/` can choose J2CL before the legacy landing-page fallback.
-3. Make the fresh-deploy default J2CL while preserving rollback to legacy GWT.
-4. Run the default-on and rollback-off verification matrix in the local staged app.
+3. Make the fresh-deploy default J2CL while preserving explicit operator-override rollback to legacy GWT.
+4. Run the default-on and rollback-off verification matrix in the local staged app, including `?view=landing` as the explicit legacy escape hatch.
 5. Record the result in the linked GitHub issue and add the changelog fragment if user-facing behavior changed.
-

--- a/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
+++ b/docs/superpowers/plans/2026-04-20-issue-924-j2cl-default-root.md
@@ -30,7 +30,7 @@ The remaining issue is that the root dispatch still short-circuits through the l
 
 - Update `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java` so the root-bootstrap decision is made before the legacy signed-out landing-page branch.
 - Keep `/?view=j2cl-root` as the explicit diagnostic route, but make `/` follow the J2CL default when the bootstrap flag is enabled.
-- Preserve `?view=landing` as the explicit landing-page escape hatch so the current public landing page is still reachable without being the default root.
+- Preserve `/?view=landing` as the explicit landing-page escape hatch so the current public landing page is still reachable without being the default root.
 - Ensure the signed-out root path can still render the J2CL shell login entry instead of falling through to the landing page when J2CL is the default.
 
 ### Bootstrap control plane

--- a/wave/config/changelog.d/2026-04-20-j2cl-default-root.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-default-root.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-20-j2cl-default-root",
+  "version": "Unreleased",
+  "date": "2026-04-20",
+  "title": "Make the J2CL root shell the default `/` experience",
+  "summary": "The root `/` route now boots the J2CL shell by default, while `/?view=j2cl-root` stays available as the explicit diagnostic route and `?view=landing` remains the legacy landing escape hatch.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Seeded the j2cl-root-bootstrap feature flag from ui.j2cl_root_bootstrap_enabled with a fresh-deploy default of true",
+        "The root `/` route now boots the J2CL shell when the bootstrap flag is enabled, including for signed-out visitors",
+        "The legacy landing page still remains available through `?view=landing`, and rollback to the legacy root stays config-driven"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-20-j2cl-default-root.json
+++ b/wave/config/changelog.d/2026-04-20-j2cl-default-root.json
@@ -10,7 +10,7 @@
       "items": [
         "Seeded the j2cl-root-bootstrap feature flag from ui.j2cl_root_bootstrap_enabled with a fresh-deploy default of true",
         "The root `/` route now boots the J2CL shell when the bootstrap flag is enabled, including for signed-out visitors",
-        "The legacy landing page still remains available through `?view=landing`, and rollback to the legacy root stays config-driven"
+        "The legacy landing page still remains available through `/?view=landing`, and rollback to the legacy root stays config-driven"
       ]
     }
   ]

--- a/wave/config/reference.conf
+++ b/wave/config/reference.conf
@@ -492,8 +492,9 @@ wave.fragments.applier.impl = "noop"
 # polling mechanism. Disabled by default until Phase 4 (client integration)
 # is complete.
 search.ot_search_enabled = false
-# Bootstrap the J2CL root shell on / only when explicitly enabled.
-ui.j2cl_root_bootstrap_enabled = false
+# Bootstrap the J2CL root shell on / by default for fresh deployments.
+# Existing stored/admin overrides in the feature-flag store still win.
+ui.j2cl_root_bootstrap_enabled = true
 # Controls the synchronous startup warmup in ServerMain that pre-builds either
 # the owner wave view or the entire wave map. Default false because eager
 # warmup can block startup on a full wave scan; leaving it off preserves the

--- a/wave/config/reference.conf
+++ b/wave/config/reference.conf
@@ -492,8 +492,9 @@ wave.fragments.applier.impl = "noop"
 # polling mechanism. Disabled by default until Phase 4 (client integration)
 # is complete.
 search.ot_search_enabled = false
-# Bootstrap the J2CL root shell on / by default for fresh deployments.
-# Existing stored/admin overrides in the feature-flag store still win.
+# This reference.conf value is the fresh-deploy default; stored/admin values
+# in the feature-flag store win when there is no explicit operator override,
+# and an operator override may be reconciled into the store at startup.
 ui.j2cl_root_bootstrap_enabled = true
 # Controls the synchronous startup warmup in ServerMain that pre-builds either
 # the owner wave view or the entire wave map. Default false because eager

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/ServerMainConfigOverrideTest.java
@@ -53,6 +53,25 @@ public final class ServerMainConfigOverrideTest {
   }
 
   @Test
+  public void loadCoreConfigDefaultsJ2clRootBootstrapToTrue() {
+    String previousConfigPath = System.getProperty("wave.server.config");
+    if (previousConfigPath != null) {
+      System.clearProperty("wave.server.config");
+    }
+    try {
+      Config config = ServerMain.loadCoreConfig();
+
+      assertTrue(config.getBoolean("ui.j2cl_root_bootstrap_enabled"));
+    } finally {
+      if (previousConfigPath == null) {
+        System.clearProperty("wave.server.config");
+      } else {
+        System.setProperty("wave.server.config", previousConfigPath);
+      }
+    }
+  }
+
+  @Test
   public void loadCoreConfigRejectsMissingWaveServerConfigOverride() {
     Path missingConfig =
         Path.of(System.getProperty("java.io.tmpdir"), "missing-server-main-config-" + System.nanoTime());

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -42,7 +42,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("task-search", "Enable tasks:me search filter and Tasks toolbar button", true, Collections.emptyMap()));
     defaults.add(new FeatureFlag("mentions-search", "Enable @mention search filter and Mentions toolbar button", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
-    defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on /", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on /", true, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
@@ -32,12 +32,12 @@ import org.waveprotocol.box.server.persistence.KnownFeatureFlags;
 
 public final class FeatureFlagSeederJ2clBootstrapTest {
   @Test
-  public void knownBootstrapFlagIsRegisteredAndDefaultsOff() throws Exception {
+  public void knownBootstrapFlagIsRegisteredAndDefaultsOn() throws Exception {
     MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
     FeatureFlagService service = new FeatureFlagService(store);
     try {
       assertTrue(KnownFeatureFlags.isKnownFlag("j2cl-root-bootstrap"));
-      assertFalse(service.getEnabledFlagNames(null).contains("j2cl-root-bootstrap"));
+      assertTrue(service.getEnabledFlagNames(null).contains("j2cl-root-bootstrap"));
     } finally {
       service.shutdown();
     }
@@ -118,5 +118,24 @@ public final class FeatureFlagSeederJ2clBootstrapTest {
     FeatureFlag flag = store.get("j2cl-root-bootstrap");
 
     assertTrue(flag.isEnabled());
+  }
+
+  @Test
+  public void reconcileAppliesExplicitJ2clRootBootstrapRollback() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(
+        new FeatureFlag(
+            "j2cl-root-bootstrap",
+            "Bootstrap the J2CL root shell on /",
+            true,
+            new LinkedHashMap<>()));
+
+    FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
+        store, ConfigFactory.parseString("ui.j2cl_root_bootstrap_enabled = false"));
+
+    FeatureFlag flag = store.get("j2cl-root-bootstrap");
+
+    assertTrue(flag != null);
+    assertFalse(flag.isEnabled());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -108,6 +108,44 @@ public final class WaveClientServletJ2clBootstrapTest {
   }
 
   @Test
+  public void signedOutRootUsesLegacyLandingPageWhenBootstrapFlagIsOff() throws Exception {
+    WaveClientServlet servlet = createServlet(null, false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getSession(false)).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertFalse(html.contains("data-j2cl-root-shell"));
+    assertTrue(html.contains("SupaWave - Real-time Collaborative Communication"));
+    assertTrue(html.contains("nav-link-signin"));
+    assertTrue(html.contains("nav-link-register"));
+  }
+
+  @Test
+  public void explicitLandingRouteStillUsesLandingPageWhenBootstrapFlagIsOn() throws Exception {
+    WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), true);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn("landing");
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertFalse(html.contains("data-j2cl-root-shell"));
+    assertTrue(html.contains("SupaWave - Real-time Collaborative Communication"));
+    assertTrue(html.contains("nav-link-signin"));
+  }
+
+  @Test
   public void explicitDiagnosticRootRouteStillWorksWithoutBootstrapFlag() throws Exception {
     WaveClientServlet servlet = createServlet(null, false);
     HttpServletRequest request = mock(HttpServletRequest.class);


### PR DESCRIPTION
## Summary
- cut over plain `/` so the J2CL root shell is the default root experience while keeping `/?view=j2cl-root` as the diagnostic route and `?view=landing` as the explicit legacy landing escape hatch
- align the bootstrap control plane so fresh deployments default to J2CL while config-based rollback remains authoritative and test-covered
- add focused default-root / rollback tests, the default-root changelog fragment, and the dual-bootstrap cutover matrix in the runbook

## Verification
- `sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest org.waveprotocol.box.server.ServerMainConfigOverrideTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt -batch compileGwt Universal/stage`
- default-on mode on port `9912`:
  - `PORT=9912 bash scripts/wave-smoke.sh check`
  - `/` -> J2CL root shell
  - `/?view=landing` -> legacy landing page
  - `/?view=j2cl-root` -> J2CL root shell
- rollback-off mode on port `9912` with explicit `ui.j2cl_root_bootstrap_enabled=false` override:
  - `PORT=9912 bash scripts/wave-smoke.sh check`
  - `/` -> legacy landing/GWT root
  - `/?view=landing` -> legacy landing page
  - `/?view=j2cl-root` -> J2CL root shell

Closes #924.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Root `/` now boots the J2CL shell by default for signed-in and signed-out users; legacy landing remains at `/?view=landing` as an escape hatch.

* **Documentation**
  * Added cutover plan, runbook, and changelog documenting default-root behavior, precedence rules, verification matrix, and rollback mechanics.

* **Tests**
  * Added/updated tests verifying default J2CL root, legacy rollback behavior, and explicit diagnostic routes.

* **Chores**
  * Default feature-flag changed to enable J2CL root bootstrap by default (configurable for rollback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->