### PR TITLE
Fix Grafana perf exports and expand Gatling run comparison dashboard

### DIFF
--- a/docs/superpowers/plans/2026-04-23-perf-gatling-dashboard-repair.md
+++ b/docs/superpowers/plans/2026-04-23-perf-gatling-dashboard-repair.md
@@ -312,9 +312,17 @@ Create:
 
 ```json
 {
-  "type": "ops",
-  "component": "perf-observability",
-  "summary": "Repair Grafana perf metrics export and expand Gatling run-comparison panels."
+  "releaseId": "2026-04-23-perf-gatling-dashboard-repair",
+  "version": "unreleased",
+  "date": "2026-04-23",
+  "title": "Repair perf metrics export and Gatling dashboard comparisons",
+  "summary": "Repair Grafana perf metrics export and expand Gatling run-comparison panels.",
+  "sections": [
+    {
+      "type": "changed",
+      "summary": "Repair the Grafana perf observability pipeline and expand Gatling dashboard views for comparison across branch, SHA, run, simulation, and request."
+    }
+  ]
 }
 ```
 
@@ -353,6 +361,6 @@ Expected: PASS and `/tmp/search-summary.json` contains p95/p99 plus request-leve
 - [ ] **Step 5: Commit**
 
 ```bash
-git add wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json wave/config/changelog.json
+git add wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json
 git commit -m "chore: record perf dashboard repair"
 ```

--- a/docs/superpowers/plans/2026-04-23-perf-gatling-dashboard-repair.md
+++ b/docs/superpowers/plans/2026-04-23-perf-gatling-dashboard-repair.md
@@ -1,0 +1,358 @@
+# Perf Gatling Dashboard Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Repair the Grafana perf observability pipeline so current perf runs ship data again, then expand the exported Gatling data and dashboard so runs can be compared meaningfully across branch, SHA, run, simulation, and request.
+
+**Architecture:** Replace the fragile console-text parsing path with Gatling report JSON parsing from the generated report directories, keep `scripts/wave-perf.sh` authoritative for per-simulation summaries, fix the Alloy scrape configuration so remote_write actually starts, and redesign the Grafana dashboard around run selectors plus richer per-request and distribution views. Keep the CI workflow and dashboard upsert path intact, but validate them against the real April 23 artifact failure mode.
+
+**Tech Stack:** Python `unittest`, GitHub Actions, Grafana Alloy, Prometheus exposition format, Grafana dashboard JSON, existing Gatling 3.10.5 report artifacts.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|------|----------------|
+| `scripts/perf_metrics_exporter.py` | Parse Gatling JSON artifacts, build richer summary files, and expose stable Prometheus metrics |
+| `scripts/tests/test_perf_metrics_exporter.py` | Lock parsing and exposition behavior to Gatling JSON artifacts instead of console text |
+| `scripts/render_perf_alloy_config.py` | Generate Alloy config with valid scrape timeout or interval settings |
+| `scripts/tests/test_perf_alloy_config.py` | Prove the Alloy config includes valid scrape settings and the exporter summary hook |
+| `scripts/wave-perf.sh` | Locate the correct Gatling report directory per simulation and write stable summary JSON files |
+| `.github/workflows/perf.yml` | Keep exporter and Alloy startup wiring valid for CI |
+| `scripts/tests/test_perf_workflow_config.py` | Validate workflow assumptions relevant to the repaired export path |
+| `grafana/dashboards/perf-observability.json` | Add run comparison, richer Gatling views, and request-level panels |
+| `scripts/tests/test_grafana_dashboard_upsert.py` | Lock the expected perf dashboard panels after the redesign |
+| `wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json` | Changelog fragment for the observability/dashboard behavior change |
+
+### Task 1: Switch perf summaries to Gatling JSON artifacts
+
+**Files:**
+- Modify: `scripts/perf_metrics_exporter.py`
+- Modify: `scripts/tests/test_perf_metrics_exporter.py`
+
+- [ ] **Step 1: Write the failing exporter tests**
+
+Extend `scripts/tests/test_perf_metrics_exporter.py` so it builds summaries from Gatling report JSON payloads rather than a console-text sample. Add fixtures inline for one simulation-level `global_stats.json` and one request-rich `stats.json`, then assert the summary includes:
+
+```python
+self.assertEqual({"ok": 12, "ko": 0}, summary["requests"])
+self.assertEqual({"mean": 13, "max": 21, "p95": 20, "p99": 21}, summary["timings_ms"])
+self.assertAlmostEqual(1.0, summary["success_ratio"])
+self.assertEqual(12, summary["distribution"]["lt_800ms"]["count"])
+self.assertEqual("Search inbox", summary["request_metrics"][0]["request_name"])
+self.assertEqual(10, summary["request_metrics"][0]["requests"]["ok"])
+```
+
+Also add a negative test that proves `build_summary(...)` no longer depends on a `successful requests` console line.
+
+- [ ] **Step 2: Run the exporter tests to verify they fail**
+
+Run: `python3 -m unittest scripts.tests.test_perf_metrics_exporter`
+
+Expected: FAIL because the current exporter only parses console text and does not accept Gatling report JSON or emit request-level metrics.
+
+- [ ] **Step 3: Implement JSON-backed summary parsing**
+
+Update `scripts/perf_metrics_exporter.py` to:
+
+```python
+def load_gatling_report(report_dir: Path) -> dict:
+    global_stats = json.loads((report_dir / "js" / "global_stats.json").read_text(encoding="utf-8"))
+    request_tree = json.loads((report_dir / "js" / "stats.json").read_text(encoding="utf-8"))
+    return {"global": global_stats, "requests": request_tree.get("contents", {})}
+
+def build_summary(simulation: str, report_dir: Path, metadata: dict, exit_code: int) -> dict:
+    report = load_gatling_report(report_dir)
+    global_stats = report["global"]
+    requests = global_stats["numberOfRequests"]
+    total_requests = requests["ok"] + requests["ko"]
+    success_ratio = (requests["ok"] / total_requests) if total_requests else 0.0
+    return {
+        "simulation": simulation,
+        "requests": {"ok": requests["ok"], "ko": requests["ko"]},
+        "timings_ms": {
+            "mean": global_stats["meanResponseTime"]["total"],
+            "max": global_stats["maxResponseTime"]["total"],
+            "p95": global_stats["percentiles3"]["total"],
+            "p99": global_stats["percentiles4"]["total"],
+        },
+        "distribution": {
+            "lt_800ms": global_stats["group1"],
+            "between_800ms_1200ms": global_stats["group2"],
+            "gte_1200ms": global_stats["group3"],
+            "failed": global_stats["group4"],
+        },
+        "request_metrics": build_request_metrics(report["requests"]),
+        "success_ratio": success_ratio,
+    }
+```
+
+Keep the existing summary labels and assertion evaluation, but compute `success_ratio` from request counts instead of parsing a missing console stat.
+
+- [ ] **Step 4: Expand Prometheus exposition to include richer Gatling data**
+
+Extend `render_metrics(...)` so it still emits:
+- `wave_perf_run_info`
+- `wave_perf_response_time_ms`
+- `wave_perf_requests_count`
+- `wave_perf_success_ratio`
+- `wave_perf_assertion_status`
+- `wave_perf_last_run_timestamp_seconds`
+
+and also emits:
+
+```python
+wave_perf_distribution_count{...,bucket="lt_800ms"} 12
+wave_perf_distribution_ratio{...,bucket="lt_800ms"} 1.0
+wave_perf_request_response_time_ms{...,request_name="Search inbox",stat="p95"} 20
+wave_perf_request_requests_count{...,request_name="Search inbox",status="ok"} 10
+wave_perf_request_mean_requests_per_second{...,request_name="Search inbox"} 2.0
+```
+
+Keep labels low-cardinality by exporting request display names exactly as found in the Gatling JSON and avoiding per-sample timestamps beyond the existing run labels.
+
+- [ ] **Step 5: Re-run the exporter tests**
+
+Run: `python3 -m unittest scripts.tests.test_perf_metrics_exporter`
+
+Expected: PASS with JSON-backed summaries, request-level metrics, and distribution metrics rendered correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/perf_metrics_exporter.py scripts/tests/test_perf_metrics_exporter.py
+git commit -m "fix: parse Gatling perf summaries from report JSON"
+```
+
+### Task 2: Repair summary generation in `wave-perf.sh`
+
+**Files:**
+- Modify: `scripts/wave-perf.sh`
+- Modify: `scripts/tests/test_perf_alloy_config.py`
+
+- [ ] **Step 1: Write the failing script-level assertions**
+
+Update `scripts/tests/test_perf_alloy_config.py` so the script assertions require:
+
+```python
+self.assertIn('report_dir=$(find target/gatling -maxdepth 1 -type d -name', script_text)
+self.assertIn('--report-dir "$report_dir"', script_text)
+self.assertIn('if [[ -z "$report_dir" ]]; then', script_text)
+self.assertIn('WARN: failed to locate Gatling report directory for $sim', script_text)
+```
+
+This should replace the current assumption that the exporter only needs `--output-file`.
+
+- [ ] **Step 2: Run the config tests to verify they fail**
+
+Run: `python3 -m unittest scripts.tests.test_perf_alloy_config`
+
+Expected: FAIL because `scripts/wave-perf.sh` does not yet pass a Gatling report directory into the exporter.
+
+- [ ] **Step 3: Update `wave-perf.sh` to summarize from report directories**
+
+After each simulation run in `scripts/wave-perf.sh`, resolve the newest matching report directory and call the exporter with it:
+
+```bash
+report_dir="$(find target/gatling -maxdepth 1 -type d -name "$(echo "$sim" | tr '[:upper:]' '[:lower:]')-*' | sort | tail -n 1)"
+if [[ -z "$report_dir" ]]; then
+  rm -f "$summary_file" "$tmp_summary_file"
+  echo "[perf] WARN: failed to locate Gatling report directory for $sim" >&2
+else
+  python3 scripts/perf_metrics_exporter.py summarize \
+    --simulation "$sim" \
+    --report-dir "$report_dir" \
+    --summary-file "$tmp_summary_file" \
+    --exit-code "$sim_code" \
+    ...
+fi
+```
+
+Keep the temp-file move pattern so a failed summarize never leaves a stale summary file behind.
+
+- [ ] **Step 4: Re-run the script/config tests**
+
+Run: `python3 -m unittest scripts.tests.test_perf_alloy_config`
+
+Expected: PASS with the script using report directories and still preserving temp-file summary writes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/wave-perf.sh scripts/tests/test_perf_alloy_config.py
+git commit -m "fix: write perf summaries from Gatling report directories"
+```
+
+### Task 3: Fix Alloy scrape configuration and lock the workflow
+
+**Files:**
+- Modify: `scripts/render_perf_alloy_config.py`
+- Modify: `scripts/tests/test_perf_alloy_config.py`
+- Modify: `scripts/tests/test_perf_workflow_config.py`
+
+- [ ] **Step 1: Write the failing timeout assertions**
+
+Extend the Alloy config tests so they require every scrape job to declare a timeout no greater than the interval:
+
+```python
+self.assertIn('scrape_interval = "5s"', config)
+self.assertIn('scrape_timeout = "5s"', config)
+```
+
+Add a workflow assertion that the generated config path is still used by the `Start Grafana Alloy` step.
+
+- [ ] **Step 2: Run the Alloy/workflow tests to verify they fail**
+
+Run: `python3 -m unittest scripts.tests.test_perf_alloy_config scripts.tests.test_perf_workflow_config`
+
+Expected: FAIL because the generated Alloy config currently omits `scrape_timeout`, leaving the invalid 10s default in place.
+
+- [ ] **Step 3: Implement the Alloy config repair**
+
+Update `scripts/render_perf_alloy_config.py` so each scrape block declares an explicit timeout that matches the interval:
+
+```python
+prometheus.scrape "wave" {
+  targets = discovery.relabel.wave.output
+  forward_to = [prometheus.remote_write.perf.receiver]
+  scrape_interval = "5s"
+  scrape_timeout = "5s"
+}
+```
+
+Apply the same change to `perf_exporter` and `runner`.
+
+- [ ] **Step 4: Re-run the Alloy/workflow tests**
+
+Run: `python3 -m unittest scripts.tests.test_perf_alloy_config scripts.tests.test_perf_workflow_config`
+
+Expected: PASS with valid Alloy config text and unchanged workflow wiring.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/render_perf_alloy_config.py scripts/tests/test_perf_alloy_config.py scripts/tests/test_perf_workflow_config.py
+git commit -m "fix: make perf Alloy scrape config valid"
+```
+
+### Task 4: Redesign the Grafana dashboard around run comparison
+
+**Files:**
+- Modify: `grafana/dashboards/perf-observability.json`
+- Modify: `scripts/tests/test_grafana_dashboard_upsert.py`
+
+- [ ] **Step 1: Write the failing dashboard assertions**
+
+Update `scripts/tests/test_grafana_dashboard_upsert.py` so the perf dashboard must contain richer comparison surfaces such as:
+
+```python
+self.assertIn("Latest Runs", titles)
+self.assertIn("P95 by Run", titles)
+self.assertIn("P99 by Run", titles)
+self.assertIn("Request P95 by Run", titles)
+self.assertIn("Request Volume by Run", titles)
+self.assertIn("Latency Distribution", titles)
+```
+
+Also require the dashboard JSON to expose templating variables for `run_id` and `request_name`.
+
+- [ ] **Step 2: Run the dashboard tests to verify they fail**
+
+Run: `python3 -m unittest scripts.tests.test_grafana_dashboard_upsert`
+
+Expected: FAIL because the current dashboard only provides simulation-level summary panels and does not expose run or request selectors.
+
+- [ ] **Step 3: Implement the dashboard redesign**
+
+Update `grafana/dashboards/perf-observability.json` to:
+- add query variables for `run_id` and `request_name`,
+- add a table or stat-oriented “Latest Runs” section,
+- split simulation trends from run comparison views,
+- add request-level series based on the new exporter metrics,
+- add a bucketed latency distribution view using `wave_perf_distribution_count`.
+
+Representative query shapes:
+
+```json
+{
+  "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",stat=\"p95\"}",
+  "legendFormat": "{{simulation}} run {{run_id}}"
+}
+```
+
+```json
+{
+  "expr": "wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",run_id=~\"$run_id\",request_name=~\"$request_name\",stat=\"p95\"}",
+  "legendFormat": "{{request_name}}"
+}
+```
+
+- [ ] **Step 4: Re-run the dashboard tests**
+
+Run: `python3 -m unittest scripts.tests.test_grafana_dashboard_upsert`
+
+Expected: PASS with the new perf dashboard titles and selectors present while the analytics dashboard assertions remain green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add grafana/dashboards/perf-observability.json scripts/tests/test_grafana_dashboard_upsert.py
+git commit -m "feat: expand perf dashboard for Gatling run comparison"
+```
+
+### Task 5: Add changelog and run targeted verification
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json`
+
+- [ ] **Step 1: Write the changelog fragment**
+
+Create:
+
+```json
+{
+  "type": "ops",
+  "component": "perf-observability",
+  "summary": "Repair Grafana perf metrics export and expand Gatling run-comparison panels."
+}
+```
+
+- [ ] **Step 2: Run the targeted Python test suite**
+
+Run: `python3 -m unittest scripts.tests.test_perf_metrics_exporter scripts.tests.test_perf_alloy_config scripts.tests.test_perf_workflow_config scripts.tests.test_grafana_dashboard_upsert`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the changelog assembly and validation**
+
+Run: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run a narrow local reproduction against the real artifact**
+
+Run:
+
+```bash
+python3 scripts/perf_metrics_exporter.py summarize \
+  --simulation SearchLoadSimulation \
+  --report-dir /tmp/perf-run-dMDi6c/supawave/supawave/wave/target/perf-results/gatling-reports/searchloadsimulation-20260423173955267 \
+  --summary-file /tmp/search-summary.json \
+  --exit-code 0 \
+  --repo vega113/supawave \
+  --branch main \
+  --sha baba77288c3f02ebec66a155892e1cbc7f2ac6c4 \
+  --workflow perf \
+  --run-id 24849525083 \
+  --run-attempt 1
+```
+
+Expected: PASS and `/tmp/search-summary.json` contains p95/p99 plus request-level metrics.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json wave/config/changelog.json
+git commit -m "chore: record perf dashboard repair"
+```

