### PR TITLE
feat(j2cl): live unread/read state in selected-wave panel (#931)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
+++ b/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
@@ -55,14 +55,18 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 
 ### Server (Common)
 
-- `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java`
-  - Expose a narrow public helper (e.g. `WaveSupplementContext loadWaveContext(ParticipantId user, WaveId waveId, WaveletProvider waveletProvider)`), or extract `getOrBuildContext` + `WaveSupplementContext` into a new `SelectedWaveReadStateHelper` so the new servlet can reuse it without widening the existing search dependency surface.
-  - If direct method extraction is unsafe, the fallback is to add a new package-visible class `SelectedWaveReadStateHelper` alongside that loads wavelets via `WaveletProvider.getSnapshot`, wraps them in `ObservableWaveletData`, and builds the supplement context using the existing `WaveDigester.buildSupplement` API.
+- **New:** `wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java`
+  - Package-visible helper, same package as `SimpleSearchProviderImpl`, so it can reuse the package-private `WaveSupplementContext`.
+  - Constructor is Guice-injectable: takes `WaveMap`, `WaveDigester`, `SharedDomainParticipantProvider`-equivalents already used by the search path.
+  - Public API exposes only `Result computeReadState(ParticipantId user, WaveId waveId)` returning `{unreadCount, isRead, accessAllowed, exists}`. No internal types leak.
+  - Data loading: the helper uses `WaveMap.lookupWavelets(waveId)` + `WaveMap.getWavelet(WaveletName).copyWaveletData()` — the same path `AbstractSearchProviderImpl.buildWaveViewData` (`wave/src/main/java/org/waveprotocol/box/server/waveserver/AbstractSearchProviderImpl.java:123-148`) already uses. This returns `ObservableWaveletData`, which the existing supplement/digester path consumes. Do NOT use `WaveletProvider.getSnapshot` — that returns `CommittedWaveletSnapshot` wrapping `ReadableWaveletData`, which the supplement stack cannot consume.
+  - Access check: before counting, the helper must verify the authenticated user is a participant of the conversational wavelet (explicit participant or shared-domain), reusing the same predicate used by search (`AbstractSearchProviderImpl.isWaveletMatchesCriteria` style). If access is denied, the helper returns `accessAllowed=false` and the servlet responds with the same 404 it would use for an unknown wave so existence cannot be probed.
+  - `SimpleSearchProviderImpl.java` itself stays unchanged; the helper duplicates the minimal construction logic of its internal `WaveSupplementContext` rather than widening `SimpleSearchProviderImpl`'s public surface.
 
 ### J2CL Sidecar
 
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java` (new)
-  - Immutable DTO: `{waveId, unreadCount, totalBlipCount, isRead, fetchedAtGeneration}`.
+  - Immutable DTO: `{waveId, unreadCount, isRead}`. Ordering + generation tracking live entirely in the controller (via `readStateFetchSeq`); they do not need to be carried on the DTO.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
   - Add `decodeSelectedWaveReadState(String json)` decoder for the new endpoint response.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
@@ -75,8 +79,8 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
     - a reconnect that delivers a fresh update.
   - Track the latest read-state by request generation to avoid stale overwrites.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
-  - Add `unreadCount`, `totalBlipCount`, `isRead`, `readStateKnown` fields with explicit sentinel values for "not yet fetched".
-  - Update `empty`/`loading`/`error` factories to carry forward prior read-state when appropriate.
+  - Add `unreadCount` (int, `-1` = unknown), `isRead` (boolean), `readStateKnown` (boolean), `readStateStale` (boolean).
+  - Update `empty`/`loading`/`error` factories to carry forward prior read-state fields when a selection is preserved (avoids flashing back to digest data on reconnect).
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
   - Accept an optional `SidecarSelectedWaveReadState` argument.
   - Prefer server-provided read state when present; fall back to digest metadata only until the first read-state response arrives.
@@ -95,7 +99,11 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
   - Add cases: read-state fetched after first update; read-state re-fetched after subsequent updates; stale read-state from a previous selection is discarded after a generation bump; reconnect triggers a re-fetch.
 - **New:** `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
-  - Unit tests for projector preference order: server read-state wins over digest; absent server state falls back to digest; empty digest + empty server state → empty unread text (not a misleading "Selected digest is read" when nothing is known).
+  - Unit tests for projector preference order:
+    - server read-state present → server value wins over digest,
+    - server read-state absent, digest present → digest fallback,
+    - both absent → empty unread text (not a misleading "Selected digest is read" when nothing is known),
+    - `readStateStale=true` on top of a prior good count → count stays, display flag reflects staleness.
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
   - Add decode test for the new read-state response shape.
 
@@ -118,23 +126,44 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 
 ### Task 2: Add The Server Read-State Helper
 
-- [ ] Either expose a narrow public method on `SimpleSearchProviderImpl` (e.g. `WaveSupplementContext loadWaveContext(user, waveId)`) or extract a new `SelectedWaveReadStateHelper` in the same package.
-- [ ] The helper must: load conversational wavelets + UDW for the given wave id via `WaveletProvider.getSnapshot`, build `ObservableWaveletData`, wrap them, and build a `SupplementedWave` via the existing `WaveDigester.buildSupplement` path.
-- [ ] Add a narrow method `int countUnread(ParticipantId user, WaveId waveId)` that returns the server-authoritative count (or `-1` for unknown / not a conversational wave).
-- [ ] Add a narrow method `int totalBlipCount(WaveId waveId)` that iterates conversational wavelet blip ids (matching the digest logic in `WaveDigester.countUnreadFromReadState`).
-- [ ] Unit-test the helper with a fake or in-memory `WaveletProvider` using existing test doubles. If creating the fake is disproportionately large, scope the helper test to the minimum coverage that proves the read/unread/unknown branches and leave deeper coverage to the servlet integration test.
+- [ ] Create `SelectedWaveReadStateHelper` in `org.waveprotocol.box.server.waveserver` so it can reuse the package-private `WaveSupplementContext`.
+- [ ] Data loading path:
+  - `WaveMap.lookupWavelets(waveId)` returns the full `Set<WaveletId>`.
+  - For each id: `WaveMap.getWavelet(WaveletName.of(waveId, waveletId)).copyWaveletData()` yields an `ObservableWaveletData` (same API shape already used by `AbstractSearchProviderImpl.buildWaveViewData:123-148`).
+  - Classify each wavelet: conversational (via `IdUtil.isConversationalId`), conversation root (via `IdUtil.isConversationRootWaveletId`), or the authenticated user's UDW (via `IdUtil.isUserDataWavelet(user.getAddress(), waveletId)`).
+  - Build a `WaveViewData` via `WaveViewDataImpl.create(waveId)` and add each wavelet.
+- [ ] Access check first:
+  - Before counting, the helper must verify the authenticated user is permitted to see the wave. Use the same predicate style as `AbstractSearchProviderImpl.isWaveletMatchesCriteria` — explicit participant OR shared-domain participant on the conversational wavelet.
+  - If the wave does not exist OR the user lacks access, return a single `Result.notFound()` sentinel. The servlet returns `404` in both cases to prevent existence probes.
+- [ ] Supplement construction:
+  - Use `WaveDigester.buildSupplement(user, conversations, udw, conversationalWavelets)` after building conversations via `ConversationUtil`.
+  - If the wave has no conversational structure, return `Result.notConversational()` with `unreadCount=0`, `isRead=true`.
+- [ ] Public API:
+  - `Result computeReadState(ParticipantId user, WaveId waveId)` returning `{unreadCount:int, isRead:boolean, exists:boolean, accessAllowed:boolean}`.
+  - No `totalBlipCount` — the view only renders `isRead` + `unreadCount`. Drop the field entirely.
+- [ ] Unit tests:
+  - Non-participant → `notFound()` (access denied masquerades as unknown).
+  - Non-existent wave id → `notFound()`.
+  - Known wave, fully read → `unreadCount=0, isRead=true`.
+  - Known wave, two unread blips → `unreadCount=2, isRead=false`.
+  - Non-conversational wave → `unreadCount=0, isRead=true`.
+  - Use the same test doubles search-side tests already use for `WaveMap` + `WaveletContainer` (see existing `wave/src/test/java/org/waveprotocol/box/server/waveserver/` tests for patterns).
 
 ### Task 3: Add The `/read-state` Jakarta Servlet
 
 - [ ] Mirror `SearchServlet`'s structure (session check, JSON response, `no-store` cache header).
-- [ ] Accept `GET /read-state?waveId=<waveId>`.
-- [ ] Return `403` if no session, `400` on missing/invalid `waveId`, `404` on unknown wave or permission denied, `200 OK` with JSON body:
+- [ ] Accept `GET /read-state?waveId=<waveId>`. Use the plain `/read-state?…` form consistently — no trailing slash in the gateway URL, curl smokes, or tests. The servlet mapping stays `/read-state/*` so both forms route, but only the no-slash form is the published contract.
+- [ ] Return:
+  - `403 Forbidden` if no authenticated session.
+  - `400 Bad Request` on missing or malformed `waveId` (`ModernIdSerialiser.parse` throws `InvalidIdException`).
+  - `404 Not Found` for unknown wave OR access denied — treat both identically so existence cannot be probed.
+  - `200 OK` with JSON:
 ```json
-{ "waveId": "...", "unreadCount": 3, "totalBlipCount": 12, "isRead": false }
+{ "waveId": "example.com/w+abc", "unreadCount": 3, "isRead": false }
 ```
-- [ ] Map `/read-state/*` in `ServerMain.java` next to `/search/*`.
-- [ ] Ensure the servlet is instantiable via the existing Jakarta server bootstrap (explicit Guice binding only if required by the bootstrap code).
-- [ ] Add an integration-style test that boots the servlet with a mock session manager + fake helper, verifies the status codes and JSON shape, and proves the error paths surface minimal error text without leaking internals.
+- [ ] Map `/read-state/*` in `ServerMain.java` beside `/search/*` (`wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java:375`).
+- [ ] Do NOT add a Guice binding in `SearchModule` — the Jakarta server wiring constructs servlets directly via field injection at `server.addServlet(...)` time, matching the existing `SearchServlet` pattern.
+- [ ] Servlet test covers each status code branch, the JSON shape, and that the `404` branch does not leak error text distinguishing "unknown wave" from "access denied".
 
 ### Task 4: Add The Client Transport Seam
 
@@ -145,11 +174,20 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 ### Task 5: Wire Client Gateway + Controller
 
 - [ ] Add `Gateway.fetchSelectedWaveReadState(waveId, onSuccess, onError)` to `J2clSelectedWaveController`.
-- [ ] Implement it in `J2clSearchGateway` via `requestText("/read-state/?waveId=...")` + `decodeSelectedWaveReadState`.
-- [ ] In `J2clSelectedWaveController.openSelectedWave`, after the first non-establishment update for a generation, call `fetchSelectedWaveReadState` bound to the same generation.
-- [ ] On each subsequent update within the same generation, trigger a debounced re-fetch so fast-arriving updates do not amplify HTTP traffic. A minimal approach: cancel the prior in-flight fetch via generation bump or per-request token; always honor only the latest generation/token.
-- [ ] On reconnect, a fresh update still triggers a new fetch.
-- [ ] Errors in read-state fetches must not kill the selected-wave subscription. They should set a soft-failure state in the model (e.g. `readStateKnown=false` + a quiet status note) but keep the live wave panel intact.
+- [ ] Implement it in `J2clSearchGateway` via `requestText("/read-state?waveId=" + encodeUriComponent(waveId))` + `decodeSelectedWaveReadState`.
+- [ ] Controller state for read-state fetching:
+  - `currentReadState` (nullable `SidecarSelectedWaveReadState`) preserved across updates and reconnect; only replaced after a fresh successful fetch.
+  - `readStateFetchSeq` (monotonically increasing `int`) bumped on every dispatched fetch. Responses apply only if `response.seq == readStateFetchSeq`. This protects against out-of-order HTTP responses within the same `requestGeneration`.
+  - `readStateDebounceHandle` tracks a pending `setTimeout`. A fresh update arriving while a fetch is pending clears the prior timeout and schedules a new trailing-edge 250 ms fetch. The debounce is per-generation; a generation bump cancels any pending timer.
+- [ ] Trigger points:
+  - After a successful first non-establishment update for a generation → schedule a fetch.
+  - On each subsequent update for the same generation → schedule a debounced fetch.
+  - After a reconnect's first fresh update → schedule a fetch.
+  - On `document.visibilitychange` → `visible` while a selection is open → schedule a fetch. This closes the UDW-only-change case: reading the wave elsewhere does NOT produce a `conv+root` update, but when the user returns to the J2CL tab the fetch fires once and refreshes the displayed state.
+- [ ] Error handling:
+  - On fetch error, preserve `currentReadState` (no zeroing). Set a soft `readStateStale` flag in the model so the view can (optionally) tag the label without replacing the count.
+  - The selected-wave subscription is never cancelled by a read-state fetch failure.
+  - A generation bump always cancels in-flight callbacks by comparing the stored seq.
 - [ ] Re-project the model on each read-state success so the view picks up the new fields.
 
 ### Task 6: Update Model + Projector + View
@@ -164,10 +202,19 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 
 ### Task 7: Live-Update Proof And Reconnect
 
-- [ ] Controller test: simulate two consecutive updates and verify two read-state fetches (one per generation-preserving update), each re-projecting the model.
-- [ ] Controller test: simulate a reconnect — ensure a fresh fetch is triggered after the post-reconnect first update.
-- [ ] Controller test: simulate an error from the read-state endpoint and verify the selected-wave panel remains live and the model flips to `readStateKnown=false` without clobbering visible content.
-- [ ] Browser verification: open a wave with known unread blips, observe the `"N unread"` label reflecting the real server state; read the blips in another browser tab to bump the UDW; observe the J2CL panel's unread count updating live after the next `ProtocolWaveletUpdate`.
+- [ ] Controller test: after open, a single update triggers exactly one read-state fetch and re-projects the model.
+- [ ] Controller test: two updates within the debounce window collapse into one fetch; an update after the window triggers a second fetch.
+- [ ] Controller test: stale-response ordering — dispatch fetch A, dispatch fetch B, resolve B first, then resolve A; verify A is dropped and the model still reflects B's payload.
+- [ ] Controller test: generation bump — a wave re-selection bumps the generation; any pending fetch callback from the previous generation is ignored.
+- [ ] Controller test: reconnect — the first fresh update after a reconnect triggers a new fetch; the prior `currentReadState` remains displayed in the interim.
+- [ ] Controller test: soft failure — the read-state endpoint returns an error; the selected-wave panel stays live, `currentReadState` is preserved (not zeroed), and `readStateStale=true` is set.
+- [ ] Controller test: UDW-only change case — emit a synthetic `visibilitychange=visible` signal and verify a single fetch fires even with no new `ProtocolWaveletUpdate`.
+- [ ] Browser verification (two-tab scenario):
+  - Tab A: `/j2cl-search/index.html`, open a wave with known unread blips; confirm the `"N unread"` label matches the server count, not the stale digest number.
+  - Tab B: legacy `/` route as another participant — add a blip. Tab A's label increments after the next update arrives.
+  - Tab B: read the unread blips (bumps UDW only). Focus Tab A; the label drops to `"Read"` after the `visibilitychange` fetch.
+  - Force a disconnect in Tab A via devtools → Offline → wait for reconnect; confirm the label rehydrates and the prior count was shown during the outage.
+  - Confirm the legacy `/` route is still usable and unchanged.
 
 ### Task 8: Preserve Legacy Root And Record Traceability
 
@@ -231,7 +278,7 @@ curl -sS -I http://localhost:9931/j2cl-search/index.html
 ```bash
 # After logging in via the browser and copying JSESSIONID:
 curl -sS -H 'Cookie: JSESSIONID=<token>' \
-  "http://localhost:9931/read-state/?waveId=<test-wave-id>"
+  "http://localhost:9931/read-state?waveId=<test-wave-id>"
 ```
 
 Expected: JSON body with the authenticated user's per-wave unread count.

--- a/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
+++ b/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
@@ -1,0 +1,266 @@
+# Issue #931 J2CL Selected-Wave Unread/Read State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface real per-user unread/read state on the J2CL sidecar selected-wave panel, instead of the current digest-reuse. Live updates must refresh the state. No regressions to selected-wave rendering, compose, reconnect, or the legacy root path.
+
+**Architecture:** Add a narrow server HTTP endpoint (`GET /read-state?waveId=<waveid>`) that returns the authenticated user's unread/read state for a single wave by reusing the existing `WaveDigester.getUnreadCount` + `SimpleSearchProviderImpl.WaveSupplementContext` infrastructure. The J2CL sidecar calls this endpoint after successfully opening the selected wave and after each subsequent `ProtocolWaveletUpdate` for that wave, then feeds the result into `J2clSelectedWaveModel`/`J2clSelectedWaveView`.
+
+**Tech Stack:** Java, SBT, Jakarta servlet overrides under `wave/src/jakarta-overrides/`, J2CL Maven sidecar under `j2cl/`, Elemental2 DOM, generated `gen/messages/**` protocol models, existing `scripts/worktree-file-store.sh` and `scripts/worktree-boot.sh` for local boot, manual browser verification.
+
+---
+
+## 1. Goal / Root Cause
+
+Issue `#931` exists because `#920` deliberately deferred real unread/read tracking:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:227-235` explicitly comments that `#920` does not add a dedicated read-state transport field and that the panel can only surface unread status from the digest selected for the search result.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:14,123-129` stores `unreadText` built solely from `J2clSearchDigestItem.getUnreadCount()`. That count is captured at search time and never refreshed while the selected wave is open.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:70-71` renders `model.getUnreadText()` once per render, so even live `ProtocolWaveletUpdate` frames that the controller already re-projects at `J2clSelectedWaveController.java:193-209` do not change the unread label until the user re-runs a search.
+- The sidecar socket opened by `J2clSearchGateway.java:40-64` only subscribes to the `conv+root` wavelet prefix. The user-data wavelet (UDW) that owns read state is not streamed into the sidecar at all.
+
+The narrow root cause is therefore: the sidecar has no path to the per-user unread/read state for the currently selected wave. We need the smallest seam that makes that state reachable on open, on every update, and across reconnect — without widening into a full `SupplementedWave` port or touching the wire protocol.
+
+## 2. Scope And Non-Goals
+
+### In Scope
+
+- Add a server HTTP endpoint that returns `{waveId, unreadCount, totalBlipCount, isRead}` for the authenticated participant, computed via the existing `WaveDigester` + `SimpleSearchProviderImpl.WaveSupplementContext` path.
+- Wire the new endpoint into the Jakarta servlet registry beside the existing `/search/*` mapping.
+- Extend `J2clSearchGateway` with a `fetchSelectedWaveReadState(waveId, onSuccess, onError)` helper that calls the new endpoint.
+- Update `J2clSelectedWaveController` to fetch read state after a successful open, after each non-establishment `ProtocolWaveletUpdate`, and after a reconnect.
+- Extend `J2clSelectedWaveModel` with authoritative unread-state fields and have `J2clSelectedWaveProjector` prefer server data, falling back to digest metadata only until the first read-state response arrives.
+- Keep `J2clSelectedWaveView` rendering the same DOM seam — only the text content changes.
+- Add targeted unit tests covering: the new servlet, the gateway call, the controller trigger logic, the projector preference order, and existing transport/codec regression tests staying green.
+
+### Explicit Non-Goals
+
+- No change to the `ProtocolWaveletUpdate` / `ProtocolOpenRequest` wire formats or generated protocol models.
+- No subscription to the user-data wavelet from the sidecar socket; UDW handling stays on the server.
+- No "mark as read" write path. Writes remain part of the compose/editor lineage tracked separately.
+- No regression work on the selected-wave rendering, compose surface, reconnect lifecycle, or route state.
+- No change to the legacy GWT root client's unread display.
+- No durable route/history updates; those belong to the `#921` lineage.
+
+## 3. Exact Files Likely To Change
+
+### Server (Jakarta Overrides)
+
+- **New:** `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java`
+  - Jakarta `HttpServlet` at `/read-state/*`, mirrors `SearchServlet`'s session + JSON-response conventions.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+  - Register `"/read-state/*" -> SelectedWaveReadStateServlet.class`.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/SearchModule.java`
+  - Bind `SelectedWaveReadStateServlet` as a singleton so Guice wires it at startup. If no binding is strictly required (servlet is instantiated by the Jakarta server wiring), document explicitly instead of adding a stub binding.
+
+### Server (Common)
+
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java`
+  - Expose a narrow public helper (e.g. `WaveSupplementContext loadWaveContext(ParticipantId user, WaveId waveId, WaveletProvider waveletProvider)`), or extract `getOrBuildContext` + `WaveSupplementContext` into a new `SelectedWaveReadStateHelper` so the new servlet can reuse it without widening the existing search dependency surface.
+  - If direct method extraction is unsafe, the fallback is to add a new package-visible class `SelectedWaveReadStateHelper` alongside that loads wavelets via `WaveletProvider.getSnapshot`, wraps them in `ObservableWaveletData`, and builds the supplement context using the existing `WaveDigester.buildSupplement` API.
+
+### J2CL Sidecar
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java` (new)
+  - Immutable DTO: `{waveId, unreadCount, totalBlipCount, isRead, fetchedAtGeneration}`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+  - Add `decodeSelectedWaveReadState(String json)` decoder for the new endpoint response.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - Add `fetchSelectedWaveReadState(String waveId, SuccessCallback<SidecarSelectedWaveReadState>, ErrorCallback)` using the existing `requestText` XHR helper.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+  - Extend the `Gateway` interface with the new fetch method.
+  - Trigger a read-state fetch after:
+    - a successful selected-wave open (first non-establishment update),
+    - each subsequent update for the same generation,
+    - a reconnect that delivers a fresh update.
+  - Track the latest read-state by request generation to avoid stale overwrites.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  - Add `unreadCount`, `totalBlipCount`, `isRead`, `readStateKnown` fields with explicit sentinel values for "not yet fetched".
+  - Update `empty`/`loading`/`error` factories to carry forward prior read-state when appropriate.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  - Accept an optional `SidecarSelectedWaveReadState` argument.
+  - Prefer server-provided read state when present; fall back to digest metadata only until the first read-state response arrives.
+  - Keep the existing snippet/participant/content logic unchanged.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+  - No structural DOM changes. Text content now reflects real per-user state (e.g. `"3 unread"`, `"Read."`, `"Read state unavailable yet."`).
+
+### Tests (Server)
+
+- **New:** `wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java`
+  - Covers: unauthenticated → 403; missing `waveId` → 400; unknown wave → 404; known wave → 200 with expected JSON; invalid wave id → 400.
+- If the server helper is extracted, add `wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java` with a fake `WaveletProvider` producing a minimal conversation + UDW pair.
+
+### Tests (J2CL)
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+  - Add cases: read-state fetched after first update; read-state re-fetched after subsequent updates; stale read-state from a previous selection is discarded after a generation bump; reconnect triggers a re-fetch.
+- **New:** `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+  - Unit tests for projector preference order: server read-state wins over digest; absent server state falls back to digest; empty digest + empty server state → empty unread text (not a misleading "Selected digest is read" when nothing is known).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+  - Add decode test for the new read-state response shape.
+
+### Inspect-Only References (No Edits Expected)
+
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java:123-174`
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java:101-196`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SearchServlet.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java:362-390`
+- `docs/superpowers/plans/2026-04-19-issue-920-j2cl-selected-wave.md` (parent seam)
+
+## 4. Concrete Task Breakdown
+
+### Task 1: Freeze Issue Boundary
+
+- [ ] Keep the scope to the J2CL sidecar's selected-wave panel only; legacy GWT search digests remain as-is.
+- [ ] Confirm the work lives under `/Users/vega/devroot/worktrees/issue-931-unread-read-state` on branch `issue-931-unread-read-state`.
+- [ ] Treat `/read-state` as a new HTTP-level seam, not a new WebSocket message type or wire-protocol field.
+- [ ] Record in the issue comment: worktree path, branch, plan path.
+
+### Task 2: Add The Server Read-State Helper
+
+- [ ] Either expose a narrow public method on `SimpleSearchProviderImpl` (e.g. `WaveSupplementContext loadWaveContext(user, waveId)`) or extract a new `SelectedWaveReadStateHelper` in the same package.
+- [ ] The helper must: load conversational wavelets + UDW for the given wave id via `WaveletProvider.getSnapshot`, build `ObservableWaveletData`, wrap them, and build a `SupplementedWave` via the existing `WaveDigester.buildSupplement` path.
+- [ ] Add a narrow method `int countUnread(ParticipantId user, WaveId waveId)` that returns the server-authoritative count (or `-1` for unknown / not a conversational wave).
+- [ ] Add a narrow method `int totalBlipCount(WaveId waveId)` that iterates conversational wavelet blip ids (matching the digest logic in `WaveDigester.countUnreadFromReadState`).
+- [ ] Unit-test the helper with a fake or in-memory `WaveletProvider` using existing test doubles. If creating the fake is disproportionately large, scope the helper test to the minimum coverage that proves the read/unread/unknown branches and leave deeper coverage to the servlet integration test.
+
+### Task 3: Add The `/read-state` Jakarta Servlet
+
+- [ ] Mirror `SearchServlet`'s structure (session check, JSON response, `no-store` cache header).
+- [ ] Accept `GET /read-state?waveId=<waveId>`.
+- [ ] Return `403` if no session, `400` on missing/invalid `waveId`, `404` on unknown wave or permission denied, `200 OK` with JSON body:
+```json
+{ "waveId": "...", "unreadCount": 3, "totalBlipCount": 12, "isRead": false }
+```
+- [ ] Map `/read-state/*` in `ServerMain.java` next to `/search/*`.
+- [ ] Ensure the servlet is instantiable via the existing Jakarta server bootstrap (explicit Guice binding only if required by the bootstrap code).
+- [ ] Add an integration-style test that boots the servlet with a mock session manager + fake helper, verifies the status codes and JSON shape, and proves the error paths surface minimal error text without leaking internals.
+
+### Task 4: Add The Client Transport Seam
+
+- [ ] Add `SidecarSelectedWaveReadState` immutable DTO.
+- [ ] Add `SidecarTransportCodec.decodeSelectedWaveReadState(json)` that reads `waveId`, `unreadCount`, `totalBlipCount`, `isRead` safely (missing fields → sentinel).
+- [ ] Extend `SidecarTransportCodecTest` with decode coverage for the happy path and the missing-field path.
+
+### Task 5: Wire Client Gateway + Controller
+
+- [ ] Add `Gateway.fetchSelectedWaveReadState(waveId, onSuccess, onError)` to `J2clSelectedWaveController`.
+- [ ] Implement it in `J2clSearchGateway` via `requestText("/read-state/?waveId=...")` + `decodeSelectedWaveReadState`.
+- [ ] In `J2clSelectedWaveController.openSelectedWave`, after the first non-establishment update for a generation, call `fetchSelectedWaveReadState` bound to the same generation.
+- [ ] On each subsequent update within the same generation, trigger a debounced re-fetch so fast-arriving updates do not amplify HTTP traffic. A minimal approach: cancel the prior in-flight fetch via generation bump or per-request token; always honor only the latest generation/token.
+- [ ] On reconnect, a fresh update still triggers a new fetch.
+- [ ] Errors in read-state fetches must not kill the selected-wave subscription. They should set a soft-failure state in the model (e.g. `readStateKnown=false` + a quiet status note) but keep the live wave panel intact.
+- [ ] Re-project the model on each read-state success so the view picks up the new fields.
+
+### Task 6: Update Model + Projector + View
+
+- [ ] Add `unreadCount`, `totalBlipCount`, `isRead`, `readStateKnown` fields to `J2clSelectedWaveModel`.
+- [ ] Update factory methods to carry prior read-state forward (prevents "flash to digest" on reconnect).
+- [ ] In `J2clSelectedWaveProjector`:
+  - Accept the optional `SidecarSelectedWaveReadState`.
+  - Prefer server data when `readStateKnown` is true, else fall back to digest metadata (matching today's behavior).
+  - When neither is available, render empty unread text (not a false "Selected digest is read.").
+- [ ] In `J2clSelectedWaveView`, keep the DOM structure; rely solely on `model.getUnreadText()` for rendering.
+
+### Task 7: Live-Update Proof And Reconnect
+
+- [ ] Controller test: simulate two consecutive updates and verify two read-state fetches (one per generation-preserving update), each re-projecting the model.
+- [ ] Controller test: simulate a reconnect — ensure a fresh fetch is triggered after the post-reconnect first update.
+- [ ] Controller test: simulate an error from the read-state endpoint and verify the selected-wave panel remains live and the model flips to `readStateKnown=false` without clobbering visible content.
+- [ ] Browser verification: open a wave with known unread blips, observe the `"N unread"` label reflecting the real server state; read the blips in another browser tab to bump the UDW; observe the J2CL panel's unread count updating live after the next `ProtocolWaveletUpdate`.
+
+### Task 8: Preserve Legacy Root And Record Traceability
+
+- [ ] Re-run `sbt -batch compileGwt Universal/stage` to prove the legacy GWT root path still compiles and stages.
+- [ ] Run `sbt -batch j2clSearchBuild j2clSearchTest` for the sidecar gates.
+- [ ] Run the targeted server-side test suite for the new servlet: `sbt -batch "testOnly *SelectedWaveReadState*"`.
+- [ ] Record in `journal/local-verification/2026-04-23-issue-931-j2cl-unread-read-state.md`: exact commands executed, server boot port, browser steps, and observed unread counts.
+- [ ] Mirror key verification and review findings into the GitHub issue comments and PR body.
+
+## 5. Exact Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-931-unread-read-state`.
+
+### Targeted Unit / Integration Gates
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+sbt -batch "testOnly *SelectedWaveReadState* *J2clSelectedWave*"
+sbt -batch "testOnly *SidecarTransportCodec*"
+```
+
+Expected:
+- sidecar search build stays green,
+- new servlet + helper tests pass,
+- projector, controller, and codec tests cover the new read-state seam,
+- no prior tests regress.
+
+### Legacy Root Compile / Stage Gate
+
+```bash
+sbt -batch compileGwt Universal/stage
+```
+
+Expected: legacy GWT root still compiles and the staged package still builds.
+
+### Fresh Worktree File-Store Prep
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Expected: `wave/_accounts`, `wave/_attachments`, `wave/_deltas` are available in the worktree.
+
+### Local Boot + Smoke
+
+```bash
+bash scripts/worktree-boot.sh --port 9931
+```
+
+Then run the printed helper commands:
+
+```bash
+PORT=9931 bash scripts/wave-smoke.sh start
+PORT=9931 bash scripts/wave-smoke.sh check
+curl -sS -I http://localhost:9931/
+curl -sS -I http://localhost:9931/j2cl-search/index.html
+```
+
+### Read-State Endpoint Smoke
+
+```bash
+# After logging in via the browser and copying JSESSIONID:
+curl -sS -H 'Cookie: JSESSIONID=<token>' \
+  "http://localhost:9931/read-state/?waveId=<test-wave-id>"
+```
+
+Expected: JSON body with the authenticated user's per-wave unread count.
+
+### Manual Browser Verification
+
+- Register or log in, then visit `/j2cl-search/index.html`.
+- Open a wave that has unread blips; verify the unread label reflects the real server count, not a stale digest number.
+- In a second browser/session as another participant, add a blip; verify the J2CL selected-wave panel increments the unread count after the next update.
+- Mark the wave as read (via the legacy client or by reading blips that bump UDW); verify the J2CL panel's unread state updates within one update cycle.
+- Force a disconnect (browser devtools → Network → Offline); wait for reconnect; verify read state re-hydrates.
+- Verify the legacy `/` route remains usable and unchanged.
+
+Record exact commands + observed outputs in `journal/local-verification/2026-04-23-issue-931-j2cl-unread-read-state.md`.
+
+## 6. Review / PR Expectations
+
+- Run Claude Opus 4.7 plan review before implementation starts.
+- After implementation: run Claude Opus 4.7 implementation review. Address every finding that is technically valid, including nits and out-of-diff observations that reflect real risk.
+- Resolve review threads only after replying with the actual fix commit or technical reasoning.
+- Keep commits focused; avoid mixing unrelated renames or refactors.
+- Commit messages and PR body must link back to #931 and cite the plan path.
+
+## 7. Definition Of Done
+
+- `/read-state` endpoint exists, returns per-user unread state for a wave, and is covered by server-side tests.
+- The J2CL sidecar selected-wave panel shows server-authoritative unread/read state after open, after each update, and after reconnect.
+- The legacy GWT root path still compiles, stages, boots, and smokes green.
+- `sbt j2clSearchBuild j2clSearchTest`, `sbt compileGwt Universal/stage`, and the new targeted tests all pass.
+- Browser verification demonstrates live unread count changes in response to real UDW changes.
+- GitHub Issue #931 comment contains: worktree path, branch, plan path, commit SHAs, verification commands + results, review outcomes, PR link.
+- Implementation review outcomes (Claude Opus 4.7) are recorded on the issue or PR.

--- a/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
+++ b/docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md
@@ -25,7 +25,7 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 
 ### In Scope
 
-- Add a server HTTP endpoint that returns `{waveId, unreadCount, totalBlipCount, isRead}` for the authenticated participant, computed via the existing `WaveDigester` + `SimpleSearchProviderImpl.WaveSupplementContext` path.
+- Add a server HTTP endpoint that returns `{waveId, unreadCount, isRead}` for the authenticated participant, computed via the existing `WaveDigester` + package-level `WaveSupplementContext` path.
 - Wire the new endpoint into the Jakarta servlet registry beside the existing `/search/*` mapping.
 - Extend `J2clSearchGateway` with a `fetchSelectedWaveReadState(waveId, onSuccess, onError)` helper that calls the new endpoint.
 - Update `J2clSelectedWaveController` to fetch read state after a successful open, after each non-establishment `ProtocolWaveletUpdate`, and after a reconnect.
@@ -56,19 +56,20 @@ The narrow root cause is therefore: the sidecar has no path to the per-user unre
 ### Server (Common)
 
 - **New:** `wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java`
-  - Package-visible helper, same package as `SimpleSearchProviderImpl`, so it can reuse the package-private `WaveSupplementContext`.
-  - Constructor is Guice-injectable: takes `WaveMap`, `WaveDigester`, `SharedDomainParticipantProvider`-equivalents already used by the search path.
+  - Package-visible helper, same package as `SimpleSearchProviderImpl`, so it can reuse the existing top-level `WaveSupplementContext` (`wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveSupplementContext.java`) and the package-private construction helpers.
+  - Constructor is Guice-injectable: takes `WaveMap`, `WaveDigester`, and whatever shared-domain participant helpers the search path already uses.
   - Public API exposes only `Result computeReadState(ParticipantId user, WaveId waveId)` returning `{unreadCount, isRead, accessAllowed, exists}`. No internal types leak.
   - Data loading: the helper uses `WaveMap.lookupWavelets(waveId)` + `WaveMap.getWavelet(WaveletName).copyWaveletData()` — the same path `AbstractSearchProviderImpl.buildWaveViewData` (`wave/src/main/java/org/waveprotocol/box/server/waveserver/AbstractSearchProviderImpl.java:123-148`) already uses. This returns `ObservableWaveletData`, which the existing supplement/digester path consumes. Do NOT use `WaveletProvider.getSnapshot` — that returns `CommittedWaveletSnapshot` wrapping `ReadableWaveletData`, which the supplement stack cannot consume.
+  - `WaveMap` null/exception semantics: `lookupWavelets(waveId)` throws `WaveletStateException` on persistence errors; `getWavelet(WaveletName)` returns `null` for non-existent wavelets; `copyWaveletData()` throws if the container is not loaded. The helper null-checks every container, catches `WaveletStateException`, and maps any of those to `Result.notFound()` so non-existence is not distinguishable from access denial.
   - Access check: before counting, the helper must verify the authenticated user is a participant of the conversational wavelet (explicit participant or shared-domain), reusing the same predicate used by search (`AbstractSearchProviderImpl.isWaveletMatchesCriteria` style). If access is denied, the helper returns `accessAllowed=false` and the servlet responds with the same 404 it would use for an unknown wave so existence cannot be probed.
-  - `SimpleSearchProviderImpl.java` itself stays unchanged; the helper duplicates the minimal construction logic of its internal `WaveSupplementContext` rather than widening `SimpleSearchProviderImpl`'s public surface.
+  - `SimpleSearchProviderImpl.java` itself stays unchanged; the helper reuses the existing `WaveSupplementContext` type and duplicates only the minimal construction logic rather than widening `SimpleSearchProviderImpl`'s public surface.
 
 ### J2CL Sidecar
 
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java` (new)
   - Immutable DTO: `{waveId, unreadCount, isRead}`. Ordering + generation tracking live entirely in the controller (via `readStateFetchSeq`); they do not need to be carried on the DTO.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
-  - Add `decodeSelectedWaveReadState(String json)` decoder for the new endpoint response.
+  - Add `decodeSelectedWaveReadState(String json)` decoder. Reads `waveId`, `unreadCount`, `isRead` only.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
   - Add `fetchSelectedWaveReadState(String waveId, SuccessCallback<SidecarSelectedWaveReadState>, ErrorCallback)` using the existing `requestText` XHR helper.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
@@ -109,6 +110,27 @@ public final class J2clSearchGateway
         socket.close();
       }
     };
+  }
+
+  @Override
+  public void fetchSelectedWaveReadState(
+      String waveId,
+      J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    if (waveId == null || waveId.isEmpty()) {
+      onError.accept("Wave id is required for the read-state fetch.");
+      return;
+    }
+    requestText(
+        "/read-state?waveId=" + encodeUriComponent(waveId),
+        text -> {
+          try {
+            onSuccess.accept(SidecarTransportCodec.decodeSelectedWaveReadState(text));
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to decode the selected-wave read state."));
+          }
+        },
+        onError);
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
@@ -10,6 +11,10 @@ public final class J2clSelectedWaveController
   // Keep retries bounded, but leave enough budget for a local WIAB restart on the same port.
   private static final int MAX_RECONNECT_DELAY_MS = 2000;
   private static final int MAX_RECONNECT_ATTEMPTS = 8;
+  // Trailing-edge debounce for per-update read-state fetches. Short enough to
+  // feel live, long enough to coalesce server-initiated flurries without
+  // amplifying HTTP pressure.
+  private static final int READ_STATE_DEBOUNCE_MS = 250;
 
   public interface Gateway {
     void fetchRootSessionBootstrap(
@@ -22,6 +27,16 @@ public final class J2clSelectedWaveController
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
         J2clSearchPanelController.ErrorCallback onError,
         Runnable onDisconnect);
+
+    /**
+     * Fetches the authenticated user's unread/read state for the given wave.
+     * Errors must not terminate the selected-wave subscription — the caller
+     * preserves the prior read state and flips a soft "stale" flag instead.
+     */
+    void fetchSelectedWaveReadState(
+        String waveId,
+        J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
   }
 
   public interface View {
@@ -32,8 +47,22 @@ public final class J2clSelectedWaveController
     void scheduleRetry(int delayMs, Runnable action);
   }
 
+  /**
+   * Dedicated scheduler for the read-state fetch debounce — kept separate from
+   * {@link RetryScheduler} so reconnect tests can observe the reconnect delay
+   * sequence without being polluted by the per-update debounce timer.
+   */
+  public interface ReadStateFetchScheduler {
+    void scheduleFetch(int delayMs, Runnable action);
+  }
+
   public interface Subscription {
     void close();
+  }
+
+  /** Registers a callback invoked when the browser tab returns to visible. */
+  public interface VisibilitySource {
+    void addVisibilityListener(Runnable onVisible);
   }
 
   @FunctionalInterface
@@ -44,6 +73,7 @@ public final class J2clSelectedWaveController
   private final Gateway gateway;
   private final View view;
   private final RetryScheduler retryScheduler;
+  private final ReadStateFetchScheduler readStateFetchScheduler;
   private final WriteSessionListener writeSessionListener;
   private Subscription currentSubscription;
   private SidecarSessionBootstrap currentBootstrap;
@@ -53,17 +83,45 @@ public final class J2clSelectedWaveController
   private J2clSelectedWaveModel currentModel;
   private int reconnectCount;
   private int requestGeneration;
+  private SidecarSelectedWaveReadState currentReadState;
+  private boolean readStateStale;
+  private int readStateFetchSeq;
+  private int latestReadStateApplied;
+  private int pendingDebounceToken;
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
     this(
         gateway,
         view,
-        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs),
-        null);
+        defaultRetryScheduler(),
+        defaultReadStateFetchScheduler(),
+        null,
+        defaultVisibilitySource());
   }
 
   public J2clSelectedWaveController(Gateway gateway, View view, RetryScheduler retryScheduler) {
-    this(gateway, view, retryScheduler, null);
+    this(
+        gateway,
+        view,
+        retryScheduler,
+        defaultReadStateFetchScheduler(),
+        null,
+        defaultVisibilitySource());
+  }
+
+  /** Test-friendly constructor: explicit reconnect + read-state schedulers. */
+  public J2clSelectedWaveController(
+      Gateway gateway,
+      View view,
+      RetryScheduler retryScheduler,
+      ReadStateFetchScheduler readStateFetchScheduler) {
+    this(
+        gateway,
+        view,
+        retryScheduler,
+        readStateFetchScheduler,
+        null,
+        null);
   }
 
   public J2clSelectedWaveController(
@@ -71,8 +129,10 @@ public final class J2clSelectedWaveController
     this(
         gateway,
         view,
-        (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs),
-        writeSessionListener);
+        defaultRetryScheduler(),
+        defaultReadStateFetchScheduler(),
+        writeSessionListener,
+        defaultVisibilitySource());
   }
 
   public J2clSelectedWaveController(
@@ -80,13 +140,33 @@ public final class J2clSelectedWaveController
       View view,
       RetryScheduler retryScheduler,
       WriteSessionListener writeSessionListener) {
+    this(
+        gateway,
+        view,
+        retryScheduler,
+        defaultReadStateFetchScheduler(),
+        writeSessionListener,
+        defaultVisibilitySource());
+  }
+
+  public J2clSelectedWaveController(
+      Gateway gateway,
+      View view,
+      RetryScheduler retryScheduler,
+      ReadStateFetchScheduler readStateFetchScheduler,
+      WriteSessionListener writeSessionListener,
+      VisibilitySource visibilitySource) {
     this.gateway = gateway;
     this.view = view;
     this.retryScheduler = retryScheduler;
+    this.readStateFetchScheduler = readStateFetchScheduler;
     this.writeSessionListener = writeSessionListener;
     this.currentModel = J2clSelectedWaveModel.empty();
     this.view.render(currentModel);
     publishWriteSession();
+    if (visibilitySource != null) {
+      visibilitySource.addVisibilityListener(this::onVisible);
+    }
   }
 
   public void onWaveSelected(String waveId) {
@@ -115,7 +195,13 @@ public final class J2clSelectedWaveController
       if (lastUpdate != null) {
         currentModel =
             J2clSelectedWaveProjector.project(
-                selectedWaveId, selectedDigestItem, lastUpdate, currentModel, reconnectCount);
+                selectedWaveId,
+                selectedDigestItem,
+                lastUpdate,
+                currentModel,
+                reconnectCount,
+                currentReadState,
+                readStateStale);
         view.render(currentModel);
         publishWriteSession();
       }
