### PR TITLE
Restore GWT as the default root UI

### DIFF
--- a/docs/BUILDING-sbt.md
+++ b/docs/BUILDING-sbt.md
@@ -74,8 +74,8 @@ supported JDK 17 / Jakarta server path and the repo's current SBT layout.
 - Status: `/statusz/socket` returns websocket/http address info (JSON)
 - HTTP endpoints:
   - `/auth/signin` (GXP-backed login page)
-  - `/` (J2CL root shell by default; operators can set
-    `ui.j2cl_root_bootstrap_enabled=false` to restore the legacy GWT bootstrap)
+  - `/` (legacy GWT bootstrap by default; operators can set
+    `ui.j2cl_root_bootstrap_enabled=true` to switch `/` to the J2CL root shell)
   - `/static/*`, `/render/*`, `/webclient/*`, `/j2cl-search/*`, `/j2cl/*`
     (served by Jetty `ResourceServlet`; the maintained J2CL assets include
     `/j2cl/index.html` and `/j2cl-search/sidecar/j2cl-sidecar.js`)

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -21,9 +21,10 @@ distribution:
 1. Build: `sbt Universal/stage`
 2. Start: `bash scripts/wave-smoke.sh start` (waits for HTTP readiness)
 3. Check: `bash scripts/wave-smoke.sh check`
-   - Expected: `ROOT_STATUS=200`, `ROOT_SHELL=present`, `HEALTH_STATUS=200`,
-     `LANDING_STATUS=200`, `J2CL_ROOT_STATUS=200`, `J2CL_ROOT_SHELL=present`,
-     `J2CL_INDEX_STATUS=200`, `SIDECAR_STATUS=200`, `WEBCLIENT_STATUS=404`
+   - Expected: `ROOT_STATUS=200`, `ROOT_GWT=present`, `ROOT_SHELL=present`
+     (compatibility alias), `HEALTH_STATUS=200`, `LANDING_STATUS=200`,
+     `J2CL_ROOT_STATUS=200`, `J2CL_ROOT_SHELL=present`,
+     `J2CL_INDEX_STATUS=200`, `SIDECAR_STATUS=200`, `WEBCLIENT_STATUS=200`
 4. Stop: `bash scripts/wave-smoke.sh stop`
 
 For issue worktrees, use

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -127,7 +127,7 @@ curl -fsS -o /dev/null http://localhost:9900/j2cl-debug/index.html
 
 Expected result:
 
-- `/` renders the legacy GWT bootstrap asset (`webclient/webclient.nocache.js`)
+- `/` renders the legacy GWT bootstrap marker
 - `/?view=landing` returns success
 - `/?view=j2cl-root` renders the J2CL root-shell marker
 - `/j2cl-search/index.html` is present
@@ -147,7 +147,7 @@ Open these in the same signed-in browser session:
 
 On `/`:
 
-- the legacy GWT bootstrap loads
+- the legacy GWT bootstrap page boots
 - sign-in and sign-out controls remain available
 - the root app remains usable
 

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -115,7 +115,7 @@ While the server is running:
 ```bash
 curl -fsS -o /dev/null http://localhost:9900/
 curl -fsS -o /dev/null http://localhost:9900/?view=landing
-curl -fsS http://localhost:9900/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9900/ | grep -F 'webclient/webclient.nocache.js'
 curl -fsS http://localhost:9900/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 curl -fsS -o /dev/null http://localhost:9900/j2cl-search/index.html
 curl -fsS -o /dev/null http://localhost:9900/j2cl/index.html
@@ -127,9 +127,9 @@ curl -fsS -o /dev/null http://localhost:9900/j2cl-debug/index.html
 
 Expected result:
 
-- `/` renders the J2CL root-shell marker
+- `/` renders the legacy GWT bootstrap asset (`webclient/webclient.nocache.js`)
 - `/?view=landing` returns success
-- `/` and `/?view=j2cl-root` both render the J2CL root-shell marker
+- `/?view=j2cl-root` renders the J2CL root-shell marker
 - `/j2cl-search/index.html` is present
 - `/j2cl/index.html` is present (production sidecar artifact from `Universal/stage`)
 - the J2CL search bundle itself is present and non-placeholder
@@ -147,7 +147,7 @@ Open these in the same signed-in browser session:
 
 On `/`:
 
-- the J2CL root shell boots
+- the legacy GWT bootstrap loads
 - sign-in and sign-out controls remain available
 - the root app remains usable
 
@@ -207,9 +207,9 @@ Expected result:
 ```bash
 bash scripts/worktree-boot.sh --port 9915
 RUNTIME_CONFIG="$(find journal/runtime-config -maxdepth 1 -name '*-port-9915.application.conf' | head -n1)"
-cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap-off.application.conf
-printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap-off.application.conf
-PORT=9915 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap-off.application.conf" bash scripts/wave-smoke.sh start
+cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap-on.application.conf
+printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap-on.application.conf
+PORT=9915 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap-on.application.conf" bash scripts/wave-smoke.sh start
 curl -fsS http://localhost:9915/ | grep -F 'data-j2cl-root-shell'
 curl -fsS http://localhost:9915/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 test "$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:9915/webclient/webclient.nocache.js)" = 200

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -21,11 +21,11 @@ As of 2026-04-19, the current J2CL browser surfaces are:
 - `/j2cl/index.html`
   - production-profile J2CL bundle used by packaging
 
-The root `/` route now boots the J2CL root shell by default, but issue #949
-restores the rollback-ready coexistence contract: operators can set
-`ui.j2cl_root_bootstrap_enabled=false` to serve the legacy GWT bootstrap on `/`
-again while keeping `/?view=landing` as the explicit public landing page and
-`/?view=j2cl-root` as the direct J2CL diagnostic route.
+The root `/` route now boots the legacy GWT bootstrap by default, while the
+coexistence contract from issue `#949` keeps `/?view=j2cl-root` as the direct
+J2CL diagnostic route and lets operators set
+`ui.j2cl_root_bootstrap_enabled=true` to switch `/` to the J2CL root shell
+without a code rollback.
 
 ## Fast J2CL-Only Checks
 
@@ -177,16 +177,16 @@ PORT=9900 bash scripts/wave-smoke.sh stop
 
 ## Dual-Mode Coexistence Matrix
 
-Use this matrix when validating both the default-on J2CL root mode and the
-rollback-off legacy root mode.
+Use this matrix when validating both the default-on legacy GWT root mode and
+the opt-in J2CL root mode.
 
-### Mode A: Default-on J2CL Root With Coexistence Assets
+### Mode A: Default-on Legacy GWT Root With Coexistence Assets
 
 ```bash
 bash scripts/worktree-boot.sh --port 9914
 PORT=9914 bash scripts/wave-smoke.sh start
 PORT=9914 bash scripts/wave-smoke.sh check
-curl -fsS http://localhost:9914/ | grep -F 'data-j2cl-root-shell'
+curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
 curl -fsS http://localhost:9914/?view=landing | grep -F 'nav-link-signin'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 curl -fsS http://localhost:9914/j2cl-search/sidecar/j2cl-sidecar.js | grep -E 'WaveSandboxEntryPoint|j2cl'
@@ -196,21 +196,21 @@ PORT=9914 bash scripts/wave-smoke.sh stop
 
 Expected result:
 
-- `/` serves the J2CL root shell
+- `/` serves the legacy GWT bootstrap page
 - `/?view=landing` still reaches the explicit public landing page
 - `/?view=j2cl-root` still serves the same J2CL root shell as the direct diagnostic route
 - the sidecar bundle is present and non-placeholder
-- `/webclient/webclient.nocache.js` is reachable as rollback evidence
+- `/webclient/webclient.nocache.js` is reachable as part of the active default path
 
-### Mode B: Rollback-off Legacy Root With Direct J2CL Diagnostics Still Available
+### Mode B: Opt-in J2CL Root With Direct J2CL Diagnostics Still Available
 
 ```bash
 bash scripts/worktree-boot.sh --port 9915
 RUNTIME_CONFIG="$(find journal/runtime-config -maxdepth 1 -name '*-port-9915.application.conf' | head -n1)"
 cp "$RUNTIME_CONFIG" /tmp/j2cl-root-bootstrap-off.application.conf