--- a/grafana/dashboards/perf-observability.json
+++ b/grafana/dashboards/perf-observability.json
@@ -174,8 +174,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_request_requests_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",request_name=~\"$request_name\",status=\"ok\"}",
-          "legendFormat": "{{request_name}} ok run {{run_id}} attempt {{run_attempt}}",
+          "expr": "sum by (simulation, request_name, run_id, run_attempt) (wave_perf_request_requests_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",request_name=~\"$request_name\"})",
+          "legendFormat": "{{simulation}} {{request_name}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],

--- a/grafana/dashboards/perf-observability.json
+++ b/grafana/dashboards/perf-observability.json
@@ -54,13 +54,24 @@
         "multi": true
       },
       {
+        "name": "run_attempt",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "__PROMETHEUS_DS_UID__"
+        },
+        "query": "label_values(wave_perf_run_info{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}, run_attempt)",
+        "includeAll": true,
+        "multi": true
+      },
+      {
         "name": "request_name",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "__PROMETHEUS_DS_UID__"
         },
-        "query": "label_values(wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}, request_name)",
+        "query": "label_values(wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"}, request_name)",
         "includeAll": true,
         "multi": true
       }
@@ -77,7 +88,7 @@
       },
       "targets": [
         {
-          "expr": "topk(20, wave_perf_last_run_timestamp_seconds{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"})",
+          "expr": "topk(20, wave_perf_last_run_timestamp_seconds{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"})",
           "instant": true,
           "format": "table",
           "refId": "A"
