### PR TITLE
fix(j2cl): keep selected-wave version/hash basis atomic

### DIFF
--- a/docs/superpowers/plans/2026-04-22-issue-936-selected-wave-basis-atomic.md
+++ b/docs/superpowers/plans/2026-04-22-issue-936-selected-wave-basis-atomic.md
@@ -1,0 +1,215 @@
+Status: Proposed
+Updated: 2026-04-22
+Owner: Lane (issue-936)
+Issue: https://github.com/vega113/supawave/issues/936
+Worktree: /Users/vega/devroot/worktrees/issue-936-selected-wave-basis-atomic
+Branch: issue-936-selected-wave-basis-atomic
+
+# Issue #936 — Keep J2CL selected-wave version/hash basis atomic
+
+## Summary
+
+`J2clSelectedWaveProjector.buildWriteSession(...)` currently advances
+`baseVersion` and `historyHash` independently when it folds a new
+`SidecarSelectedWaveUpdate` into the cached write session. If an update
+carries a newer `resultingVersion` while `resultingVersionHistoryHash` is
+null or empty, the projector combines the new version with the previous
+hash and publishes an invalid pair. The sidecar reply path now depends on
+that pair, so a mismatched pair makes the client look ready while it
+builds a delta basis the server will reject.
+
+Fix: treat `resultingVersion` + `resultingVersionHistoryHash` as a coupled
+atomic pair. Advance the write session's `(baseVersion, historyHash)` only
+when both values arrive together; otherwise preserve the previous pair
+untouched.
+
+## Out of scope
+
+- Server-side changes in `SidecarTransportCodec` or its producers. The
+  transport continues to send both fields; this change only hardens the
+  client projector against partial updates.
+- Any changes to `J2clSidecarWriteSession` shape or to how
+  `J2clSidecarComposeController` consumes the session — only the
+  construction rules change.
+- Channel id / reply-target blip id resolution. Those already preserve the
+  previous value independently and are not part of the reported bug.
+
+## Current behavior (pre-fix)
+
+File: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+
+`buildWriteSession` resolves four fields independently:
+
+1. `channelId`: from update, else from previous write session.
+2. `replyTargetBlipId`: from update documents/fragments, else previous.
+3. `baseVersion`: `resolveBaseVersion(update)` — returns
+   `update.getResultingVersion()` when ≥ 0, else the fragments snapshot
+   version, else the max document last-modified version. If the result is
+   < 0, fall back to `previous.getWriteSession().getBaseVersion()`.
+4. `historyHash`: `update.getResultingVersionHistoryHash()` when non-empty,
+   else `previous.getWriteSession().getHistoryHash()`.
+
+Failure mode the issue calls out:
+
+- Update arrives with `resultingVersion = N+1` and empty
+  `resultingVersionHistoryHash`.
+- Previous session has `(baseVersion = N, historyHash = H_N)`.
+- Projector emits `(baseVersion = N+1, historyHash = H_N)` — a mismatched
+  pair.
+
+There is a second latent case with the same shape that must also be
+fixed to make the invariant durable:
+
+- Update arrives with `resultingVersion < 0` but `fragments.snapshotVersion
+  = M` (or max doc version = M). `resolveBaseVersion` promotes M as the
+  new base. If previous session has `(K, H_K)` with K != M, we again
+  emit a mismatched pair `(M, H_K)`.
+
+## Target behavior (post-fix)
+
+The `(baseVersion, historyHash)` pair must move together. Only two
+transitions are legal:
+
+- **Advance**: the incoming update supplies both a new
+  `resultingVersion >= 0` AND a non-empty
+  `resultingVersionHistoryHash`. Use those two values as the new pair.
+- **Preserve**: otherwise, keep the previous write session's
+  `(baseVersion, historyHash)` exactly as-is.
+
+If neither an advance nor a preserve is possible (no coupled pair in the
+update AND no previous write session), the projector returns `null` for
+the write session, just as today when inputs are incomplete.
+
+Channel id and reply-target blip id resolution keep their current
+"prefer update, fall back to previous" semantics — they are not part of
+the coupled pair.
+
+## Implementation
+
+### Edit — `J2clSelectedWaveProjector.java`
+
+Replace the two independent resolutions (`resolveBaseVersion` result +
+`historyHash` fallback) with a single coupled resolution inside
+`buildWriteSession`:
+
+```
+long baseVersion;
+String historyHash;
+
+long updateVersion = update.getResultingVersion();
+String updateHash = update.getResultingVersionHistoryHash();
+boolean updateHasCoupledPair =
+    updateVersion >= 0 && updateHash != null && !updateHash.isEmpty();
+
+if (updateHasCoupledPair) {
+  baseVersion = updateVersion;
+  historyHash = updateHash;
+} else if (previous != null && previous.getWriteSession() != null) {
+  baseVersion = previous.getWriteSession().getBaseVersion();
+  historyHash = previous.getWriteSession().getHistoryHash();
+} else {
+  return null;
+}
+```
+
+Delete the now-unused `resolveBaseVersion` helper (it encoded the
+snapshot/document fallback that silently created mismatched pairs).
+
+Keep the existing null/empty guard at the bottom of `buildWriteSession`
+— after the coupled resolution, the only way the guard can still reject
+is when channelId or replyTargetBlipId is missing.
+
+### Regression test
+
+Add a new JVM test class
+`j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+that exercises `J2clSelectedWaveProjector.project` directly. Rationale:
+the projector is static and pure, and the existing reflective controller
+harness would force a full sidecar boot just to exercise this unit.
+
+Test cases:
+
+1. `advancesWriteSessionWhenUpdateCarriesCoupledVersionAndHash`: previous
+   session is `(44, "ABCD")`; new update carries `(50, "EFGH")`; expect
+   `(50, "EFGH")`.
+2. `preservesPreviousPairWhenUpdateOmitsHistoryHash` (the regression
+   test the issue requires): previous session is `(44, "ABCD")`; new
+   update carries `resultingVersion = 50` and
+   `resultingVersionHistoryHash = null` (and separately, `""`); expect
+   `(44, "ABCD")`. This is the exact failure mode PR #935 left open.
+3. `preservesPreviousPairWhenUpdateHasNoResultingVersion`: previous
+   session is `(44, "ABCD")`; update carries `resultingVersion = -1` and
+   populated fragments/document versions; expect `(44, "ABCD")` — the
+   snapshot/document fallback must not silently advance version against
+   the stale hash.
+4. `returnsNullWriteSessionWhenNoPreviousAndUpdateLacksCoupledPair`:
+   previous is null; update has `resultingVersion = -1` or empty hash;
+   expect `null` write session.
+5. `buildsWriteSessionOnFirstCoupledUpdate`: previous is null; update
+   carries `(0, "ZERO")` (mirrors the existing `versionZeroSelected...`
+   test); expect `(0, "ZERO")` — confirms version zero is a valid
+   advance value.
+
+All five tests construct `SidecarSelectedWaveUpdate` directly and call
+`J2clSelectedWaveProjector.project`. No reflection, no controller harness.
+
+### No changes required
+
+- `J2clSidecarWriteSession.java` — shape unchanged.
+- `J2clSelectedWaveController.java` — calls projector once per update;
+  no behavior change.
+- `SidecarSelectedWaveUpdate.java` — transport shape unchanged.
+- `SidecarTransportCodec.java` — encoder/decoder unchanged.
+
+## Verification
+
+Targeted Maven run (mirrors PR #935's verification pattern, restricted to
+the changed projector and its nearest neighbors):
+
+```
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest \
+  test
+```
+
+Record the exact command and outcome in the linked issue comment.
+
+No server-boot sanity check is warranted: this change is pure client-side
+projector logic with no runtime initialization, no schema, no UI surface,
+and no feature flag. The write-session construction rule is covered by
+unit tests; no local-verification journal entry is required for this
+slice.
+
+No changelog fragment: the change has no user-visible behavior on its own
+(it only prevents an invalid delta basis from being handed to the reply
+submit path, which is a correctness guarantee, not a product change).
+
+## Risk assessment
+
+- **Behavior narrowing**: the snapshot/document version fallback in
+  `resolveBaseVersion` is removed. Verified no caller depends on that
+  fallback in isolation: the only write session that ever materialized
+  from that path would have required a matching `historyHash` to pass
+  the null/empty guard, and a hash never originated from fragments/docs.
+  So the fallback either produced the bug described in #936 or produced
+  `null` — both outcomes are preserved or improved by the new logic.
+- **Previous tests**: the existing
+  `J2clSelectedWaveControllerTest.selectedWaveUpdateBuildsWriteSessionWithHistoryHash`,
+  `selectedWaveUpdatePromotesWriteSessionMetadata`, and
+  `versionZeroSelectedWaveUpdateStillBuildsWriteSession` all pass an
+  update with coupled `(resultingVersion, resultingVersionHistoryHash)`
+  pairs. They stay green under the new rule.
+
+## Acceptance checklist
+
+- [ ] `buildWriteSession` resolves `(baseVersion, historyHash)` as a
+      coupled pair (advance-both or preserve-both).
+- [ ] `resolveBaseVersion` removed.
+- [ ] New `J2clSelectedWaveProjectorTest` covers the five cases above,
+      including the partial-update regression case from #936.
+- [ ] Targeted Maven run passes.
+- [ ] Plan Claude review clean.
+- [ ] Implementation Claude review clean.
+- [ ] Issue comment records worktree, plan path, commits, verification,
+      review outcomes.
+- [ ] PR opened against main and merged (or explicitly blocked).

--- a/docs/superpowers/plans/2026-04-22-issue-936-selected-wave-basis-atomic.md
+++ b/docs/superpowers/plans/2026-04-22-issue-936-selected-wave-basis-atomic.md
@@ -92,7 +92,7 @@ Replace the two independent resolutions (`resolveBaseVersion` result +
 `historyHash` fallback) with a single coupled resolution inside
 `buildWriteSession`:
 
-```
+```java
 long baseVersion;
 String historyHash;
 
@@ -166,7 +166,7 @@ All five tests construct `SidecarSelectedWaveUpdate` directly and call
 Targeted Maven run (mirrors PR #935's verification pattern, restricted to
 the changed projector and its nearest neighbors):
 
-```
+```bash
 ./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
   -Dtest=org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest \
   test

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -67,22 +67,22 @@ public final class J2clSelectedWaveProjector {
         && previous.getWriteSession() != null) {
       replyTargetBlipId = previous.getWriteSession().getReplyTargetBlipId();
     }
-    long baseVersion = resolveBaseVersion(update);
-    if (baseVersion < 0 && previous != null && previous.getWriteSession() != null) {
+    long baseVersion;
+    String historyHash;
+    long updateVersion = update.getResultingVersion();
+    String updateHash = update.getResultingVersionHistoryHash();
+    boolean updateHasCoupledPair =
+        updateVersion >= 0 && updateHash != null && !updateHash.isEmpty();
+    if (updateHasCoupledPair) {
+      baseVersion = updateVersion;
+      historyHash = updateHash;
+    } else if (previous != null && previous.getWriteSession() != null) {
       baseVersion = previous.getWriteSession().getBaseVersion();
-    }
-    String historyHash = update.getResultingVersionHistoryHash();
-    if ((historyHash == null || historyHash.isEmpty())
-        && previous != null
-        && previous.getWriteSession() != null) {
       historyHash = previous.getWriteSession().getHistoryHash();
+    } else {
+      return null;
     }
-    if (channelId == null
-        || channelId.isEmpty()
-        || replyTargetBlipId == null
-        || baseVersion < 0
-        || historyHash == null
-        || historyHash.isEmpty()) {
+    if (channelId == null || channelId.isEmpty() || replyTargetBlipId == null) {
       return null;
     }
     return new J2clSidecarWriteSession(
@@ -133,21 +133,6 @@ public final class J2clSelectedWaveProjector {
       }
     }
     return fallback;
-  }
-
-  private static long resolveBaseVersion(SidecarSelectedWaveUpdate update) {
-    if (update.getResultingVersion() >= 0) {
-      return update.getResultingVersion();
-    }
-    SidecarSelectedWaveFragments fragments = update.getFragments();
-    if (fragments != null && fragments.getSnapshotVersion() >= 0) {
-      return fragments.getSnapshotVersion();
-    }
-    long maxDocumentVersion = 0L;
-    for (SidecarSelectedWaveDocument document : update.getDocuments()) {
-      maxDocumentVersion = Math.max(maxDocumentVersion, document.getLastModifiedVersion());
-    }
-    return maxDocumentVersion;
   }
 
   private static List<String> extractContentEntries(SidecarSelectedWaveFragments fragments) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -82,7 +82,7 @@ public final class J2clSelectedWaveProjector {
     } else {
       return null;
     }
-    if (channelId == null || channelId.isEmpty() || replyTargetBlipId == null) {
+    if (channelId == null || channelId.isEmpty() || replyTargetBlipId == null || replyTargetBlipId.isEmpty()) {
       return null;
     }
     return new J2clSidecarWriteSession(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -1,0 +1,168 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
+
+public class J2clSelectedWaveProjectorTest {
+  private static final String WAVE_ID = "example.com/w+1";
+  private static final String WAVELET_NAME = "example.com!w+1/example.com!conv+root";
+  private static final String CHANNEL_ID = "chan-1";
+
+  @Test
+  public void advancesWriteSessionWhenUpdateCarriesCoupledVersionAndHash() {
+    J2clSelectedWaveModel previous = modelWithWriteSession(44L, "ABCD");
+
+    J2clSelectedWaveModel result =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            null,
+            updateWithVersionAndHash(50L, "EFGH"),
+            previous,
+            0);
+
+    J2clSidecarWriteSession writeSession = result.getWriteSession();
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(50L, writeSession.getBaseVersion());
+    Assert.assertEquals("EFGH", writeSession.getHistoryHash());
+  }
+
+  @Test
+  public void preservesPreviousPairWhenUpdateOmitsHistoryHash() {
+    J2clSelectedWaveModel previous = modelWithWriteSession(44L, "ABCD");
+
+    J2clSidecarWriteSession nullHash =
+        J2clSelectedWaveProjector.project(
+                WAVE_ID, null, updateWithVersionAndHash(50L, null), previous, 0)
+            .getWriteSession();
+    Assert.assertNotNull(nullHash);
+    Assert.assertEquals(44L, nullHash.getBaseVersion());
+    Assert.assertEquals("ABCD", nullHash.getHistoryHash());
+
+    J2clSidecarWriteSession emptyHash =
+        J2clSelectedWaveProjector.project(
+                WAVE_ID, null, updateWithVersionAndHash(50L, ""), previous, 0)
+            .getWriteSession();
+    Assert.assertNotNull(emptyHash);
+    Assert.assertEquals(44L, emptyHash.getBaseVersion());
+    Assert.assertEquals("ABCD", emptyHash.getHistoryHash());
+  }
+
+  @Test
+  public void preservesPreviousPairWhenUpdateHasNoResultingVersion() {
+    J2clSelectedWaveModel previous = modelWithWriteSession(44L, "ABCD");
+
+    SidecarSelectedWaveUpdate update =
+        new SidecarSelectedWaveUpdate(
+            2,
+            WAVELET_NAME,
+            true,
+            CHANNEL_ID,
+            -1L,
+            null,
+            Arrays.asList("user@example.com"),
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 60L, 61L, "Later content")),
+            new SidecarSelectedWaveFragments(
+                70L,
+                50L,
+                70L,
+                Arrays.asList(
+                    new SidecarSelectedWaveFragmentRange("blip:b+root", 50L, 70L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment("blip:b+root", "Later content", 0, 0))));
+
+    J2clSidecarWriteSession writeSession =
+        J2clSelectedWaveProjector.project(WAVE_ID, null, update, previous, 0).getWriteSession();
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(44L, writeSession.getBaseVersion());
+    Assert.assertEquals("ABCD", writeSession.getHistoryHash());
+  }
+
+  @Test
+  public void returnsNullWriteSessionWhenNoPreviousAndUpdateLacksCoupledPair() {
+    SidecarSelectedWaveUpdate noVersion =
+        new SidecarSelectedWaveUpdate(
+            1,
+            WAVELET_NAME,
+            true,
+            CHANNEL_ID,
+            -1L,
+            "ABCD",
+            Arrays.asList("user@example.com"),
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 1L, 2L, "Bootstrap")),
+            null);
+    Assert.assertNull(
+        J2clSelectedWaveProjector.project(WAVE_ID, null, noVersion, null, 0).getWriteSession());
+
+    SidecarSelectedWaveUpdate noHash = updateWithVersionAndHash(5L, null);
+    Assert.assertNull(
+        J2clSelectedWaveProjector.project(WAVE_ID, null, noHash, null, 0).getWriteSession());
+  }
+
+  @Test
+  public void buildsWriteSessionOnFirstCoupledUpdate() {
+    SidecarSelectedWaveUpdate update = updateWithVersionAndHash(0L, "ZERO");
+
+    J2clSidecarWriteSession writeSession =
+        J2clSelectedWaveProjector.project(WAVE_ID, null, update, null, 0).getWriteSession();
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(0L, writeSession.getBaseVersion());
+    Assert.assertEquals("ZERO", writeSession.getHistoryHash());
+    Assert.assertEquals(CHANNEL_ID, writeSession.getChannelId());
+    Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
+  }
+
+  private static SidecarSelectedWaveUpdate updateWithVersionAndHash(
+      long resultingVersion, String resultingVersionHistoryHash) {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        WAVELET_NAME,
+        true,
+        CHANNEL_ID,
+        resultingVersion,
+        resultingVersionHistoryHash,
+        Arrays.asList("user@example.com"),
+        Arrays.asList(
+            new SidecarSelectedWaveDocument(
+                "b+root", "user@example.com", 33L, 44L, "content")),
+        new SidecarSelectedWaveFragments(
+            resultingVersion >= 0 ? resultingVersion : 0L,
+            0L,
+            resultingVersion >= 0 ? resultingVersion : 0L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 0L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("blip:b+root", "content", 0, 0))));
+  }
+
+  private static J2clSelectedWaveModel modelWithWriteSession(long baseVersion, String historyHash) {
+    J2clSidecarWriteSession writeSession =
+        new J2clSidecarWriteSession(WAVE_ID, CHANNEL_ID, baseVersion, historyHash, "b+root");
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        WAVE_ID,
+        "title",
+        "snippet",
+        "",
+        "",
+        "",
+        0,
+        Collections.<String>emptyList(),
+        Collections.<String>emptyList(),
+        writeSession);
+  }
+}

--- a/wave/config/changelog.d/2026-04-22-j2cl-selected-wave-basis-atomic.json
+++ b/wave/config/changelog.d/2026-04-22-j2cl-selected-wave-basis-atomic.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-22-j2cl-selected-wave-basis-atomic",
+  "version": "Unreleased",
+  "date": "2026-04-22",
+  "title": "J2CL sidecar reply path now keeps the selected-wave version and history hash aligned",
+  "summary": "The J2CL selected-wave projector treats resultingVersion and resultingVersionHistoryHash as a coupled atomic pair so a reply submit cannot use a newer version with a stale history hash.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2clSelectedWaveProjector only advances the selected-wave write-session basis when both resultingVersion and resultingVersionHistoryHash arrive together; otherwise the previous pair is preserved, preventing invalid hashed-version pairs from reaching the sidecar reply submit path"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Treat `resultingVersion` and `resultingVersionHistoryHash` as a coupled atomic pair in `J2clSelectedWaveProjector.buildWriteSession`: advance both when the update supplies both, otherwise preserve the previous pair as-is.
- Remove the snapshot/document-version fallback (`resolveBaseVersion`) that silently promoted a version without a matching hash.
- Add `J2clSelectedWaveProjectorTest` with the regression case from the issue plus advance, preserve-on-missing-version, no-previous, and first-coupled-update paths.

## Why
The sidecar reply submit path now depends on the projected write session. Under the old logic, a selected-wave update carrying a newer version but an empty history hash would combine the new version with the previous hash, publishing an invalid hashed-version pair that the server would reject when the client tried to reply.

## Verification
```
./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
  -Dtest=org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest \
  test
```
Result: `Tests run: 20, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS`.

## Plan & review
- Plan: `docs/superpowers/plans/2026-04-22-issue-936-selected-wave-basis-atomic.md`
- Plan review (Claude Opus 4.7): CLEAN
- Implementation review (Claude Opus 4.7): CLEAN

Closes #936.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treat write-session version and history-hash as an atomic paired basis so partial updates no longer create mismatched version/hash combinations.

* **Tests**
  * Added unit tests covering coupled-update advancement, preservation when history-hash is missing, fallback behavior, and missing-prior-session edge cases.

* **Documentation**
  * Added a changelog entry and a proposed plan documenting the behavioral change and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->