-printf '\nui.j2cl_root_bootstrap_enabled=false\n' >> /tmp/j2cl-root-bootstrap-off.application.conf
+printf '\nui.j2cl_root_bootstrap_enabled=true\n' >> /tmp/j2cl-root-bootstrap-off.application.conf
 PORT=9915 JAVA_OPTS="-Djava.util.logging.config.file=$PWD/wave/config/wiab-logging.conf -Djava.security.auth.login.config=$PWD/wave/config/jaas.config -Dwave.server.config=/tmp/j2cl-root-bootstrap-off.application.conf" bash scripts/wave-smoke.sh start
-curl -fsS http://localhost:9915/ | grep -F 'webclient/webclient.nocache.js'
+curl -fsS http://localhost:9915/ | grep -F 'data-j2cl-root-shell'
 curl -fsS http://localhost:9915/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
 test "$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:9915/webclient/webclient.nocache.js)" = 200
 test "$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:9915/?view=landing)" = 200
@@ -219,9 +219,9 @@ PORT=9915 bash scripts/wave-smoke.sh stop
 
 Expected result:
 
-- plain `/` restores the legacy GWT bootstrap page when the operator override is off
+- plain `/` switches to the J2CL root shell when the operator override is on
 - `/?view=j2cl-root` still serves the J2CL root shell for diagnosis
-- `/webclient/webclient.nocache.js` remains reachable in rollback mode
+- `/webclient/webclient.nocache.js` remains reachable in opt-in J2CL mode
 - `/?view=landing` remains the explicit public landing page
 
 ## When To Use Direct Maven Instead Of SBT

--- a/scripts/test-worktree-diagnostics.sh
+++ b/scripts/test-worktree-diagnostics.sh
@@ -88,6 +88,7 @@ if [[ "${1-}" != "check" ]]; then
 fi
 
 printf '%s\n' "${TEST_SMOKE_OUTPUT:-ROOT_STATUS=200
+ROOT_GWT=present
 ROOT_SHELL=present
 HEALTH_STATUS=200
 LANDING_STATUS=200
@@ -95,7 +96,7 @@ J2CL_ROOT_STATUS=200
 J2CL_ROOT_SHELL=present
 J2CL_INDEX_STATUS=200
 SIDECAR_STATUS=200
-WEBCLIENT_STATUS=404}"
+WEBCLIENT_STATUS=200}"
 exit "${TEST_SMOKE_EXIT:-0}"
 EOF
   chmod +x "${repo_root}/scripts/wave-smoke.sh"
@@ -167,8 +168,9 @@ run_bundle_shape_case() {
   assert_contains "${output}" '`GET /j2cl/index.html` -> `200`'
   assert_contains "${output}" '`GET /j2cl-search/sidecar/j2cl-sidecar.js` -> `200`'
   assert_contains "${output}" 'Smoke exit: `0`'
+  assert_contains "${output}" 'ROOT_GWT=present'
   assert_contains "${output}" 'ROOT_SHELL=present'
-  assert_contains "${output}" 'WEBCLIENT_STATUS=404'
+  assert_contains "${output}" 'WEBCLIENT_STATUS=200'
   assert_contains "${output}" "Runtime config: ${repo_root}/journal/runtime-config/issue-587-worktree-diagnostics-20260412-port-9904.application.conf"
   assert_contains "${output}" "Evidence file: ${repo_root}/journal/local-verification/${prior_date}-issue-587-worktree-diagnostics-20260412.md"
   assert_contains "${output}" "startup line 2"

--- a/scripts/wave-smoke-ui.sh
+++ b/scripts/wave-smoke-ui.sh
@@ -46,7 +46,7 @@ j2cl_index_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PO
 sidecar_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl-search/sidecar/j2cl-sidecar.js || true)
 legacy_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/webclient/webclient.nocache.js || true)
 
