### PR TITLE
fix(ui): keep compact inline avatar on author row (#981)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-981-compact-inline-avatar-row.md
+++ b/docs/superpowers/plans/2026-04-23-issue-981-compact-inline-avatar-row.md
@@ -1,0 +1,158 @@
+# Compact Inline Avatar Same-Row Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep compact inline blip avatars on the same row as the author/metabar at depths 0-2 without reintroducing the old left-gutter width loss.
+
+**Architecture:** Reuse the existing `compact-inline-blips` runtime body class and current DOM structure. Replace the current compact depth 0-2 stacked-column rules with a small grid layout where the avatar and metabar share the top row and the content container spans both columns below, while depth 3+ reset rules keep the baseline slide-nav layout unchanged.
+
+**Tech Stack:** GWT CssResource CSS (`Blip.css`), JVM CSS contract test (`CompactInlineBlipCssContractTest`), changelog fragment + changelog assembly validation.
+
+---
+
+**Issue:** [#981](https://github.com/vega113/supawave/issues/981)
+**Worktree:** `/Users/vega/devroot/worktrees/issue-981-compact-inline-avatar-row`
+**Branch:** `codex/issue-981-compact-inline-avatar-row`
+
+## Scope
+
+- Keep using the existing `compact-inline-blips` feature flag.
+- No new flag, no new Java flag plumbing, no DOM builder changes unless the CSS-only approach proves impossible.
+- Preserve root blip layout and the depth 3+ reset behavior added after PR #930.
+- Add a regression contract that proves the compact layout is same-row on desktop and mobile.
+
+## Fixed layout contract
+
+- Compact depth 0-2 `.meta` uses `display: grid`.
+- Compact depth 0-2 `.meta` uses `grid-template-columns: auto minmax(0, 1fr)`.
+- Compact depth 0-2 `.meta` uses explicit spacing instead of a stacked avatar margin:
+  - desktop: `column-gap: 0.35em`, `row-gap: 0.25em`, `padding-left: 0.75em`
+  - mobile: `column-gap: 0.3em`, `row-gap: 0.2em`, `padding-left: 0.5em`
+- Compact depth 0-2 `.avatar` is `float: none`, `grid-column: 1`, `grid-row: 1`, with `margin-left: 0` and `margin-bottom: 0`.
+- Compact depth 0-2 `.metabar` is `grid-column: 2`, `grid-row: 1`, and `min-width: 0`.
+- Compact depth 0-2 `.contentContainer` is `grid-column: 1 / -1` and `grid-row: 2`.
+- Avatar sizes stay fixed at the current compact values unless the CSS contract is updated in the same change:
+  - desktop depth 0/1/2: `24px`, `22px`, `20px`
+  - mobile depth 0/1/2: `22px`, `20px`, `20px`
+
+## Files
+
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java`
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+- Create: `wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json`
+
+### Task 1: Lock the intended CSS shape with a failing regression test
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java`
+
+- [ ] Update the desktop compact regex assertions so depths 0-2 require a same-row layout instead of the current stacked avatar rules.
+- [ ] Require the compact depth 0-2 `.meta` block to declare a two-column grid with a narrow avatar column and content below.
+- [ ] Require the compact depth 0-2 `.meta` block to declare `grid-template-columns: auto minmax(0, 1fr)` plus the explicit desktop/mobile `column-gap`, `row-gap`, and `padding-left` values from the fixed layout contract.
+- [ ] Require the compact depth 0-2 `.avatar` block to stop floating, sit in the first row, and drop the stack-specific bottom margin.
+- [ ] Require the compact depth 0-2 `.metabar` block to sit in the first row next to the avatar and keep `min-width: 0`.
+- [ ] Require the compact depth 0-2 `.contentContainer` block to span both columns so the body text reuses the width under the avatar.
+- [ ] Mirror the same-row expectations for `.compact-inline-blips-mobile`.
+- [ ] Require the old stacked-column markers (`display: flex`, `flex-direction: column`, avatar `margin-bottom`) to disappear from the compact depth 0-2 rule blocks themselves instead of merely being shadowed elsewhere.
+- [ ] Assert the current mobile selector name verbatim as `.compact-inline-blips-mobile` so the test cannot silently drift to a renamed selector.
+- [ ] Assert the compact avatar sizes in the desktop/mobile depth 0-2 rule blocks so size changes require an intentional contract update.
+- [ ] Run the focused test and confirm it fails for the expected reason before touching production CSS.
+
+Run:
+```bash
+sbt "wave/testOnly org.waveprotocol.box.server.util.CompactInlineBlipCssContractTest"
+```
+
+Expected before the CSS fix:
+- FAIL because the current CSS still matches the stacked avatar assertions from PR #930.
+
+### Task 2: Replace the stacked compact layout with a same-row grid
+
+**Files:**
+- Modify: `wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css`
+
+- [ ] Change compact depth 0-2 `.meta` rules from `display: flex` / `flex-direction: column` to a small grid that places the avatar beside the metabar and the content below them.
+- [ ] Keep compact depth 0-2 `padding-left` reduced relative to baseline so the old avatar gutter does not return.
+- [ ] Move compact depth 0-2 avatars out of float positioning, place them in the first grid row, and preserve the current compact avatar sizes for each depth.
+- [ ] Place compact depth 0-2 `.metabar` in the first grid row with `min-width: 0` so the author line can still ellipsize correctly.
+- [ ] Make compact depth 0-2 `.contentContainer` span the full grid width below the header row.
+- [ ] Apply the same-row pattern to `.compact-inline-blips-mobile` with the existing mobile padding scale, again without reintroducing the legacy gutter.
+- [ ] Delete the previous compact stacked-column rules rather than leaving them in place underneath the grid rules.
+- [ ] Keep the existing depth 3+ reset selectors restoring baseline `.meta` / `.avatar` behavior.
+- [ ] Run the focused CSS contract test and confirm it passes.
+
+Run:
+```bash
+sbt "wave/testOnly org.waveprotocol.box.server.util.CompactInlineBlipCssContractTest"
+```
+
+Expected after the CSS fix:
+- PASS for desktop same-row assertions, mobile same-row assertions, and depth 3+ reset assertions.
+
+### Task 3: Record the user-facing change and validate the changelog
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json`
+
+- [ ] Add a new changelog fragment describing the compact inline follow-up: avatar stays on the same row as the author line while remaining behind the existing `compact-inline-blips` rollout.
+- [ ] Use wording equivalent to: `Compact inline replies now keep the avatar on the same row as the author line to save space on desktop and mobile when compact-inline-blips is enabled.`
+- [ ] Rebuild `wave/config/changelog.json`.
+- [ ] Validate the assembled changelog.
+
+Run:
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
+```
+
+Expected:
+- `assemble-changelog.py` exits 0 and regenerates `wave/config/changelog.json`.
+- `validate-changelog.py` exits 0.
+
+### Task 4: Local verification, self-review, external review, and PR flow
+
+**Files:**
+- Re-read the diff in the three files above before review and PR.
+
+- [ ] Reuse the main repo file store in this worktree for realistic threaded-wave verification.
+- [ ] Rebuild the GWT client so the `Blip.css` changes actually reach the served browser bundle.
+- [ ] Start a local server from the worktree on a free port.
+- [ ] Enable or confirm the existing `compact-inline-blips` flag in the local admin UI or store; do not create a new flag.
+- [ ] Verify in a browser that a nested inline reply shows avatar + author row on the same line on desktop width.
+- [ ] Verify the same layout at a `375px` mobile viewport width.
+- [ ] Verify root blips still use the baseline layout and depth 3+ still falls back to the existing reset behavior.
+- [ ] Verify long author text still ellipsizes correctly and the metabar does not overlap the avatar or content.
+- [ ] Verify reading order remains sane by checking the DOM order is unchanged and keyboard focus/menu interaction still works.
+- [ ] Verify the reaction row still renders correctly beneath the content container after the compact grid change.
+- [ ] Capture one desktop and one mobile screenshot for the PR body.
+- [ ] Run a self-review over the final diff for scope creep, mobile regressions, and metabar/content overlap risks.
+- [ ] Run required external review on the implementation diff via `claude-review` and address any findings before PR.
+- [ ] Update issue #981 with plan path, verification commands/results, review outcome, commit SHA, and PR link.
+- [ ] Open the PR against `main`, then monitor CI and merge status until it lands.
+
+Run:
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Local verification commands:
+```bash
+bash scripts/worktree-boot.sh --port <free-port> --shared-file-store
+```
+
+Targeted regression/build commands:
+```bash
+sbt "wave/testOnly org.waveprotocol.box.server.util.CompactInlineBlipCssContractTest"
+sbt compileGwt
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
+```
+
+## Non-goals
+
+- No StageTwo feature-flag changes unless investigation proves the existing body-class plumbing is broken.
+- No edits to `KnownFeatureFlags.java` unless we discover the current flag metadata itself blocks rollout.
+- No slide-nav redesign or depth-limit changes.
+- No root blip chrome redesign.
+- No reaction-row DOM/CSS redesign beyond verifying it still renders correctly beneath the compact grid.
+- No RTL-specific redesign in this follow-up; preserve current DOM order and note any RTL issue separately if encountered during verification.

--- a/wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json
+++ b/wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-23-compact-inline-avatar-row",
+  "version": "PR pending",
+  "date": "2026-04-23",
+  "title": "Keep compact inline avatars on the author row",
+  "summary": "Updates the compact-inline-blips follow-up so inline reply avatars stay on the same row as the author line while the content still reuses the reclaimed width on desktop and mobile.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Depth 0-2 compact inline replies now keep the avatar on the same row as the author metadata on desktop and mobile.",
+        "Compact inline reply content still spans the reclaimed width below that row, while root blips and depth 3+ reset behavior stay unchanged."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json
+++ b/wave/config/changelog.d/2026-04-23-compact-inline-avatar-row.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-23-compact-inline-avatar-row",
-  "version": "PR pending",
+  "version": "PR #981",
   "date": "2026-04-23",
   "title": "Keep compact inline avatars on the author row",
   "summary": "Updates the compact-inline-blips follow-up so inline reply avatars stay on the same row as the author line while the content still reuses the reclaimed width on desktop and mobile.",

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -481,16 +481,10 @@
   min-width: 0;
   margin-left: 0;
   margin-bottom: 0;
-  margin-left: 0;
 }
 .compact-inline-blips [data-depth="0"] .contentContainer,
 .compact-inline-blips [data-depth="1"] .contentContainer,
 .compact-inline-blips [data-depth="2"] .contentContainer {
-  grid-column: 1 / -1;
-}
-.compact-inline-blips [data-depth="0"] .draftActive-notification,
-.compact-inline-blips [data-depth="1"] .draftActive-notification,
-.compact-inline-blips [data-depth="2"] .draftActive-notification {
   grid-column: 1 / -1;
 }
 .compact-inline-blips [data-depth="0"] .draftActive-notification,
@@ -578,16 +572,10 @@
   min-width: 0;
   margin-left: 0;
   margin-bottom: 0;
-  margin-left: 0;
 }
 .compact-inline-blips-mobile [data-depth="0"] .contentContainer,
 .compact-inline-blips-mobile [data-depth="1"] .contentContainer,
 .compact-inline-blips-mobile [data-depth="2"] .contentContainer {
-  grid-column: 1 / -1;
-}
-.compact-inline-blips-mobile [data-depth="0"] .draftActive-notification,
-.compact-inline-blips-mobile [data-depth="1"] .draftActive-notification,
-.compact-inline-blips-mobile [data-depth="2"] .draftActive-notification {
   grid-column: 1 / -1;
 }
 .compact-inline-blips-mobile [data-depth="0"] .draftActive-notification,

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -479,6 +479,7 @@
   grid-column: 2;
   grid-row: 1;
   min-width: 0;