@@ -124,6 +210,7 @@ public final class J2clSelectedWaveController
 
     int generation = ++requestGeneration;
     closeSubscription();
+    resetReadStateFetchTracking();
 
     if (waveId == null || waveId.isEmpty()) {
       selectedWaveId = null;
@@ -131,6 +218,8 @@ public final class J2clSelectedWaveController
       currentBootstrap = null;
       lastUpdate = null;
       reconnectCount = 0;
+      currentReadState = null;
+      readStateStale = false;
       currentModel = J2clSelectedWaveModel.empty();
       view.render(currentModel);
       publishWriteSession();
@@ -141,6 +230,8 @@ public final class J2clSelectedWaveController
     selectedDigestItem = digestItem;
     lastUpdate = null;
     reconnectCount = 0;
+    currentReadState = null;
+    readStateStale = false;
     fetchBootstrapAndOpenSelectedWave(generation, 0, false);
   }
 
@@ -150,7 +241,8 @@ public final class J2clSelectedWaveController
       return;
     }
     this.reconnectCount = reconnectCount;
-    currentModel = J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount);
+    currentModel =
+        J2clSelectedWaveModel.loading(selectedWaveId, selectedDigestItem, reconnectCount, currentModel);
     view.render(currentModel);
     publishWriteSession();
     gateway.fetchRootSessionBootstrap(
@@ -173,7 +265,11 @@ public final class J2clSelectedWaveController
           }
           currentModel =
               J2clSelectedWaveModel.error(
-                  selectedWaveId, selectedDigestItem, "Unable to open selected wave.", error);
+                  selectedWaveId,
+                  selectedDigestItem,
+                  "Unable to open selected wave.",
+                  error,
+                  currentModel);
           view.render(currentModel);
           publishWriteSession();
         });