-echo "ROOT=$root_status ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
+echo "ROOT=$root_status ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) ROOT_SHELL=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
 
 if [[ "${root_status}" == "000" ]]; then
   echo "Server did not start or port not reachable" >&2

--- a/scripts/wave-smoke-ui.sh
+++ b/scripts/wave-smoke-ui.sh
@@ -37,16 +37,18 @@ root_body_file=$(mktemp)
 root_status=$(curl -sS --max-time 10 -o "$root_body_file" -w "%{http_code}" http://127.0.0.1:$PORT/ || true)
 root_body=$(cat "$root_body_file" 2>/dev/null || true)
 rm -f "$root_body_file"
+root_gwt_presence=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)
 landing_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/?view=landing || true)
 j2cl_root_body_file=$(mktemp)
 j2cl_root_status=$(curl -sS --max-time 10 -o "$j2cl_root_body_file" -w "%{http_code}" http://127.0.0.1:$PORT/?view=j2cl-root || true)
 j2cl_root_body=$(cat "$j2cl_root_body_file" 2>/dev/null || true)
 rm -f "$j2cl_root_body_file"
+j2cl_root_shell_presence=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing)
 j2cl_index_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl/index.html || true)
 sidecar_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl-search/sidecar/j2cl-sidecar.js || true)
 legacy_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/webclient/webclient.nocache.js || true)
 
-echo "ROOT=$root_status ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) ROOT_SHELL=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
+echo "ROOT=$root_status ROOT_GWT=$root_gwt_presence ROOT_SHELL=$root_gwt_presence LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$j2cl_root_shell_presence J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
 
 if [[ "${root_status}" == "000" ]]; then
   echo "Server did not start or port not reachable" >&2

--- a/scripts/wave-smoke-ui.sh
+++ b/scripts/wave-smoke-ui.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 # wave-smoke-ui.sh — build (if needed), run briefly, and probe UI endpoints
 # - Starts :wave:run in background
-# - Waits for HTTP 200 from root, verifies the J2CL shell marker, and checks both
-#   maintained J2CL assets and the rollback-ready /webclient asset
+# - Waits for HTTP 200 from root, verifies the default legacy GWT bootstrap, and
+#   checks both maintained J2CL assets and the rollback-ready /webclient asset
 # - Tails logs on failure; always cleans up the background process
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
@@ -46,7 +46,7 @@ j2cl_index_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PO
 sidecar_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl-search/sidecar/j2cl-sidecar.js || true)
 legacy_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/webclient/webclient.nocache.js || true)
 
-echo "ROOT=$root_status ROOT_SHELL=$([[ "$root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
+echo "ROOT=$root_status ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing) LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing) J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
 
 if [[ "${root_status}" == "000" ]]; then
   echo "Server did not start or port not reachable" >&2
@@ -54,21 +54,22 @@ if [[ "${root_status}" == "000" ]]; then
   exit 1
 fi
 
-# Require the J2CL root shell body on both the default root and explicit diagnostic route.
+# Require the legacy GWT bootstrap on the default root and the J2CL root shell on
+# the explicit diagnostic route.
 if [[ "$root_status" -ne 200 ]]; then
   echo "Unexpected root status: $root_status" >&2
   tail -n 200 "$RUN_OUT" || true
   exit 1
 fi
 
-if [[ "$root_body" != *'data-j2cl-root-shell'* ]]; then
-  echo "Root page did not render the J2CL shell marker" >&2
+if [[ "$root_body" != *'webclient/webclient.nocache.js'* ]]; then
+  echo "Root page did not render the legacy GWT bootstrap asset" >&2
   tail -n 200 "$RUN_OUT" || true
   exit 1
 fi
 