@@ -95,8 +106,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",stat=\"p95\"}",
-          "legendFormat": "{{simulation}} run {{run_id}}",
+          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",stat=\"p95\"}",
+          "legendFormat": "{{simulation}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -112,8 +123,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",stat=\"p99\"}",
-          "legendFormat": "{{simulation}} run {{run_id}}",
+          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",stat=\"p99\"}",
+          "legendFormat": "{{simulation}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -129,8 +140,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_success_ratio{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
-          "legendFormat": "{{simulation}} run {{run_id}}",
+          "expr": "wave_perf_success_ratio{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"}",
+          "legendFormat": "{{simulation}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -146,8 +157,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",request_name=~\"$request_name\",stat=\"p95\"}",
-          "legendFormat": "{{request_name}} run {{run_id}}",
+          "expr": "wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",request_name=~\"$request_name\",stat=\"p95\"}",
+          "legendFormat": "{{request_name}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -163,8 +174,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_request_requests_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",request_name=~\"$request_name\",status=\"ok\"}",
-          "legendFormat": "{{request_name}} ok run {{run_id}}",
+          "expr": "wave_perf_request_requests_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",request_name=~\"$request_name\",status=\"ok\"}",
+          "legendFormat": "{{request_name}} ok run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -180,8 +191,9 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_distribution_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
-          "legendFormat": "{{simulation}} {{bucket}} run {{run_id}}",
+          "expr": "wave_perf_distribution_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"}",
+          "legendFormat": "{{simulation}} {{bucket}} run {{run_id}} attempt {{run_attempt}}",
+          "instant": true,
           "refId": "A"
         }
       ],
@@ -197,8 +209,8 @@
       },
       "targets": [
         {
-          "expr": "wave_perf_mean_requests_per_second{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
-          "legendFormat": "{{simulation}} run {{run_id}}",
+          "expr": "wave_perf_mean_requests_per_second{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"}",
+          "legendFormat": "{{simulation}} run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -214,8 +226,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (run_id) (rate(http_server_exceptions_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\"}[5m]))",
-          "legendFormat": "run {{run_id}}",
+          "expr": "sum by (run_id, run_attempt) (rate(http_server_exceptions_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\"}[5m]))",
+          "legendFormat": "run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -231,8 +243,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (run_id) (jvm_memory_used_bytes{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",area=\"heap\"})",
-          "legendFormat": "heap run {{run_id}}",
+          "expr": "sum by (run_id, run_attempt) (jvm_memory_used_bytes{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",area=\"heap\"})",
+          "legendFormat": "heap run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],
@@ -248,8 +260,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (run_id) (rate(node_cpu_seconds_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",mode!=\"idle\"}[5m]))",
-          "legendFormat": "cpu run {{run_id}}",
+          "expr": "sum by (run_id, run_attempt) (rate(node_cpu_seconds_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",run_attempt=~\"$run_attempt\",mode!=\"idle\"}[5m]))",
+          "legendFormat": "cpu run {{run_id}} attempt {{run_attempt}}",
           "refId": "A"
         }
       ],

--- a/grafana/dashboards/perf-observability.json
+++ b/grafana/dashboards/perf-observability.json
@@ -2,11 +2,11 @@
   "id": null,
   "uid": "wave-perf-observability",
   "title": "Wave Perf Observability",
-  "tags": ["perf", "grafana-cloud", "wave"],
+  "tags": ["perf", "grafana-cloud", "wave", "gatling"],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 1,
-  "refresh": "5m",
+  "version": 2,
+  "refresh": "1m",
   "templating": {
     "list": [
       {
@@ -27,7 +27,7 @@
           "type": "prometheus",
           "uid": "__PROMETHEUS_DS_UID__"
         },
-        "query": "label_values(wave_perf_run_info, simulation)",
+        "query": "label_values(wave_perf_run_info{branch=~\"$branch\"}, simulation)",
         "includeAll": true,
         "multi": true
       },
@@ -38,7 +38,29 @@
           "type": "prometheus",
           "uid": "__PROMETHEUS_DS_UID__"
         },
-        "query": "label_values(wave_perf_run_info, sha)",
+        "query": "label_values(wave_perf_run_info{branch=~\"$branch\",simulation=~\"$simulation\"}, sha)",
+        "includeAll": true,
+        "multi": true
+      },
+      {
+        "name": "run_id",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "__PROMETHEUS_DS_UID__"
+        },
+        "query": "label_values(wave_perf_run_info{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\"}, run_id)",
+        "includeAll": true,
+        "multi": true
+      },
+      {
+        "name": "request_name",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "__PROMETHEUS_DS_UID__"
+        },
+        "query": "label_values(wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}, request_name)",
         "includeAll": true,
         "multi": true
       }
@@ -47,56 +69,143 @@
   "panels": [
     {
       "id": 1,
-      "type": "stat",
-      "title": "Latest Perf Status",
+      "type": "table",
+      "title": "Latest Runs",
       "datasource": {
         "type": "prometheus",
         "uid": "__PROMETHEUS_DS_UID__"
       },
       "targets": [
         {
-          "expr": "sum by (simulation) (last_over_time(wave_perf_run_info{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\"}[30d]))",
+          "expr": "topk(20, wave_perf_last_run_timestamp_seconds{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"})",
+          "instant": true,
+          "format": "table",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 }
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 }
     },
     {
       "id": 2,
       "type": "timeseries",
-      "title": "P95 by Simulation",
+      "title": "P95 by Run",
       "datasource": {
         "type": "prometheus",
         "uid": "__PROMETHEUS_DS_UID__"
       },
       "targets": [
         {
-          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",stat=\"p95\"}",
-          "legendFormat": "{{simulation}}",
+          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",stat=\"p95\"}",
+          "legendFormat": "{{simulation}} run {{run_id}}",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 6, "y": 0 }
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 }
     },
     {
       "id": 3,
       "type": "timeseries",
-      "title": "P99 by Simulation",
+      "title": "P99 by Run",
       "datasource": {
         "type": "prometheus",
         "uid": "__PROMETHEUS_DS_UID__"
       },
       "targets": [
         {
-          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",stat=\"p99\"}",
-          "legendFormat": "{{simulation}}",
+          "expr": "wave_perf_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",stat=\"p99\"}",
+          "legendFormat": "{{simulation}} run {{run_id}}",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 0 }
     },
     {
       "id": 4,
+      "type": "timeseries",
+      "title": "Success Ratio by Run",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__PROMETHEUS_DS_UID__"
+      },
+      "targets": [
+        {
+          "expr": "wave_perf_success_ratio{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
+          "legendFormat": "{{simulation}} run {{run_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 7 }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Request P95 by Run",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__PROMETHEUS_DS_UID__"
+      },
+      "targets": [
+        {
+          "expr": "wave_perf_request_response_time_ms{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",request_name=~\"$request_name\",stat=\"p95\"}",
+          "legendFormat": "{{request_name}} run {{run_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 7 }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Request Volume by Run",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__PROMETHEUS_DS_UID__"
+      },
+      "targets": [
+        {
+          "expr": "wave_perf_request_requests_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\",request_name=~\"$request_name\",status=\"ok\"}",
+          "legendFormat": "{{request_name}} ok run {{run_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 7 }
+    },
+    {
+      "id": 7,
+      "type": "barchart",
+      "title": "Latency Distribution",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__PROMETHEUS_DS_UID__"
+      },
+      "targets": [
+        {
+          "expr": "wave_perf_distribution_count{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
+          "legendFormat": "{{simulation}} {{bucket}} run {{run_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Global Request Rate by Run",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__PROMETHEUS_DS_UID__"
+      },
+      "targets": [
+        {
+          "expr": "wave_perf_mean_requests_per_second{branch=~\"$branch\",simulation=~\"$simulation\",sha=~\"$sha\",run_id=~\"$run_id\"}",
+          "legendFormat": "{{simulation}} run {{run_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 }
+    },
+    {
+      "id": 9,
       "type": "timeseries",
       "title": "Wave HTTP Errors",
       "datasource": {
@@ -105,14 +214,15 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(http_server_exceptions_total[5m]))",
+          "expr": "sum by (run_id) (rate(http_server_exceptions_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\"}[5m]))",
+          "legendFormat": "run {{run_id}}",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 23 }
     },
     {
-      "id": 5,
+      "id": 10,
       "type": "timeseries",
       "title": "JVM Heap",
       "datasource": {
@@ -121,30 +231,15 @@
       },
       "targets": [
         {
-          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
+          "expr": "sum by (run_id) (jvm_memory_used_bytes{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",area=\"heap\"})",
+          "legendFormat": "heap run {{run_id}}",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 23 }
     },
     {
-      "id": 6,
-      "type": "timeseries",
-      "title": "GC Activity",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "__PROMETHEUS_DS_UID__"
-      },
-      "targets": [
-        {
-          "expr": "rate(jvm_gc_memory_allocated_bytes_total[5m])",
-          "refId": "A"
-        }
-      ],
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
-    },
-    {
-      "id": 7,
+      "id": 11,
       "type": "timeseries",
       "title": "Runner CPU",
       "datasource": {
@@ -153,27 +248,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m]))",
+          "expr": "sum by (run_id) (rate(node_cpu_seconds_total{branch=~\"$branch\",sha=~\"$sha\",run_id=~\"$run_id\",mode!=\"idle\"}[5m]))",
+          "legendFormat": "cpu run {{run_id}}",
           "refId": "A"
         }
       ],
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
-    },
-    {
-      "id": 8,
-      "type": "timeseries",
-      "title": "Runner Memory",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "__PROMETHEUS_DS_UID__"
-      },
-      "targets": [
-        {
-          "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes",
-          "refId": "A"
-        }
-      ],
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 }
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 23 }
     }
   ]
 }

