### PR TITLE
Fix OT-search bootstrap filter normalization

### DIFF
--- a/wave/config/changelog.d/2026-04-21-issue-944-ot-search-bootstrap-filter-normalization.json
+++ b/wave/config/changelog.d/2026-04-21-issue-944-ot-search-bootstrap-filter-normalization.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-21-issue-944-ot-search-bootstrap-filter-normalization",
+  "version": "Unreleased",
+  "date": "2026-04-21",
+  "title": "OT search open requests normalize the live-search wavelet filter",
+  "summary": "Synthetic OT search opens now replace caller-provided wavelet prefixes with the exact computed search wavelet id, so cold search bootstraps register the live subscription before the frontend guard checks it.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Search open RPC requests now normalize their effective wavelet filter to the computed synthetic search wavelet id instead of forwarding arbitrary caller prefixes",
+        "Cold OT-search inbox loads no longer trip the server-side 'Search subscription was not registered' bootstrap failure when the request omitted the synthetic wavelet id"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -149,11 +149,12 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
     }
     try {
       String searchQuery = request.hasSearchQuery() ? request.getSearchQuery() : null;
-      if (!validateSearchOpenRequest(controller, loggedInUser, waveId, searchQuery)) {
+      WaveletName searchWaveletName = computeSearchWaveletName(loggedInUser, searchQuery);
+      if (!validateSearchOpenRequest(controller, waveId, searchQuery, searchWaveletName)) {
         return;
       }
       IdFilter waveletIdFilter =
-          normalizeOpenWaveletIdFilter(request, loggedInUser, searchQuery);
+          normalizeOpenWaveletIdFilter(request, searchWaveletName);
       frontend.openRequest(
           loggedInUser,
           waveId,
@@ -297,38 +298,42 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
     }
   }
 
-  private boolean validateSearchOpenRequest(
-      RpcController controller,
+  @Nullable
+  private WaveletName computeSearchWaveletName(
       @Nullable ParticipantId loggedInUser,
-      WaveId waveId,
       @Nullable String searchQuery) {
     if (searchQuery == null || searchQuery.isEmpty() || searchWaveletManager == null
         || loggedInUser == null) {
+      return null;
+    }
+    return searchWaveletManager.computeWaveletName(loggedInUser, searchQuery);
+  }
+
+  private boolean validateSearchOpenRequest(
+      RpcController controller,
+      WaveId waveId,
+      @Nullable String searchQuery,
+      @Nullable WaveletName searchWaveletName) {
+    if (searchWaveletName == null) {
       return true;
     }
-    WaveletName expectedSearchWaveletName =
-        searchWaveletManager.computeWaveletName(loggedInUser, searchQuery);
-    if (expectedSearchWaveletName.waveId.equals(waveId)) {
+    if (searchWaveletName.waveId.equals(waveId)) {
       return true;
     }
     LOG.warning("Rejecting search open for " + waveId + " query '" + searchQuery
-        + "' expected " + expectedSearchWaveletName.waveId);
+        + "' expected " + searchWaveletName.waveId);
     controller.setFailed("Invalid search query for target wave");
     return false;
   }
 
   private IdFilter normalizeOpenWaveletIdFilter(
       ProtocolOpenRequest request,
-      @Nullable ParticipantId loggedInUser,
-      @Nullable String searchQuery) {
-    if (searchQuery == null || searchQuery.isEmpty() || searchWaveletManager == null
-        || loggedInUser == null) {
+      @Nullable WaveletName searchWaveletName) {
+    if (searchWaveletName == null) {
       return IdFilter.of(Collections.<WaveletId>emptySet(), request.getWaveletIdPrefixList());
     }
-    WaveletName expectedSearchWaveletName =
-        searchWaveletManager.computeWaveletName(loggedInUser, searchQuery);
     return IdFilter.of(
-        Collections.singleton(expectedSearchWaveletName.waveletId),
+        Collections.singleton(searchWaveletName.waveletId),
         Collections.<String>emptySet());
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -141,8 +141,6 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       controller.setFailed(e.getMessage());
       return;
     }
-    IdFilter waveletIdFilter =
-        IdFilter.of(Collections.<WaveletId>emptySet(), request.getWaveletIdPrefixList());
 
     ParticipantId loggedInUser = asBoxController(controller).getLoggedInUser();
     MDC.put("waveId", waveId.serialise());
@@ -154,6 +152,8 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       if (!validateSearchOpenRequest(controller, loggedInUser, waveId, searchQuery)) {
         return;
       }
+      IdFilter waveletIdFilter =
+          normalizeOpenWaveletIdFilter(request, loggedInUser, searchQuery);
       frontend.openRequest(
           loggedInUser,
           waveId,
@@ -315,6 +315,21 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
         + "' expected " + expectedSearchWaveletName.waveId);
     controller.setFailed("Invalid search query for target wave");
     return false;
+  }
+
+  private IdFilter normalizeOpenWaveletIdFilter(
+      ProtocolOpenRequest request,
+      @Nullable ParticipantId loggedInUser,
+      @Nullable String searchQuery) {
+    if (searchQuery == null || searchQuery.isEmpty() || searchWaveletManager == null
+        || loggedInUser == null) {
+      return IdFilter.of(Collections.<WaveletId>emptySet(), request.getWaveletIdPrefixList());
+    }
+    WaveletName expectedSearchWaveletName =
+        searchWaveletManager.computeWaveletName(loggedInUser, searchQuery);
+    return IdFilter.of(
+        Collections.singleton(expectedSearchWaveletName.waveletId),
+        Collections.<String>emptySet());
   }
 
   /** Returns true if the wavelet id represents a synthetic open/marker wavelet. */

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeClientFrontend.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/testing/FakeClientFrontend.java
@@ -42,6 +42,8 @@ import java.util.Map;
   */
 public class FakeClientFrontend implements ClientFrontend, WaveBus.Subscriber {
   public String lastSearchQuery;
+  public WaveId lastOpenWaveId;
+  public IdFilter lastOpenWaveletIdFilter;
 
   private static class SubmitRecord {
     final SubmitRequestListener listener;
@@ -91,6 +93,8 @@ public class FakeClientFrontend implements ClientFrontend, WaveBus.Subscriber {
       Collection<WaveClientRpc.WaveletVersion> knownWavelets, String searchQuery,
       OpenListener openListener) {
     lastSearchQuery = searchQuery;
+    lastOpenWaveId = waveId;
+    lastOpenWaveletIdFilter = waveletIdFilter;
     openListeners.put(waveId, openListener);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcImplTest.java
@@ -36,11 +36,13 @@ import org.waveprotocol.box.server.rpc.testing.FakeServerRpcController;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.util.testing.TestingConstants;
 import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
+import org.waveprotocol.wave.model.id.IdFilter;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.federation.Proto.ProtocolWaveletOperation;
 import org.waveprotocol.wave.model.id.InvalidIdException;
 import org.waveprotocol.wave.model.id.ModernIdSerialiser;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.data.WaveletData;
 
@@ -183,6 +185,55 @@ public class WaveClientRpcImplTest extends TestCase implements TestingConstants 
     });
 
     assertEquals("mentions:me", frontend.lastSearchQuery);
+    assertFalse(controller.failed());
+  }
+
+  public void testOpenNormalizesSearchWaveletFilterWhenPrefixListEmpty() {
+    WaveletName searchWaveletName =
+        searchWaveletManager.computeWaveletName(PARTICIPANT, "mentions:me");
+    ProtocolOpenRequest request = ProtocolOpenRequest.newBuilder()
+        .setParticipantId(USER)
+        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(searchWaveletName.waveId))
+        .setSearchQuery("mentions:me")
+        .build();
+
+    rpcImpl.open(controller, request, new RpcCallback<ProtocolWaveletUpdate>() {
+      @Override
+      public void run(ProtocolWaveletUpdate update) {
+      }
+    });
+
+    assertEquals(searchWaveletName.waveId, frontend.lastOpenWaveId);
+    assertNotNull(frontend.lastOpenWaveletIdFilter);
+    assertTrue(IdFilter.accepts(frontend.lastOpenWaveletIdFilter, searchWaveletName.waveletId));
+    assertEquals(1, frontend.lastOpenWaveletIdFilter.getIds().size());
+    assertTrue(frontend.lastOpenWaveletIdFilter.getPrefixes().isEmpty());
+    assertFalse(controller.failed());
+  }
+
+  public void testOpenReplacesSearchWaveletPrefixesWithExactWaveletId() {
+    WaveletName searchWaveletName =
+        searchWaveletManager.computeWaveletName(PARTICIPANT, "mentions:me");
+    WaveletId anotherWaveletId = WaveletId.of(searchWaveletName.waveletId.getDomain(), "conv+other");
+    ProtocolOpenRequest request = ProtocolOpenRequest.newBuilder()
+        .setParticipantId(USER)
+        .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(searchWaveletName.waveId))
+        .setSearchQuery("mentions:me")
+        .addWaveletIdPrefix("")
+        .build();
+
+    rpcImpl.open(controller, request, new RpcCallback<ProtocolWaveletUpdate>() {
+      @Override
+      public void run(ProtocolWaveletUpdate update) {
+      }
+    });
+
+    assertEquals(searchWaveletName.waveId, frontend.lastOpenWaveId);
+    assertNotNull(frontend.lastOpenWaveletIdFilter);
+    assertTrue(IdFilter.accepts(frontend.lastOpenWaveletIdFilter, searchWaveletName.waveletId));
+    assertFalse(IdFilter.accepts(frontend.lastOpenWaveletIdFilter, anotherWaveletId));
+    assertEquals(1, frontend.lastOpenWaveletIdFilter.getIds().size());
+    assertTrue(frontend.lastOpenWaveletIdFilter.getPrefixes().isEmpty());
     assertFalse(controller.failed());
   }
 