-if [[ "$root_body" == *'webclient/webclient.nocache.js'* ]]; then
-  echo "Root page unexpectedly referenced the legacy bootstrap asset in default J2CL mode" >&2
+if [[ "$root_body" == *'data-j2cl-root-shell'* ]]; then
+  echo "Root page unexpectedly rendered the J2CL shell in default GWT mode" >&2
   tail -n 200 "$RUN_OUT" || true
   exit 1
 fi

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -179,14 +179,16 @@ status() {
 
 check() {
   local root_body_file root_body j2cl_root_body_file j2cl_root_body legacy_status
+  local root_gwt_presence j2cl_root_shell_presence
 
   root_body_file=$(mktemp)
   root_status=$(curl -sS --max-time 10 -o "$root_body_file" -w "%{http_code}" "http://localhost:$PORT/" || true)
   root_body=$(cat "$root_body_file" 2>/dev/null || true)
   rm -f "$root_body_file"
+  root_gwt_presence=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)
   echo "ROOT_STATUS=${root_status:-000}"
-  echo "ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)"
-  echo "ROOT_SHELL=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)"
+  echo "ROOT_GWT=${root_gwt_presence}"
+  echo "ROOT_SHELL=${root_gwt_presence}"
 
   if [[ "${root_status}" -ne 200 ]]; then
     echo "Unexpected root status: ${root_status}" >&2
@@ -222,8 +224,9 @@ check() {
   j2cl_root_status=$(curl -sS --max-time 10 -o "$j2cl_root_body_file" -w "%{http_code}" "http://localhost:$PORT/?view=j2cl-root" || true)
   j2cl_root_body=$(cat "$j2cl_root_body_file" 2>/dev/null || true)
   rm -f "$j2cl_root_body_file"
+  j2cl_root_shell_presence=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing)
   echo "J2CL_ROOT_STATUS=${j2cl_root_status:-000}"
-  echo "J2CL_ROOT_SHELL=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing)"
+  echo "J2CL_ROOT_SHELL=${j2cl_root_shell_presence}"
   if [[ "${j2cl_root_status}" -ne 200 ]]; then
     echo "Unexpected J2CL root status: ${j2cl_root_status}" >&2
     return 1

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -186,6 +186,7 @@ check() {
   rm -f "$root_body_file"
   echo "ROOT_STATUS=${root_status:-000}"
   echo "ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)"
+  echo "ROOT_SHELL=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)"
 
   if [[ "${root_status}" -ne 200 ]]; then
     echo "Unexpected root status: ${root_status}" >&2

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -185,20 +185,20 @@ check() {
   root_body=$(cat "$root_body_file" 2>/dev/null || true)
   rm -f "$root_body_file"
   echo "ROOT_STATUS=${root_status:-000}"
-  echo "ROOT_SHELL=$([[ "$root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing)"
+  echo "ROOT_GWT=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)"
 
   if [[ "${root_status}" -ne 200 ]]; then
     echo "Unexpected root status: ${root_status}" >&2
     return 1
   fi
 
-  if ! grep -Fq 'data-j2cl-root-shell' <<<"$root_body"; then
-    echo "Root page did not render the J2CL shell marker: data-j2cl-root-shell" >&2
+  if ! grep -Fq 'webclient/webclient.nocache.js' <<<"$root_body"; then
+    echo "Root page did not render the legacy GWT bootstrap asset" >&2
     return 1
   fi
 
-  if grep -Fq 'webclient/webclient.nocache.js' <<<"$root_body"; then
-    echo "Root page unexpectedly referenced the legacy bootstrap asset in default J2CL mode" >&2
+  if grep -Fq 'data-j2cl-root-shell' <<<"$root_body"; then
+    echo "Root page unexpectedly rendered the J2CL shell in default GWT mode" >&2
     return 1
   fi
 

--- a/wave/config/changelog.d/2026-04-21-gwt-default-root.json
+++ b/wave/config/changelog.d/2026-04-21-gwt-default-root.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-21-gwt-default-root",
+  "version": "Unreleased",
+  "date": "2026-04-21",
+  "title": "Legacy GWT is the default root UI again while J2CL remains opt-in",
+  "summary": "The rollback-ready coexistence path remains in place, but fresh/default root bootstrap now points back to the legacy GWT UI until J2CL reaches parity.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Changed the default `j2cl-root-bootstrap` setting back to off so `/` boots the legacy GWT UI again by default",
+        "Kept `/?view=j2cl-root` and the coexistence plumbing available for explicit J2CL testing and rollout work"
+      ]
+    }
+  ]
+}