--- a/scripts/perf_metrics_exporter.py
+++ b/scripts/perf_metrics_exporter.py
@@ -183,6 +183,10 @@ def render_metrics(summaries: list[dict]) -> str:
       "# TYPE wave_perf_request_requests_count gauge",
       "# HELP wave_perf_request_mean_requests_per_second Wave perf request-level throughput metrics.",
       "# TYPE wave_perf_request_mean_requests_per_second gauge",
+      "# HELP wave_perf_request_distribution_count Wave perf request-level latency distribution counts.",
+      "# TYPE wave_perf_request_distribution_count gauge",
+      "# HELP wave_perf_request_distribution_ratio Wave perf request-level latency distribution ratios from 0 to 1.",
+      "# TYPE wave_perf_request_distribution_ratio gauge",
       "# HELP wave_perf_success_ratio Wave perf success ratio from 0 to 1.",
       "# TYPE wave_perf_success_ratio gauge",
       "# HELP wave_perf_assertion_status Wave perf assertion pass status where 1 is pass and 0 is fail.",
@@ -204,7 +208,10 @@ def render_metrics(summaries: list[dict]) -> str:
           f'wave_perf_distribution_ratio{{{_format_labels(summary, {"bucket": bucket_name})}}} {bucket["percentage"] / 100.0}'
       )
     for request_metric in summary.get("request_metrics", []):
