### PR TITLE
docs: add J2CL parity architecture memo

### DIFF
--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -44,6 +44,7 @@ docs/DEV_SETUP.md
 docs/BUILDING-sbt.md
 docs/SMOKE_TESTS.md
 docs/current-state.md
+docs/j2cl-parity-architecture.md
 docs/github-issues.md
 docs/agents/README.md
 docs/architecture/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ Split of responsibility:
 - [`persistence-topology-audit.md`](persistence-topology-audit.md)
 - [`j2cl-gwt3-inventory.md`](j2cl-gwt3-inventory.md)
 - [`j2cl-gwt3-decision-memo.md`](j2cl-gwt3-decision-memo.md)
+- [`j2cl-parity-architecture.md`](j2cl-parity-architecture.md)
 
 ## Ledgers
 

--- a/docs/j2cl-parity-architecture.md
+++ b/docs/j2cl-parity-architecture.md
@@ -1,0 +1,438 @@
+# J2CL Parity Architecture
+
+Status: Proposed  
+Updated: 2026-04-22  
+Owner: Project Maintainers  
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)  
+Task issue: [#954](https://github.com/vega113/supawave/issues/954)
+
+## 1. Decision Summary
+
+Recommendation:
+
+- keep **J2CL as the application/runtime layer** for Wave models, OT/state, transport, routing, and backend coordination
+- adopt **Lit custom elements as the long-term view composition layer**
+- use **server-rendered read-only HTML for first paint**, then progressively upgrade only the interactive regions instead of trying to hydrate the entire page as one framework-owned tree
+- use **viewport-scoped fragment loading** as the default large-wave path, not whole-wave bootstrap
+
+Do **not** make one of these two moves:
+
+- do not keep scaling the current manual Elemental2 DOM approach into full StageOne/StageTwo/StageThree parity
+- do not switch the primary browser runtime to a React-owned root tree
+
+This memo **complements** [docs/j2cl-gwt3-decision-memo.md](./j2cl-gwt3-decision-memo.md). The earlier memo answered whether staged J2CL migration was viable at all. This memo answers the next question: **what runtime architecture should close the remaining GWT parity gap now that the first staged J2CL slices already exist?**
+
+## 2. Current Repo Baseline
+
+### 2.1 The legacy GWT client is still organized as staged runtime layers
+
+The old client is not just a large pile of widgets. It has a runtime contract:
+
+- `StageOne` owns the basic read surface: wave panel, focus frame, collapse, thread navigation, DOM view provider, and CSS-backed rendering (`wave/src/main/java/org/waveprotocol/wave/client/StageOne.java:45-190`).
+- `StageTwo` owns live runtime behavior: connector activation, fragments wiring, dynamic rendering, and feature installation (`wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:1013-1184`).
+- `StageThree` owns editing capabilities: edit actions/session, edit toolbar, view toolbar, mention/task/reaction-adjacent edit infrastructure (`wave/src/main/java/org/waveprotocol/wave/client/StageThree.java:66-220`).
+- `Stages` and `StagesProvider` load those stages in order and then wire the real app behavior around them, including init-wave flow, `WaveContext`, toolbar actions, archive/pin wiring, and history mode (`wave/src/main/java/org/waveprotocol/wave/client/Stages.java:37-120`, `wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java:159-225`).
+
+That separation still matters. Closing parity is not only "render the same widgets in J2CL." It is replacing the staged lifecycle that currently controls read surface, live updates, and editing.
+
+### 2.2 The shipped J2CL client exists, but its view layer is still ad hoc
+
+The current J2CL path already proves the migration is real:
+
+- the search/read/write flow exists
+- the root shell exists
+- the reversible bootstrap seam exists
+- the GWT rollback path still exists
+
+But the J2CL UI layer is currently built from direct DOM construction and manual `render(...)` calls:
+
+- search shell: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:12-240`
+- selected-wave panel: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:7-105`
+- compose flow: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java`
+- root shell wrapper: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:9-102`
+
+The transport/backend seam is also real, but transitional:
+
+- `J2clSearchGateway` fetches bootstrap data by scraping `/`, uses `XMLHttpRequest` for `/search`, and opens `/socket` directly with `document.cookie` session extraction (`j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:16-250`).
+
+That is good enough for staged proof slices. It is not a durable parity architecture for the rest of the client.
+
+### 2.3 The repo already has the two key loading primitives needed for parity
+
+The missing architecture is not blocked on greenfield invention. Two important seams already exist:
+
+- **server prerender / shell swap**
+  - `WavePreRenderer` already prerenders a user's most recent wave to HTML for first paint and explicitly documents that GWT later replaces it with a shell swap rather than true hydration (`wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java:40-161`)
+  - the config flag for this is already present as `enable_prerendering` (`wave/config/reference.conf:127-132`)
+- **viewport-scoped fragments / dynamic rendering**
+  - the client already has a dynamic-rendering/fragments mode in `StageTwo` (`wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:1017-1184`)
+  - the transport already carries viewport hints from the client (`wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java:183-224`)
+  - the server already clamps and applies initial visible-segment selection (`wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:371-428`)
+  - the feature/config knobs already exist (`wave/config/reference.conf:405-441`)
+
+This means the parity plan should not be "render the whole wave, then optimize later." The repo is already telling us the correct long-term direction: **first paint a small readable surface, then grow the active region incrementally.**
+
+### 2.4 The current coexistence contract must remain first-class
+
+The repo is still in dual-root mode:
+
+- `/` serves the legacy GWT bootstrap by default
+- `/?view=j2cl-root` is the direct J2CL diagnostic route
+- operators can still switch `/` to the J2CL root via `ui.j2cl_root_bootstrap_enabled=true`
+
+That contract is recorded in the current J2CL runbook (`docs/runbooks/j2cl-sidecar-testing.md:13-29`, `:178-220`) and in the current root-default restore work merged in PR `#953`.
+
+The architecture recommendation must therefore preserve **coexistence and rollback** until read/live/edit parity is actually proven.
+
+## 3. The Real Parity Gap
+
+The remaining gap is not "J2CL lacks a few screens." It is this:
+
+| Legacy contract | Current J2CL state | Gap |
+|---|---|---|
+| StageOne builds the readable wave surface and its interaction scaffolding | J2CL has isolated search, selected-wave, and compose views, but no durable read-surface component model | No scalable replacement for WavePanel-era composition, focus, collapse, thread-nav, and incremental read rendering |
+| StageTwo owns live state, transport, fragments, reconnect, and feature activation | J2CL already has socket/search/bootstrap seams, but they are controller-local and transitional | No durable live-runtime layer that can own selected-wave state, route, fragments, read state, and reconnect across the full app |
+| StageThree owns editing/toolbars on top of the live/read layers | J2CL has a narrow write pilot only | No durable composition/edit stage for real toolbar/editor parity |
+| GWT can shell-swap from server prerendered HTML | J2CL currently mounts interactive DOM directly | No deliberate "read-only first, interactive later" contract for the J2CL path |
+| GWT dynamic rendering can load partial visible content | J2CL selected-wave view still projects a small textual summary model | No parity path yet for visible-region wave rendering at scale |
+
+So the architecture question is:
+
+**What UI/runtime structure can host J2CL-owned logic while supporting progressive enhancement, incremental visible-region rendering, and coexistence with Java-server-rendered HTML?**
+
+## 4. Framework Options
+
+### 4.1 Option A: stay on plain Elemental2 + manual DOM
+
+This is the status-quo direction.
+
+Pros:
+
+- no new view framework
+- minimal new build surface
+- entirely Java/J2CL-owned
+
+Cons:
+
+- the current J2CL code already shows the scaling problem: every view is manually assembling DOM and manually diffing view state
+- there is no durable composition/lifecycle boundary comparable to the old stage model
+- there is no framework help for component reuse, update scoping, testing structure, accessibility discipline, or progressive enhancement boundaries
+- this turns parity work into a custom in-house UI framework project
+
+Verdict: **reject**
+
+Use plain Elemental2 only for low-level DOM/interop seams, not as the long-term UI composition model.
+
+### 4.2 Option B: Lit custom elements with J2CL-owned controllers
+
+Lit's strengths match this repo unusually well:
+
+- Lit components are standard web components and can be used in plain HTML, other frameworks, or progressively enhanced pages ([What is Lit?](https://lit.dev/docs/v3/))
+- Lit is explicitly positioned for interoperability and incremental adoption, including existing projects and server-rendered HTML ([Adding Lit to an existing project](https://lit.dev/docs/tools/adding-lit/), [Tools and workflows overview](https://lit.dev/docs/tools/overview/))
+- Lit has a component lifecycle, reactive properties, and scoped rendering without taking ownership of the whole document ([Components overview](https://lit.dev/docs/components/overview/))
+- Lit SSR and hydration exist for Lit-owned subtrees, including loading custom element definitions later and hydrating declarative-shadow-root output when needed ([Lit SSR server usage](https://lit.dev/docs/ssr/server-usage/), [Lit SSR client usage](https://lit.dev/docs/ssr/client-usage/))
+
+Pros:
+
+- maps naturally to progressive enhancement and HTML-first server output
+- custom elements are a narrow interop boundary between Java/J2CL logic and browser UI composition
+- lets J2CL remain authoritative for transport, OT/state, routing, and backend coordination
+- incremental migration can happen panel-by-panel instead of root-by-root
+- unlike React, Lit does not require the whole page to become one framework-owned tree
+
+Cons:
+
+- introduces a second language/runtime boundary for the view layer
+- Lit SSR/hydration is still a Labs path and should not be the first dependency for the whole app
+- some build plumbing is needed to ship Lit component modules cleanly beside the J2CL bundle
+
+Verdict: **recommend**
+
+Use Lit for the view layer, but keep the authoritative app state and transport in J2CL.
+
+### 4.3 Option C: React as the primary root framework
+
+React is strong at server rendering and hydration:
+
+- `renderToPipeableStream` can stream the shell and later content from the server ([React `renderToPipeableStream`](https://react.dev/reference/react-dom/server/renderToPipeableStream))
+- `hydrateRoot` can attach React to server-rendered HTML on the client, but the server and client trees must match and mismatches are bugs ([React `hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot))
+
+Pros:
+
+- very mature SSR/hydration ecosystem
+- rich component model and tooling
+- strong testing ecosystem
+
+Cons:
+
+- the main React hydration model assumes the server rendered **the same React tree**
+- this repo's server is Java-first and already renders HTML through Java servlets/renderers
+- making React the primary runtime would push SupaWave toward a Node/JS SSR tier or duplicated render logic
+- that would invert the current staged migration by moving view ownership out of the J2CL path instead of completing it
+
+Verdict: **reject as the primary runtime**
+
+React is a good reference point, but adopting it would amount to a second migration: from GWT to J2CL **and** from Java-owned UI logic to a JS-owned root tree.
+
+## 5. Why Lit Wins Here
+
+The decisive factor is not that Lit has "better features" than React. It is that Lit fits the repo's actual constraints:
+
+1. **J2CL wants a narrow framework boundary, not a new totalizing runtime.**  
+   J2CL explicitly positions itself as Java that can work tightly with the web ecosystem rather than locking the app into one framework ([google/j2cl README](https://github.com/google/j2cl)). Lit's custom-element model fits that. React does not.
+
+2. **The server is already Java and already renders HTML.**  
+   SupaWave already has Java-side HTML renderers and prerender hooks. Lit can progressively enhance that world. React would prefer to own that world.
+
+3. **Parity work needs upgrade boundaries, not whole-root replacement.**  
+   Search rail, selected-wave chrome, compose affordances, toolbar surfaces, and thread-nav/focus surfaces can become custom elements incrementally. That is much closer to the current migration shape than a React root rewrite.
+
+4. **Large-wave rendering needs component boundaries around visible fragments.**  
+   Lit components can host visible-region sections cleanly while J2CL controllers own the fragment lifecycle and transport.
+
+So the right split is:
+
+- **J2CL Java**: models, OT/state, session bootstrap contract, route state, selected-wave/open/submit flows, fragment transport, read-state logic, feature flags
+- **Lit custom elements**: shell chrome, search rail, selected-wave sections, compose panels, toolbar/view panels, fragment-region containers
+- **Java server HTML**: first paint, read-only snapshot HTML, bootstrap JSON, rollback/coexistence routing
+
+## 6. Proposed Stage Mapping For The J2CL Era
+
+Do not literally recreate `StageOne`, `StageTwo`, and `StageThree` as old-style interfaces. But do preserve their responsibilities:
+
+### 6.1 Read Surface Stage
+
+Purpose:
+
+- wave/read DOM ownership
+- focus and selection framing
+- collapse/thread navigation
+- visible-region component boundaries
+- read-only rendering that can start from server HTML
+
+Maps back to:
+
+- `StageOne` (`wave/src/main/java/org/waveprotocol/wave/client/StageOne.java:51-190`)
+
+Recommended implementation shape:
+
+- J2CL controller/model layer owns read state and fragment window state
+- Lit custom elements render the read surface and subregions
+- server can provide initial read-only HTML per visible region
+
+### 6.2 Live Surface Stage
+
+Purpose:
+
+- socket/session/bootstrap lifecycle
+- reconnect
+- read-state refresh
+- route/history
+- fragment fetch policy
+- feature activation and live-update application
+
+Maps back to:
+
+- `StageTwo` (`wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:1017-1184`)
+
+Recommended implementation shape:
+
+- J2CL remains authoritative here
+- no framework should own this state machine
+- Lit components receive state snapshots/events through a narrow boundary
+
+### 6.3 Compose Stage
+
+Purpose:
+
+- edit session
+- toolbar state
+- mention/task/reaction/edit affordances
+- write-path orchestration on top of the live/read layers
+
+Maps back to:
+
+- `StageThree` (`wave/src/main/java/org/waveprotocol/wave/client/StageThree.java:72-220`)
+
+Recommended implementation shape:
+
+- keep compose/edit orchestration in J2CL
+- use Lit for toolbar and compose panel composition
+- do not attempt compose-stage parity until the read/live stages are structurally stable
+
+## 7. Read-Only First, Interactive Later
+
+### 7.1 What not to do
+
+Do not make the next step "render the full interactive app on the client, but faster."
+
+That misses the point of the existing prerender and fragments seams.
+
+### 7.2 Recommended load contract
+
+1. **Server renders shell + read-only content**
+   - route shell
+   - signed-in/out chrome
+   - selected wave or visible fragment slice as static HTML
+   - bootstrap JSON for user/session/route/wave ids/visible-fragment hints
+
+2. **Browser paints immediately**
+   - no dependency on full J2CL runtime boot before content is visible
+
+3. **J2CL boots**
+   - reads bootstrap JSON, not scraped HTML where possible
+   - opens live transport
+   - establishes selected-wave/read-state/fragment state
+
+4. **Lit components upgrade interactive regions**
+   - search rail
+   - shell chrome
+   - selected-wave controls
+   - compose/edit affordances
+
+5. **Visible regions become live**
+   - first through state attachment and event wiring
+   - then through fragment-driven updates and incremental expansion
+
+This first wave does **not** depend on Lit SSR. The intended first-paint path remains Java-server-rendered HTML plus progressive client upgrade. Lit SSR stays an optional later optimization for JS-owned subtrees if and when the repo decides that a Lit-rendered server path is worth the extra moving parts.
+
+### 7.3 Why this fits SupaWave better than full framework hydration
+
+`WavePreRenderer` already documents that the legacy system does a shell swap rather than true hydration (`wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java:40-47`). That is the right starting mental model for J2CL too.
+
+The next J2CL architecture should therefore aim for:
+
+- **progressive upgrade**
+- **interactive islands**
+- **read-only server ownership of first paint**
+
+not a requirement that the whole page be rendered by one client framework on both server and browser.
+
+Lit supports that direction better than React because it can be introduced as component boundaries on top of HTML-first pages, while React's main hydration model expects the same React tree on both sides.
+
+## 8. Large Waves: Visible Region First
+
+The correct parity target is not "load the whole wave more efficiently." It is "load only the region the user needs now."
+
+The repo already supports that direction:
+
+- client open requests can include `viewportStartBlipId`, `viewportDirection`, and `viewportLimit` (`wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java:183-224`)
+- server-side selection already clamps and emits a visible segment window (`wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:371-428`)
+- config already defines dynamic rendering and viewport limits (`wave/config/reference.conf:405-441`)
+
+### Recommended J2CL parity contract
+
+- initial open should request:
+  - manifest/index
+  - visible-region blips only
+  - bounded `viewportLimit`
+- J2CL live stage owns:
+  - scroll/selection-derived viewport target
+  - fetch-next / fetch-previous behavior
+  - reconnect/resume rules
+- Lit read-surface components own:
+  - region containers
+  - insertion/removal presentation
+  - loading placeholders
+  - local interaction affordances
+
+This also means the selected-wave view in its current text-summary form should evolve into **fragment-region rendering**, not into a full eager whole-wave DOM dump.
+
+## 9. Backend Coordination Changes The Repo Should Make
+
+These are architectural recommendations, not this issue's implementation scope:
+
+### 9.1 Replace HTML scraping bootstrap with explicit bootstrap data
+
+Today `J2clSearchGateway` reads session/bootstrap details by fetching `/` and parsing HTML (`j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:23-37`).
+
+That should become:
+
+- server-rendered bootstrap JSON in the page
+- explicit route/session/socket metadata
+- explicit read-only snapshot metadata
+
+This is a durability/readability change, not an auth-hardening implementation in `#954`. But it should be designed together with the follow-up auth hardening seam below so the repo does not replace HTML scraping with a bootstrap format that immediately conflicts with the eventual socket-auth cleanup.
+
+### 9.2 Keep auth/session hardening separate, but document the seam
+
+The current J2CL path still reads `JSESSIONID` from `document.cookie` before socket auth (`j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:54-57`, `:151-154`).
+
+That is a known follow-up problem, but it should not block the view-framework decision. The memo should treat it as a required transport seam to clean up, not a reason to pick a different UI framework.
+
+## 10. Build And Tooling Impact
+
+The framework choice does affect tooling:
+
+- the current J2CL sidecar is a Maven-driven J2CL bundle with Elemental2/JsInterop (`j2cl/pom.xml`)
+- Lit does **not** require a framework-specific compiler or full-stack platform, which makes it feasible to add beside the current sidecar rather than replacing the whole build
+
+Recommended build stance:
+
+- keep the authoritative application/runtime build in the existing J2CL sidecar path
+- add a small, explicit UI-module build only for Lit custom elements if needed
+- do not make Node/JS SSR a prerequisite for the next parity wave
+
+If the view layer cannot be introduced without a large parallel toolchain, the recommendation should be revisited. At the moment, Lit's minimal-tooling posture is one of the main reasons it fits.
+
+The same is true for QA: this architecture should extend the current J2CL verification path in `docs/runbooks/j2cl-sidecar-testing.md`, not bypass it. Browser verification remains part of parity proof until the legacy GWT path is actually retired.
+
+## 11. Accessibility And Localization
+
+Parity is not just rendering and transport. The replacement stack also needs a plausible story for:
+
+- keyboard navigation
+- focus retention
+- thread navigation affordances
+- toolbar semantics
+- screen-reader-visible structure
+- localized labels/messages
+
+This is another reason to avoid growing the current manual DOM layer forever. Component boundaries make it much easier to enforce accessible shell/read/compose structure consistently than one-off DOM assembly in every view class.
+
+## 12. Recommended Next Slices Under #904
+
+This memo implies the following follow-on sequence:
+
+1. **Adopt the J2CL runtime split explicitly**
+   - J2CL owns models/transport/route/live state
+   - Lit owns UI composition
+
+2. **Introduce explicit bootstrap JSON + read-only HTML islands**
+   - stop depending on HTML scraping as the long-term bootstrap seam
+
+3. **Port StageOne parity as a read-surface layer**
+   - focus, collapse, thread-nav, visible fragment containers
+
+4. **Port StageTwo parity as a live-surface layer**
+   - read state, reconnect, route/history, fragment requester policy, visible-region updates
+
+5. **Only then expand StageThree parity**
+   - toolbar/edit/compose parity on top of a stable read/live base
+
+This keeps the current rollback contract intact while moving the architecture toward a client that can eventually replace GWT without another total rewrite.
+
+## 13. External References
+
+- J2CL README: https://github.com/google/j2cl
+- Elemental2 README: https://github.com/google/elemental2
+- Lit overview: https://lit.dev/docs/v3/
+- Lit components overview: https://lit.dev/docs/components/overview/
+- Lit SSR server usage: https://lit.dev/docs/ssr/server-usage/
+- Lit SSR client usage: https://lit.dev/docs/ssr/client-usage/
+- Lit tools overview: https://lit.dev/docs/tools/overview/
+- React `hydrateRoot`: https://react.dev/reference/react-dom/client/hydrateRoot
+- React `renderToPipeableStream`: https://react.dev/reference/react-dom/server/renderToPipeableStream
+
+## 14. Bottom Line
+
+The repo should not choose between:
+
+- "keep hand-writing DOM in J2CL forever"
+- "move the whole UI to React"
+
+The correct middle path is:
+
+**J2CL for application logic and live runtime, Lit for composable browser UI, Java server HTML for read-only first paint, and fragment-window loading as the default large-wave strategy.**
+
+That is the smallest architecture change that can still plausibly close the real GWT parity gap.

--- a/docs/j2cl-parity-architecture.md
+++ b/docs/j2cl-parity-architecture.md
@@ -3,6 +3,7 @@
 Status: Proposed  
 Updated: 2026-04-22  
 Owner: Project Maintainers  
+Review cadence: on-change
 Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)  
 Task issue: [#954](https://github.com/vega113/supawave/issues/954)
 

--- a/docs/superpowers/plans/2026-04-22-issue-954-j2cl-parity-architecture.md
+++ b/docs/superpowers/plans/2026-04-22-issue-954-j2cl-parity-architecture.md
@@ -1,0 +1,235 @@
+# Issue #954 J2CL Parity Architecture Investigation Plan
+
+> **For agentic workers:** Treat this as an investigation/documentation slice, not an implementation spike. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a repo-backed architecture memo that explains the remaining parity gap between the legacy GWT client and the current J2CL client, recommends the long-term J2CL UI framework/runtime approach, and defines how SupaWave should handle read-only-first load, backend coordination, and viewport-scoped wave loading during the rest of the migration.
+
+**Architecture:** Start from the current post-`#953` coexistence baseline: the repo already ships a J2CL sidecar, selected-wave read flow, route state, write pilot, root shell, reversible bootstrap seam, legacy-GWT rollback path, server-side pre-render hooks, and viewport-aware fragment transport. The deliverable for `#954` is a committed markdown memo that ties those existing seams together into one migration architecture: map the old `StageOne` / `StageTwo` / `StageThree` responsibilities to J2CL-era equivalents, compare realistic UI framework options for the J2CL view layer, and recommend a parity-first sequence for server rendering, hydration/upgrade, and incremental wave loading.
+
+**Tech Stack:** Markdown docs under `docs/`, existing J2CL Maven sidecar under `j2cl/`, legacy GWT client under `wave/src/main/java/org/waveprotocol/wave/client/**`, Jakarta servlet/rendering code, primary-source framework documentation, GitHub issue/PR traceability, and Claude review for plan plus implementation review loops.
+
+---
+
+## 1. Goal / Baseline / Why This Exists
+
+Issue `#954` exists because the staged J2CL migration is now far enough along that the remaining gap is no longer “can J2CL render anything?” It is “what architecture gets the repo from the current sidecar/root-shell proof to practical parity with GWT without backing into another UI dead end?”
+
+Observed repo facts that make this memo necessary:
+
+- `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java` still defines the first real reader-stage runtime boundary around `WavePanelImpl`, focus, collapse, thread navigation, DOM view providers, and CSS-backed wave rendering.
+- `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java` still owns connector activation, feature installation, fragments wiring, dynamic rendering, and selected-wave runtime behavior.
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java` still assembles the real GWT app around those stages and then publishes `WaveContext`, toolbar wiring, archive/pin hooks, and history behavior.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`, `J2clSelectedWaveView.java`, `J2clSidecarComposeView.java`, and `j2cl/root/J2clRootShellView.java` currently build the J2CL UI directly with Elemental2 DOM calls and manual render methods; there is no higher-level component model yet.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java` already coordinates with the backend through root-bootstrap HTML scraping, `/search`, and `/socket`, but it still carries transitional seams like `document.cookie` WebSocket auth.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java` and `wave/config/reference.conf` already define a server-side pre-render + shell-swap seam for the legacy client, proving the repo already has a place to discuss read-only-first rendering rather than inventing it from scratch.
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`, `RemoteViewServiceMultiplexer.java`, and the dynamic-rendering/fragments code already define viewport-hinted partial-wave transport, so large-wave incremental loading should be part of the parity architecture instead of a later afterthought.
+- `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java` and `wave/src/main/java/org/waveprotocol/wave/client/Stages.java` still matter because parity is not only read-only rendering; the GWT runtime still has a staged lifecycle for editing, toolbars, and feature activation that the memo must either preserve conceptually or replace deliberately.
+
+The memo should answer the remaining architectural question: what is the repo’s intended post-GWT UI stack and migration shape now that the first staged J2CL slices are already real?
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- compare the current GWT runtime architecture and the shipped J2CL runtime architecture
+- explain the parity gap in runtime/framework terms, not only widget inventory
+- map the old stage model (`StageOne`, `StageTwo`, `StageThree`) to J2CL-era responsibilities
+- evaluate realistic framework options for the J2CL UI layer and recommend one
+- define how server-rendered read-only content, client hydration/upgrade, and backend transport should fit together in this repo
+- define how large-wave loading should use viewport/fragments seams instead of whole-wave bootstrap
+- produce one committed markdown memo under `docs/`
+
+### Explicit Non-Goals
+
+- no implementation of the chosen framework
+- no production cutover of `/` back to J2CL
+- no removal of the legacy GWT client
+- no broad code refactors outside the new memo and any small doc-index updates needed to reference it
+- no attempt to solve the J2CL auth hardening or unread-state follow-up issues as part of this doc slice
+
+## 3. Exact Files To Read And Likely Files To Change
+
+### Primary Repo Evidence Inputs
+
+- `docs/j2cl-gwt3-decision-memo.md`
+- `docs/j2cl-preparatory-work.md`
+- `docs/superpowers/plans/j2cl-full-migration-plan.md`
+- `docs/runbooks/j2cl-sidecar-testing.md`
+- `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/Stages.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/StagesProvider.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java`
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java`
+- `wave/config/reference.conf`
+
+### External Anchors
+
+- `docs/runbooks/j2cl-sidecar-testing.md`
+- `docs/j2cl-gwt3-decision-memo.md` as the prior migration-baseline memo that the new doc must explicitly complement or supersede
+- issue `#904` and merged PR `#953` as the live coexistence/rollback anchors for the current dual-root state
+
+### Likely New / Updated Files
+
+- `docs/j2cl-parity-architecture.md`
+- optional: `docs/README.md` or `docs/DOC_REGISTRY.md` only if the new memo needs an index entry
+
+## 4. Investigation Questions The Memo Must Answer
+
+### Runtime Architecture
+
+- [ ] What responsibilities do `StageOne`, `StageTwo`, and `StageThree` currently own in the GWT client, and which of those are still missing or only partially represented in the J2CL path?
+- [ ] How do `Stages.java` and `StagesProvider.java` sequence those stage responsibilities today, and which of those sequencing/lifecycle seams must survive in the J2CL-era architecture?
+- [ ] Which current J2CL seams are already good foundations for parity, and which ones are intentionally temporary?
+- [ ] Which gaps are UI-only, and which are framework/runtime gaps (rendering model, lifecycle, routing, state ownership, backend bootstrap, incremental transport)?
+- [ ] How would J2CL-owned Java models, events, and view-state cross the boundary into the chosen framework/runtime, and what interop seam keeps that bridge narrow instead of spreading framework code through the whole client?
+- [ ] How does the post-`#953` contract constrain the recommendation: GWT remains the default root UI while J2CL sidecar/root diagnostics stay available during the coexistence window?
+
+### Framework Decision
+
+- [ ] What UI framework/runtime options are realistic for a J2CL-based SupaWave client?
+- [ ] Which option best supports:
+  - J2CL-hosted application logic
+  - SSR/read-only-first rendering with later client upgrade
+  - incremental, component-scoped updates for large waves
+  - gradual migration instead of a big-bang rewrite
+  - thin interop with existing backend/bootstrap seams
+  - tolerable build/tooling impact on the current SBT + J2CL Maven sidecar pipeline
+  - preserving accessibility and localization parity while GWT and J2CL coexist
+- [ ] Keep the framework comparison intentionally small: at most one short comparison table plus a concise recommendation section, not a broad ecosystem survey.
+- [ ] The memo must compare at least:
+  - continuing with plain Elemental2/manual DOM
+  - a lightweight component/view model that works with plain custom elements / Web Components
+  - React as the concrete mainstream SSR/hydration framework comparison point
+- [ ] The memo must make one clear recommendation and explain why the rejected options are weaker for this repo.
+
+### Backend / Loading Model
+
+- [ ] How should the root bootstrap, session bootstrap, auth state, and selected-wave open flow coordinate between server and J2CL client?
+- [ ] What is the recommended “read-only first, interactive later” flow for SupaWave, and where should the server stop versus where should the client take over?
+- [ ] How should large waves use viewport-scoped fragment loading and dynamic rendering rather than whole-wave loading?
+- [ ] Which current repo seams make that feasible now, and what follow-on gaps remain?
+
+## 5. Concrete Task Breakdown
+
+### Task 1: Freeze The Investigation Boundary
+
+- [ ] Keep `#954` scoped to one architecture memo plus any small index link updates needed for discoverability.
+- [ ] Treat `#904` as the parent tracker and avoid widening this slice into implementation work that belongs to the later child issues.
+- [ ] Record the plan path in the issue comments before the main doc lands.
+
+### Task 2: Capture The Current Repo Baseline
+
+- [ ] Read the current migration docs and the live J2CL/GWT code seams listed above.
+- [ ] Extract repo-specific evidence for:
+  - old GWT staging/runtime boundaries
+  - current J2CL view architecture
+  - existing server prerender support
+  - existing viewport/fragments support
+- [ ] Avoid generic statements unless the repo evidence or primary-source docs support them.
+
+### Task 3: Research External Framework Options From Primary Sources
+
+- [ ] Use current primary-source documentation for the candidate framework options.
+- [ ] Keep the candidate shortlist explicit and bounded:
+  - plain Elemental2/manual DOM as the status-quo baseline
+  - a Web Components-oriented option (for example Lit-style component composition)
+  - React as the mainstream SSR/hydration framework option with a larger runtime boundary
+- [ ] Constrain the research to framework capabilities that materially matter for SupaWave:
+  - SSR/hydration or resumable upgrade
+  - incremental rendering/state granularity
+  - interop tolerance for J2CL-driven logic
+  - migration ergonomics from manual DOM or server-rendered HTML
+  - build/toolchain cost in the current repo
+  - a11y/i18n parity implications
+- [ ] Keep the final comparison short and decision-oriented rather than producing a general framework survey: one short table, three options maximum, one explicit recommendation.
+
+### Task 4: Write The Architecture Memo
+
+- [ ] Create `docs/j2cl-parity-architecture.md`.
+- [ ] Structure the memo roughly as:
+  - current baseline
+  - remaining parity gap
+  - stage-model remapping
+  - framework options and recommendation
+  - J2CL-to-framework interop seam
+  - read-only-first + hydration architecture
+  - viewport-scoped wave loading architecture
+  - rollback/coexistence constraints from the current GWT + J2CL dual-root state, grounded in `docs/runbooks/j2cl-sidecar-testing.md`, `#904`, and merged PR `#953`
+  - relationship to `docs/j2cl-gwt3-decision-memo.md` and whether this memo complements or supersedes it
+  - proposed next slices / decision checklist tied back to `#904`
+- [ ] Make every repo-behavior claim traceable to specific files or current docs.
+- [ ] Keep the recommendation opinionated enough to drive future issue slicing.
+- [ ] Describe the auth/session bootstrap seam as a current constraint when relevant, but do not widen the memo into solving `document.cookie` WebSocket auth hardening in this slice.
+
+### Task 5: Review Loop Before PR
+
+- [ ] Self-review the memo for scope drift, unsupported claims, and missing parity seams.
+- [ ] Run the required Claude review loop on the plan first.
+- [ ] Address any valid Claude plan-review findings, rerun, and stop only when the plan review is effectively clean or blocked for a documented provider reason.
+- [ ] After the memo is written, run a second Claude review on the implementation diff, address valid findings, and rerun until clean or until a real blocker remains.
+
+### Task 6: Traceability And PR Closeout
+
+- [ ] Add issue comments with:
+  - worktree path
+  - plan path
+  - review outcomes
+  - commit SHAs
+  - PR link
+- [ ] Because this is a doc-only slice, verification should focus on:
+  - doc completeness and internal consistency
+  - clean diff (`git diff --check`)
+  - successful review loops
+- [ ] Do not update `docs/superpowers/plans/j2cl-full-migration-plan.md` or older migration docs unless the final memo needs a minimal pointer for discoverability.
+- [ ] Start a PR monitor after the PR is opened and keep it alive until the PR is actually merged or truly blocked.
+
+## 6. Review / Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-954-j2cl-parity-architecture`.
+
+### Diff Sanity
+
+```bash
+git diff --check
+```
+
+Expected result:
+
+- no whitespace or patch-format issues in the doc changes
+
+### Plan Review
+
+Use the repo-required Claude review flow against the plan file diff or plan file content, targeting the newest Claude Opus 4.7 model available in the local workflow.
+
+Expected result:
+
+- plan review produces either no actionable findings or a bounded set of comments that get addressed and rerun before memo authoring continues
+
+### Implementation Review
+
+Use the same Claude review flow against the final doc diff before PR.
+
+Expected result:
+
+- no remaining actionable findings on the committed memo diff
+
+## 7. Definition Of Done
+
+- `docs/j2cl-parity-architecture.md` exists and is committed
+- the memo explains the parity gap in terms of SupaWave’s actual runtime seams, not only abstract migration advice
+- the memo makes one explicit UI framework/runtime recommendation and justifies it against realistic alternatives
+- the memo explains how server-side read-only-first rendering, later client hydration/upgrade, and viewport-scoped large-wave loading should work together in this repo
+- the memo states how the current rollback/coexistence contract constrains the recommended architecture during the remaining migration window
+- the memo ties the recommendation back to concrete follow-on slices under `#904`
+- `git diff --check` has been run clean on the final doc changes
+- the issue and PR both contain the plan path, review evidence, and final doc traceability
+- the PR is opened and placed under active monitoring until merged or truly blocked

--- a/wave/config/changelog.d/2026-04-22-j2cl-parity-architecture-memo.json
+++ b/wave/config/changelog.d/2026-04-22-j2cl-parity-architecture-memo.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-22-j2cl-parity-architecture-memo",
+  "version": "PR #956",
+  "date": "2026-04-22",
+  "title": "The J2CL parity architecture memo now defines the recommended long-term view/runtime split",
+  "summary": "The new architecture memo documents the repo-backed recommendation to keep J2CL for runtime/state/transport concerns, use Lit custom elements for long-term UI composition, and preserve server-rendered first paint plus rollback-ready coexistence.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a dedicated J2CL parity architecture memo that maps the legacy staged GWT runtime responsibilities to the recommended J2CL-plus-Lit direction",
+        "Documented why the parity path should keep server-rendered read-only first paint, viewport-scoped fragment loading, and the existing coexistence/rollback contract instead of moving to a React-owned root"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `docs/j2cl-parity-architecture.md` with a repo-backed recommendation for closing the remaining GWT/J2CL parity gap
- add the task plan under `docs/superpowers/plans/2026-04-22-issue-954-j2cl-parity-architecture.md`
- index the new memo in `docs/README.md` and `docs/DOC_REGISTRY.md`

## Decision
- keep J2CL for runtime/state/transport/backend coordination
- use Lit custom elements for long-term UI composition instead of scaling manual Elemental2 DOM or moving to a React-owned root
- keep server-rendered read-only first paint and viewport-scoped fragment loading as the parity path for large waves

## Verification
- `git diff --check`

## Review
- Claude Opus 4.7 plan review: pass after iterative fixes
- Claude Opus 4.7 implementation review: pass

Closes #954
Related: #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive J2CL parity architecture memo describing runtime and view-layer recommendations, migration sequence, and backend/loading considerations.
  * Added a structured investigation and plan document outlining goals, scope, tasks, and verification steps for pursuing J2CL parity.
  * Updated the documentation index/registry and release changelog to include the new architecture and planning entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->