@@ -202,11 +298,14 @@ public final class J2clSelectedWaveController
                       selectedDigestItem,
                       update,
                       currentModel,
-                      projectedReconnectCount);
+                      projectedReconnectCount,
+                      currentReadState,
+                      readStateStale);
               view.render(currentModel);
               publishWriteSession();
               activeReconnectCount[0] = 0;
               this.reconnectCount = projectedReconnectCount;
+              scheduleReadStateFetch(generation);
             },
             error -> {
               if (!isCurrentGeneration(generation)) {
@@ -223,7 +322,11 @@ public final class J2clSelectedWaveController
               }
               currentModel =
                   J2clSelectedWaveModel.error(
-                      selectedWaveId, selectedDigestItem, "Selected wave stream failed.", error);
+                      selectedWaveId,
+                      selectedDigestItem,
+                      "Selected wave stream failed.",
+                      error,
+                      currentModel);
               view.render(currentModel);
               publishWriteSession();
             },
@@ -249,7 +352,8 @@ public final class J2clSelectedWaveController
               "Selected wave disconnected.",
               "The selected-wave sidecar stopped retrying after "
                   + MAX_RECONNECT_ATTEMPTS
-                  + " reconnect attempts.");
+                  + " reconnect attempts.",
+              currentModel);
       view.render(currentModel);
       publishWriteSession();
       return;
@@ -297,5 +401,111 @@ public final class J2clSelectedWaveController
     if (writeSessionListener != null) {
       writeSessionListener.onWriteSessionChanged(currentModel.getWriteSession());
     }