### PR DESCRIPTION
## Summary
- normalize OT-search open requests to the exact computed synthetic search wavelet id at the RPC boundary
- add regressions for empty-prefix and non-empty-prefix search opens so the filter replacement behavior stays pinned
- add the changelog fragment for the bootstrap / blank-inbox fix

## Verification
- python3 scripts/assemble-changelog.py
- sbt "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcImplTest"
- sbt "testOnly org.waveprotocol.box.server.frontend.ClientFrontendImplTest"
- python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
- sbt "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcImplTest org.waveprotocol.box.server.frontend.ClientFrontendImplTest"
- sbt wave/compile
- bash scripts/worktree-boot.sh --port 9900
- PORT=9900 bash scripts/wave-smoke.sh check
- headless local login/inbox sanity on http://127.0.0.1:9900/
- rg -n "IllegalStateException: Search subscription was not registered|Search subscription was not registered" target/universal/stage/wave_server.out

## Review
- Direct reviewer: no findings
- Claude code review: no blockers; only low-risk follow-up ideas

Fixes #944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize synthetic OT search wavelet filters to the exact computed search wavelet ID and prevent bootstrap failures on cold OT-search inbox loads when the synthetic wavelet ID is omitted.

* **Tests**
  * Added tests verifying search open requests produce the normalized exact-wavelet filter and do not fail the RPC controller.

* **Chores**
  * Added a changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->