### PR TITLE
Expose admin link in the J2CL root shell

### DIFF
--- a/wave/config/changelog.d/2026-04-21-j2cl-root-shell-admin-access.json
+++ b/wave/config/changelog.d/2026-04-21-j2cl-root-shell-admin-access.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-21-j2cl-root-shell-admin-access",
+  "version": "Unreleased",
+  "date": "2026-04-21",
+  "title": "Admin and owner sessions can reach the existing admin controls from the J2CL root shell",
+  "summary": "The active J2CL root shell now exposes a server-rendered Admin link for admin and owner sessions so they can reach the existing `/admin` page and Feature Flags controls without falling back to the legacy shell.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added a role-gated Admin link to the signed-in J2CL root-shell navigation for `admin` and `owner` sessions",
+        "Kept the existing `/admin` page as the feature-flags entry point instead of introducing a separate J2CL-native admin surface"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3217,7 +3217,10 @@ public final class HtmlRenderer {
       String rootShellReturnTarget, String websocketAddress) {
     JSONObject resolvedSessionJson = sessionJson == null ? new JSONObject() : sessionJson;
     String address = resolvedSessionJson.optString(SessionConstants.ADDRESS, "");
+    String role = resolvedSessionJson.optString(SessionConstants.ROLE, HumanAccountData.ROLE_USER);
     boolean signedIn = address != null && !address.isEmpty();
+    boolean isAdminOrOwner =
+        HumanAccountData.ROLE_ADMIN.equals(role) || HumanAccountData.ROLE_OWNER.equals(role);
     String resolvedReturnTarget = normalizeLocalReturnTarget(rootShellReturnTarget);
     String safeResolvedReturnTarget = StringEscapeUtils.escapeHtml4(resolvedReturnTarget);
     String safeEncodedReturnTarget =
@@ -3279,6 +3282,9 @@ public final class HtmlRenderer {
     sb.append("    <nav class=\"j2cl-root-shell-nav\" aria-label=\"Session controls\">\n");
     if (signedIn) {
       sb.append("      <span class=\"j2cl-root-shell-pill\">Signed in as ").append(escapeHtml(address)).append("</span>\n");
+      if (isAdminOrOwner) {
+        sb.append("      <a data-j2cl-root-admin-link=\"true\" class=\"j2cl-root-shell-link secondary\" href=\"/admin\">Admin</a>\n");
+      }
       sb.append("      <a data-j2cl-root-signout=\"true\" class=\"j2cl-root-shell-link secondary\" href=\"/auth/signout?r=")
           .append(safeEncodedReturnTarget)
           .append("\">Sign out</a>\n");

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
@@ -35,6 +35,8 @@ import jakarta.servlet.http.HttpSession;
 import org.junit.Test;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.FeatureFlagService;
 import org.waveprotocol.box.server.persistence.FeatureFlagStore;
@@ -137,6 +139,29 @@ public final class WaveClientServletJ2clRootShellTest {
   }
 
   @Test
+  public void signedInAdminJ2clRootShellShowsAdminLink() throws Exception {
+    String html = renderSignedInJ2clRootShellWithRole(HumanAccountData.ROLE_ADMIN);
+
+    assertTrue(html.contains("data-j2cl-root-admin-link=\"true\""));
+    assertTrue(html.contains("href=\"/admin\""));
+  }
+
+  @Test
+  public void signedInOwnerJ2clRootShellShowsAdminLink() throws Exception {
+    String html = renderSignedInJ2clRootShellWithRole(HumanAccountData.ROLE_OWNER);
+
+    assertTrue(html.contains("data-j2cl-root-admin-link=\"true\""));
+    assertTrue(html.contains("href=\"/admin\""));
+  }
+
+  @Test
+  public void signedInUserJ2clRootShellDoesNotShowAdminLink() throws Exception {
+    String html = renderSignedInJ2clRootShellWithRole(HumanAccountData.ROLE_USER);
+
+    assertFalse(html.contains("data-j2cl-root-admin-link=\"true\""));
+  }
+
+  @Test
   public void signedInJ2clRootShellStillExposesLegacyBootstrapGlobals() throws Exception {
     WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"));
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -191,6 +216,10 @@ public final class WaveClientServletJ2clRootShellTest {
   }
 
   private static WaveClientServlet createServlet(ParticipantId user) throws Exception {
+    return createServlet(user, HumanAccountData.ROLE_USER);
+  }
+
+  private static WaveClientServlet createServlet(ParticipantId user, String role) throws Exception {
     Config config = ConfigFactory.parseString(
         "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
             + "core.http_websocket_public_address=\"\"\n"
@@ -198,16 +227,40 @@ public final class WaveClientServletJ2clRootShellTest {
             + "core.search_type=\"memory\"\n"
             + "administration.analytics_account=\"\"\n");
     SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
     when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
     when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(role);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+    }
     return new WaveClientServlet(
         "example.com",
         config,
         sessionManager,
-        mock(AccountStore.class),
+        accountStore,
         new VersionServlet("test", 0L),
         mock(WavePreRenderer.class),
         new FeatureFlagService(featureFlagStore()));
+  }
+
+  private static String renderSignedInJ2clRootShellWithRole(String role) throws Exception {
+    WaveClientServlet servlet =
+        createServlet(ParticipantId.ofUnsafe("alice@example.com"), role);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn("j2cl-root");
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+    return body.toString();
   }
 
   private static FeatureFlagStore featureFlagStore() throws Exception {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
@@ -159,6 +159,7 @@ public final class WaveClientServletJ2clRootShellTest {
     String html = renderSignedInJ2clRootShellWithRole(HumanAccountData.ROLE_USER);
 
     assertFalse(html.contains("data-j2cl-root-admin-link=\"true\""));
+    assertFalse(html.contains("href=\"/admin\""));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a role-gated Admin affordance to the active J2CL root-shell nav for owner/admin sessions
- cover owner, admin, and non-admin visibility in the focused root-shell Jakarta test
- add the changelog fragment for active-shell admin access

## Verification
- python3 scripts/assemble-changelog.py
- sbt "jakartaTest:testOnly org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"
- python3 scripts/validate-changelog.py
- sbt "wave/compile"
- bash scripts/worktree-boot.sh --port 9918 --shared-file-store --file-store-source /Users/vega/devroot/incubator-wave
- PORT=9918 bash scripts/wave-smoke.sh check
- signed-in owner/admin/non-admin verification against the staged local server, including `/admin` and the existing Feature Flags tab

## Review
- Direct reviewer: no findings
- Claude code review: no correctness blockers; only context/coverage notes

Fixes #948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show a role-gated "Admin" link in the signed-in root-shell navigation for admin and owner accounts.

* **Tests**
  * Added unit tests validating admin-link visibility for admin/owner vs. regular users.

* **Documentation**
  * Added a changelog entry describing the change and its rollout; the existing /admin page remains the Feature Flags entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->