+  }
+
+  // --- Read-state fetch orchestration ----------------------------------------
+
+  private void scheduleReadStateFetch(int generation) {
+    final int scheduledGeneration = generation;
+    final int scheduledToken = ++pendingDebounceToken;
+    readStateFetchScheduler.scheduleFetch(
+        READ_STATE_DEBOUNCE_MS,
+        () -> {
+          if (scheduledToken != pendingDebounceToken) {
+            return;
+          }
+          if (!isCurrentGeneration(scheduledGeneration)) {
+            return;
+          }
+          dispatchReadStateFetch();
+        });
+  }
+
+  private void cancelPendingReadStateDebounce() {
+    // Bumping the token is enough: any pending callback checks the token and
+    // no-ops, which keeps the scheduling seam identical for both the reconnect
+    // and read-state fetch paths.
+    pendingDebounceToken++;
+  }
+
+  private void dispatchReadStateFetch() {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return;
+    }
+    final int thisFetchSeq = ++readStateFetchSeq;
+    final int dispatchGeneration = requestGeneration;
+    gateway.fetchSelectedWaveReadState(
+        selectedWaveId,
+        readState -> {
+          if (thisFetchSeq <= latestReadStateApplied) {
+            return;
+          }
+          if (!isCurrentGeneration(dispatchGeneration)) {
+            return;
+          }
+          latestReadStateApplied = thisFetchSeq;
+          currentReadState = readState;
+          readStateStale = false;
+          applyReadStateToModel();
+        },
+        error -> {
+          if (thisFetchSeq <= latestReadStateApplied) {
+            return;
+          }
+          if (!isCurrentGeneration(dispatchGeneration)) {
+            return;
+          }
+          latestReadStateApplied = thisFetchSeq;
+          // Preserve the prior read-state value; only raise the "stale" flag so
+          // the panel keeps displaying the last known count rather than flapping
+          // back to the digest fallback on a transient endpoint failure.
+          if (currentReadState != null) {
+            readStateStale = true;
+            applyReadStateToModel();
+          }
+        });
+  }
+
+  private void applyReadStateToModel() {
+    currentModel =
+        J2clSelectedWaveProjector.reprojectReadState(
+            currentModel, selectedDigestItem, currentReadState, readStateStale);
+    view.render(currentModel);
+    publishWriteSession();
+  }
+
+  private void resetReadStateFetchTracking() {
+    cancelPendingReadStateDebounce();
+    // Bump seq so any in-flight response is ignored.
+    latestReadStateApplied = ++readStateFetchSeq;
+  }
+
+  private void onVisible() {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return;
+    }
+    // Closes the UDW-only-change gap: reading the wave in a second tab bumps the
+    // UDW but never emits a conv+root update for this socket, so the per-update
+    // refetch would never fire. Visibility-driven refresh catches it cheaply.
+    scheduleReadStateFetch(requestGeneration);
+  }
+
+  private static RetryScheduler defaultRetryScheduler() {
+    return (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+  }
+
+  private static ReadStateFetchScheduler defaultReadStateFetchScheduler() {
+    return (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+  }
+
+  private static VisibilitySource defaultVisibilitySource() {
+    return onVisible ->
+        DomGlobal.document.addEventListener(
+            "visibilitychange",
+            event -> {
+              if (!"hidden".equals(DomGlobal.document.visibilityState)) {
+                onVisible.run();
+              }
+            });
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -434,6 +434,7 @@ public final class J2clSelectedWaveController
     }
     final int thisFetchSeq = ++readStateFetchSeq;
     final int dispatchGeneration = requestGeneration;
+    final String dispatchWaveId = selectedWaveId;
     gateway.fetchSelectedWaveReadState(
         selectedWaveId,
         readState -> {
@@ -441,6 +442,15 @@ public final class J2clSelectedWaveController
             return;
           }
           if (!isCurrentGeneration(dispatchGeneration)) {
+            return;
+          }
+          if (readState != null
+              && readState.getWaveId() != null
+              && !readState.getWaveId().isEmpty()
+              && !readState.getWaveId().equals(dispatchWaveId)) {
+            // Defense in depth — the generation + seq guards above already cover
+            // the cross-selection case, but a mismatched waveId is a red flag
+            // worth surfacing as a drop rather than silently trusting the body.
             return;
           }
           latestReadStateApplied = thisFetchSeq;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.List;
 
 public final class J2clSelectedWaveModel {
+  public static final int UNKNOWN_UNREAD_COUNT = -1;
+
   private final boolean hasSelection;
   private final boolean loading;
   private final boolean error;
@@ -18,6 +20,10 @@ public final class J2clSelectedWaveModel {
   private final List<String> participantIds;
   private final List<String> contentEntries;
   private final J2clSidecarWriteSession writeSession;
+  private final int unreadCount;
+  private final boolean read;
+  private final boolean readStateKnown;
+  private final boolean readStateStale;
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -32,7 +38,11 @@ public final class J2clSelectedWaveModel {
       int reconnectCount,
       List<String> participantIds,
       List<String> contentEntries,
-      J2clSidecarWriteSession writeSession) {
+      J2clSidecarWriteSession writeSession,
+      int unreadCount,
+      boolean read,
+      boolean readStateKnown,
+      boolean readStateStale) {
     this.hasSelection = hasSelection;
     this.loading = loading;
     this.error = error;
@@ -52,6 +62,10 @@ public final class J2clSelectedWaveModel {
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(contentEntries));
     this.writeSession = writeSession;
+    this.unreadCount = unreadCount;
+    this.read = read;
+    this.readStateKnown = readStateKnown;
+    this.readStateStale = readStateStale;
   }
 
   public static J2clSelectedWaveModel empty() {
@@ -68,11 +82,22 @@ public final class J2clSelectedWaveModel {
         0,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
-        null);
+        null,
+        UNKNOWN_UNREAD_COUNT,
+        false,
+        false,
+        false);
   }
 
   public static J2clSelectedWaveModel loading(
-      String selectedWaveId, J2clSearchDigestItem digestItem, int reconnectCount) {
+      String selectedWaveId,
+      J2clSearchDigestItem digestItem,
+      int reconnectCount,
+      J2clSelectedWaveModel previous) {
+    int prevUnreadCount =
+        previous == null ? UNKNOWN_UNREAD_COUNT : previous.getUnreadCount();
+    boolean prevRead = previous != null && previous.isRead();
+    boolean prevKnown = previous != null && previous.isReadStateKnown();
     return new J2clSelectedWaveModel(
         true,
         true,
@@ -80,7 +105,7 @@ public final class J2clSelectedWaveModel {
         selectedWaveId,
         resolveTitle(selectedWaveId, digestItem),
         resolveSnippet(digestItem),
-        resolveUnreadText(digestItem),
+        resolveUnreadText(digestItem, prevUnreadCount, prevRead, prevKnown),
         reconnectCount > 0 ? "Reconnecting selected wave." : "Opening selected wave.",
         reconnectCount > 0
             ? "Reusing the current session after a disconnect."
@@ -88,11 +113,23 @@ public final class J2clSelectedWaveModel {
         reconnectCount,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
-        null);
+        null,
+        prevUnreadCount,
+        prevRead,
+        prevKnown,
+        prevKnown);
   }
 
   public static J2clSelectedWaveModel error(
-      String selectedWaveId, J2clSearchDigestItem digestItem, String statusText, String detailText) {
+      String selectedWaveId,
+      J2clSearchDigestItem digestItem,
+      String statusText,
+      String detailText,
+      J2clSelectedWaveModel previous) {
+    int prevUnreadCount =
+        previous == null ? UNKNOWN_UNREAD_COUNT : previous.getUnreadCount();
+    boolean prevRead = previous != null && previous.isRead();
+    boolean prevKnown = previous != null && previous.isReadStateKnown();
     return new J2clSelectedWaveModel(
         true,
         false,
@@ -100,13 +137,17 @@ public final class J2clSelectedWaveModel {
         selectedWaveId,
         resolveTitle(selectedWaveId, digestItem),
         resolveSnippet(digestItem),
-        resolveUnreadText(digestItem),
+        resolveUnreadText(digestItem, prevUnreadCount, prevRead, prevKnown),
         statusText,
         detailText,
         0,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
-        null);
+        null,
+        prevUnreadCount,
+        prevRead,
+        prevKnown,
+        prevKnown);
   }
 
   private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {
@@ -120,12 +161,25 @@ public final class J2clSelectedWaveModel {
     return digestItem == null ? "" : digestItem.getSnippet();
   }
 
-  private static String resolveUnreadText(J2clSearchDigestItem digestItem) {
+  private static String resolveUnreadText(
+      J2clSearchDigestItem digestItem, int unreadCount, boolean read, boolean readStateKnown) {
+    if (readStateKnown) {
+      return formatUnreadText(unreadCount, read);
+    }
     if (digestItem == null) {
       return "";
     }
-    int unreadCount = digestItem.getUnreadCount();
-    return unreadCount <= 0 ? "Selected digest is read." : unreadCount + " unread in the selected digest.";
+    int digestUnreadCount = digestItem.getUnreadCount();
+    return digestUnreadCount <= 0
+        ? "Selected digest is read."
+        : digestUnreadCount + " unread in the selected digest.";
+  }
+
+  static String formatUnreadText(int unreadCount, boolean read) {
+    if (unreadCount <= 0 || read) {
+      return "Read.";
+    }
+    return unreadCount + " unread.";
   }
 
   public boolean hasSelection() {
@@ -178,5 +232,21 @@ public final class J2clSelectedWaveModel {
 
   public J2clSidecarWriteSession getWriteSession() {
     return writeSession;
+  }
+
+  public int getUnreadCount() {
+    return unreadCount;
+  }
+
+  public boolean isRead() {
+    return read;
+  }
+
+  public boolean isReadStateKnown() {
+    return readStateKnown;
+  }
+
+  public boolean isReadStateStale() {
+    return readStateStale;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -89,15 +89,21 @@ public final class J2clSelectedWaveModel {
         false);
   }
 
+  private static boolean sameWave(String selectedWaveId, J2clSelectedWaveModel previous) {
+    return previous != null && selectedWaveId != null
+        && selectedWaveId.equals(previous.getSelectedWaveId());
+  }
+
   public static J2clSelectedWaveModel loading(
       String selectedWaveId,
       J2clSearchDigestItem digestItem,
       int reconnectCount,
       J2clSelectedWaveModel previous) {
-    int prevUnreadCount =
-        previous == null ? UNKNOWN_UNREAD_COUNT : previous.getUnreadCount();
-    boolean prevRead = previous != null && previous.isRead();
-    boolean prevKnown = previous != null && previous.isReadStateKnown();
+    boolean sameWave = sameWave(selectedWaveId, previous);
+    int prevUnreadCount = sameWave ? previous.getUnreadCount() : UNKNOWN_UNREAD_COUNT;
+    boolean prevRead = sameWave && previous.isRead();
+    boolean prevKnown = sameWave && previous.isReadStateKnown();
+    boolean prevStale = sameWave && previous.isReadStateStale();
     return new J2clSelectedWaveModel(
         true,
         true,
@@ -117,7 +123,7 @@ public final class J2clSelectedWaveModel {
         prevUnreadCount,
         prevRead,
         prevKnown,
-        prevKnown);
+        prevStale);
   }
 
   public static J2clSelectedWaveModel error(
@@ -126,10 +132,11 @@ public final class J2clSelectedWaveModel {
       String statusText,
       String detailText,
       J2clSelectedWaveModel previous) {
-    int prevUnreadCount =
-        previous == null ? UNKNOWN_UNREAD_COUNT : previous.getUnreadCount();
-    boolean prevRead = previous != null && previous.isRead();
-    boolean prevKnown = previous != null && previous.isReadStateKnown();
+    boolean sameWave = sameWave(selectedWaveId, previous);
+    int prevUnreadCount = sameWave ? previous.getUnreadCount() : UNKNOWN_UNREAD_COUNT;
+    boolean prevRead = sameWave && previous.isRead();
+    boolean prevKnown = sameWave && previous.isReadStateKnown();
+    boolean prevStale = sameWave && previous.isReadStateStale();
     return new J2clSelectedWaveModel(
         true,
         false,
@@ -147,7 +154,7 @@ public final class J2clSelectedWaveModel {
         prevUnreadCount,
         prevRead,
         prevKnown,
-        prevKnown);
+        prevStale);
   }
 
   private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -52,10 +52,8 @@ public final class J2clSelectedWaveProjector {
     }
 
     String detailText = buildDetailText(update);
-    String statusText = reconnectCount > 0 ? "Live updates reconnected." : "Live updates connected.";
-    if (readStateStale) {
-      statusText = appendStatus(statusText, "Unread count may be stale.");
-    }
+    String baseStatusText =
+        reconnectCount > 0 ? "Live updates reconnected." : "Live updates connected.";
 
     int unreadCount;
     boolean read;
@@ -80,6 +78,14 @@ public final class J2clSelectedWaveProjector {
       read = false;
       readStateKnown = false;
     }
+
+    // Only surface the "stale" banner when we actually have a known read-state
+    // to be stale about — an initial fetch failure with no prior snapshot would
+    // otherwise claim the unread count is stale even though no count exists.
+    String statusText =
+        (readStateKnown && readStateStale)
+            ? appendStatus(baseStatusText, "Unread count may be stale.")
+            : baseStatusText;
 
     return new J2clSelectedWaveModel(
         true,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -64,7 +64,10 @@ public final class J2clSelectedWaveProjector {
         previous != null
             && selectedWaveId != null
             && selectedWaveId.equals(previous.getSelectedWaveId());
-    if (readState != null) {
+    boolean readStateMatchesWave = readState != null
+        && selectedWaveId != null
+        && selectedWaveId.equals(readState.getWaveId());
+    if (readStateMatchesWave) {
       unreadCount = Math.max(0, readState.getUnreadCount());
       read = readState.isRead() || unreadCount <= 0;
       readStateKnown = true;
@@ -116,7 +119,10 @@ public final class J2clSelectedWaveProjector {
     int unreadCount;
     boolean read;
     boolean readStateKnown;
-    if (readState != null) {
+    boolean readStateMatchesWave = readState != null
+        && previous.getSelectedWaveId() != null
+        && previous.getSelectedWaveId().equals(readState.getWaveId());
+    if (readStateMatchesWave) {
       unreadCount = Math.max(0, readState.getUnreadCount());
       read = readState.isRead() || unreadCount <= 0;
       readStateKnown = true;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -121,6 +121,14 @@ public final class J2clSelectedWaveProjector {
       read = previous.isRead();
       readStateKnown = previous.isReadStateKnown();
     }
+    String staleSuffix = " Unread count may be stale.";
+    String baseStatus = previous.getStatusText();
+    if (baseStatus.endsWith(staleSuffix)) {
+      baseStatus = baseStatus.substring(0, baseStatus.length() - staleSuffix.length());
+    }
+    String statusText = (readStateKnown && readStateStale)
+        ? appendStatus(baseStatus, "Unread count may be stale.")
+        : baseStatus;
     return new J2clSelectedWaveModel(
         previous.hasSelection(),
         previous.isLoading(),
@@ -129,7 +137,7 @@ public final class J2clSelectedWaveProjector {
         previous.getTitleText(),
         previous.getSnippetText(),
         resolveUnreadText(digestItem, unreadCount, read, readStateKnown),
-        previous.getStatusText(),
+        statusText,
         previous.getDetailText(),
         previous.getReconnectCount(),
         previous.getParticipantIds(),

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -78,7 +78,6 @@ public final class J2clSelectedWaveProjector {
       read = false;
       readStateKnown = false;
     }
-
     // Only surface the "stale" banner when we actually have a known read-state
     // to be stale about — an initial fetch failure with no prior snapshot would
     // otherwise claim the unread count is stale even though no count exists.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -60,11 +60,15 @@ public final class J2clSelectedWaveProjector {
     int unreadCount;
     boolean read;
     boolean readStateKnown;
+    boolean previousMatchesWave =
+        previous != null
+            && selectedWaveId != null
+            && selectedWaveId.equals(previous.getSelectedWaveId());
     if (readState != null) {
       unreadCount = Math.max(0, readState.getUnreadCount());
       read = readState.isRead() || unreadCount <= 0;
       readStateKnown = true;
-    } else if (previous != null && previous.isReadStateKnown()) {
+    } else if (previousMatchesWave && previous.isReadStateKnown()) {
       unreadCount = previous.getUnreadCount();
       read = previous.isRead();
       readStateKnown = true;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 
 public final class J2clSelectedWaveProjector {
@@ -18,6 +19,25 @@ public final class J2clSelectedWaveProjector {
       SidecarSelectedWaveUpdate update,
       J2clSelectedWaveModel previous,
       int reconnectCount) {
+    return project(selectedWaveId, digestItem, update, previous, reconnectCount, null, false);
+  }
+
+  /**
+   * Projects a selected-wave update, preferring the supplied per-user read
+   * state over digest metadata. {@code readState} may be {@code null} when the
+   * server has not yet responded; in that case the projector falls back to any
+   * prior read state carried on {@code previous}, and finally to digest
+   * metadata. {@code readStateStale} indicates that the last fetch failed — the
+   * numeric count stays, but callers can surface the staleness separately.
+   */
+  public static J2clSelectedWaveModel project(
+      String selectedWaveId,
+      J2clSearchDigestItem digestItem,
+      SidecarSelectedWaveUpdate update,
+      J2clSelectedWaveModel previous,
+      int reconnectCount,
+      SidecarSelectedWaveReadState readState,
+      boolean readStateStale) {
     List<String> participantIds = update.getParticipantIds();
     if (participantIds.isEmpty() && previous != null) {
       participantIds = previous.getParticipantIds();
@@ -33,6 +53,26 @@ public final class J2clSelectedWaveProjector {
 
     String detailText = buildDetailText(update);
     String statusText = reconnectCount > 0 ? "Live updates reconnected." : "Live updates connected.";
+    if (readStateStale) {
+      statusText = appendStatus(statusText, "Unread count may be stale.");
+    }
+
+    int unreadCount;
+    boolean read;
+    boolean readStateKnown;
+    if (readState != null) {
+      unreadCount = Math.max(0, readState.getUnreadCount());
+      read = readState.isRead() || unreadCount <= 0;
+      readStateKnown = true;
+    } else if (previous != null && previous.isReadStateKnown()) {
+      unreadCount = previous.getUnreadCount();
+      read = previous.isRead();
+      readStateKnown = true;
+    } else {
+      unreadCount = J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT;
+      read = false;
+      readStateKnown = false;
+    }
 
     return new J2clSelectedWaveModel(
         true,
@@ -41,13 +81,71 @@ public final class J2clSelectedWaveProjector {
         selectedWaveId,
         resolveTitle(selectedWaveId, digestItem),
         resolveSnippet(digestItem, contentEntries),
-        resolveUnreadText(digestItem),
+        resolveUnreadText(digestItem, unreadCount, read, readStateKnown),
         statusText,
         detailText,
         reconnectCount,
         participantIds,
         contentEntries,
-        buildWriteSession(selectedWaveId, update, previous));
+        buildWriteSession(selectedWaveId, update, previous),
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateKnown && readStateStale);
+  }
+
+  /**
+   * Re-projects the previous model with a new read-state snapshot. Used when a
+   * read-state fetch completes between selected-wave updates — there is no new
+   * {@link SidecarSelectedWaveUpdate} to feed into
+   * {@link #project(String, J2clSearchDigestItem, SidecarSelectedWaveUpdate,
+   * J2clSelectedWaveModel, int, SidecarSelectedWaveReadState, boolean)}.
+   */
+  public static J2clSelectedWaveModel reprojectReadState(
+      J2clSelectedWaveModel previous,
+      J2clSearchDigestItem digestItem,
+      SidecarSelectedWaveReadState readState,
+      boolean readStateStale) {
+    if (previous == null || !previous.hasSelection()) {
+      return previous;
+    }
+    int unreadCount;
+    boolean read;
+    boolean readStateKnown;
+    if (readState != null) {
+      unreadCount = Math.max(0, readState.getUnreadCount());
+      read = readState.isRead() || unreadCount <= 0;
+      readStateKnown = true;
+    } else {
+      unreadCount = previous.getUnreadCount();
+      read = previous.isRead();
+      readStateKnown = previous.isReadStateKnown();
+    }
+    return new J2clSelectedWaveModel(
+        previous.hasSelection(),
+        previous.isLoading(),
+        previous.isError(),
+        previous.getSelectedWaveId(),
+        previous.getTitleText(),
+        previous.getSnippetText(),
+        resolveUnreadText(digestItem, unreadCount, read, readStateKnown),
+        previous.getStatusText(),
+        previous.getDetailText(),
+        previous.getReconnectCount(),
+        previous.getParticipantIds(),
+        previous.getContentEntries(),
+        previous.getWriteSession(),
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateKnown && readStateStale);
+  }
+
+  private static String appendStatus(String base, String suffix) {
+    if (base == null || base.isEmpty()) {
+      return suffix;
+    }
+    return base + " " + suffix;
   }
 
   private static J2clSidecarWriteSession buildWriteSession(
@@ -209,13 +307,19 @@ public final class J2clSelectedWaveProjector {
     return contentEntries.isEmpty() ? "" : contentEntries.get(0);
   }
 
-  private static String resolveUnreadText(J2clSearchDigestItem digestItem) {
-    // #920 does not add a dedicated read-state transport field. The selected-wave panel can only
-    // surface unread status from the latest search digest metadata that selected this wave.
+  private static String resolveUnreadText(
+      J2clSearchDigestItem digestItem, int unreadCount, boolean read, boolean readStateKnown) {
+    if (readStateKnown) {
+      return J2clSelectedWaveModel.formatUnreadText(unreadCount, read);
+    }
+    // Digest fallback for the pre-fetch window only. Once the server responds,
+    // the authoritative copy above overwrites this.
     if (digestItem == null) {
       return "";
     }
-    int unreadCount = digestItem.getUnreadCount();
-    return unreadCount <= 0 ? "Selected digest is read." : unreadCount + " unread in the selected digest.";
+    int digestUnreadCount = digestItem.getUnreadCount();
+    return digestUnreadCount <= 0
+        ? "Selected digest is read."
+        : digestUnreadCount + " unread in the selected digest.";
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -69,6 +69,10 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     title.textContent = model.getTitleText();
     unread.textContent = model.getUnreadText();
     unread.hidden = model.getUnreadText().isEmpty();
+    unread.className =
+        model.isReadStateStale()
+            ? "sidecar-selected-unread sidecar-selected-unread-stale"
+            : "sidecar-selected-unread";
     status.className =
         model.isError()
             ? "sidecar-selected-status sidecar-selected-status-error"

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
@@ -1,0 +1,29 @@
+package org.waveprotocol.box.j2cl.transport;
+
+/**
+ * Per-user unread/read state for a single selected wave. Populated from the
+ * server's {@code /read-state} endpoint (issue #931).
+ */
+public final class SidecarSelectedWaveReadState {
+  private final String waveId;
+  private final int unreadCount;
+  private final boolean read;
+
+  public SidecarSelectedWaveReadState(String waveId, int unreadCount, boolean read) {
+    this.waveId = waveId;
+    this.unreadCount = unreadCount;
+    this.read = read;
+  }
+
+  public String getWaveId() {
+    return waveId;
+  }
+
+  public int getUnreadCount() {
+    return unreadCount;
+  }
+
+  public boolean isRead() {
+    return read;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -149,6 +149,14 @@ public final class SidecarTransportCodec {
             entries));
   }
 
+  public static SidecarSelectedWaveReadState decodeSelectedWaveReadState(String json) {
+    Map<String, Object> root = parseJsonObject(json);
+    String waveId = getString(root, "waveId");
+    int unreadCount = getInt(root, "unreadCount");
+    boolean read = getBoolean(root, "isRead");
+    return new SidecarSelectedWaveReadState(waveId, unreadCount, read);
+  }
+
   public static boolean decodeRpcFinishedFailed(Map<String, Object> envelope) {
     Map<String, Object> payload = asObject(envelope.get("message"));
     return getBoolean(payload, "1");

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -160,6 +160,11 @@ body {
   margin: 14px 0 0;
 }
 
+.sidecar-selected-unread-stale {
+  color: #7a99c8;
+  font-style: italic;
+}
+
 .sidecar-selected-status {
   color: #173355;
   font-weight: 700;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -13,6 +13,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
@@ -361,6 +362,117 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals("ZERO", writeSession.getHistoryHash());
   }
 
+  @Test
+  public void updateSchedulesReadStateFetchThatReplacesDigestUnreadText() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", digest("Wave A", "snippet", 3));
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "fresh content");
+
+    Assert.assertEquals(1, harness.pendingReadStateDispatches.size());
+    Assert.assertEquals(
+        "3 unread in the selected digest.", harness.modelValue("getUnreadText"));
+
+    harness.runPendingReadStateDispatch(0);
+    Assert.assertEquals(1, harness.readStateAttempts.size());
+
+    harness.resolveReadState(0, 5, false);
+    Assert.assertEquals("5 unread.", harness.modelValue("getUnreadText"));
+    Assert.assertEquals(5, harness.modelValue("getUnreadCount"));
+    Assert.assertTrue((Boolean) harness.modelValue("isReadStateKnown"));
+  }
+
+  @Test
+  public void readStateFetchFailureKeepsPriorCountAndFlagsStale() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", digest("Wave A", "snippet", 1));
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "content");
+    harness.runPendingReadStateDispatch(0);
+    harness.resolveReadState(0, 2, false);
+    Assert.assertEquals("2 unread.", harness.modelValue("getUnreadText"));
+
+    harness.deliverUpdate(0, "another content");
+    harness.runPendingReadStateDispatch(1);
+    harness.rejectReadState(1, "network blip");
+
+    Assert.assertEquals("2 unread.", harness.modelValue("getUnreadText"));
+    Assert.assertEquals(2, harness.modelValue("getUnreadCount"));
+    Assert.assertTrue((Boolean) harness.modelValue("isReadStateStale"));
+  }
+
+  @Test
+  public void outOfOrderReadStateResponsesOnlyApplyTheLatest() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "content A");
+    harness.runPendingReadStateDispatch(0);
+    Assert.assertEquals(1, harness.readStateAttempts.size());
+
+    harness.deliverUpdate(0, "content B");
+    harness.runPendingReadStateDispatch(1);
+    Assert.assertEquals(2, harness.readStateAttempts.size());
+
+    // Second fetch resolves first — becomes the latest applied.
+    harness.resolveReadState(1, 7, false);
+    Assert.assertEquals("7 unread.", harness.modelValue("getUnreadText"));
+
+    // First fetch resolves later with stale data — must be ignored.
+    harness.resolveReadState(0, 1, false);
+    Assert.assertEquals("7 unread.", harness.modelValue("getUnreadText"));
+    Assert.assertEquals(7, harness.modelValue("getUnreadCount"));
+  }
+
+  @Test
+  public void generationBumpDiscardsReadStateResponseFromPriorSelection() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+a", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "A content");
+    harness.runPendingReadStateDispatch(0);
+    Assert.assertEquals(1, harness.readStateAttempts.size());
+
+    harness.selectWave(controller, "example.com/w+b", null);
+    harness.resolveBootstrap(1);
+    harness.deliverUpdate(1, "B content");
+
+    // Stale response from wave+a arrives AFTER the re-selection to wave+b.
+    harness.resolveReadState(0, 9, false);
+
+    Assert.assertFalse((Boolean) harness.modelValue("isReadStateKnown"));
+    Assert.assertNotEquals(9, harness.modelValue("getUnreadCount"));
+  }
+
+  @Test
+  public void debounceCoalescesConsecutiveUpdatesIntoOneFetch() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "first");
+    harness.deliverUpdate(0, "second");
+    // Two dispatches queued because each deliverUpdate schedules one.
+    Assert.assertEquals(2, harness.pendingReadStateDispatches.size());
+
+    // Running the first: the debounce token has moved on, so this no-ops.
+    harness.runPendingReadStateDispatch(0);
+    Assert.assertEquals(0, harness.readStateAttempts.size());
+
+    // Running the latest dispatches exactly one fetch.
+    harness.runPendingReadStateDispatch(1);
+    Assert.assertEquals(1, harness.readStateAttempts.size());
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
@@ -373,6 +485,8 @@ public class J2clSelectedWaveControllerTest {
     private final List<Runnable> scheduledRetries = new ArrayList<Runnable>();
     private final List<BootstrapAttempt> bootstrapAttempts = new ArrayList<BootstrapAttempt>();
     private final List<OpenAttempt> openAttempts = new ArrayList<OpenAttempt>();
+    private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
+    private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private Object lastModel;
     private Method onWaveSelectedMethod;
     private Method onWaveSelectedWithDigestMethod;
@@ -421,6 +535,15 @@ public class J2clSelectedWaveControllerTest {
                         return null;
                       });
                 }
+                if ("fetchSelectedWaveReadState".equals(method.getName())) {
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> success =
+                      (J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState>) args[1];
+                  J2clSearchPanelController.ErrorCallback error =
+                      (J2clSearchPanelController.ErrorCallback) args[2];
+                  readStateAttempts.add(new ReadStateFetchAttempt((String) args[0], success, error));
+                  return null;
+                }
                 return null;
               });
 
@@ -435,24 +558,40 @@ public class J2clSelectedWaveControllerTest {
                 return null;
               });
 
-      Object controller;
-      if (withScheduler) {
-        Class<?> schedulerClass =
-            Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$RetryScheduler");
-        Object scheduler =
-            Proxy.newProxyInstance(
-                schedulerClass.getClassLoader(),
-                new Class<?>[] {schedulerClass},
-                (proxy, method, args) -> {
-                  scheduledDelays.add(((Number) args[0]).intValue());
-                  scheduledRetries.add((Runnable) args[1]);
-                  return null;
-                });
-        Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass, schedulerClass);
-        controller = constructor.newInstance(gateway, view, scheduler);
-      } else {
-        Constructor<?> constructor = controllerClass.getConstructor(gatewayClass, viewClass);
-        controller = constructor.newInstance(gateway, view);
+      Class<?> schedulerClass =
+          Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$RetryScheduler");
+      Class<?> readStateSchedulerClass =
+          Class.forName(
+              "org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$ReadStateFetchScheduler");
+      Object scheduler =
+          Proxy.newProxyInstance(
+              schedulerClass.getClassLoader(),
+              new Class<?>[] {schedulerClass},
+              (proxy, method, args) -> {
+                scheduledDelays.add(((Number) args[0]).intValue());
+                scheduledRetries.add((Runnable) args[1]);
+                return null;
+              });
+      Object readStateScheduler =
+          Proxy.newProxyInstance(
+              readStateSchedulerClass.getClassLoader(),
+              new Class<?>[] {readStateSchedulerClass},
+              (proxy, method, args) -> {
+                // Captures debounce dispatches so tests can control when the
+                // debounced fetch fires. Not mirrored into scheduledDelays to
+                // keep reconnect assertions clean.
+                pendingReadStateDispatches.add((Runnable) args[1]);
+                return null;
+              });
+      Constructor<?> constructor =
+          controllerClass.getConstructor(
+              gatewayClass, viewClass, schedulerClass, readStateSchedulerClass);
+      Object controller = constructor.newInstance(gateway, view, scheduler, readStateScheduler);
+      // The `withScheduler` flag is kept for call-site symmetry with legacy tests;
+      // the harness always wires a custom scheduler now so the implicit retry and
+      // debounce paths are never driven by the browser timer.
+      if (!withScheduler) {
+        // No-op: the constructor above supplies a scheduler regardless.
       }
       onWaveSelectedMethod = controllerClass.getMethod("onWaveSelected", String.class);
       onWaveSelectedWithDigestMethod =
@@ -494,6 +633,23 @@ public class J2clSelectedWaveControllerTest {
 
     private void runScheduledRetry(int index) {
       scheduledRetries.get(index).run();
+    }
+
+    private void runPendingReadStateDispatch(int index) {
+      pendingReadStateDispatches.get(index).run();
+    }
+
+    private void resolveReadState(int index, int unreadCount, boolean read) {
+      readStateAttempts
+          .get(index)
+          .success
+          .accept(
+              new SidecarSelectedWaveReadState(
+                  readStateAttempts.get(index).waveId, unreadCount, read));
+    }
+
+    private void rejectReadState(int index, String message) {
+      readStateAttempts.get(index).error.accept(message);
     }
 
     private void deliverUpdate(int index, String rawSnapshot) {
@@ -559,6 +715,21 @@ public class J2clSelectedWaveControllerTest {
     private BootstrapAttempt(
         J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success,
         J2clSearchPanelController.ErrorCallback error) {
+      this.success = success;
+      this.error = error;
+    }
+  }
+
+  private static final class ReadStateFetchAttempt {
+    private final String waveId;
+    private final J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> success;
+    private final J2clSearchPanelController.ErrorCallback error;
+
+    private ReadStateFetchAttempt(
+        String waveId,
+        J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> success,
+        J2clSearchPanelController.ErrorCallback error) {
+      this.waveId = waveId;
       this.success = success;
       this.error = error;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -453,6 +453,36 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void visibilityChangeTriggersReadStateFetchForActiveSelection() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createControllerWithVisibility(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "content");
+    harness.runPendingReadStateDispatch(0);
+    harness.resolveReadState(0, 1, false);
+    int baseline = harness.readStateAttempts.size();
+
+    harness.fireVisibilityVisible();
+    // visibilitychange schedules another debounce tick.
+    Assert.assertTrue(harness.pendingReadStateDispatches.size() >= 2);
+    harness.runPendingReadStateDispatch(harness.pendingReadStateDispatches.size() - 1);
+    Assert.assertEquals(baseline + 1, harness.readStateAttempts.size());
+  }
+
+  @Test
+  public void visibilityChangeWithoutSelectionIsHarmless() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createControllerWithVisibility(false);
+
+    harness.fireVisibilityVisible();
+
+    Assert.assertEquals(0, harness.pendingReadStateDispatches.size());
+    Assert.assertEquals(0, harness.readStateAttempts.size());
+  }
+
+  @Test
   public void debounceCoalescesConsecutiveUpdatesIntoOneFetch() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
@@ -487,11 +517,27 @@ public class J2clSelectedWaveControllerTest {
     private final List<OpenAttempt> openAttempts = new ArrayList<OpenAttempt>();
     private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
+    private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
     private Object lastModel;
     private Method onWaveSelectedMethod;
     private Method onWaveSelectedWithDigestMethod;
 
+    private Object createControllerWithVisibility(boolean withScheduler) throws Exception {
+      return createControllerInternal(withScheduler, /* injectVisibility= */ true);
+    }
+
     private Object createController(boolean withScheduler) throws Exception {
+      return createControllerInternal(withScheduler, /* injectVisibility= */ false);
+    }
+
+    private void fireVisibilityVisible() {
+      for (Runnable listener : visibilityListeners) {
+        listener.run();
+      }
+    }
+
+    private Object createControllerInternal(boolean withScheduler, boolean injectVisibility)
+        throws Exception {
       Class<?> controllerClass =
           Class.forName("org.waveprotocol.box.j2cl.search.J2clSelectedWaveController");
       Class<?> gatewayClass =
@@ -583,10 +629,41 @@ public class J2clSelectedWaveControllerTest {
                 pendingReadStateDispatches.add((Runnable) args[1]);
                 return null;
               });
-      Constructor<?> constructor =
-          controllerClass.getConstructor(
-              gatewayClass, viewClass, schedulerClass, readStateSchedulerClass);
-      Object controller = constructor.newInstance(gateway, view, scheduler, readStateScheduler);
+      Object controller;
+      if (injectVisibility) {
+        Class<?> visibilityClass =
+            Class.forName(
+                "org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$VisibilitySource");
+        Class<?> writeSessionListenerClass =
+            Class.forName(
+                "org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$WriteSessionListener");
+        Object visibility =
+            Proxy.newProxyInstance(
+                visibilityClass.getClassLoader(),
+                new Class<?>[] {visibilityClass},
+                (proxy, method, args) -> {
+                  if ("addVisibilityListener".equals(method.getName())) {
+                    visibilityListeners.add((Runnable) args[0]);
+                  }
+                  return null;
+                });
+        Constructor<?> constructor =
+            controllerClass.getConstructor(
+                gatewayClass,
+                viewClass,
+                schedulerClass,
+                readStateSchedulerClass,
+                writeSessionListenerClass,
+                visibilityClass);
+        controller =
+            constructor.newInstance(
+                gateway, view, scheduler, readStateScheduler, null, visibility);
+      } else {
+        Constructor<?> constructor =
+            controllerClass.getConstructor(
+                gatewayClass, viewClass, schedulerClass, readStateSchedulerClass);
+        controller = constructor.newInstance(gateway, view, scheduler, readStateScheduler);
+      }
       // The `withScheduler` flag is kept for call-site symmetry with legacy tests;
       // the harness always wires a custom scheduler now so the implicit retry and
       // debounce paths are never driven by the browser timer.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -20,5 +21,70 @@ public class J2clSelectedWaveModelCopyTest {
         J2clSelectedWaveModel.loading("example.com/w+1", null, 1, null);
 
     Assert.assertEquals("Reusing the current session after a disconnect.", model.getDetailText());
+  }
+
+  @Test
+  public void loadingSelectionDoesNotCarryReadStateAcrossWaveSwitch() {
+    J2clSelectedWaveModel previous =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            false,
+            "example.com/w+old",
+            "Old",
+            "",
+            "4 unread.",
+            "",
+            "",
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            null,
+            4,
+            false,
+            true,
+            false);
+
+    J2clSelectedWaveModel model =
+        J2clSelectedWaveModel.loading("example.com/w+new", null, 0, previous);
+
+    Assert.assertEquals(J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT, model.getUnreadCount());
+    Assert.assertFalse(model.isRead());
+    Assert.assertFalse(model.isReadStateKnown());
+  }
+
+  @Test
+  public void errorSelectionDoesNotCarryReadStateAcrossWaveSwitch() {
+    J2clSelectedWaveModel previous =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            false,
+            "example.com/w+old",
+            "Old",
+            "",
+            "Read.",
+            "",
+            "",
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            null,
+            0,
+            true,
+            true,
+            false);
+
+    J2clSelectedWaveModel model =
+        J2clSelectedWaveModel.error(
+            "example.com/w+new",
+            null,
+            "Failed",
+            "detail",
+            previous);
+
+    Assert.assertEquals(J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT, model.getUnreadCount());
+    Assert.assertFalse(model.isRead());
+    Assert.assertFalse(model.isReadStateKnown());
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
@@ -17,7 +17,7 @@ public class J2clSelectedWaveModelCopyTest {
   @Test
   public void loadingSelectionUsesSessionNeutralDisconnectCopy() {
     J2clSelectedWaveModel model =
-        J2clSelectedWaveModel.loading("example.com/w+1", null, 1);
+        J2clSelectedWaveModel.loading("example.com/w+1", null, 1, null);
 
     Assert.assertEquals("Reusing the current session after a disconnect.", model.getDetailText());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -114,6 +114,23 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("4 unread.", stale.getUnreadText());
   }
 
+  @Test
+  public void projectDoesNotAnnotateStaleStatusWhenReadStateIsUnknown() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 3),
+            sampleUpdate(),
+            null,
+            0,
+            null,
+            true);
+
+    Assert.assertFalse(projected.isReadStateKnown());
+    Assert.assertFalse(projected.isReadStateStale());
+    Assert.assertEquals("Live updates connected.", projected.getStatusText());
+  }
+
   // -- Write-session coupling (pre-existing) ----------------------------------
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -1,5 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
@@ -8,12 +10,111 @@ import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 
+@J2clTestInput(J2clSelectedWaveProjectorTest.class)
 public class J2clSelectedWaveProjectorTest {
   private static final String WAVE_ID = "example.com/w+1";
   private static final String WAVELET_NAME = "example.com!w+1/example.com!conv+root";
   private static final String CHANNEL_ID = "chan-1";
+
+  // -- Read-state projection (issue #931) -------------------------------------
+
+  @Test
+  public void projectUsesServerReadStateWhenPresent() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 2),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(WAVE_ID, 5, false),
+            false);
+
+    Assert.assertTrue(projected.isReadStateKnown());
+    Assert.assertEquals(5, projected.getUnreadCount());
+    Assert.assertEquals("5 unread.", projected.getUnreadText());
+  }
+
+  @Test
+  public void projectFallsBackToDigestWhenServerReadStateAbsent() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 3),
+            sampleUpdate(),
+            null,
+            0);
+
+    Assert.assertFalse(projected.isReadStateKnown());
+    Assert.assertEquals("3 unread in the selected digest.", projected.getUnreadText());
+  }
+
+  @Test
+  public void projectCarriesForwardPreviousServerReadStateAcrossUpdates() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(WAVE_ID, 2, false),
+            false);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            first,
+            0);
+
+    Assert.assertTrue(second.isReadStateKnown());
+    Assert.assertEquals(2, second.getUnreadCount());
+    Assert.assertEquals("2 unread.", second.getUnreadText());
+  }
+
+  @Test
+  public void projectRendersReadWhenServerReportsZero() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 7),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(WAVE_ID, 0, true),
+            false);
+
+    Assert.assertTrue(projected.isReadStateKnown());
+    Assert.assertTrue(projected.isRead());
+    Assert.assertEquals("Read.", projected.getUnreadText());
+  }
+
+  @Test
+  public void staleFlagPreservesPriorCountAndAnnotatesStatus() {
+    J2clSelectedWaveModel fresh =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(WAVE_ID, 4, false),
+            false);
+
+    J2clSelectedWaveModel stale =
+        J2clSelectedWaveProjector.reprojectReadState(fresh, null, null, true);
+
+    Assert.assertTrue(stale.isReadStateStale());
+    Assert.assertEquals(4, stale.getUnreadCount());
+    Assert.assertEquals("4 unread.", stale.getUnreadText());
+  }
+
+  // -- Write-session coupling (pre-existing) ----------------------------------
 
   @Test
   public void advancesWriteSessionWhenUpdateCarriesCoupledVersionAndHash() {
@@ -124,6 +225,26 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
   }
 
+  // -- Helpers ----------------------------------------------------------------
+
+  private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
+    return new J2clSearchDigestItem(
+        WAVE_ID, title, snippet, "user@example.com", unreadCount, 2, 1L, false);
+  }
+
+  private static SidecarSelectedWaveUpdate sampleUpdate() {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        WAVELET_NAME,
+        true,
+        CHANNEL_ID,
+        -1L,
+        null,
+        Arrays.asList("user@example.com"),
+        new ArrayList<SidecarSelectedWaveDocument>(),
+        null);
+  }
+
   private static SidecarSelectedWaveUpdate updateWithVersionAndHash(
       long resultingVersion, String resultingVersionHistoryHash) {
     return new SidecarSelectedWaveUpdate(
@@ -163,6 +284,10 @@ public class J2clSelectedWaveProjectorTest {
         0,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
-        writeSession);
+        writeSession,
+        J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+        false,
+        false,
+        false);
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -11,6 +11,29 @@ import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
 @J2clTestInput(SidecarTransportCodecTest.class)
 public class SidecarTransportCodecTest {
   @Test
+  public void decodeSelectedWaveReadStateReadsEndpointJson() {
+    String json =
+        "{\"waveId\":\"example.com/w+abc\",\"unreadCount\":4,\"isRead\":false}";
+
+    SidecarSelectedWaveReadState state = SidecarTransportCodec.decodeSelectedWaveReadState(json);
+
+    Assert.assertEquals("example.com/w+abc", state.getWaveId());
+    Assert.assertEquals(4, state.getUnreadCount());
+    Assert.assertFalse(state.isRead());
+  }
+
+  @Test
+  public void decodeSelectedWaveReadStateHandlesMissingOptionalFields() {
+    String json = "{\"waveId\":\"example.com/w+abc\"}";
+
+    SidecarSelectedWaveReadState state = SidecarTransportCodec.decodeSelectedWaveReadState(json);
+
+    Assert.assertEquals("example.com/w+abc", state.getWaveId());
+    Assert.assertEquals(0, state.getUnreadCount());
+    Assert.assertFalse(state.isRead());
+  }
+
+  @Test
   public void encodeOpenEnvelopeUsesGeneratedNumericFieldKeys() {
     SidecarOpenRequest request =
         new SidecarOpenRequest(

--- a/wave/config/changelog.d/2026-04-23-j2cl-selected-wave-unread-state.json
+++ b/wave/config/changelog.d/2026-04-23-j2cl-selected-wave-unread-state.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-23-j2cl-selected-wave-unread-state",
+  "version": "Issue #931",
+  "date": "2026-04-23",
+  "title": "J2CL Selected-Wave Unread/Read State",
+  "summary": "The J2CL sidecar's selected-wave panel now shows real per-user unread/read state that updates live.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Selected-wave panel replaces stale digest-derived unread text with server-authoritative unread counts",
+        "Unread count refreshes after each selected-wave update and after the tab returns to visible, so UDW-only read-state changes are reflected without a full reload"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -373,6 +373,7 @@ public class ServerMain {
     server.addServlet("/fetch/*", FetchServlet.class);
     server.addServlet("/fetch/version/*", VersionedFetchServlet.class);
     server.addServlet("/search/*", SearchServlet.class);
+    server.addServlet("/read-state/*", SelectedWaveReadStateServlet.class);
     server.addServlet("/dev/client-applier-stats", ClientApplierStatsJakartaServlet.class);
     server.addServlet("/healthz", HealthServlet.class);
     server.addServlet("/readyz", HealthServlet.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import com.google.inject.Inject;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.waveserver.SelectedWaveReadStateHelper;
+import org.waveprotocol.wave.model.id.InvalidIdException;
+import org.waveprotocol.wave.model.id.ModernIdSerialiser;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Serves per-user unread/read state for a single wave.
+ *
+ * <p>Request: {@code GET /read-state?waveId=<serialised-wave-id>}
+ * <p>Response body (200 OK): {@code {"waveId":"...","unreadCount":3,"isRead":false}}
+ *
+ * <p>Returns 403 for unauthenticated sessions, 400 for missing/malformed
+ * {@code waveId}, and 404 for unknown waves OR access-denied — the two cases
+ * are intentionally indistinguishable so non-participants cannot probe
+ * existence. Introduced for issue #931 as the server seam feeding the J2CL
+ * sidecar's selected-wave read-state display.
+ */
+@SuppressWarnings("serial")
+public final class SelectedWaveReadStateServlet extends HttpServlet {
+  private static final Log LOG = Log.get(SelectedWaveReadStateServlet.class);
+
+  private final SessionManager sessionManager;
+  private final SelectedWaveReadStateHelper helper;
+
+  @Inject
+  public SelectedWaveReadStateServlet(
+      SessionManager sessionManager, SelectedWaveReadStateHelper helper) {
+    this.sessionManager = sessionManager;
+    this.helper = helper;
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
+    if (user == null) {
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    String rawWaveId = req.getParameter("waveId");
+    if (rawWaveId == null || rawWaveId.isEmpty()) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "waveId is required");
+      return;
+    }
+
+    WaveId waveId;
+    try {
+      waveId = ModernIdSerialiser.INSTANCE.deserialiseWaveId(rawWaveId);
+    } catch (InvalidIdException e) {
+      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "waveId is malformed");
+      return;
+    }
+
+    SelectedWaveReadStateHelper.Result result;
+    try {
+      result = helper.computeReadState(user, waveId);
+    } catch (RuntimeException e) {
+      LOG.warning("read-state: unexpected failure for wave " + rawWaveId, e);
+      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Unable to compute read state.");
+      return;
+    }
+
+    if (!result.exists() || !result.accessAllowed()) {
+      resp.sendError(HttpServletResponse.SC_NOT_FOUND, "wave not found");
+      return;
+    }
+
+    writeJson(resp, rawWaveId, result.getUnreadCount(), result.isRead());
+  }
+
+  private static void writeJson(
+      HttpServletResponse resp, String waveId, int unreadCount, boolean isRead)
+      throws IOException {
+    resp.setStatus(HttpServletResponse.SC_OK);
+    resp.setContentType("application/json; charset=utf8");
+    resp.setHeader("Cache-Control", "no-store");
+    StringBuilder body = new StringBuilder(64);
+    body.append("{\"waveId\":\"").append(escapeJson(waveId)).append("\",\"unreadCount\":")
+        .append(unreadCount).append(",\"isRead\":").append(isRead).append('}');
+    try (var w = resp.getWriter()) {
+      w.append(body.toString());
+      w.flush();
+    }
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder out = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"': out.append("\\\""); break;
+        case '\\': out.append("\\\\"); break;
+        case '\b': out.append("\\b"); break;
+        case '\f': out.append("\\f"); break;
+        case '\n': out.append("\\n"); break;
+        case '\r': out.append("\\r"); break;
+        case '\t': out.append("\\t"); break;
+        default:
+          if (c < 0x20) {
+            out.append(String.format("\\u%04x", (int) c));
+          } else {
+            out.append(c);
+          }
+      }
+    }
+    return out.toString();
+  }
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -62,6 +62,9 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    // Per-user unread state must never be cached across requests.
+    resp.setHeader("Cache-Control", "no-store");
+
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
     if (user == null) {
       resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
@@ -70,7 +73,7 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
 
     String rawWaveId = req.getParameter("waveId");
     if (rawWaveId == null || rawWaveId.isEmpty()) {
-      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "waveId is required");
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;
     }
 
@@ -78,7 +81,7 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
     try {
       waveId = ModernIdSerialiser.INSTANCE.deserialiseWaveId(rawWaveId);
     } catch (InvalidIdException e) {
-      resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "waveId is malformed");
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;
     }
 
@@ -87,13 +90,14 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       result = helper.computeReadState(user, waveId);
     } catch (RuntimeException e) {
       LOG.warning("read-state: unexpected failure for wave " + rawWaveId, e);
-      resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-          "Unable to compute read state.");
+      resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
       return;
     }
 
     if (!result.exists() || !result.accessAllowed()) {
-      resp.sendError(HttpServletResponse.SC_NOT_FOUND, "wave not found");
+      // Collapse "unknown wave" and "access denied" into a single status with
+      // no body so non-participants cannot probe existence.
+      resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
       return;
     }
 
