### PR TITLE
feat(j2cl): add explicit bootstrap JSON contract (#963)

### DIFF
--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -175,6 +175,59 @@ server:
 PORT=9900 bash scripts/wave-smoke.sh stop
 ```
 
+## Bootstrap JSON Contract (issue #963)
+
+The J2CL sidecar and root shell now boot from `/bootstrap.json` — a typed,
+server-owned contract — instead of regex-scraping `window.__session` and
+`window.__websocket_address` from the root HTML page. The endpoint is defined
+by `org.waveprotocol.box.common.J2clBootstrapContract` and served by
+`J2clBootstrapServlet`.
+
+Inspect the contract directly:
+
+```bash
+curl -fsS -H 'Accept: application/json' http://localhost:9900/bootstrap.json | jq .
+```
+
+Expected top-level keys and fields:
+
+- `session.domain` — always present
+- `session.address` / `session.role` / `session.features` — present only when signed in
+- `session.id` — per-request ID seed (regenerated per call by design; do not rely on equality with the HTML page's `__session.id`)
+- `socket.address` — the presented WebSocket `host:port`
+- `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`, `shell.routeReturnTarget`
+
+Response headers:
+
+- `Content-Type: application/json;charset=UTF-8`
+- `Cache-Control: no-store`
+- `Pragma: no-cache`
+- `Vary: Cookie`
+- `X-Content-Type-Options: nosniff`
+
+Non-`GET` methods must return HTTP 405 with an `Allow: GET` response header:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://localhost:9900/bootstrap.json
+```
+
+Forward compatibility: follow-up work under issue #933 may add a
+`socket.token` field. J2CL clients must ignore unknown keys under `socket`,
+`session`, and `shell`.
+
+Coexistence: the legacy inline `var __session = ...; var __websocket_address =
+...;` script block stays in the rendered HTML for one release so a previously
+deployed J2CL bundle that still calls `SidecarSessionBootstrap.fromRootHtml`
+keeps working through a rolling deploy. Cleanup of that temporary overlap is
+tracked in issue `#978`.
+
+Rollback rule: newer J2CL bundles now expect `/bootstrap.json` and do not fall
+back to HTML scraping. During the overlap window, roll the server forward
+before the client, and roll the client back before or together with any server
+rollback so clients do not land on a server that no longer matches their
+bootstrap expectations. The remaining `session.id` divergence between HTML and
+`/bootstrap.json` is tracked separately in issue `#979`.
+
 ## Dual-Mode Coexistence Matrix
 
 Use this matrix when validating both the default-on legacy GWT root mode and

--- a/docs/superpowers/plans/2026-04-22-issue-963-j2cl-bootstrap-json-plan.md
+++ b/docs/superpowers/plans/2026-04-22-issue-963-j2cl-bootstrap-json-plan.md
@@ -1,0 +1,315 @@
+# Issue #963 J2CL Bootstrap JSON And Shell Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current J2CL bootstrap path that scrapes `/` HTML for `window.__session` / `window.__websocket_address` with an explicit, server-owned bootstrap JSON endpoint plus typed shell metadata, while preserving the existing coexistence/rollback seam and coordinating with the `#933` auth-hardening work.
+
+**Architecture:** Add a new Jakarta servlet at `/bootstrap.json` that serves the existing `SessionConstants` payload (domain/address/id_seed/role/features) plus the websocket address and an explicit set of shell metadata fields (build commit, server build time, release id, route return target). Route the J2CL client (`SandboxEntryPoint`, `J2clSearchGateway`, `J2clRootShellController`) through a new typed loader that calls this endpoint instead of fetching `/` and regex-parsing HTML. Keep the inline `var __session` / `var __websocket_address` script block in the existing HTML renderers for one more release so rollback to an older J2CL build is possible, and keep the feature-flag bootstrap decision in `WaveClientServlet#doGet` untouched. Do **not** widen into `#933`: the new JSON endpoint stays authenticated via the same `HttpSession`/`SessionManager` contract that the existing HTML page already uses.
+
+**Tech Stack:** Java, Jakarta servlets, SBT, the existing `SessionManager` / `AccountStore` / `FeatureFlagService` / `VersionServlet`, `WaveClientServlet`, `HtmlRenderer`, the J2CL sidecar/root-shell assets under `j2cl/`, `SidecarTransportCodec` JSON parsing helpers, and local browser/smoke verification.
+
+---
+
+## Problem Framing
+
+The J2CL sidecar bootstraps itself today by issuing `GET /`, receiving the server-rendered root HTML, and then regex-scraping two inline globals out of it:
+
+- `window.__session = {...};` – the `SessionConstants` payload (`domain`, `address`, `id`, `role`, `features`)
+- `window.__websocket_address = "...";` – the presented WebSocket `host:port`
+
+`SidecarSessionBootstrap.fromRootHtml` in `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java` does this scraping with a hand-rolled `String.indexOf` + `findMatchingBrace` parser. `J2clSearchGateway.fetchRootSessionBootstrap` and `SandboxEntryPoint.SidecarProofRunner.run` both call it on `GET /`.
+
+This coupling breaks two pieces of downstream parity work:
+
+1. Server-rendered first paint (`#965`) and the Lit root shell (`#964`) need the freedom to change the `/` HTML body – chrome, server-rendered selected wave, etc. – without breaking the J2CL bootstrap because something moved relative to the `__session` literal.
+2. The existing scraping contract is inline-script-in-HTML, so every consumer has to re-implement the parser (the hand-rolled brace matcher already lives in `SidecarSessionBootstrap` *and* the existing test `SidecarTransportCodecTest#extractSessionBootstrapAddressFromRootHtml` enshrines the fragile format).
+
+`#963` replaces that seam with an explicit server-owned bootstrap JSON endpoint and makes `SidecarSessionBootstrap` consume that JSON directly. It also formalises the shell-level metadata (build commit, release id, return target, websocket address) that the HTML currently exposes via `<meta>` tags and `data-*` attributes so that the J2CL client can read one typed document instead of reaching into the DOM.
+
+`#963` is explicitly **not**:
+
+- auth hardening (HttpOnly cookie work is `#933`)
+- a change to the `j2cl-root-bootstrap` feature-flag rollout decision (`#923`)
+- a change to the default `/` experience
+- a JSON representation of any data the HTML page does not already expose to the client
+
+## Coordination With `#933`
+
+`#933` will later replace the `document.cookie` + `ProtocolAuthenticate` socket auth path with a signed bootstrap token or a server-owned handshake. To stay compatible with that work:
+
+- The bootstrap JSON response schema reserves a top-level `socket` object. In `#963` it carries only `{ "address": "..." }`. `#933` can add a `socket.token` or `socket.authToken` field without a schema migration.
+- The new endpoint serves the same origin the existing `/` page does and relies on the servlet's `HttpSession` for authn; it does **not** put session identifiers in the response body.
+- The HTTP contract requires `Cache-Control: no-store` so a future `socket.token` never lives in a shared cache.
+
+This keeps `#963` narrow while leaving room for `#933`.
+
+## Exact Seams / Files
+
+### New server-side endpoint
+
+- Add: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+  - Register the new servlet at `/bootstrap.json` ahead of the existing `/` mapping.
+- Inspect first, modify only if factoring is needed: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+  - The `getSessionJson(WebSession)` and `resolveWebsocketAddressForPage(HttpServletRequest)` helpers are the canonical sources for the session payload and websocket address; the new servlet must use the same code paths (extract into package-private helpers if needed, no logic change).
+
+### Shared bootstrap contract
+
+- Add: `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`
+  - A tiny class that pins the endpoint path (`"/bootstrap.json"`) and the JSON field names (`session`, `socket.address`, `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`, `shell.routeReturnTarget`). Session field names stay aligned with `SessionConstants`. Used by the servlet, tests, and docs as the canonical server-owned contract; no behavior.
+
+### J2CL client wiring
+
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java`
+  - Add `fromBootstrapJson(String json)` that decodes via `SidecarTransportCodec.parseJsonObject`.
+  - Keep the `fromRootHtml(String)` method in place for one release; mark it `@Deprecated` with a javadoc pointing to `fromBootstrapJson`. Remove all **call sites** (`J2clSearchGateway.fetchRootSessionBootstrap`, `SandboxEntryPoint.SidecarProofRunner.run`) inside this PR; the method itself is deleted in follow-up issue `#978` after the new contract has soaked.
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - Change `fetchRootSessionBootstrap(...)` to `GET /bootstrap.json` and decode via `fromBootstrapJson`.
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+  - In `SidecarProofRunner.run()`, fetch `/bootstrap.json` instead of `/` and decode via `fromBootstrapJson`.
+- Inspect first, touch only if test fixtures need it: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+  - The root-shell controller currently reuses `J2clSearchGateway`; once the gateway's fetch path is swapped, no controller change is required.
+
+### Server HTML compatibility
+
+- Inspect first, modify only if a factor-out helper avoids duplication: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+  - Keep the existing `var __session = ...; var __websocket_address = ...;` inline script block in both `renderWaveClientPage` and `renderJ2clRootShellPage` so an older cached J2CL build can still scrape the HTML during the overlap window. This plan does **not** remove that inline script; doing so is a follow-up after the new contract has soaked.
+
+### Tests
+
+- Add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletIT.java` (or a plain unit test under `wave/src/test/...` if a Jakarta test harness is unnecessary)
+  - Signed-in request returns `session.address`, `session.domain`, `session.role`, `session.features`, `socket.address`, `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`.
+  - Signed-out request returns the same shape with `session.address` absent but still HTTP 200 and `application/json`.
+  - Response is `Cache-Control: no-store` and `Content-Type: application/json;charset=UTF-8`.
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+  - Replace / augment `extractSessionBootstrapAddressFromRootHtml` with a `fromBootstrapJson` variant that exercises the same fields.
+  - Keep the `fromRootHtml` test only if the method stays for the deprecation window; otherwise delete the test in the same commit that deletes the method.
+- Modify or extend: `wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletTest.java` or a peer JSON-endpoint test to confirm the session-JSON helper still emits the same fields for the HTML and JSON paths.
+
+### Release note
+
+- Add: `wave/config/changelog.d/2026-04-22-j2cl-bootstrap-json.json`
+- Regenerate only: `wave/config/changelog.json` (via the existing assemble/validate workflow).
+
+### Documentation
+
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+  - Add a short section describing how to hit `/bootstrap.json` manually and what the response schema is.
+- Modify: `docs/j2cl-parity-issue-map.md`
+  - Append the resolved `#963` status line in section 4.3 once the PR merges.
+
+## Minimal Acceptance Slices
+
+### Slice 1: Server-owned bootstrap JSON endpoint
+
+- `GET /bootstrap.json` returns a well-formed JSON document whose shape is pinned by `J2clBootstrapContract`.
+- Authenticated requests include `session.address` and `session.features`.
+- Unauthenticated requests still return 200 with a session object that omits `address`/`features` but includes `domain`.
+- The response always includes `socket.address` and the `shell.*` metadata (`buildCommit`, `serverBuildTime`, `currentReleaseId`, `routeReturnTarget`).
+- The servlet reuses the same session-JSON and websocket-address code paths as `WaveClientServlet` so the two surfaces cannot drift on fields other than the per-request `session.id` seed.
+- Response carries `Cache-Control: no-store`, `Pragma: no-cache`, `Vary: Cookie`, `X-Content-Type-Options: nosniff`, and `Content-Type: application/json;charset=UTF-8`.
+- Non-GET methods return HTTP 405.
+
+### Slice 2: J2CL client consumes the JSON
+
+- `SidecarSessionBootstrap.fromBootstrapJson(String)` decodes the new endpoint and returns the existing `SidecarSessionBootstrap` value object.
+- `J2clSearchGateway.fetchRootSessionBootstrap` fetches `/bootstrap.json` and uses `fromBootstrapJson`.
+- `SandboxEntryPoint.SidecarProofRunner.run()` fetches `/bootstrap.json` and uses `fromBootstrapJson`.
+- Runtime behavior (socket open, search call, selected-wave open) is unchanged.
+
+### Slice 3: Coexistence / rollback preserved
+
+- `HtmlRenderer.renderWaveClientPage` and `HtmlRenderer.renderJ2clRootShellPage` still emit `var __session = ...; var __websocket_address = ...;` so a previously deployed J2CL build that still scrapes HTML keeps working during rolling deploys.
+- `WaveClientServlet#doGet` is untouched; the `j2cl-root-bootstrap` feature flag still chooses the root shell.
+- Turning off the J2CL root shell via the existing feature flag still renders the legacy GWT root without code rollback.
+- The new JSON endpoint is mounted regardless of the flag state: it is a data contract, not a rollout control.
+
+### Slice 4: `#933` compatibility surface
+
+- The JSON schema includes a `socket` object nested under the top-level payload, not a flat `websocketAddress` field.
+- `SidecarSessionBootstrap.fromBootstrapJson` ignores unknown keys under `socket` so `#933` can add `socket.token` without a client change.
+- The endpoint returns `Cache-Control: no-store`, `Pragma: no-cache`, `Vary: Cookie`, and `X-Content-Type-Options: nosniff` (Task 2 pins the headers).
+- Only GET is supported; non-GET methods return 405.
+
+## Implementation Tasks
+
+### Task 1: Define the shared bootstrap contract
+
+**Files:**
+- Add: `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`
+
+- [ ] Pin the endpoint path constant (`"/bootstrap.json"`) and the JSON field names (`session`, `socket`, `shell`, `buildCommit`, `serverBuildTime`, `currentReleaseId`, `routeReturnTarget`, `features`).
+- [ ] Do not put behavior in this class; it is a naming contract shared between servlet and tests.
+- [ ] Keep it in `wave/src/main/java/org/waveprotocol/box/common` so it is visible to both Jakarta-overrides and J2CL tests.
+
+### Task 2: Implement the bootstrap JSON servlet
+
+**Files:**
+- Add: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+- Inspect first, modify only if factoring is required: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+
+- [ ] Implement a `@Singleton` Jakarta servlet that builds the response from the same `SessionManager` / `AccountStore` / `FeatureFlagService` / `Config` inputs `WaveClientServlet` already consumes, plus `VersionServlet.getBuildCommit()` / `VersionServlet.getBuildTime()` / `VersionServlet.getCurrentReleaseId()` for the `shell.*` fields (same accessors `WaveClientServlet` calls in its constructor).
+- [ ] Reuse `WaveClientServlet.getSessionJson` by extracting it to a package-private helper (or inject a `SessionJsonProvider`) rather than duplicating the role/feature lookup. Do not copy-paste the logic.
+- [ ] Inject the already-resolved `websocketPresentedAddress` field the same way `WaveClientServlet` does (its `resolveWebsocketAddressForPage` is literally `return websocketPresentedAddress;`); no per-request work.
+- [ ] Implement **GET only**; override `doPost` / `doPut` / `doDelete` to return HTTP 405 so the CSRF-irrelevance argument is explicit.
+- [ ] Emit `Cache-Control: no-store`, `Pragma: no-cache`, `Content-Type: application/json;charset=UTF-8`, `Vary: Cookie` (defensive against intermediaries that ignore `no-store`), and `X-Content-Type-Options: nosniff`.
+- [ ] Register the servlet in `ServerMain#addServlet("/bootstrap.json", J2clBootstrapServlet.class)` **before** the final `addServlet("/", WaveClientServlet.class)` mapping so the literal path wins over the root catch-all.
+- [ ] Log only counts/failures; never log the session JSON body.
+
+### Task 3: Add a JSON-aware bootstrap decoder on the J2CL client
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java`
+
+- [ ] Add `public static SidecarSessionBootstrap fromBootstrapJson(String json)` that parses via `SidecarTransportCodec.parseJsonObject`.
+- [ ] Require `session.address` when present; if the caller is the signed-out path, throw an `IllegalStateException` with a user-ready message so the caller can surface "please sign in".
+- [ ] Require `socket.address` and fail with a descriptive message if it is missing or empty.
+- [ ] Do not leak the raw JSON into the error message.
+- [ ] Keep `fromRootHtml` for now, but javadoc it as deprecated with a pointer to `fromBootstrapJson`.
+
+### Task 4: Switch the J2CL bootstrap call sites to the JSON endpoint
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java`
+
+- [ ] Use the `J2clBootstrapContract.PATH` constant (import the shared class) for the fetch URL.
+- [ ] Decode with `fromBootstrapJson`.
+- [ ] Preserve the existing error-surfacing contract: the existing `onError.accept(String)` pattern must still fire with a human-readable message on decode failure.
+- [ ] Do not change `readCookie`/`JSESSIONID` behavior; that is `#933`'s scope.
+- [ ] Do not change the socket open sequence except for the fetch source.
+
+### Task 5: Update the fromRootHtml test coverage for the new decoder
+
+**Files:**
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+
+- [ ] Add `extractSessionBootstrapFromBootstrapJson` that feeds a realistic JSON envelope through `fromBootstrapJson` and asserts address + websocket address.
+- [ ] Add a "missing socket.address" negative test and a "missing session.address for signed-in payload" negative test.
+- [ ] Keep the legacy `extractSessionBootstrapAddressFromRootHtml` test while `fromRootHtml` remains; remove it in the same PR only if the deprecated method is removed.
+
+### Task 6: Cover the new servlet
+
+**Files:**
+- Add: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletIT.java` (preferred) or a unit peer under `wave/src/test/...` that mocks the Jakarta request/response.
+
+- [ ] Signed-in request returns `session.address`, `session.domain`, `session.role`, `session.features`, `socket.address`, `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`, `shell.routeReturnTarget`.
+- [ ] Signed-out request returns HTTP 200, `application/json`, includes `session.domain` and `socket.address`, omits `session.address` and `session.features`.
+- [ ] Response headers: `Cache-Control: no-store`, `Pragma: no-cache`, `Vary: Cookie`, `X-Content-Type-Options: nosniff`, `Content-Type: application/json;charset=UTF-8`.
+- [ ] Non-GET methods (POST/PUT/DELETE) return HTTP 405 with no body.
+- [ ] `session.features` never includes `j2cl-root-bootstrap`'s internal decision; it mirrors whatever `WaveClientServlet.getSessionJson` already emits for the flag list (no new leak surface).
+- [ ] `session.id` is present but allowed to differ between this response and any concurrent HTML page load (`ID_SEED` is regenerated per call); that is by design.
+
+### Task 7: Preserve HTML compatibility and rollback
+
+**Files:**
+- Inspect first, modify only if a factor-out helper avoids duplication: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+
+- [ ] Do not remove the existing `var __session = ...; var __websocket_address = ...;` inline script block.
+- [ ] Do not rename existing `data-*` attributes on the J2CL root shell (`data-j2cl-root-shell`, `data-j2cl-root-return-target`).
+- [ ] If a helper is needed so the servlet and the HTML renderer produce the same session JSON shape, factor it into a shared method rather than duplicating the logic. Note: `SessionConstants.ID_SEED` is regenerated per request today (`new RandomBase64Generator().next(10)` in `WaveClientServlet.getSessionJson`). This means the `session.id` returned by `/bootstrap.json` will differ from the `id` embedded in the HTML for the same browser load. This is by design (the ID seed has no cross-request meaning) and the existing J2CL bootstrap only consumes `address`/`domain`/`role`/`features`, so the divergence is behaviorally safe. Document this in the servlet's class-level javadoc so future maintainers do not "fix" the divergence by introducing a shared cache.
+
+### Task 8: Record the rollout contract
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-22-j2cl-bootstrap-json.json`
+- Regenerate only: `wave/config/changelog.json`
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+- Modify: `docs/j2cl-parity-issue-map.md`
+
+- [ ] Add a changelog fragment that says the J2CL sidecar/root shell now bootstraps from `/bootstrap.json` and no longer scrapes the root HTML page.
+- [ ] Keep the changelog focused on the bootstrap contract; do not advertise `#933` work.
+- [ ] Add a `/bootstrap.json` verification section to the sidecar testing runbook with a sample response and the exact `curl` commands.
+- [ ] Annotate section 4.3 of `docs/j2cl-parity-issue-map.md` with the PR link once opened.
+
+## Verification Matrix
+
+All commands run from `/Users/vega/devroot/worktrees/issue-963-bootstrap-json`.
+
+### Mode A: targeted unit/integration tests
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletIT"
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest"
+sbt -batch j2clSandboxTest j2clSearchTest
+```
+
+Note: `WaveClientServletJ2clBootstrapTest` already exists under `wave/src/test/java/.../rpc/` as the existing feature-flag test. This PR only runs it (unchanged) to prove the existing flag rollout still works; it does not add new cases to it.
+
+Expected:
+
+- the new bootstrap-JSON decoder tests pass
+- the servlet test matrix (signed-in, signed-out, cache headers) passes
+- the existing J2CL root-bootstrap and root-shell tests are still green
+- the J2CL sidecar and search modules still compile and pass their JVM-side tests
+
+### Mode B: server smoke + bootstrap JSON contract
+
+```bash
+sbt -batch compileGwt Universal/stage
+bash scripts/worktree-boot.sh --port 9914
+PORT=9914 bash scripts/wave-smoke.sh start
+
+# legacy GWT root still works
+curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
+
+# bootstrap JSON endpoint shape
+curl -fsS -H 'Accept: application/json' http://localhost:9914/bootstrap.json \
+  | jq -e '.session.domain and .socket.address and .shell.buildCommit' > /dev/null
+
+# response headers pin caching and content type
+curl -fsSI http://localhost:9914/bootstrap.json | grep -Fi 'cache-control: no-store'
+curl -fsSI http://localhost:9914/bootstrap.json | grep -Fi 'content-type: application/json'
+
+PORT=9914 bash scripts/wave-smoke.sh stop
+```
+
+Expected:
+
+- the legacy root path is unchanged
+- `/bootstrap.json` returns a typed payload with the three top-level keys
+- cache headers pin `no-store` and `application/json`
+
+### Mode C: J2CL sidecar still boots end-to-end
+
+Manual browser step (record outcome in the issue):
+
+1. Start the worktree on port 9914.
+2. Open `http://localhost:9914/j2cl-search/index.html`.
+3. Confirm the search panel mounts without any `__session` bootstrap error in the browser console (a clean worktree may have zero digests; the assertion is on the bootstrap path, not on populated search results).
+4. Open `http://localhost:9914/?view=j2cl-root`.
+5. Confirm the root shell still renders and the sidecar mounts without console errors.
+
+Expected:
+
+- no `__session` scraping error
+- no regression in search/selected-wave/compose flows
+- no console warning about the HTML format change
+
+## Rollback / Fallback
+
+- Rollback is a revert of this PR. The contract is additive:
+  - `/bootstrap.json` can stay mounted safely because it is read-only.
+  - The existing inline `var __session = ...; var __websocket_address = ...;` block stays in the HTML so an older J2CL build that still calls `fromRootHtml` continues to work during a rolling deploy.
+- If the new endpoint misbehaves in production, the immediate mitigation is to revert the four J2CL client files (`SidecarSessionBootstrap`, `J2clSearchGateway`, `SandboxEntryPoint`, plus the shared contract import). Server-side mitigation is to disable routing by removing the servlet registration, which has zero blast radius on other surfaces.
+- The `#933` handoff point is the `socket` object in the response body; if `#933` lands first and wants a different shape, it can change that block without touching the JSON field names shipped in this PR.
+
+## Risks
+
+- **Schema drift between HTML and JSON.** If the new servlet duplicates session-JSON building, the two surfaces will diverge. Mitigation: reuse the same `getSessionJson(WebSession)` path via factoring, not duplication.
+- **Cache poisoning.** If a proxy caches `/bootstrap.json` for a signed-out user and then serves it to a signed-in user, the response would hide per-user features. Mitigation: `Cache-Control: no-store`, plus explicit test coverage.
+- **`#933` lock-in.** If the JSON shape commits to a flat `websocketAddress` at the top level, `#933` cannot add a socket-token without breaking clients. Mitigation: nest under `socket` from day one.
+- **Removing the inline HTML globals too early.** If the inline `__session`/`__websocket_address` script is deleted in the same PR that adds the JSON endpoint, an older cached J2CL build will break on a rolling deploy. Mitigation: keep the inline block in both renderers for this PR; plan the removal as a follow-up.
+- **Signed-out bootstrap.** The J2CL sidecar already tolerates a signed-out `__session` that lacks `address`. The new decoder must preserve this so the root shell can still display a signed-out chrome and log in the user.
+- **Known-flag filtering.** `session.features` must continue to reflect the same feature flags `WaveClientServlet.getSessionJson` already publishes; adding more flags in the JSON body is out of scope for this PR.
+
+## Self-Check
+
+- Coverage check: every acceptance slice maps to at least one implementation task (Slice 1 → Task 2 + Task 6; Slice 2 → Tasks 3/4 + Task 5; Slice 3 → Task 7; Slice 4 → Tasks 1/2/3).
+- Scope check: this plan adds one server-side JSON endpoint, rewires the J2CL bootstrap call sites, and does not touch auth/socket behavior, feature-flag rollout, or the default-root experience.
+- Coexistence check: the inline HTML globals remain so a previously deployed J2CL build keeps working during rolling deploy.
+- Fallback check: a revert of this PR leaves the system in its current scraping-based state with no data loss.
+- `#933` check: the socket-auth surface stays unchanged; the JSON schema reserves a nested block for `#933` to extend.
+- Verification check: Mode A covers unit/integration, Mode B covers server smoke + contract shape, Mode C covers the end-to-end J2CL boot.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -244,18 +244,20 @@ public final class SandboxEntryPoint {
       waitingForUpdate = false;
       int generation = ++runGeneration;
       setNeutral(
-          "Fetching root bootstrap",
-          "Reading the live root page session so the sidecar can reuse the active legacy login context.");
+          "Fetching bootstrap JSON",
+          "Reading "
+              + SidecarSessionBootstrap.BOOTSTRAP_PATH
+              + " so the sidecar can reuse the active legacy login context.");
       requestText(
-          "/",
-          html -> {
+          SidecarSessionBootstrap.BOOTSTRAP_PATH,
+          payload -> {
             if (!shouldHandleAsyncCallback(generation, runGeneration)) {
               return;
             }
             SidecarSessionBootstrap bootstrap;
             try {
-              bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
-            } catch (IllegalArgumentException e) {
+              bootstrap = SidecarSessionBootstrap.fromBootstrapJson(payload);
+            } catch (RuntimeException e) {
               setError("Root bootstrap missing", e.getMessage());
               return;
             }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -27,11 +27,13 @@ public final class J2clSearchGateway
   public void fetchRootSessionBootstrap(
       J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
       J2clSearchPanelController.ErrorCallback onError) {
+    // #963: read the server-owned bootstrap JSON contract instead of scraping
+    // the root HTML page.
     requestText(
-        "/",
-        html -> {
+        SidecarSessionBootstrap.BOOTSTRAP_PATH,
+        payload -> {
           try {
-            onSuccess.accept(SidecarSessionBootstrap.fromRootHtml(html));
+            onSuccess.accept(SidecarSessionBootstrap.fromBootstrapJson(payload));
           } catch (RuntimeException e) {
             onError.accept(messageOrDefault(e, "Unable to read the root session bootstrap."));
           }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -3,6 +3,8 @@ package org.waveprotocol.box.j2cl.transport;
 import java.util.Map;
 
 public final class SidecarSessionBootstrap {
+  public static final String BOOTSTRAP_PATH = "/bootstrap.json";
+
   private final String address;
   private final String websocketAddress;
 
@@ -45,6 +47,76 @@ public final class SidecarSessionBootstrap {
     return normalizeHostName(trimmed);
   }
 
+  /**
+   * Decode the server-owned bootstrap JSON introduced by issue #963. The
+   * expected shape mirrors the server-owned bootstrap contract introduced by
+   * issue #963. Unknown keys under any nested object are ignored so
+   * forward-compatible extensions do not require a client change.
+   *
+   * <pre>
+   * {
+   *   "session": { "address": "...", ... },
+   *   "socket":  { "address": "host:port", ... },
+   *   "shell":   { ... }
+   * }
+   * </pre>
+   *
+   * <p>This method throws {@link IllegalStateException} when the payload is
+   * well-formed but represents a signed-out session, and
+   * {@link IllegalArgumentException} when the payload itself is malformed.
+   */
+  public static SidecarSessionBootstrap fromBootstrapJson(String json) {
+    if (json == null) {
+      throw new IllegalArgumentException("Bootstrap JSON must not be null");
+    }
+    Map<String, Object> root;
+    try {
+      root = SidecarTransportCodec.parseJsonObject(json);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Bootstrap JSON was not a valid object", e);
+    }
+    Object sessionValue = root.get("session");
+    if (!(sessionValue instanceof Map)) {
+      throw new IllegalArgumentException("Bootstrap JSON did not include a session object");
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> session = (Map<String, Object>) sessionValue;
+    Object addressValue = session.get("address");
+    if (!(addressValue instanceof String)) {
+      throw new IllegalStateException(
+          "Bootstrap JSON did not include a signed-in session address; please sign in.");
+    }
+    String address = ((String) addressValue).trim();
+    if (address.isEmpty() || "null".equals(address)) {
+      throw new IllegalStateException(
+          "Bootstrap JSON did not include a signed-in session address; please sign in.");
+    }
+    Object socketValue = root.get("socket");
+    if (!(socketValue instanceof Map)) {
+      throw new IllegalArgumentException("Bootstrap JSON did not include a socket object");
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> socket = (Map<String, Object>) socketValue;
+    Object socketAddressValue = socket.get("address");
+    if (!(socketAddressValue instanceof String)) {
+      throw new IllegalArgumentException("Bootstrap JSON did not include a socket address");
+    }
+    String socketAddress = ((String) socketAddressValue).trim();
+    if (socketAddress.isEmpty() || "null".equals(socketAddress)) {
+      throw new IllegalArgumentException("Bootstrap JSON did not include a socket address");
+    }
+    return new SidecarSessionBootstrap(address, socketAddress);
+  }
+
+  /**
+   * @deprecated Use {@link #fromBootstrapJson(String)} which reads the explicit
+   *     server-owned {@code /bootstrap.json} endpoint introduced by issue #963.
+   *     This legacy method is retained for one release so rolling deployments
+   *     can keep serving older J2CL bundles that still scraped the root HTML
+   *     page; it will be removed once the new contract has soaked. Follow-up
+   *     cleanup is tracked in issue #978.
+   */
+  @Deprecated
   public static SidecarSessionBootstrap fromRootHtml(String html) {
     if (html == null) {
       throw new IllegalArgumentException("Root HTML must not be null");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -217,6 +217,60 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void extractSessionBootstrapFromBootstrapJson() {
+    String json =
+        "{\"session\":{\"domain\":\"example.com\",\"address\":\"user@example.com\","
+            + "\"id\":\"seed\",\"role\":\"user\",\"features\":[\"mentions-search\"]},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\"},"
+            + "\"shell\":{\"buildCommit\":\"abc\",\"serverBuildTime\":1700000000000,"
+            + "\"currentReleaseId\":\"r1\",\"routeReturnTarget\":\"/?view=j2cl-root\"}}";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromBootstrapJson(json);
+
+    Assert.assertEquals("user@example.com", bootstrap.getAddress());
+    Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+  }
+
+  @Test
+  public void bootstrapJsonIgnoresUnknownKeysUnderSocketForIssue933Compat() {
+    String json =
+        "{\"session\":{\"address\":\"user@example.com\"},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\",\"token\":\"future-933-token\"}}";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromBootstrapJson(json);
+
+    Assert.assertEquals("user@example.com", bootstrap.getAddress());
+    Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+  }
+
+  @Test
+  public void bootstrapJsonRejectsMissingSocketAddress() {
+    String json = "{\"session\":{\"address\":\"user@example.com\"},\"socket\":{}}";
+    expectIllegalArgumentContains(
+        "socket address", () -> SidecarSessionBootstrap.fromBootstrapJson(json));
+  }
+
+  @Test
+  public void bootstrapJsonSignalsSignedOutWithIllegalStateWhenAddressMissing() {
+    String json = "{\"session\":{\"domain\":\"example.com\"},\"socket\":{\"address\":\"h:1\"}}";
+    try {
+      SidecarSessionBootstrap.fromBootstrapJson(json);
+      Assert.fail("Expected IllegalStateException for signed-out session bootstrap");
+    } catch (IllegalStateException expected) {
+      Assert.assertTrue(
+          "Expected sign-in prompt, got: " + expected.getMessage(),
+          expected.getMessage().contains("sign in"));
+    }
+  }
+
+  @Test
+  public void bootstrapJsonRejectsMissingSessionObject() {
+    String json = "{\"socket\":{\"address\":\"h:1\"}}";
+    expectIllegalArgumentContains(
+        "session object", () -> SidecarSessionBootstrap.fromBootstrapJson(json));
+  }
+
+  @Test
   public void parseJsonObjectRejectsInvalidUnicodeEscapeSequences() {
     expectIllegalArgumentContains(
         "unicode escape",

--- a/wave/config/changelog.d/2026-04-22-j2cl-bootstrap-json.json
+++ b/wave/config/changelog.d/2026-04-22-j2cl-bootstrap-json.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-22-j2cl-bootstrap-json",
+  "version": "Issue #963",
+  "date": "2026-04-22",
+  "title": "J2CL sidecar and root shell now bootstrap from /bootstrap.json instead of scraping root HTML",
+  "summary": "The J2CL client now reads session, socket, and shell metadata from an explicit server-owned /bootstrap.json endpoint. The historical scraping path that parsed window.__session and window.__websocket_address out of the root HTML page is retained for one release so rolling deploys keep working, but new builds no longer depend on it. During the overlap window, server rollback must happen with or after client rollback because newer J2CL bundles do not fall back to HTML scraping.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a server-owned /bootstrap.json endpoint that publishes the session, socket, and shell metadata the J2CL client needs to boot, with Cache-Control: no-store and GET-only enforcement",
+        "Switched the J2CL sidecar and root-shell bootstrap call sites to the new JSON contract so they no longer regex-scrape the rendered root HTML page",
+        "Reserved a nested socket object in the JSON schema so issue #933 can add signed handshake tokens without a client-side schema migration"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -14,6 +14,7 @@ import com.google.inject.name.Names;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigParseOptions;
+import org.waveprotocol.box.common.J2clBootstrapContract;
 import org.waveprotocol.box.server.authentication.AccountStoreHolder;
 import org.waveprotocol.box.server.executor.ExecutorsModule;
 import org.waveprotocol.box.server.frontend.ClientFrontend;
@@ -440,6 +441,10 @@ public class ServerMain {
     // SEO endpoints
     server.addServlet("/robots.txt", RobotsServlet.class);
     server.addServlet("/sitemap.xml", SitemapServlet.class);
+
+    // Bootstrap JSON endpoint (#963) must be registered before the root
+    // catch-all so the literal bootstrap mapping wins.
+    server.addServlet(J2clBootstrapContract.PATH, J2clBootstrapServlet.class);
 
     server.addServlet("/", WaveClientServlet.class);
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import com.google.inject.Inject;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import javax.inject.Singleton;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.waveprotocol.box.common.J2clBootstrapContract;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Serves {@code /bootstrap.json} — the server-owned, explicit bootstrap contract
+ * introduced by issue #963. Replaces the historical J2CL path that fetched
+ * {@code /} and regex-scraped {@code window.__session} / {@code
+ * window.__websocket_address} out of the rendered HTML.
+ *
+ * <p>The payload shape is pinned by {@link J2clBootstrapContract}:
+ *
+ * <pre>
+ * {
+ *   "session": { ...SessionConstants fields... },
+ *   "socket":  { "address": "host:port" },
+ *   "shell":   { "buildCommit", "serverBuildTime", "currentReleaseId", "routeReturnTarget" }
+ * }
+ * </pre>
+ *
+ * <p>The session block is produced by {@link WaveClientServlet#buildSessionJson}
+ * so the HTML and JSON surfaces cannot drift on role/feature/domain/address.
+ * Note that {@link org.waveprotocol.box.common.SessionConstants#ID_SEED} is
+ * regenerated per call by that helper; the {@code session.id} returned here
+ * therefore need not match the one a concurrent HTML page load emits. The
+ * historical J2CL scraping path only ever consumed address/domain/role/features,
+ * so this divergence is behaviorally safe and is documented here so future
+ * maintainers do not "fix" the divergence by introducing a shared cache.
+ *
+ * <p>This endpoint is read-only. Non-GET requests return HTTP 405. It relies on
+ * the same {@link jakarta.servlet.http.HttpSession} authn contract as {@link
+ * WaveClientServlet}: signed-out callers get a session block that omits
+ * {@code address}/{@code features} but still includes {@code domain}.
+ *
+ * <p>Forward compatibility: issue #933 may extend the {@code socket} object
+ * with a signed handshake token. Clients must ignore unknown keys under each
+ * nested object.
+ */
+@SuppressWarnings("serial")
+@Singleton
+public final class J2clBootstrapServlet extends HttpServlet {
+  private static final Log LOG = Log.get(J2clBootstrapServlet.class);
+
+  private final WaveClientServlet waveClientServlet;
+  private final VersionServlet versionServlet;
+
+  @Inject
+  public J2clBootstrapServlet(
+      WaveClientServlet waveClientServlet, VersionServlet versionServlet) {
+    this.waveClientServlet = waveClientServlet;
+    this.versionServlet = versionServlet;
+  }
+
+  @Override
+  protected void service(HttpServletRequest request, HttpServletResponse response)
+      throws jakarta.servlet.ServletException, IOException {
+    if (!"GET".equals(request.getMethod())) {
+      methodNotAllowed(response);
+      return;
+    }
+    super.service(request, response);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    WebSession webSession = WebSessions.from(request, false);
+    JSONObject sessionJson = waveClientServlet.buildSessionJson(webSession);
+    String websocketAddress = waveClientServlet.presentedWebsocketAddress();
+    String routeReturnTarget = buildRouteReturnTarget(request);
+
+    JSONObject body = new JSONObject();
+    try {
+      body.put(J2clBootstrapContract.KEY_SESSION, sessionJson);
+
+      JSONObject socket = new JSONObject();
+      socket.put(J2clBootstrapContract.SOCKET_ADDRESS, websocketAddress);
+      body.put(J2clBootstrapContract.KEY_SOCKET, socket);
+
+      JSONObject shell = new JSONObject();
+      shell.put(
+          J2clBootstrapContract.SHELL_BUILD_COMMIT,
+          versionServlet.getBuildCommit() == null ? "" : versionServlet.getBuildCommit());
+      shell.put(J2clBootstrapContract.SHELL_SERVER_BUILD_TIME, versionServlet.getBuildTime());
+      String releaseId = versionServlet.getCurrentReleaseId();
+      shell.put(
+          J2clBootstrapContract.SHELL_CURRENT_RELEASE_ID, releaseId == null ? "" : releaseId);
+      shell.put(J2clBootstrapContract.SHELL_ROUTE_RETURN_TARGET, routeReturnTarget);
+      body.put(J2clBootstrapContract.KEY_SHELL, shell);
+    } catch (JSONException e) {
+      LOG.severe("Failed to encode J2CL bootstrap JSON");
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
+    }
+
+    response.setContentType("application/json;charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
+    response.setHeader("Cache-Control", "no-store");
+    response.setHeader("Pragma", "no-cache");
+    response.setHeader("Vary", "Cookie");
+    response.setHeader("X-Content-Type-Options", "nosniff");
+    response.setStatus(HttpServletResponse.SC_OK);
+    try (var w = response.getWriter()) {
+      w.write(body.toString());
+    }
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    methodNotAllowed(response);
+  }
+
+  @Override
+  protected void doPut(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    methodNotAllowed(response);
+  }
+
+  @Override
+  protected void doDelete(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    methodNotAllowed(response);
+  }
+
+  private static void methodNotAllowed(HttpServletResponse response) {
+    response.setHeader("Allow", "GET");
+    response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+  }
+
+  /**
+   * Build the canonical "return to J2CL root shell" URL that mirrors
+   * {@code WaveClientServlet#buildJ2clRootShellReturnTarget(HttpServletRequest)}
+   * while preserving the deployment base path for non-root installs.
+   */
+  private static String buildRouteReturnTarget(HttpServletRequest request) {
+    String basePath = request.getContextPath();
+    if (basePath == null || basePath.isEmpty()) {
+      basePath = "/";
+    } else if (!basePath.endsWith("/")) {
+      basePath = basePath + "/";
+    }
+    StringBuilder returnTarget = new StringBuilder(basePath).append("?view=j2cl-root");
+    String query = request.getParameter("q");
+    if (query != null && !query.isEmpty()) {
+      returnTarget.append("&q=").append(encodeReturnTargetComponent(query));
+    }
+    String wave = request.getParameter("wave");
+    if (wave != null && !wave.isEmpty()) {
+      returnTarget.append("&wave=").append(encodeReturnTargetComponent(wave));
+    }
+    return returnTarget.toString();
+  }
+
+  private static String encodeReturnTargetComponent(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -411,6 +411,26 @@ public class WaveClientServlet extends HttpServlet {
     ret.put(FLAG_MAP.get(name), trimmed);
   }
 
+  /**
+   * Build the {@link SessionConstants}-shaped session payload for the current
+   * request. Package-private so that sibling servlets (e.g. {@link
+   * J2clBootstrapServlet}) can reuse the exact same role/feature/ID-seed logic
+   * rather than duplicating it. The returned object is fresh per call; the
+   * {@link SessionConstants#ID_SEED} seed is regenerated on every invocation.
+   */
+  JSONObject buildSessionJson(WebSession session) {
+    return getSessionJson(session);
+  }
+
+  /**
+   * Return the same presented WebSocket address this servlet would have
+   * embedded into the rendered HTML page. Exposed for sibling servlets that
+   * need to mirror the address into a JSON contract without re-reading config.
+   */
+  String presentedWebsocketAddress() {
+    return websocketPresentedAddress;
+  }
+
   private JSONObject getSessionJson(WebSession session) {
     try {
       ParticipantId user = sessionManager.getLoggedInUser(session);

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.waveprotocol.box.common.J2clBootstrapContract;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class J2clBootstrapServletTest {
+
+  @Test
+  public void signedInRequestReturnsSessionAndSocketAndShell() throws Exception {
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    createServlet(ParticipantId.ofUnsafe("alice@example.com"))
+        .doGet(signedInRequest(), response);
+
+    JSONObject json = new JSONObject(body.toString());
+    JSONObject session = json.getJSONObject(J2clBootstrapContract.KEY_SESSION);
+    assertEquals("alice@example.com", session.getString(J2clBootstrapContract.SESSION_ADDRESS));
+    assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
+    assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+    assertTrue(session.has(J2clBootstrapContract.SESSION_ID));
+    assertTrue(session.has(J2clBootstrapContract.SESSION_FEATURES));
+    assertFalse(session.isNull(J2clBootstrapContract.SESSION_FEATURES));
+
+    JSONObject socket = json.getJSONObject(J2clBootstrapContract.KEY_SOCKET);
+    assertEquals("127.0.0.1:9898", socket.getString(J2clBootstrapContract.SOCKET_ADDRESS));
+
+    JSONObject shell = json.getJSONObject(J2clBootstrapContract.KEY_SHELL);
+    assertEquals("test", shell.getString(J2clBootstrapContract.SHELL_BUILD_COMMIT));
+    assertEquals(0L, shell.getLong(J2clBootstrapContract.SHELL_SERVER_BUILD_TIME));
+    assertTrue(shell.has(J2clBootstrapContract.SHELL_CURRENT_RELEASE_ID));
+    assertEquals("/?view=j2cl-root", shell.getString(J2clBootstrapContract.SHELL_ROUTE_RETURN_TARGET));
+  }
+
+  @Test
+  public void routeReturnTargetPropagatesQueryAndWaveRouteParams() throws Exception {
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getContextPath()).thenReturn("/wave");
+    when(request.getParameter("q")).thenReturn("with:@");
+    when(request.getParameter("wave")).thenReturn("example.com/w+1");
+
+    createServlet(ParticipantId.ofUnsafe("alice@example.com")).doGet(request, response);
+
+    String target =
+        new JSONObject(body.toString())
+            .getJSONObject(J2clBootstrapContract.KEY_SHELL)
+            .getString(J2clBootstrapContract.SHELL_ROUTE_RETURN_TARGET);
+    assertEquals("/wave/?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B1", target);
+  }
+
+  @Test
+  public void signedOutRequestOmitsAddressAndFeatures() throws Exception {
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getSession(false)).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+
+    createServlet(null).doGet(request, response);
+
+    JSONObject json = new JSONObject(body.toString());
+    JSONObject session = json.getJSONObject(J2clBootstrapContract.KEY_SESSION);
+    assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
+    assertFalse(session.has(J2clBootstrapContract.SESSION_ADDRESS));
+    assertFalse(session.has(J2clBootstrapContract.SESSION_FEATURES));
+    assertEquals(
+        "127.0.0.1:9898",
+        json.getJSONObject(J2clBootstrapContract.KEY_SOCKET)
+            .getString(J2clBootstrapContract.SOCKET_ADDRESS));
+  }
+
+  @Test
+  public void responseHeadersPinCachingAndContentType() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+
+    createServlet(ParticipantId.ofUnsafe("alice@example.com"))
+        .doGet(signedInRequest(), response);
+
+    verify(response).setContentType("application/json;charset=UTF-8");
+    verify(response).setHeader("Cache-Control", "no-store");
+    verify(response).setHeader("Pragma", "no-cache");
+    verify(response).setHeader("Vary", "Cookie");
+    verify(response).setHeader("X-Content-Type-Options", "nosniff");
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+  }
+
+  @Test
+  public void nonGetMethodsReturn405() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    J2clBootstrapServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"));
+
+    servlet.service(requestWithMethod("POST"), response);
+    servlet.service(requestWithMethod("PUT"), response);
+    servlet.service(requestWithMethod("DELETE"), response);
+    servlet.service(requestWithMethod("HEAD"), response);
+    servlet.service(requestWithMethod("OPTIONS"), response);
+    servlet.service(requestWithMethod("TRACE"), response);
+    servlet.service(requestWithMethod("PATCH"), response);
+
+    verify(response, org.mockito.Mockito.times(7))
+        .setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+    verify(response, org.mockito.Mockito.times(7)).setHeader(eq("Allow"), eq("GET"));
+  }
+
+  private static HttpServletRequest requestWithMethod(String method) {
+    HttpServletRequest request = signedInRequest();
+    when(request.getMethod()).thenReturn(method);
+    return request;
+  }
+
+  private static HttpServletRequest signedInRequest() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getContextPath()).thenReturn("");
+    when(request.getMethod()).thenReturn("GET");
+    return request;
+  }
+
+  private static J2clBootstrapServlet createServlet(ParticipantId user) throws Exception {
+    Config config =
+        ConfigFactory.parseString(
+            "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+                + "core.http_websocket_public_address=\"\"\n"
+                + "core.http_websocket_presented_address=\"\"\n"
+                + "core.search_type=\"memory\"\n"
+                + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+    }
+    VersionServlet versionServlet = new VersionServlet("test", 0L);
+    WaveClientServlet waveClientServlet =
+        new WaveClientServlet(
+            "example.com",
+            config,
+            sessionManager,
+            accountStore,
+            versionServlet,
+            mock(WavePreRenderer.class),
+            new FeatureFlagService(featureFlagStore()));
+    return new J2clBootstrapServlet(waveClientServlet, versionServlet);
+  }
+
+  private static FeatureFlagStore featureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(Collections.emptyList());
+    return store;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.common;
+
+/**
+ * Pinned naming contract for the J2CL bootstrap JSON endpoint introduced by
+ * issue #963. Shared by the server-side servlet, tests, and documentation so
+ * the server-owned contract has one canonical source of truth.
+ *
+ * <p>This class is intentionally behavior-free; it only exposes path and field
+ * name constants. The JSON schema is:
+ *
+ * <pre>
+ * {
+ *   "session": { "domain": "...", "address": "...", "id": "...", "role": "...", "features": [...] },
+ *   "socket":  { "address": "..." },
+ *   "shell":   { "buildCommit": "...", "serverBuildTime": 0,
+ *                "currentReleaseId": "...", "routeReturnTarget": "..." }
+ * }
+ * </pre>
+ *
+ * <p>Forward compatibility: follow-up work under issue #933 may add more fields
+ * under {@code socket} (e.g. a signed bootstrap token). Clients must therefore
+ * ignore unknown keys under each nested object.
+ */
+public final class J2clBootstrapContract {
+  public static final String PATH = "/bootstrap.json";
+
+  public static final String KEY_SESSION = "session";
+  public static final String KEY_SOCKET = "socket";
+  public static final String KEY_SHELL = "shell";
+
+  public static final String SESSION_DOMAIN = "domain";
+  public static final String SESSION_ADDRESS = "address";
+  public static final String SESSION_ID = "id";
+  public static final String SESSION_ROLE = "role";
+  public static final String SESSION_FEATURES = "features";
+
+  public static final String SOCKET_ADDRESS = "address";
+
+  public static final String SHELL_BUILD_COMMIT = "buildCommit";
+  public static final String SHELL_SERVER_BUILD_TIME = "serverBuildTime";
+  public static final String SHELL_CURRENT_RELEASE_ID = "currentReleaseId";
+  public static final String SHELL_ROUTE_RETURN_TARGET = "routeReturnTarget";
+
+  private J2clBootstrapContract() {}
+}


### PR DESCRIPTION
## Summary
- add a new server-owned `/bootstrap.json` endpoint for J2CL bootstrap metadata
- switch the J2CL sidecar/root-shell bootstrap call sites from HTML scraping to the typed JSON contract
- preserve the legacy HTML bootstrap script for one-release coexistence and document the rollback rule
- add tests, plan doc, runbook updates, and changelog fragment for the new contract

## Validation
- `sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest" "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest" "testOnly org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest" j2clSandboxTest j2clSearchTest`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `git diff --check`

## Review
- Claude Opus 4.7 plan review completed before implementation
- Claude Opus 4.7 implementation review completed on the final diff
- follow-up cleanup issues filed: #978, #979

Closes #963
Related: #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * J2CL clients now bootstrap session, socket and shell metadata from a dedicated /bootstrap.json endpoint (UI shows fetching/reading bootstrap JSON); legacy HTML globals remain for one-release fallback.

* **Documentation**
  * Added runbook, rollout/rollback plan, and changelog documenting the new bootstrap contract and operational constraints.

* **Tests**
  * Added server and client tests for JSON payloads, signed-out behavior, headers, URL-encoding, and non-GET 405 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->