+  margin-left: 0;
   margin-bottom: 0;
   margin-left: 0;
 }
@@ -486,7 +487,11 @@
 .compact-inline-blips [data-depth="1"] .contentContainer,
 .compact-inline-blips [data-depth="2"] .contentContainer {
   grid-column: 1 / -1;
-  grid-row: 2;
+}
+.compact-inline-blips [data-depth="0"] .draftActive-notification,
+.compact-inline-blips [data-depth="1"] .draftActive-notification,
+.compact-inline-blips [data-depth="2"] .draftActive-notification {
+  grid-column: 1 / -1;
 }
 .compact-inline-blips [data-depth="0"] .draftActive-notification,
 .compact-inline-blips [data-depth="1"] .draftActive-notification,
@@ -571,6 +576,7 @@
   grid-column: 2;
   grid-row: 1;
   min-width: 0;
+  margin-left: 0;
   margin-bottom: 0;
   margin-left: 0;
 }
@@ -578,7 +584,11 @@
 .compact-inline-blips-mobile [data-depth="1"] .contentContainer,
 .compact-inline-blips-mobile [data-depth="2"] .contentContainer {
   grid-column: 1 / -1;
-  grid-row: 2;
+}
+.compact-inline-blips-mobile [data-depth="0"] .draftActive-notification,
+.compact-inline-blips-mobile [data-depth="1"] .draftActive-notification,
+.compact-inline-blips-mobile [data-depth="2"] .draftActive-notification {
+  grid-column: 1 / -1;
 }
 .compact-inline-blips-mobile [data-depth="0"] .draftActive-notification,
 .compact-inline-blips-mobile [data-depth="1"] .draftActive-notification,

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -453,22 +453,39 @@
 @external .compact-inline-blips;
 @external .compact-inline-blips-mobile;
 