--- a/wave/config/reference.conf
+++ b/wave/config/reference.conf
@@ -492,9 +492,9 @@ wave.fragments.applier.impl = "noop"
 # polling mechanism. Disabled by default until Phase 4 (client integration)
 # is complete.
 search.ot_search_enabled = false
-# Keep / on the J2CL root shell by default while allowing operators to
-# restore the legacy GWT /webclient bootstrap without a code rollback.
-ui.j2cl_root_bootstrap_enabled = true
+# Keep / on the legacy GWT bootstrap by default while allowing operators to
+# switch the root route to the J2CL shell without a code rollback.
+ui.j2cl_root_bootstrap_enabled = false
 # Controls the synchronous startup warmup in ServerMain that pre-builds either
 # the owner wave view or the entire wave map. Default false because eager
 # warmup can block startup on a full wave scan; leaving it off preserves the

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -42,7 +42,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("task-search", "Enable tasks:me search filter and Tasks toolbar button", true, Collections.emptyMap()));
     defaults.add(new FeatureFlag("mentions-search", "Enable @mention search filter and Mentions toolbar button", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
-    defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", true, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederJ2clBootstrapTest.java
@@ -32,12 +32,12 @@ import org.waveprotocol.box.server.persistence.KnownFeatureFlags;
 
 public final class FeatureFlagSeederJ2clBootstrapTest {
   @Test
-  public void knownBootstrapFlagIsRegisteredAndDefaultsOn() throws Exception {
+  public void knownBootstrapFlagIsRegisteredAndDefaultsOff() throws Exception {
     MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
     FeatureFlagService service = new FeatureFlagService(store);
     try {
       assertTrue(KnownFeatureFlags.isKnownFlag("j2cl-root-bootstrap"));
-      assertTrue(service.getEnabledFlagNames(null).contains("j2cl-root-bootstrap"));
+      assertFalse(service.getEnabledFlagNames(null).contains("j2cl-root-bootstrap"));
     } finally {
       service.shutdown();
     }


### PR DESCRIPTION
## Summary
- switch the default `j2cl-root-bootstrap` setting back off so `/` boots legacy GWT by default again
- keep the coexistence/rollback path intact, including the explicit `/?view=j2cl-root` route
- update the focused tests and smoke/runbook expectations that encoded J2CL as the default root

## Verification
- python3 scripts/assemble-changelog.py
- sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederJ2clBootstrapTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
- python3 scripts/validate-changelog.py
- sbt -batch wave/compile
- bash scripts/worktree-boot.sh --port 9922
- staged local runtime proof on port 9922: `/` contains `webclient/webclient.nocache.js`, while `/?view=j2cl-root` contains `data-j2cl-root-shell`

Fixes #952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the legacy GWT UI as the default bootstrap for the root (/) endpoint; the J2CL root shell remains available via an opt-in configuration.

* **Documentation**
  * Updated docs, runbooks, and smoke-test guidance to reflect the default legacy bootstrap and the opt-in J2CL route.

* **Tests**
  * Adjusted feature-flag and smoke tests to assert the revised default bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->