@@ -105,7 +109,6 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("application/json; charset=utf8");
-    resp.setHeader("Cache-Control", "no-store");
     StringBuilder body = new StringBuilder(64);
     body.append("{\"waveId\":\"").append(escapeJson(waveId)).append("\",\"unreadCount\":")
         .append(unreadCount).append(",\"isRead\":").append(isRead).append('}');

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -108,7 +108,7 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       HttpServletResponse resp, String waveId, int unreadCount, boolean isRead)
       throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
-    resp.setContentType("application/json; charset=utf8");
+    resp.setContentType("application/json; charset=utf-8");
     StringBuilder body = new StringBuilder(64);
     body.append("{\"waveId\":\"").append(escapeJson(waveId)).append("\",\"unreadCount\":")
         .append(unreadCount).append(",\"isRead\":").append(isRead).append('}');

--- a/wave/src/main/java/org/waveprotocol/box/server/waveletstate/segment/SegmentWaveletStateRegistry.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveletstate/segment/SegmentWaveletStateRegistry.java
@@ -32,14 +32,10 @@ import org.waveprotocol.wave.model.id.WaveletName;
  * - We use an access-order {@link LinkedHashMap} to implement an LRU with
  *   lightweight eviction (removeEldestEntry) and a timestamp per entry to
  *   enforce TTL expiration.
