### PR TITLE
Automate Grafana dashboard provisioning for Wave analytics

### DIFF
--- a/.github/workflows/grafana-dashboards.yml
+++ b/.github/workflows/grafana-dashboards.yml
@@ -28,6 +28,9 @@ on:
         required: false
         default: 'false'
 
+permissions:
+  contents: read
+
 jobs:
   dashboards:
     name: Validate and publish Grafana dashboards

--- a/.github/workflows/grafana-dashboards.yml
+++ b/.github/workflows/grafana-dashboards.yml
@@ -1,0 +1,61 @@
+name: Grafana Dashboards
+run-name: >-
+  ${{ github.event_name == 'pull_request' && format('Grafana Dashboards PR #{0} @ {1}', github.event.pull_request.number, github.event.pull_request.head.sha) || github.event_name == 'push' && format('Grafana Dashboards {0} @ {1}', github.ref_name, github.sha) || github.event_name == 'workflow_dispatch' && format('Grafana Dashboards {0} @ {1}', github.ref_name, github.sha) || format('Grafana Dashboards {0}', github.event_name) }}
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/grafana-dashboards.yml'
+      - 'scripts/upsert_grafana_dashboard.py'
+      - 'scripts/tests/test_grafana_dashboard_upsert.py'
+      - 'scripts/tests/test_grafana_dashboards_workflow.py'
+      - 'grafana/dashboards/perf-observability.json'
+      - 'deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/grafana-dashboards.yml'
+      - 'scripts/upsert_grafana_dashboard.py'
+      - 'scripts/tests/test_grafana_dashboard_upsert.py'
+      - 'scripts/tests/test_grafana_dashboards_workflow.py'
+      - 'grafana/dashboards/perf-observability.json'
+      - 'deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json'
+  workflow_dispatch:
+    inputs:
+      publish_from_current_ref:
+        description: 'Allow dashboard upsert from the current non-main ref.'
+        required: false
+        default: 'false'
+
+jobs:
+  dashboards:
+    name: Validate and publish Grafana dashboards
+    runs-on: ubuntu-latest
+    env:
+      GRAFANA_URL: ${{ vars.GRAFANA_URL }}
+      HAS_GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN != '' && 'true' || '' }}
+      GRAFANA_PROMETHEUS_DATASOURCE_UID: ${{ vars.GRAFANA_PROMETHEUS_DATASOURCE_UID }}
+      GRAFANA_FOLDER_UID: ${{ vars.GRAFANA_FOLDER_UID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run dashboard tests
+        run: |
+          python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow
+
+      - name: Upsert Grafana dashboards
+        if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event.inputs.publish_from_current_ref == 'true') && env.GRAFANA_URL != '' && env.HAS_GRAFANA_DASHBOARD_API_TOKEN == 'true' && env.GRAFANA_PROMETHEUS_DATASOURCE_UID != '' }}
+        env:
+          GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN }}
+        run: |
+          python3 scripts/upsert_grafana_dashboard.py --strict \
+            --dashboard grafana/dashboards/perf-observability.json \
+            --dashboard deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -128,7 +128,7 @@ jobs:
           GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN }}
         run: |
           if [ -f scripts/upsert_grafana_dashboard.py ]; then
-            python3 scripts/upsert_grafana_dashboard.py
+            python3 scripts/upsert_grafana_dashboard.py --dashboard grafana/dashboards/perf-observability.json
           else
             echo "Grafana dashboard helper not present yet; skipping"
           fi

