### PR TITLE
fix(j2cl): drop JSESSIONID document.cookie read from sidecar auth (#933)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
+++ b/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
@@ -18,7 +18,7 @@
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java` — delete now-dead `encodeAuthenticateEnvelope(int, String)` method.
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` test; add a negative regression test verifying no `ProtocolAuthenticate` envelope helper exists (by leaving it out of the production code and of the test surface).
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` test; add a regression test for `buildSearchUrl`/other remaining surface only if something else is removed that needs new coverage (likely nothing to add).
-- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — new "security" changelog fragment documenting the hardening.
+- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — new "fix" changelog fragment documenting the hardening.
 
 ### Out-of-scope (explicitly)
 - The legacy GWT client `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveWebSocketClient.java` also reads `JSESSIONID` via `Cookies.getCookie`. Issue #933 scope says "in the J2CL sidecar", and the issue body explicitly limits scope to "stop reading `JSESSIONID` from app-visible JavaScript in the J2CL sidecar". Do not touch this file.
@@ -38,10 +38,10 @@
 ### Test files modified
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` (covers a method we are removing).
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` (covers a helper we are removing).
-- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a fake `WebSocket` captures the first frame sent on `onopen`; assert it is a `ProtocolOpenRequest`, not a `ProtocolAuthenticate`. One test for the selected-wave path, one for the submit path. This protects against regressions that would re-introduce the cookie-based auth handshake.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a static-contract/envelope-level guard that verifies the J2CL search gateway no longer relies on or exposes a `ProtocolAuthenticate` send path after the cookie-based auth handshake is removed. This protects against regressions that would re-introduce the sidecar auth envelope.
 
 ### New files
-- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — single `security`-section fragment.
+- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — single `fix`-section fragment.
 
 ### Removed files
 - None.

--- a/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
+++ b/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
@@ -38,7 +38,7 @@
 ### Test files modified
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` (covers a method we are removing).
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` (covers a helper we are removing).
-- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a static-contract/envelope-level guard that verifies the J2CL search gateway no longer relies on or exposes a `ProtocolAuthenticate` send path after the cookie-based auth handshake is removed. This protects against regressions that would re-introduce the sidecar auth envelope.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a gateway first-frame helper seam that verifies the selected-wave and submit paths emit `ProtocolOpenRequest` / `ProtocolSubmitRequest` rather than `ProtocolAuthenticate`, while also guarding that the transport codec no longer re-exposes an auth-envelope helper.
 
 ### New files
 - `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — single `fix`-section fragment.
@@ -55,11 +55,11 @@
 **Files:**
 - Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
 
-**Rationale:** TDD — write the regression test first so we can see it pass before and after (once callers stop sending the auth envelope, the test ensures they don't re-introduce the pattern). The test exercises `J2clSearchGateway.openSelectedWave` and `submit` by driving the real WebSocket `onopen` callback through a fake socket and inspecting the first frame string sent.
+**Rationale:** TDD — write the regression test first so we can see it pass before and after (once callers stop sending the auth envelope, the test ensures they don't re-introduce the pattern). The test exercises the exact first outbound gateway frames via package-private helper seams that the `onopen` callbacks use.
 
-The J2CL unit-test harness uses `@J2clTestInput`. `J2clSearchGateway` currently constructs a real `elemental2.dom.WebSocket`, which is not testable from a pure-JVM JUnit run. For this reason we keep the test in the J2CL test directory (run via `./j2cl/mvnw`), and use the `WebSocket` constructor directly but extract the assertion to focus on the encoded open envelope.
+The J2CL unit-test harness uses `@J2clTestInput`. `J2clSearchGateway` currently constructs a real `elemental2.dom.WebSocket`, which is not testable from a pure-JVM JUnit run. For this reason we keep the test in the J2CL test directory (run via `./j2cl/mvnw`) and extract package-private first-frame helpers that the gateway's `onopen` callbacks use.
 
-Because `elemental2.dom.WebSocket` cannot be constructed in a pure Java test context, we avoid testing the gateway directly. Instead, **structure the test at the envelope level**: verify that `SidecarTransportCodec` no longer exposes `encodeAuthenticateEnvelope` and that the only envelopes the gateway encodes on open are `encodeOpenEnvelope` / `encodeSubmitEnvelope`. This is a static-contract regression test rather than a socket interaction test.
+Because `elemental2.dom.WebSocket` cannot be constructed in a pure Java test context, we avoid testing the gateway directly. Instead, **structure the test around the gateway's first-frame helpers**: verify that the selected-wave path emits `ProtocolOpenRequest`, the submit path emits `ProtocolSubmitRequest`, and `SidecarTransportCodec` no longer exposes `encodeAuthenticateEnvelope`.
 
 - [ ] **Step 1: Write the regression test**
 
@@ -71,21 +71,42 @@ import com.google.j2cl.junit.apt.J2clTestInput;
 import java.lang.reflect.Method;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
 
 /**
- * Issue #933 name-guard: the J2CL sidecar transport codec must not expose a
- * ProtocolAuthenticate envelope helper again by accident. This is a
- * static-contract regression, not a behavioral test of the gateways — it
- * cannot catch a future regression that hand-inlines the cookie read in
- * J2clSearchGateway or SandboxEntryPoint. For that defense, see the
- * local-browser verification recorded under
- * journal/local-verification/2026-04-23-issue-933-sidecar-ws-auth.md, which
- * inspects the live /socket frames for the absence of a ProtocolAuthenticate
- * payload.
+ * Issue #933 regression coverage for the first outbound J2CL sidecar frames.
+ * Sidecar auth is now established entirely by the WebSocket upgrade handshake,
+ * so the selected-wave and submit sockets must begin with ProtocolOpenRequest /
+ * ProtocolSubmitRequest instead of an auth envelope.
  */
 @J2clTestInput(J2clSearchGatewayAuthFrameTest.class)
 public class J2clSearchGatewayAuthFrameTest {
+  @Test
+  public void selectedWaveSocketStartsWithProtocolOpenRequest() {
+    String frame =
+        J2clSearchGateway.buildSelectedWaveOpenFrame(
+            new SidecarSessionBootstrap("rose@example.com", "socket.example.test"),
+            "example.com/w+abc");
+
+    Assert.assertEquals("ProtocolOpenRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertFalse(frame.contains("ProtocolAuthenticate"));
+  }
+
+  @Test
+  public void submitSocketStartsWithProtocolSubmitRequest() {
+    String frame =
+        J2clSearchGateway.buildSubmitFrame(
+            new SidecarSubmitRequest(
+                "example.com/w+abc/conv+root",
+                "{\"ops\":[]}",
+                "channel-7"));
+
+    Assert.assertEquals("ProtocolSubmitRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertFalse(frame.contains("ProtocolAuthenticate"));
+  }
+
   @Test
   public void transportCodecDoesNotExposeAuthenticateEnvelopeHelper() {
     for (Method method : SidecarTransportCodec.class.getDeclaredMethods()) {

--- a/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
+++ b/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
@@ -1,0 +1,477 @@
+# Issue #933 — Harden J2CL Sidecar WebSocket Auth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the J2CL sidecar from reading `JSESSIONID` out of `document.cookie` and sending it in a `ProtocolAuthenticate` frame, so the primary session cookie can remain `HttpOnly`, while preserving existing selected-wave/search/submit functionality.
+
+**Architecture:** The server already authenticates WebSocket connections during the HTTP upgrade handshake: `WaveWebSocketEndpoint.onOpen` reads the `HttpSession` captured by `ServerEndpointConfig.Configurator.modifyHandshake` and resolves the `ParticipantId` via `SessionManager.getLoggedInUser`. `ServerRpcProvider.Connection.message` already prefers that handshake-time `loggedInUser` over a `ProtocolAuthenticate` token and ignores the token when the handshake-time user is present (see `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java:234`). That means the sidecar's `ProtocolAuthenticate` envelope has always been redundant on same-origin connections — browsers automatically send cookies (including `HttpOnly` ones) on the WebSocket upgrade request, so handshake auth works regardless. The fix is to delete the redundant client-side cookie read + `ProtocolAuthenticate` send from the J2CL sidecar. No server changes are required.
+
+**Tech Stack:** J2CL (Closure transpile of Java), Jakarta EE 10 WebSocket endpoint (Jetty 12), GWT-era protobuf messages for wire protocol, JUnit 4 + `com.google.j2cl.junit.apt.J2clTestInput` test harness.
+
+---
+
+## Scope
+
+### In-scope
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java` — remove cookie read + `encodeAuthenticateEnvelope` send in `openSelectedWave` (line 54-57) and `submit` (line 151-154); delete the `readCookie` helper.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java` — remove cookie read + `encodeAuthenticateEnvelope` send in `SidecarProofRunner.openSocket` (line 317-320); delete `readCookie` and `readCookieFromHeader` helpers.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java` — delete now-dead `encodeAuthenticateEnvelope(int, String)` method.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` test; add a negative regression test verifying no `ProtocolAuthenticate` envelope helper exists (by leaving it out of the production code and of the test surface).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` test; add a regression test for `buildSearchUrl`/other remaining surface only if something else is removed that needs new coverage (likely nothing to add).
+- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — new "security" changelog fragment documenting the hardening.
+
+### Out-of-scope (explicitly)
+- The legacy GWT client `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveWebSocketClient.java` also reads `JSESSIONID` via `Cookies.getCookie`. Issue #933 scope says "in the J2CL sidecar", and the issue body explicitly limits scope to "stop reading `JSESSIONID` from app-visible JavaScript in the J2CL sidecar". Do not touch this file.
+- Flipping `network.session_cookie_http_only` defaults in `wave/config/application.conf`, `deploy/caddy/application.conf`, or `deploy/contabo/application.conf`. Those defaults still need to accommodate the legacy GWT client; changing them is a follow-up once the legacy client also migrates. The issue says the session cookie *can* remain HttpOnly — it no longer requires the sidecar to opt-out. We are not flipping the operator-visible default in this slice.
+- Server-side `ProtocolAuthenticate` handling in `ServerRpcProvider`. We leave the existing handler intact so the legacy GWT client keeps working; the sidecar simply stops sending the envelope.
+- `wave/src/gatling/**` and `wave/src/e2e-test/**` — gatling scenarios and the Jakarta e2e harness use their own cookie/token machinery (confirmed: `WaveE2eTest`, `WaveApiClient`, `WaveWebSocketClient` under `e2e-test`, and `WaveDataSeeder`/`WaveAuth` under `gatling` each handle sessions independently and do not depend on sidecar code). They remain untouched.
+
+---
+
+## File Structure
+
+### Production files modified
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java` — remove cookie-read + send in both `openSelectedWave` (WebSocket onopen) and `submit` (WebSocket onopen). Delete the private `readCookie(String)` helper and the unused `DomGlobal.document` import if no other callers remain.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java` — remove cookie-read + send in `SidecarProofRunner.openSocket`. Delete the private `readCookie(String)` helper and the package-private `readCookieFromHeader(String, String)` helper along with its percent-decoding fallback methods (`decodeUriComponentSafe`, `decodeUriComponentFallback`, `decodeUriComponentNative`, `appendUtf8Bytes`, `hexValue`, `isMissingNativeUriCodec`). These decoding helpers exist only to support `readCookieFromHeader`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java` — delete `encodeAuthenticateEnvelope(int, String)`. Nothing else in the sidecar uses it.
+
+### Test files modified
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` (covers a method we are removing).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` (covers a helper we are removing).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a fake `WebSocket` captures the first frame sent on `onopen`; assert it is a `ProtocolOpenRequest`, not a `ProtocolAuthenticate`. One test for the selected-wave path, one for the submit path. This protects against regressions that would re-introduce the cookie-based auth handshake.
+
+### New files
+- `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — single `security`-section fragment.
+
+### Removed files
+- None.
+
+---
+
+## Task Breakdown
+
+### Task 1: Add regression tests that assert sidecar does NOT send ProtocolAuthenticate
+
+**Files:**
+- Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
+
+**Rationale:** TDD — write the regression test first so we can see it pass before and after (once callers stop sending the auth envelope, the test ensures they don't re-introduce the pattern). The test exercises `J2clSearchGateway.openSelectedWave` and `submit` by driving the real WebSocket `onopen` callback through a fake socket and inspecting the first frame string sent.
+
+The J2CL unit-test harness uses `@J2clTestInput`. `J2clSearchGateway` currently constructs a real `elemental2.dom.WebSocket`, which is not testable from a pure-JVM JUnit run. For this reason we keep the test in the J2CL test directory (run via `./j2cl/mvnw`), and use the `WebSocket` constructor directly but extract the assertion to focus on the encoded open envelope.
+
+Because `elemental2.dom.WebSocket` cannot be constructed in a pure Java test context, we avoid testing the gateway directly. Instead, **structure the test at the envelope level**: verify that `SidecarTransportCodec` no longer exposes `encodeAuthenticateEnvelope` and that the only envelopes the gateway encodes on open are `encodeOpenEnvelope` / `encodeSubmitEnvelope`. This is a static-contract regression test rather than a socket interaction test.
+
+- [ ] **Step 1: Write the regression test**
+
+```java
+// j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.lang.reflect.Method;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+
+/**
+ * Issue #933 name-guard: the J2CL sidecar transport codec must not expose a
+ * ProtocolAuthenticate envelope helper again by accident. This is a
+ * static-contract regression, not a behavioral test of the gateways — it
+ * cannot catch a future regression that hand-inlines the cookie read in
+ * J2clSearchGateway or SandboxEntryPoint. For that defense, see the
+ * local-browser verification recorded under
+ * journal/local-verification/2026-04-23-issue-933-sidecar-ws-auth.md, which
+ * inspects the live /socket frames for the absence of a ProtocolAuthenticate
+ * payload.
+ */
+@J2clTestInput(J2clSearchGatewayAuthFrameTest.class)
+public class J2clSearchGatewayAuthFrameTest {
+  @Test
+  public void transportCodecDoesNotExposeAuthenticateEnvelopeHelper() {
+    for (Method method : SidecarTransportCodec.class.getDeclaredMethods()) {
+      Assert.assertFalse(
+          "SidecarTransportCodec must not expose encodeAuthenticateEnvelope; "
+              + "sidecar auth is handled by the WebSocket upgrade handshake (#933)",
+          "encodeAuthenticateEnvelope".equals(method.getName()));
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run the test — expected outcome depends on ordering**
+
+Run:
+```bash
+sbt -batch "j2clSearchTest -Dtest=J2clSearchGatewayAuthFrameTest"
+```
+or equivalently:
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q \
+  -Dtest=J2clSearchGatewayAuthFrameTest test
+```
+
+The test is expected to **FAIL here** because Task 4 has not yet removed `encodeAuthenticateEnvelope`. The test will turn green only after Task 4 lands. This is the intended TDD ordering: we commit the guard first, watch it go red, then turn it green by removing the helper.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+git commit -m "test(j2cl): add regression for sidecar auth handshake (#933)"
+```
+
+---
+
+### Task 2: Remove JSESSIONID cookie read + ProtocolAuthenticate send from J2clSearchGateway
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+
+- [ ] **Step 1: Delete cookie-read + auth send in openSelectedWave onopen**
+
+Replace lines 49-65 of `J2clSearchGateway.java`:
+
+```java
+    socket.onopen =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          socket.send(
+              SidecarTransportCodec.encodeOpenEnvelope(
+                  1,
+                  new SidecarOpenRequest(
+                      bootstrap.getAddress(),
+                      waveId,
+                      java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
+        };
+```
+
+Drop the `readCookie("JSESSIONID")` lookup and the `encodeAuthenticateEnvelope` send only. **Keep the existing sequence number `1` for the open RPC.** The server does not require a specific starting sequence, and renumbering is unnecessary churn that would touch call-site expectations and break any downstream inspection that keys on sequence numbers.
+
+- [ ] **Step 2: Delete cookie-read + auth send in submit onopen**
+
+Replace lines 146-156 of `J2clSearchGateway.java`:
+
+```java
+    socket.onopen =
+        event -> {
+          if (closedByClient[0]) {
+            return;
+          }
+          socket.send(SidecarTransportCodec.encodeSubmitEnvelope(1, request));
+        };
+```
+
+(Same rationale: drop the auth send. Keep the submit sequence number `1`, unchanged from the existing code.)
+
+- [ ] **Step 3: Delete now-unused readCookie helper and unused imports**
+
+Delete the private `readCookie(String name)` method and, if no other callers of `DomGlobal.document` remain in this file, keep the import (it is still used by `DomGlobal.location.protocol` in `buildWebSocketUrl` — inspect and leave as-is). Verify by running:
+```bash
+rg "DomGlobal\." j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+```
+Expected: at least one remaining use (`DomGlobal.location.protocol`).
+
+Delete:
+```java
+  private static String readCookie(String name) {
+    String cookieHeader = DomGlobal.document.cookie;
+    if (cookieHeader == null || cookieHeader.isEmpty()) {
+      return null;
+    }
+    String[] cookies = cookieHeader.split(";");
+    for (String cookie : cookies) {
+      String trimmed = cookie.trim();
+      String prefix = name + "=";
+      if (trimmed.startsWith(prefix)) {
+        return trimmed.substring(prefix.length());
+      }
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 4: Manual compile check**
+
+Run:
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q -DskipTests compile
+```
+Expected: BUILD SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+git commit -m "fix(j2cl): drop JSESSIONID cookie read from sidecar search gateway (#933)"
+```
+
+---
+
+### Task 3: Remove JSESSIONID cookie read + ProtocolAuthenticate send from SandboxEntryPoint
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+
+- [ ] **Step 1: Simplify SidecarProofRunner.openSocket onopen**
+
+Replace the `ws.onopen = event -> { ... }` body (lines 312-331) with:
+
+```java
+      ws.onopen = event -> {
+        if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
+          return;
+        }
+        waitingForUpdate = true;
+        ws.send(
+            SidecarTransportCodec.encodeOpenEnvelope(
+                1,
+                new SidecarOpenRequest(
+                    bootstrap.getAddress(),
+                    digest.getWaveId(),
+                    Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
+        setNeutral(
+            "Awaiting ProtocolWaveletUpdate",
+            "Socket connected; open sent for " + digest.getWaveId() + ".");
+      };
+```
+
+Drops the `readCookie("JSESSIONID")` lookup, drops the `encodeAuthenticateEnvelope` send, and removes "auth/" from the neutral status detail text (was `"auth/open sent"`, now `"open sent"`) because we no longer send an auth envelope. **Keep the open RPC sequence number unchanged at `1`** for consistency with the other sidecar sites.
+
+- [ ] **Step 2: Delete readCookie, readCookieFromHeader, and their decoding helpers**
+
+Delete from `SandboxEntryPoint.java`:
+- `private static String readCookie(String name)`
+- `static String readCookieFromHeader(String cookieHeader, String name)`
+- `private static String decodeUriComponentSafe(String value)`
+- `private static String decodeUriComponentFallback(String value)`
+- `@JsMethod(...) private static native String decodeUriComponentNative(String value)`
+- `private static void appendUtf8Bytes(StringBuilder decoded, byte[] bytes, int length)`
+- `private static int hexValue(char ch)`
+- `private static boolean isMissingNativeUriCodec(Error err)`
+
+Keep `encodeUriComponent(String)` — it is still used in `buildSearchUrl()`.
+
+- [ ] **Step 3: Remove now-unused imports**
+
+After the deletions, verify imports still in use with:
+```bash
+rg "^import " j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+```
+And scan the file body for each imported symbol. Candidates to remove once their only uses are deleted:
+- (`jsinterop.annotations.JsPackage` remains used by `encodeUriComponent`.)
+
+If any are orphaned, delete them. Otherwise leave them alone.
+
+- [ ] **Step 4: Compile + run existing sandbox smoke tests**
+
+Run:
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q -DskipTests compile
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q \
+  -Dtest=SandboxBuildSmokeTest test
+```
+Expected: `malformedCookieValueReturnsNull` **FAILS** because `readCookieFromHeader` is gone. Other tests still pass.
+
+- [ ] **Step 5: Delete the stale cookie test in SandboxBuildSmokeTest**
+
+Edit `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` and remove the `@Test public void malformedCookieValueReturnsNull() { ... }` method.
+
+- [ ] **Step 6: Re-run sandbox smoke tests, expect all pass**
+
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q \
+  -Dtest=SandboxBuildSmokeTest test
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java \
+        j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+git commit -m "fix(j2cl): drop JSESSIONID cookie read from sandbox sidecar proof (#933)"
+```
+
+---
+
+### Task 4: Remove encodeAuthenticateEnvelope from SidecarTransportCodec
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+
+- [ ] **Step 1: Delete encodeAuthenticateEnvelope**
+
+Remove from `SidecarTransportCodec.java`:
+```java
+  public static String encodeAuthenticateEnvelope(int sequenceNumber, String token) {
+    return "{\"sequenceNumber\":"
+        + sequenceNumber
+        + ",\"messageType\":\"ProtocolAuthenticate\",\"message\":{\"1\":\""
+        + escapeJson(token)
+        + "\"}}";
+  }
+```
+
+- [ ] **Step 2: Delete the paired test in SidecarTransportCodecTest**
+
+Remove:
+```java
+  @Test
+  public void encodeAuthenticateEnvelopePreservesLegacyWrapperShape() {
+    String json = SidecarTransportCodec.encodeAuthenticateEnvelope(7, "cookie-token");
+
+    Assert.assertTrue(json.contains("\"sequenceNumber\":7"));
+    Assert.assertTrue(json.contains("\"messageType\":\"ProtocolAuthenticate\""));
+    Assert.assertTrue(json.contains("\"message\":{\"1\":\"cookie-token\"}"));
+  }
+```
+
+- [ ] **Step 3: Run codec tests + the new regression test**
+
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q \
+  -Dtest=SidecarTransportCodecTest,J2clSearchGatewayAuthFrameTest test
+```
+Expected: both pass. The regression test from Task 1 now passes because `encodeAuthenticateEnvelope` no longer exists.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java \
+        j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+git commit -m "refactor(j2cl): delete unused sidecar ProtocolAuthenticate codec helper (#933)"
+```
+
+---
+
+### Task 5: Add changelog fragment
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json`
+
+- [ ] **Step 1: Write the changelog fragment**
+
+```json
+{
+  "releaseId": "2026-04-23-j2cl-sidecar-auth-handshake",
+  "version": "Unreleased",
+  "date": "2026-04-23",
+  "title": "J2CL sidecar no longer reads the session cookie from JavaScript",
+  "summary": "The J2CL search sidecar and sandbox proof now rely on the WebSocket upgrade handshake for authentication, so the primary session cookie can remain HttpOnly.",
+  "sections": [
+    {
+      "type": "security",
+      "items": [
+        "Removed the JSESSIONID lookup via document.cookie from the J2CL sidecar's selected-wave, submit, and sandbox proof sockets so the session cookie can stay HttpOnly",
+        "Deleted the now-unused sidecar ProtocolAuthenticate envelope helper to prevent regressions that would re-introduce the client-side cookie handshake"
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Assemble and validate changelog**
+
+AGENTS.md says fragments drive a regenerated `wave/config/changelog.json`; don't hand-edit the JSON. Run assemble, then validate:
+
+```bash
+python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
+```
+
+Both must exit 0. Assemble regenerates `wave/config/changelog.json` from the fragments; validate is the authoritative gate.
+
+- [ ] **Step 3: Commit**
+
+Only add `changelog.json` if the assemble step changed it:
+
+```bash
+git add wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json
+if ! git diff --quiet -- wave/config/changelog.json; then
+  git add wave/config/changelog.json
+fi
+git commit -m "docs(changelog): record J2CL sidecar auth handshake hardening (#933)"
+```
+
+---
+
+### Task 6: Run full targeted verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the J2CL sidecar unit suite (sbt form, authoritative)**
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+```
+Expected: PASS. This is the canonical repo invocation (see `build.sbt`), and it transitively runs the maven-wrapped tests under `./j2cl/`. If a direct-maven form is faster for iteration, the equivalent is:
+```bash
+./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q \
+  -Dtest=SidecarTransportCodecTest,SandboxBuildSmokeTest,J2clSelectedWaveControllerTest,J2clSearchGatewayAuthFrameTest test
+```
+
+- [ ] **Step 2: Compile the GWT build to confirm nothing cross-module regressed**
+
+Because this slice touches only J2CL sidecar surface, a full `Universal/stage` is overkill. Run the narrower gate:
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest compileGwt
+```
+Expected: success. If CI requires a staged build, `sbt -batch Universal/stage` can be added, but record the exact command run.
+
+- [ ] **Step 3: Local browser smoke**
+
+Boot the local dev server and register a fresh user (per repo feedback: do not assume `vega` exists):
+1. Start the server (per `docs/runbooks/worktree-lane-lifecycle.md`).
+2. Register a new test user at `/auth/register` (or repo-equivalent).
+3. Visit `/j2cl-search/index.html`.
+4. Confirm search results render.
+5. Select a wave; confirm the selected-wave panel renders content.
+6. In DevTools Application tab, confirm the `JSESSIONID` cookie is present. Open DevTools Console and run `document.cookie` — the `JSESSIONID` entry must be **absent** if the deployment sets `network.session_cookie_http_only = true`. With the default `wave/config/application.conf` (which still has `session_cookie_http_only = false` for legacy-GWT compatibility), `JSESSIONID` will still appear in `document.cookie`, but the sidecar must not read it. Confirm this by searching Network tab frames on the `/socket` connection for a `ProtocolAuthenticate` payload — there must be none from the sidecar flows.
+7. Capture result in `journal/local-verification/2026-04-23-issue-933-sidecar-ws-auth.md`.
+
+Minimum acceptable artifact: a note that says "sidecar open+search flow still works; /socket frames contain no ProtocolAuthenticate message".
+
+---
+
+### Task 7: Open PR and monitor
+
+**Files:** `wave/config/changelog.d/*`, PR body.
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+git push -u origin issue-933-sidecar-ws-auth
+gh pr create --base main \
+  --title "fix(j2cl): drop JSESSIONID document.cookie read from sidecar auth (#933)" \
+  --body "$(cat <<'EOF'
+## Summary
+- remove JSESSIONID cookie reads + ProtocolAuthenticate sends from J2CL sidecar clients (search gateway, sandbox proof)
+- rely solely on the WebSocket upgrade handshake (already established in `WaveWebSocketEndpoint.onOpen`) for sidecar auth, so the primary session cookie can remain HttpOnly
+- delete unused `encodeAuthenticateEnvelope` helper and its test; add static-contract regression test in `J2clSearchGatewayAuthFrameTest`
+
+## Scope
+- J2CL sidecar only. Legacy GWT `WaveWebSocketClient` unchanged. No server-side auth handler changes. Operator-visible config defaults for `network.session_cookie_http_only` unchanged in this PR.
+
+## Verification
+- `./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -q -Dtest=SidecarTransportCodecTest,SandboxBuildSmokeTest,J2clSelectedWaveControllerTest,J2clSearchGatewayAuthFrameTest test`
+- local browser: register fresh user, confirm `/j2cl-search/index.html` search + selected-wave still work; confirm the `/socket` frames no longer contain a `ProtocolAuthenticate` payload from the sidecar flow
+- changelog validated with `scripts/validate-changelog.py`
+
+Closes #933
+EOF
+)"
+```
+
+- [ ] **Step 2: Monitor PR**
+
+Follow the standard PR-monitor workflow (create a `wave-pr-monitor` pane per feedback) until merged. Address each review thread with a real fix or a reasoned reply before resolving.
+
+---
+
+## Self-Review Checklist
+
+- [x] Spec coverage — the issue body's three scope bullets are all addressed: (1) stop reading JSESSIONID from app-visible JS ✓ (Tasks 2–3), (2) adopt handshake auth for sidecar sockets ✓ (server already does this; we remove the redundant client path), (3) preserve selected-wave/search ✓ (Task 6 verifies).
+- [x] No placeholders.
+- [x] Type/name consistency — every method and class reference used in later tasks is defined or present in earlier tasks / existing code.
+- [x] Scope discipline — legacy GWT client and operator config defaults explicitly out-of-scope.

--- a/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
+++ b/docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md
@@ -31,14 +31,14 @@
 ## File Structure
 
 ### Production files modified
-- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java` — remove cookie-read + send in both `openSelectedWave` (WebSocket onopen) and `submit` (WebSocket onopen). Delete the private `readCookie(String)` helper and the unused `DomGlobal.document` import if no other callers remain.
-- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java` — remove cookie-read + send in `SidecarProofRunner.openSocket`. Delete the private `readCookie(String)` helper and the package-private `readCookieFromHeader(String, String)` helper along with its percent-decoding fallback methods (`decodeUriComponentSafe`, `decodeUriComponentFallback`, `decodeUriComponentNative`, `appendUtf8Bytes`, `hexValue`, `isMissingNativeUriCodec`). These decoding helpers exist only to support `readCookieFromHeader`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java` — remove cookie-read + send in both `openSelectedWave` (WebSocket onopen) and `submit` (WebSocket onopen). Delete the private `readCookie(String)` helper and the unused `DomGlobal.document` import if no other callers remain. Also reject cross-host websocket addresses up front because the HttpOnly session cookie is only sent back to the current page host.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java` — remove cookie-read + send in `SidecarProofRunner.openSocket`. Delete the private `readCookie(String)` helper and the package-private `readCookieFromHeader(String, String)` helper along with its percent-decoding fallback methods (`decodeUriComponentSafe`, `decodeUriComponentFallback`, `decodeUriComponentNative`, `appendUtf8Bytes`, `hexValue`, `isMissingNativeUriCodec`). These decoding helpers exist only to support `readCookieFromHeader`. Also fail the sandbox proof fast on cross-host websocket addresses for the same cookie-scope reason.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java` — delete `encodeAuthenticateEnvelope(int, String)`. Nothing else in the sidecar uses it.
 
 ### Test files modified
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java` — delete `encodeAuthenticateEnvelopePreservesLegacyWrapperShape` (covers a method we are removing).
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java` — delete `malformedCookieValueReturnsNull` (covers a helper we are removing).
-- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a gateway first-frame helper seam that verifies the selected-wave and submit paths emit `ProtocolOpenRequest` / `ProtocolSubmitRequest` rather than `ProtocolAuthenticate`, while also guarding that the transport codec no longer re-exposes an auth-envelope helper.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java` *(new)* — regression test: a gateway first-frame helper seam that verifies the selected-wave and submit paths emit `ProtocolOpenRequest` / `ProtocolSubmitRequest` rather than `ProtocolAuthenticate`, while also guarding that the websocket address stays on the current page host and that the transport codec no longer re-exposes an auth-envelope helper.
 
 ### New files
 - `wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json` — single `fix`-section fragment.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -31,6 +31,8 @@ import org.waveprotocol.box.j2cl.transport.SidecarWaveletUpdateSummary;
 public final class SandboxEntryPoint {
   private static final String DEFAULT_MODE = "sidecar";
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
+  private static final String CROSS_HOST_WEBSOCKET_ERROR =
+      "The J2CL sidecar sandbox requires core.http_websocket_presented_address to use the current page host when HttpOnly session cookies are enabled.";
 
   private SandboxEntryPoint() {
   }
@@ -306,6 +308,11 @@ public final class SandboxEntryPoint {
 
     private void openSocket(
         SidecarSessionBootstrap bootstrap, SidecarSearchResponse.Digest digest, int generation) {
+      if (!SidecarSessionBootstrap.usesCompatibleCookieHost(
+          DomGlobal.location.hostname, bootstrap.getWebSocketAddress())) {
+        setError("Cross-host websocket unsupported", CROSS_HOST_WEBSOCKET_ERROR);
+        return;
+      }
       WebSocket ws =
           new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
       socket = ws;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -314,10 +314,6 @@ public final class SandboxEntryPoint {
           return;
         }
         waitingForUpdate = true;
-        String token = readCookie("JSESSIONID");
-        if (token != null && !token.isEmpty()) {
-          ws.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
-        }
         ws.send(
             SidecarTransportCodec.encodeOpenEnvelope(
                 1,
@@ -327,7 +323,7 @@ public final class SandboxEntryPoint {
                     Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
         setNeutral(
             "Awaiting ProtocolWaveletUpdate",
-            "Socket connected; auth/open sent for " + digest.getWaveId() + ".");
+            "Socket connected; open sent for " + digest.getWaveId() + ".");
       };
       ws.onmessage = event -> {
         if (!shouldHandleSocketCallback(generation, runGeneration, ws == socket)) {
@@ -476,146 +472,6 @@ public final class SandboxEntryPoint {
     request.send();
   }
 
-  private static String readCookie(String name) {
-    return readCookieFromHeader(DomGlobal.document.cookie, name);
-  }
-
-  static String readCookieFromHeader(String cookieHeader, String name) {
-    if (cookieHeader == null || cookieHeader.isEmpty()) {
-      return null;
-    }
-    String[] cookies = cookieHeader.split(";");
-    for (String cookie : cookies) {
-      String trimmed = cookie.trim();
-      String prefix = name + "=";
-      if (trimmed.startsWith(prefix)) {
-        try {
-          return decodeUriComponentSafe(trimmed.substring(prefix.length()));
-        } catch (RuntimeException e) {
-          return null;
-        }
-      }
-    }
-    return null;
-  }
-
   @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")
   private static native String encodeUriComponent(String value);
-
-  @JsMethod(namespace = JsPackage.GLOBAL, name = "decodeURIComponent")
-  private static native String decodeUriComponentNative(String value);
-
-  private static String decodeUriComponentSafe(String value) {
-    try {
-      return decodeUriComponentNative(value);
-    } catch (Error err) {
-      if (!isMissingNativeUriCodec(err)) {
-        throw err;
-      }
-      return decodeUriComponentFallback(value);
-    }
-  }
-
-  private static String decodeUriComponentFallback(String value) {
-    if (value == null || value.indexOf('%') < 0) {
-      return value;
-    }
-    StringBuilder decoded = new StringBuilder(value.length());
-    byte[] bytes = new byte[value.length()];
-    int index = 0;
-    while (index < value.length()) {
-      char ch = value.charAt(index);
-      if (ch != '%') {
-        decoded.append(ch);
-        index++;
-        continue;
-      }
-      int byteCount = 0;
-      while (index < value.length() && value.charAt(index) == '%') {
-        if (index + 2 >= value.length()) {
-          throw new IllegalArgumentException("Incomplete percent escape");
-        }
-        bytes[byteCount++] =
-            (byte) ((hexValue(value.charAt(index + 1)) << 4) | hexValue(value.charAt(index + 2)));
-        index += 3;
-      }
-      appendUtf8Bytes(decoded, bytes, byteCount);
-    }
-    return decoded.toString();
-  }
-
-  private static void appendUtf8Bytes(StringBuilder decoded, byte[] bytes, int length) {
-    int index = 0;
-    while (index < length) {
-      int first = bytes[index] & 0xFF;
-      if ((first & 0x80) == 0) {
-        decoded.append((char) first);
-        index++;
-        continue;
-      }
-
-      int additionalBytes;
-      int codePoint;
-      int minCodePoint;
-      if ((first & 0xE0) == 0xC0) {
-        additionalBytes = 1;
-        codePoint = first & 0x1F;
-        minCodePoint = 0x80;
-      } else if ((first & 0xF0) == 0xE0) {
-        additionalBytes = 2;
-        codePoint = first & 0x0F;
-        minCodePoint = 0x800;
-      } else if ((first & 0xF8) == 0xF0) {
-        additionalBytes = 3;
-        codePoint = first & 0x07;
-        minCodePoint = 0x10000;
-      } else {
-        throw new IllegalArgumentException("Invalid UTF-8 leading byte");
-      }
-
-      if (index + additionalBytes >= length) {
-        throw new IllegalArgumentException("Incomplete UTF-8 sequence");
-      }
-
-      for (int i = 0; i < additionalBytes; i++) {
-        int continuation = bytes[++index] & 0xFF;
-        if ((continuation & 0xC0) != 0x80) {
-          throw new IllegalArgumentException("Invalid UTF-8 continuation byte");
-        }
-        codePoint = (codePoint << 6) | (continuation & 0x3F);
-      }
-
-      if (codePoint < minCodePoint
-          || codePoint > 0x10FFFF
-          || (codePoint >= 0xD800 && codePoint <= 0xDFFF)) {
-        throw new IllegalArgumentException("Invalid UTF-8 code point");
-      }
-
-      if (codePoint <= 0xFFFF) {
-        decoded.append((char) codePoint);
-      } else {
-        int supplementary = codePoint - 0x10000;
-        decoded.append((char) ((supplementary >> 10) + 0xD800));
-        decoded.append((char) ((supplementary & 0x3FF) + 0xDC00));
-      }
-      index++;
-    }
-  }
-
-  private static int hexValue(char ch) {
-    if (ch >= '0' && ch <= '9') {
-      return ch - '0';
-    }
-    if (ch >= 'A' && ch <= 'F') {
-      return ch - 'A' + 10;
-    }
-    if (ch >= 'a' && ch <= 'f') {
-      return ch - 'a' + 10;
-    }
-    throw new IllegalArgumentException("Invalid hex digit");
-  }
-
-  private static boolean isMissingNativeUriCodec(Error err) {
-    return "java.lang.UnsatisfiedLinkError".equals(err.getClass().getName());
-  }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -51,13 +51,7 @@ public final class J2clSearchGateway
           if (closedByClient[0]) {
             return;
           }
-          socket.send(
-              SidecarTransportCodec.encodeOpenEnvelope(
-                  1,
-                  new SidecarOpenRequest(
-                      bootstrap.getAddress(),
-                      waveId,
-                      java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX))));
+          socket.send(buildSelectedWaveOpenFrame(bootstrap, waveId));
         };
     socket.onmessage =
         event -> {
@@ -144,7 +138,7 @@ public final class J2clSearchGateway
           if (closedByClient[0]) {
             return;
           }
-          socket.send(SidecarTransportCodec.encodeSubmitEnvelope(1, request));
+          socket.send(buildSubmitFrame(request));
         };
     socket.onmessage =
         event -> {
@@ -196,6 +190,19 @@ public final class J2clSearchGateway
         + index
         + "&numResults="
         + numResults;
+  }
+
+  static String buildSelectedWaveOpenFrame(SidecarSessionBootstrap bootstrap, String waveId) {
+    return SidecarTransportCodec.encodeOpenEnvelope(
+        1,
+        new SidecarOpenRequest(
+            bootstrap.getAddress(),
+            waveId,
+            java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX)));
+  }
+
+  static String buildSubmitFrame(SidecarSubmitRequest request) {
+    return SidecarTransportCodec.encodeSubmitEnvelope(1, request);
   }
 
   private static void requestText(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -51,10 +51,6 @@ public final class J2clSearchGateway
           if (closedByClient[0]) {
             return;
           }
-          String token = readCookie("JSESSIONID");
-          if (token != null && !token.isEmpty()) {
-            socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
-          }
           socket.send(
               SidecarTransportCodec.encodeOpenEnvelope(
                   1,
@@ -148,10 +144,6 @@ public final class J2clSearchGateway
           if (closedByClient[0]) {
             return;
           }
-          String token = readCookie("JSESSIONID");
-          if (token != null && !token.isEmpty()) {
-            socket.send(SidecarTransportCodec.encodeAuthenticateEnvelope(0, token));
-          }
           socket.send(SidecarTransportCodec.encodeSubmitEnvelope(1, request));
         };
     socket.onmessage =
@@ -244,22 +236,6 @@ public final class J2clSearchGateway
     }
     closedByClient[0] = true;
     socket.close();
-  }
-
-  private static String readCookie(String name) {
-    String cookieHeader = DomGlobal.document.cookie;
-    if (cookieHeader == null || cookieHeader.isEmpty()) {
-      return null;
-    }
-    String[] cookies = cookieHeader.split(";");
-    for (String cookie : cookies) {
-      String trimmed = cookie.trim();
-      String prefix = name + "=";
-      if (trimmed.startsWith(prefix)) {
-        return trimmed.substring(prefix.length());
-      }
-    }
-    return null;
   }
 
   @JsMethod(namespace = JsPackage.GLOBAL, name = "encodeURIComponent")

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -19,6 +19,8 @@ public final class J2clSearchGateway
         J2clSelectedWaveController.Gateway,
         J2clSidecarComposeController.Gateway {
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
+  private static final String CROSS_HOST_WEBSOCKET_ERROR =
+      "The J2CL sidecar requires core.http_websocket_presented_address to use the current page host when HttpOnly session cookies are enabled.";
 
   @Override
   public void fetchRootSessionBootstrap(
@@ -43,6 +45,11 @@ public final class J2clSearchGateway
       J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
       J2clSearchPanelController.ErrorCallback onError,
       Runnable onDisconnect) {
+    if (!SidecarSessionBootstrap.usesCompatibleCookieHost(
+        DomGlobal.location.hostname, bootstrap.getWebSocketAddress())) {
+      onError.accept(CROSS_HOST_WEBSOCKET_ERROR);
+      return () -> {};
+    }
     WebSocket socket =
         new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
     final boolean[] closedByClient = new boolean[] {false};
@@ -129,6 +136,11 @@ public final class J2clSearchGateway
       SidecarSubmitRequest request,
       J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
       J2clSearchPanelController.ErrorCallback onError) {
+    if (!SidecarSessionBootstrap.usesCompatibleCookieHost(
+        DomGlobal.location.hostname, bootstrap.getWebSocketAddress())) {
+      onError.accept(CROSS_HOST_WEBSOCKET_ERROR);
+      return;
+    }
     WebSocket socket =
         new WebSocket(buildWebSocketUrl(DomGlobal.location.protocol, bootstrap.getWebSocketAddress()));
     final boolean[] closedByClient = new boolean[] {false};

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -164,6 +164,13 @@ public final class SidecarSessionBootstrap {
   }
 
   private static String normalizeHostName(String hostName) {
-    return hostName == null ? "" : hostName.trim();
+    if (hostName == null) {
+      return "";
+    }
+    String trimmed = hostName.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]") && trimmed.length() > 2) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -19,6 +19,32 @@ public final class SidecarSessionBootstrap {
     return websocketAddress;
   }
 
+  public static boolean usesCompatibleCookieHost(String pageHostname, String websocketAddress) {
+    String expectedHost = normalizeHostName(pageHostname);
+    String websocketHost = websocketHostName(websocketAddress);
+    return !expectedHost.isEmpty() && expectedHost.equalsIgnoreCase(websocketHost);
+  }
+
+  public static String websocketHostName(String websocketAddress) {
+    if (websocketAddress == null) {
+      return "";
+    }
+    String trimmed = websocketAddress.trim();
+    if (trimmed.isEmpty()) {
+      return "";
+    }
+    if (trimmed.startsWith("[")) {
+      int closingBracket = trimmed.indexOf(']');
+      return closingBracket > 1 ? trimmed.substring(1, closingBracket) : "";
+    }
+    int firstColon = trimmed.indexOf(':');
+    int lastColon = trimmed.lastIndexOf(':');
+    if (firstColon >= 0 && firstColon == lastColon) {
+      return normalizeHostName(trimmed.substring(0, firstColon));
+    }
+    return normalizeHostName(trimmed);
+  }
+
   public static SidecarSessionBootstrap fromRootHtml(String html) {
     if (html == null) {
       throw new IllegalArgumentException("Root HTML must not be null");
@@ -135,5 +161,9 @@ public final class SidecarSessionBootstrap {
       }
     }
     throw new IllegalArgumentException("Unterminated __websocket_address string");
+  }
+
+  private static String normalizeHostName(String hostName) {
+    return hostName == null ? "" : hostName.trim();
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -10,14 +10,6 @@ public final class SidecarTransportCodec {
   private SidecarTransportCodec() {
   }
 
-  public static String encodeAuthenticateEnvelope(int sequenceNumber, String token) {
-    return "{\"sequenceNumber\":"
-        + sequenceNumber
-        + ",\"messageType\":\"ProtocolAuthenticate\",\"message\":{\"1\":\""
-        + escapeJson(token)
-        + "\"}}";
-  }
-
   public static String encodeOpenEnvelope(int sequenceNumber, SidecarOpenRequest request) {
     StringBuilder json = new StringBuilder(128);
     json.append("{\"sequenceNumber\":")

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -4,6 +4,7 @@ import com.google.j2cl.junit.apt.J2clTestInput;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
 @J2clTestInput(SandboxBuildSmokeTest.class)
 public class SandboxBuildSmokeTest {
@@ -68,6 +69,16 @@ public class SandboxBuildSmokeTest {
     Assert.assertEquals(
         "ws://socket.example.test/socket",
         SandboxEntryPoint.buildWebSocketUrl("http:", "socket.example.test"));
+  }
+
+  @Test
+  public void websocketCompatibilityRejectsDifferentHostNames() {
+    Assert.assertTrue(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "wave.example.test", "wave.example.test:7443"));
+    Assert.assertFalse(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "wave.example.test", "socket.example.test:7443"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/sandbox/SandboxBuildSmokeTest.java
@@ -86,10 +86,4 @@ public class SandboxBuildSmokeTest {
         "mentions:me unread:true",
         J2clSidecarRouteCodec.parse("?q=mentions%3Ame+unread%3Atrue").getQuery());
   }
-
-  @Test
-  public void malformedCookieValueReturnsNull() {
-    Assert.assertNull(
-        SandboxEntryPoint.readCookieFromHeader("JSESSIONID=%; theme=dark", "JSESSIONID"));
-  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -60,6 +60,9 @@ public class J2clSearchGatewayAuthFrameTest {
     Assert.assertFalse(
         SidecarSessionBootstrap.usesCompatibleCookieHost(
             "wave.example.com", "socket.example.com:7443"));
+    Assert.assertTrue(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "[2001:db8::1]", "[2001:db8::1]:7443"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -1,0 +1,34 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.lang.reflect.Method;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+
+/**
+ * Issue #933 name-guard: the J2CL sidecar transport codec must not expose a
+ * ProtocolAuthenticate envelope helper again by accident. Sidecar auth is now
+ * established entirely by the WebSocket upgrade handshake (the server resolves
+ * loggedInUser from the HttpSession before any frames are exchanged).
+ *
+ * <p>This is a static-contract regression, not a behavioural test of the
+ * gateways — it cannot catch a future regression that hand-inlines a cookie
+ * read in {@link J2clSearchGateway} or the sandbox sidecar. For that defence,
+ * see the local-browser verification recorded under
+ * {@code journal/local-verification/2026-04-23-issue-933-sidecar-ws-auth.md},
+ * which inspects the live {@code /socket} frames for the absence of a
+ * {@code ProtocolAuthenticate} payload.
+ */
+@J2clTestInput(J2clSearchGatewayAuthFrameTest.class)
+public class J2clSearchGatewayAuthFrameTest {
+  @Test
+  public void transportCodecDoesNotExposeAuthenticateEnvelopeHelper() {
+    for (Method method : SidecarTransportCodec.class.getDeclaredMethods()) {
+      Assert.assertFalse(
+          "SidecarTransportCodec must not expose encodeAuthenticateEnvelope; "
+              + "sidecar auth is handled by the WebSocket upgrade handshake (#933)",
+          "encodeAuthenticateEnvelope".equals(method.getName()));
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -4,13 +4,16 @@ import com.google.j2cl.junit.apt.J2clTestInput;
 import java.lang.reflect.Method;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
 
 /**
- * Issue #933 name-guard: the J2CL sidecar transport codec must not expose a
- * ProtocolAuthenticate envelope helper again by accident. Sidecar auth is now
- * established entirely by the WebSocket upgrade handshake (the server resolves
- * loggedInUser from the HttpSession before any frames are exchanged).
+ * Issue #933 regression coverage for the first outbound J2CL sidecar frames.
+ * Sidecar auth is now established entirely by the WebSocket upgrade handshake
+ * (the server resolves loggedInUser from the HttpSession before any frames are
+ * exchanged), so the selected-wave and submit sockets must begin with
+ * ProtocolOpenRequest / ProtocolSubmitRequest instead of an auth envelope.
  *
  * <p>This is a static-contract regression, not a behavioural test of the
  * gateways — it cannot catch a future regression that hand-inlines a cookie
@@ -22,6 +25,30 @@ import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
  */
 @J2clTestInput(J2clSearchGatewayAuthFrameTest.class)
 public class J2clSearchGatewayAuthFrameTest {
+  @Test
+  public void selectedWaveSocketStartsWithProtocolOpenRequest() {
+    String frame =
+        J2clSearchGateway.buildSelectedWaveOpenFrame(
+            new SidecarSessionBootstrap("rose@example.com", "socket.example.test"),
+            "example.com/w+abc");
+
+    Assert.assertEquals("ProtocolOpenRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertFalse(frame.contains("ProtocolAuthenticate"));
+  }
+
+  @Test
+  public void submitSocketStartsWithProtocolSubmitRequest() {
+    String frame =
+        J2clSearchGateway.buildSubmitFrame(
+            new SidecarSubmitRequest(
+                "example.com/w+abc/conv+root",
+                "{\"ops\":[]}",
+                "channel-7"));
+
+    Assert.assertEquals("ProtocolSubmitRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertFalse(frame.contains("ProtocolAuthenticate"));
+  }
+
   @Test
   public void transportCodecDoesNotExposeAuthenticateEnvelopeHelper() {
     for (Method method : SidecarTransportCodec.class.getDeclaredMethods()) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -50,6 +50,19 @@ public class J2clSearchGatewayAuthFrameTest {
   }
 
   @Test
+  public void websocketCookieHostMustMatchCurrentPageHost() {
+    Assert.assertTrue(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "wave.example.com", "wave.example.com:7443"));
+    Assert.assertTrue(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "wave.example.com", "wave.example.com"));
+    Assert.assertFalse(
+        SidecarSessionBootstrap.usesCompatibleCookieHost(
+            "wave.example.com", "socket.example.com:7443"));
+  }
+
+  @Test
   public void transportCodecDoesNotExposeAuthenticateEnvelopeHelper() {
     for (Method method : SidecarTransportCodec.class.getDeclaredMethods()) {
       Assert.assertFalse(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -11,15 +11,6 @@ import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
 @J2clTestInput(SidecarTransportCodecTest.class)
 public class SidecarTransportCodecTest {
   @Test
-  public void encodeAuthenticateEnvelopePreservesLegacyWrapperShape() {
-    String json = SidecarTransportCodec.encodeAuthenticateEnvelope(7, "cookie-token");
-
-    Assert.assertTrue(json.contains("\"sequenceNumber\":7"));
-    Assert.assertTrue(json.contains("\"messageType\":\"ProtocolAuthenticate\""));
-    Assert.assertTrue(json.contains("\"message\":{\"1\":\"cookie-token\"}"));
-  }
-
-  @Test
   public void encodeOpenEnvelopeUsesGeneratedNumericFieldKeys() {
     SidecarOpenRequest request =
         new SidecarOpenRequest(

--- a/wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json
+++ b/wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json
@@ -9,7 +9,8 @@
       "type": "fix",
       "items": [
         "Removed the JSESSIONID lookup via document.cookie from the J2CL sidecar's selected-wave, submit, and sandbox proof sockets so the session cookie can stay HttpOnly",
-        "Deleted the now-unused sidecar ProtocolAuthenticate envelope helper to prevent regressions that would re-introduce the client-side cookie handshake"
+        "Deleted the now-unused sidecar ProtocolAuthenticate envelope helper to prevent regressions that would re-introduce the client-side cookie handshake",
+        "Added a fast-fail guard for cross-host websocket presented addresses because the handshake-only J2CL sidecar auth path now requires the current page host to receive the HttpOnly session cookie"
       ]
     }
   ]

--- a/wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json
+++ b/wave/config/changelog.d/2026-04-23-j2cl-sidecar-auth-handshake.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-23-j2cl-sidecar-auth-handshake",
+  "version": "Unreleased",
+  "date": "2026-04-23",
+  "title": "J2CL sidecar no longer reads the session cookie from JavaScript",
+  "summary": "The J2CL search sidecar and sandbox proof now rely on the WebSocket upgrade handshake for authentication, so the primary session cookie can remain HttpOnly.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the JSESSIONID lookup via document.cookie from the J2CL sidecar's selected-wave, submit, and sandbox proof sockets so the session cookie can stay HttpOnly",
+        "Deleted the now-unused sidecar ProtocolAuthenticate envelope helper to prevent regressions that would re-introduce the client-side cookie handshake"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Stop the J2CL sidecar from reading `JSESSIONID` out of `document.cookie` and sending it in a `ProtocolAuthenticate` envelope over the selected-wave, submit, and sandbox-proof sockets.
- Rely solely on the WebSocket upgrade handshake — `WaveWebSocketEndpoint.onOpen` already resolves the `ParticipantId` from the `HttpSession`, and `ServerRpcProvider.Connection.message` already prefers that handshake-time user over any `ProtocolAuthenticate` token (see `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/ServerRpcProvider.java:229-244`). So the primary session cookie can now remain `HttpOnly`.
- Delete the now-unused `SidecarTransportCodec.encodeAuthenticateEnvelope` helper and its paired test; add a static-contract regression test (`J2clSearchGatewayAuthFrameTest`) that fails if the helper is reintroduced.

## Scope
- J2CL sidecar only. Legacy GWT `wave/src/main/java/org/waveprotocol/box/webclient/client/WaveWebSocketClient.java` is intentionally left alone; it still reads `JSESSIONID` the old way, but the server handler ignores the token whenever the handshake already resolved a user, so its behaviour is unchanged.
- No server-side `ServerRpcProvider` changes.
- No operator-visible config flips — `network.session_cookie_http_only` defaults remain as shipped (legacy client still works against them).
- No gatling or e2e-test changes; those paths use their own session machinery.

## Verification
- `./j2cl/mvnw -f ./j2cl/pom.xml -Psearch-sidecar -Dtest=SidecarTransportCodecTest,SandboxBuildSmokeTest,J2clSelectedWaveControllerTest,J2clSearchGatewayAuthFrameTest test` — 42 tests pass
- `sbt -batch j2clSearchBuild` — success
- `sbt -batch j2clSearchTest` — success
- `sbt -batch compileGwt` — success (link succeeded)
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — validation passed

## Review
- Plan: `docs/superpowers/plans/2026-04-23-issue-933-sidecar-ws-auth.md`. Claude Opus 4.7 plan review iterated to GREEN LIGHT after dropping a proposed sequence-number renumber, strengthening the regression-test docstring, fixing the changelog assemble command, and expanding the out-of-scope list.
- Claude Opus 4.7 implementation review returned GREEN LIGHT. Only residual nit: the regression test is a codec name-guard rather than a behavioural gateway test, called out explicitly in the test Javadoc.

Closes #933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed client-side session-cookie reading from the sidecar and sandbox; auth now uses the WebSocket upgrade handshake so session cookies can remain HttpOnly.
  * Added a fast-fail for cross-host websocket addresses with a clear "cross-host websocket unsupported" error.
  * Updated websocket connection status text to reflect the new handshake-only flow.
  * Deleted an obsolete client-side auth helper.

* **Tests**
  * Added regression tests ensuring outbound socket frames no longer include the old auth envelope and enforcing host-compatibility; removed legacy cookie-parsing tests.

* **Documentation**
  * Added an implementation plan and changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->