### PR TITLE
Disable OT-search by default on fresh local dev servers

### DIFF
--- a/wave/config/application.conf
+++ b/wave/config/application.conf
@@ -54,5 +54,6 @@ client.flags.defaults {
 # Profiling (keeps /speedz enabled in dev)
 core.enable_profiling = false
 
-# Enable OT search (real-time search wavelets) for local testing
-search.ot_search_enabled = true
+# Keep OT search (real-time search wavelets) off by default in local dev.
+# Enable it manually when a local test specifically needs the OT bootstrap path.
+search.ot_search_enabled = false

--- a/wave/config/application.conf
+++ b/wave/config/application.conf
@@ -55,5 +55,9 @@ client.flags.defaults {
 core.enable_profiling = false
 
 # Keep OT search (real-time search wavelets) off by default in local dev.
-# Enable it manually when a local test specifically needs the OT bootstrap path.
+# NOTE: this value is only seeded into the DB on first boot (when the flag is absent).
+# After first boot, changing this line alone has no effect because the seeder preserves
+# the stored value. To re-enable OT search on an existing local store, either:
+#   a) DELETE the flag via the admin API:  DELETE /admin/flags?name=ot-search  then restart, or
+#   b) POST a new value:  POST /admin/flags  body: {"name":"ot-search","enabled":true}
 search.ot_search_enabled = false

--- a/wave/config/changelog.d/2026-04-21-issue-943-ot-search-default-off.json
+++ b/wave/config/changelog.d/2026-04-21-issue-943-ot-search-default-off.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-21-issue-943-ot-search-default-off",
+  "version": "PR #947",
+  "date": "2026-04-21",
+  "title": "Fresh local boots keep OT search off by default",
+  "summary": "Fresh local development boots now inherit the existing `search.ot_search_enabled = false` default instead of forcing OT search on, so new local stores avoid the fragile OT bootstrap path unless a developer enables it intentionally.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Fresh local stores now seed `ot-search=false` from the config overlay instead of defaulting the feature on",
+        "Existing persisted stores keep their current OT search setting unchanged"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- stop forcing OT search on in wave/config/application.conf for fresh local dev boots
- keep the fix limited to the local/staged config overlay and reuse the existing feature-flag seeding behavior
- verify with fresh-store local boot evidence that ot-search seeds false and SearchWaveletUpdater does not subscribe

## Verification
- python3 scripts/assemble-changelog.py
- sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederTest org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.server.waveserver.FeatureFlaggedSearchProviderImplTest org.waveprotocol.box.search.SearchPresenterLoadingStateTest"
- sbt -batch wave/compile
- bash scripts/worktree-boot.sh --port 9943
- PORT=9943 JAVA_OPTS=... bash scripts/wave-smoke.sh start
- PORT=9943 bash scripts/wave-smoke.sh check
- grep seeded-flag log in target/universal/stage/wave_server.out
- grep absence of SearchWaveletUpdater subscription in target/universal/stage/wave_server.out
- PORT=9943 bash scripts/wave-smoke.sh stop

## Review
- Lead review: no functional findings; deploy bundles use separate deploy/*/application.conf files so this does not silently flip production OT-search defaults
- Claude code review: no blockers; only low-risk follow-up ideas

Fixes #943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default OT search is now disabled for local development. Existing installations retain their current setting; to re-enable, remove or update the persisted flag via the admin API.
* **Documentation**
  * Added a changelog entry documenting the new default and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->