--- a/docs/superpowers/plans/2026-04-23-issue-982-grafana-analytics-dashboard-provisioning.md
+++ b/docs/superpowers/plans/2026-04-23-issue-982-grafana-analytics-dashboard-provisioning.md
@@ -1,0 +1,141 @@
+# Issue 982 Grafana Analytics Dashboard Provisioning Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the repo-owned Wave usage analytics dashboard to Grafana with the existing GitHub Actions Grafana credentials so the dashboard no longer depends on manual import.
+
+**Architecture:** Keep the live analytics emission and Alloy shipping path unchanged because host verification already shows `/metrics` exports the `wave_analytics_*` counters and Alloy remote-write is healthy. Fix the provisioning gap by extending the Grafana dashboard upsert helper to handle both dashboard placeholder styles already present in the repo, including the analytics dashboard `__inputs` export block, then add a lightweight GitHub Actions workflow that validates and upserts the dashboard with the existing `GRAFANA_*` vars and secret. In CI, the workflow should treat Grafana API failures as real failures; best-effort behavior stays available only outside the strict workflow path.
+
+**Tech Stack:** Python 3, GitHub Actions workflow YAML, Grafana dashboards API, existing Prometheus-backed dashboard JSON.
+
+---
+
+### Task 1: Lock the provisioning gap down with tests
+
+**Files:**
+- Modify: `scripts/tests/test_grafana_dashboard_upsert.py`
+- Add: `scripts/tests/test_grafana_dashboards_workflow.py`
+- Read: `deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json`
+- Read: `grafana/dashboards/perf-observability.json`
+
+- [ ] **Step 1: Add failing helper tests for the analytics dashboard path**
+
+Cover:
+- the analytics dashboard file is included in the upsert target set
+- the helper rewrites `${DS_PROMETHEUS}` datasource placeholders to the real datasource UID
+- the helper strips or neutralizes the analytics dashboard `__inputs` placeholder block so the Grafana API payload is import-ready
+- the helper still rewrites `__PROMETHEUS_DS_UID__` for the perf dashboard
+- the helper payload remains `overwrite: true`
+
+- [ ] **Step 2: Add a failing workflow-shape test**
+
+Assert the new workflow:
+- exists at `.github/workflows/grafana-dashboards.yml`
+- reuses `GRAFANA_URL`, `GRAFANA_PROMETHEUS_DATASOURCE_UID`, `GRAFANA_FOLDER_UID`, and `GRAFANA_DASHBOARD_API_TOKEN`
+- runs dashboard tests on PRs
+- only performs the live Grafana upsert on `push` to `main` or `workflow_dispatch`
+- explicitly scopes `paths:` to the dashboard helper, dashboard JSON files, and the workflow file itself
+
+- [ ] **Step 3: Run the narrow failing test target**
+
+Run:
+`python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow`
+
+Expected:
+- FAIL because the helper only targets the perf dashboard today and the workflow does not exist yet.
+
+### Task 2: Generalize the Grafana dashboard upsert helper
+
+**Files:**
+- Modify: `scripts/upsert_grafana_dashboard.py`
+- Modify: `scripts/tests/test_grafana_dashboard_upsert.py`
+
+- [ ] **Step 1: Extend the helper to upsert explicit dashboard paths**
+
+Implement:
+- a small dashboard target list that includes both `grafana/dashboards/perf-observability.json` and `deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json`
+- CLI support for repeated `--dashboard <path>` overrides so the workflow can be explicit
+- recursive datasource placeholder normalization for both `__PROMETHEUS_DS_UID__` and `${DS_PROMETHEUS}`
+- normalization that removes the analytics dashboard `__inputs` block once `${DS_PROMETHEUS}` has been resolved
+- deduplication of repeated dashboard paths before upsert
+
+- [ ] **Step 2: Keep the helper best-effort**
+
+Preserve current behavior:
+- missing credentials still exit `0` with a warning
+- HTTP and URL errors still exit `0` with a warning
+- folder UID remains optional
+
+- [ ] **Step 3: Add a strict mode for CI provisioning**
+
+Implement:
+- a `--strict` CLI flag that turns Grafana HTTP/URL failures into non-zero exits
+- workflow usage of `--strict` so a green run means the dashboard really upserted
+
+- [ ] **Step 4: Re-run the helper tests**
+
+Run:
+`python3 -m unittest scripts.tests.test_grafana_dashboard_upsert`
+
+Expected:
+- PASS with both dashboard formats covered.
+
+### Task 3: Add the lightweight dashboard provisioning workflow
+
+**Files:**
+- Add: `.github/workflows/grafana-dashboards.yml`
+- Add: `scripts/tests/test_grafana_dashboards_workflow.py`
+
+- [ ] **Step 1: Add the workflow**
+
+Workflow requirements:
+- trigger on `push` to `main` when dashboard helper/dashboard files change
+- trigger on `pull_request` for the same paths to validate tests without live upsert
+- trigger on `workflow_dispatch` for manual provisioning on a branch; this is intentional so the branch can prove Grafana creation before merge
+- run `python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow`
+- run `python3 scripts/upsert_grafana_dashboard.py --strict --dashboard grafana/dashboards/perf-observability.json --dashboard deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json` only when the event allows live provisioning and Grafana credentials are present
+
+- [ ] **Step 2: Re-run the workflow-shape tests**
+
+Run:
+`python3 -m unittest scripts.tests.test_grafana_dashboards_workflow`
+
+Expected:
+- PASS with the new workflow committed to the repo.
+
+### Task 4: Verify end to end and capture traceability
+
+**Files:**
+- Modify: `journal/local-verification/2026-04-23-issue-982-grafana-analytics-dashboard.md`
+
+- [ ] **Step 1: Run the full narrow verification set**
+
+Run:
+`python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow`
+
+Expected:
+- PASS
+
+- [ ] **Step 2: Prove the patch stayed out of the shipping path**
+
+Run:
+`git diff --name-only -- scripts/upsert_grafana_dashboard.py scripts/tests/test_grafana_dashboard_upsert.py scripts/tests/test_grafana_dashboards_workflow.py .github/workflows/grafana-dashboards.yml deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json grafana/dashboards/perf-observability.json docs/superpowers/plans/2026-04-23-issue-982-grafana-analytics-dashboard-provisioning.md`
+
+Expected:
+- Only the helper, tests, workflow, and dashboard files listed above changed; no `/metrics` or Alloy shipping files were touched.
+
+- [ ] **Step 3: Trigger the dashboard workflow on the branch**
+
+Run:
+`gh workflow run grafana-dashboards.yml --ref codex/issue-982-grafana-analytics-dashboard`
+
+Then record the workflow run URL and final status in:
+- `journal/local-verification/2026-04-23-issue-982-grafana-analytics-dashboard.md`
+- GitHub issue `#982`
+
+- [ ] **Step 4: Open the PR and monitor it through merge**
+
+After review-ready verification:
+- open the PR to `main`
+- add issue comment with plan path, verification commands, workflow run evidence, and PR URL
+- create a thread heartbeat monitor so this thread keeps checking the PR until it is merged