-/* Stack the avatar above the metabar/content so inline depth width does not
-   depend on the avatar gutter. */
+/* Keep the avatar on the same row as the metabar while letting content span
+   the full width below that row. */
 .compact-inline-blips [data-depth="0"] .meta,
 .compact-inline-blips [data-depth="1"] .meta,
 .compact-inline-blips [data-depth="2"] .meta {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 0.35em;
+  row-gap: 0.25em;
   padding-left: 0.75em;
 }
 .compact-inline-blips [data-depth="0"] .avatar,
 .compact-inline-blips [data-depth="1"] .avatar,
 .compact-inline-blips [data-depth="2"] .avatar {
   float: none;
+  grid-column: 1;
+  grid-row: 1;
   margin-left: 0;
-  margin-bottom: 0.35em;
-  align-self: flex-start;
+  margin-bottom: 0;
+}
+.compact-inline-blips [data-depth="0"] .metabar,
+.compact-inline-blips [data-depth="1"] .metabar,
+.compact-inline-blips [data-depth="2"] .metabar {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+  margin-bottom: 0;
+}
+.compact-inline-blips [data-depth="0"] .contentContainer,
+.compact-inline-blips [data-depth="1"] .contentContainer,
+.compact-inline-blips [data-depth="2"] .contentContainer {
+  grid-column: 1 / -1;
+  grid-row: 2;
 }
 
 /* --- Depth 0 --- */
