### PR TITLE
[codex] extend deploy sanity warmup window

### DIFF
--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -504,8 +504,13 @@ sanity_check() {
     # --- Step 2: Poll search until the cold slot finishes inbox warmup ----
     DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
-    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$SEARCH_REQUEST_TIMEOUT_SECONDS" \
+    while true; do
+      NOW=$(date +%s)
+      if [ "$NOW" -ge "$DEADLINE" ]; then break; fi
+      REMAINING=$(( DEADLINE - NOW ))
+      REQUEST_TIMEOUT="$SEARCH_REQUEST_TIMEOUT_SECONDS"
+      if [ "$REQUEST_TIMEOUT" -gt "$REMAINING" ]; then REQUEST_TIMEOUT="$REMAINING"; fi
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$REQUEST_TIMEOUT" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -446,6 +446,10 @@ sanity_check() {
     echo "[deploy] ERROR: SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be a positive integer (got: '${sanity_search_request_timeout_seconds}')" >&2
     return 1
   fi
+  if (( sanity_search_request_timeout_seconds > sanity_search_deadline_seconds )); then
+    echo "[deploy] ERROR: SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be less than or equal to SANITY_SEARCH_DEADLINE_SECONDS (got: '${sanity_search_request_timeout_seconds}' > '${sanity_search_deadline_seconds}')" >&2
+    return 1
+  fi
 
   echo "[deploy] Running sanity check on port ${port}..."
 

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -505,12 +505,15 @@ sanity_check() {
     DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
     while true; do
-      NOW=$(date +%s)
-      if [ "$NOW" -ge "$DEADLINE" ]; then break; fi
-      REMAINING=$(( DEADLINE - NOW ))
-      REQUEST_TIMEOUT="$SEARCH_REQUEST_TIMEOUT_SECONDS"
-      if [ "$REQUEST_TIMEOUT" -gt "$REMAINING" ]; then REQUEST_TIMEOUT="$REMAINING"; fi
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$REQUEST_TIMEOUT" \
+      remaining_time=$(( DEADLINE - $(date +%s) ))
+      if [ "$remaining_time" -le 0 ]; then
+        break
+      fi
+      request_timeout="$SEARCH_REQUEST_TIMEOUT_SECONDS"
+      if [ "$request_timeout" -gt "$remaining_time" ]; then
+        request_timeout="$remaining_time"
+      fi
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$request_timeout" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue

--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -432,8 +432,18 @@ sanity_check() {
   local addr="${SANITY_ADDRESS:-}"
   local pass="${SANITY_PASSWORD:-}"
   local port="${SANITY_PORT:-9898}"
+  local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"
+  local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"
   if [[ -z "$addr" || -z "$pass" ]]; then
     echo "[deploy] ERROR: SANITY_ADDRESS and SANITY_PASSWORD must both be set" >&2
+    return 1
+  fi
+  if ! [[ "$sanity_search_deadline_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] ERROR: SANITY_SEARCH_DEADLINE_SECONDS must be a positive integer (got: '${sanity_search_deadline_seconds}')" >&2
+    return 1
+  fi
+  if ! [[ "$sanity_search_request_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] ERROR: SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be a positive integer (got: '${sanity_search_request_timeout_seconds}')" >&2
     return 1
   fi
 
@@ -442,11 +452,15 @@ sanity_check() {
   export INTERNAL_PORT="${port}"
   export SANITY_ADDR="${addr}"
   export SANITY_PASS="${pass}"
+  export SANITY_SEARCH_DEADLINE_SECONDS="${sanity_search_deadline_seconds}"
+  export SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS="${sanity_search_request_timeout_seconds}"
   # Use host network so we can reach the specific slot's host-mapped port
   docker run --rm --network host \
     -e INTERNAL_PORT \
     -e SANITY_ADDR \
     -e SANITY_PASS \
+    -e SANITY_SEARCH_DEADLINE_SECONDS \
+    -e SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS \
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
@@ -464,6 +478,8 @@ sanity_check() {
     BASE="http://localhost:${INTERNAL_PORT}"
     ADDR="$SANITY_ADDR"
     PASS="$SANITY_PASS"
+    SEARCH_DEADLINE_SECONDS="$SANITY_SEARCH_DEADLINE_SECONDS"
+    SEARCH_REQUEST_TIMEOUT_SECONDS="$SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS"
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
@@ -481,11 +497,11 @@ sanity_check() {
     fi
     echo "[sanity] login OK"
 
-    # --- Step 2: Poll search (60 s) --------------------------------------
-    DEADLINE=$(( $(date +%s) + 60 ))
+    # --- Step 2: Poll search until the cold slot finishes inbox warmup ----
+    DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
     while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time 10 \
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$SEARCH_REQUEST_TIMEOUT_SECONDS" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue
@@ -495,7 +511,7 @@ sanity_check() {
       sleep 2
     done
     if [ -z "$WAVE_ID" ]; then
-      echo "[sanity] FAIL: search returned no waves within 60 s"
+      echo "[sanity] FAIL: search returned no waves within ${SEARCH_DEADLINE_SECONDS} s"
       exit 1
     fi
     echo "[sanity] search OK — found wave: $WAVE_ID"

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -194,8 +194,13 @@ sanity_check() {
     # --- Step 2: Poll search until the cold slot finishes inbox warmup ----
     DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
-    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$SEARCH_REQUEST_TIMEOUT_SECONDS" \
+    while true; do
+      NOW=$(date +%s)
+      if [ "$NOW" -ge "$DEADLINE" ]; then break; fi
+      REMAINING=$(( DEADLINE - NOW ))
+      REQUEST_TIMEOUT="$SEARCH_REQUEST_TIMEOUT_SECONDS"
+      if [ "$REQUEST_TIMEOUT" -gt "$REMAINING" ]; then REQUEST_TIMEOUT="$REMAINING"; fi
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$REQUEST_TIMEOUT" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -137,6 +137,10 @@ sanity_check() {
     echo "[deploy] SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be a positive integer (got: '${sanity_search_request_timeout_seconds}')" >&2
     return 1
   fi
+  if (( sanity_search_request_timeout_seconds > sanity_search_deadline_seconds )); then
+    echo "[deploy] SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be less than or equal to SANITY_SEARCH_DEADLINE_SECONDS (got: '${sanity_search_request_timeout_seconds}' > '${sanity_search_deadline_seconds}')" >&2
+    return 1
+  fi
 
   echo "[deploy] Running sanity check ..."
 

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -195,12 +195,15 @@ sanity_check() {
     DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
     while true; do
-      NOW=$(date +%s)
-      if [ "$NOW" -ge "$DEADLINE" ]; then break; fi
-      REMAINING=$(( DEADLINE - NOW ))
-      REQUEST_TIMEOUT="$SEARCH_REQUEST_TIMEOUT_SECONDS"
-      if [ "$REQUEST_TIMEOUT" -gt "$REMAINING" ]; then REQUEST_TIMEOUT="$REMAINING"; fi
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$REQUEST_TIMEOUT" \
+      remaining_time=$(( DEADLINE - $(date +%s) ))
+      if [ "$remaining_time" -le 0 ]; then
+        break
+      fi
+      request_timeout="$SEARCH_REQUEST_TIMEOUT_SECONDS"
+      if [ "$request_timeout" -gt "$remaining_time" ]; then
+        request_timeout="$remaining_time"
+      fi
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$request_timeout" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -119,6 +119,8 @@ wait_for_ready() {
 sanity_check() {
   local addr="${SANITY_ADDRESS:-}"
   local pass="${SANITY_PASSWORD:-}"
+  local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"
+  local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"
   if [[ -z "$addr" && -z "$pass" ]]; then
     echo "[deploy] SANITY_ADDRESS/SANITY_PASSWORD not set, skipping sanity check"
     return 0
@@ -127,16 +129,28 @@ sanity_check() {
     echo "[deploy] SANITY_ADDRESS and SANITY_PASSWORD must both be set" >&2
     return 1
   fi
+  if ! [[ "$sanity_search_deadline_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] SANITY_SEARCH_DEADLINE_SECONDS must be a positive integer (got: '${sanity_search_deadline_seconds}')" >&2
+    return 1
+  fi
+  if ! [[ "$sanity_search_request_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    echo "[deploy] SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS must be a positive integer (got: '${sanity_search_request_timeout_seconds}')" >&2
+    return 1
+  fi
 
   echo "[deploy] Running sanity check ..."
 
   export INTERNAL_PORT="${internal_port}"
   export SANITY_ADDR="${addr}"
   export SANITY_PASS="${pass}"
+  export SANITY_SEARCH_DEADLINE_SECONDS="${sanity_search_deadline_seconds}"
+  export SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS="${sanity_search_request_timeout_seconds}"
   docker run --rm --network host \
     -e INTERNAL_PORT \
     -e SANITY_ADDR \
     -e SANITY_PASS \
+    -e SANITY_SEARCH_DEADLINE_SECONDS \
+    -e SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS \
     "$sanity_image" sh -c '
     set -e
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
@@ -154,6 +168,8 @@ sanity_check() {
     BASE="http://127.0.0.1:${INTERNAL_PORT}"
     ADDR="$SANITY_ADDR"
     PASS="$SANITY_PASS"
+    SEARCH_DEADLINE_SECONDS="$SANITY_SEARCH_DEADLINE_SECONDS"
+    SEARCH_REQUEST_TIMEOUT_SECONDS="$SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS"
     COOKIE=/tmp/c.txt
 
     # --- Step 1: Login ---------------------------------------------------
@@ -171,11 +187,11 @@ sanity_check() {
     fi
     echo "[sanity] login OK"
 
-    # --- Step 2: Poll search (60 s) --------------------------------------
-    DEADLINE=$(( $(date +%s) + 60 ))
+    # --- Step 2: Poll search until the cold slot finishes inbox warmup ----
+    DEADLINE=$(( $(date +%s) + SEARCH_DEADLINE_SECONDS ))
     WAVE_ID=""
     while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-      if ! RESP=$(curl -sS -b "$COOKIE" --max-time 10 \
+      if ! RESP=$(curl -sS -b "$COOKIE" --max-time "$SEARCH_REQUEST_TIMEOUT_SECONDS" \
         "$BASE/search/?query=in:inbox&index=0&numResults=1" 2>&1); then
         sleep 2
         continue
@@ -185,7 +201,7 @@ sanity_check() {
       sleep 2
     done
     if [ -z "$WAVE_ID" ]; then
-      echo "[sanity] FAIL: search returned no waves within 60 s"
+      echo "[sanity] FAIL: search returned no waves within ${SEARCH_DEADLINE_SECONDS} s"
       exit 1
     fi
     echo "[sanity] search OK — found wave: $WAVE_ID"

--- a/scripts/tests/test_deploy_sanity_gate.py
+++ b/scripts/tests/test_deploy_sanity_gate.py
@@ -22,6 +22,17 @@ class DeploySanityGateTest(unittest.TestCase):
         deploy_script,
     )
 
+    contabo_script = (REPO_ROOT / "deploy" / "contabo" / "deploy.sh").read_text(encoding="utf-8")
+
+    self.assertIn(
+        'local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"',
+        contabo_script,
+    )
+    self.assertIn(
+        'local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"',
+        contabo_script,
+    )
+
   def test_deploy_fails_when_sanity_credentials_are_missing(self):
     bash_path = find_bash()
     if bash_path is None:

--- a/scripts/tests/test_deploy_sanity_gate.py
+++ b/scripts/tests/test_deploy_sanity_gate.py
@@ -10,6 +10,18 @@ DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-contabo.yml"
 
 
 class DeploySanityGateTest(unittest.TestCase):
+  def test_deploy_script_allows_longer_search_warmup_window(self):
+    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    self.assertIn(
+        'local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"',
+        deploy_script,
+    )
+    self.assertIn(
+        'local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"',
+        deploy_script,
+    )
+
   def test_deploy_fails_when_sanity_credentials_are_missing(self):
     bash_path = find_bash()
     if bash_path is None:

--- a/scripts/tests/test_deploy_sanity_gate.py
+++ b/scripts/tests/test_deploy_sanity_gate.py
@@ -6,32 +6,34 @@ from scripts.tests.deploy_harness import find_bash, run_deploy_script
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPLOY_SCRIPT = REPO_ROOT / "deploy" / "caddy" / "deploy.sh"
+CONTABO_DEPLOY_SCRIPT = REPO_ROOT / "deploy" / "contabo" / "deploy.sh"
 DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-contabo.yml"
 
 
 class DeploySanityGateTest(unittest.TestCase):
   def test_deploy_script_allows_longer_search_warmup_window(self):
-    deploy_script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    for script_path in (DEPLOY_SCRIPT, CONTABO_DEPLOY_SCRIPT):
+      deploy_script = script_path.read_text(encoding="utf-8")
 
-    self.assertIn(
-        'local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"',
-        deploy_script,
-    )
-    self.assertIn(
-        'local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"',
-        deploy_script,
-    )
+      self.assertIn(
+          'local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"',
+          deploy_script,
+      )
+      self.assertIn(
+          'local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"',
+          deploy_script,
+      )
 
-    contabo_script = (REPO_ROOT / "deploy" / "contabo" / "deploy.sh").read_text(encoding="utf-8")
+  def test_deploy_script_caps_search_requests_to_remaining_deadline(self):
+    for script_path in (DEPLOY_SCRIPT, CONTABO_DEPLOY_SCRIPT):
+      deploy_script = script_path.read_text(encoding="utf-8")
 
-    self.assertIn(
-        'local sanity_search_deadline_seconds="${SANITY_SEARCH_DEADLINE_SECONDS:-120}"',
-        contabo_script,
-    )
-    self.assertIn(
-        'local sanity_search_request_timeout_seconds="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}"',
-        contabo_script,
-    )
+      self.assertIn('remaining_time=$(( DEADLINE - $(date +%s) ))', deploy_script)
+      self.assertIn('if [ "$remaining_time" -le 0 ]; then', deploy_script)
+      self.assertIn('request_timeout="$SEARCH_REQUEST_TIMEOUT_SECONDS"', deploy_script)
+      self.assertIn('if [ "$request_timeout" -gt "$remaining_time" ]; then', deploy_script)
+      self.assertIn('request_timeout="$remaining_time"', deploy_script)
+      self.assertIn('--max-time "$request_timeout"', deploy_script)
 
   def test_deploy_fails_when_sanity_credentials_are_missing(self):
     bash_path = find_bash()

--- a/wave/config/changelog.d/2026-04-21-deploy-sanity-warmup-window.json
+++ b/wave/config/changelog.d/2026-04-21-deploy-sanity-warmup-window.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-21-deploy-sanity-warmup-window",
+  "version": "Unreleased",
+  "date": "2026-04-21",
+  "title": "Cold blue-green deploy slots get a longer inbox sanity warmup window",
+  "summary": "Deploy sanity checks now tolerate the slower first inbox search on a cold slot so healthy releases are not rejected during blue-green warmup.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Extended the deploy inbox-search sanity window for cold blue-green slots instead of failing after the previous 60 second assumption",
+        "Made the deploy search deadline and per-request timeout configurable so operators can tune the warmup gate without patching the script again"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extend the deploy search sanity warmup window for cold blue/green slots
- make the search deadline and per-request timeout configurable in both deploy scripts
- add a regression assertion covering the longer warmup defaults

## Root Cause
The April 20, 2026 `main` deploy for commit `387d436a1f61e7504f167fc99b612096822afb29` did not fail because of the J2CL root-shell servlet changes. The image built and started successfully, but the post-start Contabo sanity gate only waited 60 seconds for `GET /search/?query=in:inbox`.

On the host, the same failed image eventually passed without app-code changes: login succeeded immediately, the first search calls timed out, and the container later logged `Initialized waves view for user: testsanity1@supawave.ai ... took 72554 ms` before search returned a wave and fetch returned `200`. The deploy break was the cold-slot sanity gate assumption, not the root-shell runtime path.

## Validation
- `python3 -m unittest scripts.tests.test_deploy_sanity_gate -v`
- `python3 -m unittest scripts.tests.test_deploy_overlap_safety -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Deploy sanity checks now support configurable search deadlines and per-request timeouts to tolerate slower warmup.

* **Bug Fixes**
  - Fail-fast validation of timeout values and clearer failure messages that report the configured deadline.

* **Tests**
  - Added unit tests verifying new configuration parsing and that per-request timeouts are capped to remaining deadline.

* **Documentation**
  - Changelog entry documenting the configurable warmup window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->