--- a/scripts/tests/test_grafana_dashboard_upsert.py
+++ b/scripts/tests/test_grafana_dashboard_upsert.py
@@ -96,7 +96,7 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
 
   def test_main_skips_cleanly_when_credentials_are_missing(self):
     with mock.patch.dict(os.environ, {}, clear=True):
-      exit_code = upsert_grafana_dashboard.main()
+      exit_code = upsert_grafana_dashboard.main([])
 
     self.assertEqual(0, exit_code)
 
@@ -122,7 +122,7 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
 
     with mock.patch.dict(os.environ, env, clear=True):
       with mock.patch.object(upsert_grafana_dashboard.urllib.request, "urlopen", side_effect=error):
-        exit_code = upsert_grafana_dashboard.main()
+        exit_code = upsert_grafana_dashboard.main([])
 
     self.assertEqual(0, exit_code)
 
@@ -178,7 +178,7 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
 
     with mock.patch.dict(os.environ, env, clear=True):
       with mock.patch.object(upsert_grafana_dashboard.urllib.request, "urlopen", side_effect=fake_urlopen):
-        exit_code = upsert_grafana_dashboard.main()
+        exit_code = upsert_grafana_dashboard.main([])
 
     self.assertEqual(0, exit_code)
     self.assertEqual(2, len(requests))
@@ -218,7 +218,7 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
           "urlopen",
           side_effect=urllib.error.URLError("connection refused"),
       ):
-        exit_code = upsert_grafana_dashboard.main()
+        exit_code = upsert_grafana_dashboard.main([])
 
     self.assertEqual(0, exit_code)
 

--- a/scripts/tests/test_grafana_dashboard_upsert.py
+++ b/scripts/tests/test_grafana_dashboard_upsert.py
@@ -9,7 +9,10 @@ from scripts import upsert_grafana_dashboard
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DASHBOARD_PATH = REPO_ROOT / "grafana" / "dashboards" / "perf-observability.json"
+PERF_DASHBOARD_PATH = REPO_ROOT / "grafana" / "dashboards" / "perf-observability.json"
+ANALYTICS_DASHBOARD_PATH = (
+    REPO_ROOT / "deploy" / "supawave-host" / "grafana-dashboards" / "supawave-analytics-overview.json"
+)
 
 
 def walk_panels(dashboard: dict) -> list[dict]:
@@ -21,14 +24,66 @@ def walk_panels(dashboard: dict) -> list[dict]:
 
 
 class GrafanaDashboardUpsertTest(unittest.TestCase):
+  class _FakeResponse:
+    def __init__(self, status: int = 200):
+      self.status = status
+
+    def __enter__(self):
+      return self
+
+    def __exit__(self, exc_type, exc, tb):
+      return False
+
   def test_dashboard_contains_expected_perf_panels(self):
-    dashboard = json.loads(DASHBOARD_PATH.read_text(encoding="utf-8"))
+    dashboard = json.loads(PERF_DASHBOARD_PATH.read_text(encoding="utf-8"))
     titles = {panel["title"] for panel in walk_panels(dashboard) if "title" in panel}
 
     self.assertIn("Latest Perf Status", titles)
     self.assertIn("P95 by Simulation", titles)
     self.assertIn("JVM Heap", titles)
     self.assertIn("Runner CPU", titles)