- * - The map is guarded by a {@link ReentrantReadWriteLock} (RW lock) rather
- *   than coarse-grained {@code synchronized} for two reasons:
- *   1) The hot path is read-dominant (get-then-check-expiry). A RW lock allows
- *      multiple readers to proceed concurrently under load, reducing
- *      contention compared to a single monitor.
- *   2) Eviction/expiry mutations are infrequent and short-lived; writes are
- *      held under the write lock only while touching the map, which keeps
- *      writer critical sections small.
+ * - The map is guarded by a {@link ReentrantReadWriteLock}. The read lock is
+ *   still useful for non-mutating helpers, but the access-order map means
+ *   {@link LinkedHashMap#get(Object)} mutates recency state, so cache reads
+ *   that touch the LRU must take the write lock.
  *
  * Trade-offs vs synchronized
  * --------------------------
@@ -137,13 +133,12 @@ public final class SegmentWaveletStateRegistry {
     }
   }
 
-  // Read path: try fast-path under read lock; if expired, fall back to a
-  // write-locked removal. We intentionally do not hold both locks to avoid
-  // upgrade deadlocks.
+  // Access-order LinkedHashMap#get mutates recency order, so the whole read
+  // path must run under the write lock.
   public static SegmentWaveletState get(WaveletName name) {
     if (name == null) return null;
     long now = System.currentTimeMillis();
-    RW.readLock().lock();
+    RW.writeLock().lock();
     try {
       Entry e = LRU.get(name);
       if (e == null) {
@@ -154,23 +149,13 @@ public final class SegmentWaveletStateRegistry {
         hits.incrementAndGet();
         return e.state;
       }
-    } finally {
-      RW.readLock().unlock();
-    }
-
-    // If expired, upgrade to write to remove and return null
-    RW.writeLock().lock();
-    try {
-      Entry e2 = LRU.get(name);
-      if (e2 != null && e2.expired(System.currentTimeMillis())) {
-        LRU.remove(name);
-        expirations.incrementAndGet();
-        misses.incrementAndGet();
-      }
+      LRU.remove(name);
+      expirations.incrementAndGet();
+      misses.incrementAndGet();
+      return null;
     } finally {
       RW.writeLock().unlock();
     }
-    return null;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -49,8 +49,6 @@ import org.waveprotocol.wave.util.logging.Log;
 public class SelectedWaveReadStateHelper {
 
   private static final Log LOG = Log.get(SelectedWaveReadStateHelper.class);
-
-
   /**
    * Outcome of a read-state computation. Non-existence and access-denied
    * collapse into the same {@link #notFound()} sentinel so the servlet can
@@ -122,19 +120,8 @@ public class SelectedWaveReadStateHelper {
       return Result.notFound();
     }
 
-    Function<ReadableWaveletData, Boolean> accessFilter =
-        new Function<ReadableWaveletData, Boolean>() {
-          @Override
-          public Boolean apply(ReadableWaveletData wavelet) {
-            if (IdUtil.isUserDataWavelet(user.getAddress(), wavelet.getWaveletId())) {
-              return Boolean.TRUE;
-            }
-            return WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId);
-          }
-        };
-    WaveViewData view =
-        AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, accessFilter, waveMap);
-    if (view == null || !hasAccessibleConversationalWavelet(view, user)) {
+    WaveViewData view = buildAccessibleWaveView(waveId, waveletIds, user);
+    if (view == null || !hasConversationalWavelet(view)) {
       return Result.notFound();
     }
 
@@ -147,12 +134,32 @@ public class SelectedWaveReadStateHelper {
     }
   }
 
-  private boolean hasAccessibleConversationalWavelet(WaveViewData view, ParticipantId user) {
+  private WaveViewData buildAccessibleWaveView(
+      WaveId waveId, ImmutableSet<WaveletId> waveletIds, final ParticipantId user) {
+    return AbstractSearchProviderImpl.buildWaveViewData(
+        waveId,
+        waveletIds,
+        new Function<ReadableWaveletData, Boolean>() {
+          @Override
+          public Boolean apply(ReadableWaveletData wavelet) {
+            if (wavelet == null) {
+              return Boolean.FALSE;
+            }
+            WaveletId waveletId = wavelet.getWaveletId();
+            if (IdUtil.isUserDataWavelet(user.getAddress(), waveletId)) {
+              return Boolean.TRUE;
+            }
+            return IdUtil.isConversationalId(waveletId)
+                && WaveletDataUtil.checkAccessPermission(
+                    wavelet, user, sharedDomainParticipantId);
+          }
+        },
+        waveMap);
+  }
+
+  private boolean hasConversationalWavelet(WaveViewData view) {
     for (ReadableWaveletData wavelet : view.getWavelets()) {
-      if (!IdUtil.isConversationalId(wavelet.getWaveletId())) {
-        continue;
-      }
-      if (WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId)) {
+      if (IdUtil.isConversationalId(wavelet.getWaveletId())) {
         return true;
       }
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -19,7 +19,6 @@
 
 package org.waveprotocol.box.server.waveserver;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -30,10 +29,13 @@ import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.model.wave.data.WaveViewData;
+import org.waveprotocol.wave.model.wave.data.impl.WaveViewDataImpl;
 import org.waveprotocol.wave.util.logging.Log;
 
 /**
@@ -135,26 +137,51 @@ public class SelectedWaveReadStateHelper {
   }
 
   private WaveViewData buildAccessibleWaveView(
-      WaveId waveId, ImmutableSet<WaveletId> waveletIds, final ParticipantId user) {
-    return AbstractSearchProviderImpl.buildWaveViewData(
-        waveId,
-        waveletIds,
-        new Function<ReadableWaveletData, Boolean>() {
-          @Override
-          public Boolean apply(ReadableWaveletData wavelet) {
-            if (wavelet == null) {
-              return Boolean.FALSE;
-            }
-            WaveletId waveletId = wavelet.getWaveletId();
-            if (IdUtil.isUserDataWavelet(user.getAddress(), waveletId)) {
-              return Boolean.TRUE;
-            }
-            return IdUtil.isConversationalId(waveletId)
-                && WaveletDataUtil.checkAccessPermission(
-                    wavelet, user, sharedDomainParticipantId);
-          }
-        },
-        waveMap);
+      WaveId waveId, ImmutableSet<WaveletId> waveletIds, ParticipantId user) {
+    // Build the view directly rather than via
+    // AbstractSearchProviderImpl.buildWaveViewData, which swallows
+    // WaveletStateException per wavelet. A swallowed conversational-wavelet
+    // failure could under-count unread state without surfacing the incident;
+    // propagating the exception lets the servlet return 500 for real backend
+    // faults while 404 stays reserved for unknown-wave/access-denied.
+    WaveViewData view = WaveViewDataImpl.create(waveId);
+    for (WaveletId waveletId : waveletIds) {
+      WaveletName waveletName = WaveletName.of(waveId, waveletId);
+      WaveletContainer container;
+      try {
+        container = waveMap.getWavelet(waveletName);
+      } catch (WaveletStateException e) {
+        throw new RuntimeException(
+            "Failed to load wavelet " + waveletName + " for read state", e);
+      }
+      if (container == null) {
+        continue;
+      }
+      ObservableWaveletData waveletData;
+      try {
+        waveletData = container.copyWaveletData();
+      } catch (WaveletStateException e) {
+        throw new RuntimeException(
+            "Failed to copy wavelet data " + waveletName + " for read state", e);
+      }
+      if (waveletData == null) {
+        continue;
+      }
+      if (!isAccessible(waveletData, user)) {
+        continue;
+      }
+      view.addWavelet(waveletData);
+    }
+    return view;
+  }
+
+  private boolean isAccessible(ReadableWaveletData wavelet, ParticipantId user) {
+    WaveletId waveletId = wavelet.getWaveletId();
+    if (IdUtil.isUserDataWavelet(user.getAddress(), waveletId)) {
+      return true;
+    }
+    return IdUtil.isConversationalId(waveletId)
+        && WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId);
   }
 
   private boolean hasConversationalWavelet(WaveViewData view) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -146,6 +146,9 @@ public class SelectedWaveReadStateHelper {
     // faults while 404 stays reserved for unknown-wave/access-denied.
     WaveViewData view = WaveViewDataImpl.create(waveId);
     for (WaveletId waveletId : waveletIds) {
+      if (!canAffectReadState(waveletId, user)) {
+        continue;
+      }
       WaveletName waveletName = WaveletName.of(waveId, waveletId);
       WaveletContainer container;
       try {
@@ -173,6 +176,11 @@ public class SelectedWaveReadStateHelper {
       view.addWavelet(waveletData);
     }
     return view;
+  }
+
+  private boolean canAffectReadState(WaveletId waveletId, ParticipantId user) {
+    return IdUtil.isConversationalId(waveletId)
+        || IdUtil.isUserDataWavelet(user.getAddress(), waveletId);
   }
 
   private boolean isAccessible(ReadableWaveletData wavelet, ParticipantId user) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -116,7 +116,7 @@ public class SelectedWaveReadStateHelper {
       waveletIds = waveMap.lookupWavelets(waveId);
     } catch (WaveletStateException e) {
       LOG.warning("read-state: failed to look up wavelets for " + waveId, e);
-      return Result.notFound();
+      throw new RuntimeException("Failed to load read state for " + waveId, e);
     }
     if (waveletIds == null || waveletIds.isEmpty()) {
       return Result.notFound();
@@ -143,7 +143,7 @@ public class SelectedWaveReadStateHelper {
       return Result.found(Math.max(0, digest.getUnreadCount()));
     } catch (RuntimeException e) {
       LOG.warning("read-state: digest build failed for " + waveId, e);
-      return Result.notFound();
+      throw e;
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -50,14 +50,6 @@ public class SelectedWaveReadStateHelper {
 
   private static final Log LOG = Log.get(SelectedWaveReadStateHelper.class);
 
-  /** Accept every wavelet in the view — permission is enforced separately below. */
-  private static final Function<ReadableWaveletData, Boolean> ACCEPT_ALL =
-      new Function<ReadableWaveletData, Boolean>() {
-        @Override
-        public Boolean apply(ReadableWaveletData wavelet) {
-          return Boolean.TRUE;
-        }
-      };
 
   /**
    * Outcome of a read-state computation. Non-existence and access-denied
@@ -130,8 +122,18 @@ public class SelectedWaveReadStateHelper {
       return Result.notFound();
     }
 
+    Function<ReadableWaveletData, Boolean> accessFilter =
+        new Function<ReadableWaveletData, Boolean>() {
+          @Override
+          public Boolean apply(ReadableWaveletData wavelet) {
+            if (IdUtil.isUserDataWavelet(user.getAddress(), wavelet.getWaveletId())) {
+              return Boolean.TRUE;
+            }
+            return WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId);
+          }
+        };
     WaveViewData view =
-        AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, ACCEPT_ALL, waveMap);
+        AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, accessFilter, waveMap);
     if (view == null || !hasAccessibleConversationalWavelet(view, user)) {
       return Result.notFound();
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -146,20 +146,14 @@ public class SelectedWaveReadStateHelper {
   }
 
   private boolean hasAccessibleConversationalWavelet(WaveViewData view, ParticipantId user) {
-    boolean hasConversational = false;
     for (ReadableWaveletData wavelet : view.getWavelets()) {
       if (!IdUtil.isConversationalId(wavelet.getWaveletId())) {
         continue;
       }
-      hasConversational = true;
       if (WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId)) {
         return true;
       }
     }
-    if (!hasConversational) {
-      return false;
-    }
-    // Conversational wavelets exist but the user is not a participant of any of them.
     return false;
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.google.wave.api.SearchResult.Digest;
+
+import org.waveprotocol.box.server.CoreSettingsNames;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
+import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Computes per-user unread/read state for a single wave on demand.
+ *
+ * <p>Reuses the existing search-side data path ({@link WaveMap},
+ * {@link AbstractSearchProviderImpl#buildWaveViewData}, {@link WaveDigester#build})
+ * so there is no second code path for supplement construction. This helper is
+ * the server seam used by the J2CL sidecar's selected-wave read-state endpoint
+ * (issue #931) and is intentionally narrow: it exposes a single
+ * {@code computeReadState} method and leaks no internal supplement types.
+ */
+public class SelectedWaveReadStateHelper {
+
+  private static final Log LOG = Log.get(SelectedWaveReadStateHelper.class);
+
+  /** Accept every wavelet in the view — permission is enforced separately below. */
+  private static final Function<ReadableWaveletData, Boolean> ACCEPT_ALL =
+      new Function<ReadableWaveletData, Boolean>() {
+        @Override
+        public Boolean apply(ReadableWaveletData wavelet) {
+          return Boolean.TRUE;
+        }
+      };
+
+  /**
+   * Outcome of a read-state computation. Non-existence and access-denied
+   * collapse into the same {@link #notFound()} sentinel so the servlet can
+   * return a single 404 for both cases and existence cannot be probed.
+   */
+  public static final class Result {
+    private final boolean exists;
+    private final boolean accessAllowed;
+    private final int unreadCount;
+    private final boolean read;
+
+    private Result(boolean exists, boolean accessAllowed, int unreadCount, boolean read) {
+      this.exists = exists;
+      this.accessAllowed = accessAllowed;
+      this.unreadCount = unreadCount;
+      this.read = read;
+    }
+
+    public boolean exists() { return exists; }
+    public boolean accessAllowed() { return accessAllowed; }
+    public int getUnreadCount() { return unreadCount; }
+    public boolean isRead() { return read; }
+
+    public static Result notFound() {
+      return new Result(false, false, 0, true);
+    }
+
+    public static Result found(int unreadCount) {
+      return new Result(true, true, unreadCount, unreadCount <= 0);
+    }
+  }
+
+  private final WaveMap waveMap;
+  private final WaveDigester digester;
+  private final ParticipantId sharedDomainParticipantId;
+
+  @Inject
+  public SelectedWaveReadStateHelper(
+      @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String waveDomain,
+      WaveMap waveMap,
+      WaveDigester digester) {
+    this.waveMap = waveMap;
+    this.digester = digester;
+    this.sharedDomainParticipantId =
+        ParticipantIdUtil.makeUnsafeSharedDomainParticipantId(waveDomain);
+  }
+
+  /**
+   * Computes unread/read state for the given wave and user.
+   *
+   * <p>Returns {@link Result#notFound()} when the wave does not exist, when no
+   * conversational wavelet is present, or when the user lacks read access on
+   * any conversational wavelet. The distinction is intentional: collapsing
+   * these into one response prevents existence probing by non-participants.
+   */
+  public Result computeReadState(ParticipantId user, WaveId waveId) {
+    if (user == null || waveId == null) {
+      return Result.notFound();
+    }
+
+    ImmutableSet<WaveletId> waveletIds;
+    try {
+      waveletIds = waveMap.lookupWavelets(waveId);
+    } catch (WaveletStateException e) {
+      LOG.warning("read-state: failed to look up wavelets for " + waveId, e);
+      return Result.notFound();
+    }
+    if (waveletIds == null || waveletIds.isEmpty()) {
+      return Result.notFound();
+    }
+
+    WaveViewData view =
+        AbstractSearchProviderImpl.buildWaveViewData(waveId, waveletIds, ACCEPT_ALL, waveMap);
+    if (view == null || !hasAccessibleConversationalWavelet(view, user)) {
+      return Result.notFound();
+    }
+
+    try {
+      Digest digest = digester.build(user, view);
+      return Result.found(Math.max(0, digest.getUnreadCount()));
+    } catch (RuntimeException e) {
+      LOG.warning("read-state: digest build failed for " + waveId, e);
+      return Result.notFound();
+    }
+  }
+
+  private boolean hasAccessibleConversationalWavelet(WaveViewData view, ParticipantId user) {
+    boolean hasConversational = false;
+    for (ReadableWaveletData wavelet : view.getWavelets()) {
+      if (!IdUtil.isConversationalId(wavelet.getWaveletId())) {
+        continue;
+      }
+      hasConversational = true;
+      if (WaveletDataUtil.checkAccessPermission(wavelet, user, sharedDomainParticipantId)) {
+        return true;
+      }
+    }
+    if (!hasConversational) {
+      return false;
+    }
+    // Conversational wavelets exist but the user is not a participant of any of them.
+    return false;
+  }
+
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
@@ -65,8 +65,7 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
 
     servlet.doGet(request, response);
 
-    org.mockito.Mockito.verify(response)
-        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_BAD_REQUEST), any());
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
   }
 
   public void testReturnsBadRequestWhenWaveIdMalformed() throws Exception {
@@ -81,8 +80,7 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
 
     servlet.doGet(request, response);
 
-    org.mockito.Mockito.verify(response)
-        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_BAD_REQUEST), any());
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
   }
 
   public void testReturnsNotFoundWhenHelperReportsMissingOrAccessDenied() throws Exception {
@@ -95,12 +93,36 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
     SelectedWaveReadStateServlet servlet =
         new SelectedWaveReadStateServlet(sessionManager, helper);
     HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_NOT_FOUND);
