### PR TITLE
docs: freeze GWT parity matrix and slice packet template (#961)

### DIFF
--- a/docs/DOC_REGISTRY.md
+++ b/docs/DOC_REGISTRY.md
@@ -46,6 +46,8 @@ docs/current-state.md
 docs/j2cl-parity-architecture.md
 docs/j2cl-lit-implementation-workflow.md
 docs/j2cl-parity-issue-map.md
+docs/j2cl-gwt-parity-matrix.md
+docs/j2cl-parity-slice-packet-template.md
 docs/github-issues.md
 docs/agents/README.md
 docs/architecture/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,8 @@ Split of responsibility:
 - [`j2cl-parity-architecture.md`](j2cl-parity-architecture.md)
 - [`j2cl-lit-implementation-workflow.md`](j2cl-lit-implementation-workflow.md)
 - [`j2cl-parity-issue-map.md`](j2cl-parity-issue-map.md)
+- [`j2cl-gwt-parity-matrix.md`](j2cl-gwt-parity-matrix.md)
+- [`j2cl-parity-slice-packet-template.md`](j2cl-parity-slice-packet-template.md)
 
 ## Ledgers
 

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -203,7 +203,7 @@ enumerates; any other rich-edit affordances remain deferred per Section 10.
 | R-4.4 | `#931` |
 | R-4.8 | `#936` |
 | R-4.1, R-4.3 | `#933` for HttpOnly-compatible auth |
-| R-5.* | R-3.* and R-4.* reaching gate state for the same slice |
+| R-5.\* | R-3.\* and R-4.\* reaching gate state for the same slice |
 | R-6.1, R-6.3 | R-4.2, R-6.2 |
 
 These are behavior dependencies, not scheduling claims. The issue map owns the

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -49,8 +49,10 @@ Every parity slice in Section 4 of the issue map must:
 
 Row-sourcing rules enforced by review:
 
-- every row cites at least one concrete GWT seam (file + approximate line
-  range) or a merged parity architecture reference
+- each matrix section cites at least one concrete GWT seam (file +
+  approximate line range) or a merged parity architecture reference in its
+  "Origin" prefix; rows in that section inherit that sourcing unless a row
+  adds a more specific citation
 - rows describe observable behavior, not implementation detail
 - visual latitude is expressed as what *may* change, so implementers do not
   default to pixel-level replication where the architecture memo explicitly
@@ -171,12 +173,13 @@ coverage: `#967`, `#968`.
 ## 8. Parity Gate
 
 The parity gate enumerates the rows that must all be closed before the
-future opt-in default-root bootstrap issue (`#5.1` in the issue map) may even
-be opened.
+future opt-in default-root bootstrap item (issue-map §5.1) may even be
+opened as a GitHub issue.
 
 This section is descriptive only. It captures the parity threshold; it does
-not grant authority to open `#5.1`, `#5.2`, or `#5.3`. Those issues remain
-gated by the issue map and `#904`.
+not grant authority to open the items in issue-map §5.1, §5.2, or §5.3.
+Those items remain gated by the issue map and `#904`, and their section
+numbers are not GitHub issue IDs.
 
 Gate rows (must all be closed, with evidence linked from each slice packet):
 

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -1,0 +1,237 @@
+# J2CL GWT Parity Matrix
+
+Status: Proposed  
+Owner: Project Maintainers  
+Updated: 2026-04-22  
+Review cadence: on-change  
+
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Task issue: [#961](https://github.com/vega113/supawave/issues/961)
+Related: [`docs/j2cl-parity-architecture.md`](./j2cl-parity-architecture.md),
+[`docs/j2cl-parity-issue-map.md`](./j2cl-parity-issue-map.md),
+[`docs/j2cl-lit-implementation-workflow.md`](./j2cl-lit-implementation-workflow.md)
+Template: [`docs/j2cl-parity-slice-packet-template.md`](./j2cl-parity-slice-packet-template.md)
+
+## 1. Purpose
+
+This document is the acceptance contract for every downstream J2CL/Lit parity
+slice under `#904`. It freezes the GWT behavior the J2CL client must match
+before any default-root cutover can be reconsidered.
+
+The reviewed issue map (PR #972) defined *which* slices exist and *in what
+order*. This matrix defines *what each slice must preserve* and *how parity is
+proved*. Without it, `#963`–`#971` would each re-derive acceptance criteria,
+silently drifting from observed GWT behavior.
+
+Scope bounds:
+
+- this is a behavior inventory, not an architecture memo
+- it does not change the framework/runtime direction established in
+  `docs/j2cl-parity-architecture.md`
+- it does not open or re-scope any GitHub issue; the chain `#961`–`#971`
+  remains governed by the issue map
+- it does not perform any Lit/J2CL implementation
+
+## 2. How To Use This Matrix
+
+Every parity slice in Section 4 of the issue map must:
+
+1. fill in the per-slice packet
+   ([template](./j2cl-parity-slice-packet-template.md)) inside its own GitHub
+   issue body or issue-scoped plan before implementation begins;
+2. cite the exact matrix row IDs below under "Parity matrix rows claimed"
+   (row IDs are stable anchors of the form `R-<section>.<n>`, e.g. `R-3.2`);
+3. declare rollout flag, telemetry/observability checkpoints, browser-harness
+   coverage, and verification shape consistent with the rows it claims;
+4. treat any row not claimed by an existing slice as deferred, not dropped —
+   new coverage must be added either to an existing packet or to the
+   addendum in Section 10.
+
+Row-sourcing rules enforced by review:
+
+- every row cites at least one concrete GWT seam (file + approximate line
+  range) or a merged parity architecture reference
+- rows describe observable behavior, not implementation detail
+- visual latitude is expressed as what *may* change, so implementers do not
+  default to pixel-level replication where the architecture memo explicitly
+  allows modernization
+
+Column legend (applies to every table below):
+
+| Column | Meaning |
+| --- | --- |
+| ID | Stable anchor used by downstream slice packets |
+| Target behavior | Observable capability the J2CL/Lit surface must expose |
+| Required to match GWT | Behaviors/semantics that must not regress |
+| Allowed to change visually | Latitude the Lit/design-system packet may use |
+| Keyboard / focus | Keyboard, caret, and focus-frame expectations |
+| Accessibility | Roles, labels, announcements, and contrast expectations |
+| i18n | Locale/RTL/translation expectations |
+| Browser harness | Expected coverage in the automated browser harness |
+| Telemetry / observability | Signals required at the parity gate |
+| Verification shape | Smoke / browser / harness combination required |
+| Downstream slices | Issue numbers from the issue map that own this row |
+
+Verification shapes reuse
+[`docs/runbooks/browser-verification.md`](./runbooks/browser-verification.md)
+and
+[`docs/runbooks/change-type-verification-matrix.md`](./runbooks/change-type-verification-matrix.md):
+
+- **smoke** — `worktree-boot.sh` + `wave-smoke.sh start|check|stop`
+- **browser** — narrow manual or scripted path on `http://localhost:<port>/`
+- **harness** — descendant of the GWT browser harness tracked in the
+  GWTTestCase verification matrix
+
+## 3. Read Surface (StageOne-Origin)
+
+Origin: `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java:44-197`.
+
+The read surface owns wave-panel rendering, focus framing, collapse, thread
+navigation, and the view provider that reads semantics from DOM. The J2CL
+baseline currently has narrow selected-wave rendering but no durable read
+container model. Downstream coverage: `#965`, `#966`, `#967`.
+
+| ID | Target behavior | Required to match GWT | Allowed to change visually | Keyboard / focus | Accessibility | i18n | Browser harness | Telemetry / observability | Verification shape | Downstream slices |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-3.1 | Open-wave rendering — wave panel assembles blip/thread DOM from conversation view | Blips, threads, and inline replies appear with stable identity; deep nesting renders without layout collapse; reply ordering matches conversation model | Shell chrome, spacing, typography, and component styling may change per the Lit design packet | Focus enters a predictable first blip on open; focus state is preserved through incremental updates | Conversation tree exposes landmark/list structure; blip regions carry reachable labels | Existing locale fallback and RTL mirroring for blip content preserved | New read-surface harness coverage descends from existing StageOne-era tests in the GWTTestCase matrix | First-render timing and blip count signal emitted via the existing client stats channel | smoke + browser + harness | `#965`, `#966` |
+| R-3.2 | Focus framing — `FocusFramePresenter`-equivalent selection indicator across blips | Arrow/tab navigation moves the frame; frame survives incremental render and collapse toggles | Frame visuals (color, outline, animation) may change | Arrow-key, `j`/`k`-style, and shift+tab semantics preserved where they exist today | Focused blip is announced as the active region; focus outline meets contrast on light and dark themes | No new locale-specific behavior required | Keyboard-navigation path covered by harness fixtures | Focus-change events are observable (count/target) for regression detection | smoke + browser + harness | `#966` |
+| R-3.3 | Collapse — thread collapse/expand toggles | Collapse preserves scroll anchor, read state, and child visibility rules; collapsed threads remain reachable via keyboard | Toggle affordance and animation may change | Space/enter on the toggle works; keyboard focus does not jump away on expand | Toggle announces collapsed/expanded state | Toggle label respects locale | Collapse/expand covered by harness fixtures | Collapse toggle count emitted | smoke + browser + harness | `#966` |
+| R-3.4 | Thread navigation — next/previous unread and deep-reply jumps (`ThreadNavigationPresenter`) | Unread-aware navigation order matches GWT when unread state exists (after `#931`); wrap/clamp behavior preserved | Control placement and icon set may change | Existing shortcut bindings preserved | Navigation controls carry reachable labels and discoverable shortcuts | Labels translate | Harness fixture covers at least one multi-thread wave | Navigation events (direction, target blip id) emitted | smoke + browser + harness | `#931`, `#966` |
+| R-3.5 | Visible-region container model — read surface can be composed from visible fragment sections | Panel can render when only a visible window is hydrated; scroll into unloaded range triggers load without layout thrash | Loading placeholders may use Lit design-packet styling | Scrolling does not steal focus; keyboard scroll shortcuts still work | Placeholders announce loading state to AT | Existing directional/RTL scroll preserved | Harness has a fragment-window fixture covering initial and grow cases | Visible-window extension and clamp events emitted | smoke + browser + harness | `#967` |
+| R-3.6 | DOM-as-view provider — read surface can expose semantic views from DOM | Semantic queries used by keyboard, focus, collapse, and menu code work against the new container | Underlying element tagging may change, as long as the provider stays consistent | n/a (infrastructural) | n/a (infrastructural) | n/a | Harness continues to resolve semantic views for existing fixtures | Internal assertion/log signal when provider fails to resolve a view | smoke + harness | `#966`, `#967` |
+
+## 4. Live Surface (StageTwo-Origin)
+
+Origin: `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:194-469`
+and `:1013-1184` for dynamic rendering/fragments wiring. Current J2CL
+sidecar/root-shell seams are transitional and controller-local. Downstream
+coverage: `#933`, `#936`, `#963`, `#967`, `#968`.
+
+| ID | Target behavior | Required to match GWT | Allowed to change visually | Keyboard / focus | Accessibility | i18n | Browser harness | Telemetry / observability | Verification shape | Downstream slices |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-4.1 | Socket/session lifecycle | Live socket opens on authenticated load; session identity matches server-issued session; disconnect is recoverable | n/a (non-visual) | n/a | n/a | n/a | Harness covers open + forced close + reopen | Connection open/close/error counters emitted | smoke + harness | `#933`, `#968` |
+| R-4.2 | Bootstrap contract — route/session/socket metadata reaches the client without scraping arbitrary root HTML | J2CL no longer scrapes `/` HTML for session/bootstrap state; bootstrap JSON is stable and versioned; legacy GWT root continues to boot unchanged | Server HTML shell may change | n/a | n/a | n/a | Harness boots against both legacy and J2CL roots | Bootstrap success/failure signals with reason codes | smoke + browser + harness | `#963`, `#965` |
+| R-4.3 | Reconnect | Transient socket loss recovers without user action; pending ops are not lost silently; route/selected-wave state is preserved across reconnect | Reconnect banner styling may change | Focus is not stolen by reconnect | Reconnect announces to AT (live region) | Banner label translates | Harness simulates transient drop + recover | Reconnect attempt/outcome counters emitted | smoke + browser + harness | `#968` |
+| R-4.4 | Read/unread state live updates | Per-user read/unread state updates without page reload; digest counts match selected-wave state (`#931`) | Badge styling may change | n/a | Counts exposed to AT | Counts localize | Harness covers multi-wave unread transitions | Unread state change events emitted | smoke + browser + harness | `#931`, `#968` |
+| R-4.5 | Route/history integration | Back/forward, deep links to wave/folder, and signed-in/out transitions work; state survives reload | Shell chrome may change | Focus lands predictably after navigation | Navigation announced | Route labels translate | Harness covers at least one deep-link path | Route transitions counted per type | smoke + browser + harness | `#968` |
+| R-4.6 | Fragment fetch policy — viewport-scoped loading | Visible-region requests honor the existing client hints and server clamps; whole-wave fallback is not the default for large waves | Loading affordances may change | Scroll-driven fetch does not lose focus | Loading regions announced | n/a | Harness fragment fixture exercises initial + extension | Fragment fetch counts, hit/miss, clamp applied | smoke + browser + harness | `#967`, `#968` |
+| R-4.7 | Feature activation and live-update application | Active features (search, supplement, diff controller, reader) remain activated in the live surface; live updates apply without full rerender | n/a (non-visual) | n/a | n/a | n/a | Harness smoke fixture exercises live update application | Active-feature presence assertions logged | smoke + harness | `#968` |
+| R-4.8 | Selected-wave version/hash basis atomicity | Writes use an atomic version/hash basis; no silent drift between read snapshot and submit basis | n/a | n/a | n/a | n/a | Harness covers submit-under-race fixture | Version/hash mismatch assertions emitted | smoke + harness | `#936` |
+
+## 5. Compose / Edit Surface (StageThree-Origin)
+
+Origin: `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java:66-301`.
+Current J2CL compose is a narrow write pilot. Downstream coverage:
+`#969`, `#970`, `#971`.
+
+| ID | Target behavior | Required to match GWT | Allowed to change visually | Keyboard / focus | Accessibility | i18n | Browser harness | Telemetry / observability | Verification shape | Downstream slices |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-5.1 | Compose / reply flow | Daily compose and reply paths emit conversation-model ops equivalent to GWT; drafts do not corrupt document state; version/hash basis is atomic (`#936`) | Composer chrome may change per the design packet | Enter-to-send semantics, newline handling, and caret survival during live updates preserved | Composer is a reachable and labeled region; submission has an accessible control | Composer text direction respects user locale; placeholders translate | Harness has a compose-and-submit fixture | Compose open/submit counts with success/failure reason | smoke + browser + harness | `#969` |
+| R-5.2 | View and edit toolbars | Daily formatting controls (bold/italic/list/link/heading) remain reachable and functional; state toggles mirror selection | Toolbar layout, grouping, and iconography may change | Shortcut bindings preserved where they exist; toolbar is keyboard-reachable | Toolbar controls carry roles/labels and respect pressed state | Labels and tooltips translate | Harness exercises at least one formatting and one view toggle | Toolbar action counts emitted | smoke + browser + harness | `#969` |
+| R-5.3 | Mentions and autocomplete | Mention trigger, suggestion selection, and submit semantics preserved; mention identity round-trips through the model | Suggestion popover styling may change | Arrow-key navigation and enter/escape semantics preserved | Suggestions list exposes listbox semantics | Locale-aware matching preserved | Harness covers mention insertion fixture | Mention pick/abandon counts emitted | smoke + browser + harness | `#970` |
+| R-5.4 | Tasks and related metadata overlays | Task toggle, completion state, and associated metadata overlays preserved; state persists through live updates | Overlay visuals may change | Keyboard toggling preserved | Overlays announce state changes | Labels translate | Harness covers task-toggle fixture | Task state-change counts emitted | smoke + browser + harness | `#970` |
+| R-5.5 | Reactions and comparable interaction overlays | Reaction add/remove and counts preserved; overlays remain reachable and do not trap focus | Reaction set, chip styling, and placement may change | Keyboard add/remove preserved | Reaction counts announced | Counts localize | Harness covers at least one reaction fixture | Reaction add/remove counts emitted | smoke + browser + harness | `#970` |
+| R-5.6 | Attachment workflow | Daily attachment upload/download/open paths preserved; failure modes surface user-visible errors; attachments round-trip through the model | Attachment tile styling may change | Attachment affordances are keyboard-reachable | Attachment regions labeled; errors announced | Error text translates | Harness covers one upload and one download fixture | Attachment upload/download counts with outcomes | smoke + browser + harness | `#971` |
+| R-5.7 | Remaining rich-edit daily affordances | Daily-path rich-edit behaviors identified by the packet for `#971` (for example: lists, block quotes, inline links) preserved | Visuals may change per the design packet | Keyboard semantics for the affordances preserved | Affordances labeled | n/a | Harness covers at least one fixture per affordance | Action counts emitted | smoke + browser + harness | `#971` |
+
+Non-daily editor edge cases that do not ship in `#971` are captured in
+Section 10 rather than silently dropped.
+
+## 6. Server-First First Paint And Shell Swap
+
+Origin: `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java:40-161`
+and the `enable_prerendering` flag in `wave/config/reference.conf:127-132`.
+Downstream coverage: `#963`, `#965`.
+
+| ID | Target behavior | Required to match GWT | Allowed to change visually | Keyboard / focus | Accessibility | i18n | Browser harness | Telemetry / observability | Verification shape | Downstream slices |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-6.1 | Server-rendered read-only first paint | Route shell, signed-in/out chrome, and selected-wave/visible-fragment HTML arrive before full client activation; content is readable without JS for the visible region | Shell/chrome styling may change | First focus target is predictable and does not jump on upgrade | Server HTML alone is AT-usable for read-only content | Locale text respects user preference on server HTML | Harness measures first-paint content presence before client boot signal | First-paint timing and shell-swap success/failure events emitted | smoke + browser + harness | `#965` |
+| R-6.2 | Bootstrap JSON contract (paired with R-4.2) | Bootstrap JSON carries user/session/route/wave ids and visible-fragment hints; versioned and validated; rollback-safe | n/a (non-visual) | n/a | n/a | n/a | Harness asserts bootstrap JSON shape for both roots | Bootstrap JSON version and reject reasons emitted | smoke + harness | `#963` |
+| R-6.3 | Shell-swap upgrade path | J2CL boot upgrades server HTML in place; no unstyled flash; no duplicate roots during upgrade | Transition may restyle | Focus is not stolen by the upgrade | ARIA live regions quiesce on upgrade | n/a | Harness covers shell-swap fixture | Shell-swap event with success/failure + reason code | smoke + browser + harness | `#965` |
+| R-6.4 | Rollback-safe coexistence | `/?view=j2cl-root` remains a direct route; legacy GWT at `/` remains the default until parity gate is met; operator-level toggle remains reversible | Styling of debug routes may change | n/a | n/a | n/a | Harness covers both roots | Route-selection and rollback-path signals emitted | smoke + harness | `#963`, `#965` |
+
+## 7. Viewport-Scoped Fragment Windows
+
+Origin: dynamic rendering/fragments wiring at
+`wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:1013-1184`,
+transport viewport hints at
+`wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java:183-224`,
+server clamp at
+`wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:371-428`,
+configuration knobs at `wave/config/reference.conf:405-441`. Downstream
+coverage: `#967`, `#968`.
+
+| ID | Target behavior | Required to match GWT | Allowed to change visually | Keyboard / focus | Accessibility | i18n | Browser harness | Telemetry / observability | Verification shape | Downstream slices |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| R-7.1 | Initial visible window | Initial window size, clamp, and selection preserve existing server behavior | Placeholder styling may change | Initial focus is stable | Initial window is AT-usable | n/a | Harness covers initial-window fixture | Initial-window size/clamp events emitted | smoke + browser + harness | `#967` |
+| R-7.2 | Extension on scroll | Extending into unloaded range fetches and applies fragments without losing scroll anchor | Extension affordances may restyle | Scroll does not steal focus | Extension announces loading | n/a | Harness extension fixture | Extension fetch counts and outcomes | smoke + browser + harness | `#967` |
+| R-7.3 | Server clamp behavior | Server-applied clamps and limits remain explicit and visible through telemetry; client does not override server clamp silently | n/a (non-visual) | n/a | n/a | n/a | Harness clamp fixture | Clamp applied/rejected counters emitted | smoke + harness | `#967`, `#968` |
+| R-7.4 | No regression to whole-wave bootstrap for large waves | Large-wave open never falls back to whole-wave payload when viewport-scoped path is available | n/a | n/a | n/a | n/a | Harness covers large-wave fixture | Fallback to whole-wave bootstrap emits a warning counter | smoke + harness | `#967` |
+
+## 8. Parity Gate
+
+The parity gate enumerates the rows that must all be closed before the
+future opt-in default-root bootstrap issue (`#5.1` in the issue map) may even
+be opened.
+
+This section is descriptive only. It captures the parity threshold; it does
+not grant authority to open `#5.1`, `#5.2`, or `#5.3`. Those issues remain
+gated by the issue map and `#904`.
+
+Gate rows (must all be closed, with evidence linked from each slice packet):
+
+- read surface: `R-3.1`, `R-3.2`, `R-3.3`, `R-3.4`, `R-3.5`
+- live surface: `R-4.1`, `R-4.2`, `R-4.3`, `R-4.4`, `R-4.5`, `R-4.6`, `R-4.8`
+- compose / edit: `R-5.1`, `R-5.2`, `R-5.3`, `R-5.4`, `R-5.5`, `R-5.6`
+- server-first: `R-6.1`, `R-6.2`, `R-6.3`, `R-6.4`
+- fragments: `R-7.1`, `R-7.2`, `R-7.3`, `R-7.4`
+
+`R-3.6` and `R-4.7` are infrastructural enablers: they must be satisfied as a
+by-product of their owning slices, and are not gate rows on their own.
+Infrastructural rows are validated by their owning slice's harness fixture
+rather than by a dedicated gate entry.
+
+`R-5.7` must close only for the daily-path affordances the `#971` packet
+enumerates; any other rich-edit affordances remain deferred per Section 10.
+
+## 9. Cross-Slice Dependencies
+
+| Row | Depends on |
+| --- | --- |
+| R-3.5 | R-4.6, R-7.1, R-7.2 |
+| R-4.2, R-6.2 | each other — bootstrap JSON contract is a single change |
+| R-4.4 | `#931` |
+| R-4.8 | `#936` |
+| R-4.1, R-4.3 | `#933` for HttpOnly-compatible auth |
+| R-5.* | R-3.* and R-4.* reaching gate state for the same slice |
+| R-6.1, R-6.3 | R-4.2, R-6.2 |
+
+These are behavior dependencies, not scheduling claims. The issue map owns the
+scheduling chain.
+
+## 10. Deferred Edge Cases
+
+Legacy GWT behavior that is explicitly out of scope for the parity gate is
+recorded here so it is not silently dropped:
+
+- non-daily editor edge cases not captured by R-5.1, R-5.2, or R-5.7 (for
+  example: rare legacy formatting paths, one-off keyboard shortcuts that do
+  not appear in the `#969`/`#971` packet) — to be revisited only after the
+  gate closes or via a dedicated addendum packet linked from this section
+- browser-harness descendants whose GWT-only assumptions are incompatible with
+  the Lit/J2CL surface — accounted for in the GWT retirement issue
+  (future `#5.3` per the issue map), not in the parity-acquisition chain
+- Lit SSR for any surface beyond the server-rendered first-paint read region —
+  deferred per the parity architecture memo
+
+Downstream slices that discover additional deferred behavior must add a
+bullet here rather than silently omit it.
+
+## 11. Change Policy
+
+- New rows or amendments are made by adding an entry to this file in a
+  reviewed PR. The review should be run under Claude Opus 4.7 consistent with
+  the workflow defined in `AGENTS.md`.
+- Row IDs are append-only. Removed behavior is marked deprecated in place so
+  existing slice packets do not break their anchors.
+- The `Updated:` metadata field must be refreshed on every edit.

--- a/docs/j2cl-parity-slice-packet-template.md
+++ b/docs/j2cl-parity-slice-packet-template.md
@@ -1,0 +1,251 @@
+# J2CL Parity Slice Packet Template
+
+Status: Proposed  
+Owner: Project Maintainers  
+Updated: 2026-04-22  
+Review cadence: on-change  
+
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Task issue: [#961](https://github.com/vega113/supawave/issues/961)
+Related: [`docs/j2cl-gwt-parity-matrix.md`](./j2cl-gwt-parity-matrix.md),
+[`docs/j2cl-parity-issue-map.md`](./j2cl-parity-issue-map.md),
+[`docs/j2cl-parity-architecture.md`](./j2cl-parity-architecture.md)
+
+## 1. Purpose
+
+This template is the structured packet every downstream J2CL/Lit parity slice
+(`#963`–`#971` in the issue map) must fill in before implementation begins.
+It is the contract a slice makes with the parity matrix: it names the rows
+claimed, the rollout seam, the verification plan, and the traceability links
+back to the acceptance source of truth.
+
+How to use it:
+
+1. Copy the template in Section 3 into the slice's GitHub issue body or its
+   `docs/superpowers/plans/<date>-issue-<num>-<slug>.md` plan.
+2. Fill every field. "n/a" is acceptable only with a short reason.
+3. Link back to `#961`, the parity matrix, and the issue map from the packet.
+4. Keep the packet and the matrix in lockstep: if the slice discovers behavior
+   that the matrix does not cover, update the matrix in the same PR or in a
+   predecessor doc-only PR.
+
+A completed example is shown in Section 4 for slice `#966`. The example is a
+sample packet only; it does not authorize or schedule `#966` implementation.
+
+## 2. Minimum Contents
+
+Every packet must contain:
+
+- slice identity
+- parity matrix rows claimed (anchors into
+  [`j2cl-gwt-parity-matrix.md`](./j2cl-gwt-parity-matrix.md))
+- GWT seams the slice de-risks (file + approximate line range)
+- rollout flag / rollout seam
+- server/client surface list
+- required-match behaviors (pulled from matrix rows)
+- allowed-change visuals (pulled from matrix rows)
+- keyboard / focus plan
+- accessibility plan
+- i18n plan
+- browser-harness coverage plan
+- telemetry and observability checkpoints
+- verification plan (smoke/browser/harness; exact commands expected in the
+  linked issue and in `journal/local-verification/` if applicable)
+- rollback plan
+- traceability (back-links to `#961`, the matrix, the issue map, and the
+  parity architecture memo)
+
+## 3. Template
+
+Copy the block below into the slice issue or plan:
+
+```markdown
+## Slice Parity Packet — Issue #<NN>
+
+**Title:** <slice title from issue map>
+**Stage:** read | live | compose | server-first | fragments
+**Dependencies (from issue map §6):** <e.g. #963, #966>
+
+### Parity matrix rows claimed
+- R-<section>.<n> — <one-line paraphrase>
+- R-<section>.<n> — <one-line paraphrase>
+
+### GWT seams de-risked
+- `<repo-relative-path>:<start>-<end>` — <what it owns>
+- `<repo-relative-path>:<start>-<end>` — <what it owns>
+
+### Rollout flag / rollout seam
+- Flag: `<ClientFlags / config key / route flag>`
+- Default: `<off | on>` during implementation
+- Reversibility: <how an operator disables without a code rollback>
+
+### Server / client surface list
+- Server: `<servlet, renderer, RPC, or config key>`
+- Client: `<J2CL entry point, Lit element(s), controller>`
+
+### Required-match behaviors (from matrix)
+- <row ID>: <behavior; cite GWT seam if it adds clarity>
+
+### Allowed-change visuals (from matrix)
+- <row ID>: <what may change>
+
+### Keyboard / focus plan
+- <keyboard/caret/focus expectations this slice preserves>
+
+### Accessibility plan
+- <AT-visible roles/labels/announcements this slice preserves or adds>
+
+### i18n plan
+- <locale/RTL/translation expectations>
+
+### Browser-harness coverage
+- <existing or new harness fixtures the slice adds/updates>
+
+### Telemetry and observability checkpoints
+- <signals required at parity gate; metric/counter/log names>
+
+### Verification plan
+- Smoke:
+  - `bash scripts/worktree-boot.sh --port <port>`
+  - `PORT=<port> JAVA_OPTS='...' bash scripts/wave-smoke.sh start`
+  - `PORT=<port> bash scripts/wave-smoke.sh check`
+  - `PORT=<port> bash scripts/wave-smoke.sh stop`
+- Browser:
+  - Required by `docs/runbooks/change-type-verification-matrix.md`? <yes/no + row>
+  - Route(s) and narrow user-visible path(s)
+- Harness:
+  - Fixture(s) and expected outcomes
+
+### Rollback plan
+- Flag flip / route flip / feature disable
+- Operator-visible indicator
+
+### Traceability
+- Parity matrix: `docs/j2cl-gwt-parity-matrix.md`
+- Packet origin: `#961`
+- Issue map: `docs/j2cl-parity-issue-map.md`
+- Architecture memo: `docs/j2cl-parity-architecture.md`
+- Linked issue(s): `#<NN>`, `#904`
+- Linked plan: `docs/superpowers/plans/<date>-issue-<NN>-<slug>.md`
+```
+
+## 4. Worked Example — Slice Packet For `#966`
+
+The following is an illustrative packet for slice `#966`
+(StageOne read-surface parity). It shows the expected level of detail and
+the exact cross-links. It is not a schedule commitment for `#966` and does
+not itself authorize implementation.
+
+All concrete names below — flag key, Java package path, Lit element names —
+are illustrative placeholders. The real `#966` packet will pick the real
+names when that slice is actually planned.
+
+```markdown
+## Slice Parity Packet — Issue #966 (ILLUSTRATIVE EXAMPLE)
+
+**Title:** Port StageOne read-surface parity to Lit for open-wave rendering,
+focus, collapse, and thread navigation
+**Stage:** read
+**Dependencies (from issue map §6):** #961, #962, #963, #964
+
+### Parity matrix rows claimed
+- R-3.1 — Open-wave rendering
+- R-3.2 — Focus framing
+- R-3.3 — Collapse
+- R-3.4 — Thread navigation (coordinates with #931 for unread state)
+- R-3.6 — DOM-as-view provider (infrastructural enabler)
+
+### GWT seams de-risked
+- `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java:44-197`
+  — read surface lifecycle, focus/collapse/thread-nav installation, view
+  provider
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/WavePanelImpl.java`
+  — panel assembly invoked by StageOne
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java`
+  — DOM semantic view provider
+
+### Rollout flag / rollout seam
+- Flag: `ui.lit_read_surface_enabled` (client flag, gated behind
+  `ui.j2cl_root_bootstrap_enabled`)
+- Default: `off` during implementation
+- Reversibility: operator disables the flag; `/` continues to serve the
+  legacy GWT root; `/?view=j2cl-root` continues to work unchanged
+
+### Server / client surface list
+- Server: existing `WavePreRenderer` output plus bootstrap JSON from #963
+- Client: J2CL controllers under `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/`
+  plus Lit custom elements for wave panel, focus frame, collapse toggle,
+  thread-nav control
+
+### Required-match behaviors (from matrix)
+- R-3.1: blip/thread/inline-reply identity stable across incremental updates
+- R-3.2: focus frame survives incremental render and collapse toggles
+- R-3.3: collapse preserves scroll anchor, read state, and child visibility
+- R-3.4: unread-aware navigation order preserved when unread state exists
+- R-3.6: semantic view queries continue to resolve against the new DOM
+
+### Allowed-change visuals (from matrix)
+- Shell chrome, spacing, typography, icon set; focus outline visuals;
+  toggle animation; loading placeholders (consumed from the #962 design
+  packet)
+
+### Keyboard / focus plan
+- Preserve existing arrow/tab/shift+tab semantics
+- Preserve space/enter toggle semantics on collapse controls
+- Focused blip is the active AT region; no focus loss on incremental render
+
+### Accessibility plan
+- Conversation tree exposes landmark/list roles
+- Collapse toggle announces expanded/collapsed state
+- Focus outline meets contrast on light and dark themes
+
+### i18n plan
+- Preserve locale fallback and RTL mirroring for blip content
+- New control labels translate via the existing message bundle
+
+### Browser-harness coverage
+- Add or migrate fixtures descended from the existing StageOne-era tests in
+  the GWTTestCase verification matrix, covering at least: open+render,
+  keyboard navigation, collapse+expand, next-unread navigation
+
+### Telemetry and observability checkpoints
+- First-render timing and blip count (client stats channel)
+- Focus-change event counts
+- Collapse toggle counts
+- Thread-nav event counts with target blip id
+- Provider-resolution failure log signal
+
+### Verification plan
+- Smoke:
+  - `bash scripts/worktree-boot.sh --port 9900`
+  - `PORT=9900 JAVA_OPTS='...' bash scripts/wave-smoke.sh start`
+  - `PORT=9900 bash scripts/wave-smoke.sh check`
+  - `PORT=9900 bash scripts/wave-smoke.sh stop`
+- Browser:
+  - Required by `change-type-verification-matrix.md` (`GWT client/UI` row)
+  - Open `http://localhost:9900/?view=j2cl-root` with the flag enabled and
+    exercise open-wave, focus navigation, collapse, and next-unread
+- Harness:
+  - Run the read-surface fixture set; confirm parity with existing expected
+    outcomes
+
+### Rollback plan
+- Disable `ui.lit_read_surface_enabled`; J2CL root falls back to the
+  previous read path; `/` continues to serve the legacy GWT root
+
+### Traceability
+- Parity matrix: `docs/j2cl-gwt-parity-matrix.md`
+- Packet origin: `#961`
+- Issue map: `docs/j2cl-parity-issue-map.md`
+- Architecture memo: `docs/j2cl-parity-architecture.md`
+- Linked issue(s): `#966`, `#904`
+- Linked plan: `docs/superpowers/plans/<date>-issue-966-j2cl-read-surface.md`
+```
+
+## 5. Change Policy
+
+- Edits to this template are made in reviewed PRs under Claude Opus 4.7 review,
+  consistent with `AGENTS.md`.
+- When the parity matrix gains new mandatory fields, this template must be
+  updated in the same PR.
+- Filled-in packets live in their slice's issue or plan, not in this file.

--- a/docs/j2cl-parity-slice-packet-template.md
+++ b/docs/j2cl-parity-slice-packet-template.md
@@ -222,7 +222,7 @@ focus, collapse, and thread navigation
   - `PORT=9900 bash scripts/wave-smoke.sh check`
   - `PORT=9900 bash scripts/wave-smoke.sh stop`
 - Browser:
-  - Required by `change-type-verification-matrix.md` (`GWT client/UI` row)
+  - Required by `docs/runbooks/change-type-verification-matrix.md` (`GWT client/UI` row)
   - Open `http://localhost:9900/?view=j2cl-root` with the flag enabled and
     exercise open-wave, focus navigation, collapse, and next-unread
 - Harness:

--- a/docs/superpowers/plans/2026-04-22-issue-961-gwt-parity-matrix.md
+++ b/docs/superpowers/plans/2026-04-22-issue-961-gwt-parity-matrix.md
@@ -1,0 +1,231 @@
+# Issue #961 GWT Parity Matrix And Slice Packet Template Plan
+
+> **For agentic workers:** Treat this as a docs-only slice. No runtime or
+> product code changes. Steps use `- [ ]` syntax for tracking.
+
+**Goal:** Produce two committed Markdown artifacts that become the acceptance
+source of truth for every downstream J2CL/Lit parity slice under `#904`:
+
+1. `docs/j2cl-gwt-parity-matrix.md` — the frozen GWT behavior inventory that
+   defines, per target flow/surface, what must match, what may change, and how
+   parity is verified.
+2. `docs/j2cl-parity-slice-packet-template.md` — the per-slice packet template
+   that downstream parity issues (`#963`–`#971`) must fill in before
+   implementation starts.
+
+**Non-goals:**
+- no Lit/J2CL parity implementation
+- no change to the default root route
+- no change to framework/runtime recommendations in the parity architecture memo
+- no new GitHub issues (the chain `#961`..`#971` is already open)
+
+**Tech stack / inputs:**
+- `docs/j2cl-parity-architecture.md` (merged decision memo)
+- `docs/j2cl-parity-issue-map.md` (reviewed issue chain, merged via PR #972)
+- `docs/j2cl-lit-implementation-workflow.md` (design workflow)
+- `docs/runbooks/browser-verification.md` and
+  `docs/runbooks/change-type-verification-matrix.md` (verification baseline)
+- Current GWT stage seams:
+  - `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java`
+  - `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java`
+- Current J2CL surface:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/**`
+- Doc guardrails: `scripts/check-doc-links.sh`, `scripts/check-doc-freshness.sh`
+
+---
+
+## 1. Why This Exists
+
+The issue map (`#960`/PR #972) froze the execution chain but did not define what
+"parity" means per surface. Without a committed inventory and a per-slice
+packet template, `#963`–`#971` would each re-derive acceptance criteria ad hoc,
+silently drifting from the current GWT behavior the repo still depends on.
+
+This task produces the acceptance contract those downstream slices will cite.
+
+## 2. Scope
+
+### 2.1 In Scope
+
+- inventory the GWT behavior that parity slices must match, grouped by the
+  existing StageOne/StageTwo/StageThree responsibilities plus the server-first
+  and fragment-window seams the issue map already calls out
+- record, per row: required behaviors, visual latitude, keyboard/focus
+  expectations, accessibility expectations, i18n expectations, browser-harness
+  coverage expectations, telemetry/observability checkpoints, and the
+  verification shape (smoke, browser, harness)
+- define the per-slice packet template every downstream parity issue must fill
+  in (title, rollout flag seam, parity matrix rows it claims to close,
+  browser-verification plan, telemetry checkpoints, rollback notes,
+  traceability back to `#961` and the issue map)
+- register both new docs in `docs/README.md` and `docs/DOC_REGISTRY.md`
+- add a changelog fragment under `wave/config/changelog.d/`
+
+### 2.2 Explicit Non-Goals
+
+- no implementation of any parity slice
+- no modification of `docs/j2cl-parity-architecture.md` or
+  `docs/j2cl-parity-issue-map.md` beyond cross-linking if required
+- no attempt to re-open or widen the issue-map scope
+- no new GitHub issues
+
+## 3. Structure Of The Parity Matrix
+
+`docs/j2cl-gwt-parity-matrix.md` should be organized as:
+
+1. Metadata header block (Status, Owner, Updated, Review cadence) consistent
+   with `DOC_REGISTRY.md` rules.
+2. Purpose + how-to-use section explaining that this doc is the acceptance
+   contract for `#963`–`#971` and must be cited by every slice packet.
+3. Stage-aligned sections, mirroring the issue-map stage mapping:
+   - **Read surface (StageOne-origin)** — open-wave rendering, focus framing,
+     collapse, thread navigation, visible-region read container model
+   - **Live surface (StageTwo-origin)** — socket/session lifecycle, reconnect,
+     read-state refresh, route/history, fragment fetch policy, feature
+     activation
+   - **Compose / edit surface (StageThree-origin)** — compose/reply flow,
+     view/edit toolbar, mention/task/reaction/interaction overlays, attachment
+     and remaining rich-edit daily workflows
+   - **Server-first + shell-swap** — prerendered read HTML, bootstrap JSON
+     contract, shell upgrade path
+   - **Viewport-scoped fragments** — initial visible window, extension under
+     scroll, server clamp behavior
+4. One table per section with columns:
+   `Target behavior` | `Required to match GWT` | `Allowed to change visually` |
+   `Keyboard / focus` | `Accessibility` | `i18n` | `Browser harness` |
+   `Telemetry / observability` | `Verification shape` |
+   `Downstream slice(s)`.
+5. Parity gate subsection enumerating the rows that must all be "closed"
+   before opt-in cutover (`#5.1`) can even be opened. This section is
+   descriptive only: it captures the parity threshold, it does not grant
+   authority to open `#5.1`/`#5.2`/`#5.3`. Those issues remain gated by the
+   issue map.
+6. Addendum section for intentionally out-of-scope legacy edge cases (explicit
+   deferral list so they are not silently dropped).
+
+Row sourcing rules:
+- every row must cite at least one concrete GWT seam (file + approximate line
+  range) or a merged parity architecture reference; no speculative rows
+- rows must be scoped to observable behavior, not implementation detail
+
+## 4. Structure Of The Slice Packet Template
+
+`docs/j2cl-parity-slice-packet-template.md` should contain:
+
+1. Metadata header block.
+2. Short purpose statement and usage contract (every parity slice in
+   `#963`–`#971` fills this in; packet lives in the issue body or an
+   issue-scoped plan, not in the matrix itself).
+3. Template body with placeholder fields:
+   - Slice identity: issue number, title, stage, dependencies
+   - Parity matrix rows claimed (direct anchors into the matrix doc)
+   - GWT seam(s) this slice de-risks (file + approximate line range, mirroring
+     the matrix row-sourcing rule so packet and matrix stay in lockstep)
+   - Rollout flag / rollout seam
+   - Server/client surface list
+   - Required-match behaviors (pulled from matrix)
+   - Allowed-change visuals
+   - Keyboard / focus plan
+   - Accessibility plan
+   - i18n plan
+   - Browser-harness coverage
+   - Telemetry and observability checkpoints
+   - Verification plan (smoke/browser/harness, exact commands expected in the
+     linked issue)
+   - Rollback plan
+   - Traceability (back-links to `#961`, the issue-map doc, and the parity
+     architecture memo)
+4. Worked example filled in against one concrete slice already on the chain
+   (pick `#966` StageOne read-surface parity because it is the largest
+   user-visible slice and already well-described in the issue map) to prove
+   the template is usable.
+
+## 5. Task Breakdown
+
+### Task 1: Baseline review (read-only)
+- [ ] Re-read `docs/j2cl-parity-issue-map.md` Section 4 + Section 6 to keep
+  downstream issue numbers and ordering accurate.
+- [ ] Re-read `docs/j2cl-parity-architecture.md` §2–§7 to anchor the stage
+  mapping.
+- [ ] Skim StageOne/StageTwo/StageThree seams to pick accurate line ranges for
+  matrix row citations; do not expand scope beyond citations.
+
+### Task 2: Write the parity matrix doc
+- [ ] Create `docs/j2cl-gwt-parity-matrix.md` with metadata header, purpose,
+  stage sections, tables, parity gate section, and deferred-edge-case
+  addendum as defined in Section 3.
+- [ ] Keep tables narrow enough to render readably; split long cells into
+  sub-bullets under the row where useful.
+
+### Task 3: Write the slice packet template
+- [ ] Create `docs/j2cl-parity-slice-packet-template.md` with metadata header,
+  template body, and the worked example against `#966` as defined in
+  Section 4.
+
+### Task 4: Register the docs and add changelog
+- [ ] Add both new paths to `docs/DOC_REGISTRY.md` under `## Covered docs`.
+- [ ] Add both new paths to the References block of `docs/README.md`,
+  adjacent to `docs/j2cl-parity-issue-map.md`.
+- [ ] Add a changelog fragment
+  `wave/config/changelog.d/2026-04-22-j2cl-parity-matrix.json` following
+  the format of `2026-04-22-j2cl-parity-issue-map.json`, describing the
+  matrix/template addition.
+
+### Task 5: Verification
+- [ ] `git diff --check`
+- [ ] `bash scripts/check-doc-freshness.sh`
+- [ ] `bash scripts/check-doc-links.sh`
+- [ ] `python scripts/validate-changelog.py` (validates fragments under
+  `wave/config/changelog.d/`; default args are correct, confirmed from
+  `scripts/validate-changelog.py --help`)
+
+### Task 6: Review
+- [ ] Self-review for overlap with the parity architecture memo and issue map.
+- [ ] Run Claude Opus 4.7 review on the plan before implementation.
+- [ ] Run Claude Opus 4.7 review on the implementation diff; resolve valid
+  comments.
+
+### Task 7: Traceability + PR
+- [ ] Commit the two new docs, `DOC_REGISTRY.md`/`README.md` updates, and the
+  changelog fragment together.
+- [ ] Push the branch and open a PR against `main` that cites this plan, both
+  new doc paths, the verification commands/results, and both review outcomes.
+- [ ] Update issue `#961` with worktree path, branch, plan path, commit SHA(s),
+  verification output, review outcomes, and PR URL.
+- [ ] Monitor the PR to merge (or document concrete blocker).
+
+## 6. Verification Summary
+
+Expected command + outcome record (to be mirrored into the issue):
+
+```bash
+git diff --check
+bash scripts/check-doc-freshness.sh
+bash scripts/check-doc-links.sh
+python scripts/validate-changelog.py
+```
+
+The changelog validator uses default paths (`wave/config/changelog.d/` for
+fragments, `wave/config/changelog.json` for the assembled output).
+
+
+Expected: all four exit 0; no runtime/product changes so no server smoke
+required (Change-Type Verification Matrix row: docs-only → curl/smoke not
+required).
+
+## 7. Definition Of Done
+
+- `docs/j2cl-gwt-parity-matrix.md` exists, covers every stage listed in the
+  issue map, and is referenced from every Section-4 downstream slice's packet
+  template.
+- `docs/j2cl-parity-slice-packet-template.md` exists and includes the worked
+  example for `#966`.
+- Both docs are registered in `docs/DOC_REGISTRY.md` and appear under
+  References in `docs/README.md`.
+- Changelog fragment is committed and validates.
+- Doc guardrail scripts pass.
+- Claude Opus 4.7 reviews (plan + implementation) are clean.
+- Issue `#961` carries worktree, branch, plan path, commits, verification
+  evidence, review outcomes, and PR URL.
+- The PR merges (or the blocker is recorded concretely in the issue).

--- a/wave/config/changelog.d/2026-04-22-j2cl-parity-matrix.json
+++ b/wave/config/changelog.d/2026-04-22-j2cl-parity-matrix.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-22-j2cl-parity-matrix",
+  "version": "Issue #961",
+  "date": "2026-04-22",
+  "title": "The J2CL GWT parity matrix and slice packet template freeze the acceptance contract for every downstream parity slice",
+  "summary": "A committed GWT parity matrix now defines, per target flow/surface, the behaviors the J2CL client must match before any default-root cutover can be reconsidered. A per-slice packet template makes every downstream parity issue declare its rollout seam, verification plan, telemetry checkpoints, and traceability back to the matrix.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added docs/j2cl-gwt-parity-matrix.md as the parity acceptance contract covering read, live, compose, server-first, and viewport-fragment surfaces with stable row anchors that downstream slices cite",
+        "Added docs/j2cl-parity-slice-packet-template.md with a structured packet every parity slice must fill in, plus a worked example for the StageOne read-surface slice"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `docs/j2cl-gwt-parity-matrix.md` as the committed acceptance contract covering read, live, compose, server-first, and viewport-fragment surfaces
- add `docs/j2cl-parity-slice-packet-template.md` with an illustrative worked example for `#966`
- register both docs in `docs/DOC_REGISTRY.md` and `docs/README.md`
- add changelog fragment `wave/config/changelog.d/2026-04-22-j2cl-parity-matrix.json`
- add plan under `docs/superpowers/plans/2026-04-22-issue-961-gwt-parity-matrix.md`

## Scope
Docs-only. No implementation, no framework/runtime changes, no new GitHub issues. The parity-acquisition chain (`#961`–`#971`) and cutover gating remain governed by the issue map (`docs/j2cl-parity-issue-map.md`, merged via #972).

## Verification
- `git diff --check` — clean
- `bash scripts/check-doc-freshness.sh` — 22 covered docs, 0 incomplete
- `bash scripts/check-doc-links.sh` — 175 links checked, 0 broken
- `python scripts/validate-changelog.py` — passed

Change-type matrix row: docs-only. No server smoke or browser verification required.

## Review
- Self-review complete
- Claude Opus 4.7 plan review: PASS
- Claude Opus 4.7 implementation review: PASS (optional styling/clarity suggestions applied)

Closes #961
Related: #904, #960, #972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive J2CL GWT parity matrix defining acceptance criteria and structured row-based tracking.
  * Added a slice-parity packet template with a worked example for downstream submissions.
  * Added a planning doc outlining tasks and verification steps for parity work.
  * Registered the new docs in the docs registry and README, and added a changelog entry recording these additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->