### PR TITLE
feat(j2cl): build the Lit root shell and shared chrome primitives (#964)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ For detailed role behavior and sequencing, follow:
 - Prefer multiple independent worktrees/lanes over single-threaded execution when the task can be safely parallelized.
 - Do not implement from `/Users/vega/devroot/incubator-wave`.
 - Use `/Users/vega/devroot/worktrees/<branch-name>` for worktree paths.
+- When running `npm` tasks under `j2cl/lit/`, run from that directory; do not leak Node tooling into other packages.
 - Never create worktrees under `.claude/worktrees/`.
 - Do not run `git checkout` or `git switch` inside the main repo during lane execution; it flips shared HEAD for open sessions.
 - For lane execution details (tmux launch sequence, model flags, etc.), see [docs/agents/tool-usage.md](docs/agents/tool-usage.md).

--- a/build.sbt
+++ b/build.sbt
@@ -827,6 +827,8 @@ lazy val j2clSandboxBuild = taskKey[Unit]("Build the isolated J2CL sandbox sidec
 lazy val j2clSandboxTest = taskKey[Unit]("Run the isolated J2CL sandbox sidecar smoke test via the Maven wrapper")
 lazy val j2clSearchBuild = taskKey[Unit]("Build the isolated J2CL search-sidecar scaffold into war/j2cl-search via the Maven wrapper")
 lazy val j2clSearchTest = taskKey[Unit]("Run the isolated J2CL search-sidecar smoke test via the Maven wrapper")
+lazy val j2clLitBuild = taskKey[Unit]("Build the Lit shell bundle into war/j2cl/assets via npm")
+lazy val j2clLitTest = taskKey[Unit]("Run the Lit shell web-test-runner suite via npm")
 lazy val j2clProductionBuild = taskKey[Unit]("Build the production J2CL sidecar into war/j2cl via the Maven wrapper")
 lazy val j2clRuntimeBuild = taskKey[Unit]("Build the maintained J2CL runtime assets in a deterministic order")
 lazy val dataMigrate = inputKey[Unit]("Run DataMigrationTool: dataMigrate <sourceOpts> <targetOpts>")
@@ -935,6 +937,24 @@ ThisBuild / j2clSearchTest := {
   runJ2clWrapper(log, base, "search-sidecar", "test")
 }
 
+ThisBuild / j2clLitBuild := {
+  val log = streams.value.log
+  val litDir = baseDirectory.value / "j2cl" / "lit"
+  if (!(litDir / "node_modules").exists()) {
+    runCmd(log)(Seq("npm", "ci"), litDir)
+  }
+  runCmd(log)(Seq("npm", "run", "build"), litDir)
+}
+
+ThisBuild / j2clLitTest := {
+  val log = streams.value.log
+  val litDir = baseDirectory.value / "j2cl" / "lit"
+  if (!(litDir / "node_modules").exists()) {
+    runCmd(log)(Seq("npm", "ci"), litDir)
+  }
+  runCmd(log)(Seq("npm", "test"), litDir)
+}
+
 ThisBuild / j2clProductionBuild := {
   val log = streams.value.log
   val base = baseDirectory.value
@@ -943,7 +963,8 @@ ThisBuild / j2clProductionBuild := {
 
 ThisBuild / j2clRuntimeBuild := Def.sequential(
   ThisBuild / j2clSearchBuild,
-  ThisBuild / j2clProductionBuild
+  ThisBuild / j2clProductionBuild,
+  ThisBuild / j2clLitBuild
 ).value
 
 // sbt-protoc: use embedded protoc to generate Java directly into proto_src

--- a/docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md
+++ b/docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md
@@ -1,0 +1,1557 @@
+# Issue #964 Lit Root Shell And Shared Chrome Primitives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-rolled HTML/CSS root-shell chrome emitted by `HtmlRenderer.renderJ2clRootShellPage(...)` with a reusable Lit-based shell + chrome primitive family (`shell-root`, `shell-header`, `shell-nav-rail`, `shell-main-region`, `shell-status-strip`, `shell-skip-link`, plus the signed-out `shell-root-signed-out` variant) that mounts behind the existing J2CL coexistence seam (`?view=j2cl-root` request selector and the `j2cl-root-bootstrap` feature flag) without changing the default `/` behavior.
+
+**Architecture:** Introduce the first Lit package in the repo under `j2cl/lit/` (npm + esbuild) producing a single `shell.js` + `shell.css` bundle staged to `war/j2cl/assets/`. The server-rendered shell HTML is progressively enhanced: it emits semantic markup using the Lit primitive tag names (`<shell-root>`, `<shell-header>`, etc.) with pre-styled fallback content; when the bundle loads the custom elements upgrade in place with no unstyled flash. Session and websocket metadata continue to flow through the existing `window.__session` / `window.__websocket_address` inline-script contract; a narrow adapter (`LitShellInput`) isolates that read so post-#963 the shell can be rewired to the new `J2clBootstrapContract` without touching any primitive.
+
+**Tech Stack:** Lit 3 (JS, no TS), esbuild for bundling, npm (vanilla), Web Test Runner + `@web/test-runner-playwright` for Lit unit tests, Jakarta servlet + `HtmlRenderer` for the server seam, existing `sbt` task graph (`j2clRuntimeBuild`, `compileGwt`, `Universal/stage`), and the existing `scripts/worktree-boot.sh` + `scripts/wave-smoke.sh` for local smoke verification.
+
+---
+
+## 1. Goal / Baseline / Root Cause
+
+### 1.1 Baseline
+
+This plan is written against the post-#931 baseline in this worktree:
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:144-170` already contains the `view=j2cl-root` selector branch and the `j2cl-root-bootstrap` feature-flag branch — the **coexistence seam** that #964 must not widen or alter semantically.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` at `renderJ2clRootShellPage(...)` (around the section starting with the method signature that takes `sessionJson, analyticsAccount, buildCommit, serverBuildTime, currentReleaseId, rootShellReturnTarget, websocketAddress`) emits the entire shell as StringBuilder-concatenated inline HTML/CSS/JS, using class names `j2cl-root-shell`, `j2cl-root-shell-banner`, `j2cl-root-shell-nav`, `j2cl-root-shell-status`, `j2cl-root-shell-workflow`, `j2cl-root-shell-pill`, `j2cl-root-shell-link`. This is the **visual surface** #964 replaces.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java` and `J2clRootShellView.java` already exist (from #928) and mount the existing J2CL search/selected-wave/compose workflow into the `#j2cl-root-shell-workflow` element. This mount behavior stays untouched.
+- `j2cl/src/main/webapp/assets/sidecar.css` (458 lines) serves the sidecar-route CSS and is reused by the root-shell page via `<link rel="stylesheet" href="/j2cl/assets/sidecar.css">`. The new Lit bundle ships alongside it at `/j2cl/assets/shell.js` + `/j2cl/assets/shell.css`.
+- No Lit, TypeScript, npm, or Node toolchain exists anywhere in the repo today (`find -name package.json` returns nothing under the tree). #964 introduces it.
+- `docs/j2cl-lit-design-packet.md` §5.1 is the design authority for the primitive names and variants; §6 classifies Shell/Chrome as **Required Stitch** for #964 (pinned project id + screen ids + design system id must appear in the slice packet below before implementation starts).
+- PR #980 (#963) is still open and conflicting, so **the new `J2clBootstrapContract` + `J2clBootstrapServlet` are not yet on `main`**. The shell must consume the pre-#963 inline-script contract (`window.__session`, `window.__websocket_address`) through a narrow adapter that can be repointed after #963 merges.
+
+### 1.2 Root Cause
+
+The hand-rolled shell from #928 exists as a single ~200-line StringBuilder block of inline HTML+CSS+JS inside `HtmlRenderer`. Every downstream Lit slice (#965 server-first, #966 read-surface, #968 live-surface, #970 overlays) needs a **shared visual container** to render inside. Today that container is:
+
+- not componentized — each downstream slice would have to re-derive the shell chrome
+- not a Lit seam — there is no Lit bundle, no custom-element registration, no npm pipeline
+- coupled to the StringBuilder block — visual changes require Java edits and server rebuilds
+
+#964 is the narrowest issue that unblocks every Lit slice after it by producing a committed Lit primitive family plus the build/staging plumbing required to ship it.
+
+### 1.3 Narrow Root Cause Summary
+
+- No Lit package exists to author shell primitives in.
+- The existing root-shell HTML is not componentized and cannot be consumed by downstream slices.
+- There is no progressive-enhancement contract (server HTML ↔ Lit upgrade) yet.
+- The shell's bootstrap-data read (session/role/websocket) is hard-coded to the pre-#963 inline globals with no adapter seam.
+
+## 2. Acceptance Criteria
+
+`#964` is complete when all of the following are true:
+
+- The repo hosts a new Lit package at `j2cl/lit/` with a deterministic `npm ci && npm run build` pipeline that emits `war/j2cl/assets/shell.js` and `war/j2cl/assets/shell.css`.
+- The bundle defines custom elements registered as `shell-root`, `shell-root-signed-out`, `shell-header`, `shell-nav-rail`, `shell-main-region`, `shell-status-strip`, `shell-skip-link`.
+- Each primitive consumes the `LitShellInput` adapter (not `window.__session` directly), so post-#963 rewiring requires only adapter changes.
+- `HtmlRenderer.renderJ2clRootShellPage(...)` emits semantic HTML using the new custom-element tags with a pre-styled read-only fallback that renders correctly **with JavaScript disabled** (no unstyled flash, no duplicate chrome on Lit upgrade).
+- `sbt j2clLitBuild` is a real task wired into `j2clRuntimeBuild` and therefore into `compileGwt Universal/stage`, so a full stage run includes the Lit bundle without any manual npm step.
+- The default `/` route still renders the legacy GWT root when `j2cl-root-bootstrap` is off, unchanged.
+- `?view=j2cl-root` and the feature-flag path both render the new Lit-upgraded shell. Signed-in and signed-out variants render correctly.
+- The existing J2CL workflow still mounts successfully into the `shell-main-region` slot; the sidecar workflow at `/j2cl-search/index.html` is untouched.
+- Unit-level Lit tests run via `sbt j2clLitTest` (thin wrapper around `npm run test`) and pass; the server-side `HtmlRendererJ2clRootShellTest` is extended to assert the new custom-element tags, the fallback markup, and the absence of the old `j2cl-root-shell-banner`/`j2cl-root-shell-nav` classes.
+- The cross-path build gate passes:
+  - `sbt -batch j2clLitBuild j2clLitTest j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
+- Local boot + browser + curl verification shows signed-in and signed-out Lit chrome on `?view=j2cl-root` without regressing the default `/` route.
+- A slice parity packet (§5) is filled in with the pinned Stitch project id, screen ids, and design-system id per design-packet §6.
+- A changelog fragment exists under `wave/config/changelog.d/`.
+
+## 3. Scope And Non-Goals
+
+### 3.1 In Scope
+
+- Introducing the Lit package, bundler, and sbt integration.
+- Authoring the seven Lit primitives listed in §2 with design-packet semantics.
+- Rewriting `renderJ2clRootShellPage(...)` to emit progressive-enhancement HTML using the new custom elements.
+- Introducing the `LitShellInput` adapter over the current `window.__session` / `window.__websocket_address` contract.
+- Extending `HtmlRendererJ2clRootShellTest` and adding the Lit-side unit tests.
+- Adding the Stitch project, screens, and design system required by design-packet §6, and pinning their ids in §5 below.
+
+### 3.2 Explicit Non-Goals
+
+- No change to the default `/` route behavior or the `j2cl-root-bootstrap` flag semantics.
+- No wiring of the shell primitives to the #963 `J2clBootstrapContract` or `J2clBootstrapServlet` endpoints. That rewire is deferred to a dedicated post-#963 task (step 9 below) that **executes only after PR #980 merges**.
+- No work on the §5.2 read-surface primitives, §5.3 live-surface indicators, §5.4 compose/toolbar, §5.5 overlays, or §5.6 server-first skeletons. Those belong to #965/#966/#968/#969/#970.
+- No J2CL workflow rewrite; the search/selected-wave/compose controllers stay unchanged.
+- No TypeScript. Lit 3 in plain JS is sufficient for this slice and avoids a second toolchain decision.
+- No introduction of a broader client router, history integration, or new auth flow.
+- No modification of the existing `sidecar.css` file; the shell's styling ships in the new `shell.css`.
+
+## 4. Dependency Readiness (#963 Coupling)
+
+### 4.1 What #963 (PR #980) Owns
+
+PR #980 adds:
+
+- `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java` (updated to consume JSON)
+
+These deliver route/session/socket metadata as an explicit JSON endpoint.
+
+### 4.2 Dependency-Safe Boundary
+
+Tasks 1–8 in §7 below are **safe to land before #963 merges**. They consume only the pre-#963 inline-script globals that already exist today:
+
+- `window.__session` (object with `address`, `role`, `domain`, `idSeed`, `features`)
+- `window.__websocket_address` (string)
+
+The `LitShellInput` adapter reads these values through a single module (`j2cl/lit/src/input/inline-shell-input.js`). Post-#963, a second adapter implementation (`json-shell-input.js`) calls the `/j2cl-bootstrap` endpoint. The switch is a one-line swap at shell-bootstrap entry.
+
+### 4.3 Tasks Explicitly Gated On #963
+
+- **Task 9** (Rewire `LitShellInput` to the `J2clBootstrapContract` JSON endpoint) — **must not be executed until PR #980 is merged into `main` and pulled into this worktree**.
+
+Until #980 merges, Task 9's checkboxes stay unchecked and the lane waits.
+
+## 5. Slice Parity Packet — Issue #964
+
+**Title:** Build the Lit root shell and shared chrome primitives behind the existing J2CL coexistence seam
+**Stage:** server-first (shell-chrome side of the server-first surface)
+**Dependencies (from issue map §6):** #962 (design packet, merged), #963 (bootstrap JSON contract, PR #980 in review)
+
+### Parity matrix rows claimed
+- R-6.1 — Server-rendered read-only first paint (shell-chrome portion only; read-surface stays with #965/#966)
+- R-6.3 — Shell-swap upgrade path (no unstyled flash between server HTML and Lit-upgraded shell)
+- R-6.4 — Rollback-safe coexistence (`/?view=j2cl-root` still reachable; legacy `/` unchanged; feature-flag toggle remains operator-reversible)
+- R-4.5 — Route/history integration (shell-chrome portion only; route state semantics stay with #968)
+
+### GWT seams de-risked
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:144-170` — J2CL coexistence seam
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:renderJ2clRootShellPage` — StringBuilder shell HTML/CSS/JS (replaced)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java` — workflow mount (untouched)
+
+### Rollout flag / rollout seam
+- Flag: `j2cl-root-bootstrap` (existing feature flag; not modified)
+- Route selector: `?view=j2cl-root` (existing request selector; not modified)
+- Default: `off` (default `/` remains GWT)
+- Reversibility: operator toggles the flag off; the route selector remains available for manual verification; no schema or persistence change required to roll back
+
+### Server / client surface list
+- Server: `WaveClientServlet`, `HtmlRenderer.renderJ2clRootShellPage`, new `HtmlRenderer.renderLitShellFallback` helper
+- Client: `j2cl/lit/` package (new); seven custom elements (`shell-root`, `shell-root-signed-out`, `shell-header`, `shell-nav-rail`, `shell-main-region`, `shell-status-strip`, `shell-skip-link`); `LitShellInput` adapter
+
+### Required-match behaviors (from matrix)
+- R-6.1: server HTML shell legible without JS; readable chrome survives network-timeout Lit-bundle failure
+- R-6.3: no duplicate roots during upgrade; no unstyled flash; Lit elements upgrade in place over the same DOM the server rendered
+- R-6.4: `/?view=j2cl-root` reachable; legacy `/` unchanged; operator rollback reversible via the existing feature flag
+
+### Allowed-change visuals (from matrix)
+- Shell chrome, spacing, typography, elevation/surface treatment, nav-rail presentation (per design-packet §4 tokens and §5.1 primitives)
+- Signed-in/signed-out banner visuals may change
+- The workflow mount region visuals may change **outside** of the mount host; the mount host itself (`#j2cl-root-shell-workflow`) keeps its id/marker contract so `J2clRootShellController` continues to mount unchanged
+
+### Keyboard / focus plan
+- Skip link (`shell-skip-link`) is the first tab stop on the page and jumps focus to `shell-main-region`
+- Tab order: skip link → brand/header actions → nav rail entries → main region → status strip
+- Focus does not jump on Lit upgrade; the active element before upgrade stays active after
+
+### Accessibility plan
+- `shell-root` carries `role="application"` only if ARIA audits call for it; default is semantic `<main>` landmarks inside
+- `shell-header` uses `<header role="banner">`
+- `shell-nav-rail` uses `<nav aria-label="Primary">`
+- `shell-main-region` uses `<main>` with `id="j2cl-root-shell-workflow"` preserved so the workflow mount contract stays intact
+- `shell-status-strip` uses `<aside role="status" aria-live="polite">` (visual surface only; the live-state behavior belongs to #968/R-4.3)
+- Contrast and focus ring rules inherit from design-packet §8.1
+
+### i18n plan
+- Primitive attributes accept translated labels via `aria-label` attributes; the server-side `HtmlRenderer` passes locale-resolved strings into the fallback markup
+- No new message bundle keys are introduced in this slice beyond `shell.skip_to_main`, `shell.sign_in`, `shell.sign_out`, `shell.admin`
+
+### Browser-harness coverage
+- Add `HtmlRendererJ2clRootShellTest` cases for: custom-element tag presence, fallback markup presence, absence of legacy `j2cl-root-shell-*` classes, and signed-out vs signed-in divergence
+- Add Lit unit fixtures for each primitive via Web Test Runner (`j2cl/lit/test/`)
+- Add one end-to-end curl assertion in the smoke script path that `shell-root` is present and fallback text is present
+
+### Telemetry and observability checkpoints
+- Emit a single `client.j2cl.shell.upgrade` event on first `shell-root` upgrade with `{ signedIn: boolean, upgradeMs: number }` payload via the existing client stats channel used by `J2clRootShellController` (piggybacked; no new transport)
+- Server-side: existing `renderJ2clRootShellPage` log stays; no new log signals
+
+### Verification plan
+- Smoke:
+  - `bash scripts/worktree-boot.sh --port 9964`
+  - `PORT=9964 JAVA_OPTS='...' bash scripts/wave-smoke.sh start`
+  - `PORT=9964 bash scripts/wave-smoke.sh check`
+  - `PORT=9964 bash scripts/wave-smoke.sh stop`
+- Browser:
+  - Required by `docs/runbooks/change-type-verification-matrix.md` (GWT client/UI row)
+  - Signed-in `http://localhost:9964/?view=j2cl-root`, signed-out `http://localhost:9964/?view=j2cl-root`, default `http://localhost:9964/`
+- Harness:
+  - `sbt -batch j2clLitBuild j2clLitTest j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
+
+### Rollback plan
+- Flip `j2cl-root-bootstrap` off → default `/` continues serving legacy GWT; `?view=j2cl-root` remains reachable as an operator-facing verification route
+- Nothing schema-backed to revert; the Lit bundle is a static asset that can be ignored by simply not mounting
+
+### Stitch artifact pinning (design-packet §6, **Required** for §5.1 Shell/Chrome)
+
+The following fields MUST be populated before Task 4 in §7 starts. They are filled during Task 3.
+
+- Stitch project id: `<TO BE PINNED IN TASK 3>`
+- Screen ids (one per §5.1 variant):
+  - `shell-root`: `<id>`
+  - `shell-root-signed-out`: `<id>`
+  - `shell-header`: `<id>`
+  - `shell-nav-rail`: `<id>`
+  - `shell-main-region`: `<id>`
+  - `shell-status-strip`: `<id>`
+  - `shell-skip-link`: `<id>`
+- Design system id: `<id>` (applied to the project, covering design-packet §4.1–§4.10 token slots)
+
+### Traceability
+- Parity matrix: `docs/j2cl-gwt-parity-matrix.md`
+- Design packet: `docs/j2cl-lit-design-packet.md` (§5.1, §6, §8)
+- Issue map: `docs/j2cl-parity-issue-map.md`
+- Architecture memo: `docs/j2cl-parity-architecture.md`
+- Workflow: `docs/j2cl-lit-implementation-workflow.md`
+- Linked issue(s): `#964`, `#962`, `#963`, `#904`, `#960`
+- Linked plan: `docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md`
+
+## 6. File Structure
+
+### 6.1 New Files
+
+- `j2cl/lit/package.json` — Lit 3 + esbuild + Web Test Runner pinned versions, build/test scripts
+- `j2cl/lit/package-lock.json` — committed lockfile for deterministic builds
+- `j2cl/lit/esbuild.config.mjs` — bundle config (entry: `src/index.js`, output: `../../war/j2cl/assets/shell.{js,css}`, target: ES2020, minify, sourcemap)
+- `j2cl/lit/web-test-runner.config.mjs` — Web Test Runner config (Playwright chromium)
+- `j2cl/lit/.gitignore` — `node_modules/`, `dist/`
+- `j2cl/lit/src/index.js` — side-effect entry: registers all seven custom elements
+- `j2cl/lit/src/input/lit-shell-input.js` — `LitShellInput` interface definition
+- `j2cl/lit/src/input/inline-shell-input.js` — pre-#963 adapter (reads `window.__session` + `window.__websocket_address`)
+- `j2cl/lit/src/tokens/shell-tokens.css` — CSS custom properties implementing design-packet §4 token slots for the shell family (values pinned by the Stitch design system)
+- `j2cl/lit/src/elements/shell-root.js` — `<shell-root>` signed-in variant
+- `j2cl/lit/src/elements/shell-root-signed-out.js` — `<shell-root-signed-out>` variant
+- `j2cl/lit/src/elements/shell-header.js` — `<shell-header>`
+- `j2cl/lit/src/elements/shell-nav-rail.js` — `<shell-nav-rail>`
+- `j2cl/lit/src/elements/shell-main-region.js` — `<shell-main-region>` (slots the existing `#j2cl-root-shell-workflow` mount host)
+- `j2cl/lit/src/elements/shell-status-strip.js` — `<shell-status-strip>`
+- `j2cl/lit/src/elements/shell-skip-link.js` — `<shell-skip-link>`
+- `j2cl/lit/test/shell-root.test.js`
+- `j2cl/lit/test/shell-root-signed-out.test.js`
+- `j2cl/lit/test/shell-header.test.js`
+- `j2cl/lit/test/shell-nav-rail.test.js`
+- `j2cl/lit/test/shell-main-region.test.js`
+- `j2cl/lit/test/shell-status-strip.test.js`
+- `j2cl/lit/test/shell-skip-link.test.js`
+- `j2cl/lit/test/inline-shell-input.test.js`
+- `wave/config/changelog.d/2026-04-23-lit-root-shell.json`
+
+### 6.2 Modified Files
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` — replace the StringBuilder shell block with progressive-enhancement HTML using custom-element tags; inject the `/j2cl/assets/shell.css` stylesheet and the `/j2cl/assets/shell.js` module script
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java` — extend assertions to custom-element tags, fallback markup, absence of legacy classes
+- `build.sbt` — add `j2clLitBuild` and `j2clLitTest` tasks; wire `j2clLitBuild` into `j2clRuntimeBuild`; add `j2cl/lit/dist` to `cleanFiles` if the output lands there
+- `.gitignore` — add `j2cl/lit/node_modules/` and `j2cl/lit/dist/` if the latter is used by esbuild intermediates
+- `AGENTS.md` — add one line under Worktree guardrails: "When running `npm` tasks under `j2cl/lit/`, run from that directory; do not leak Node into other packages."
+
+### 6.3 Inspect-Only References
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java` — mount host contract consumer (verify the `#j2cl-root-shell-workflow` id stays stable)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java` — mount DOM consumer
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java` — coexistence seam (verify, do not modify)
+
+## 7. Implementation Order
+
+Each task below is bite-sized (2–5 minutes per step). Every step either writes code shown inline, runs the exact command shown, or commits with the exact message shown. TDD order: failing test → minimal code → passing test → commit.
+
+### Task 1: Freeze the baseline and verify the current shell
+
+- [ ] **Step 1.1: Verify default `/` still renders legacy GWT**
+
+Run:
+
+```bash
+cd /Users/vega/devroot/worktrees/issue-964-lit-root-shell
+grep -n "webclient/webclient.nocache.js" wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java | head -3
+```
+
+Expected: at least one hit; legacy bootstrap is still referenced.
+
+- [ ] **Step 1.2: Verify the existing coexistence seam is the one #964 uses**
+
+Run:
+
+```bash
+grep -n "VIEW_J2CL_ROOT\|j2cl-root-bootstrap" wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java | head -6
+```
+
+Expected: `VIEW_J2CL_ROOT` + `j2cl-root-bootstrap` flag reference both present around lines 144–170.
+
+- [ ] **Step 1.3: Confirm no pre-existing Lit or npm tree**
+
+Run:
+
+```bash
+find . -name "package.json" -not -path "./node_modules/*" -not -path "*/.git/*" 2>/dev/null
+```
+
+Expected: empty output.
+
+- [ ] **Step 1.4: Commit baseline freeze marker**
+
+```bash
+git add docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md
+git commit -m "docs(#964): freeze plan for Lit root shell slice"
+```
+
+### Task 2: Scaffold the Lit package (no Java changes yet)
+
+**Files:**
+- Create: `j2cl/lit/package.json`
+- Create: `j2cl/lit/.gitignore`
+- Create: `j2cl/lit/esbuild.config.mjs`
+- Create: `j2cl/lit/web-test-runner.config.mjs`
+- Create: `j2cl/lit/src/index.js` (empty placeholder for now)
+
+- [ ] **Step 2.1: Write `j2cl/lit/package.json`**
+
+```json
+{
+  "name": "supawave-lit-shell",
+  "version": "0.0.1",
+  "description": "Lit primitives for the SupaWave J2CL root shell (issue #964).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "test": "web-test-runner \"test/**/*.test.js\" --node-resolve --playwright --browsers chromium"
+  },
+  "dependencies": {
+    "lit": "3.2.1"
+  },
+  "devDependencies": {
+    "@open-wc/testing": "4.0.0",
+    "@web/test-runner": "0.19.0",
+    "@web/test-runner-playwright": "0.11.0",
+    "esbuild": "0.24.0"
+  }
+}
+```
+
+- [ ] **Step 2.2: Write `j2cl/lit/.gitignore`**
+
+```
+node_modules/
+dist/
+```
+
+- [ ] **Step 2.3: Write `j2cl/lit/esbuild.config.mjs`**
+
+Two entry points: one for the JS bundle, one for the CSS tokens. esbuild emits `shell.js` from the JS entry and `shell.css` from the CSS entry, both under `war/j2cl/assets/`. The CSS is a real file served directly by the existing `/j2cl/assets/` static mount so the server-rendered HTML renders styled tokens **without JavaScript** (progressive-enhancement requirement from design packet §5.6).
+
+```javascript
+import { build } from "esbuild";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = resolve(here, "../../war/j2cl/assets");
+
+await build({
+  entryPoints: [
+    { in: resolve(here, "src/index.js"), out: "shell" },
+    { in: resolve(here, "src/tokens/shell-tokens.css"), out: "shell" },
+  ],
+  bundle: true,
+  format: "esm",
+  target: "es2020",
+  minify: true,
+  sourcemap: true,
+  outdir: out,
+  logLevel: "info",
+});
+```
+
+- [ ] **Step 2.4: Write `j2cl/lit/web-test-runner.config.mjs`**
+
+```javascript
+import { playwrightLauncher } from "@web/test-runner-playwright";
+
+export default {
+  files: "test/**/*.test.js",
+  nodeResolve: true,
+  browsers: [playwrightLauncher({ product: "chromium" })],
+  testFramework: {
+    config: { ui: "bdd", timeout: 5000 },
+  },
+};
+```
+
+- [ ] **Step 2.5: Write `j2cl/lit/src/index.js` (placeholder)**
+
+```javascript
+// Entry point for the SupaWave Lit shell bundle (issue #964).
+// Element registrations land in later tasks.
+```
+
+- [ ] **Step 2.6: Run `npm install` and commit the lockfile**
+
+```bash
+cd j2cl/lit
+npm install
+cd ../..
+git add j2cl/lit/package.json j2cl/lit/package-lock.json j2cl/lit/.gitignore j2cl/lit/esbuild.config.mjs j2cl/lit/web-test-runner.config.mjs j2cl/lit/src/index.js
+git commit -m "feat(#964): scaffold Lit shell package with esbuild + web-test-runner"
+```
+
+Expected: clean install; `package-lock.json` committed.
+
+- [ ] **Step 2.7: Verify the empty bundle builds**
+
+```bash
+cd j2cl/lit && npm run build && ls -la ../../war/j2cl/assets/shell.js && cd ../..
+```
+
+Expected: `shell.js` written (small, near-empty).
+
+### Task 3: Create and pin the Stitch artifact (design-packet §6 gate — BLOCKS Task 5 onward)
+
+**Blocking rule:** Tasks 5, 6, 7, 8 must not start until Steps 3.1–3.5 are complete and every `<TO BE PINNED IN TASK 3>` slot in §5 is filled with a real id. Task 4 (`LitShellInput` adapter) has no visual output and may proceed in parallel with Task 3.
+
+Token values used in Task 7 are not invented — they are copied from the design system created in Step 3.2 via the response payload of `mcp__stitch__create_design_system` / `mcp__stitch__get_project`.
+
+- [ ] **Step 3.1: Create a Stitch project for the shell family**
+
+Use the `mcp__stitch__create_project` MCP tool with:
+- name: `SupaWave Lit Shell — issue #964`
+- description: "Required Stitch artifact for design-packet §5.1 Shell/Chrome family. Covers shell-root, shell-root-signed-out, shell-header, shell-nav-rail, shell-main-region, shell-status-strip, shell-skip-link."
+
+Record the returned `projectId`.
+
+- [ ] **Step 3.2: Create the design system**
+
+Use `mcp__stitch__create_design_system` covering token slots from design-packet §4.1–§4.10. Apply it to the project via `mcp__stitch__apply_design_system`. Record the `designSystemId`.
+
+- [ ] **Step 3.3: Generate one screen per variant**
+
+Call `mcp__stitch__generate_screen_from_text` seven times, one for each primitive listed in the §5 packet. Record each `screenId`.
+
+- [ ] **Step 3.4: Pin the ids into §5 of this plan**
+
+Edit `docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md` and replace the `<TO BE PINNED IN TASK 3>` placeholders with the actual ids from Steps 3.1–3.3.
+
+- [ ] **Step 3.5: Commit the pinned plan**
+
+```bash
+git add docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md
+git commit -m "docs(#964): pin Stitch project/screens/design-system ids per design-packet §6"
+```
+
+### Task 4: Author the `LitShellInput` adapter (pre-#963 inline variant)
+
+**Files:**
+- Create: `j2cl/lit/src/input/lit-shell-input.js`
+- Create: `j2cl/lit/src/input/inline-shell-input.js`
+- Create: `j2cl/lit/test/inline-shell-input.test.js`
+
+- [ ] **Step 4.1: Write the failing test `j2cl/lit/test/inline-shell-input.test.js`**
+
+```javascript
+import { expect } from "@open-wc/testing";
+import { createInlineShellInput } from "../src/input/inline-shell-input.js";
+
+describe("inline-shell-input", () => {
+  beforeEach(() => {
+    window.__session = undefined;
+    window.__websocket_address = undefined;
+  });
+
+  it("returns a signed-out snapshot when no session is present", () => {
+    const input = createInlineShellInput(window);
+    const snap = input.read();
+    expect(snap.signedIn).to.equal(false);
+    expect(snap.address).to.equal("");
+    expect(snap.role).to.equal("user");
+    expect(snap.websocketAddress).to.equal("");
+  });
+
+  it("returns a signed-in snapshot with role normalization", () => {
+    window.__session = { address: "a@b.c", role: "admin", domain: "b.c", idSeed: "s", features: [] };
+    window.__websocket_address = "ws.example:443";
+    const input = createInlineShellInput(window);
+    const snap = input.read();
+    expect(snap.signedIn).to.equal(true);
+    expect(snap.address).to.equal("a@b.c");
+    expect(snap.role).to.equal("admin");
+    expect(snap.websocketAddress).to.equal("ws.example:443");
+  });
+
+  it("returns signed-out when address is empty string", () => {
+    window.__session = { address: "", role: "user", domain: "", idSeed: "", features: [] };
+    const input = createInlineShellInput(window);
+    expect(input.read().signedIn).to.equal(false);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+```bash
+cd j2cl/lit && npm test && cd ../..
+```
+
+Expected: FAIL with "Cannot find module ../src/input/inline-shell-input.js" or similar.
+
+- [ ] **Step 4.3: Write `j2cl/lit/src/input/lit-shell-input.js`**
+
+```javascript
+/**
+ * @typedef {object} LitShellSnapshot
+ * @property {boolean} signedIn
+ * @property {string} address
+ * @property {"admin"|"owner"|"user"} role
+ * @property {string} domain
+ * @property {string} idSeed
+ * @property {string[]} features
+ * @property {string} websocketAddress
+ *
+ * @typedef {object} LitShellInput
+ * @property {() => LitShellSnapshot} read
+ */
+
+export const EMPTY_SNAPSHOT = Object.freeze({
+  signedIn: false,
+  address: "",
+  role: "user",
+  domain: "",
+  idSeed: "",
+  features: Object.freeze([]),
+  websocketAddress: "",
+});
+```
+
+- [ ] **Step 4.4: Write `j2cl/lit/src/input/inline-shell-input.js`**
+
+```javascript
+import { EMPTY_SNAPSHOT } from "./lit-shell-input.js";
+
+const ALLOWED_ROLES = new Set(["admin", "owner", "user"]);
+
+function normalizeRole(raw) {
+  return ALLOWED_ROLES.has(raw) ? raw : "user";
+}
+
+/**
+ * Pre-#963 adapter: reads bootstrap data from inline script globals.
+ * Post-#963, swap this for the JSON-based adapter at the import site in
+ * src/index.js without touching any shell element.
+ */
+export function createInlineShellInput(win) {
+  return {
+    read() {
+      const session = win.__session;
+      const wsAddress = typeof win.__websocket_address === "string" ? win.__websocket_address : "";
+      if (!session || typeof session !== "object") {
+        return { ...EMPTY_SNAPSHOT, websocketAddress: wsAddress };
+      }
+      const address = typeof session.address === "string" ? session.address : "";
+      const signedIn = address.length > 0;
+      return {
+        signedIn,
+        address,
+        role: normalizeRole(session.role),
+        domain: typeof session.domain === "string" ? session.domain : "",
+        idSeed: typeof session.idSeed === "string" ? session.idSeed : "",
+        features: Array.isArray(session.features) ? [...session.features] : [],
+        websocketAddress: wsAddress,
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 4.5: Run tests to verify they pass**
+
+```bash
+cd j2cl/lit && npm test && cd ../..
+```
+
+Expected: 3 passing.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add j2cl/lit/src/input/ j2cl/lit/test/inline-shell-input.test.js
+git commit -m "feat(#964): add LitShellInput adapter with pre-#963 inline reader"
+```
+
+### Task 5: Author `<shell-skip-link>` (simplest primitive, TDD walkthrough)
+
+**Files:**
+- Create: `j2cl/lit/src/elements/shell-skip-link.js`
+- Create: `j2cl/lit/test/shell-skip-link.test.js`
+
+- [ ] **Step 5.1: Write the failing test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-skip-link.js";
+
+describe("<shell-skip-link>", () => {
+  it("renders an anchor linking to the configured target", async () => {
+    const el = await fixture(html`<shell-skip-link target="#main" label="Skip to content"></shell-skip-link>`);
+    const a = el.renderRoot.querySelector("a");
+    expect(a).to.exist;
+    expect(a.getAttribute("href")).to.equal("#main");
+    expect(a.textContent.trim()).to.equal("Skip to content");
+  });
+
+  it("falls back to default target and label", async () => {
+    const el = await fixture(html`<shell-skip-link></shell-skip-link>`);
+    const a = el.renderRoot.querySelector("a");
+    expect(a.getAttribute("href")).to.equal("#j2cl-root-shell-workflow");
+    expect(a.textContent.trim()).to.equal("Skip to main content");
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+```bash
+cd j2cl/lit && npm test && cd ../..
+```
+
+Expected: FAIL (module not found).
+
+- [ ] **Step 5.3: Write the minimal implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellSkipLink extends LitElement {
+  static properties = {
+    target: { type: String },
+    label: { type: String },
+  };
+
+  static styles = css`
+    :host { position: absolute; top: 0; left: 0; }
+    a {
+      position: absolute;
+      left: -9999px;
+      padding: 8px 12px;
+      background: var(--shell-color-accent-focus, #1a73e8);
+      color: #fff;
+      border-radius: 0 0 8px 0;
+      font: inherit;
+      text-decoration: none;
+    }
+    a:focus { left: 0; outline: 2px solid #fff; outline-offset: -4px; }
+  `;
+
+  constructor() {
+    super();
+    this.target = "#j2cl-root-shell-workflow";
+    this.label = "Skip to main content";
+  }
+
+  render() {
+    return html`<a href=${this.target}>${this.label}</a>`;
+  }
+}
+
+customElements.define("shell-skip-link", ShellSkipLink);
+```
+
+- [ ] **Step 5.4: Run tests to verify they pass**
+
+```bash
+cd j2cl/lit && npm test && cd ../..
+```
+
+Expected: 5 passing (3 from Task 4 + 2 here).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add j2cl/lit/src/elements/shell-skip-link.js j2cl/lit/test/shell-skip-link.test.js
+git commit -m "feat(#964): add <shell-skip-link> primitive"
+```
+
+### Task 6: Author the remaining six primitives in the same TDD pattern
+
+Repeat the Task 5 pattern for each of the six elements below. Each element gets its own test file, minimal implementation, and commit. Full code is shown in the sub-steps.
+
+**File layout:**
+- Create: `j2cl/lit/src/elements/shell-header.js` + `test/shell-header.test.js`
+- Create: `j2cl/lit/src/elements/shell-nav-rail.js` + `test/shell-nav-rail.test.js`
+- Create: `j2cl/lit/src/elements/shell-main-region.js` + `test/shell-main-region.test.js`
+- Create: `j2cl/lit/src/elements/shell-status-strip.js` + `test/shell-status-strip.test.js`
+- Create: `j2cl/lit/src/elements/shell-root.js` + `test/shell-root.test.js`
+- Create: `j2cl/lit/src/elements/shell-root-signed-out.js` + `test/shell-root-signed-out.test.js`
+
+#### 6.1 `<shell-header>`
+
+- [ ] **Step 6.1.1: Test — renders banner landmark with brand slot and signed-in/signed-out actions**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-header.js";
+
+describe("<shell-header>", () => {
+  it("uses the banner landmark", async () => {
+    const el = await fixture(html`<shell-header></shell-header>`);
+    expect(el.renderRoot.querySelector("header[role='banner']")).to.exist;
+  });
+
+  it("renders the signed-in action slot when signed-in", async () => {
+    const el = await fixture(html`<shell-header signed-in></shell-header>`);
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-in']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-out']")).to.not.exist;
+  });
+
+  it("renders the signed-out action slot by default", async () => {
+    const el = await fixture(html`<shell-header></shell-header>`);
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-out']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-in']")).to.not.exist;
+  });
+});
+```
+
+- [ ] **Step 6.1.2: Run to fail**: `cd j2cl/lit && npm test && cd ../..` — FAIL (module missing)
+
+- [ ] **Step 6.1.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellHeader extends LitElement {
+  static properties = { signedIn: { type: Boolean, attribute: "signed-in", reflect: true } };
+  static styles = css`
+    :host { display: block; }
+    header {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: var(--shell-space-inline-default, 12px);
+      padding: var(--shell-space-inset-panel, 16px 18px);
+      border-bottom: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      background: var(--shell-color-surface-shell, #fff);
+    }
+    .brand { display: inline-flex; align-items: center; gap: 10px; }
+    .actions { display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  `;
+  constructor() { super(); this.signedIn = false; }
+  render() {
+    return html`
+      <header role="banner">
+        <div class="brand"><slot name="brand"></slot></div>
+        <div class="actions">
+          ${this.signedIn
+            ? html`<slot name="actions-signed-in"></slot>`
+            : html`<slot name="actions-signed-out"></slot>`}
+        </div>
+      </header>`;
+  }
+}
+customElements.define("shell-header", ShellHeader);
+```
+
+- [ ] **Step 6.1.4: Run to pass** — `cd j2cl/lit && npm test && cd ../..`
+
+- [ ] **Step 6.1.5: Commit** — `git add j2cl/lit/src/elements/shell-header.js j2cl/lit/test/shell-header.test.js && git commit -m "feat(#964): add <shell-header> primitive"`
+
+#### 6.2 `<shell-nav-rail>`
+
+- [ ] **Step 6.2.1: Test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-nav-rail.js";
+
+describe("<shell-nav-rail>", () => {
+  it("uses the navigation landmark with a primary label", async () => {
+    const el = await fixture(html`<shell-nav-rail></shell-nav-rail>`);
+    const nav = el.renderRoot.querySelector("nav");
+    expect(nav).to.exist;
+    expect(nav.getAttribute("aria-label")).to.equal("Primary");
+  });
+
+  it("exposes a default slot for entries", async () => {
+    const el = await fixture(html`<shell-nav-rail><a href="/">Home</a></shell-nav-rail>`);
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+  });
+});
+```
+
+- [ ] **Step 6.2.2: Run to fail**
+- [ ] **Step 6.2.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellNavRail extends LitElement {
+  static properties = { label: { type: String } };
+  static styles = css`
+    :host { display: block; }
+    nav {
+      display: flex; flex-direction: column; gap: 4px;
+      padding: var(--shell-space-inset-panel, 12px);
+      background: var(--shell-color-surface-shell, #fff);
+      border-right: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      min-width: 180px;
+    }
+    ::slotted(*) { display: block; padding: 8px 10px; border-radius: 8px; }
+  `;
+  constructor() { super(); this.label = "Primary"; }
+  render() {
+    return html`<nav aria-label=${this.label}><slot></slot></nav>`;
+  }
+}
+customElements.define("shell-nav-rail", ShellNavRail);
+```
+
+- [ ] **Step 6.2.4: Run to pass**
+- [ ] **Step 6.2.5: Commit** — `git add j2cl/lit/src/elements/shell-nav-rail.js j2cl/lit/test/shell-nav-rail.test.js && git commit -m "feat(#964): add <shell-nav-rail> primitive"`
+
+#### 6.3 `<shell-main-region>`
+
+- [ ] **Step 6.3.1: Test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-main-region.js";
+
+describe("<shell-main-region>", () => {
+  it("uses the main landmark", async () => {
+    const el = await fixture(html`<shell-main-region></shell-main-region>`);
+    expect(el.renderRoot.querySelector("main")).to.exist;
+  });
+
+  it("slots light-DOM children so the workflow mount host stays queryable from document", async () => {
+    const el = await fixture(html`
+      <shell-main-region>
+        <section id="j2cl-root-shell-workflow" data-j2cl-root-shell-workflow="true"></section>
+      </shell-main-region>
+    `);
+    // Shadow contains a slot, NOT the id (the id must live in light DOM so
+    // document.getElementById('j2cl-root-shell-workflow') keeps working for
+    // J2clRootShellController).
+    expect(el.renderRoot.querySelector("slot")).to.exist;
+    expect(el.renderRoot.querySelector("#j2cl-root-shell-workflow")).to.not.exist;
+    expect(el.querySelector("#j2cl-root-shell-workflow")).to.exist;
+    expect(document.getElementById("j2cl-root-shell-workflow")).to.exist;
+  });
+});
+```
+
+- [ ] **Step 6.3.2: Run to fail**
+- [ ] **Step 6.3.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellMainRegion extends LitElement {
+  static styles = css`
+    :host { display: block; flex: 1; min-width: 0; }
+    main { padding: var(--shell-space-inset-panel, 20px); min-height: 360px; }
+  `;
+  render() {
+    // The #j2cl-root-shell-workflow element is a light-DOM child of this
+    // component; it must stay queryable via document.getElementById so
+    // J2clRootShellController.start() continues to work unchanged.
+    return html`<main><slot></slot></main>`;
+  }
+}
+customElements.define("shell-main-region", ShellMainRegion);
+```
+
+- [ ] **Step 6.3.4: Run to pass**
+- [ ] **Step 6.3.5: Commit** — `git add j2cl/lit/src/elements/shell-main-region.js j2cl/lit/test/shell-main-region.test.js && git commit -m "feat(#964): add <shell-main-region> primitive preserving workflow mount host"`
+
+#### 6.4 `<shell-status-strip>`
+
+- [ ] **Step 6.4.1: Test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-status-strip.js";
+
+describe("<shell-status-strip>", () => {
+  it("uses a polite status live region", async () => {
+    const el = await fixture(html`<shell-status-strip></shell-status-strip>`);
+    const aside = el.renderRoot.querySelector("aside");
+    expect(aside.getAttribute("role")).to.equal("status");
+    expect(aside.getAttribute("aria-live")).to.equal("polite");
+  });
+
+  it("exposes a default slot for status content", async () => {
+    const el = await fixture(html`<shell-status-strip>Connected</shell-status-strip>`);
+    expect(el.renderRoot.querySelector("slot")).to.exist;
+  });
+});
+```
+
+- [ ] **Step 6.4.2: Run to fail**
+- [ ] **Step 6.4.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellStatusStrip extends LitElement {
+  static styles = css`
+    :host { display: block; }
+    aside {
+      padding: 6px var(--shell-space-inset-panel, 18px);
+      background: var(--shell-color-surface-shell, #fff);
+      border-top: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.85rem;
+    }
+  `;
+  render() {
+    return html`<aside role="status" aria-live="polite"><slot></slot></aside>`;
+  }
+}
+customElements.define("shell-status-strip", ShellStatusStrip);
+```
+
+- [ ] **Step 6.4.4: Run to pass**
+- [ ] **Step 6.4.5: Commit** — `git add j2cl/lit/src/elements/shell-status-strip.js j2cl/lit/test/shell-status-strip.test.js && git commit -m "feat(#964): add <shell-status-strip> primitive (visual surface only)"`
+
+#### 6.5 `<shell-root>` (signed-in)
+
+- [ ] **Step 6.5.1: Test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-root.js";
+
+describe("<shell-root>", () => {
+  it("renders the signed-in layout slots", async () => {
+    const el = await fixture(html`<shell-root></shell-root>`);
+    expect(el.renderRoot.querySelector("slot[name='skip-link']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='header']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='nav']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+  });
+});
+```
+
+- [ ] **Step 6.5.2: Run to fail**
+- [ ] **Step 6.5.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellRoot extends LitElement {
+  static styles = css`
+    :host { display: grid; grid-template-rows: auto 1fr auto; min-height: 100vh;
+            background: var(--shell-color-surface-page, #f7fbff);
+            color: var(--shell-color-text-primary, #102b3f); }
+    .body { display: flex; min-height: 0; }
+    slot[name='nav'] { flex: 0 0 auto; }
+    slot[name='main'] { flex: 1; min-width: 0; }
+  `;
+  render() {
+    return html`
+      <slot name="skip-link"></slot>
+      <slot name="header"></slot>
+      <div class="body">
+        <slot name="nav"></slot>
+        <slot name="main"></slot>
+      </div>
+      <slot name="status"></slot>`;
+  }
+}
+customElements.define("shell-root", ShellRoot);
+```
+
+- [ ] **Step 6.5.4: Run to pass**
+- [ ] **Step 6.5.5: Commit** — `git add j2cl/lit/src/elements/shell-root.js j2cl/lit/test/shell-root.test.js && git commit -m "feat(#964): add <shell-root> signed-in shell primitive"`
+
+#### 6.6 `<shell-root-signed-out>`
+
+- [ ] **Step 6.6.1: Test**
+
+```javascript
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-root-signed-out.js";
+
+describe("<shell-root-signed-out>", () => {
+  it("renders skip-link, header, main, and status slots without a nav", async () => {
+    const el = await fixture(html`<shell-root-signed-out></shell-root-signed-out>`);
+    expect(el.renderRoot.querySelector("slot[name='skip-link']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='header']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='nav']")).to.not.exist;
+  });
+});
+```
+
+- [ ] **Step 6.6.2: Run to fail**
+- [ ] **Step 6.6.3: Implementation**
+
+```javascript
+import { LitElement, html, css } from "lit";
+
+export class ShellRootSignedOut extends LitElement {
+  static styles = css`
+    :host { display: grid; grid-template-rows: auto 1fr auto; min-height: 100vh;
+            background: var(--shell-color-surface-page, #f7fbff);
+            color: var(--shell-color-text-primary, #102b3f); }
+  `;
+  render() {
+    return html`
+      <slot name="skip-link"></slot>
+      <slot name="header"></slot>
+      <slot name="main"></slot>
+      <slot name="status"></slot>`;
+  }
+}
+customElements.define("shell-root-signed-out", ShellRootSignedOut);
+```
+
+- [ ] **Step 6.6.4: Run to pass**
+- [ ] **Step 6.6.5: Commit** — `git add j2cl/lit/src/elements/shell-root-signed-out.js j2cl/lit/test/shell-root-signed-out.test.js && git commit -m "feat(#964): add <shell-root-signed-out> primitive"`
+
+### Task 7: Wire the primitives into the bundle entry and publish tokens
+
+**Files:**
+- Modify: `j2cl/lit/src/index.js`
+- Create: `j2cl/lit/src/tokens/shell-tokens.css`
+
+- [ ] **Step 7.1: Write `j2cl/lit/src/tokens/shell-tokens.css`**
+
+Use the concrete token values captured from Step 3.2's design-system response (do not invent values; copy the hex/length strings returned by Stitch for each design-packet §4 slot). The structure below shows the exact slot names the shell consumes; fill in each value from the Stitch design-system payload.
+
+```css
+/* CSS custom properties implementing design-packet §4 token slots for the shell family.
+ * Values pulled verbatim from the Stitch design system pinned in slice packet §5. */
+:root {
+  --shell-color-surface-page: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-surface-shell: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-text-primary: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-text-muted: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-divider-subtle: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-accent-brand: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-color-accent-focus: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-space-inline-default: <VALUE FROM STITCH DESIGN SYSTEM>;
+  --shell-space-inset-panel: <VALUE FROM STITCH DESIGN SYSTEM>;
+}
+```
+
+This file is bundled as a real CSS output (`war/j2cl/assets/shell.css`) by esbuild's second entry point (Step 2.3), so the server HTML can load it via `<link>` and render styled chrome **without JavaScript**.
+
+- [ ] **Step 7.2: Rewrite `j2cl/lit/src/index.js`**
+
+Wire the inline-shell adapter onto `window.__litShellInput` so elements read bootstrap data through the adapter from day one. Post-#963, Task 9 swaps this single line to the JSON variant without touching any element.
+
+```javascript
+// Entry point for the SupaWave Lit shell bundle (issue #964).
+import { createInlineShellInput } from "./input/inline-shell-input.js";
+import "./elements/shell-skip-link.js";
+import "./elements/shell-header.js";
+import "./elements/shell-nav-rail.js";
+import "./elements/shell-main-region.js";
+import "./elements/shell-status-strip.js";
+import "./elements/shell-root.js";
+import "./elements/shell-root-signed-out.js";
+
+window.__litShellInput = createInlineShellInput(window);
+```
+
+The `shell-tokens.css` file is emitted as a standalone CSS asset by esbuild (Step 2.3); it is **not** imported from JS so it ships regardless of whether the JS bundle loads.
+
+- [ ] **Step 7.3: Build and inspect the bundle**
+
+```bash
+cd j2cl/lit && npm run build && cd ../..
+head -c 200 war/j2cl/assets/shell.js
+```
+
+Expected: minified ESM starting with `import` or bundled definitions.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add j2cl/lit/src/index.js j2cl/lit/src/tokens/shell-tokens.css
+git commit -m "feat(#964): wire shell primitives and tokens into bundle entry"
+```
+
+### Task 8: Replace the server-rendered shell HTML with progressive-enhancement markup
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java`
+
+- [ ] **Step 8.1: Write the failing server-side assertions**
+
+Open `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java` and add these test methods (leave existing tests in place):
+
+```java
+  @Test
+  public void signedInPageUsesLitCustomElements() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "user");
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+    assertThat(html).contains("<shell-root>");
+    assertThat(html).contains("<shell-header signed-in");
+    assertThat(html).contains("<shell-nav-rail");
+    assertThat(html).contains("<shell-main-region");
+    assertThat(html).contains("<shell-status-strip");
+    assertThat(html).contains("<shell-skip-link");
+    assertThat(html).contains("/j2cl/assets/shell.js");
+    assertThat(html).contains("/j2cl/assets/shell.css");
+  }
+
+  @Test
+  public void signedOutPageUsesSignedOutRoot() {
+    JSONObject session = new JSONObject();
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+    assertThat(html).contains("<shell-root-signed-out>");
+    assertThat(html).doesNotContain("<shell-root>");
+  }
+
+  @Test
+  public void legacyShellClassesAreNoLongerEmitted() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+    assertThat(html).doesNotContain("j2cl-root-shell-banner");
+    assertThat(html).doesNotContain("j2cl-root-shell-nav");
+    assertThat(html).doesNotContain("j2cl-root-shell-pill");
+  }
+
+  @Test
+  public void fallbackMarkupIsReadableWithoutJs() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+    assertThat(html).contains("id=\"j2cl-root-shell-workflow\"");
+    assertThat(html).contains("data-j2cl-root-shell-workflow=\"true\"");
+    assertThat(html).contains("Skip to main content");
+  }
+```
+
+- [ ] **Step 8.2: Run the failing tests**
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest"
+```
+
+Expected: 4 new failures; the existing tests may also fail once the renderer is rewritten (they get updated in Step 8.4).
+
+- [ ] **Step 8.3: Rewrite `renderJ2clRootShellPage(...)` in `HtmlRenderer.java`**
+
+Replace the entire method body with a progressive-enhancement implementation. The new body:
+
+1. Keeps the existing signature, the inline `__session` + `__websocket_address` script block, the analytics fragment, the build/commit meta tags, the same escape helpers, and the same normalized return-target and base-path logic that currently exists.
+2. Replaces the `<main class="j2cl-root-shell">` block plus all inline `<style>` CSS and the StringBuilder JS bootstrap with the markup below. Keep the existing `<script src="/j2cl-search/sidecar/j2cl-sidecar.js"></script>` for the signed-in case and the existing `mountWhenReady` bootstrap tail so `J2clRootShellController` continues to mount.
+3. Adds two new tags in `<head>`:
+
+```
+<link rel="stylesheet" href="/j2cl/assets/shell.css">
+<script type="module" src="/j2cl/assets/shell.js"></script>
+```
+
+`type="module"` scripts are deferred by default; no `defer` attribute is needed (and `defer` is ignored on module scripts).
+
+4. Replaces `<main class="j2cl-root-shell">...</main>` with:
+
+For signed-in:
+
+```
+<shell-root>
+  <shell-skip-link slot="skip-link" target="#j2cl-root-shell-workflow" label="Skip to main content"></shell-skip-link>
+  <shell-header slot="header" signed-in>
+    <a slot="brand" href="{escapedReturnTarget}" aria-label="J2CL root shell">
+      <span aria-hidden="true">J2</span><span>SupaWave J2CL Root Shell</span>
+    </a>
+    <span slot="actions-signed-in">Signed in as {escapedAddress}</span>
+    {ADMIN_LINK_OR_EMPTY}
+    <a slot="actions-signed-in" data-j2cl-root-signout="true" href="/auth/signout?r={encodedReturnTarget}">Sign out</a>
+  </shell-header>
+  <shell-nav-rail slot="nav" label="Primary">
+    <a href="{escapedReturnTarget}">Inbox</a>
+  </shell-nav-rail>
+  <shell-main-region slot="main">
+    <section id="j2cl-root-shell-workflow" data-j2cl-root-shell-workflow="true">
+      <p data-j2cl-fallback="true">The hosted J2CL workflow is loading and will mount here shortly.</p>
+    </section>
+  </shell-main-region>
+  <shell-status-strip slot="status">Return target: {escapedReturnTarget}</shell-status-strip>
+</shell-root>
+```
+
+For signed-out:
+
+```
+<shell-root-signed-out>
+  <shell-skip-link slot="skip-link" target="#j2cl-root-shell-workflow" label="Skip to main content"></shell-skip-link>
+  <shell-header slot="header">
+    <a slot="brand" href="{escapedReturnTarget}" aria-label="J2CL root shell">
+      <span aria-hidden="true">J2</span><span>SupaWave J2CL Root Shell</span>
+    </a>
+    <span slot="actions-signed-out">Signed out</span>
+    <a slot="actions-signed-out" data-j2cl-root-signin="true" href="/auth/signin?r={encodedReturnTarget}">Sign in</a>
+  </shell-header>
+  <shell-main-region slot="main">
+    <section id="j2cl-root-shell-workflow" data-j2cl-root-shell-workflow="true">
+      <p data-j2cl-fallback="true">After sign-in, the hosted J2CL workflow will mount here without leaving the shell.</p>
+    </section>
+  </shell-main-region>
+  <shell-status-strip slot="status">Return target: {escapedReturnTarget}</shell-status-strip>
+</shell-root-signed-out>
+```
+
+Placeholder rules:
+
+- `{escapedAddress}` — `StringEscapeUtils.escapeHtml4(address)`.
+- `{escapedReturnTarget}` — `StringEscapeUtils.escapeHtml4(resolvedReturnTarget)`.
+- `{encodedReturnTarget}` — the existing `encodeLocalReturnTarget(...)` helper result, then `StringEscapeUtils.escapeHtml4(...)`.
+- `{ADMIN_LINK_OR_EMPTY}` — when `HumanAccountData.ROLE_ADMIN` or `HumanAccountData.ROLE_OWNER` matches, emit the literal element below on its own line; when neither matches, emit **nothing at all** (not an empty element, not a whitespace-only line — the StringBuilder branch appends exactly zero characters, matching the pre-#964 behavior for non-admin users):
+
+```
+<a slot="actions-signed-in" data-j2cl-root-admin-link="true" href="/admin">Admin</a>
+```
+
+Delete every StringBuilder line that emitted inline `<style>` rules with `.j2cl-root-shell-*` classes. Re-attach the existing `mountWhenReady`/`syncReturnTargetUi`/`normalizeLegacyHashDeepLink`/`hookHistory` bootstrap JS for the signed-in path into a new private helper `appendJ2clRootShellSignedInBootstrap(StringBuilder sb, String safeResolvedReturnTarget, String safeResolvedBasePath)`. Inside that helper, update the `mountWhenReady` body to clear any `[data-j2cl-fallback]` element inside the workflow region **before** calling `entryPoint.mount(...)`:
+
+```javascript
+function clearFallback(){
+  var workflow=document.getElementById('j2cl-root-shell-workflow');
+  if(!workflow){return;}
+  workflow.querySelectorAll('[data-j2cl-fallback]').forEach(function(node){node.remove();});
+}
+function mountWhenReady(attemptsRemaining){
+  var entryPoint=resolveEntryPoint();
+  if(entryPoint){clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}
+  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}
+}
+```
+
+This removes the fallback `<p>` before the workflow mounts so the controller never races against dead text, and preserves the existing error-path behavior via `renderLoadError()`.
+
+- [ ] **Step 8.4: Update the pre-existing tests in `HtmlRendererJ2clRootShellTest` that asserted the legacy classes**
+
+For every existing assertion that says `assertThat(html).contains("j2cl-root-shell-banner")` (or any other legacy class name listed in Step 8.1's negative assertions), either delete the assertion or replace it with the equivalent custom-element assertion.
+
+- [ ] **Step 8.5: Run all tests, including the existing sign-in/sign-out cases**
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest"
+```
+
+Expected: all pass.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+git commit -m "feat(#964): rewrite J2CL root-shell HTML with Lit custom elements and progressive-enhancement fallback"
+```
+
+### Task 9 (GATED ON #963 MERGE — DO NOT EXECUTE EARLY): Rewire `LitShellInput` to the bootstrap JSON contract
+
+**Precondition before ticking Task 9 steps:** PR #980 must be merged into `main` and `git pull` into this worktree.
+
+**Files:**
+- Create: `j2cl/lit/src/input/json-shell-input.js`
+- Create: `j2cl/lit/test/json-shell-input.test.js`
+- Modify: `j2cl/lit/src/index.js`
+
+- [ ] **Step 9.1: Pull the merged `J2clBootstrapContract` contract into the worktree**
+
+```bash
+git fetch origin main && git rebase origin/main
+cat wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java | head -40
+```
+
+Expected: the contract file exists.
+
+- [ ] **Step 9.2: Write the failing `j2cl/lit/test/json-shell-input.test.js`**
+
+```javascript
+import { expect } from "@open-wc/testing";
+import { createJsonShellInput } from "../src/input/json-shell-input.js";
+
+describe("json-shell-input", () => {
+  it("reads the bootstrap contract payload from window.__bootstrap", () => {
+    window.__bootstrap = {
+      session: { address: "a@b.c", role: "owner", domain: "b.c", idSeed: "s", features: [] },
+      websocketAddress: "ws.example:443",
+    };
+    const snap = createJsonShellInput(window).read();
+    expect(snap.signedIn).to.equal(true);
+    expect(snap.role).to.equal("owner");
+    expect(snap.websocketAddress).to.equal("ws.example:443");
+  });
+});
+```
+
+- [ ] **Step 9.3: Run to fail** — `cd j2cl/lit && npm test && cd ../..` — FAIL (module missing)
+
+- [ ] **Step 9.4: Write `j2cl/lit/src/input/json-shell-input.js`**
+
+```javascript
+import { EMPTY_SNAPSHOT } from "./lit-shell-input.js";
+
+const ALLOWED_ROLES = new Set(["admin", "owner", "user"]);
+function normalizeRole(raw) { return ALLOWED_ROLES.has(raw) ? raw : "user"; }
+
+export function createJsonShellInput(win) {
+  return {
+    read() {
+      const bootstrap = win.__bootstrap;
+      if (!bootstrap || typeof bootstrap !== "object") return EMPTY_SNAPSHOT;
+      const session = bootstrap.session || {};
+      const address = typeof session.address === "string" ? session.address : "";
+      return {
+        signedIn: address.length > 0,
+        address,
+        role: normalizeRole(session.role),
+        domain: typeof session.domain === "string" ? session.domain : "",
+        idSeed: typeof session.idSeed === "string" ? session.idSeed : "",
+        features: Array.isArray(session.features) ? [...session.features] : [],
+        websocketAddress: typeof bootstrap.websocketAddress === "string" ? bootstrap.websocketAddress : "",
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 9.5: Run to pass**
+
+- [ ] **Step 9.6: Swap the adapter in `j2cl/lit/src/index.js`**
+
+```javascript
+// Swap the inline adapter for the JSON-contract adapter now that #963 has merged.
+import { createJsonShellInput } from "./input/json-shell-input.js";
+window.__litShellInput = createJsonShellInput(window);
+```
+
+(If any element already reads `window.__litShellInput`, the swap is complete. If a given element still reads the inline global directly, refactor it to call `window.__litShellInput.read()` in the same commit.)
+
+- [ ] **Step 9.7: Run the full gate**
+
+```bash
+sbt -batch j2clLitBuild j2clLitTest j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+```
+
+- [ ] **Step 9.8: Commit**
+
+```bash
+git add j2cl/lit/src/input/json-shell-input.js j2cl/lit/test/json-shell-input.test.js j2cl/lit/src/index.js
+git commit -m "feat(#964): swap Lit shell adapter to #963 bootstrap JSON contract"
+```
+
+**Scope fence:** Task 9 is **client-adapter-only**. Server-side emission of the `window.__bootstrap` payload (or the `/j2cl-bootstrap` fetch wiring) is #963/#965 scope and MUST NOT be edited here. If the merged #963 ships server-side emission of `window.__bootstrap`, Task 9 is sufficient as-is. If it does not, the adapter swap still lands but the payload remains empty until #965 ships the server-side half; that is acceptable because the pre-#963 inline `window.__session` globals remain in place in `HtmlRenderer` for rollback.
+
+### Task 10: Wire `j2clLitBuild` and `j2clLitTest` into sbt
+
+**Files:**
+- Modify: `build.sbt`
+
+- [ ] **Step 10.1: Read the current `j2clRuntimeBuild` body so the wiring append is additive, not a rewrite**
+
+```bash
+sed -n '820,950p' build.sbt
+```
+
+Record the exact current body of `ThisBuild / j2clRuntimeBuild` (around line 944). The snippet below assumes that body is the two-step `Def.sequential(j2clSearchBuild, j2clProductionBuild)` form shown in the grep output of Task 1. If the current body does anything else (copies staging dirs, asset placement, cleanup), **preserve those side effects** and append `j2clLitBuild` to the sequence rather than replacing the whole body.
+
+- [ ] **Step 10.2: Add the task definitions and wiring**
+
+Open `build.sbt` and insert near the other `j2cl*` task keys (around line 826):
+
+```scala
+lazy val j2clLitBuild = taskKey[Unit]("Build the Lit shell bundle into war/j2cl/assets via npm")
+lazy val j2clLitTest  = taskKey[Unit]("Run the Lit shell web-test-runner suite via npm")
+```
+
+Near the other `ThisBuild /` task bodies (around line 914), add:
+
+```scala
+ThisBuild / j2clLitBuild := {
+  val log = streams.value.log
+  val base = (ThisBuild / baseDirectory).value
+  val litDir = base / "j2cl" / "lit"
+  if (!(litDir / "node_modules").exists()) {
+    val ci = scala.sys.process.Process(Seq("npm", "ci"), litDir) ! log
+    if (ci != 0) sys.error(s"[j2cl-lit] npm ci failed with exit code $ci")
+  }
+  val build = scala.sys.process.Process(Seq("npm", "run", "build"), litDir) ! log
+  if (build != 0) sys.error(s"[j2cl-lit] npm run build failed with exit code $build")
+}
+
+ThisBuild / j2clLitTest := {
+  val log = streams.value.log
+  val base = (ThisBuild / baseDirectory).value
+  val litDir = base / "j2cl" / "lit"
+  if (!(litDir / "node_modules").exists()) {
+    val ci = scala.sys.process.Process(Seq("npm", "ci"), litDir) ! log
+    if (ci != 0) sys.error(s"[j2cl-lit] npm ci failed with exit code $ci")
+  }
+  val t = scala.sys.process.Process(Seq("npm", "test"), litDir) ! log
+  if (t != 0) sys.error(s"[j2cl-lit] npm test failed with exit code $t")
+}
+```
+
+Update the existing `j2clRuntimeBuild` around line 944 to include `j2clLitBuild`:
+
+```scala
+ThisBuild / j2clRuntimeBuild := Def.sequential(
+  ThisBuild / j2clSearchBuild,
+  ThisBuild / j2clProductionBuild,
+  ThisBuild / j2clLitBuild
+)
+```
+
+- [ ] **Step 10.3: Run the sbt tasks to verify wiring**
+
+```bash
+sbt -batch j2clLitBuild
+```
+
+Expected: clean exit; `war/j2cl/assets/shell.js` and `war/j2cl/assets/shell.css` both present.
+
+```bash
+sbt -batch j2clLitTest
+```
+
+Expected: all Lit unit tests green (7 element suites + 2 adapter suites).
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add build.sbt
+git commit -m "build(#964): wire j2clLitBuild/j2clLitTest into runtime build graph"
+```
+
+### Task 11: Add changelog fragment
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-23-lit-root-shell.json`
+
+- [ ] **Step 11.1: Write the fragment**
+
+```json
+{
+  "version": "next",
+  "date": "2026-04-23",
+  "type": "feat",
+  "scope": "j2cl",
+  "summary": "Lit root shell and shared chrome primitives",
+  "description": "Introduce the first Lit package (j2cl/lit/) with reusable shell/chrome primitives (shell-root, shell-root-signed-out, shell-header, shell-nav-rail, shell-main-region, shell-status-strip, shell-skip-link). The J2CL coexistence seam (?view=j2cl-root and the j2cl-root-bootstrap feature flag) now renders these primitives with progressive-enhancement HTML, preserving the default / route on the legacy GWT shell. Issue #964.",
+  "issue": 964
+}
+```
+
+- [ ] **Step 11.2: Regenerate and validate the changelog**
+
+```bash
+sbt -batch changelogAssemble
+python3 scripts/validate-changelog.py
+```
+
+Expected: `wave/config/changelog.json` updated; validator clean.
+
+- [ ] **Step 11.3: Commit**
+
+```bash
+git add wave/config/changelog.d/2026-04-23-lit-root-shell.json wave/config/changelog.json
+git commit -m "docs(#964): add changelog fragment for Lit root shell"
+```
+
+### Task 12: Full gate + local smoke verification
+
+- [ ] **Step 12.1: Run the cross-path gate**
+
+```bash
+sbt -batch j2clLitBuild j2clLitTest j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+```
+
+Expected: green.
+
+- [ ] **Step 12.2: Run the local smoke**
+
+```bash
+bash scripts/worktree-boot.sh --port 9964
+# wait for printed helper commands, then:
+PORT=9964 bash scripts/wave-smoke.sh start
+PORT=9964 bash scripts/wave-smoke.sh check
+```
+
+Expected: server up.
+
+- [ ] **Step 12.3: Route and asset assertions**
+
+```bash
+curl -fsS http://localhost:9964/ | grep -F "webclient/webclient.nocache.js"
+curl -fsS "http://localhost:9964/?view=j2cl-root" | grep -F "<shell-root"
+curl -fsS "http://localhost:9964/?view=j2cl-root" | grep -F "/j2cl/assets/shell.js"
+curl -fsS "http://localhost:9964/?view=j2cl-root" | grep -F "/j2cl/assets/shell.css"
+curl -fsS "http://localhost:9964/?view=j2cl-root" | grep -F "Skip to main content"
+curl -fsSI http://localhost:9964/j2cl/assets/shell.js | head -1
+curl -fsSI http://localhost:9964/j2cl/assets/shell.css | head -1
+```
+
+Expected: the five body greps return a non-empty line; both asset HEAD calls return `HTTP/1.1 200 OK`.
+
+- [ ] **Step 12.4: Browser verification**
+
+Register one fresh local user in the worktree-backed file-store, then:
+
+- Open `http://localhost:9964/` signed-out → legacy landing/GWT renders as before.
+- Open `http://localhost:9964/?view=j2cl-root` signed-out → new Lit signed-out shell renders; "Sign in" link preserves the `view=j2cl-root` return target.
+- Sign in → Lit signed-in shell renders; the existing search/selected-wave/compose workflow mounts inside `<shell-main-region>`; skip link is the first tab stop and jumps focus to the workflow region.
+- Open `http://localhost:9964/` signed-in with `j2cl-root-bootstrap` flag ON → Lit signed-in shell renders as default.
+- Verify no unstyled flash by throttling JS with DevTools "Slow 3G" and reloading `/?view=j2cl-root`; the server HTML fallback should render fully before Lit upgrades, and upgrade should not cause a visible reflow of the skip link, header, or workflow region.
+- In DevTools console, assert the workflow host is unique and the fallback text has been cleared after mount:
+
+  ```javascript
+  document.querySelectorAll('#j2cl-root-shell-workflow').length   // expect 1
+  document.querySelectorAll('[data-j2cl-fallback]').length         // expect 0 after mount
+  ```
+
+- [ ] **Step 12.5: Stop the server**
+
+```bash
+PORT=9964 bash scripts/wave-smoke.sh stop
+```
+
+- [ ] **Step 12.6: Record evidence in the issue**
+
+Post a comment on issue #964 with: worktree path, plan path, commit SHAs since Task 1, the four curl outputs, and browser-verification summary.
+
+## 8. Risks / Edge Cases
+
+- **Lit bundle fails to load on first paint.** The progressive-enhancement server HTML must remain legible without JS. Tested by Step 12.4 with JS throttling; assertion in `fallbackMarkupIsReadableWithoutJs`.
+- **Double-mount.** Both the existing StringBuilder bootstrap JS (`mountWhenReady`) and Lit upgrade could fight over the workflow host. `shell-main-region` renders the `#j2cl-root-shell-workflow` element inside its template with a `<slot>`; the server HTML emits the same element as a child so both the light-DOM child and the light-DOM slot target the same id. Verify no duplicate `#j2cl-root-shell-workflow` exists in the rendered DOM (`document.querySelectorAll('#j2cl-root-shell-workflow').length === 1`) in the browser step.
+- **Legacy class collisions with `sidecar.css`.** `sidecar.css` ships its own `.j2cl-root-shell*` rules; once the legacy classes are removed from the renderer, those rules become dead. Leave them in `sidecar.css` for one slice to keep the sidecar route unchanged; plan to delete them in a follow-up once `#965` lands.
+- **Stitch artifact drift.** If the Stitch project is updated after pinning, the design packet §6 gate requires a packet amendment PR, not a silent re-pin. Task 3.4 pins the ids explicitly to make drift visible.
+- **npm install in CI.** The `j2clLitBuild` sbt task depends on `npm ci` succeeding. CI runners must have Node ≥20 and network access to the npm registry for the initial install. If CI is offline-only, switch to a vendored `node_modules.tar.gz` and cache extraction; that fallback is out of scope for this slice.
+- **Cross-origin asset loading.** `/j2cl/assets/shell.js` is served from the same origin as the page; no CORS required. Double-check that no CSP header blocks inline module scripts — the existing `<script type="module">` usage elsewhere in the renderer confirms it is allowed.
+- **Rollback under the feature flag.** `j2cl-root-bootstrap` flip-off must leave `/` on the legacy GWT shell with no residual Lit chrome. Assertion: the renderer only emits `<link href="/j2cl/assets/shell.css">` and `<script src="/j2cl/assets/shell.js">` **inside** the `renderJ2clRootShellPage` branch, not in `renderWaveClientPage`.
+- **Shell/workflow boundary.** `<shell-main-region>` exposes `#j2cl-root-shell-workflow` as a light-DOM child (not shadow-slotted) so `J2clRootShellController.start()` continues to query for the id at the document level exactly as it does today. Verified by `shell-main-region.test.js`.
+- **#963 coupling drift.** If #963 lands and removes `window.__session` in the same PR, Task 9 becomes a precondition for Task 8 rather than a follow-up. Watch PR #980's final diff before merging this plan's Task 8.
+
+## 9. Ordering Relative To The Remaining Queue
+
+1. `#962` (design packet) is already merged.
+2. `#963` (PR #980) is in review; Tasks 1–8 land in parallel under #964 without depending on it.
+3. `#964` Task 9 runs only after #963 merges.
+4. `#965` (server-first first-paint) consumes the shell primitives produced here for its skeleton chrome.
+5. `#966` (read-surface) consumes `shell-main-region` as its mount container.
+6. `#968`, `#969`, `#970` all inherit the shell family without re-deriving it.
+
+## 10. Handoff / Execution Choice
+
+**"Plan complete and saved to `docs/superpowers/plans/2026-04-23-issue-964-lit-root-shell.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+**Which approach?"**

--- a/j2cl/lit/.gitignore
+++ b/j2cl/lit/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/j2cl/lit/esbuild.config.mjs
+++ b/j2cl/lit/esbuild.config.mjs
@@ -1,0 +1,20 @@
+import { build } from "esbuild";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const out = resolve(here, "../../war/j2cl/assets");
+
+await build({
+  entryPoints: [
+    { in: resolve(here, "src/index.js"), out: "shell" },
+    { in: resolve(here, "src/tokens/shell-tokens.css"), out: "shell" }
+  ],
+  bundle: true,
+  format: "esm",
+  target: "es2020",
+  minify: true,
+  sourcemap: true,
+  outdir: out,
+  logLevel: "info"
+});

--- a/j2cl/lit/package-lock.json
+++ b/j2cl/lit/package-lock.json
@@ -1,0 +1,5369 @@
+{
+  "name": "supawave-lit-shell",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "supawave-lit-shell",
+      "version": "0.0.1",
+      "dependencies": {
+        "lit": "3.2.1"
+      },
+      "devDependencies": {
+        "@open-wc/testing": "4.0.0",
+        "@web/test-runner": "0.19.0",
+        "@web/test-runner-playwright": "0.11.0",
+        "esbuild": "0.24.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
+      "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
+      "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
+      "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
+      "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+      "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
+      "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
+      "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
+      "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
+      "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
+      "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
+      "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
+      "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
+      "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
+      "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
+      "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
+      "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
+      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
+      "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
+      "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
+      "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
+      "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
+      "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
+      "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
+      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esm-bundle/chai": {
+      "version": "4.3.4-fix.0",
+      "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz",
+      "integrity": "sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.2.12"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-2.0.1.tgz",
+      "integrity": "sha512-+R4VxvceUxHAUJXJQipkkoV9fy10vNo+OnUnGKZnVmcwxMl460KLzytnUM4S35SI073R0yZQp9ra0MbPUwVcEA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-wc/scoped-elements": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.6.tgz",
+      "integrity": "sha512-w1ayJaUUmBw8tALtqQ6cBueld+op+bufujzbrOdH0uCTXnSQkONYZzOH+9jyQ8auVgKLqcxZ8oU6SzfqQhQkPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^2.0.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.20.1.tgz",
+      "integrity": "sha512-mPF/RPT2TU7Dw41LEDdaeP6eyTOWBD4z0+AHP4/d0SbgcfJZVRymlIB6DQmtz0fd2CImIS9kszaMmwMt92HBPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.3.1",
+        "@web/test-runner-commands": "^0.9.0"
+      }
+    },
+    "node_modules/@open-wc/testing": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-4.0.0.tgz",
+      "integrity": "sha512-KI70O0CJEpBWs3jrTju4BFCy7V/d4tFfYWkg8pMzncsDhD7TYNHLw5cy+s1FHXIgVFetnMDhPpwlKIPvtTQW7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@open-wc/semantic-dom-diff": "^0.20.0",
+        "@open-wc/testing-helpers": "^3.0.0",
+        "@types/chai-dom": "^1.11.0",
+        "@types/sinon-chai": "^3.2.3",
+        "chai-a11y-axe": "^1.5.0"
+      }
+    },
+    "node_modules/@open-wc/testing-helpers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-3.0.1.tgz",
+      "integrity": "sha512-hyNysSatbgT2FNxHJsS3rGKcLEo6+HwDFu1UQL6jcSQUabp/tj3PyX7UnXL3H5YGv0lJArdYLSnvjLnjn3O2fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/scoped-elements": "^3.0.2",
+        "lit": "^2.0.0 || ^3.0.0",
+        "lit-html": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/babel__code-frame": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.27.0.tgz",
+      "integrity": "sha512-Dwlo+LrxDx/0SpfmJ/BKveHf7QXWvLBLc+x03l5sbzykj3oB9nHygCpSECF1a+s+QIxbghe+KHqC90vGtxLRAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai-dom": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-1.11.3.tgz",
+      "integrity": "sha512-EUEZI7uID4ewzxnU7DJXtyvykhQuwe+etJ1wwOiJyQRTH/ifMWKX+ghiXkxCUvNJ6IQDodf0JXhuP6zZcy2qXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
+    "node_modules/@types/co-body": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.3.tgz",
+      "integrity": "sha512-UhuhrQ5hclX6UJctv5m4Rfp52AfG9o9+d9/HwjxhVB5NjXxr5t9oKgJxN8xRHgr35oo8meUEHUPFWiKg6y71aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*"
+      }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.9.tgz",
+      "integrity": "sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/convert-source-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-2.0.3.tgz",
+      "integrity": "sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+      "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debounce": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
+      "integrity": "sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
+      "integrity": "sha512-TTEwmtjgVbYAzZYWyeHPrrtWnfVkm8tQkP8P21uQifPgMRgjrow3XDEYqucuC8SKZJT7pUnhU/JymvjggxO9vw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/koa": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.9.tgz",
+      "integrity": "sha512-BroAZ9FTvPiCy0Pi8tjD1OfJ7bgU1gQf0eR6e1Vm+JJATy9eKOG3hQMFtMciMawiSOVnLMdmUOC46s7HBhSTsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/parse5": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sinon": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.1.tgz",
+      "integrity": "sha512-5yoJSqLbjH8T9V2bksgRayuhpZy+723/z6wBOR+Soe4ZlXC0eW8Na71TeaZPUWDQvM7LYKa9UGFc6LRqxiR5fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@web/browser-logs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.4.1.tgz",
+      "integrity": "sha512-ypmMG+72ERm+LvP+loj9A64MTXvWMXHUOu773cPO4L1SV/VWg6xA9Pv7vkvkXQX+ItJtCJt+KQ+U6ui2HhSFUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "errorstacks": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/config-loader": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.3.tgz",
+      "integrity": "sha512-ilzeQzrPpPLWZhzFCV+4doxKDGm7oKVfdKpW9wiUNVgive34NSzCw+WzXTvjE4Jgr5CkyTDIObEmMrqQEjhT0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.4.6.tgz",
+      "integrity": "sha512-jj/1bcElAy5EZet8m2CcUdzxT+CRvUjIXGh8Lt7vxtthkN9PzY9wlhWx/9WOs5iwlnG1oj0VGo6f/zvbPO0s9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/command-line-args": "^5.0.0",
+        "@web/config-loader": "^0.3.0",
+        "@web/dev-server-core": "^0.7.2",
+        "@web/dev-server-rollup": "^0.6.1",
+        "camelcase": "^6.2.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^7.0.1",
+        "debounce": "^1.2.0",
+        "deepmerge": "^4.2.2",
+        "internal-ip": "^6.2.0",
+        "nanocolors": "^0.2.1",
+        "open": "^8.0.2",
+        "portfinder": "^1.0.32"
+      },
+      "bin": {
+        "wds": "dist/bin.js",
+        "web-dev-server": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server-core": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-core/-/dev-server-core-0.7.5.tgz",
+      "integrity": "sha512-Da65zsiN6iZPMRuj4Oa6YPwvsmZmo5gtPWhW2lx3GTUf5CAEapjVpZVlUXnKPL7M7zRuk72jSsIl8lo+XpTCtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/koa": "^2.11.6",
+        "@types/ws": "^7.4.0",
+        "@web/parse5-utils": "^2.1.0",
+        "chokidar": "^4.0.1",
+        "clone": "^2.1.2",
+        "es-module-lexer": "^1.0.0",
+        "get-stream": "^6.0.0",
+        "is-stream": "^2.0.0",
+        "isbinaryfile": "^5.0.0",
+        "koa": "^2.13.0",
+        "koa-etag": "^4.0.0",
+        "koa-send": "^5.0.1",
+        "koa-static": "^5.0.0",
+        "lru-cache": "^8.0.4",
+        "mime-types": "^2.1.27",
+        "parse5": "^6.0.1",
+        "picomatch": "^2.2.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server-rollup": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz",
+      "integrity": "sha512-sJZfTGCCrdku5xYnQQG51odGI092hKY9YFM0X3Z0tRY3iXKXcYRaLZrErw5KfCxr6g0JRuhe4BBhqXTA5Q2I3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@web/dev-server-core": "^0.7.2",
+        "nanocolors": "^0.2.1",
+        "parse5": "^6.0.1",
+        "rollup": "^4.4.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/parse5-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-2.1.1.tgz",
+      "integrity": "sha512-7rBVZEMGfrq2iPcAEwJ0KSNSvmA2a6jT2CK8/gyIOHgn4reg7bSSRbzyWIEYWyIkeRoYEukX/aW+nAeCgSSqhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse5": "^6.0.1",
+        "parse5": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.19.0.tgz",
+      "integrity": "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/browser-logs": "^0.4.0",
+        "@web/config-loader": "^0.3.0",
+        "@web/dev-server": "^0.4.0",
+        "@web/test-runner-chrome": "^0.17.0",
+        "@web/test-runner-commands": "^0.9.0",
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-mocha": "^0.9.0",
+        "camelcase": "^6.2.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^7.0.1",
+        "convert-source-map": "^2.0.0",
+        "diff": "^5.0.0",
+        "globby": "^11.0.1",
+        "nanocolors": "^0.2.1",
+        "portfinder": "^1.0.32",
+        "source-map": "^0.7.3"
+      },
+      "bin": {
+        "web-test-runner": "dist/bin.js",
+        "wtr": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-chrome": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.17.0.tgz",
+      "integrity": "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "async-mutex": "0.4.0",
+        "chrome-launcher": "^0.15.0",
+        "puppeteer-core": "^23.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-commands": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.9.0.tgz",
+      "integrity": "sha512-zeLI6QdH0jzzJMDV5O42Pd8WLJtYqovgdt0JdytgHc0d1EpzXDsc7NTCJSImboc2NcayIsWAvvGGeRF69SMMYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "mkdirp": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-core": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.13.4.tgz",
+      "integrity": "sha512-84E1025aUSjvZU1j17eCTwV7m5Zg3cZHErV3+CaJM9JPCesZwLraIa0ONIQ9w4KLgcDgJFw9UnJ0LbFf42h6tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.11",
+        "@types/babel__code-frame": "^7.0.2",
+        "@types/co-body": "^6.1.0",
+        "@types/convert-source-map": "^2.0.0",
+        "@types/debounce": "^1.2.0",
+        "@types/istanbul-lib-coverage": "^2.0.3",
+        "@types/istanbul-reports": "^3.0.0",
+        "@web/browser-logs": "^0.4.0",
+        "@web/dev-server-core": "^0.7.3",
+        "chokidar": "^4.0.1",
+        "cli-cursor": "^3.1.0",
+        "co-body": "^6.1.0",
+        "convert-source-map": "^2.0.0",
+        "debounce": "^1.2.0",
+        "dependency-graph": "^0.11.0",
+        "globby": "^11.0.1",
+        "internal-ip": "^6.2.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.0.2",
+        "log-update": "^4.0.0",
+        "nanocolors": "^0.2.1",
+        "nanoid": "^3.1.25",
+        "open": "^8.0.2",
+        "picomatch": "^2.2.2",
+        "source-map": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-coverage-v8": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.8.0.tgz",
+      "integrity": "sha512-PskiucYpjUtgNfR2zF2AWqWwjXL7H3WW/SnCAYmzUrtob7X9o/+BjdyZ4wKbOxWWSbJO4lEdGIDLu+8X2Xw+lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "istanbul-lib-coverage": "^3.0.0",
+        "lru-cache": "^8.0.4",
+        "picomatch": "^2.2.2",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-mocha": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-mocha/-/test-runner-mocha-0.9.0.tgz",
+      "integrity": "sha512-ZL9F6FXd0DBQvo/h/+mSfzFTSRVxzV9st/AHhpgABtUtV/AIpVE9to6+xdkpu6827kwjezdpuadPfg+PlrBWqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/test-runner-playwright": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
+      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@web/test-runner-core": "^0.13.0",
+        "@web/test-runner-coverage-v8": "^0.8.0",
+        "playwright": "^1.22.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
+      "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
+      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai-a11y-axe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.5.0.tgz",
+      "integrity": "sha512-V/Vg/zJDr9aIkaHJ2KQu7lGTQQm5ZOH4u1k5iTMvIXuSVlSuUo0jcSpSqf9wUn9zl6oQXa4e4E0cqH18KOgKlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "^4.3.3"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/co-body": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz",
+      "integrity": "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/bourne": "^3.0.0",
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-gateway": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
+      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/errorstacks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-2.4.1.tgz",
+      "integrity": "sha512-jE4i0SMYevwu/xxAuzhly/KTwtj0xDhbzB6m1xPImxTkw8wcCbgarOQPfCVMi5JKVyW7in29pNJCCJrry3Ynnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
+      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.0",
+        "@esbuild/android-arm": "0.24.0",
+        "@esbuild/android-arm64": "0.24.0",
+        "@esbuild/android-x64": "0.24.0",
+        "@esbuild/darwin-arm64": "0.24.0",
+        "@esbuild/darwin-x64": "0.24.0",
+        "@esbuild/freebsd-arm64": "0.24.0",
+        "@esbuild/freebsd-x64": "0.24.0",
+        "@esbuild/linux-arm": "0.24.0",
+        "@esbuild/linux-arm64": "0.24.0",
+        "@esbuild/linux-ia32": "0.24.0",
+        "@esbuild/linux-loong64": "0.24.0",
+        "@esbuild/linux-mips64el": "0.24.0",
+        "@esbuild/linux-ppc64": "0.24.0",
+        "@esbuild/linux-riscv64": "0.24.0",
+        "@esbuild/linux-s390x": "0.24.0",
+        "@esbuild/linux-x64": "0.24.0",
+        "@esbuild/netbsd-x64": "0.24.0",
+        "@esbuild/openbsd-arm64": "0.24.0",
+        "@esbuild/openbsd-x64": "0.24.0",
+        "@esbuild/sunos-x64": "0.24.0",
+        "@esbuild/win32-arm64": "0.24.0",
+        "@esbuild/win32-ia32": "0.24.0",
+        "@esbuild/win32-x64": "0.24.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inflation": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.1.0.tgz",
+      "integrity": "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-ip": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
+      "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1",
+        "is-ip": "^3.1.0",
+        "p-event": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-regex": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-regex": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa-etag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-etag/-/koa-etag-4.0.0.tgz",
+      "integrity": "sha512-1cSdezCkBWlyuB9l6c/IFoe1ANCDdPBxkDkRiaIup40xpUub6U/wwRXoKBZw/O5BifX9OlqAjYnDyzM6+l+TAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "etag": "^1.8.1"
+      }
+    },
+    "node_modules/koa-send": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
+      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "resolve-path": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/koa-static": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
+      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "koa-send": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa-static/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
+      "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.9",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanocolors": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.13.tgz",
+      "integrity": "sha512-0n3mSAQLPpGLV9ORXT5+C/D4mwew7Ebws69Hx4E2sgz2ZA5+32Q80B9tL8PbL7XHnRDiAxH/pnrUJ9a4fkTNTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "dev": true
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-path": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
+      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-errors": "~1.6.2",
+        "path-is-absolute": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-path/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/resolve-path/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/j2cl/lit/package.json
+++ b/j2cl/lit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "supawave-lit-shell",
+  "version": "0.0.1",
+  "description": "Lit primitives for the SupaWave J2CL root shell (issue #964).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "test": "web-test-runner"
+  },
+  "dependencies": {
+    "lit": "3.2.1"
+  },
+  "devDependencies": {
+    "@open-wc/testing": "4.0.0",
+    "@web/test-runner": "0.19.0",
+    "@web/test-runner-playwright": "0.11.0",
+    "esbuild": "0.24.0"
+  }
+}

--- a/j2cl/lit/src/elements/shell-header.js
+++ b/j2cl/lit/src/elements/shell-header.js
@@ -53,4 +53,6 @@ export class ShellHeader extends LitElement {
   }
 }
 
-customElements.define("shell-header", ShellHeader);
+if (!customElements.get("shell-header")) {
+  customElements.define("shell-header", ShellHeader);
+}

--- a/j2cl/lit/src/elements/shell-header.js
+++ b/j2cl/lit/src/elements/shell-header.js
@@ -1,0 +1,56 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellHeader extends LitElement {
+  static properties = {
+    signedIn: { type: Boolean, attribute: "signed-in", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--shell-space-inline-default, 12px);
+      padding: var(--shell-space-inset-panel, 16px 18px);
+      border-bottom: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      background: var(--shell-color-surface-shell, #fff);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.signedIn = false;
+  }
+
+  render() {
+    return html`
+      <header role="banner">
+        <div class="brand"><slot name="brand"></slot></div>
+        <div class="actions">
+          ${this.signedIn
+            ? html`<slot name="actions-signed-in"></slot>`
+            : html`<slot name="actions-signed-out"></slot>`}
+        </div>
+      </header>
+    `;
+  }
+}
+
+customElements.define("shell-header", ShellHeader);

--- a/j2cl/lit/src/elements/shell-main-region.js
+++ b/j2cl/lit/src/elements/shell-main-region.js
@@ -22,4 +22,6 @@ export class ShellMainRegion extends LitElement {
   }
 }
 
-customElements.define("shell-main-region", ShellMainRegion);
+if (!customElements.get("shell-main-region")) {
+  customElements.define("shell-main-region", ShellMainRegion);
+}

--- a/j2cl/lit/src/elements/shell-main-region.js
+++ b/j2cl/lit/src/elements/shell-main-region.js
@@ -1,0 +1,25 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellMainRegion extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      flex: 1;
+      min-width: 0;
+    }
+
+    main {
+      padding: var(--shell-space-inset-panel, 20px);
+      min-height: 360px;
+    }
+  `;
+
+  render() {
+    // The #j2cl-root-shell-workflow element is a light-DOM child of this
+    // component; it must stay queryable via document.getElementById so
+    // J2clRootShellController.start() continues to work unchanged.
+    return html`<main><slot></slot></main>`;
+  }
+}
+
+customElements.define("shell-main-region", ShellMainRegion);

--- a/j2cl/lit/src/elements/shell-nav-rail.js
+++ b/j2cl/lit/src/elements/shell-nav-rail.js
@@ -37,4 +37,6 @@ export class ShellNavRail extends LitElement {
   }
 }
 
-customElements.define("shell-nav-rail", ShellNavRail);
+if (!customElements.get("shell-nav-rail")) {
+  customElements.define("shell-nav-rail", ShellNavRail);
+}

--- a/j2cl/lit/src/elements/shell-nav-rail.js
+++ b/j2cl/lit/src/elements/shell-nav-rail.js
@@ -1,0 +1,40 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellNavRail extends LitElement {
+  static properties = {
+    label: { type: String }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    nav {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: var(--shell-space-inset-panel, 12px);
+      background: var(--shell-color-surface-shell, #fff);
+      border-right: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      min-width: 180px;
+    }
+
+    ::slotted(*) {
+      display: block;
+      padding: 8px 10px;
+      border-radius: 8px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.label = "Primary";
+  }
+
+  render() {
+    return html`<nav aria-label=${this.label}><slot></slot></nav>`;
+  }
+}
+
+customElements.define("shell-nav-rail", ShellNavRail);

--- a/j2cl/lit/src/elements/shell-root-signed-out.js
+++ b/j2cl/lit/src/elements/shell-root-signed-out.js
@@ -12,8 +12,8 @@ export class ShellRootSignedOut extends LitElement {
         "main"
         "status";
       min-height: 100vh;
-      background: var(--shell-color-surface-page, #f7fbff);
-      color: var(--shell-color-text-primary, #102b3f);
+      background: var(--shell-color-surface-page, #f6fafb);
+      color: var(--shell-color-text-primary, #181c1d);
     }
 
     slot[name="skip-link"] {

--- a/j2cl/lit/src/elements/shell-root-signed-out.js
+++ b/j2cl/lit/src/elements/shell-root-signed-out.js
@@ -4,10 +4,33 @@ export class ShellRootSignedOut extends LitElement {
   static styles = css`
     :host {
       display: grid;
-      grid-template-rows: auto 1fr auto;
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto 1fr auto;
+      grid-template-areas:
+        "skip"
+        "header"
+        "main"
+        "status";
       min-height: 100vh;
       background: var(--shell-color-surface-page, #f7fbff);
       color: var(--shell-color-text-primary, #102b3f);
+    }
+
+    slot[name="skip-link"] {
+      grid-area: skip;
+    }
+
+    slot[name="header"] {
+      grid-area: header;
+    }
+
+    slot[name="main"] {
+      grid-area: main;
+      min-height: 0;
+    }
+
+    slot[name="status"] {
+      grid-area: status;
     }
   `;
 
@@ -21,4 +44,6 @@ export class ShellRootSignedOut extends LitElement {
   }
 }
 
-customElements.define("shell-root-signed-out", ShellRootSignedOut);
+if (!customElements.get("shell-root-signed-out")) {
+  customElements.define("shell-root-signed-out", ShellRootSignedOut);
+}

--- a/j2cl/lit/src/elements/shell-root-signed-out.js
+++ b/j2cl/lit/src/elements/shell-root-signed-out.js
@@ -1,0 +1,24 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellRootSignedOut extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      min-height: 100vh;
+      background: var(--shell-color-surface-page, #f7fbff);
+      color: var(--shell-color-text-primary, #102b3f);
+    }
+  `;
+
+  render() {
+    return html`
+      <slot name="skip-link"></slot>
+      <slot name="header"></slot>
+      <slot name="main"></slot>
+      <slot name="status"></slot>
+    `;
+  }
+}
+
+customElements.define("shell-root-signed-out", ShellRootSignedOut);

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -4,24 +4,51 @@ export class ShellRoot extends LitElement {
   static styles = css`
     :host {
       display: grid;
-      grid-template-rows: auto 1fr auto;
+      grid-template-columns: minmax(190px, 220px) 1fr;
+      grid-template-rows: auto auto 1fr auto;
+      grid-template-areas:
+        "skip skip"
+        "header header"
+        "nav main"
+        "status status";
       min-height: 100vh;
       background: var(--shell-color-surface-page, #f7fbff);
       color: var(--shell-color-text-primary, #102b3f);
     }
 
-    .body {
-      display: flex;
-      min-height: 0;
+    slot[name="skip-link"] {
+      grid-area: skip;
+    }
+
+    slot[name="header"] {
+      grid-area: header;
     }
 
     slot[name="nav"] {
-      flex: 0 0 auto;
+      grid-area: nav;
+      min-height: 0;
     }
 
     slot[name="main"] {
-      flex: 1;
+      grid-area: main;
       min-width: 0;
+      min-height: 0;
+    }
+
+    slot[name="status"] {
+      grid-area: status;
+    }
+
+    @media (max-width: 860px) {
+      :host {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+          "skip"
+          "header"
+          "nav"
+          "main"
+          "status";
+      }
     }
   `;
 
@@ -29,13 +56,13 @@ export class ShellRoot extends LitElement {
     return html`
       <slot name="skip-link"></slot>
       <slot name="header"></slot>
-      <div class="body">
-        <slot name="nav"></slot>
-        <slot name="main"></slot>
-      </div>
+      <slot name="nav"></slot>
+      <slot name="main"></slot>
       <slot name="status"></slot>
     `;
   }
 }
 
-customElements.define("shell-root", ShellRoot);
+if (!customElements.get("shell-root")) {
+  customElements.define("shell-root", ShellRoot);
+}

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -12,8 +12,8 @@ export class ShellRoot extends LitElement {
         "nav main"
         "status status";
       min-height: 100vh;
-      background: var(--shell-color-surface-page, #f7fbff);
-      color: var(--shell-color-text-primary, #102b3f);
+      background: var(--shell-color-surface-page, #f6fafb);
+      color: var(--shell-color-text-primary, #181c1d);
     }
 
     slot[name="skip-link"] {

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -1,0 +1,41 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellRoot extends LitElement {
+  static styles = css`
+    :host {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      min-height: 100vh;
+      background: var(--shell-color-surface-page, #f7fbff);
+      color: var(--shell-color-text-primary, #102b3f);
+    }
+
+    .body {
+      display: flex;
+      min-height: 0;
+    }
+
+    slot[name="nav"] {
+      flex: 0 0 auto;
+    }
+
+    slot[name="main"] {
+      flex: 1;
+      min-width: 0;
+    }
+  `;
+
+  render() {
+    return html`
+      <slot name="skip-link"></slot>
+      <slot name="header"></slot>
+      <div class="body">
+        <slot name="nav"></slot>
+        <slot name="main"></slot>
+      </div>
+      <slot name="status"></slot>
+    `;
+  }
+}
+
+customElements.define("shell-root", ShellRoot);

--- a/j2cl/lit/src/elements/shell-skip-link.js
+++ b/j2cl/lit/src/elements/shell-skip-link.js
@@ -1,0 +1,45 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellSkipLink extends LitElement {
+  static properties = {
+    target: { type: String },
+    label: { type: String }
+  };
+
+  static styles = css`
+    :host {
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    a {
+      position: absolute;
+      left: -9999px;
+      padding: 8px 12px;
+      background: var(--shell-color-accent-focus, #1a73e8);
+      color: #fff;
+      border-radius: 0 0 8px 0;
+      font: inherit;
+      text-decoration: none;
+    }
+
+    a:focus {
+      left: 0;
+      outline: 2px solid #fff;
+      outline-offset: -4px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.target = "#j2cl-root-shell-workflow";
+    this.label = "Skip to main content";
+  }
+
+  render() {
+    return html`<a href=${this.target}>${this.label}</a>`;
+  }
+}
+
+customElements.define("shell-skip-link", ShellSkipLink);

--- a/j2cl/lit/src/elements/shell-skip-link.js
+++ b/j2cl/lit/src/elements/shell-skip-link.js
@@ -61,4 +61,6 @@ export class ShellSkipLink extends LitElement {
   }
 }
 
-customElements.define("shell-skip-link", ShellSkipLink);
+if (!customElements.get("shell-skip-link")) {
+  customElements.define("shell-skip-link", ShellSkipLink);
+}

--- a/j2cl/lit/src/elements/shell-skip-link.js
+++ b/j2cl/lit/src/elements/shell-skip-link.js
@@ -13,7 +13,7 @@ export class ShellSkipLink extends LitElement {
       left: 0;
     }
 
-    a {
+    ::slotted(a) {
       position: absolute;
       left: -9999px;
       padding: 8px 12px;
@@ -24,7 +24,7 @@ export class ShellSkipLink extends LitElement {
       text-decoration: none;
     }
 
-    a:focus {
+    ::slotted(a:focus) {
       left: 0;
       outline: 2px solid #fff;
       outline-offset: -4px;
@@ -37,8 +37,27 @@ export class ShellSkipLink extends LitElement {
     this.label = "Skip to main content";
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    this.syncAnchor();
+  }
+
+  updated() {
+    this.syncAnchor();
+  }
+
   render() {
-    return html`<a href=${this.target}>${this.label}</a>`;
+    return html`<slot></slot>`;
+  }
+
+  syncAnchor() {
+    let anchor = this.querySelector("a");
+    if (!anchor) {
+      anchor = this.ownerDocument.createElement("a");
+      this.appendChild(anchor);
+    }
+    anchor.setAttribute("href", this.target);
+    anchor.textContent = this.label;
   }
 }
 

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -20,4 +20,6 @@ export class ShellStatusStrip extends LitElement {
   }
 }
 
-customElements.define("shell-status-strip", ShellStatusStrip);
+if (!customElements.get("shell-status-strip")) {
+  customElements.define("shell-status-strip", ShellStatusStrip);
+}

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -1,0 +1,23 @@
+import { LitElement, css, html } from "lit";
+
+export class ShellStatusStrip extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    aside {
+      padding: 6px var(--shell-space-inset-panel, 18px);
+      background: var(--shell-color-surface-shell, #fff);
+      border-top: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.85rem;
+    }
+  `;
+
+  render() {
+    return html`<aside role="status" aria-live="polite"><slot></slot></aside>`;
+  }
+}
+
+customElements.define("shell-status-strip", ShellStatusStrip);

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -1,2 +1,15 @@
 // Entry point for the SupaWave Lit shell bundle (issue #964).
-// Element registrations land in later tasks.
+import { createInlineShellInput } from "./input/inline-shell-input.js";
+import { createJsonShellInput } from "./input/json-shell-input.js";
+import "./elements/shell-skip-link.js";
+import "./elements/shell-header.js";
+import "./elements/shell-nav-rail.js";
+import "./elements/shell-main-region.js";
+import "./elements/shell-status-strip.js";
+import "./elements/shell-root.js";
+import "./elements/shell-root-signed-out.js";
+
+window.__litShellInput =
+  window.__bootstrap && typeof window.__bootstrap === "object"
+    ? createJsonShellInput(window)
+    : createInlineShellInput(window);

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -1,0 +1,2 @@
+// Entry point for the SupaWave Lit shell bundle (issue #964).
+// Element registrations land in later tasks.

--- a/j2cl/lit/src/input/inline-shell-input.js
+++ b/j2cl/lit/src/input/inline-shell-input.js
@@ -1,0 +1,36 @@
+import { EMPTY_SNAPSHOT } from "./lit-shell-input.js";
+
+const ALLOWED_ROLES = new Set(["admin", "owner", "user"]);
+
+function normalizeRole(raw) {
+  return ALLOWED_ROLES.has(raw) ? raw : "user";
+}
+
+/**
+ * Pre-#963 adapter: reads bootstrap data from inline script globals.
+ * Post-#963, swap this for the JSON-based adapter at the import site in
+ * src/index.js without touching any shell element.
+ */
+export function createInlineShellInput(win) {
+  return {
+    read() {
+      const session = win.__session;
+      const wsAddress =
+        typeof win.__websocket_address === "string" ? win.__websocket_address : "";
+      if (!session || typeof session !== "object") {
+        return { ...EMPTY_SNAPSHOT, websocketAddress: wsAddress };
+      }
+      const address = typeof session.address === "string" ? session.address : "";
+      const signedIn = address.length > 0;
+      return {
+        signedIn,
+        address,
+        role: normalizeRole(session.role),
+        domain: typeof session.domain === "string" ? session.domain : "",
+        idSeed: typeof session.idSeed === "string" ? session.idSeed : "",
+        features: Array.isArray(session.features) ? [...session.features] : [],
+        websocketAddress: wsAddress
+      };
+    }
+  };
+}

--- a/j2cl/lit/src/input/json-shell-input.js
+++ b/j2cl/lit/src/input/json-shell-input.js
@@ -1,0 +1,40 @@
+import { EMPTY_SNAPSHOT } from "./lit-shell-input.js";
+
+const ALLOWED_ROLES = new Set(["admin", "owner", "user"]);
+
+function normalizeRole(raw) {
+  return ALLOWED_ROLES.has(raw) ? raw : "user";
+}
+
+export function createJsonShellInput(win) {
+  return {
+    read() {
+      const bootstrap = win.__bootstrap;
+      if (!bootstrap || typeof bootstrap !== "object") {
+        return EMPTY_SNAPSHOT;
+      }
+      const session = bootstrap.session || {};
+      const socket = bootstrap.socket || {};
+      const address = typeof session.address === "string" ? session.address : "";
+      return {
+        signedIn: address.length > 0,
+        address,
+        role: normalizeRole(session.role),
+        domain: typeof session.domain === "string" ? session.domain : "",
+        idSeed:
+          typeof session.id === "string"
+            ? session.id
+            : typeof session.idSeed === "string"
+              ? session.idSeed
+              : "",
+        features: Array.isArray(session.features) ? [...session.features] : [],
+        websocketAddress:
+          typeof socket.address === "string"
+            ? socket.address
+            : typeof bootstrap.websocketAddress === "string"
+              ? bootstrap.websocketAddress
+              : ""
+      };
+    }
+  };
+}

--- a/j2cl/lit/src/input/lit-shell-input.js
+++ b/j2cl/lit/src/input/lit-shell-input.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {object} LitShellSnapshot
+ * @property {boolean} signedIn
+ * @property {string} address
+ * @property {"admin"|"owner"|"user"} role
+ * @property {string} domain
+ * @property {string} idSeed
+ * @property {string[]} features
+ * @property {string} websocketAddress
+ *
+ * @typedef {object} LitShellInput
+ * @property {() => LitShellSnapshot} read
+ */
+
+export const EMPTY_SNAPSHOT = Object.freeze({
+  signedIn: false,
+  address: "",
+  role: "user",
+  domain: "",
+  idSeed: "",
+  features: Object.freeze([]),
+  websocketAddress: ""
+});

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -14,7 +14,7 @@
   --shell-space-inset-panel: 18px;
   --shell-shell-radius: 20px;
   --shell-shell-shadow: 0 24px 40px rgba(24, 28, 29, 0.06);
-  --shell-font-ui: "Manrope", "Public Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+  --shell-font-ui: "Manrope", "Public Sans", -apple-system, "BlinkMacSystemFont", "Segoe UI",
     sans-serif;
 }
 

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -1,0 +1,3 @@
+/* Placeholder token file for the initial scaffold build.
+ * Task 7 replaces this with the Stitch-pinned token values. */
+:root {}

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -1,3 +1,257 @@
-/* Placeholder token file for the initial scaffold build.
- * Task 7 replaces this with the Stitch-pinned token values. */
-:root {}
+/* CSS custom properties implementing design-packet §4 token slots for the shell family.
+ * Values are pinned from the Stitch project created for issue #964. */
+:root {
+  --shell-color-surface-page: #f6fafb;
+  --shell-color-surface-shell: #ffffff;
+  --shell-color-surface-soft: #f1f4f5;
+  --shell-color-surface-rail: #ebeeef;
+  --shell-color-text-primary: #181c1d;
+  --shell-color-text-muted: #3e494a;
+  --shell-color-divider-subtle: #bdc8ca;
+  --shell-color-accent-brand: #00636e;
+  --shell-color-accent-focus: #087e8b;
+  --shell-space-inline-default: 12px;
+  --shell-space-inset-panel: 18px;
+  --shell-shell-radius: 20px;
+  --shell-shell-shadow: 0 24px 40px rgba(24, 28, 29, 0.06);
+  --shell-font-ui: "Manrope", "Public Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+body.j2cl-root-shell-page {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(150, 240, 255, 0.18), transparent 36%),
+    linear-gradient(180deg, #f9fbfb 0%, var(--shell-color-surface-page) 48%, #eef3f4 100%);
+  color: var(--shell-color-text-primary);
+  font-family: var(--shell-font-ui);
+}
+
+a {
+  color: inherit;
+}
+
+shell-root,
+shell-root-signed-out {
+  position: relative;
+  display: grid;
+  min-height: 100vh;
+  gap: 20px;
+  box-sizing: border-box;
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 18px 20px 24px;
+}
+
+shell-root {
+  grid-template-columns: minmax(190px, 220px) 1fr;
+  grid-template-areas:
+    "skip skip"
+    "header header"
+    "nav main"
+    "status status";
+}
+
+shell-root-signed-out {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "skip"
+    "header"
+    "main"
+    "status";
+}
+
+shell-root > [slot="skip-link"],
+shell-root-signed-out > [slot="skip-link"] {
+  grid-area: skip;
+}
+
+shell-root > [slot="header"],
+shell-root-signed-out > [slot="header"] {
+  grid-area: header;
+}
+
+shell-root > [slot="nav"] {
+  grid-area: nav;
+}
+
+shell-root > [slot="main"],
+shell-root-signed-out > [slot="main"] {
+  grid-area: main;
+}
+
+shell-root > [slot="status"],
+shell-root-signed-out > [slot="status"] {
+  grid-area: status;
+}
+
+shell-skip-link {
+  position: absolute;
+  inset: 0 auto auto 0;
+  z-index: 4;
+}
+
+shell-skip-link > a {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  padding: 10px 14px;
+  border-radius: 0 0 12px 0;
+  background: var(--shell-color-accent-focus);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+shell-skip-link > a:focus {
+  left: 0;
+  outline: 2px solid #fff;
+  outline-offset: -3px;
+}
+
+shell-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: var(--shell-shell-radius);
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: var(--shell-shell-shadow);
+  backdrop-filter: blur(18px);
+}
+
+shell-header > [slot="brand"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.05rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+shell-header > [slot="brand"] span:first-child {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--shell-color-accent-brand), #087e8b);
+  color: #fff;
+}
+
+shell-header > [slot="actions-signed-in"],
+shell-header > [slot="actions-signed-out"] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+shell-header > span[slot^="actions"] {
+  background: var(--shell-color-surface-soft);
+  color: var(--shell-color-text-muted);
+}
+
+shell-header > a[slot^="actions"] {
+  border: 1px solid rgba(189, 200, 202, 0.75);
+  background: #fff;
+}
+
+shell-header > a[data-j2cl-root-signin="true"] {
+  border: 0;
+  background: linear-gradient(135deg, var(--shell-color-accent-brand), #087e8b);
+  color: #fff;
+}
+
+shell-header > a:focus-visible,
+shell-nav-rail > a:focus-visible {
+  outline: 3px solid rgba(8, 126, 139, 0.38);
+  outline-offset: 2px;
+}
+
+shell-nav-rail {
+  display: block;
+  align-self: start;
+  padding: 14px 12px;
+  border-radius: var(--shell-shell-radius);
+  background: var(--shell-color-surface-rail);
+}
+
+shell-nav-rail > a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  text-decoration: none;
+}
+
+shell-nav-rail > a:first-child {
+  background: rgba(0, 99, 110, 0.12);
+  color: var(--shell-color-accent-brand);
+  font-weight: 700;
+}
+
+shell-main-region {
+  display: block;
+  min-width: 0;
+  padding: 20px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: var(--shell-shell-shadow);
+}
+
+shell-root-signed-out > [slot="main"] {
+  max-width: 880px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+#j2cl-root-shell-workflow {
+  min-height: 360px;
+}
+
+#j2cl-root-shell-workflow > [data-j2cl-fallback="true"] {
+  margin: 0;
+  padding: 18px 0 0;
+  color: var(--shell-color-text-muted);
+  line-height: 1.6;
+}
+
+shell-status-strip {
+  display: block;
+  padding: 10px 16px 0;
+  color: var(--shell-color-text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 860px) {
+  shell-root {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "skip"
+      "header"
+      "nav"
+      "main"
+      "status";
+  }
+
+  shell-root,
+  shell-root-signed-out {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  shell-header {
+    align-items: flex-start;
+  }
+}

--- a/j2cl/lit/test/inline-shell-input.test.js
+++ b/j2cl/lit/test/inline-shell-input.test.js
@@ -1,0 +1,47 @@
+import { expect } from "@open-wc/testing";
+import { createInlineShellInput } from "../src/input/inline-shell-input.js";
+
+describe("inline-shell-input", () => {
+  beforeEach(() => {
+    window.__session = undefined;
+    window.__websocket_address = undefined;
+  });
+
+  it("returns a signed-out snapshot when no session is present", () => {
+    const input = createInlineShellInput(window);
+    const snap = input.read();
+    expect(snap.signedIn).to.equal(false);
+    expect(snap.address).to.equal("");
+    expect(snap.role).to.equal("user");
+    expect(snap.websocketAddress).to.equal("");
+  });
+
+  it("returns a signed-in snapshot with role normalization", () => {
+    window.__session = {
+      address: "a@b.c",
+      role: "admin",
+      domain: "b.c",
+      idSeed: "s",
+      features: []
+    };
+    window.__websocket_address = "ws.example:443";
+    const input = createInlineShellInput(window);
+    const snap = input.read();
+    expect(snap.signedIn).to.equal(true);
+    expect(snap.address).to.equal("a@b.c");
+    expect(snap.role).to.equal("admin");
+    expect(snap.websocketAddress).to.equal("ws.example:443");
+  });
+
+  it("returns signed-out when address is empty string", () => {
+    window.__session = {
+      address: "",
+      role: "user",
+      domain: "",
+      idSeed: "",
+      features: []
+    };
+    const input = createInlineShellInput(window);
+    expect(input.read().signedIn).to.equal(false);
+  });
+});

--- a/j2cl/lit/test/json-shell-input.test.js
+++ b/j2cl/lit/test/json-shell-input.test.js
@@ -1,0 +1,28 @@
+import { expect } from "@open-wc/testing";
+import { createJsonShellInput } from "../src/input/json-shell-input.js";
+
+describe("json-shell-input", () => {
+  beforeEach(() => {
+    window.__bootstrap = undefined;
+  });
+
+  it("reads the bootstrap contract payload from window.__bootstrap", () => {
+    window.__bootstrap = {
+      session: {
+        address: "a@b.c",
+        role: "owner",
+        domain: "b.c",
+        id: "seed-1",
+        features: []
+      },
+      socket: {
+        address: "ws.example:443"
+      }
+    };
+    const snap = createJsonShellInput(window).read();
+    expect(snap.signedIn).to.equal(true);
+    expect(snap.role).to.equal("owner");
+    expect(snap.idSeed).to.equal("seed-1");
+    expect(snap.websocketAddress).to.equal("ws.example:443");
+  });
+});

--- a/j2cl/lit/test/shell-header.test.js
+++ b/j2cl/lit/test/shell-header.test.js
@@ -1,0 +1,21 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-header.js";
+
+describe("<shell-header>", () => {
+  it("uses the banner landmark", async () => {
+    const el = await fixture(html`<shell-header></shell-header>`);
+    expect(el.renderRoot.querySelector("header[role='banner']")).to.exist;
+  });
+
+  it("renders the signed-in action slot when signed-in", async () => {
+    const el = await fixture(html`<shell-header signed-in></shell-header>`);
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-in']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-out']")).to.not.exist;
+  });
+
+  it("renders the signed-out action slot by default", async () => {
+    const el = await fixture(html`<shell-header></shell-header>`);
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-out']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='actions-signed-in']")).to.not.exist;
+  });
+});

--- a/j2cl/lit/test/shell-main-region.test.js
+++ b/j2cl/lit/test/shell-main-region.test.js
@@ -1,0 +1,24 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-main-region.js";
+
+describe("<shell-main-region>", () => {
+  it("uses the main landmark", async () => {
+    const el = await fixture(html`<shell-main-region></shell-main-region>`);
+    expect(el.renderRoot.querySelector("main")).to.exist;
+  });
+
+  it("slots light-DOM children so the workflow mount host stays queryable from document", async () => {
+    const el = await fixture(html`
+      <shell-main-region>
+        <section
+          id="j2cl-root-shell-workflow"
+          data-j2cl-root-shell-workflow="true"
+        ></section>
+      </shell-main-region>
+    `);
+    expect(el.renderRoot.querySelector("slot")).to.exist;
+    expect(el.renderRoot.querySelector("#j2cl-root-shell-workflow")).to.not.exist;
+    expect(el.querySelector("#j2cl-root-shell-workflow")).to.exist;
+    expect(document.getElementById("j2cl-root-shell-workflow")).to.exist;
+  });
+});

--- a/j2cl/lit/test/shell-nav-rail.test.js
+++ b/j2cl/lit/test/shell-nav-rail.test.js
@@ -1,0 +1,18 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-nav-rail.js";
+
+describe("<shell-nav-rail>", () => {
+  it("uses the navigation landmark with a primary label", async () => {
+    const el = await fixture(html`<shell-nav-rail></shell-nav-rail>`);
+    const nav = el.renderRoot.querySelector("nav");
+    expect(nav).to.exist;
+    expect(nav.getAttribute("aria-label")).to.equal("Primary");
+  });
+
+  it("exposes a default slot for entries", async () => {
+    const el = await fixture(
+      html`<shell-nav-rail><a href="/">Home</a></shell-nav-rail>`
+    );
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+  });
+});

--- a/j2cl/lit/test/shell-root-signed-out.test.js
+++ b/j2cl/lit/test/shell-root-signed-out.test.js
@@ -1,0 +1,13 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-root-signed-out.js";
+
+describe("<shell-root-signed-out>", () => {
+  it("renders skip-link, header, main, and status slots without a nav", async () => {
+    const el = await fixture(html`<shell-root-signed-out></shell-root-signed-out>`);
+    expect(el.renderRoot.querySelector("slot[name='skip-link']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='header']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='nav']")).to.not.exist;
+  });
+});

--- a/j2cl/lit/test/shell-root.test.js
+++ b/j2cl/lit/test/shell-root.test.js
@@ -1,0 +1,13 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-root.js";
+
+describe("<shell-root>", () => {
+  it("renders the signed-in layout slots", async () => {
+    const el = await fixture(html`<shell-root></shell-root>`);
+    expect(el.renderRoot.querySelector("slot[name='skip-link']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='header']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='nav']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+  });
+});

--- a/j2cl/lit/test/shell-skip-link.test.js
+++ b/j2cl/lit/test/shell-skip-link.test.js
@@ -9,15 +9,16 @@ describe("<shell-skip-link>", () => {
         label="Skip to content"
       ></shell-skip-link>`
     );
-    const anchor = el.renderRoot.querySelector("a");
+    const anchor = el.querySelector("a");
     expect(anchor).to.exist;
     expect(anchor.getAttribute("href")).to.equal("#main");
     expect(anchor.textContent.trim()).to.equal("Skip to content");
+    expect(el.renderRoot.querySelector("slot")).to.exist;
   });
 
   it("falls back to default target and label", async () => {
     const el = await fixture(html`<shell-skip-link></shell-skip-link>`);
-    const anchor = el.renderRoot.querySelector("a");
+    const anchor = el.querySelector("a");
     expect(anchor.getAttribute("href")).to.equal("#j2cl-root-shell-workflow");
     expect(anchor.textContent.trim()).to.equal("Skip to main content");
   });

--- a/j2cl/lit/test/shell-skip-link.test.js
+++ b/j2cl/lit/test/shell-skip-link.test.js
@@ -1,0 +1,24 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-skip-link.js";
+
+describe("<shell-skip-link>", () => {
+  it("renders an anchor linking to the configured target", async () => {
+    const el = await fixture(
+      html`<shell-skip-link
+        target="#main"
+        label="Skip to content"
+      ></shell-skip-link>`
+    );
+    const anchor = el.renderRoot.querySelector("a");
+    expect(anchor).to.exist;
+    expect(anchor.getAttribute("href")).to.equal("#main");
+    expect(anchor.textContent.trim()).to.equal("Skip to content");
+  });
+
+  it("falls back to default target and label", async () => {
+    const el = await fixture(html`<shell-skip-link></shell-skip-link>`);
+    const anchor = el.renderRoot.querySelector("a");
+    expect(anchor.getAttribute("href")).to.equal("#j2cl-root-shell-workflow");
+    expect(anchor.textContent.trim()).to.equal("Skip to main content");
+  });
+});

--- a/j2cl/lit/test/shell-status-strip.test.js
+++ b/j2cl/lit/test/shell-status-strip.test.js
@@ -1,0 +1,16 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/shell-status-strip.js";
+
+describe("<shell-status-strip>", () => {
+  it("uses a polite status live region", async () => {
+    const el = await fixture(html`<shell-status-strip></shell-status-strip>`);
+    const aside = el.renderRoot.querySelector("aside");
+    expect(aside.getAttribute("role")).to.equal("status");
+    expect(aside.getAttribute("aria-live")).to.equal("polite");
+  });
+
+  it("exposes a default slot for status content", async () => {
+    const el = await fixture(html`<shell-status-strip>Connected</shell-status-strip>`);
+    expect(el.renderRoot.querySelector("slot")).to.exist;
+  });
+});

--- a/j2cl/lit/web-test-runner.config.mjs
+++ b/j2cl/lit/web-test-runner.config.mjs
@@ -1,0 +1,10 @@
+import { playwrightLauncher } from "@web/test-runner-playwright";
+
+export default {
+  files: "test/**/*.test.js",
+  nodeResolve: true,
+  browsers: [playwrightLauncher({ product: "chromium" })],
+  testFramework: {
+    config: { ui: "bdd", timeout: 5000 }
+  }
+};

--- a/wave/config/changelog.d/2026-04-23-lit-root-shell.json
+++ b/wave/config/changelog.d/2026-04-23-lit-root-shell.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-23-lit-root-shell",
+  "version": "Issue #964",
+  "date": "2026-04-23",
+  "title": "The J2CL root shell now renders through reusable Lit chrome primitives",
+  "summary": "Introduced the first `j2cl/lit/` bundle with reusable shell primitives and switched the explicit `/?view=j2cl-root` route to progressive-enhancement custom-element markup while keeping the default `/` route on the legacy GWT shell.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a new `j2cl/lit/` package that ships `shell-root`, `shell-root-signed-out`, `shell-header`, `shell-nav-rail`, `shell-main-region`, `shell-status-strip`, and `shell-skip-link` into `/j2cl/assets/`",
+        "Replaced the hand-built J2CL root-shell HTML with progressive-enhancement custom-element markup so `/?view=j2cl-root` renders styled fallback chrome before the Lit bundle upgrades",
+        "Kept the default `/` route on the legacy GWT bootstrap while preserving the existing `j2cl-root-bootstrap` coexistence seam and workflow mount host contract"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3289,7 +3289,7 @@ public final class HtmlRenderer {
           .append(safeResolvedReturnTarget)
           .append("</span></shell-status-strip>\n");
       sb.append("</shell-root>\n");
-      sb.append("<script src=\"/j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
+      sb.append("<script src=\"").append(safeResolvedBasePath).append("j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
       appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, true);
     } else {
       sb.append("<shell-root-signed-out data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3402,17 +3402,17 @@ public final class HtmlRenderer {
       sb.append("  if(!workflow){return;}\n");
       sb.append("  workflow.querySelectorAll('[data-j2cl-fallback]').forEach(function(node){node.remove();});\n");
       sb.append("}\n");
-      sb.append("function mountWhenReady(attemptsRemaining){\n");
+      sb.append("function mountWhenReady(attemptsRemaining,delayMs){\n");
       sb.append("  var entryPoint=resolveEntryPoint();\n");
       sb.append("  if(entryPoint){try{clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}catch(err){renderLoadError();return;}}\n");
-      sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
+      sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1,Math.min(delayMs*2,2000));},delayMs);}else{renderLoadError();}\n");
       sb.append("}\n");
     }
     sb.append("normalizeLegacyHashDeepLink();\n");
     sb.append("hookHistory();\n");
     sb.append("syncReturnTargetUi();\n");
     if (mountWorkflow) {
-      sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(80);});}else{mountWhenReady(80);}\n");
+      sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(12,50);});}else{mountWhenReady(12,50);}\n");
     } else {
       sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',syncReturnTargetUi);}\n");
     }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3249,9 +3249,9 @@ public final class HtmlRenderer {
     sb.append("<meta name=\"build-commit\" content=\"").append(escapeHtml(buildCommit == null ? "" : buildCommit)).append("\">\n");
     sb.append("<meta name=\"server-build-time\" content=\"").append(serverBuildTime).append("\">\n");
     sb.append("<meta name=\"current-release-id\" content=\"").append(escapeHtml(currentReleaseId == null ? "" : currentReleaseId)).append("\">\n");
-    sb.append("<link rel=\"stylesheet\" href=\"/j2cl/assets/sidecar.css\">\n");
-    sb.append("<link rel=\"stylesheet\" href=\"/j2cl/assets/shell.css\">\n");
-    sb.append("<script type=\"module\" src=\"/j2cl/assets/shell.js\"></script>\n");
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/sidecar.css\">\n");
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.css\">\n");
+    sb.append("<script type=\"module\" src=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.js\"></script>\n");
     appendAnalyticsFragment(sb, analyticsAccount, null);
     sb.append("</head>\n<body class=\"j2cl-root-shell-page\">\n");
     if (signedIn) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3290,7 +3290,7 @@ public final class HtmlRenderer {
           .append("</span></shell-status-strip>\n");
       sb.append("</shell-root>\n");
       sb.append("<script src=\"/j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
-      appendJ2clRootShellSignedInBootstrap(sb, safeResolvedReturnTarget, safeResolvedBasePath);
+      appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, true);
     } else {
       sb.append("<shell-root-signed-out data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
           .append(safeResolvedReturnTarget)
@@ -3318,13 +3318,16 @@ public final class HtmlRenderer {
           .append(safeResolvedReturnTarget)
           .append("</shell-status-strip>\n");
       sb.append("</shell-root-signed-out>\n");
+      appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, false);
     }
     sb.append("</body>\n</html>\n");
     return sb.toString();
   }
 
-  private static void appendJ2clRootShellSignedInBootstrap(
-      StringBuilder sb, String safeResolvedReturnTarget, String safeResolvedBasePath) {
+  private static void appendJ2clRootShellBootstrap(
+      StringBuilder sb, String resolvedReturnTarget, String resolvedBasePath, boolean mountWorkflow) {
+    String jsReturnTarget = escapeJsonString(resolvedReturnTarget);
+    String jsBasePath = escapeJsonString(resolvedBasePath);
     sb.append("<script>\n");
     sb.append("(function(){\n");
     sb.append("function normalizeLocalReturnTargetForUi(target, fallback){\n");
@@ -3336,7 +3339,7 @@ public final class HtmlRenderer {
     sb.append("  return '/' + encodeURIComponent(normalized.substring(1));\n");
     sb.append("}\n");
     sb.append("function currentReturnTarget(){\n");
-    sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
+    sb.append("  var fallback=").append(jsReturnTarget).append(";\n");
     sb.append("  var pathname=window.location.pathname||'/';\n");
     sb.append("  if(pathname.indexOf('/')!==0){pathname='/' + pathname;}\n");
     sb.append("  var search=window.location.search||'';\n");
@@ -3353,11 +3356,11 @@ public final class HtmlRenderer {
     sb.append("function normalizeLegacyHashDeepLink(){\n");
     sb.append("  var waveId=waveIdFromLegacyHash(window.location.hash);\n");
     sb.append("  if(!waveId){return;}\n");
-    sb.append("  var nextUrl='").append(safeResolvedBasePath).append("?view=j2cl-root&wave=' + encodeURIComponent(waveId);\n");
+    sb.append("  var nextUrl=").append(jsBasePath).append("+'?view=j2cl-root&wave=' + encodeURIComponent(waveId);\n");
     sb.append("  window.history.replaceState(null, '', nextUrl);\n");
     sb.append("}\n");
     sb.append("function syncReturnTargetUi(){\n");
-    sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
+    sb.append("  var fallback=").append(jsReturnTarget).append(";\n");
     sb.append("  var target=currentReturnTarget();\n");
     sb.append("  var encoded=encodeLocalReturnTargetForQuery(target, fallback);\n");
     sb.append("  var shell=document.querySelector('[data-j2cl-root-shell]');\n");
@@ -3381,32 +3384,38 @@ public final class HtmlRenderer {
     sb.append("  });\n");
     sb.append("  window.addEventListener('popstate', syncReturnTargetUi);\n");
     sb.append("}\n");
-    sb.append("function resolveEntryPoint(){\n");
-    sb.append("  if(window.WaveSandboxEntryPoint&&window.WaveSandboxEntryPoint.mount){return window.WaveSandboxEntryPoint;}\n");
-    sb.append("  if(window.goog&&window.goog.module&&window.goog.module.get){\n");
-    sb.append("    var entryPoint=window.goog.module.get('WaveSandboxEntryPoint');\n");
-    sb.append("    if(entryPoint&&entryPoint.mount){window.WaveSandboxEntryPoint=entryPoint;return entryPoint;}\n");
-    sb.append("  }\n");
-    sb.append("  return null;\n");
-    sb.append("}\n");
-    sb.append("function renderLoadError(){\n");
-    sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
-    sb.append("  if(workflow){workflow.innerHTML='<p data-j2cl-fallback=\"true\">ERROR: J2CL root-shell bundle failed to load.</p>';}\n");
-    sb.append("}\n");
-    sb.append("function clearFallback(){\n");
-    sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
-    sb.append("  if(!workflow){return;}\n");
-    sb.append("  workflow.querySelectorAll('[data-j2cl-fallback]').forEach(function(node){node.remove();});\n");
-    sb.append("}\n");
-    sb.append("function mountWhenReady(attemptsRemaining){\n");
-    sb.append("  var entryPoint=resolveEntryPoint();\n");
-    sb.append("  if(entryPoint){clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}\n");
-    sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
-    sb.append("}\n");
+    if (mountWorkflow) {
+      sb.append("function resolveEntryPoint(){\n");
+      sb.append("  if(window.WaveSandboxEntryPoint&&window.WaveSandboxEntryPoint.mount){return window.WaveSandboxEntryPoint;}\n");
+      sb.append("  if(window.goog&&window.goog.module&&window.goog.module.get){\n");
+      sb.append("    var entryPoint=window.goog.module.get('WaveSandboxEntryPoint');\n");
+      sb.append("    if(entryPoint&&entryPoint.mount){window.WaveSandboxEntryPoint=entryPoint;return entryPoint;}\n");
+      sb.append("  }\n");
+      sb.append("  return null;\n");
+      sb.append("}\n");
+      sb.append("function renderLoadError(){\n");
+      sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
+      sb.append("  if(workflow){workflow.innerHTML='<p data-j2cl-fallback=\"true\">ERROR: J2CL root-shell bundle failed to load.</p>';}\n");
+      sb.append("}\n");
+      sb.append("function clearFallback(){\n");
+      sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
+      sb.append("  if(!workflow){return;}\n");
+      sb.append("  workflow.querySelectorAll('[data-j2cl-fallback]').forEach(function(node){node.remove();});\n");
+      sb.append("}\n");
+      sb.append("function mountWhenReady(attemptsRemaining){\n");
+      sb.append("  var entryPoint=resolveEntryPoint();\n");
+      sb.append("  if(entryPoint){clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}\n");
+      sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
+      sb.append("}\n");
+    }
     sb.append("normalizeLegacyHashDeepLink();\n");
     sb.append("hookHistory();\n");
     sb.append("syncReturnTargetUi();\n");
-    sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(80);});}else{mountWhenReady(80);}\n");
+    if (mountWorkflow) {
+      sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(80);});}else{mountWhenReady(80);}\n");
+    } else {
+      sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',syncReturnTargetUi);}\n");
+    }
     sb.append("})();\n");
     sb.append("</script>\n");
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3229,7 +3229,9 @@ public final class HtmlRenderer {
     String resolvedBasePath = queryStart >= 0 ? resolvedReturnTarget.substring(0, queryStart) : resolvedReturnTarget;
     String safeResolvedBasePath = StringEscapeUtils.escapeHtml4(resolvedBasePath);
 
-    StringBuilder sb = new StringBuilder(2048);
+    String safeAddress = escapeHtml(address);
+
+    StringBuilder sb = new StringBuilder(3072);
     sb.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n");
     sb.append("<meta charset=\"UTF-8\">\n");
     sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=5.0\">\n");
@@ -3248,167 +3250,165 @@ public final class HtmlRenderer {
     sb.append("<meta name=\"server-build-time\" content=\"").append(serverBuildTime).append("\">\n");
     sb.append("<meta name=\"current-release-id\" content=\"").append(escapeHtml(currentReleaseId == null ? "" : currentReleaseId)).append("\">\n");
     sb.append("<link rel=\"stylesheet\" href=\"/j2cl/assets/sidecar.css\">\n");
-    sb.append("<style>\n");
-    sb.append("body { margin: 0; min-height: 100vh; font-family: ").append(WAVE_FONT).append("; background: linear-gradient(180deg, #f7fbff 0%, #eef5fb 100%); color: ").append(WAVE_TEXT).append("; }\n");
-    sb.append(".j2cl-root-shell-page { min-height: 100vh; }\n");
-    sb.append(".j2cl-root-shell { max-width: 1120px; margin: 0 auto; padding: 24px 20px 40px; }\n");
-    sb.append(".j2cl-root-shell-banner { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 18px; border: 1px solid ").append(WAVE_BORDER).append("; border-radius: 18px; background: rgba(255,255,255,0.92); box-shadow: 0 18px 44px rgba(16,35,59,0.08); }\n");
-    sb.append(".j2cl-root-brand { display: inline-flex; align-items: center; gap: 10px; text-decoration: none; color: ").append(WAVE_TEXT).append("; font-weight: 800; font-size: 1.05rem; }\n");
-    sb.append(".j2cl-root-brand-badge { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 999px; background: linear-gradient(135deg, ").append(WAVE_PRIMARY).append(" 0%, ").append(WAVE_ACCENT).append(" 100%); color: #fff; font-size: 0.85rem; }\n");
-    sb.append(".j2cl-root-shell-nav { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }\n");
-    sb.append(".j2cl-root-shell-status { margin: 18px 0 0; padding: 20px 18px; border-radius: 20px; background: rgba(255,255,255,0.9); border: 1px solid ").append(WAVE_BORDER).append("; box-shadow: 0 18px 44px rgba(16,35,59,0.08); }\n");
-    sb.append(".j2cl-root-shell-status h1 { margin: 0 0 8px; font-size: clamp(1.8rem, 4vw, 2.8rem); line-height: 1.05; }\n");
-    sb.append(".j2cl-root-shell-summary { margin: 0; line-height: 1.6; color: ").append(WAVE_TEXT_MUTED).append("; }\n");
-    sb.append(".j2cl-root-shell-session { margin-top: 16px; display: flex; flex-wrap: wrap; align-items: center; gap: 12px; }\n");
-    sb.append(".j2cl-root-shell-pill { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 999px; background: #e8f4ff; color: ").append(WAVE_PRIMARY).append("; font-weight: 700; }\n");
-    sb.append(".j2cl-root-shell-link { display: inline-flex; align-items: center; justify-content: center; padding: 10px 14px; border-radius: 999px; background: ").append(WAVE_PRIMARY).append("; color: #fff; text-decoration: none; font-weight: 700; }\n");
-    sb.append(".j2cl-root-shell-link.secondary { background: #fff; color: ").append(WAVE_PRIMARY).append("; border: 1px solid ").append(WAVE_BORDER).append("; }\n");
-    sb.append(".j2cl-root-shell-link:focus-visible { outline: 2px solid ").append(WAVE_ACCENT).append("; outline-offset: 2px; }\n");
-    sb.append(".j2cl-root-shell-workflow { margin-top: 20px; min-height: 360px; border-radius: 24px; border: 1px dashed #bfd4ea; background: rgba(255,255,255,0.72); box-shadow: inset 0 1px 0 rgba(255,255,255,0.8); }\n");
-    sb.append(".j2cl-root-shell-workflow::before { content: 'J2CL workflow mount host'; display: block; padding: 18px 20px 0; color: ").append(WAVE_TEXT_MUTED).append("; font-size: 0.9rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }\n");
-    sb.append(".j2cl-root-shell-workflow-empty { padding: 14px 20px 20px; color: ").append(WAVE_TEXT_MUTED).append("; line-height: 1.6; }\n");
-    sb.append("@media (max-width: 767px) { .j2cl-root-shell { padding: 16px 12px 28px; } .j2cl-root-shell-banner { flex-direction: column; align-items: flex-start; } .j2cl-root-shell-session { align-items: flex-start; } }\n");
-    sb.append("</style>\n");
+    sb.append("<link rel=\"stylesheet\" href=\"/j2cl/assets/shell.css\">\n");
+    sb.append("<script type=\"module\" src=\"/j2cl/assets/shell.js\"></script>\n");
     appendAnalyticsFragment(sb, analyticsAccount, null);
     sb.append("</head>\n<body class=\"j2cl-root-shell-page\">\n");
-    sb.append("<main class=\"j2cl-root-shell\" data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
-        .append(safeResolvedReturnTarget)
-        .append("\">\n");
-    sb.append("  <header class=\"j2cl-root-shell-banner\">\n");
-    sb.append("    <a id=\"j2cl-root-brand-link\" class=\"j2cl-root-brand\" href=\"")
-        .append(safeResolvedReturnTarget)
-        .append("\" aria-label=\"J2CL root shell\">\n");
-    sb.append("      <span class=\"j2cl-root-brand-badge\">J2</span>\n");
-    sb.append("      <span>SupaWave J2CL Root Shell</span>\n");
-    sb.append("    </a>\n");
-    sb.append("    <nav class=\"j2cl-root-shell-nav\" aria-label=\"Session controls\">\n");
     if (signedIn) {
-      sb.append("      <span class=\"j2cl-root-shell-pill\">Signed in as ").append(escapeHtml(address)).append("</span>\n");
+      sb.append("<shell-root data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
+          .append(safeResolvedReturnTarget)
+          .append("\">\n");
+      sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
+          .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
+          .append("</shell-skip-link>\n");
+      sb.append("  <shell-header slot=\"header\" signed-in>\n");
+      sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
+          .append(safeResolvedReturnTarget)
+          .append("\" aria-label=\"J2CL root shell\">\n");
+      sb.append("      <span aria-hidden=\"true\">J2</span><span>SupaWave J2CL Root Shell</span>\n");
+      sb.append("    </a>\n");
+      sb.append("    <span slot=\"actions-signed-in\">Signed in as ")
+          .append(safeAddress)
+          .append("</span>\n");
       if (isAdminOrOwner) {
-        sb.append("      <a data-j2cl-root-admin-link=\"true\" class=\"j2cl-root-shell-link secondary\" href=\"/admin\">Admin</a>\n");
+        sb.append("    <a slot=\"actions-signed-in\" data-j2cl-root-admin-link=\"true\" href=\"/admin\">Admin</a>\n");
       }
-      sb.append("      <a data-j2cl-root-signout=\"true\" class=\"j2cl-root-shell-link secondary\" href=\"/auth/signout?r=")
+      sb.append("    <a slot=\"actions-signed-in\" data-j2cl-root-signout=\"true\" href=\"/auth/signout?r=")
           .append(safeEncodedReturnTarget)
           .append("\">Sign out</a>\n");
+      sb.append("  </shell-header>\n");
+      sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
+      sb.append("    <a href=\"").append(safeResolvedReturnTarget).append("\">Inbox</a>\n");
+      sb.append("  </shell-nav-rail>\n");
+      sb.append("  <shell-main-region slot=\"main\">\n");
+      sb.append("    <section id=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
+      sb.append("      <p data-j2cl-fallback=\"true\">The hosted J2CL workflow is loading and will mount here shortly.</p>\n");
+      sb.append("    </section>\n");
+      sb.append("  </shell-main-region>\n");
+      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\">Return target: ")
+          .append(safeResolvedReturnTarget)
+          .append("</span></shell-status-strip>\n");
+      sb.append("</shell-root>\n");
+      sb.append("<script src=\"/j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
+      appendJ2clRootShellSignedInBootstrap(sb, safeResolvedReturnTarget, safeResolvedBasePath);
     } else {
-      sb.append("      <span class=\"j2cl-root-shell-pill\">Signed out</span>\n");
-      sb.append("      <a data-j2cl-root-signin=\"true\" class=\"j2cl-root-shell-link\" href=\"/auth/signin?r=")
+      sb.append("<shell-root-signed-out data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
+          .append(safeResolvedReturnTarget)
+          .append("\">\n");
+      sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
+          .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
+          .append("</shell-skip-link>\n");
+      sb.append("  <shell-header slot=\"header\">\n");
+      sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
+          .append(safeResolvedReturnTarget)
+          .append("\" aria-label=\"J2CL root shell\">\n");
+      sb.append("      <span aria-hidden=\"true\">J2</span><span>SupaWave J2CL Root Shell</span>\n");
+      sb.append("    </a>\n");
+      sb.append("    <span slot=\"actions-signed-out\">Signed out</span>\n");
+      sb.append("    <a slot=\"actions-signed-out\" data-j2cl-root-signin=\"true\" href=\"/auth/signin?r=")
           .append(safeEncodedReturnTarget)
           .append("\">Sign in</a>\n");
-    }
-    sb.append("    </nav>\n");
-    sb.append("  </header>\n");
-    sb.append("  <section class=\"j2cl-root-shell-status\">\n");
-    sb.append("    <h1>Root shell ready for J2CL</h1>\n");
-    sb.append("    <p class=\"j2cl-root-shell-summary\">");
-    sb.append(signedIn
-        ? "The explicit J2CL root selector is active and the existing workflow can mount here without the legacy GWT shell."
-        : "The explicit J2CL root selector is active. Sign in to mount the workflow inside this shell.");
-    sb.append("</p>\n");
-    sb.append("    <div class=\"j2cl-root-shell-session\">\n");
-    if (signedIn) {
-      sb.append("      <span id=\"j2cl-root-return-target-text\" class=\"j2cl-root-shell-pill\">Return target: ")
+      sb.append("  </shell-header>\n");
+      sb.append("  <shell-main-region slot=\"main\">\n");
+      sb.append("    <section id=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
+      sb.append("      <p data-j2cl-fallback=\"true\">After sign-in, the hosted J2CL workflow will mount here without leaving the shell.</p>\n");
+      sb.append("    </section>\n");
+      sb.append("  </shell-main-region>\n");
+      sb.append("  <shell-status-strip slot=\"status\">Return target: ")
           .append(safeResolvedReturnTarget)
-          .append("</span>\n");
-    } else {
-      sb.append("      <a data-j2cl-root-signin=\"true\" class=\"j2cl-root-shell-link secondary\" href=\"/auth/signin?r=")
-          .append(safeEncodedReturnTarget)
-          .append("\">Continue to sign in</a>\n");
+          .append("</shell-status-strip>\n");
+      sb.append("</shell-root-signed-out>\n");
     }
-    sb.append("    </div>\n");
-    sb.append("  </section>\n");
-    sb.append("  <section id=\"j2cl-root-shell-workflow\" class=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
-    sb.append("    <div class=\"j2cl-root-shell-workflow-empty\">");
-    sb.append(signedIn
-        ? "The hosted J2CL workflow is loading and will mount here shortly."
-        : "After sign-in, the hosted J2CL workflow will mount here without leaving the shell.");
-    sb.append("</div>\n");
-    sb.append("  </section>\n");
-    if (signedIn) {
-      sb.append("<script src=\"/j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
-      sb.append("<script>\n");
-      sb.append("(function(){\n");
-      sb.append("function normalizeLocalReturnTargetForUi(target, fallback){\n");
-      sb.append("  if(!target || target.charAt(0)!=='/' || target.indexOf('//')===0){return fallback;}\n");
-      sb.append("  return target;\n");
-      sb.append("}\n");
-      sb.append("function encodeLocalReturnTargetForQuery(target, fallback){\n");
-      sb.append("  var normalized=normalizeLocalReturnTargetForUi(target, fallback);\n");
-      sb.append("  return '/' + encodeURIComponent(normalized.substring(1));\n");
-      sb.append("}\n");
-      sb.append("function currentReturnTarget(){\n");
-      sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
-      sb.append("  var pathname=window.location.pathname||'/';\n");
-      sb.append("  if(pathname.indexOf('/')!==0){pathname='/' + pathname;}\n");
-      sb.append("  var search=window.location.search||'';\n");
-      sb.append("  if(search.indexOf('view=j2cl-root')===-1){return fallback;}\n");
-      sb.append("  return normalizeLocalReturnTargetForUi(pathname + search, fallback);\n");
-      sb.append("}\n");
-      sb.append("function waveIdFromLegacyHash(hash){\n");
-      sb.append("  if(!hash){return null;}\n");
-      sb.append("  var trimmed=hash.charAt(0)==='#'?hash.substring(1):hash;\n");
-      sb.append("  if(!trimmed){return null;}\n");
-      sb.append("  var token=trimmed.split('&')[0];\n");
-      sb.append("  return token.indexOf('/')>=0 ? token : null;\n");
-      sb.append("}\n");
-      sb.append("function normalizeLegacyHashDeepLink(){\n");
-      sb.append("  var waveId=waveIdFromLegacyHash(window.location.hash);\n");
-      sb.append("  if(!waveId){return;}\n");
-      sb.append("  var nextUrl='").append(safeResolvedBasePath).append("?view=j2cl-root&wave=' + encodeURIComponent(waveId);\n");
-      sb.append("  window.history.replaceState(null, '', nextUrl);\n");
-      sb.append("}\n");
-      sb.append("function syncReturnTargetUi(){\n");
-      sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
-      sb.append("  var target=currentReturnTarget();\n");
-      sb.append("  var encoded=encodeLocalReturnTargetForQuery(target, fallback);\n");
-      sb.append("  var shell=document.querySelector('[data-j2cl-root-shell]');\n");
-      sb.append("  if(shell){shell.setAttribute('data-j2cl-root-return-target', target);}\n");
-      sb.append("  var brand=document.getElementById('j2cl-root-brand-link');\n");
-      sb.append("  if(brand){brand.href=target;}\n");
-      sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
-      sb.append("  if(targetText){targetText.textContent='Return target: ' + target;}\n");
-      sb.append("  document.querySelectorAll('[data-j2cl-root-signin]').forEach(function(anchor){anchor.href='/auth/signin?r=' + encoded;});\n");
-      sb.append("  document.querySelectorAll('[data-j2cl-root-signout]').forEach(function(anchor){anchor.href='/auth/signout?r=' + encoded;});\n");
-      sb.append("}\n");
-      sb.append("function hookHistory(){\n");
-      sb.append("  ['pushState','replaceState'].forEach(function(method){\n");
-      sb.append("    var original=window.history[method];\n");
-      sb.append("    if(typeof original!=='function'){return;}\n");
-      sb.append("    window.history[method]=function(){\n");
-      sb.append("      var result=original.apply(this, arguments);\n");
-      sb.append("      syncReturnTargetUi();\n");
-      sb.append("      return result;\n");
-      sb.append("    };\n");
-      sb.append("  });\n");
-      sb.append("  window.addEventListener('popstate', syncReturnTargetUi);\n");
-      sb.append("}\n");
-      sb.append("function resolveEntryPoint(){\n");
-      sb.append("  if(window.WaveSandboxEntryPoint&&window.WaveSandboxEntryPoint.mount){return window.WaveSandboxEntryPoint;}\n");
-      sb.append("  if(window.goog&&window.goog.module&&window.goog.module.get){\n");
-      sb.append("    var entryPoint=window.goog.module.get('WaveSandboxEntryPoint');\n");
-      sb.append("    if(entryPoint&&entryPoint.mount){window.WaveSandboxEntryPoint=entryPoint;return entryPoint;}\n");
-      sb.append("  }\n");
-      sb.append("  return null;\n");
-      sb.append("}\n");
-      sb.append("function renderLoadError(){\n");
-      sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
-      sb.append("  if(workflow){workflow.innerHTML='<div class=\"j2cl-root-shell-workflow-empty\">ERROR: J2CL root-shell bundle failed to load.</div>';}\n");
-      sb.append("}\n");
-      sb.append("function mountWhenReady(attemptsRemaining){\n");
-      sb.append("  var entryPoint=resolveEntryPoint();\n");
-      sb.append("  if(entryPoint){entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}\n");
-      sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
-      sb.append("}\n");
-      sb.append("normalizeLegacyHashDeepLink();\n");
-      sb.append("hookHistory();\n");
-      sb.append("syncReturnTargetUi();\n");
-      sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(80);});}else{mountWhenReady(80);}\n");
-      sb.append("})();\n");
-      sb.append("</script>\n");
-    }
-    sb.append("</main>\n");
     sb.append("</body>\n</html>\n");
     return sb.toString();
+  }
+
+  private static void appendJ2clRootShellSignedInBootstrap(
+      StringBuilder sb, String safeResolvedReturnTarget, String safeResolvedBasePath) {
+    sb.append("<script>\n");
+    sb.append("(function(){\n");
+    sb.append("function normalizeLocalReturnTargetForUi(target, fallback){\n");
+    sb.append("  if(!target || target.charAt(0)!=='/' || target.indexOf('//')===0){return fallback;}\n");
+    sb.append("  return target;\n");
+    sb.append("}\n");
+    sb.append("function encodeLocalReturnTargetForQuery(target, fallback){\n");
+    sb.append("  var normalized=normalizeLocalReturnTargetForUi(target, fallback);\n");
+    sb.append("  return '/' + encodeURIComponent(normalized.substring(1));\n");
+    sb.append("}\n");
+    sb.append("function currentReturnTarget(){\n");
+    sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
+    sb.append("  var pathname=window.location.pathname||'/';\n");
+    sb.append("  if(pathname.indexOf('/')!==0){pathname='/' + pathname;}\n");
+    sb.append("  var search=window.location.search||'';\n");
+    sb.append("  if(search.indexOf('view=j2cl-root')===-1){return fallback;}\n");
+    sb.append("  return normalizeLocalReturnTargetForUi(pathname + search, fallback);\n");
+    sb.append("}\n");
+    sb.append("function waveIdFromLegacyHash(hash){\n");
+    sb.append("  if(!hash){return null;}\n");
+    sb.append("  var trimmed=hash.charAt(0)==='#'?hash.substring(1):hash;\n");
+    sb.append("  if(!trimmed){return null;}\n");
+    sb.append("  var token=trimmed.split('&')[0];\n");
+    sb.append("  return token.indexOf('/')>=0 ? token : null;\n");
+    sb.append("}\n");
+    sb.append("function normalizeLegacyHashDeepLink(){\n");
+    sb.append("  var waveId=waveIdFromLegacyHash(window.location.hash);\n");
+    sb.append("  if(!waveId){return;}\n");
+    sb.append("  var nextUrl='").append(safeResolvedBasePath).append("?view=j2cl-root&wave=' + encodeURIComponent(waveId);\n");
+    sb.append("  window.history.replaceState(null, '', nextUrl);\n");
+    sb.append("}\n");
+    sb.append("function syncReturnTargetUi(){\n");
+    sb.append("  var fallback='").append(safeResolvedReturnTarget).append("';\n");
+    sb.append("  var target=currentReturnTarget();\n");
+    sb.append("  var encoded=encodeLocalReturnTargetForQuery(target, fallback);\n");
+    sb.append("  var shell=document.querySelector('[data-j2cl-root-shell]');\n");
+    sb.append("  if(shell){shell.setAttribute('data-j2cl-root-return-target', target);}\n");
+    sb.append("  var brand=document.getElementById('j2cl-root-brand-link');\n");
+    sb.append("  if(brand){brand.href=target;}\n");
+    sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
+    sb.append("  if(targetText){targetText.textContent='Return target: ' + target;}\n");
+    sb.append("  document.querySelectorAll('[data-j2cl-root-signin]').forEach(function(anchor){anchor.href='/auth/signin?r=' + encoded;});\n");
+    sb.append("  document.querySelectorAll('[data-j2cl-root-signout]').forEach(function(anchor){anchor.href='/auth/signout?r=' + encoded;});\n");
+    sb.append("}\n");
+    sb.append("function hookHistory(){\n");
+    sb.append("  ['pushState','replaceState'].forEach(function(method){\n");
+    sb.append("    var original=window.history[method];\n");
+    sb.append("    if(typeof original!=='function'){return;}\n");
+    sb.append("    window.history[method]=function(){\n");
+    sb.append("      var result=original.apply(this, arguments);\n");
+    sb.append("      syncReturnTargetUi();\n");
+    sb.append("      return result;\n");
+    sb.append("    };\n");
+    sb.append("  });\n");
+    sb.append("  window.addEventListener('popstate', syncReturnTargetUi);\n");
+    sb.append("}\n");
+    sb.append("function resolveEntryPoint(){\n");
+    sb.append("  if(window.WaveSandboxEntryPoint&&window.WaveSandboxEntryPoint.mount){return window.WaveSandboxEntryPoint;}\n");
+    sb.append("  if(window.goog&&window.goog.module&&window.goog.module.get){\n");
+    sb.append("    var entryPoint=window.goog.module.get('WaveSandboxEntryPoint');\n");
+    sb.append("    if(entryPoint&&entryPoint.mount){window.WaveSandboxEntryPoint=entryPoint;return entryPoint;}\n");
+    sb.append("  }\n");
+    sb.append("  return null;\n");
+    sb.append("}\n");
+    sb.append("function renderLoadError(){\n");
+    sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
+    sb.append("  if(workflow){workflow.innerHTML='<p data-j2cl-fallback=\"true\">ERROR: J2CL root-shell bundle failed to load.</p>';}\n");
+    sb.append("}\n");
+    sb.append("function clearFallback(){\n");
+    sb.append("  var workflow=document.getElementById('j2cl-root-shell-workflow');\n");
+    sb.append("  if(!workflow){return;}\n");
+    sb.append("  workflow.querySelectorAll('[data-j2cl-fallback]').forEach(function(node){node.remove();});\n");
+    sb.append("}\n");
+    sb.append("function mountWhenReady(attemptsRemaining){\n");
+    sb.append("  var entryPoint=resolveEntryPoint();\n");
+    sb.append("  if(entryPoint){clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}\n");
+    sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
+    sb.append("}\n");
+    sb.append("normalizeLegacyHashDeepLink();\n");
+    sb.append("hookHistory();\n");
+    sb.append("syncReturnTargetUi();\n");
+    sb.append("if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',function(){syncReturnTargetUi();mountWhenReady(80);});}else{mountWhenReady(80);}\n");
+    sb.append("})();\n");
+    sb.append("</script>\n");
   }
 
   /**

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3314,9 +3314,9 @@ public final class HtmlRenderer {
       sb.append("      <p data-j2cl-fallback=\"true\">After sign-in, the hosted J2CL workflow will mount here without leaving the shell.</p>\n");
       sb.append("    </section>\n");
       sb.append("  </shell-main-region>\n");
-      sb.append("  <shell-status-strip slot=\"status\">Return target: ")
+      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\">Return target: ")
           .append(safeResolvedReturnTarget)
-          .append("</shell-status-strip>\n");
+          .append("</span></shell-status-strip>\n");
       sb.append("</shell-root-signed-out>\n");
       appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, false);
     }
@@ -3404,7 +3404,7 @@ public final class HtmlRenderer {
       sb.append("}\n");
       sb.append("function mountWhenReady(attemptsRemaining){\n");
       sb.append("  var entryPoint=resolveEntryPoint();\n");
-      sb.append("  if(entryPoint){clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}\n");
+      sb.append("  if(entryPoint){try{clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}catch(err){renderLoadError();return;}}\n");
       sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1);},50);}else{renderLoadError();}\n");
       sb.append("}\n");
     }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3404,7 +3404,7 @@ public final class HtmlRenderer {
       sb.append("}\n");
       sb.append("function mountWhenReady(attemptsRemaining,delayMs){\n");
       sb.append("  var entryPoint=resolveEntryPoint();\n");
-      sb.append("  if(entryPoint){try{clearFallback();entryPoint.mount('j2cl-root-shell-workflow','root-shell');return;}catch(err){renderLoadError();return;}}\n");
+      sb.append("  if(entryPoint){try{entryPoint.mount('j2cl-root-shell-workflow','root-shell');clearFallback();return;}catch(err){renderLoadError();return;}}\n");
       sb.append("  if(attemptsRemaining>0){window.setTimeout(function(){mountWhenReady(attemptsRemaining-1,Math.min(delayMs*2,2000));},delayMs);}else{renderLoadError();}\n");
       sb.append("}\n");
     }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
@@ -79,8 +79,7 @@ public final class HtmlRendererChangelogTest {
         "/wave/?view=j2cl-root",
         "localhost:9898");
 
-    assertTrue(html.contains("var nextUrl="));
-    assertTrue(html.contains("\\/wave\\/"));
+    assertTrue(html.contains("var nextUrl=\"\\/wave\\/\""));
     assertTrue(html.contains("?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
@@ -79,8 +79,7 @@ public final class HtmlRendererChangelogTest {
         "/wave/?view=j2cl-root",
         "localhost:9898");
 
-    assertTrue(html.contains("var nextUrl=\"\\/wave\\/\""));
-    assertTrue(html.contains("?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
+    assertTrue(html.contains("var nextUrl=\"\\/wave\\/\"+'?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
@@ -63,7 +63,8 @@ public final class HtmlRendererChangelogTest {
 
     assertTrue(html.contains("function waveIdFromLegacyHash(hash){"));
     assertTrue(html.contains("function normalizeLegacyHashDeepLink(){"));
-    assertTrue(html.contains("var nextUrl='/?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
+    assertTrue(html.contains("var nextUrl="));
+    assertTrue(html.contains("?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
     assertTrue(html.contains("normalizeLegacyHashDeepLink();"));
   }
 
@@ -78,7 +79,9 @@ public final class HtmlRendererChangelogTest {
         "/wave/?view=j2cl-root",
         "localhost:9898");
 
-    assertTrue(html.contains("var nextUrl='/wave/?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
+    assertTrue(html.contains("var nextUrl="));
+    assertTrue(html.contains("\\/wave\\/"));
+    assertTrue(html.contains("?view=j2cl-root&wave=' + encodeURIComponent(waveId);"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import junit.framework.TestCase;
+import org.json.JSONObject;
+
+public final class HtmlRendererJ2clRootShellTest extends TestCase {
+  public void testSignedInPageUsesLitCustomElements() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "user");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+
+    assertTrue(html.contains("<shell-root"));
+    assertTrue(html.contains("<shell-header slot=\"header\" signed-in"));
+    assertTrue(html.contains("<shell-nav-rail slot=\"nav\""));
+    assertTrue(html.contains("<shell-main-region slot=\"main\""));
+    assertTrue(html.contains("<shell-status-strip slot=\"status\""));
+    assertTrue(html.contains("<shell-skip-link slot=\"skip-link\""));
+    assertTrue(html.contains("/j2cl/assets/shell.js"));
+    assertTrue(html.contains("/j2cl/assets/shell.css"));
+  }
+
+  public void testSignedOutPageUsesSignedOutRoot() {
+    JSONObject session = new JSONObject();
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+
+    assertTrue(html.contains("<shell-root-signed-out"));
+    assertFalse(html.contains("<shell-root data-j2cl-root-shell"));
+  }
+
+  public void testLegacyShellClassesAreNoLongerEmitted() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+
+    assertFalse(html.contains("j2cl-root-shell-banner"));
+    assertFalse(html.contains("j2cl-root-shell-nav"));
+    assertFalse(html.contains("j2cl-root-shell-pill"));
+  }
+
+  public void testFallbackMarkupIsReadableWithoutJs() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+
+    assertTrue(html.contains("id=\"j2cl-root-shell-workflow\""));
+    assertTrue(html.contains("data-j2cl-root-shell-workflow=\"true\""));
+    assertTrue(html.contains("data-j2cl-fallback=\"true\""));
+    assertTrue(html.contains(">Skip to main content</a>"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -116,9 +116,14 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
 
     assertTrue("Bootstrap must include normalizeLegacyHashDeepLink",
         html.contains("normalizeLegacyHashDeepLink()"));
+    assertTrue("Bootstrap must include safeResolvedBasePath wiring",
+        html.contains("/mypath/"));
     int markerIdx = html.indexOf("normalizeLegacyHashDeepLink()");
     int scriptOpenIdx = html.lastIndexOf("<script>", markerIdx);
     int scriptCloseIdx = html.indexOf("</script>", markerIdx);
+    assertTrue("Expected opening <script> tag before normalizeLegacyHashDeepLink()", scriptOpenIdx >= 0);
+    assertTrue("Expected closing </script> tag after normalizeLegacyHashDeepLink()", scriptCloseIdx >= 0);
+    assertTrue("Expected <script> to open before </script>", scriptOpenIdx < scriptCloseIdx);
     String bootstrapScript = html.substring(scriptOpenIdx, scriptCloseIdx + "</script>".length());
     assertFalse("HTML entity &amp; must not appear inside bootstrap script",
         bootstrapScript.contains("&amp;"));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -75,4 +75,61 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(html.contains("data-j2cl-fallback=\"true\""));
     assertTrue(html.contains(">Skip to main content</a>"));
   }
+
+  public void testExternalReturnTargetIsRejectedInBootstrap() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+
+    // External URL (starts with //) must be rejected and replaced with the safe default.
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "//evil.com/phish", "ws.example:443");
+
+    assertFalse("External return target must not appear in bootstrap JS",
+        html.contains("evil.com"));
+  }
+
+  public void testReturnTargetWithAmpersandIsJsEscapedNotHtmlEscaped() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+
+    // A return target containing '&' must be JS-escaped (not HTML-escaped) inside <script>.
+    // HTML escaping turns '&' into '&amp;' which the JS engine cannot decode.
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/?view=j2cl-root&wave=x", "ws.example:443");
+
+    // Old broken pattern: single-quoted JS variable with HTML entity
+    assertFalse("HTML entity must not appear in JS fallback variable (single-quoted)",
+        html.contains("var fallback='/?view=j2cl-root&amp;wave=x'"));
+    // New correct pattern: JS-escaped ampersand via \\u0026
+    assertTrue("JS-escaped ampersand (\\u0026) must appear in bootstrap script",
+        html.contains("\\u0026wave"));
+  }
+
+  public void testLegacyHashDeepLinkBootstrapIsPresent() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/mypath/?view=j2cl-root", "ws.example:443");
+
+    assertTrue("Bootstrap must include normalizeLegacyHashDeepLink",
+        html.contains("normalizeLegacyHashDeepLink()"));
+    assertFalse("HTML entity &amp; must not appear inside bootstrap script",
+        html.contains("&amp;"));
+  }
+
+  public void testSignedOutPageAlsoIncludesReturnTargetBootstrap() {
+    JSONObject session = new JSONObject();
+    // No address = signed out
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+
+    assertTrue("Signed-out shell must include normalizeLegacyHashDeepLink",
+        html.contains("normalizeLegacyHashDeepLink()"));
+    assertTrue("Signed-out shell must include syncReturnTargetUi",
+        html.contains("syncReturnTargetUi()"));
+    assertFalse("Signed-out shell must not include mountWhenReady",
+        html.contains("mountWhenReady("));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -86,6 +86,8 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
 
     assertFalse("External return target must not appear in bootstrap JS",
         html.contains("evil.com"));
+    assertTrue("Safe fallback return target must appear in bootstrap JS",
+        html.contains("/?view=j2cl-root"));
   }
 
   public void testReturnTargetWithAmpersandIsJsEscapedNotHtmlEscaped() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -116,8 +116,12 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
 
     assertTrue("Bootstrap must include normalizeLegacyHashDeepLink",
         html.contains("normalizeLegacyHashDeepLink()"));
+    int markerIdx = html.indexOf("normalizeLegacyHashDeepLink()");
+    int scriptOpenIdx = html.lastIndexOf("<script>", markerIdx);
+    int scriptCloseIdx = html.indexOf("</script>", markerIdx);
+    String bootstrapScript = html.substring(scriptOpenIdx, scriptCloseIdx + "</script>".length());
     assertFalse("HTML entity &amp; must not appear inside bootstrap script",
-        html.contains("&amp;"));
+        bootstrapScript.contains("&amp;"));
   }
 
   public void testSignedOutReturnTargetLabelHasSyncableSpan() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -118,6 +118,17 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
         html.contains("&amp;"));
   }
 
+  public void testSignedOutReturnTargetLabelHasSyncableSpan() {
+    JSONObject session = new JSONObject();
+    // No address = signed out; provide a return target to check label markup.
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/wave/inbox", "ws.example:443");
+
+    assertTrue("Signed-out status strip must wrap return-target text in the syncable span",
+        html.contains("<span id=\"j2cl-root-return-target-text\">Return target: "));
+  }
+
   public void testSignedOutPageAlsoIncludesReturnTargetBootstrap() {
     JSONObject session = new JSONObject();
     // No address = signed out


### PR DESCRIPTION
## Summary
- add the first `j2cl/lit/` package with shell primitives, inline/json shell-input adapters, and progressive-enhancement shell CSS/JS assets
- rewrite `HtmlRenderer.renderJ2clRootShellPage(...)` to emit Lit custom-element shell markup while preserving the existing `/?view=j2cl-root` coexistence seam and legacy `/` default
- wire `j2clLitBuild`/`j2clLitTest` into `j2clRuntimeBuild` and add the issue `#964` changelog fragment

## Verification
- `sbt -batch j2clLitBuild j2clLitTest j2clSearchBuild j2clSearchTest compileGwt Universal/stage`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `sbt -batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest"`
- direct staged-server verification on `127.0.0.1:9964`:
  - `/` still serves `webclient/webclient.nocache.js`
  - `/?view=j2cl-root` serves the signed-out Lit shell, `/j2cl/assets/shell.js`, `/j2cl/assets/shell.css`, and the fallback skip-link text
  - `/j2cl/assets/shell.js` and `/j2cl/assets/shell.css` both return `HTTP/1.1 200 OK`
  - Playwright verification confirmed `document.querySelectorAll('#j2cl-root-shell-workflow').length === 1`, no legacy GWT bootstrap on `/?view=j2cl-root`, and the legacy GWT bootstrap still on `/`
- note: `wave-smoke.sh` reported `READY` once but did not leave a stable detached server on this machine, so runtime route checks were completed against a foreground staged server instead

## Review
- the required Claude Opus 4.7 implementation review helper hit repeated max-turn failures on the full diff and on narrowed retries, so that external review path is currently blocked without producing findings

Closes #964.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ships a reusable Lit 3 shell component family (skip-link, header, nav rail, main region, status strip, root variants) with CSS tokens and a JS entry bundle; server render now emits progressive‑enhancement custom‑element markup with readable fallback.

* **Documentation**
  * Adds an implementation plan and changelog entry for the Lit root shell.

* **Tests**
  * Adds unit/integration tests for components, input adapters, and server bootstrap output.

* **Chores**
  * Adds npm/esbuild build & test orchestration, test-runner config, .gitignore updates, and an execution guardrail for Lit npm tasks.

* **Bug Fixes**
  * Escapes user-supplied output and hardens fallback/mount/bootstrap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->