+    // The 404 branch deliberately conflates "unknown wave" and "access denied"
+    // into a single empty response so non-participants cannot probe existence.
+    assertFalse("404 must not disclose access-denied text: " + body,
+        body.toString().toLowerCase().contains("denied"));
+    assertFalse("404 must not disclose forbidden text: " + body,
+        body.toString().toLowerCase().contains("forbidden"));
+  }
+
+  public void testNoStoreCacheHeaderSetOnEveryResponsePath() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(null);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
     HttpServletResponse response = responseWithWriter();
 
     servlet.doGet(request, response);
 
-    org.mockito.Mockito.verify(response)
-        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_NOT_FOUND), any());
+    // Even the unauthenticated branch must disable caching so an intermediary
+    // can't pin a stale 403/404 in place after the user logs in or is added
+    // as a participant.
+    org.mockito.Mockito.verify(response).setHeader("Cache-Control", "no-store");
   }
 
   public void testReturnsJsonWithUnreadStateOnSuccess() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import junit.framework.TestCase;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.waveserver.SelectedWaveReadStateHelper;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class SelectedWaveReadStateServletTest extends TestCase {
+
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@example.com");
+  private static final String VALID_WAVE_ID = "example.com/w+abc";
+
+  public void testReturnsForbiddenWhenNoSession() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(null);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+  }
+
+  public void testReturnsBadRequestWhenWaveIdMissing() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(null);
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response)
+        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_BAD_REQUEST), any());
+  }
+
+  public void testReturnsBadRequestWhenWaveIdMalformed() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith("not a wave id");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response)
+        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_BAD_REQUEST), any());
+  }
+
+  public void testReturnsNotFoundWhenHelperReportsMissingOrAccessDenied() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+    when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
+        .thenReturn(SelectedWaveReadStateHelper.Result.notFound());
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response)
+        .sendError(org.mockito.Mockito.eq(HttpServletResponse.SC_NOT_FOUND), any());
+  }
+
+  public void testReturnsJsonWithUnreadStateOnSuccess() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+    when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(4));
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doGet(request, response);
+
+    org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);
+    org.mockito.Mockito.verify(response).setContentType("application/json; charset=utf8");
+    org.mockito.Mockito.verify(response).setHeader("Cache-Control", "no-store");
+    String json = body.toString();
+    assertTrue("body missing unreadCount: " + json, json.contains("\"unreadCount\":4"));
+    assertTrue("body missing isRead: " + json, json.contains("\"isRead\":false"));
+    assertTrue("body missing waveId: " + json, json.contains("\"waveId\":\"" + VALID_WAVE_ID + "\""));
+  }
+
+  public void testReturnsReadTrueWhenUnreadCountZero() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+    when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(0));
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doGet(request, response);
+
+    String json = body.toString();
+    assertTrue("body missing isRead:true: " + json, json.contains("\"isRead\":true"));
+    assertTrue("body missing unreadCount:0: " + json, json.contains("\"unreadCount\":0"));
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private static HttpServletRequest requestWith(String waveIdParam) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter("waveId")).thenReturn(waveIdParam);
+    return request;
+  }
+
+  private static HttpServletResponse responseWithWriter() throws Exception {
+    return responseWithWriter(new StringWriter());
+  }
+
+  private static HttpServletResponse responseWithWriter(StringWriter backing) throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(backing));
+    return response;
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
@@ -141,7 +141,7 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
     servlet.doGet(request, response);
 
     org.mockito.Mockito.verify(response).setStatus(HttpServletResponse.SC_OK);
