### PR TITLE
fix(editor): enable IME tracer via feature flags and remote upload

### DIFF
--- a/docs/superpowers/plans/2026-04-22-issue-955-ime-trace-flag-upload-plan.md
+++ b/docs/superpowers/plans/2026-04-22-issue-955-ime-trace-flag-upload-plan.md
@@ -1,0 +1,64 @@
+# Issue #955 Plan: IME Trace Feature-Flag Enablement And Remote Upload
+
+## Scope
+
+- Issue: [#955](https://github.com/vega113/supawave/issues/955)
+- Branch: `issue-955-ime-trace-flag-upload`
+- Worktree: `/Users/vega/devroot/worktrees/issue-955-ime-trace-flag-upload`
+
+## Root Cause
+
+- `ImeDebugTracer` currently enables itself only from `?ime_debug=on` and `localStorage.ime_debug`, so admins cannot turn it on per user through the repo's feature-flag system.
+- The server already has `RemoteLoggingJakartaServlet`, but the current tree no longer mounts the historical `/webclient/remote_logging` route, and there is no client uploader in the tracer.
+- The existing per-user flag path already exists end to end for other features:
+  `FeatureFlagService` -> `WaveClientServlet` session JSON -> `Session.hasFeature(...)`.
+
+## Intended Fix
+
+- Add a dedicated known feature flag for the IME tracer so admins can allowlist individual users.
+- Update `ImeDebugTracer` to enable when either:
+  - the feature flag is present in `Session.get().hasFeature(...)`, or
+  - the legacy local override (`?ime_debug=on` / `localStorage`) is on.
+- Make the tracer re-check the feature-flag source lazily until it becomes available so an early `isEnabled()` call does not permanently miss the session flag.
+- Keep the existing console + overlay sinks, and add a best-effort same-origin uploader that POSTs `text/plain;charset=utf-8` batches to `/webclient/remote_logging`.
+- Preserve per-line readability on the server side by logging uploaded trace lines individually rather than summarizing a whole multi-line batch into one truncated line.
+- Restore the exact remote logging servlet mapping at `/webclient/remote_logging`.
+
+## Files Likely Touched
+
+- `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServlet.java`
+- `wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java`
+- `wave/config/changelog.d/*`
+
+## Acceptance Criteria
+
+- [ ] A named IME tracer feature flag exists in the admin feature-flag catalog.
+- [ ] A per-user allowlist entry for that flag causes the current user session to enable the tracer without manual URL/localStorage steps.
+- [ ] Tracer lines can be forwarded to the server via the existing remote logging servlet route.
+- [ ] Uploaded trace batches retain individual trace lines in server logs with authenticated-user context.
+- [ ] Existing local override behavior continues to work as a fallback.
+- [ ] Automated tests cover the new flag availability and the remote logging endpoint behavior touched by the change.
+- [ ] Local verification proves the route exists and the app still boots with the tracer disabled by default.
+
+## Test Plan
+
+- [ ] `sbt "wave/testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.server.rpc.RemoteLoggingJakartaServletTest"`
+- [ ] Add and run any extra focused test if the route restoration or session-feature visibility needs one.
+- [ ] `python3 scripts/assemble-changelog.py`
+- [ ] `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+
+## Local Verification
+
+- [ ] Start the app from the worktree on a non-conflicting port.
+- [ ] Confirm exact-path `/webclient/remote_logging` is mounted, not shadowed by `/webclient/*`, and requires auth.
+- [ ] Confirm the main app still loads normally with tracing off by default.
+- [ ] Confirm a flagged user session exposes the new flag to the GWT client and that tracer uploads reach server logs.
+
+## Out Of Scope
+
+- Broader editor behavior fixes for Android IME corruption itself.
+- General-purpose client logging redesign beyond the IME tracer path.

--- a/wave/config/changelog.d/2026-04-22-issue-955-ime-debug-tracer-feature-flag-upload.json
+++ b/wave/config/changelog.d/2026-04-22-issue-955-ime-debug-tracer-feature-flag-upload.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-04-22-issue-955-ime-debug-tracer-feature-flag-upload",
+  "version": "Unreleased",
+  "date": "2026-04-22",
+  "title": "IME tracer feature-flag enablement and server log upload",
+  "summary": "Turns the Android IME diagnostic tracer into a real per-user feature-flagged tool instead of a URL/localStorage-only toggle, and restores the remote logging path so tracer output can be forwarded back to the server for authenticated debugging sessions.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Registered the IME diagnostic tracer as a known feature flag so admins can enable it per user",
+        "Updated the client tracer to honor the feature flag in addition to the legacy local URL/localStorage override",
+        "Restored the /webclient/remote_logging servlet mapping and forwarded IME tracer lines there as authenticated text/plain uploads",
+        "Server-side remote logging now records uploaded plain-text trace lines individually with user context instead of collapsing a whole batch into one summary line"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServlet.java
@@ -18,6 +18,7 @@ import org.waveprotocol.wave.util.logging.Log;
  * This is a best-effort compatibility shim; it does not implement full GWT RPC.
  */
 public class RemoteLoggingJakartaServlet extends HttpServlet {
+  public static final String REMOTE_LOGGING_URL = "/webclient/remote_logging";
   private static final Log LOG = Log.get(RemoteLoggingJakartaServlet.class);
   private final SessionManager sessionManager;
 
@@ -88,7 +89,8 @@ public class RemoteLoggingJakartaServlet extends HttpServlet {
       } catch (Throwable ignore) { /* fall through to summary */ }
 
       if (level == null) level = "INFO";
-      String line = "[remote_log][gwt] level=" + level +
+      String line = "[remote_log][gwt] user=" + sanitize(loggedInUser.getAddress()) +
+          " level=" + level +
           (logger != null ? (" logger=" + sanitize(logger)) : "") +
           (message != null ? (" msg=" + sanitize(message)) : (" msg=" + summarize(payload)));
       switch (level) {
@@ -101,10 +103,27 @@ public class RemoteLoggingJakartaServlet extends HttpServlet {
       return;
     }
 
-    LOG.info("[remote_log] " + summarize(payload));
+    logPlainTextPayload(loggedInUser, payload);
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("text/plain; charset=utf-8");
     resp.getOutputStream().write("OK".getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void logPlainTextPayload(ParticipantId loggedInUser, String payload) {
+    String user = loggedInUser == null ? "" : sanitize(loggedInUser.getAddress());
+    boolean loggedAny = false;
+    String[] lines = payload == null ? new String[0] : payload.split("\\r?\\n");
+    for (String line : lines) {
+      String sanitized = sanitize(line);
+      if (sanitized.isEmpty()) {
+        continue;
+      }
+      LOG.info("[remote_log] user=" + user + " " + sanitized);
+      loggedAny = true;
+    }
+    if (!loggedAny) {
+      LOG.info("[remote_log] user=" + user + " <empty>");
+    }
   }
 
   private static String summarize(String s) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServlet.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
 
@@ -19,12 +20,16 @@ import org.waveprotocol.wave.util.logging.Log;
  */
 public class RemoteLoggingJakartaServlet extends HttpServlet {
   public static final String REMOTE_LOGGING_URL = "/webclient/remote_logging";
+  private static final String IME_TRACER_FLAG = "ime-debug-tracer";
   private static final Log LOG = Log.get(RemoteLoggingJakartaServlet.class);
   private final SessionManager sessionManager;
+  private final FeatureFlagService featureFlagService;
 
   @Inject
-  public RemoteLoggingJakartaServlet(SessionManager sessionManager) {
+  public RemoteLoggingJakartaServlet(SessionManager sessionManager,
+      FeatureFlagService featureFlagService) {
     this.sessionManager = sessionManager;
+    this.featureFlagService = featureFlagService;
   }
 
   @Override
@@ -33,6 +38,10 @@ public class RemoteLoggingJakartaServlet extends HttpServlet {
     ParticipantId loggedInUser = sessionManager.getLoggedInUser(session);
     if (loggedInUser == null) {
       resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Authentication required");
+      return;
+    }
+    if (!featureFlagService.isEnabled(IME_TRACER_FLAG, loggedInUser.getAddress())) {
+      resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Feature not enabled");
       return;
     }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java
@@ -636,6 +636,7 @@ public class ServerRpcProvider {
             addJ2clServlet(context, "jakarta-j2cl-debug", j2clDebugResource, "/j2cl-debug", "/j2cl-debug/*");
             addJ2clServlet(context, "jakarta-j2cl", j2clResource, "/j2cl", "/j2cl/*");
 
+            addServlet(RemoteLoggingJakartaServlet.REMOTE_LOGGING_URL, org.waveprotocol.box.server.rpc.RemoteLoggingJakartaServlet.class);
             addServlet(org.waveprotocol.box.stat.StatService.STAT_URL, org.waveprotocol.box.server.stat.StatuszJakartaServlet.class);
             addServlet("/metrics", org.waveprotocol.box.server.stat.MetricsPrometheusServlet.class);
 

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -42,6 +42,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("task-search", "Enable tasks:me search filter and Tasks toolbar button", true, Collections.emptyMap()));
     defaults.add(new FeatureFlag("mentions-search", "Enable @mention search filter and Mentions toolbar button", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("ime-debug-tracer", "Enable IME diagnostic trace overlay and remote log upload", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -71,6 +71,10 @@ public final class ImeDebugTracer {
   private static final String REMOTE_LOGGING_URL = "/webclient/remote_logging";
   private static final int MAX_OVERLAY_LINES = 200;
   private static final int MAX_FIELD_LEN = 120;
+  private static final int ENABLE_REFRESH_RETRY_INTERVAL_MS = 1000;
+  private static final int REMOTE_UPLOAD_MAX_BATCH_CHARS = 4096;
+  private static final int REMOTE_UPLOAD_MAX_BATCH_LINES = 20;
+  private static final int REMOTE_UPLOAD_DELAY_MS = 750;
 
   private ImeDebugTracer() {
     // Utility.
@@ -79,12 +83,13 @@ public final class ImeDebugTracer {
   private static boolean initialized = false;
   private static boolean enabled = false;
   private static double baselineMs = 0.0;
+  private static double nextRefreshAttemptMs = 0.0;
 
   /** Cheap fast-path gate. Safe to call from every hot site. */
   public static boolean isEnabled() {
     if (!initialized) {
       initialize();
-    } else if (!enabled) {
+    } else if (!enabled && shouldRetryRefresh()) {
       refreshEnabledState();
     }
     return enabled;
@@ -108,9 +113,19 @@ public final class ImeDebugTracer {
       return;
     }
     enabled = true;
+    nextRefreshAttemptMs = 0.0;
     baselineMs = nowMsJsni();
     installGlobalEventListenersJsni(baselineMs);
     ensureOverlayJsni();
+  }
+
+  private static boolean shouldRetryRefresh() {
+    double now = System.currentTimeMillis();
+    if (now < nextRefreshAttemptMs) {
+      return false;
+    }
+    nextRefreshAttemptMs = now + ENABLE_REFRESH_RETRY_INTERVAL_MS;
+    return true;
   }
 
   private static boolean isSessionFlagEnabled() {
@@ -280,7 +295,11 @@ public final class ImeDebugTracer {
       String line = buf.toString();
       consoleLogJsni(line);
       appendToOverlayJsni(line);
-      queueRemoteLogJsni(line);
+      queueRemoteLogJsni(
+          line,
+          REMOTE_UPLOAD_MAX_BATCH_CHARS,
+          REMOTE_UPLOAD_MAX_BATCH_LINES,
+          REMOTE_UPLOAD_DELAY_MS);
     }
   }
 
@@ -423,7 +442,11 @@ public final class ImeDebugTracer {
   /** Callable from JSNI so the global event listeners can queue remote logs too. */
   @SuppressWarnings("unused")
   private static void queueRemoteLogJsniBridge(String msg) {
-    queueRemoteLogJsni(msg);
+    queueRemoteLogJsni(
+        msg,
+        REMOTE_UPLOAD_MAX_BATCH_CHARS,
+        REMOTE_UPLOAD_MAX_BATCH_LINES,
+        REMOTE_UPLOAD_DELAY_MS);
   }
 
   private static native void ensureOverlayJsni() /*-{
@@ -490,7 +513,8 @@ public final class ImeDebugTracer {
     }
   }-*/;
 
-  private static native void queueRemoteLogJsni(String line) /*-{
+  private static native void queueRemoteLogJsni(
+      String line, int maxBatchChars, int maxBatchLines, int flushDelayMs) /*-{
     try {
       var w = $wnd;
       var state = w.__imeDebugRemoteLogState;
@@ -536,12 +560,12 @@ public final class ImeDebugTracer {
 
       state.queue.push(line);
       state.queuedChars += (line ? line.length : 0) + 1;
-      if (state.queuedChars >= 4096 || state.queue.length >= 20) {
+      if (state.queuedChars >= maxBatchChars || state.queue.length >= maxBatchLines) {
         flush();
         return;
       }
       if (!state.timer) {
-        state.timer = w.setTimeout(flush, 750);
+        state.timer = w.setTimeout(flush, flushDelayMs);
       }
     } catch (e) {
       // swallow

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -85,6 +85,7 @@ public final class ImeDebugTracer {
 
   private static boolean initialized = false;
   private static boolean enabled = false;
+  private static boolean remoteUploadEnabled = false;
   private static double baselineMs = 0.0;
   private static double nextRefreshAttemptMs = 0.0;
 
@@ -112,10 +113,12 @@ public final class ImeDebugTracer {
     if (enabled) {
       return;
     }
-    if (!isSessionFlagEnabled() && !FLAG_ON.equals(readFlagJsni())) {
+    boolean sessionEnabled = isSessionFlagEnabled();
+    if (!sessionEnabled && !FLAG_ON.equals(readFlagJsni())) {
       return;
     }
     enabled = true;
+    remoteUploadEnabled = sessionEnabled;
     nextRefreshAttemptMs = 0.0;
     baselineMs = nowMsJsni();
     installGlobalEventListenersJsni(baselineMs);
@@ -298,13 +301,15 @@ public final class ImeDebugTracer {
       String line = buf.toString();
       consoleLogJsni(line);
       appendToOverlayJsni(line);
-      queueRemoteLogJsni(
-          line,
-          REMOTE_UPLOAD_MAX_BATCH_CHARS,
-          REMOTE_UPLOAD_MAX_BATCH_LINES,
-          REMOTE_UPLOAD_DELAY_MS,
-          REMOTE_UPLOAD_MAX_QUEUE_LINES,
-          REMOTE_UPLOAD_MAX_QUEUE_CHARS);
+      if (remoteUploadEnabled) {
+        queueRemoteLogJsni(
+            line,
+            REMOTE_UPLOAD_MAX_BATCH_CHARS,
+            REMOTE_UPLOAD_MAX_BATCH_LINES,
+            REMOTE_UPLOAD_DELAY_MS,
+            REMOTE_UPLOAD_MAX_QUEUE_LINES,
+            REMOTE_UPLOAD_MAX_QUEUE_CHARS);
+      }
     }
   }
 
@@ -447,6 +452,9 @@ public final class ImeDebugTracer {
   /** Callable from JSNI so the global event listeners can queue remote logs too. */
   @SuppressWarnings("unused")
   private static void queueRemoteLogJsniBridge(String msg) {
+    if (!remoteUploadEnabled) {
+      return;
+    }
     queueRemoteLogJsni(
         msg,
         REMOTE_UPLOAD_MAX_BATCH_CHARS,

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -416,14 +416,26 @@ public final class ImeDebugTracer {
         return 'err:' + e;
       }
     }
+    function formatField(value) {
+      if (value === null || value === undefined) return 'null';
+      var s = String(value);
+      var maxLen = @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::MAX_FIELD_LEN;
+      if (s.length > maxLen) s = s.substring(0, maxLen) + '…';
+      return s
+          .replace(/\\/g, '\\\\')
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, '\\n')
+          .replace(/\r/g, '\\r')
+          .replace(/\t/g, '\\t');
+    }
     function handler(e) {
       try {
         var t = ((w.performance && w.performance.now ? w.performance.now() : new Date().getTime()) - baseline).toFixed(1);
         var msg = '+' + t + 'ms GLOBAL ' + e.type;
-        if (e.key !== undefined) msg += ' key="' + e.key + '"';
+        if (e.key !== undefined) msg += ' key="' + formatField(e.key) + '"';
         if (e.keyCode !== undefined) msg += ' code=' + e.keyCode;
-        if (e.data !== undefined) msg += ' data="' + (e.data === null ? 'null' : String(e.data)) + '"';
-        if (e.inputType) msg += ' inputType="' + e.inputType + '"';
+        if (e.data !== undefined) msg += ' data="' + formatField(e.data) + '"';
+        if (e.inputType) msg += ' inputType="' + formatField(e.inputType) + '"';
         if (e.isComposing !== undefined) msg += ' isComposing=' + e.isComposing;
         if (e.target) msg += ' target=' + describeNode(e.target);
         msg += ' sel=' + describeSelection();

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -538,10 +538,31 @@ public final class ImeDebugTracer {
           return;
         }
 
-        state.inFlight = true;
-        var payload = state.queue.join('\n');
-        state.queue = [];
+        var batch = [];
+        var batchChars = 0;
+        var batchCount = 0;
+        while (batchCount < state.queue.length && batch.length < maxBatchLines) {
+          var nextLine = state.queue[batchCount];
+          var nextChars = (nextLine ? nextLine.length : 0) + (batch.length > 0 ? 1 : 0);
+          if (batch.length > 0 && batchChars + nextChars > maxBatchChars) {
+            break;
+          }
+          batch.push(nextLine);
+          batchChars += nextChars;
+          batchCount++;
+        }
+        if (!batch.length) {
+          batch.push(state.queue[0]);
+          batchCount = 1;
+        }
+        state.queue = state.queue.slice(batchCount);
         state.queuedChars = 0;
+        for (var i = 0; i < state.queue.length; i++) {
+          state.queuedChars += (state.queue[i] ? state.queue[i].length : 0) + 1;
+        }
+
+        state.inFlight = true;
+        var payload = batch.join('\n');
 
         var xhr = new XMLHttpRequest();
         xhr.open('POST', @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_LOGGING_PATH, true);

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -201,6 +201,15 @@ public final class ImeDebugTracer {
     return escape(s.substring(0, 200)) + "…(+" + (s.length() - 200) + ")";
   }
 
+  static String formatFieldValue(String value) {
+    if (value == null) {
+      return "null";
+    }
+    boolean truncated = value.length() > MAX_FIELD_LEN;
+    String formatted = escape(truncated ? value.substring(0, MAX_FIELD_LEN) : value);
+    return truncated ? formatted + '\u2026' : formatted;
+  }
+
   private static String escape(String s) {
     if (s == null) {
       return "";
@@ -267,13 +276,7 @@ public final class ImeDebugTracer {
       if (value == null) {
         buf.append("null");
       } else {
-        boolean truncated = value.length() > MAX_FIELD_LEN;
-        String v = truncated ? value.substring(0, MAX_FIELD_LEN) : value;
-        buf.append('"').append(escape(v));
-        if (truncated) {
-          buf.append('\u2026');
-        }
-        buf.append('"');
+        buf.append('"').append(formatFieldValue(value)).append('"');
       }
       return this;
     }
@@ -417,16 +420,8 @@ public final class ImeDebugTracer {
       }
     }
     function formatField(value) {
-      if (value === null || value === undefined) return 'null';
-      var s = String(value);
-      var maxLen = @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::MAX_FIELD_LEN;
-      if (s.length > maxLen) s = s.substring(0, maxLen) + '…';
-      return s
-          .replace(/\\/g, '\\\\')
-          .replace(/"/g, '\\"')
-          .replace(/\n/g, '\\n')
-          .replace(/\r/g, '\\r')
-          .replace(/\t/g, '\\t');
+      return @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::formatFieldValueForJsniBridge(Ljava/lang/String;)(
+          value === null ? null : String(value));
     }
     function handler(e) {
       try {
@@ -459,6 +454,11 @@ public final class ImeDebugTracer {
   @SuppressWarnings("unused")
   private static void appendToOverlayJsniBridge(String msg) {
     appendToOverlayJsni(msg);
+  }
+
+  @SuppressWarnings("unused")
+  private static String formatFieldValueForJsniBridge(String value) {
+    return formatFieldValue(value);
   }
 
   /** Callable from JSNI so the global event listeners can queue remote logs too. */

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -68,13 +68,14 @@ import com.google.gwt.dom.client.Text;
 public final class ImeDebugTracer {
   private static final String FEATURE_FLAG_NAME = "ime-debug-tracer";
   private static final String FLAG_ON = "on";
-  private static final String REMOTE_LOGGING_URL = "/webclient/remote_logging";
+  private static final String REMOTE_LOGGING_PATH = "webclient/remote_logging";
   private static final int MAX_OVERLAY_LINES = 200;
   private static final int MAX_FIELD_LEN = 120;
   private static final int ENABLE_REFRESH_RETRY_INTERVAL_MS = 1000;
   private static final int REMOTE_UPLOAD_MAX_BATCH_CHARS = 4096;
   private static final int REMOTE_UPLOAD_MAX_BATCH_LINES = 20;
   private static final int REMOTE_UPLOAD_DELAY_MS = 750;
+  private static final int REMOTE_UPLOAD_TIMEOUT_MS = 10000;
 
   private ImeDebugTracer() {
     // Utility.
@@ -543,19 +544,30 @@ public final class ImeDebugTracer {
         state.queuedChars = 0;
 
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_LOGGING_URL, true);
+        xhr.open('POST', @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_LOGGING_PATH, true);
         xhr.withCredentials = true;
+        xhr.timeout = @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_UPLOAD_TIMEOUT_MS;
         xhr.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
-        xhr.onreadystatechange = function() {
-          if (xhr.readyState !== 4) {
-            return;
-          }
+        function finish() {
           state.inFlight = false;
           if (state.queue.length) {
             flush();
           }
+        }
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState !== 4) {
+            return;
+          }
+          finish();
         };
-        xhr.send(payload);
+        xhr.onerror = finish;
+        xhr.onabort = finish;
+        xhr.ontimeout = finish;
+        try {
+          xhr.send(payload);
+        } catch (e) {
+          finish();
+        }
       }
 
       state.queue.push(line);

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -569,7 +569,12 @@ public final class ImeDebugTracer {
         xhr.withCredentials = true;
         xhr.timeout = @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_UPLOAD_TIMEOUT_MS;
         xhr.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
+        var finished = false;
         function finish() {
+          if (finished) {
+            return;
+          }
+          finished = true;
           state.inFlight = false;
           if (state.queue.length) {
             flush();

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -66,14 +66,15 @@ import com.google.gwt.dom.client.Text;
  * should reveal which link in the pipeline is actually dropping characters.
  */
 public final class ImeDebugTracer {
+  private static final String FEATURE_FLAG_NAME = "ime-debug-tracer";
+  private static final String FLAG_ON = "on";
+  private static final String REMOTE_LOGGING_URL = "/webclient/remote_logging";
+  private static final int MAX_OVERLAY_LINES = 200;
+  private static final int MAX_FIELD_LEN = 120;
 
   private ImeDebugTracer() {
     // Utility.
   }
-
-  private static final String FLAG_ON = "on";
-  private static final int MAX_OVERLAY_LINES = 200;
-  private static final int MAX_FIELD_LEN = 120;
 
   private static boolean initialized = false;
   private static boolean enabled = false;
@@ -83,6 +84,8 @@ public final class ImeDebugTracer {
   public static boolean isEnabled() {
     if (!initialized) {
       initialize();
+    } else if (!enabled) {
+      refreshEnabledState();
     }
     return enabled;
   }
@@ -91,14 +94,30 @@ public final class ImeDebugTracer {
     initialized = true;
     try {
       syncFlagFromUrlJsni();
-      enabled = FLAG_ON.equals(readFlagJsni());
-      if (enabled) {
-        baselineMs = nowMsJsni();
-        installGlobalEventListenersJsni(baselineMs);
-        ensureOverlayJsni();
-      }
+      refreshEnabledState();
     } catch (Throwable t) {
       enabled = false;
+    }
+  }
+
+  private static void refreshEnabledState() {
+    if (enabled) {
+      return;
+    }
+    if (!isSessionFlagEnabled() && !FLAG_ON.equals(readFlagJsni())) {
+      return;
+    }
+    enabled = true;
+    baselineMs = nowMsJsni();
+    installGlobalEventListenersJsni(baselineMs);
+    ensureOverlayJsni();
+  }
+
+  private static boolean isSessionFlagEnabled() {
+    try {
+      return hasSessionFeatureJsni(FEATURE_FLAG_NAME);
+    } catch (Throwable t) {
+      return false;
     }
   }
 
@@ -261,6 +280,7 @@ public final class ImeDebugTracer {
       String line = buf.toString();
       consoleLogJsni(line);
       appendToOverlayJsni(line);
+      queueRemoteLogJsni(line);
     }
   }
 
@@ -293,6 +313,20 @@ public final class ImeDebugTracer {
       return $wnd.localStorage.getItem("ime_debug") || "";
     } catch (e) {
       return "";
+    }
+  }-*/;
+
+  private static native boolean hasSessionFeatureJsni(String name) /*-{
+    try {
+      var session = $wnd.__session;
+      var features = session && session.features;
+      if (!features || !features.length) return false;
+      for (var i = 0; i < features.length; i++) {
+        if (features[i] === name) return true;
+      }
+      return false;
+    } catch (e) {
+      return false;
     }
   }-*/;
 
@@ -366,6 +400,7 @@ public final class ImeDebugTracer {
         msg += ' sel=' + describeSelection();
         if ($wnd.console && $wnd.console.log) { $wnd.console.log('[IME-DBG] ' + msg); }
         @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::appendToOverlayJsniBridge(Ljava/lang/String;)(msg);
+        @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::queueRemoteLogJsniBridge(Ljava/lang/String;)(msg);
       } catch (err) {
         // swallow
       }
@@ -383,6 +418,12 @@ public final class ImeDebugTracer {
   @SuppressWarnings("unused")
   private static void appendToOverlayJsniBridge(String msg) {
     appendToOverlayJsni(msg);
+  }
+
+  /** Callable from JSNI so the global event listeners can queue remote logs too. */
+  @SuppressWarnings("unused")
+  private static void queueRemoteLogJsniBridge(String msg) {
+    queueRemoteLogJsni(msg);
   }
 
   private static native void ensureOverlayJsni() /*-{
@@ -444,6 +485,64 @@ public final class ImeDebugTracer {
         ov.removeChild(ov.firstChild);
       }
       ov.scrollTop = ov.scrollHeight;
+    } catch (e) {
+      // swallow
+    }
+  }-*/;
+
+  private static native void queueRemoteLogJsni(String line) /*-{
+    try {
+      var w = $wnd;
+      var state = w.__imeDebugRemoteLogState;
+      if (!state) {
+        state = {
+          queue: [],
+          queuedChars: 0,
+          timer: null,
+          inFlight: false
+        };
+        w.__imeDebugRemoteLogState = state;
+      }
+
+      function flush() {
+        if (state.timer) {
+          w.clearTimeout(state.timer);
+          state.timer = null;
+        }
+        if (state.inFlight || !state.queue.length) {
+          return;
+        }
+
+        state.inFlight = true;
+        var payload = state.queue.join('\n');
+        state.queue = [];
+        state.queuedChars = 0;
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::REMOTE_LOGGING_URL, true);
+        xhr.withCredentials = true;
+        xhr.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState !== 4) {
+            return;
+          }
+          state.inFlight = false;
+          if (state.queue.length) {
+            flush();
+          }
+        };
+        xhr.send(payload);
+      }
+
+      state.queue.push(line);
+      state.queuedChars += (line ? line.length : 0) + 1;
+      if (state.queuedChars >= 4096 || state.queue.length >= 20) {
+        flush();
+        return;
+      }
+      if (!state.timer) {
+        state.timer = w.setTimeout(flush, 750);
+      }
     } catch (e) {
       // swallow
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -76,6 +76,8 @@ public final class ImeDebugTracer {
   private static final int REMOTE_UPLOAD_MAX_BATCH_LINES = 20;
   private static final int REMOTE_UPLOAD_DELAY_MS = 750;
   private static final int REMOTE_UPLOAD_TIMEOUT_MS = 10000;
+  private static final int REMOTE_UPLOAD_MAX_QUEUE_LINES = 200;
+  private static final int REMOTE_UPLOAD_MAX_QUEUE_CHARS = 65536;
 
   private ImeDebugTracer() {
     // Utility.
@@ -300,7 +302,9 @@ public final class ImeDebugTracer {
           line,
           REMOTE_UPLOAD_MAX_BATCH_CHARS,
           REMOTE_UPLOAD_MAX_BATCH_LINES,
-          REMOTE_UPLOAD_DELAY_MS);
+          REMOTE_UPLOAD_DELAY_MS,
+          REMOTE_UPLOAD_MAX_QUEUE_LINES,
+          REMOTE_UPLOAD_MAX_QUEUE_CHARS);
     }
   }
 
@@ -447,7 +451,9 @@ public final class ImeDebugTracer {
         msg,
         REMOTE_UPLOAD_MAX_BATCH_CHARS,
         REMOTE_UPLOAD_MAX_BATCH_LINES,
-        REMOTE_UPLOAD_DELAY_MS);
+        REMOTE_UPLOAD_DELAY_MS,
+        REMOTE_UPLOAD_MAX_QUEUE_LINES,
+        REMOTE_UPLOAD_MAX_QUEUE_CHARS);
   }
 
   private static native void ensureOverlayJsni() /*-{
@@ -515,7 +521,8 @@ public final class ImeDebugTracer {
   }-*/;
 
   private static native void queueRemoteLogJsni(
-      String line, int maxBatchChars, int maxBatchLines, int flushDelayMs) /*-{
+      String line, int maxBatchChars, int maxBatchLines, int flushDelayMs,
+      int maxQueueLines, int maxQueueChars) /*-{
     try {
       var w = $wnd;
       var state = w.__imeDebugRemoteLogState;
@@ -598,6 +605,11 @@ public final class ImeDebugTracer {
 
       state.queue.push(line);
       state.queuedChars += (line ? line.length : 0) + 1;
+      while (state.queue.length > maxQueueLines || state.queuedChars > maxQueueChars) {
+        var dropped = state.queue.shift();
+        state.queuedChars -= (dropped ? dropped.length : 0) + 1;
+      }
+      if (state.queuedChars < 0) { state.queuedChars = 0; }
       if (state.queuedChars >= maxBatchChars || state.queue.length >= maxBatchLines) {
         flush();
         return;

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -93,7 +93,7 @@ public final class ImeDebugTracer {
   public static boolean isEnabled() {
     if (!initialized) {
       initialize();
-    } else if (!enabled && shouldRetryRefresh()) {
+    } else if ((!enabled || !remoteUploadEnabled) && shouldRetryRefresh()) {
       refreshEnabledState();
     }
     return enabled;
@@ -110,19 +110,24 @@ public final class ImeDebugTracer {
   }
 
   private static void refreshEnabledState() {
-    if (enabled) {
+    if (enabled && remoteUploadEnabled) {
       return;
     }
     boolean sessionEnabled = isSessionFlagEnabled();
-    if (!sessionEnabled && !FLAG_ON.equals(readFlagJsni())) {
-      return;
+    if (!enabled) {
+      if (!sessionEnabled && !FLAG_ON.equals(readFlagJsni())) {
+        return;
+      }
+      enabled = true;
+      nextRefreshAttemptMs = 0.0;
+      baselineMs = nowMsJsni();
+      installGlobalEventListenersJsni(baselineMs);
+      ensureOverlayJsni();
     }
-    enabled = true;
-    remoteUploadEnabled = sessionEnabled;
-    nextRefreshAttemptMs = 0.0;
-    baselineMs = nowMsJsni();
-    installGlobalEventListenersJsni(baselineMs);
-    ensureOverlayJsni();
+    if (sessionEnabled) {
+      remoteUploadEnabled = true;
+      nextRefreshAttemptMs = 0.0;
+    }
   }
 
   private static boolean shouldRetryRefresh() {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
@@ -74,6 +74,18 @@ public final class FeatureFlagServiceTest {
     service = new FeatureFlagService(store);
 
     assertFalse(service.getEnabledFlagNames(null).contains("ime-debug-tracer"));
+
+    Map<String, Boolean> overrides = new LinkedHashMap<>();
+    overrides.put("user@example.com", true);
+    store.save(
+        new FeatureFlag(
+            "ime-debug-tracer",
+            "Enable IME diagnostic trace overlay and remote log upload",
+            false,
+            overrides));
+    service.refreshCache();
+
+    assertTrue(service.getEnabledFlagNames("user@example.com").contains("ime-debug-tracer"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.KnownFeatureFlags;
 import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
 
 public final class FeatureFlagServiceTest {
@@ -63,6 +64,16 @@ public final class FeatureFlagServiceTest {
 
     assertFalse(service.getEnabledFlagNames(null).contains("ot-search"));
     assertFalse(service.getEnabledFlagNames(null).contains("ot-search-fallback"));
+  }
+
+  @Test
+  public void imeDebugTracerFlagIsKnownButDisabledByDefault() throws Exception {
+    assertTrue(KnownFeatureFlags.isKnownFlag("ime-debug-tracer"));
+
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    service = new FeatureFlagService(store);
+
+    assertFalse(service.getEnabledFlagNames(null).contains("ime-debug-tracer"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
@@ -86,12 +86,9 @@ public final class RemoteLoggingJakartaServletTest {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     Logger logger = Logger.getLogger(RemoteLoggingJakartaServlet.class.getName());
     RecordingHandler handler = new RecordingHandler();
-    Level previousLevel = logger.getLevel();
-    boolean previousUseParentHandlers = logger.getUseParentHandlers();
 
     logger.addHandler(handler);
-    logger.setUseParentHandlers(false);
-    logger.setLevel(Level.ALL);
+    handler.setLevel(Level.ALL);
     try {
       when(request.getSession(false)).thenReturn(mock(HttpSession.class));
       when(sessionManager.getLoggedInUser(any(WebSession.class)))
@@ -117,8 +114,6 @@ public final class RemoteLoggingJakartaServletTest {
       servlet.doPost(request, response);
     } finally {
       logger.removeHandler(handler);
-      logger.setUseParentHandlers(previousUseParentHandlers);
-      logger.setLevel(previousLevel);
     }
 
     verify(response).setStatus(HttpServletResponse.SC_OK);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
@@ -16,6 +16,12 @@ import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.Test;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
@@ -69,5 +75,72 @@ public final class RemoteLoggingJakartaServletTest {
     verify(response).setStatus(HttpServletResponse.SC_OK);
     verify(response).setContentType("text/plain; charset=utf-8");
     assertEquals("OK", output.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void doPostLogsPlainTextPayloadLinesIndividuallyWithUserContext() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    RemoteLoggingJakartaServlet servlet = new RemoteLoggingJakartaServlet(sessionManager);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Logger logger = Logger.getLogger(RemoteLoggingJakartaServlet.class.getName());
+    RecordingHandler handler = new RecordingHandler();
+    Level previousLevel = logger.getLevel();
+    boolean previousUseParentHandlers = logger.getUseParentHandlers();
+
+    logger.addHandler(handler);
+    logger.setUseParentHandlers(false);
+    logger.setLevel(Level.ALL);
+    try {
+      when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+      when(sessionManager.getLoggedInUser(any(WebSession.class)))
+          .thenReturn(ParticipantId.ofUnsafe("alice@example.com"));
+      when(request.getReader()).thenReturn(
+          new BufferedReader(new StringReader("line one\nline two\n")));
+      when(request.getContentType()).thenReturn("text/plain; charset=utf-8");
+      when(response.getOutputStream()).thenReturn(new ServletOutputStream() {
+        @Override
+        public boolean isReady() {
+          return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {}
+
+        @Override
+        public void write(int b) {
+          output.write(b);
+        }
+      });
+
+      servlet.doPost(request, response);
+    } finally {
+      logger.removeHandler(handler);
+      logger.setUseParentHandlers(previousUseParentHandlers);
+      logger.setLevel(previousLevel);
+    }
+
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(response).setContentType("text/plain; charset=utf-8");
+    assertEquals("OK", output.toString(StandardCharsets.UTF_8));
+    assertEquals(2, handler.messages.size());
+    assertEquals("[remote_log] user=alice@example.com line one", handler.messages.get(0));
+    assertEquals("[remote_log] user=alice@example.com line two", handler.messages.get(1));
+  }
+
+  private static final class RecordingHandler extends Handler {
+    private final List<String> messages = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      messages.add(record.getMessage());
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/RemoteLoggingJakartaServletTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -25,13 +26,24 @@ import java.util.logging.Logger;
 import org.junit.Test;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
 public final class RemoteLoggingJakartaServletTest {
+
+  private static FeatureFlagService flagServiceWith(boolean imeTracerEnabled) throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(new FeatureFlag("ime-debug-tracer", "", imeTracerEnabled, Collections.emptyMap()));
+    return new FeatureFlagService(store);
+  }
+
   @Test
   public void doPostRejectsAnonymousRequests() throws Exception {
     SessionManager sessionManager = mock(SessionManager.class);
-    RemoteLoggingJakartaServlet servlet = new RemoteLoggingJakartaServlet(sessionManager);
+    RemoteLoggingJakartaServlet servlet =
+        new RemoteLoggingJakartaServlet(sessionManager, flagServiceWith(true));
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     when(request.getSession(false)).thenReturn(null);
@@ -43,9 +55,28 @@ public final class RemoteLoggingJakartaServletTest {
   }
 
   @Test
+  public void doPostRejectsUserWithoutImeTracerFlag() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    RemoteLoggingJakartaServlet servlet =
+        new RemoteLoggingJakartaServlet(sessionManager, flagServiceWith(false));
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(sessionManager.getLoggedInUser(any(WebSession.class)))
+        .thenReturn(ParticipantId.ofUnsafe("alice@example.com"));
+
+    servlet.doPost(request, response);
+
+    verify(response).sendError(HttpServletResponse.SC_FORBIDDEN, "Feature not enabled");
+    verify(request, never()).getReader();
+  }
+
+  @Test
   public void doPostAcceptsAuthenticatedPlainTextLogs() throws Exception {
     SessionManager sessionManager = mock(SessionManager.class);
-    RemoteLoggingJakartaServlet servlet = new RemoteLoggingJakartaServlet(sessionManager);
+    RemoteLoggingJakartaServlet servlet =
+        new RemoteLoggingJakartaServlet(sessionManager, flagServiceWith(true));
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     ByteArrayOutputStream output = new ByteArrayOutputStream();
@@ -80,7 +111,8 @@ public final class RemoteLoggingJakartaServletTest {
   @Test
   public void doPostLogsPlainTextPayloadLinesIndividuallyWithUserContext() throws Exception {
     SessionManager sessionManager = mock(SessionManager.class);
-    RemoteLoggingJakartaServlet servlet = new RemoteLoggingJakartaServlet(sessionManager);
+    RemoteLoggingJakartaServlet servlet =
+        new RemoteLoggingJakartaServlet(sessionManager, flagServiceWith(true));
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     ByteArrayOutputStream output = new ByteArrayOutputStream();


### PR DESCRIPTION
Closes #955

## Summary
- register `ime-debug-tracer` as a known feature flag and teach `ImeDebugTracer` to enable from the per-user session flag as well as the legacy local override
- restore exact `/webclient/remote_logging` servlet registration and forward tracer lines there as authenticated `text/plain` batches
- log uploaded plain-text trace lines individually with authenticated-user context and add focused tests for the new flag and remote-log behavior

## Verification
- `sbt "wave/testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.server.rpc.RemoteLoggingJakartaServletTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9900`
- `PORT=9900 bash scripts/wave-smoke.sh check`
- Anonymous `POST /webclient/remote_logging` -> `403`
- Authenticated sign-in + `POST /admin/flags` for `ime-debug-tracer` -> `200`
- Authenticated `GET /admin/flags/check?name=ime-debug-tracer` -> `{"name":"ime-debug-tracer","enabled":true}`
- Authenticated `GET /` contained `ime-debug-tracer`
- Authenticated `POST /webclient/remote_logging` -> `200` / `OK`
- `target/universal/stage/logs/wave.log` recorded:
  - `[remote_log] user=imeowner955@local.net ime line one`
  - `[remote_log] user=imeowner955@local.net ime line two`

## Review
- Self-review: no additional issues found after diff check and local verification.
- Claude Opus 4.7 review: approved, no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user IME diagnostic tracing controllable via an admin feature flag with an optional local override; activation may be deferred until session state is available.
  * Remote upload of IME trace output to a same-origin remote-logging endpoint; uploads recorded per-line with user context.

* **Documentation**
  * Added rollout/implementation plan describing flag behavior, lazy initialization, and remote-upload approach.

* **Tests**
  * New tests for feature-flag visibility and remote logging endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->