@@ -527,17 +544,34 @@
 .compact-inline-blips-mobile [data-depth="0"] .meta,
 .compact-inline-blips-mobile [data-depth="1"] .meta,
 .compact-inline-blips-mobile [data-depth="2"] .meta {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 0.3em;
+  row-gap: 0.2em;
   padding-left: 0.5em;
 }
 .compact-inline-blips-mobile [data-depth="0"] .avatar,
 .compact-inline-blips-mobile [data-depth="1"] .avatar,
 .compact-inline-blips-mobile [data-depth="2"] .avatar {
   float: none;
+  grid-column: 1;
+  grid-row: 1;
   margin-left: 0;
-  margin-bottom: 0.25em;
-  align-self: flex-start;
+  margin-bottom: 0;
+}
+.compact-inline-blips-mobile [data-depth="0"] .metabar,
+.compact-inline-blips-mobile [data-depth="1"] .metabar,
+.compact-inline-blips-mobile [data-depth="2"] .metabar {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+  margin-bottom: 0;
+}
+.compact-inline-blips-mobile [data-depth="0"] .contentContainer,
+.compact-inline-blips-mobile [data-depth="1"] .contentContainer,
+.compact-inline-blips-mobile [data-depth="2"] .contentContainer {
+  grid-column: 1 / -1;
+  grid-row: 2;
 }
 .compact-inline-blips-mobile [data-depth="0"] .avatar {
   width: 22px; height: 22px;

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -480,12 +480,18 @@
   grid-row: 1;
   min-width: 0;
   margin-bottom: 0;
+  margin-left: 0;
 }
 .compact-inline-blips [data-depth="0"] .contentContainer,
 .compact-inline-blips [data-depth="1"] .contentContainer,
 .compact-inline-blips [data-depth="2"] .contentContainer {
   grid-column: 1 / -1;
   grid-row: 2;
+}
+.compact-inline-blips [data-depth="0"] .draftActive-notification,
+.compact-inline-blips [data-depth="1"] .draftActive-notification,
+.compact-inline-blips [data-depth="2"] .draftActive-notification {
+  grid-column: 1 / -1;
 }
 
 /* --- Depth 0 --- */