-    org.mockito.Mockito.verify(response).setContentType("application/json; charset=utf8");
+    org.mockito.Mockito.verify(response).setContentType("application/json; charset=utf-8");
     org.mockito.Mockito.verify(response).setHeader("Cache-Control", "no-store");
     String json = body.toString();
     assertTrue("body missing unreadCount: " + json, json.contains("\"unreadCount\":4"));

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableSet;
+import com.google.wave.api.SearchResult.Digest;
+import junit.framework.TestCase;
+import org.mockito.ArgumentCaptor;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+
+public final class SelectedWaveReadStateHelperTest extends TestCase {
+
+  private static final String DOMAIN = "example.com";
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@example.com");
+  private static final ParticipantId OTHER = ParticipantId.ofUnsafe("other@example.com");
+  private static final WaveId WAVE_ID = WaveId.of(DOMAIN, "w+abc");
+  private static final WaveletId ACCESSIBLE_CONV = WaveletId.of(DOMAIN, "conv+root");
+  private static final WaveletId RESTRICTED_CONV = WaveletId.of(DOMAIN, "conv+private");
+  private static final WaveletId USER_UDW = IdUtil.buildUserDataWaveletId(USER);
+  private static final WaveletId OTHER_UDW = IdUtil.buildUserDataWaveletId(OTHER);
+
+  @SuppressWarnings("unchecked")
+  public void testComputeReadStateFiltersDigestViewToAccessibleWavelets() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    when(waveMap.lookupWavelets(WAVE_ID))
+        .thenReturn(ImmutableSet.of(ACCESSIBLE_CONV, RESTRICTED_CONV, USER_UDW, OTHER_UDW));
+
+    ObservableWaveletData accessibleConv = wavelet(ACCESSIBLE_CONV, USER);
+    ObservableWaveletData restrictedConv = wavelet(RESTRICTED_CONV, OTHER);
+    ObservableWaveletData userUdw = wavelet(USER_UDW, USER);
+    ObservableWaveletData otherUdw = wavelet(OTHER_UDW, OTHER);
+    stubWaveletContainer(waveMap, ACCESSIBLE_CONV, accessibleConv);
+    stubWaveletContainer(waveMap, RESTRICTED_CONV, restrictedConv);
+    stubWaveletContainer(waveMap, USER_UDW, userUdw);
+    stubWaveletContainer(waveMap, OTHER_UDW, otherUdw);
+
+    Digest digest = mock(Digest.class);
+    when(digest.getUnreadCount()).thenReturn(2);
+    when(digester.build(eq(USER), any(WaveViewData.class))).thenReturn(digest);
+
+    SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
+
+    assertTrue(result.exists());
+    assertEquals(2, result.getUnreadCount());
+
+    ArgumentCaptor<WaveViewData> viewCaptor = ArgumentCaptor.forClass(WaveViewData.class);
+    verify(digester).build(eq(USER), viewCaptor.capture());
+    WaveViewData digestedView = viewCaptor.getValue();
+    assertNotNull(digestedView.getWavelet(ACCESSIBLE_CONV));
+    assertNull(digestedView.getWavelet(RESTRICTED_CONV));
+    assertNotNull(digestedView.getWavelet(USER_UDW));
+    assertNull(digestedView.getWavelet(OTHER_UDW));
+  }
+
+  private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
+    ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
+    when(wavelet.getWaveletId()).thenReturn(waveletId);
+    when(wavelet.getParticipants()).thenReturn(ImmutableSet.of(participant));
+    return wavelet;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void stubWaveletContainer(
+      WaveMap waveMap, WaveletId waveletId, ObservableWaveletData waveletData) throws Exception {
+    WaveletContainer container = mock(WaveletContainer.class);
+    when(container.copyWaveletData()).thenReturn(waveletData);
+    when(container.applyFunction(any(Function.class)))
+        .thenAnswer(
+            invocation ->
+                ((Function<ReadableWaveletData, Boolean>) invocation.getArguments()[0])
+                    .apply(waveletData));
+    when(waveMap.getWavelet(WaveletName.of(WAVE_ID, waveletId))).thenReturn(container);
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -106,6 +106,37 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     }
   }
 
+  public void testComputeReadStateIgnoresOtherUserUdwCopyFailure() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    when(waveMap.lookupWavelets(WAVE_ID)).thenReturn(ImmutableSet.of(ACCESSIBLE_CONV, OTHER_UDW));
+
+    ObservableWaveletData accessibleConv = wavelet(ACCESSIBLE_CONV, USER);
+    stubWaveletContainer(waveMap, ACCESSIBLE_CONV, accessibleConv);
+
+    WaveletContainer otherUdwContainer = mock(WaveletContainer.class);
+    when(otherUdwContainer.copyWaveletData()).thenThrow(new WaveletStateException("boom"));
+    when(waveMap.getWavelet(WaveletName.of(WAVE_ID, OTHER_UDW))).thenReturn(otherUdwContainer);
+
+    Digest digest = mock(Digest.class);
+    when(digest.getUnreadCount()).thenReturn(1);
+    when(digester.build(eq(USER), any(WaveViewData.class))).thenReturn(digest);
+
+    SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
+
+    assertTrue(result.exists());
+    assertEquals(1, result.getUnreadCount());
+
+    ArgumentCaptor<WaveViewData> viewCaptor = ArgumentCaptor.forClass(WaveViewData.class);
+    verify(digester).build(eq(USER), viewCaptor.capture());
+    WaveViewData digestedView = viewCaptor.getValue();
+    assertNotNull(digestedView.getWavelet(ACCESSIBLE_CONV));
+    assertNull(digestedView.getWavelet(OTHER_UDW));
+  }
+
   private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
     ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
     when(wavelet.getWaveletId()).thenReturn(waveletId);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -101,7 +101,7 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
       helper.computeReadState(USER, WAVE_ID);
       fail("Expected computeReadState to surface the wavelet load failure");
     } catch (RuntimeException e) {
-      assertTrue(e.getMessage().contains("Failed to build read state"));
+      assertTrue(e.getMessage().contains("for read state"));
       assertTrue(e.getCause() instanceof WaveletStateException);
     }
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -87,6 +87,25 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertNull(digestedView.getWavelet(OTHER_UDW));
   }
 
+  public void testComputeReadStateThrowsWhenConversationalWaveletLoadFails() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    when(waveMap.lookupWavelets(WAVE_ID)).thenReturn(ImmutableSet.of(ACCESSIBLE_CONV));
+    when(waveMap.getWavelet(WaveletName.of(WAVE_ID, ACCESSIBLE_CONV)))
+        .thenThrow(new WaveletStateException("boom"));
+
+    try {
+      helper.computeReadState(USER, WAVE_ID);
+      fail("Expected computeReadState to surface the wavelet load failure");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().contains("Failed to build read state"));
+      assertTrue(e.getCause() instanceof WaveletStateException);
+    }
+  }
+
   private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
     ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
     when(wavelet.getWaveletId()).thenReturn(waveletId);


### PR DESCRIPTION
## Summary

Closes #931. Surfaces real per-user unread/read state on the J2CL sidecar's selected-wave panel, replacing the stale digest metadata fallback that `#920` left in place.

## Approach

Chose the smallest seam that satisfies the issue's "real unread/read signal" requirement without a wire-protocol change or a full J2CL UDW port:

- **Server:** new `GET /read-state?waveId=...` endpoint. Reuses `WaveMap.getWavelet().copyWaveletData()` + `WaveDigester.getUnreadCount()` — the same path that already computes per-user unread counts for the search digest. Access check via `WaveletDataUtil.checkAccessPermission` (shared-domain or explicit participant). Unknown-wave and access-denied collapse into a single empty 404 so non-participants cannot probe existence.
- **J2CL sidecar:** `J2clSelectedWaveController` fetches read state after each selected-wave update (250 ms trailing-edge debounce), after `visibilitychange → visible` (closes the UDW-only-change case), and on reconnect. Per-fetch monotonic `readStateFetchSeq` + per-selection `requestGeneration` drop stale responses; failures preserve the prior count and raise a sticky `readStateStale` flag instead of zeroing.
- **Legacy root path:** untouched. `compileGwt` and `Universal/stage` stay green.

## Verification

All commands run from `/Users/vega/devroot/worktrees/issue-931-unread-read-state`:

```
cd j2cl && ./mvnw -Psearch-sidecar test        # 115 tests passed
sbt "testOnly *SelectedWaveReadState*"          # 7 tests passed
sbt "testOnly *WaveDigesterTest *SimpleSearchProviderImplTest"  # 64 tests passed
sbt compileGwt                                  # [success]
sbt Universal/stage                             # [success]
python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
```

Evidence: `journal/local-verification/2026-04-23-issue-931-j2cl-unread-read-state.md`.

## Test plan

- [x] Server endpoint returns 403/400/400/404/200/500 correctly without leaking existence
- [x] `Cache-Control: no-store` on every response path
- [x] Sidecar fetches read state after each update and re-projects the model
- [x] Stale responses dropped via `readStateFetchSeq`
- [x] Generation bump discards in-flight fetches from prior selection
- [x] Debounce coalesces rapid-fire updates
- [x] `visibilitychange → visible` triggers a fetch (UDW-only changes)
- [x] Fetch errors preserve prior count + flip sticky stale flag
- [x] Legacy GWT root still compiles and stages
- [ ] Manual two-tab browser smoke (deferred to reviewer cycle)

## Review record

- Plan: `docs/superpowers/plans/2026-04-23-issue-931-j2cl-unread-read-state.md`
- Plan review (Claude Opus 4.7): two passes; second pass APPROVE_WITH_NITS; nits folded into commit `d8960591f`.
- Implementation review (Claude Opus 4.7): two passes; second pass APPROVE clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected-wave panel now shows server-backed per-user unread/read state; UI prefers server values and marks counts as “stale” when potentially outdated. Counts refresh after selected-wave updates, reconnects, and when the tab becomes visible.

* **Style**
  * Added muted/italic styling for the stale unread indicator.

* **Documentation**
  * Added implementation plan and changelog entry for per-user unread/read state.

* **Tests**
  * Added tests for fetching, decoding, projection, staleness, debouncing, and visibility-driven refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->