-      request_labels = {"request_name": request_metric["request_name"]}
+      request_labels = {
+          "request_name": request_metric["request_name"],
+          "request_path": request_metric["request_path"],
+      }
       for stat_name, stat_value in request_metric["timings_ms"].items():
         lines.append(
             f'wave_perf_request_response_time_ms{{{_format_labels(summary, {**request_labels, "stat": stat_name})}}} {stat_value}'
@@ -212,6 +219,13 @@ def render_metrics(summaries: list[dict]) -> str:
       for status_name, request_count in request_metric["requests"].items():
         lines.append(
             f'wave_perf_request_requests_count{{{_format_labels(summary, {**request_labels, "status": status_name})}}} {request_count}'
+        )
+      for bucket_name, bucket in request_metric["distribution"].items():
+        lines.append(
+            f'wave_perf_request_distribution_count{{{_format_labels(summary, {**request_labels, "bucket": bucket_name})}}} {bucket["count"]}'
+        )
+        lines.append(
+            f'wave_perf_request_distribution_ratio{{{_format_labels(summary, {**request_labels, "bucket": bucket_name})}}} {bucket["percentage"] / 100.0}'
         )
       lines.append(
           f'wave_perf_request_mean_requests_per_second{{{_format_labels(summary, request_labels)}}} {request_metric["mean_requests_per_second"]}'

--- a/scripts/perf_metrics_exporter.py
+++ b/scripts/perf_metrics_exporter.py
@@ -112,7 +112,7 @@ def load_gatling_report(report_dir: Path) -> dict:
 
 
 def build_summary(simulation: str, report_dir: Path, metadata: dict, exit_code: int) -> dict:
-  parsed = load_gatling_report(Path(report_dir))
+  parsed = load_gatling_report(report_dir)
   global_stats = parsed["global_stats"]
   requests = _extract_requests(global_stats)
   total_requests = requests["ok"] + requests["ko"]

--- a/scripts/perf_metrics_exporter.py
+++ b/scripts/perf_metrics_exporter.py
@@ -199,10 +199,11 @@ def render_metrics(summaries: list[dict]) -> str:
     lines.append(f"wave_perf_run_info{{{labels}}} 1")
     for stat_name, stat_value in summary["timings_ms"].items():
       lines.append(f'wave_perf_response_time_ms{{{_format_labels(summary, {"stat": stat_name})}}} {stat_value}')
-    lines.append(f"wave_perf_mean_requests_per_second{{{labels}}} {summary['mean_requests_per_second']}")
+    if "mean_requests_per_second" in summary:
+      lines.append(f"wave_perf_mean_requests_per_second{{{labels}}} {summary['mean_requests_per_second']}")
     for status_name, request_count in summary["requests"].items():
       lines.append(f'wave_perf_requests_count{{{_format_labels(summary, {"status": status_name})}}} {request_count}')
-    for bucket_name, bucket in summary["distribution"].items():
+    for bucket_name, bucket in summary.get("distribution", {}).items():
       lines.append(f'wave_perf_distribution_count{{{_format_labels(summary, {"bucket": bucket_name})}}} {bucket["count"]}')
       lines.append(
           f'wave_perf_distribution_ratio{{{_format_labels(summary, {"bucket": bucket_name})}}} {bucket["percentage"] / 100.0}'
@@ -220,16 +221,17 @@ def render_metrics(summaries: list[dict]) -> str:
         lines.append(
             f'wave_perf_request_requests_count{{{_format_labels(summary, {**request_labels, "status": status_name})}}} {request_count}'
         )
-      for bucket_name, bucket in request_metric["distribution"].items():
+      for bucket_name, bucket in request_metric.get("distribution", {}).items():
         lines.append(
             f'wave_perf_request_distribution_count{{{_format_labels(summary, {**request_labels, "bucket": bucket_name})}}} {bucket["count"]}'
         )
         lines.append(
             f'wave_perf_request_distribution_ratio{{{_format_labels(summary, {**request_labels, "bucket": bucket_name})}}} {bucket["percentage"] / 100.0}'
         )
-      lines.append(
-          f'wave_perf_request_mean_requests_per_second{{{_format_labels(summary, request_labels)}}} {request_metric["mean_requests_per_second"]}'
-      )
+      if "mean_requests_per_second" in request_metric:
+        lines.append(
+            f'wave_perf_request_mean_requests_per_second{{{_format_labels(summary, request_labels)}}} {request_metric["mean_requests_per_second"]}'
+        )
     lines.append(f"wave_perf_success_ratio{{{labels}}} {summary['success_ratio']}")
     for assertion_name, assertion_passed in summary["assertions"].items():
       value = 1 if assertion_passed else 0

--- a/scripts/perf_metrics_exporter.py
+++ b/scripts/perf_metrics_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import re
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -27,45 +26,101 @@ SIMULATION_THRESHOLDS = {
     },
 }
 
+TIMING_FIELDS = {
+    # Gatling's default charting indicators map percentiles1..4 to 50/75/95/99.
+    # If gatling.conf changes those indicators, this exporter mapping must change too.
+    "min": "minResponseTime",
+    "max": "maxResponseTime",
+    "mean": "meanResponseTime",
+    "std_dev": "standardDeviation",
+    "p50": "percentiles1",
+    "p75": "percentiles2",
+    "p95": "percentiles3",
+    "p99": "percentiles4",
+}
 
-def _match_int(pattern: str, text: str) -> int:
-  match = re.search(pattern, text, re.MULTILINE)
-  if not match:
-    raise ValueError(f"Missing Gatling stat for pattern: {pattern}")
-  return int(match.group(1))
+DISTRIBUTION_FIELDS = {
+    "lt_800ms": "group1",
+    "between_800ms_1200ms": "group2",
+    "gte_1200ms": "group3",
+    "failed": "group4",
+}
 
 
-def _match_float(pattern: str, text: str) -> float:
-  match = re.search(pattern, text, re.MULTILINE)
-  if not match:
-    raise ValueError(f"Missing Gatling stat for pattern: {pattern}")
-  return float(match.group(1))
+def _extract_total(stats: dict, field_name: str) -> int | float:
+  return stats[field_name]["total"]
 
 
-def parse_gatling_output(output_text: str) -> dict:
+def _extract_requests(stats: dict) -> dict:
+  request_counts = stats["numberOfRequests"]
   return {
-      "requests": {
-          "ok": _match_int(r"request count\s+\d+\s+\(OK=(\d+)\s+KO=\d+", output_text),
-          "ko": _match_int(r"request count\s+\d+\s+\(OK=\d+\s+KO=(\d+)", output_text),
-      },
-      "timings_ms": {
-          "mean": _match_int(r"mean response time\s+(\d+)", output_text),
-          "max": _match_int(r"max response time\s+(\d+)", output_text),
-          "p95": _match_int(r"response time 95th percentile\s+(\d+)", output_text),
-          "p99": _match_int(r"response time 99th percentile\s+(\d+)", output_text),
-      },
-      "successful_requests_pct": _match_float(r"successful requests\s+([0-9.]+)%", output_text),
+      "ok": request_counts["ok"],
+      "ko": request_counts["ko"],
   }
 
 
-def build_summary(simulation: str, output_text: str, metadata: dict, exit_code: int) -> dict:
-  parsed = parse_gatling_output(output_text)
-  requests = parsed["requests"]
+def _extract_timings(stats: dict) -> dict:
+  return {
+      stat_name: _extract_total(stats, source_name)
+      for stat_name, source_name in TIMING_FIELDS.items()
+  }
+
+
+def _extract_distribution(stats: dict) -> dict:
+  return {
+      bucket_name: {
+          "name": stats[source_name]["name"],
+          "count": stats[source_name]["count"],
+          "percentage": stats[source_name]["percentage"],
+      }
+      for bucket_name, source_name in DISTRIBUTION_FIELDS.items()
+  }
+
+
+def build_request_metrics(request_nodes: dict) -> list[dict]:
+  request_metrics = []
+
+  def walk(nodes: dict):
+    for request_node in nodes.values():
+      if request_node.get("type") == "GROUP":
+        walk(request_node.get("contents", {}))
+        continue
+      if request_node.get("type") != "REQUEST":
+        continue
+      stats = request_node["stats"]
+      request_metrics.append({
+          "request_name": request_node["name"],
+          "request_path": request_node.get("path", request_node["name"]),
+          "requests": _extract_requests(stats),
+          "timings_ms": _extract_timings(stats),
+          "distribution": _extract_distribution(stats),
+          "mean_requests_per_second": _extract_total(stats, "meanNumberOfRequestsPerSecond"),
+      })
+
+  walk(request_nodes)
+  return sorted(request_metrics, key=lambda metric: metric["request_name"])
+
+
+def load_gatling_report(report_dir: Path) -> dict:
+  js_dir = report_dir / "js"
+  global_stats = json.loads((js_dir / "global_stats.json").read_text(encoding="utf-8"))
+  stats_tree = json.loads((js_dir / "stats.json").read_text(encoding="utf-8"))
+  return {
+      "global_stats": global_stats,
+      "request_nodes": stats_tree.get("contents", {}),
+  }
+
+
+def build_summary(simulation: str, report_dir: Path, metadata: dict, exit_code: int) -> dict:
+  parsed = load_gatling_report(Path(report_dir))
+  global_stats = parsed["global_stats"]
+  requests = _extract_requests(global_stats)
   total_requests = requests["ok"] + requests["ko"]
   success_ratio = (requests["ok"] / total_requests) if total_requests else 0.0
+  timings_ms = _extract_timings(global_stats)
   thresholds = SIMULATION_THRESHOLDS.get(simulation, {})
   assertions = {
-      name: checker(parsed["timings_ms"], success_ratio)
+      name: checker(timings_ms, success_ratio)
       for name, checker in thresholds.items()
   }
   summary = {
@@ -78,9 +133,12 @@ def build_summary(simulation: str, output_text: str, metadata: dict, exit_code: 
       "run_attempt": metadata.get("run_attempt", ""),
       "exit_code": exit_code,
       "requests": requests,
-      "timings_ms": parsed["timings_ms"],
+      "timings_ms": timings_ms,
+      "distribution": _extract_distribution(global_stats),
+      "request_metrics": build_request_metrics(parsed["request_nodes"]),
+      "mean_requests_per_second": _extract_total(global_stats, "meanNumberOfRequestsPerSecond"),
       "success_ratio": success_ratio,
-      "successful_requests_pct": parsed["successful_requests_pct"],
+      "successful_requests_pct": success_ratio * 100.0,
       "assertions": assertions,
       "run_timestamp": int(metadata.get("run_timestamp", time.time())),
   }
@@ -111,8 +169,20 @@ def render_metrics(summaries: list[dict]) -> str:
       "# TYPE wave_perf_run_info gauge",
       "# HELP wave_perf_response_time_ms Wave perf response-time summary metrics in milliseconds.",
       "# TYPE wave_perf_response_time_ms gauge",
+      "# HELP wave_perf_mean_requests_per_second Wave perf throughput summary metrics.",
+      "# TYPE wave_perf_mean_requests_per_second gauge",
       "# HELP wave_perf_requests_count Wave perf request counts by outcome.",
       "# TYPE wave_perf_requests_count gauge",
+      "# HELP wave_perf_distribution_count Wave perf latency distribution counts.",
+      "# TYPE wave_perf_distribution_count gauge",
+      "# HELP wave_perf_distribution_ratio Wave perf latency distribution ratios from 0 to 1.",
+      "# TYPE wave_perf_distribution_ratio gauge",
+      "# HELP wave_perf_request_response_time_ms Wave perf request-level response-time summary metrics in milliseconds.",
+      "# TYPE wave_perf_request_response_time_ms gauge",
+      "# HELP wave_perf_request_requests_count Wave perf request-level counts by outcome.",
+      "# TYPE wave_perf_request_requests_count gauge",
+      "# HELP wave_perf_request_mean_requests_per_second Wave perf request-level throughput metrics.",
+      "# TYPE wave_perf_request_mean_requests_per_second gauge",
       "# HELP wave_perf_success_ratio Wave perf success ratio from 0 to 1.",
       "# TYPE wave_perf_success_ratio gauge",
       "# HELP wave_perf_assertion_status Wave perf assertion pass status where 1 is pass and 0 is fail.",
@@ -125,8 +195,27 @@ def render_metrics(summaries: list[dict]) -> str:
     lines.append(f"wave_perf_run_info{{{labels}}} 1")
     for stat_name, stat_value in summary["timings_ms"].items():
       lines.append(f'wave_perf_response_time_ms{{{_format_labels(summary, {"stat": stat_name})}}} {stat_value}')
+    lines.append(f"wave_perf_mean_requests_per_second{{{labels}}} {summary['mean_requests_per_second']}")
     for status_name, request_count in summary["requests"].items():
       lines.append(f'wave_perf_requests_count{{{_format_labels(summary, {"status": status_name})}}} {request_count}')
+    for bucket_name, bucket in summary["distribution"].items():
+      lines.append(f'wave_perf_distribution_count{{{_format_labels(summary, {"bucket": bucket_name})}}} {bucket["count"]}')
+      lines.append(
+          f'wave_perf_distribution_ratio{{{_format_labels(summary, {"bucket": bucket_name})}}} {bucket["percentage"] / 100.0}'
+      )
+    for request_metric in summary.get("request_metrics", []):
+      request_labels = {"request_name": request_metric["request_name"]}
+      for stat_name, stat_value in request_metric["timings_ms"].items():
+        lines.append(
+            f'wave_perf_request_response_time_ms{{{_format_labels(summary, {**request_labels, "stat": stat_name})}}} {stat_value}'
+        )
+      for status_name, request_count in request_metric["requests"].items():
+        lines.append(
+            f'wave_perf_request_requests_count{{{_format_labels(summary, {**request_labels, "status": status_name})}}} {request_count}'
+        )
+      lines.append(
+          f'wave_perf_request_mean_requests_per_second{{{_format_labels(summary, request_labels)}}} {request_metric["mean_requests_per_second"]}'
+      )
     lines.append(f"wave_perf_success_ratio{{{labels}}} {summary['success_ratio']}")
     for assertion_name, assertion_passed in summary["assertions"].items():
       value = 1 if assertion_passed else 0
@@ -182,10 +271,9 @@ def _serve(args: argparse.Namespace) -> int:
 
 
 def _summarize(args: argparse.Namespace) -> int:
-  output_text = Path(args.output_file).read_text(encoding="utf-8")
   summary = build_summary(
       simulation=args.simulation,
-      output_text=output_text,
+      report_dir=Path(args.report_dir),
       metadata=_metadata_from_args(args),
       exit_code=args.exit_code,
   )
@@ -199,7 +287,7 @@ def main() -> int:
 
   summarize_parser = subparsers.add_parser("summarize")
   summarize_parser.add_argument("--simulation", required=True)
-  summarize_parser.add_argument("--output-file", required=True)
+  summarize_parser.add_argument("--report-dir", required=True)
   summarize_parser.add_argument("--summary-file", required=True)
   summarize_parser.add_argument("--exit-code", type=int, required=True)
   summarize_parser.add_argument("--repo", default="")

--- a/scripts/render_perf_alloy_config.py
+++ b/scripts/render_perf_alloy_config.py
@@ -67,6 +67,7 @@ prometheus.scrape "wave" {{
   targets = discovery.relabel.wave.output
   forward_to = [prometheus.remote_write.perf.receiver]
   scrape_interval = "5s"
+  scrape_timeout = "5s"
 }}
 
 discovery.relabel "perf_exporter" {{
@@ -81,6 +82,7 @@ prometheus.scrape "perf_exporter" {{
   targets = discovery.relabel.perf_exporter.output
   forward_to = [prometheus.remote_write.perf.receiver]
   scrape_interval = "5s"
+  scrape_timeout = "5s"
 }}
 
 prometheus.exporter.unix "runner" {{
@@ -95,6 +97,7 @@ prometheus.scrape "runner" {{
   targets = discovery.relabel.runner.output
   forward_to = [prometheus.remote_write.perf.receiver]
   scrape_interval = "5s"
+  scrape_timeout = "5s"
 }}
 """
 

--- a/scripts/tests/test_grafana_dashboard_upsert.py
+++ b/scripts/tests/test_grafana_dashboard_upsert.py
@@ -62,6 +62,7 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
     self.assertIn("simulation", variable_names)
     self.assertIn("sha", variable_names)
     self.assertIn("run_id", variable_names)
+    self.assertIn("run_attempt", variable_names)
     self.assertIn("request_name", variable_names)
 
   def test_latest_runs_panel_orders_by_run_timestamp(self):
@@ -69,6 +70,13 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
     latest_runs_panel = find_panel(dashboard, "Latest Runs")
 
     self.assertIn("wave_perf_last_run_timestamp_seconds", latest_runs_panel["targets"][0]["expr"])
+    self.assertIn('run_attempt=~"$run_attempt"', latest_runs_panel["targets"][0]["expr"])
+
+  def test_latency_distribution_panel_uses_instant_query(self):
+    dashboard = json.loads(PERF_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    latency_distribution_panel = find_panel(dashboard, "Latency Distribution")
+
+    self.assertTrue(latency_distribution_panel["targets"][0]["instant"])
 
   def test_dashboard_contains_expected_analytics_panels(self):
     dashboard = json.loads(ANALYTICS_DASHBOARD_PATH.read_text(encoding="utf-8"))

--- a/scripts/tests/test_grafana_dashboard_upsert.py
+++ b/scripts/tests/test_grafana_dashboard_upsert.py
@@ -23,6 +23,13 @@ def walk_panels(dashboard: dict) -> list[dict]:
   return found
 
 
+def find_panel(dashboard: dict, title: str) -> dict:
+  for panel in walk_panels(dashboard):
+    if panel.get("title") == title:
+      return panel
+  raise AssertionError(f"Panel not found: {title}")
+
+
 class GrafanaDashboardUpsertTest(unittest.TestCase):
   class _FakeResponse:
     def __init__(self, status: int = 200):
@@ -38,10 +45,30 @@ class GrafanaDashboardUpsertTest(unittest.TestCase):
     dashboard = json.loads(PERF_DASHBOARD_PATH.read_text(encoding="utf-8"))
     titles = {panel["title"] for panel in walk_panels(dashboard) if "title" in panel}
 
-    self.assertIn("Latest Perf Status", titles)
-    self.assertIn("P95 by Simulation", titles)
+    self.assertIn("Latest Runs", titles)
+    self.assertIn("P95 by Run", titles)
+    self.assertIn("P99 by Run", titles)
+    self.assertIn("Request P95 by Run", titles)
+    self.assertIn("Request Volume by Run", titles)
+    self.assertIn("Latency Distribution", titles)
     self.assertIn("JVM Heap", titles)
     self.assertIn("Runner CPU", titles)
+
+  def test_perf_dashboard_contains_run_and_request_selectors(self):
+    dashboard = json.loads(PERF_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    variable_names = {entry["name"] for entry in dashboard.get("templating", {}).get("list", [])}
+
+    self.assertIn("branch", variable_names)
+    self.assertIn("simulation", variable_names)
+    self.assertIn("sha", variable_names)
+    self.assertIn("run_id", variable_names)
+    self.assertIn("request_name", variable_names)
+
+  def test_latest_runs_panel_orders_by_run_timestamp(self):
+    dashboard = json.loads(PERF_DASHBOARD_PATH.read_text(encoding="utf-8"))
+    latest_runs_panel = find_panel(dashboard, "Latest Runs")
+
+    self.assertIn("wave_perf_last_run_timestamp_seconds", latest_runs_panel["targets"][0]["expr"])
 
   def test_dashboard_contains_expected_analytics_panels(self):
     dashboard = json.loads(ANALYTICS_DASHBOARD_PATH.read_text(encoding="utf-8"))

--- a/scripts/tests/test_perf_alloy_config.py
+++ b/scripts/tests/test_perf_alloy_config.py
@@ -37,6 +37,7 @@ class PerfAlloyConfigTest(unittest.TestCase):
     self.assertIn('targets = discovery.relabel.perf_exporter.output', config)
     self.assertIn('target_label = "repo"', config)
     self.assertIn('replacement  = "vega113/supawave"', config)
+    self.assertEqual(3, config.count('scrape_timeout = "5s"'))
     self.assertNotIn("secret", config)
 
   def test_render_config_rejects_invalid_auth_env_name(self):
@@ -54,9 +55,11 @@ class PerfAlloyConfigTest(unittest.TestCase):
     script_text = WAVE_PERF_SCRIPT.read_text(encoding="utf-8")
 
     self.assertIn('${sim}-summary.json', script_text)
+    self.assertIn('report_dir="$(find target/gatling', script_text)
     self.assertIn('scripts/perf_metrics_exporter.py summarize', script_text)
     self.assertIn('--simulation "$sim"', script_text)
-    self.assertIn('--output-file "$RESULTS_DIR/${sim}-output.txt"', script_text)
+    self.assertIn('--report-dir "$report_dir"', script_text)
+    self.assertIn('failed to locate Gatling report directory for $sim', script_text)
     self.assertIn('PERF_BRANCH_NAME', script_text)
 
   def test_wave_perf_script_writes_summaries_via_temp_files(self):
@@ -66,6 +69,20 @@ class PerfAlloyConfigTest(unittest.TestCase):
     self.assertIn('rm -f "$summary_file" "$tmp_summary_file"', script_text)
     self.assertIn('--summary-file "$tmp_summary_file"', script_text)
     self.assertIn('mv "$tmp_summary_file" "$summary_file"', script_text)
+
+  def test_wave_perf_script_removes_stale_report_dirs_for_each_simulation(self):
+    script_text = WAVE_PERF_SCRIPT.read_text(encoding="utf-8")
+
+    self.assertIn('find target/gatling -maxdepth 1 -type d -name "${sim_slug}-*" -exec rm -rf {} +', script_text)
+    self.assertIn('report_dir="$(find target/gatling -maxdepth 1 -type d -name "${sim_slug}-*"', script_text)
+
+  def test_wave_perf_script_guards_missing_report_dir_lookup_under_set_e(self):
+    script_text = WAVE_PERF_SCRIPT.read_text(encoding="utf-8")
+
+    self.assertIn(
+        'report_dir="$(find target/gatling -maxdepth 1 -type d -name "${sim_slug}-*" 2>/dev/null | sort | tail -n 1 || true)"',
+        script_text,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_perf_metrics_exporter.py
+++ b/scripts/tests/test_perf_metrics_exporter.py
@@ -283,6 +283,31 @@ class PerfMetricsExporterTest(unittest.TestCase):
         metrics,
     )
 
+  def test_render_metrics_accepts_legacy_summary_without_new_fields(self):
+    legacy_summary = {
+        "simulation": "SearchLoadSimulation",
+        "repo": "vega113/supawave",
+        "branch": "main",
+        "sha": "abc123",
+        "workflow": "perf",
+        "run_id": "42",
+        "run_attempt": "1",
+        "requests": {"ok": 10, "ko": 0},
+        "timings_ms": {"mean": 12, "max": 20, "p95": 18, "p99": 20},
+        "success_ratio": 1.0,
+        "assertions": {"p95_lt_2000ms": True},
+        "run_timestamp": 1,
+    }
+
+    metrics = perf_metrics_exporter.render_metrics([legacy_summary])
+
+    self.assertIn("wave_perf_run_info", metrics)
+    self.assertIn(
+        'wave_perf_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",stat="p95"} 18',
+        metrics,
+    )
+    self.assertNotIn("wave_perf_request_distribution_count{", metrics)
+
   def test_build_metrics_response_reads_summary_files(self):
     with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
       report_dir = write_report_dir(Path(tmpdir_str))

--- a/scripts/tests/test_perf_metrics_exporter.py
+++ b/scripts/tests/test_perf_metrics_exporter.py
@@ -267,11 +267,19 @@ class PerfMetricsExporterTest(unittest.TestCase):
         metrics,
     )
     self.assertIn(
-        'wave_perf_request_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",stat="p95"} 20',
+        'wave_perf_request_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",request_path="Search inbox",stat="p95"} 20',
         metrics,
     )
     self.assertIn(
-        'wave_perf_request_requests_count{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",status="ok"} 10',
+        'wave_perf_request_requests_count{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",request_path="Search inbox",status="ok"} 10',
+        metrics,
+    )
+    self.assertIn(
+        'wave_perf_request_distribution_count{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",request_path="Search inbox",bucket="lt_800ms"} 10',
+        metrics,
+    )
+    self.assertIn(
+        'wave_perf_request_distribution_ratio{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",request_path="Search inbox",bucket="lt_800ms"} 1.0',
         metrics,
     )
 

--- a/scripts/tests/test_perf_metrics_exporter.py
+++ b/scripts/tests/test_perf_metrics_exporter.py
@@ -6,42 +6,180 @@ from pathlib import Path
 from scripts import perf_metrics_exporter
 
 
-SAMPLE_GATLING_OUTPUT = """
----- Global Information --------------------------------------------------------
-> request count                                        10 (OK=10   KO=0     )
-> min response time                                    10 (OK=10   KO=-     )
-> max response time                                    20 (OK=20   KO=-     )
-> mean response time                                   12 (OK=12   KO=-     )
-> std deviation                                         3 (OK=3    KO=-     )
-> response time 50th percentile                        11 (OK=11   KO=-     )
-> response time 75th percentile                        15 (OK=15   KO=-     )
-> response time 95th percentile                        18 (OK=18   KO=-     )
-> response time 99th percentile                        20 (OK=20   KO=-     )
-> successful requests                                100.0% (OK=10   KO=0     )
---------------------------------------------------------------------------------
-""".strip()
+SAMPLE_GLOBAL_STATS = {
+    "name": "All Requests",
+    "numberOfRequests": {
+        "total": 12,
+        "ok": 12,
+        "ko": 0,
+    },
+    "minResponseTime": {
+        "total": 6,
+        "ok": 6,
+        "ko": 0,
+    },
+    "maxResponseTime": {
+        "total": 21,
+        "ok": 21,
+        "ko": 0,
+    },
+    "meanResponseTime": {
+        "total": 13,
+        "ok": 13,
+        "ko": 0,
+    },
+    "standardDeviation": {
+        "total": 4,
+        "ok": 4,
+        "ko": 0,
+    },
+    "percentiles1": {
+        "total": 13,
+        "ok": 13,
+        "ko": 0,
+    },
+    "percentiles2": {
+        "total": 17,
+        "ok": 17,
+        "ko": 0,
+    },
+    "percentiles3": {
+        "total": 20,
+        "ok": 20,
+        "ko": 0,
+    },
+    "percentiles4": {
+        "total": 21,
+        "ok": 21,
+        "ko": 0,
+    },
+    "group1": {
+        "name": "t < 800 ms",
+        "count": 12,
+        "percentage": 100,
+    },
+    "group2": {
+        "name": "800 ms <= t < 1200 ms",
+        "count": 0,
+        "percentage": 0,
+    },
+    "group3": {
+        "name": "t >= 1200 ms",
+        "count": 0,
+        "percentage": 0,
+    },
+    "group4": {
+        "name": "failed",
+        "count": 0,
+        "percentage": 0,
+    },
+    "meanNumberOfRequestsPerSecond": {
+        "total": 2.4,
+        "ok": 2.4,
+        "ko": 0,
+    },
+}
+
+SAMPLE_STATS_TREE = {
+    "type": "GROUP",
+    "name": "All Requests",
+    "path": "",
+    "stats": SAMPLE_GLOBAL_STATS,
+    "contents": {
+        "req_register-user": {
+            "type": "REQUEST",
+            "name": "Register user",
+            "path": "Register user",
+            "stats": {
+                "name": "Register user",
+                "numberOfRequests": {"total": 1, "ok": 1, "ko": 0},
+                "minResponseTime": {"total": 19, "ok": 19, "ko": 0},
+                "maxResponseTime": {"total": 19, "ok": 19, "ko": 0},
+                "meanResponseTime": {"total": 19, "ok": 19, "ko": 0},
+                "standardDeviation": {"total": 0, "ok": 0, "ko": 0},
+                "percentiles1": {"total": 19, "ok": 19, "ko": 0},
+                "percentiles2": {"total": 19, "ok": 19, "ko": 0},
+                "percentiles3": {"total": 19, "ok": 19, "ko": 0},
+                "percentiles4": {"total": 19, "ok": 19, "ko": 0},
+                "group1": {"name": "t < 800 ms", "count": 1, "percentage": 100},
+                "group2": {"name": "800 ms <= t < 1200 ms", "count": 0, "percentage": 0},
+                "group3": {"name": "t >= 1200 ms", "count": 0, "percentage": 0},
+                "group4": {"name": "failed", "count": 0, "percentage": 0},
+                "meanNumberOfRequestsPerSecond": {"total": 0.2, "ok": 0.2, "ko": 0},
+            },
+        },
+        "req_search-inbox": {
+            "type": "REQUEST",
+            "name": "Search inbox",
+            "path": "Search inbox",
+            "stats": {
+                "name": "Search inbox",
+                "numberOfRequests": {"total": 10, "ok": 10, "ko": 0},
+                "minResponseTime": {"total": 6, "ok": 6, "ko": 0},
+                "maxResponseTime": {"total": 21, "ok": 21, "ko": 0},
+                "meanResponseTime": {"total": 13, "ok": 13, "ko": 0},
+                "standardDeviation": {"total": 4, "ok": 4, "ko": 0},
+                "percentiles1": {"total": 13, "ok": 13, "ko": 0},
+                "percentiles2": {"total": 17, "ok": 17, "ko": 0},
+                "percentiles3": {"total": 20, "ok": 20, "ko": 0},
+                "percentiles4": {"total": 21, "ok": 21, "ko": 0},
+                "group1": {"name": "t < 800 ms", "count": 10, "percentage": 100},
+                "group2": {"name": "800 ms <= t < 1200 ms", "count": 0, "percentage": 0},
+                "group3": {"name": "t >= 1200 ms", "count": 0, "percentage": 0},
+                "group4": {"name": "failed", "count": 0, "percentage": 0},
+                "meanNumberOfRequestsPerSecond": {"total": 2.0, "ok": 2.0, "ko": 0},
+            },
+        },
+    },
+}
+
+
+def write_report_dir(base_dir: Path) -> Path:
+  report_dir = base_dir / "searchloadsimulation-20260423173955267"
+  js_dir = report_dir / "js"
+  js_dir.mkdir(parents=True)
+  (js_dir / "global_stats.json").write_text(json.dumps(SAMPLE_GLOBAL_STATS), encoding="utf-8")
+  (js_dir / "stats.json").write_text(json.dumps(SAMPLE_STATS_TREE), encoding="utf-8")
+  return report_dir
 
 
 class PerfMetricsExporterTest(unittest.TestCase):
-  def test_build_summary_extracts_timings_and_threshold_assertions(self):
-    summary = perf_metrics_exporter.build_summary(
-        simulation="SearchLoadSimulation",
-        output_text=SAMPLE_GATLING_OUTPUT,
-        metadata={
-            "repo": "vega113/supawave",
-            "branch": "main",
-            "sha": "abc123",
-            "workflow": "perf",
-            "run_id": "42",
-            "run_attempt": "1",
-        },
-        exit_code=0,
-    )
+  def test_build_summary_extracts_global_and_request_metrics_from_gatling_json(self):
+    with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
+      report_dir = write_report_dir(Path(tmpdir_str))
+
+      summary = perf_metrics_exporter.build_summary(
+          simulation="SearchLoadSimulation",
+          report_dir=report_dir,
+          metadata={
+              "repo": "vega113/supawave",
+              "branch": "main",
+              "sha": "abc123",
+              "workflow": "perf",
+              "run_id": "42",
+              "run_attempt": "1",
+          },
+          exit_code=0,
+      )
 
     self.assertEqual("SearchLoadSimulation", summary["simulation"])
-    self.assertEqual({"ok": 10, "ko": 0}, summary["requests"])
-    self.assertEqual({"mean": 12, "max": 20, "p95": 18, "p99": 20}, summary["timings_ms"])
+    self.assertEqual({"ok": 12, "ko": 0}, summary["requests"])
+    self.assertEqual(
+        {
+            "min": 6,
+            "max": 21,
+            "mean": 13,
+            "std_dev": 4,
+            "p50": 13,
+            "p75": 17,
+            "p95": 20,
+            "p99": 21,
+        },
+        summary["timings_ms"],
+    )
     self.assertAlmostEqual(1.0, summary["success_ratio"])
+    self.assertEqual(100.0, summary["successful_requests_pct"])
+    self.assertEqual(12, summary["distribution"]["lt_800ms"]["count"])
     self.assertEqual(
         {
             "p95_lt_2000ms": True,
@@ -51,50 +189,111 @@ class PerfMetricsExporterTest(unittest.TestCase):
         summary["assertions"],
     )
 
-  def test_render_metrics_includes_summary_series(self):
-    summary = perf_metrics_exporter.build_summary(
-        simulation="SearchLoadSimulation",
-        output_text=SAMPLE_GATLING_OUTPUT,
-        metadata={
-            "repo": "vega113/supawave",
-            "branch": "main",
-            "sha": "abc123",
-            "workflow": "perf",
-            "run_id": "42",
-            "run_attempt": "1",
+    request_metrics = {entry["request_name"]: entry for entry in summary["request_metrics"]}
+    self.assertEqual({"Register user", "Search inbox"}, set(request_metrics))
+    self.assertEqual({"ok": 10, "ko": 0}, request_metrics["Search inbox"]["requests"])
+    self.assertEqual(20, request_metrics["Search inbox"]["timings_ms"]["p95"])
+    self.assertEqual(2.0, request_metrics["Search inbox"]["mean_requests_per_second"])
+
+  def test_build_summary_does_not_require_console_successful_requests_line(self):
+    with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
+      report_dir = write_report_dir(Path(tmpdir_str))
+
+      summary = perf_metrics_exporter.build_summary(
+          simulation="SearchLoadSimulation",
+          report_dir=report_dir,
+          metadata={},
+          exit_code=0,
+      )
+
+    self.assertEqual(1.0, summary["success_ratio"])
+    self.assertEqual(100.0, summary["successful_requests_pct"])
+
+  def test_build_summary_collects_requests_nested_under_groups(self):
+    nested_tree = json.loads(json.dumps(SAMPLE_STATS_TREE))
+    search_inbox = nested_tree["contents"].pop("req_search-inbox")
+    nested_tree["contents"]["grp_search"] = {
+        "type": "GROUP",
+        "name": "Search group",
+        "path": "Search group",
+        "contents": {
+            "req_search-inbox": search_inbox,
         },
-        exit_code=0,
-    )
+    }
+
+    with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
+      report_dir = Path(tmpdir_str) / "searchloadsimulation-20260423173955267"
+      js_dir = report_dir / "js"
+      js_dir.mkdir(parents=True)
+      (js_dir / "global_stats.json").write_text(json.dumps(SAMPLE_GLOBAL_STATS), encoding="utf-8")
+      (js_dir / "stats.json").write_text(json.dumps(nested_tree), encoding="utf-8")
+
+      summary = perf_metrics_exporter.build_summary(
+          simulation="SearchLoadSimulation",
+          report_dir=report_dir,
+          metadata={},
+          exit_code=0,
+      )
+
+    request_names = {entry["request_name"] for entry in summary["request_metrics"]}
+    self.assertIn("Search inbox", request_names)
+
+  def test_render_metrics_includes_summary_request_and_distribution_series(self):
+    with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
+      report_dir = write_report_dir(Path(tmpdir_str))
+      summary = perf_metrics_exporter.build_summary(
+          simulation="SearchLoadSimulation",
+          report_dir=report_dir,
+          metadata={
+              "repo": "vega113/supawave",
+              "branch": "main",
+              "sha": "abc123",
+              "workflow": "perf",
+              "run_id": "42",
+              "run_attempt": "1",
+          },
+          exit_code=0,
+      )
 
     metrics = perf_metrics_exporter.render_metrics([summary])
 
     self.assertIn('wave_perf_run_info{repo="vega113/supawave"', metrics)
     self.assertIn(
-        'wave_perf_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",stat="p95"} 18',
+        'wave_perf_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",stat="p95"} 20',
         metrics,
     )
     self.assertIn(
-        'wave_perf_assertion_status{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",assertion="p95_lt_2000ms"} 1',
+        'wave_perf_distribution_count{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",bucket="lt_800ms"} 12',
+        metrics,
+    )
+    self.assertIn(
+        'wave_perf_request_response_time_ms{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",stat="p95"} 20',
+        metrics,
+    )
+    self.assertIn(
+        'wave_perf_request_requests_count{repo="vega113/supawave",branch="main",sha="abc123",workflow="perf",run_id="42",run_attempt="1",simulation="SearchLoadSimulation",request_name="Search inbox",status="ok"} 10',
         metrics,
     )
 
   def test_build_metrics_response_reads_summary_files(self):
-    summary = perf_metrics_exporter.build_summary(
-        simulation="SearchLoadSimulation",
-        output_text=SAMPLE_GATLING_OUTPUT,
-        metadata={
-            "repo": "vega113/supawave",
-            "branch": "main",
-            "sha": "abc123",
-            "workflow": "perf",
-            "run_id": "42",
-            "run_attempt": "1",
-        },
-        exit_code=0,
-    )
+    with tempfile.TemporaryDirectory(prefix="perf-exporter-report-") as tmpdir_str:
+      report_dir = write_report_dir(Path(tmpdir_str))
+      summary = perf_metrics_exporter.build_summary(
+          simulation="SearchLoadSimulation",
+          report_dir=report_dir,
+          metadata={
+              "repo": "vega113/supawave",
+              "branch": "main",
+              "sha": "abc123",
+              "workflow": "perf",
+              "run_id": "42",
+              "run_attempt": "1",
+          },
+          exit_code=0,
+      )
 
-    with tempfile.TemporaryDirectory(prefix="perf-exporter-") as tmpdir_str:
-      results_dir = Path(tmpdir_str)
+      results_dir = Path(tmpdir_str) / "results"
+      results_dir.mkdir()
       (results_dir / "SearchLoadSimulation-summary.json").write_text(
           json.dumps(summary),
           encoding="utf-8",
@@ -104,6 +303,7 @@ class PerfMetricsExporterTest(unittest.TestCase):
 
     self.assertEqual("text/plain; version=0.0.4; charset=utf-8", content_type)
     self.assertIn("wave_perf_run_info", body)
+    self.assertIn("wave_perf_request_response_time_ms", body)
 
 
 if __name__ == "__main__":

--- a/scripts/wave-perf.sh
+++ b/scripts/wave-perf.sh
@@ -137,6 +137,8 @@ overall_exit=0
 for sim in SearchLoadSimulation WaveOpenSimulation FullJourneySimulation; do
   echo ""
   echo "[perf] Running $sim ..."
+  sim_slug="$(echo "$sim" | tr '[:upper:]' '[:lower:]')"
+  find target/gatling -maxdepth 1 -type d -name "${sim_slug}-*" -exec rm -rf {} + 2>/dev/null || true
 
   set +e
   WAVE_PERF_BASE_URL="$BASE_URL" \
@@ -147,27 +149,32 @@ for sim in SearchLoadSimulation WaveOpenSimulation FullJourneySimulation; do
 
   summary_file="$RESULTS_DIR/${sim}-summary.json"
   tmp_summary_file="${summary_file}.tmp"
+  report_dir="$(find target/gatling -maxdepth 1 -type d -name "${sim_slug}-*" 2>/dev/null | sort | tail -n 1 || true)"
   rm -f "$summary_file" "$tmp_summary_file"
-  set +e
-  python3 scripts/perf_metrics_exporter.py summarize \
-    --simulation "$sim" \
-    --output-file "$RESULTS_DIR/${sim}-output.txt" \
-    --summary-file "$tmp_summary_file" \
-    --exit-code "$sim_code" \
-    --repo "$PERF_REPO" \
-    --branch "$PERF_BRANCH" \
-    --sha "$PERF_SHA" \
-    --workflow "$PERF_WORKFLOW" \
-    --run-id "$PERF_RUN_ID" \
-    --run-attempt "$PERF_RUN_ATTEMPT"
-  summary_code=$?
-  set -e
-  if [[ "$summary_code" -ne 0 ]]; then
-    rm -f "$summary_file" "$tmp_summary_file"
-    echo "[perf] WARN: failed to generate summary file for $sim" >&2
+  if [[ -z "$report_dir" ]]; then
+    echo "[perf] WARN: failed to locate Gatling report directory for $sim" >&2
   else
-    mv "$tmp_summary_file" "$summary_file"
-    echo "[perf] Summary: $summary_file"
+    set +e
+    python3 scripts/perf_metrics_exporter.py summarize \
+      --simulation "$sim" \
+      --report-dir "$report_dir" \
+      --summary-file "$tmp_summary_file" \
+      --exit-code "$sim_code" \
+      --repo "$PERF_REPO" \
+      --branch "$PERF_BRANCH" \
+      --sha "$PERF_SHA" \
+      --workflow "$PERF_WORKFLOW" \
+      --run-id "$PERF_RUN_ID" \
+      --run-attempt "$PERF_RUN_ATTEMPT"
+    summary_code=$?
+    set -e
+    if [[ "$summary_code" -ne 0 ]]; then
+      rm -f "$summary_file" "$tmp_summary_file"
+      echo "[perf] WARN: failed to generate summary file for $sim" >&2
+    else
+      mv "$tmp_summary_file" "$summary_file"
+      echo "[perf] Summary: $summary_file"
+    fi
   fi
 
   if [[ "$sim_code" -ne 0 ]]; then

--- a/wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json
+++ b/wave/config/changelog.d/2026-04-23-perf-gatling-dashboard-repair.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-23-perf-gatling-dashboard-repair",
+  "version": "Issue #987",
+  "date": "2026-04-23",
+  "title": "Repair Grafana perf exports and expand Gatling run comparison",
+  "summary": "Perf workflow runs now summarize Gatling report JSON reliably, start Alloy with a valid scrape config, and publish richer run and request comparison data for the Grafana perf dashboard.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Repaired perf summary generation by reading Gatling report JSON artifacts instead of depending on brittle console output parsing",
+        "Fixed the generated Alloy scrape configuration so perf workflow runs can start remote-write and ship Wave, runner, and exporter metrics",
+        "Expanded the perf dashboard to compare runs by branch, sha, run ID, simulation, and request using richer Gatling metrics"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- repair perf summary generation by parsing Gatling report JSON instead of brittle console text
- fix the generated Alloy scrape config so the perf workflow can start remote-write cleanly
- expand the repo-owned Grafana perf dashboard for run and request comparison

## Test Plan
- `python3 -m unittest scripts.tests.test_perf_metrics_exporter scripts.tests.test_perf_alloy_config scripts.tests.test_perf_workflow_config scripts.tests.test_grafana_dashboard_upsert`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `python3 scripts/perf_metrics_exporter.py summarize --simulation SearchLoadSimulation --report-dir /tmp/perf-run-dMDi6c/supawave/supawave/wave/target/perf-results/gatling-reports/searchloadsimulation-20260423173955267 --summary-file /tmp/search-summary.json --exit-code 0 --repo vega113/supawave --branch main --sha baba77288c3f02ebec66a155892e1cbc7f2ac6c4 --workflow perf --run-id 24849525083 --run-attempt 1`

## Notes
- Live Grafana upsert could not be run from this workstation because `GRAFANA_URL`, `GRAFANA_DASHBOARD_API_TOKEN`, and `GRAFANA_PROMETHEUS_DATASOURCE_UID` are unset locally.
- This PR updates the repo-owned dashboard JSON plus the CI upsert path, so a credentialed perf run can publish the dashboard after merge.

Closes grafana/grafana#987


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Grafana perf dashboard expanded with run/request selectors, run comparison surfaces, latency-distribution panels, and faster auto-refresh.
  * Exposed richer request-level metrics: per-request response times, counts, throughput and distribution buckets.

* **Bug Fixes**
  * Perf summaries now read Gatling JSON reports (more reliable) and skip gracefully when reports are missing.
  * Scrape timeouts aligned with intervals; script orchestration hardened for missing/stale reports.

* **Documentation**
  * Added implementation plan and changelog entry.

* **Tests**
  * Updated dashboard, exporter, config and script tests to cover new metrics and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->