+
+  def test_dashboard_contains_expected_analytics_panels(self):
+    dashboard = json.loads(ANALYTICS_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    titles = {panel["title"] for panel in walk_panels(dashboard) if "title" in panel}
+
+    self.assertIn("Public Page Views", titles)
+    self.assertIn("Public API Views", titles)
+    self.assertIn("Registrations", titles)
+    self.assertIn("Active User Events", titles)
+
+  def test_default_dashboard_paths_include_perf_and_analytics(self):
+    self.assertEqual(
+        [PERF_DASHBOARD_PATH, ANALYTICS_DASHBOARD_PATH],
+        upsert_grafana_dashboard.default_dashboard_paths(),
+    )
+
+  def test_load_dashboard_targets_deduplicates_paths(self):
+    targets = upsert_grafana_dashboard.load_dashboard_targets(
+        [
+            str(PERF_DASHBOARD_PATH),
+            str(ANALYTICS_DASHBOARD_PATH),
+            str(PERF_DASHBOARD_PATH),
+        ]
+    )
+
+    self.assertEqual([PERF_DASHBOARD_PATH, ANALYTICS_DASHBOARD_PATH], targets)
+
+  def test_prepare_dashboard_rewrites_perf_dashboard_datasource_uid(self):
+    dashboard = upsert_grafana_dashboard.prepare_dashboard(PERF_DASHBOARD_PATH, "datasource")
+
+    rendered = json.dumps(dashboard)
+    self.assertIn('"uid": "datasource"', rendered)
+    self.assertNotIn("__PROMETHEUS_DS_UID__", rendered)
+    self.assertNotIn("${DS_PROMETHEUS}", rendered)
+
+  def test_prepare_dashboard_rewrites_analytics_dashboard_datasource_uid_and_strips_inputs(self):
+    dashboard = upsert_grafana_dashboard.prepare_dashboard(ANALYTICS_DASHBOARD_PATH, "datasource")
+
+    rendered = json.dumps(dashboard)
+    self.assertIn('"uid": "datasource"', rendered)
+    self.assertNotIn("${DS_PROMETHEUS}", rendered)
+    self.assertNotIn('"__inputs"', rendered)
 
   def test_build_payload_sets_overwrite_true(self):
     payload = upsert_grafana_dashboard.build_payload(
@@ -44,6 +99,12 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
       exit_code = upsert_grafana_dashboard.main()
 
     self.assertEqual(0, exit_code)
+
+  def test_main_strict_fails_when_credentials_are_missing(self):
+    with mock.patch.dict(os.environ, {}, clear=True):
+      exit_code = upsert_grafana_dashboard.main(["--strict"])
+
+    self.assertEqual(1, exit_code)
 
   def test_main_skips_cleanly_when_grafana_upsert_returns_http_error(self):
     env = {
@@ -64,6 +125,85 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
         exit_code = upsert_grafana_dashboard.main()
 
     self.assertEqual(0, exit_code)
+
+  def test_main_strict_fails_when_grafana_upsert_returns_http_error(self):
+    env = {
+        "GRAFANA_URL": "https://grafana.example.com",
+        "GRAFANA_DASHBOARD_API_TOKEN": "token",
+        "GRAFANA_PROMETHEUS_DATASOURCE_UID": "datasource",
+    }
+    error = urllib.error.HTTPError(
+        url="https://grafana.example.com/api/dashboards/db",
+        code=502,
+        msg="Bad Gateway",
+        hdrs=None,
+        fp=None,
+    )
+
+    with mock.patch.dict(os.environ, env, clear=True):
+      with mock.patch.object(upsert_grafana_dashboard.urllib.request, "urlopen", side_effect=error):
+        exit_code = upsert_grafana_dashboard.main(["--strict"])
+
+    self.assertEqual(1, exit_code)
+
+  def test_main_strict_fails_when_grafana_upsert_returns_url_error(self):
+    env = {
+        "GRAFANA_URL": "https://grafana.example.com",
+        "GRAFANA_DASHBOARD_API_TOKEN": "token",
+        "GRAFANA_PROMETHEUS_DATASOURCE_UID": "datasource",
+    }
+
+    with mock.patch.dict(os.environ, env, clear=True):
+      with mock.patch.object(
+          upsert_grafana_dashboard.urllib.request,
+          "urlopen",
+          side_effect=urllib.error.URLError("connection refused"),
+      ):
+        exit_code = upsert_grafana_dashboard.main(["--strict"])
+
+    self.assertEqual(1, exit_code)
+
+  def test_main_posts_both_default_dashboards_on_success(self):
+    env = {
+        "GRAFANA_URL": "https://grafana.example.com",
+        "GRAFANA_DASHBOARD_API_TOKEN": "token",
+        "GRAFANA_PROMETHEUS_DATASOURCE_UID": "datasource",
+        "GRAFANA_FOLDER_UID": "folder",
+    }
+    requests = []
+
+    def fake_urlopen(request, timeout=None):
+      requests.append(request)
+      return self._FakeResponse(status=200)
+
+    with mock.patch.dict(os.environ, env, clear=True):
+      with mock.patch.object(upsert_grafana_dashboard.urllib.request, "urlopen", side_effect=fake_urlopen):
+        exit_code = upsert_grafana_dashboard.main()
+
+    self.assertEqual(0, exit_code)
+    self.assertEqual(2, len(requests))
+
+    payloads = [json.loads(request.data.decode("utf-8")) for request in requests]
+    titles = [payload["dashboard"]["title"] for payload in payloads]
+
+    self.assertEqual(
+        ["Wave Perf Observability", "SupaWave Analytics Overview"],
+        titles,
+    )
+    self.assertTrue(all(payload["overwrite"] for payload in payloads))
+    self.assertTrue(all(payload["folderUid"] == "folder" for payload in payloads))
+
+  def test_upsert_dashboard_strict_fails_when_file_is_missing(self):
+    exit_code = upsert_grafana_dashboard.upsert_dashboard(
+        REPO_ROOT / "missing-dashboard.json",
+        grafana_url="https://grafana.example.com",
+        api_token="token",
+        datasource_uid="datasource",
+        folder_uid=None,
+        strict=True,
+    )
+
+    self.assertEqual(1, exit_code)
 
   def test_main_skips_cleanly_when_grafana_upsert_returns_url_error(self):
     env = {

--- a/scripts/tests/test_grafana_dashboards_workflow.py
+++ b/scripts/tests/test_grafana_dashboards_workflow.py
@@ -29,6 +29,8 @@ class GrafanaDashboardsWorkflowTest(unittest.TestCase):
   def test_workflow_reuses_existing_grafana_credentials(self):
     workflow = self._workflow()
 
+    self.assertIn("permissions:", workflow)
+    self.assertIn("contents: read", workflow)
     self.assertIn("GRAFANA_URL: ${{ vars.GRAFANA_URL }}", workflow)
     self.assertIn("GRAFANA_FOLDER_UID: ${{ vars.GRAFANA_FOLDER_UID }}", workflow)
     self.assertIn(

--- a/scripts/tests/test_grafana_dashboards_workflow.py
+++ b/scripts/tests/test_grafana_dashboards_workflow.py
@@ -1,0 +1,110 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "grafana-dashboards.yml"
+
+
+class GrafanaDashboardsWorkflowTest(unittest.TestCase):
+  @staticmethod
+  def _workflow() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+  @staticmethod
+  def _step_window(workflow: str, step_name: str) -> str:
+    lines = workflow.splitlines()
+    marker = f"      - name: {step_name}"
+    index = lines.index(marker)
+    end_index = len(lines)
+    for candidate in range(index + 1, len(lines)):
+      if lines[candidate].startswith("      - name: "):
+        end_index = candidate
+        break
+    return "\n".join(lines[index:end_index])
+
+  def test_workflow_exists(self):
+    self.assertTrue(WORKFLOW_PATH.exists())
+
+  def test_workflow_reuses_existing_grafana_credentials(self):
+    workflow = self._workflow()
+
+    self.assertIn("GRAFANA_URL: ${{ vars.GRAFANA_URL }}", workflow)
+    self.assertIn("GRAFANA_FOLDER_UID: ${{ vars.GRAFANA_FOLDER_UID }}", workflow)
+    self.assertIn(
+        "GRAFANA_PROMETHEUS_DATASOURCE_UID: ${{ vars.GRAFANA_PROMETHEUS_DATASOURCE_UID }}",
+        workflow,
+    )
+    self.assertIn(
+        "HAS_GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN != '' && 'true' || '' }}",
+        workflow,
+    )
+
+  def test_workflow_scopes_paths_to_dashboard_assets(self):
+    workflow = self._workflow()
+
+    self.assertIn(".github/workflows/grafana-dashboards.yml", workflow)
+    self.assertIn("scripts/upsert_grafana_dashboard.py", workflow)
+    self.assertIn("scripts/tests/test_grafana_dashboard_upsert.py", workflow)
+    self.assertIn("scripts/tests/test_grafana_dashboards_workflow.py", workflow)
+    self.assertIn("grafana/dashboards/perf-observability.json", workflow)
+    self.assertIn(
+        "deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json",
+        workflow,
+    )
+
+  def test_workflow_runs_validation_on_pull_requests(self):
+    workflow = self._workflow()
+    validate_step = self._step_window(workflow, "Run dashboard tests")
+
+    self.assertIn("pull_request:", workflow)
+    self.assertIn(
+        "python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow",
+        validate_step,
+    )
+
+  def test_workflow_only_upserts_outside_pull_requests(self):
+    workflow = self._workflow()
+    upsert_step = self._step_window(workflow, "Upsert Grafana dashboards")
+
+    self.assertIn("workflow_dispatch:", workflow)
+    self.assertIn("publish_from_current_ref:", workflow)
+    self.assertIn("branches: [ main ]", workflow)
+    self.assertIn("github.event_name != 'pull_request'", upsert_step)
+    self.assertIn("github.ref == 'refs/heads/main'", upsert_step)
+    self.assertIn("github.event.inputs.publish_from_current_ref == 'true'", upsert_step)
+    self.assertIn("HAS_GRAFANA_DASHBOARD_API_TOKEN == 'true'", upsert_step)
+
+  def test_workflow_upsert_uses_strict_mode_and_both_dashboards(self):
+    workflow = self._workflow()
+    upsert_step = self._step_window(workflow, "Upsert Grafana dashboards")
+
+    self.assertIn("python3 scripts/upsert_grafana_dashboard.py --strict", upsert_step)
+    self.assertIn("--dashboard grafana/dashboards/perf-observability.json", upsert_step)
+    self.assertIn(
+        "--dashboard deploy/supawave-host/grafana-dashboards/supawave-analytics-overview.json",
+        upsert_step,
+    )
+
+  def test_workflow_scopes_dashboard_token_to_upsert_step(self):
+    workflow = self._workflow()
+    job_block = workflow.split("\n    steps:\n", 1)[0]
+    validate_step = self._step_window(workflow, "Run dashboard tests")
+    upsert_step = self._step_window(workflow, "Upsert Grafana dashboards")
+
+    self.assertNotIn(
+        "GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN }}",
+        job_block,
+    )
+    self.assertNotIn(
+        "GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN }}",
+        validate_step,
+    )
+    self.assertIn(
+        "GRAFANA_DASHBOARD_API_TOKEN: ${{ secrets.GRAFANA_DASHBOARD_API_TOKEN }}",
+        upsert_step,
+    )
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/scripts/upsert_grafana_dashboard.py
+++ b/scripts/upsert_grafana_dashboard.py
@@ -105,10 +105,14 @@ def upsert_dashboard(
     print(f"warning: Grafana dashboard file is missing: {path}", file=sys.stderr)
     return 1 if strict else 0
 
-  payload = build_payload(
-      dashboard=prepare_dashboard(path, datasource_uid),
-      folder_uid=folder_uid,
-  )
+  try:
+    payload = build_payload(
+        dashboard=prepare_dashboard(path, datasource_uid),
+        folder_uid=folder_uid,
+    )
+  except (OSError, ValueError) as exc:
+    print(f"warning: Grafana dashboard read/parse error for {path}: {exc}", file=sys.stderr)
+    return 1 if strict else 0
   request = urllib.request.Request(
       f"{grafana_url.rstrip('/')}/api/dashboards/db",
       data=json.dumps(payload).encode("utf-8"),

--- a/scripts/upsert_grafana_dashboard.py
+++ b/scripts/upsert_grafana_dashboard.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import json
 import os
 import sys
@@ -8,19 +9,64 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DASHBOARD_PATH = REPO_ROOT / "grafana" / "dashboards" / "perf-observability.json"
-PLACEHOLDER_UID = "__PROMETHEUS_DS_UID__"
+PERF_DASHBOARD_PATH = REPO_ROOT / "grafana" / "dashboards" / "perf-observability.json"
+ANALYTICS_DASHBOARD_PATH = (
+    REPO_ROOT / "deploy" / "supawave-host" / "grafana-dashboards" / "supawave-analytics-overview.json"
+)
+PLACEHOLDER_UIDS = {"__PROMETHEUS_DS_UID__", "${DS_PROMETHEUS}"}
+URL_OPEN_TIMEOUT_SECONDS = 30
 
 
-def load_dashboard(path: Path = DASHBOARD_PATH) -> dict:
+def default_dashboard_paths() -> list[Path]:
+  return [PERF_DASHBOARD_PATH, ANALYTICS_DASHBOARD_PATH]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+  parser = argparse.ArgumentParser(description="Upsert Grafana dashboards with a concrete datasource UID.")
+  parser.add_argument(
+      "--dashboard",
+      action="append",
+      default=[],
+      help="Dashboard path to upsert. May be repeated. Defaults to the repo-owned perf and analytics dashboards.",
+  )
+  parser.add_argument(
+      "--strict",
+      action="store_true",
+      help="Fail on dashboard read or Grafana API errors instead of treating them as warnings.",
+  )
+  return parser.parse_args(argv)
+
+
+def load_dashboard(path: Path) -> dict:
   return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_dashboard_targets(raw_paths: list[str] | None = None) -> list[Path]:
+  candidates = raw_paths or [str(path) for path in default_dashboard_paths()]
+  targets = []
+  seen = set()
+
+  for raw_path in candidates:
+    path = Path(raw_path)
+    if not path.is_absolute():
+      path = REPO_ROOT / path
+    normalized = path.resolve(strict=False)
+    key = str(normalized)
+    if key in seen:
+      continue
+    seen.add(key)
+    targets.append(normalized)
+
+  return targets
 
 
 def inject_datasource(node, datasource_uid: str):
   if isinstance(node, dict):
     updated = {}
     for key, value in node.items():
-      if key == "uid" and value == PLACEHOLDER_UID:
+      if key == "__inputs":
+        continue
+      if key == "uid" and isinstance(value, str) and value in PLACEHOLDER_UIDS:
         updated[key] = datasource_uid
       else:
         updated[key] = inject_datasource(value, datasource_uid)
@@ -28,6 +74,12 @@ def inject_datasource(node, datasource_uid: str):
   if isinstance(node, list):
     return [inject_datasource(item, datasource_uid) for item in node]
   return node
+
+
+def prepare_dashboard(path: Path, datasource_uid: str) -> dict:
+  dashboard = inject_datasource(load_dashboard(path), datasource_uid)
+  dashboard["id"] = None
+  return dashboard
 
 
 def build_payload(dashboard: dict, folder_uid: str | None = None) -> dict:
@@ -40,18 +92,23 @@ def build_payload(dashboard: dict, folder_uid: str | None = None) -> dict:
   return payload
 
 
-def main() -> int:
-  grafana_url = os.getenv("GRAFANA_URL", "")
-  api_token = os.getenv("GRAFANA_DASHBOARD_API_TOKEN", "")
-  datasource_uid = os.getenv("GRAFANA_PROMETHEUS_DATASOURCE_UID", "")
-  folder_uid = os.getenv("GRAFANA_FOLDER_UID", "")
+def upsert_dashboard(
+    path: Path,
+    *,
+    grafana_url: str,
+    api_token: str,
+    datasource_uid: str,
+    folder_uid: str | None,
+    strict: bool,
+) -> int:
+  if not path.exists():
+    print(f"warning: Grafana dashboard file is missing: {path}", file=sys.stderr)
+    return 1 if strict else 0
 
-  if not grafana_url or not api_token or not datasource_uid:
-    print("warning: Grafana dashboard credentials are incomplete; skipping upsert", file=sys.stderr)
-    return 0
-
-  dashboard = inject_datasource(load_dashboard(), datasource_uid)
-  payload = build_payload(dashboard=dashboard, folder_uid=folder_uid or None)
+  payload = build_payload(
+      dashboard=prepare_dashboard(path, datasource_uid),
+      folder_uid=folder_uid,
+  )
   request = urllib.request.Request(
       f"{grafana_url.rstrip('/')}/api/dashboards/db",
       data=json.dumps(payload).encode("utf-8"),
@@ -63,17 +120,53 @@ def main() -> int:
   )
 
   try:
-    with urllib.request.urlopen(request) as response:
+    with urllib.request.urlopen(request, timeout=URL_OPEN_TIMEOUT_SECONDS) as response:
       if 200 <= response.status < 300:
         return 0
-      print(f"warning: Grafana dashboard upsert returned HTTP {response.status}", file=sys.stderr)
-      return 0
+      print(
+          f"warning: Grafana dashboard upsert returned HTTP {response.status} for {path}",
+          file=sys.stderr,
+      )
+      return 1 if strict else 0
   except urllib.error.HTTPError as exc:
-    print(f"warning: Grafana dashboard upsert HTTP error: {exc.code} {exc.reason}", file=sys.stderr)
-    return 0
+    print(
+        f"warning: Grafana dashboard upsert HTTP error for {path}: {exc.code} {exc.reason}",
+        file=sys.stderr,
+    )
+    return 1 if strict else 0
   except urllib.error.URLError as exc:
-    print(f"warning: Grafana dashboard upsert URL error: {exc.reason}", file=sys.stderr)
-    return 0
+    print(
+        f"warning: Grafana dashboard upsert URL error for {path}: {exc.reason}",
+        file=sys.stderr,
+    )
+    return 1 if strict else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+  args = parse_args([] if argv is None else argv)
+  grafana_url = os.getenv("GRAFANA_URL", "")
+  api_token = os.getenv("GRAFANA_DASHBOARD_API_TOKEN", "")
+  datasource_uid = os.getenv("GRAFANA_PROMETHEUS_DATASOURCE_UID", "")
+  folder_uid = os.getenv("GRAFANA_FOLDER_UID", "") or None
+
+  if not grafana_url or not api_token or not datasource_uid:
+    print("warning: Grafana dashboard credentials are incomplete; skipping upsert", file=sys.stderr)
+    return 1 if args.strict else 0
+
+  exit_code = 0
+  for path in load_dashboard_targets(args.dashboard):
+    exit_code = max(
+        exit_code,
+        upsert_dashboard(
+            path,
+            grafana_url=grafana_url,
+            api_token=api_token,
+            datasource_uid=datasource_uid,
+            folder_uid=folder_uid,
+            strict=args.strict,
+        ),
+    )
+  return exit_code
 
 
 if __name__ == "__main__":

--- a/scripts/upsert_grafana_dashboard.py
+++ b/scripts/upsert_grafana_dashboard.py
@@ -143,7 +143,7 @@ def upsert_dashboard(
 
 
 def main(argv: list[str] | None = None) -> int:
-  args = parse_args([] if argv is None else argv)
+  args = parse_args(argv)
   grafana_url = os.getenv("GRAFANA_URL", "")
   api_token = os.getenv("GRAFANA_DASHBOARD_API_TOKEN", "")
   datasource_uid = os.getenv("GRAFANA_PROMETHEUS_DATASOURCE_UID", "")
@@ -170,4 +170,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-  raise SystemExit(main())
+  raise SystemExit(main(sys.argv[1:]))

--- a/wave/config/changelog.d/2026-04-23-grafana-dashboard-provisioning.json
+++ b/wave/config/changelog.d/2026-04-23-grafana-dashboard-provisioning.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-23-grafana-dashboard-provisioning",
+  "version": "PR #983",
+  "date": "2026-04-23",
+  "title": "Grafana Dashboards Publish From Repo",
+  "summary": "Wave analytics and perf dashboards now publish from the repo through GitHub Actions instead of relying on manual Grafana imports.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added a repo-owned GitHub Actions workflow to validate and publish the Wave analytics and perf dashboards to Grafana",
+        "Hardened the Grafana dashboard upsert helper so strict CI runs fail on real API errors and accept both dashboard datasource placeholder styles"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #982

## Summary
- generalize the Grafana dashboard upsert helper so it publishes both the perf and Wave analytics dashboards
- normalize both datasource placeholder styles and strip the analytics dashboard export-only `__inputs` block
- add a dedicated `grafana-dashboards` workflow that validates on PRs and publishes on `main` or explicit branch dispatch opt-in

## Verification
- `python3 -m unittest scripts.tests.test_grafana_dashboard_upsert scripts.tests.test_grafana_dashboards_workflow`
- Host evidence: Wave `/metrics` already exports `wave_analytics_*`, Alloy already scrapes `127.0.0.1:9898/metrics`, and Grafana remote-write failures are zero
- Manual pre-merge Grafana publish proof via existing `perf.yml`: https://github.com/vega113/supawave/actions/runs/24841450355

## Notes
- The new `grafana-dashboards.yml` workflow cannot be manually dispatched before merge because GitHub only exposes dispatchable workflow metadata from the default branch. It will still validate on this PR and auto-publish after merge on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated Grafana dashboard validation and conditional publishing via a new GitHub Actions workflow (push to main or manual dispatch)
  * Repository-driven publishing for both performance and analytics dashboards
  * CLI supports multiple dashboard targets and a strict mode to fail on publish errors

* **Tests**
  * New workflow-validation tests and expanded dashboard tests covering multi-dashboard flows and strict-mode failures

* **Documentation**
  * Added implementation plan and changelog entry describing provisioning and strict-upsert behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->