@@ -566,12 +572,18 @@
   grid-row: 1;
   min-width: 0;
   margin-bottom: 0;
+  margin-left: 0;
 }
 .compact-inline-blips-mobile [data-depth="0"] .contentContainer,
 .compact-inline-blips-mobile [data-depth="1"] .contentContainer,
 .compact-inline-blips-mobile [data-depth="2"] .contentContainer {
   grid-column: 1 / -1;
   grid-row: 2;
+}
+.compact-inline-blips-mobile [data-depth="0"] .draftActive-notification,
+.compact-inline-blips-mobile [data-depth="1"] .draftActive-notification,
+.compact-inline-blips-mobile [data-depth="2"] .draftActive-notification {
+  grid-column: 1 / -1;
 }
 .compact-inline-blips-mobile [data-depth="0"] .avatar {
   width: 22px; height: 22px;

--- a/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
@@ -64,15 +64,21 @@ public final class CompactInlineBlipCssContractTest extends TestCase {
     assertContainsAll(metabar,
         "grid-column: 2;",
         "grid-row: 1;",
-        "min-width: 0;");
+        "min-width: 0;",
+        "margin-left: 0;");
 
     String contentContainer = extractRuleBody(css,
         "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.contentContainer,"
             + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.contentContainer,"
             + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.contentContainer");
-    assertContainsAll(contentContainer,
-        "grid-column: 1 / -1;",
-        "grid-row: 2;");
+    assertContainsAll(contentContainer, "grid-column: 1 / -1;");
+    assertDoesNotContain(contentContainer, "grid-row: 2;");
+
+    String draftNotification = extractRuleBody(css,
+        "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.draftActive-notification,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.draftActive-notification,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.draftActive-notification");
+    assertContainsAll(draftNotification, "grid-column: 1 / -1;");
 
     assertMatches(css,
         "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.avatar \\{"
@@ -126,15 +132,21 @@ public final class CompactInlineBlipCssContractTest extends TestCase {
     assertContainsAll(metabar,
         "grid-column: 2;",
         "grid-row: 1;",
-        "min-width: 0;");
+        "min-width: 0;",
+        "margin-left: 0;");
 
     String contentContainer = extractRuleBody(css,
         "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.contentContainer,"
             + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.contentContainer,"
             + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.contentContainer");
-    assertContainsAll(contentContainer,
-        "grid-column: 1 / -1;",
-        "grid-row: 2;");
+    assertContainsAll(contentContainer, "grid-column: 1 / -1;");
+    assertDoesNotContain(contentContainer, "grid-row: 2;");
+
+    String draftNotification = extractRuleBody(css,
+        "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.draftActive-notification,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.draftActive-notification,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.draftActive-notification");
+    assertContainsAll(draftNotification, "grid-column: 1 / -1;");
 
     assertMatches(css,
         "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.avatar \\{"

--- a/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/CompactInlineBlipCssContractTest.java
@@ -24,50 +24,132 @@ import junit.framework.TestCase;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class CompactInlineBlipCssContractTest extends TestCase {
 
-  public void testDesktopCompactInlineBlipsStackAvatarAboveContent() throws Exception {
+  public void testDesktopCompactInlineBlipsKeepAvatarAndMetabarOnSameRow() throws Exception {
     String css = readBlipCss();
 
-    assertMatches(css,
-        "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.meta,"
+    String meta = extractRuleBody(css,
+        "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.meta,"
             + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.meta,"
-            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.meta \\{"
-            + "\\s*display: flex;"
-            + "\\s*flex-direction: column;"
-            + "\\s*padding-left: 0\\.75em;"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.meta");
+    assertContainsAll(meta,
+        "display: grid;",
+        "grid-template-columns: auto minmax(0, 1fr);",
+        "column-gap: 0.35em;",
+        "row-gap: 0.25em;",
+        "padding-left: 0.75em;");
+    assertDoesNotContain(meta, "display: flex;");
+    assertDoesNotContain(meta, "flex-direction: column;");
+
+    String avatar = extractRuleBody(css,
+        "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.avatar");
+    assertContainsAll(avatar,
+        "float: none;",
+        "grid-column: 1;",
+        "grid-row: 1;",
+        "margin-left: 0;",
+        "margin-bottom: 0;");
+    assertDoesNotContain(avatar, "align-self: flex-start;");
+
+    String metabar = extractRuleBody(css,
+        "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.metabar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.metabar,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.metabar");
+    assertContainsAll(metabar,
+        "grid-column: 2;",
+        "grid-row: 1;",
+        "min-width: 0;");
+
+    String contentContainer = extractRuleBody(css,
+        "\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.contentContainer,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.contentContainer,"
+            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.contentContainer");
+    assertContainsAll(contentContainer,
+        "grid-column: 1 / -1;",
+        "grid-row: 2;");
+
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.avatar \\{"
+            + "\\s*width: 24px;"
+            + "\\s*height: 24px;"
             + "\\s*\\}.*");
     assertMatches(css,
-        "(?s).*\\.compact-inline-blips \\[data-depth=\"0\"\\] \\.avatar,"
-            + "\\s*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.avatar,"
-            + "\\s*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.avatar \\{"
-            + "\\s*float: none;"
-            + "\\s*margin-left: 0;"
-            + "\\s*margin-bottom: 0\\.35em;"
-            + "\\s*align-self: flex-start;"
+        "(?s).*\\.compact-inline-blips \\[data-depth=\"1\"\\] \\.avatar \\{"
+            + "\\s*width: 22px;"
+            + "\\s*height: 22px;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips \\[data-depth=\"2\"\\] \\.avatar \\{"
+            + "\\s*width: 20px;"
+            + "\\s*height: 20px;"
             + "\\s*\\}.*");
   }
 
-  public void testMobileCompactInlineBlipsKeepStackedAvatarLayout() throws Exception {
+  public void testMobileCompactInlineBlipsKeepAvatarAndMetabarOnSameRow() throws Exception {
     String css = readBlipCss();
 
-    assertMatches(css,
-        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.meta,"
+    String meta = extractRuleBody(css,
+        "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.meta,"
             + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.meta,"
-            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.meta \\{"
-            + "\\s*display: flex;"
-            + "\\s*flex-direction: column;"
-            + "\\s*padding-left: 0\\.5em;"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.meta");
+    assertContainsAll(meta,
+        "display: grid;",
+        "grid-template-columns: auto minmax(0, 1fr);",
+        "column-gap: 0.3em;",
+        "row-gap: 0.2em;",
+        "padding-left: 0.5em;");
+    assertDoesNotContain(meta, "display: flex;");
+    assertDoesNotContain(meta, "flex-direction: column;");
+
+    String avatar = extractRuleBody(css,
+        "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.avatar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.avatar");
+    assertContainsAll(avatar,
+        "float: none;",
+        "grid-column: 1;",
+        "grid-row: 1;",
+        "margin-left: 0;",
+        "margin-bottom: 0;");
+    assertDoesNotContain(avatar, "align-self: flex-start;");
+
+    String metabar = extractRuleBody(css,
+        "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.metabar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.metabar,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.metabar");
+    assertContainsAll(metabar,
+        "grid-column: 2;",
+        "grid-row: 1;",
+        "min-width: 0;");
+
+    String contentContainer = extractRuleBody(css,
+        "\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.contentContainer,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.contentContainer,"
+            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.contentContainer");
+    assertContainsAll(contentContainer,
+        "grid-column: 1 / -1;",
+        "grid-row: 2;");
+
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.avatar \\{"
+            + "\\s*width: 22px;"
+            + "\\s*height: 22px;"
             + "\\s*\\}.*");
     assertMatches(css,
-        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"0\"\\] \\.avatar,"
-            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.avatar,"
-            + "\\s*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.avatar \\{"
-            + "\\s*float: none;"
-            + "\\s*margin-left: 0;"
-            + "\\s*margin-bottom: 0\\.25em;"
-            + "\\s*align-self: flex-start;"
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"1\"\\] \\.avatar \\{"
+            + "\\s*width: 20px;"
+            + "\\s*height: 20px;"
+            + "\\s*\\}.*");
+    assertMatches(css,
+        "(?s).*\\.compact-inline-blips-mobile \\[data-depth=\"2\"\\] \\.avatar \\{"
+            + "\\s*width: 20px;"
+            + "\\s*height: 20px;"
             + "\\s*\\}.*");
   }
 
@@ -108,12 +190,47 @@ public final class CompactInlineBlipCssContractTest extends TestCase {
             + "\\s*\\}.*");
   }
 
+  public void testBaseRootBlipLayoutRemainsUnchanged() throws Exception {
+    String css = readBlipCss();
+
+    String meta = extractRuleBody(css, "(?m)^\\.meta");
+    assertContainsAll(meta, "padding: 0.5em 0.75em 0em 3.75em;");
+    assertDoesNotContain(meta, "display: grid;");
+
+    String avatar = extractRuleBody(css, "(?m)^\\.avatar");
+    assertContainsAll(avatar,
+        "height: 28px;",
+        "width: 28px;",
+        "float: left;",
+        "margin-left: -3em;");
+    assertDoesNotContain(avatar, "grid-column: 1;");
+  }
+
   private String readBlipCss() throws IOException {
     String resourcePath = "org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css";
     try (InputStream in = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
       assertNotNull("Missing resource: " + resourcePath, in);
       return new String(in.readAllBytes(), StandardCharsets.UTF_8);
     }
+  }
+
+  private static String extractRuleBody(String css, String selectorRegex) {
+    Matcher matcher =
+        Pattern.compile("(?s)" + selectorRegex + "\\s*\\{(.*?)\\}").matcher(css);
+    assertTrue("Missing CSS rule for selector regex: " + selectorRegex, matcher.find());
+    return matcher.group(1);
+  }
+
+  private static void assertContainsAll(String text, String... needles) {
+    for (String needle : needles) {
+      assertTrue("Expected text to contain: " + needle + "\nActual:\n" + text,
+          text.contains(needle));
+    }
+  }
+
+  private static void assertDoesNotContain(String text, String needle) {
+    assertFalse("Did not expect text to contain: " + needle + "\nActual:\n" + text,
+        text.contains(needle));
   }
 
   private static void assertMatches(String text, String regex) {


### PR DESCRIPTION
## Summary
- keep compact inline blip avatars on the same row as the author/metabar at depths 0-2
- let the content container span the reclaimed width below that row on desktop and mobile
- keep using the existing `compact-inline-blips` flag and preserve root/depth-3+ behavior

## Testing
- `sbt "wave/testOnly org.waveprotocol.box.server.util.CompactInlineBlipCssContractTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt compileGwt`
- `PORT=9914 bash scripts/wave-smoke.sh check`
- Local browser verification on `http://127.0.0.1:9914/#local.net/w+1eu2grj1g8rtyA` after enabling `compact-inline-blips` for `issue981owner@local.net`
  - desktop: `document.body.className === "compact-inline-blips"`
  - mobile 375px: `document.body.className === "mobile-wave-open compact-inline-blips compact-inline-blips-mobile"`
  - rendered inline blips showed avatar + author on the same row in both views

Closes #981.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact inline replies at depths 0–2: avatar now aligns with author metadata on the same row on desktop and mobile; reply content occupies full width beneath for clearer layout. Draft notification/banner now spans the full content width.

* **Tests**
  * Layout tests updated to validate the new grid-based compact inline positioning and per-depth avatar sizing; root/depth-3+ layout preserved.

* **Documentation**
  * Added design plan and changelog entry describing the compact inline layout update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->