### PR TITLE
feat(j2cl): port StageOne read surface parity

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
+++ b/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
@@ -35,7 +35,7 @@ The current J2CL root shell and selected-wave view are still intentionally trans
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:18-105`
   is an imperative sidecar card that renders title/snippet/unread/content blocks; it is not a semantic StageOne-equivalent wave panel.
 
-That means `#966` must stay blocked on the two upstream parity seams the issue already names:
+At plan creation time, `#966` was blocked on the two upstream parity seams the issue already named:
 
 - `#964` for the shared Lit shell/chrome primitives that every later J2CL parity slice consumes.
 - `#965` for the server-first selected-wave HTML / shell-swap seam that `#966` must upgrade in place rather than bypass.
@@ -147,7 +147,7 @@ The dependency gate must verify whether the rebased `#965` read-surface path alr
 - `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
 - `wave/src/test/java/org/waveprotocol/box/server/util/WavePanelThreadFocusContractTest.java`
 
-### New files that are expected only after `#964` stabilizes the Lit shell conventions
+### New files that are expected once `#964` stabilizes the Lit shell conventions
 
 - a new J2CL read-surface package under `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/`
   for Lit-backed read components and semantic helpers
@@ -167,12 +167,12 @@ These package names and filenames are now created as part of the `#966` implemen
 - `#963` bootstrap JSON contract is merged.
 - `#931` selected-wave unread/read state is merged.
 
-### Still blocking `#966` implementation
+### Dependencies that originally blocked `#966` implementation
 
 - `#964` must land the shared Lit shell/chrome primitives and freeze the read-surface's surrounding shell/component conventions.
 - `#965` must land the server-first selected-wave HTML / shell-swap seam so `#966` upgrades server output instead of bypassing it.
 
-### Readiness rule
+### Readiness rule used before implementation
 
 `#966` becomes implementation-ready only when all of the following are true on the working branch:
 
@@ -183,7 +183,7 @@ These package names and filenames are now created as part of the `#966` implemen
 - the rebased read path makes the collapse-state persistence seam explicit: either existing supplement-backed state is consumable, or `#966` is narrowed to in-session collapse semantics and that deferral is recorded before implementation
 - browser and Jakarta tests already covering the root shell continue to pass after rebasing onto those merges
 
-As of `2026-04-23`, this lane was **plan-ready but not implementation-ready**. The implementation has since been completed and submitted in PR `#991`.
+As of `2026-04-23`, this lane was **plan-ready but not implementation-ready**. The implementation has since been completed and submitted in PR `#991`, rebases onto `#964` / `#965`, keeps transport unchanged, and upgrades the selected-wave server HTML in place.
 
 ## 6. Task Breakdown
 

--- a/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
+++ b/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
@@ -40,7 +40,7 @@ That means `#966` must stay blocked on the two upstream parity seams the issue a
 - `#964` for the shared Lit shell/chrome primitives that every later J2CL parity slice consumes.
 - `#965` for the server-first selected-wave HTML / shell-swap seam that `#966` must upgrade in place rather than bypass.
 
-This planning lane is therefore **prep only**. It defines the implementation route and readiness criteria, but it does not authorize code that depends on `#964` / `#965` landing first.
+This planning lane was initially **prep only**. The dependency gates on `#964` / `#965` have since been satisfied and the implementation has landed in this PR (`#991`).
 
 ## 2. Claimed Parity Scope
 
@@ -156,7 +156,7 @@ The dependency gate must verify whether the rebased `#965` read-surface path alr
   - new J2CL tests under `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/`
     for semantic DOM/provider, focus, collapse, thread navigation, and root-shell upgrade behavior
 
-Do **not** create those package names or filenames in a speculative prep-only change before `#964` lands; the exact boundary should follow the shell/component conventions that PR establishes.
+These package names and filenames are now created as part of the `#966` implementation in PR `#991`, after `#964` landed and established the shell/component conventions.
 
 ## 5. Dependency Gate And Readiness
 
@@ -183,7 +183,7 @@ Do **not** create those package names or filenames in a speculative prep-only ch
 - the rebased read path makes the collapse-state persistence seam explicit: either existing supplement-backed state is consumable, or `#966` is narrowed to in-session collapse semantics and that deferral is recorded before implementation
 - browser and Jakarta tests already covering the root shell continue to pass after rebasing onto those merges
 
-As of `2026-04-23`, this lane is **plan-ready but not implementation-ready**.
+As of `2026-04-23`, this lane was **plan-ready but not implementation-ready**. The implementation has since been completed and submitted in PR `#991`.
 
 ## 6. Task Breakdown
 

--- a/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
+++ b/docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md
@@ -1,0 +1,321 @@
+# Issue #966 StageOne Read-Surface Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not start Tasks 2-8 until the dependency gate in Task 1 passes.
+
+**Goal:** Port the practical StageOne read surface to the J2CL/Lit root-shell path for daily open-wave reading, matching GWT behavior for render, focus framing, collapse, thread navigation, and semantic DOM querying without widening into editor/write parity or default-root cutover.
+
+**Architecture:** Reuse the current post-`#931`/`#963` selected-wave transport, reconnect, and per-user read-state path as the live data source, but replace the current imperative selected-wave card with a Lit-backed read surface once `#964` lands the shared shell/chrome primitives and `#965` lands the server-first read-shell / shell-swap seam. Treat GWT StageOne as the behavioral source of truth by porting its semantic DOM/provider, focus, collapse, and thread-navigation contracts in thin layers instead of redesigning those behaviors from screenshots or server HTML alone.
+
+**Tech Stack:** Java, existing GWT StageOne wave-panel stack, Jakarta server renderers, J2CL/Elemental2, Lit (after `#964`), post-`#931` selected-wave transport/read-state, parity docs `#961` / `#962` / `#963`.
+
+---
+
+## 1. Problem Framing And Dependency Boundary
+
+Issue `#966` exists because the current J2CL root path can already:
+
+- boot through the explicit bootstrap JSON contract from `#963`,
+- mount the search/read/write workflow inside the root shell,
+- open a live selected wave and keep unread/read state fresh via `#931`,
+
+but it still does **not** expose the StageOne read-surface behavior that the legacy GWT wave panel provides for daily reading:
+
+- open-wave rendering as a semantic blip/thread tree,
+- focus framing across blips,
+- collapse / expand of inline threads with persisted state,
+- deep-thread navigation,
+- a DOM-as-view seam that the rest of the read UX can reason about.
+
+The current J2CL root shell and selected-wave view are still intentionally transitional:
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3215-3405`
+  renders a server-owned root shell page with a generic workflow mount host, not the final Lit read surface.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-40`
+  creates a runtime wrapper that mounts the existing workflow, but it does not define reusable Lit shell primitives or read-surface components.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:18-105`
+  is an imperative sidecar card that renders title/snippet/unread/content blocks; it is not a semantic StageOne-equivalent wave panel.
+
+That means `#966` must stay blocked on the two upstream parity seams the issue already names:
+
+- `#964` for the shared Lit shell/chrome primitives that every later J2CL parity slice consumes.
+- `#965` for the server-first selected-wave HTML / shell-swap seam that `#966` must upgrade in place rather than bypass.
+
+This planning lane is therefore **prep only**. It defines the implementation route and readiness criteria, but it does not authorize code that depends on `#964` / `#965` landing first.
+
+## 2. Claimed Parity Scope
+
+### Matrix rows claimed
+
+- `R-3.1` Open-wave rendering
+- `R-3.2` Focus framing
+- `R-3.3` Collapse
+- `R-3.4` Thread navigation
+- `R-3.6` DOM-as-view provider
+
+### Matrix row explicitly deferred
+
+- `R-3.5` Visible-region container model stays with `#967`; `#966` may not quietly widen into fragment-window loading or clamp/extend transport.
+
+### Acceptance focus
+
+- practical read-surface parity for the daily open-wave experience
+- preserve current J2CL route / coexistence / rollback behavior
+- keep editor / compose / write parity out of scope
+
+### Explicit non-goals
+
+- no editor parity, compose-toolbar parity, or write-path redesign
+- no auth / socket / bootstrap changes (`#933` / `#963` already own those seams)
+- no default-root cutover; `/` remains GWT until later parity gates are met
+- no feature-flag or rollout-policy redesign beyond whatever `#964` / `#965` establish
+- no speculative Lit component tree before `#964` freezes the shared shell/component conventions
+
+## 3. Source Seams To Port From
+
+### GWT behavioral source of truth
+
+- `wave/src/main/java/org/waveprotocol/wave/client/StageOne.java:51-196`
+  wires the StageOne bundle: wave panel, focus frame, collapse presenter, thread navigator, and DOM-as-view provider.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/focus/FocusFramePresenter.java:99-179`
+  owns focus-frame movement, scroll-into-view behavior, and focus-change callbacks.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/collapse/CollapsePresenter.java:49-166`
+  owns persisted collapse state, toggle behavior, and the bridge into thread navigation.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/collapse/ThreadNavigationPresenter.java:76-237`
+  owns deep-thread navigation thresholds, stack state, breadcrumbs, unread-aware thread state, and history integration.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/FullStructure.java:94-120,343-385,658-865`
+  is the semantic DOM/view-provider seam that adapts DOM elements back into blip/thread/anchor/conversation views.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/FullDomRenderer.java:246-263`
+  restores persisted inline-thread collapse state while rendering the conversation tree.
+
+### Current J2CL client seams to consume, not replace blindly
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:19-520`
+  already owns bootstrap, selected-wave subscription, reconnect handling, per-update read-state fetches, and the visibility refresh path.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  already owns selected-wave model projection and should remain the narrow data-to-view adapter unless `#964` introduces a better shell-owned composition seam.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  already carries unread/read-state, reconnect, and write-session state.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java:15-67`
+  mounts the current workflow into the root shell and is the existing integration seam for `view=j2cl-root`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-60`
+  currently syncs return-target and auth-link chrome; `#964` must decide how much of this stays imperative vs Lit-owned.
+
+### Current payload-shape constraints to verify before implementation
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java`
+  currently carries only `participantIds`, `documents`, and `fragments`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java`
+  exposes `documentId`, author, modification metadata, and flat text content.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragment.java`
+  exposes only `segment`, `rawSnapshot`, and diff counters.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragments.java`
+  exposes ranges and fragment entries, but not an explicit thread-parent / anchor graph.
+
+The dependency gate must verify whether the rebased `#965` read-surface path already supplies enough structural identity to build a semantic blip/thread tree without widening transport. If it does not, `#966` must stop and either:
+
+- consume the structure entirely from server HTML supplied by `#965`, or
+- split the missing structure work into an explicit follow-up instead of smuggling a transport redesign into this slice.
+
+### Server-first seams that `#965` must provide for `#966`
+
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java:41-161`
+  already builds a `WaveViewData` and renders a server HTML snapshot, but it currently targets the "most recent wave" prerender path, not the selected-wave shell contract `#966` needs.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java:71-215`
+  can already render conversations, blips, threads, participants, and reply structure as server HTML.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3215-3405`
+  already owns the root-shell HTML, mount host, legacy bootstrap globals, and client mount bootstrap; `#965` must define the selected-wave server HTML insertion and upgrade contract inside this shell.
+
+## 4. Likely Files And Ownership
+
+### Existing files that should stay the main integration seam
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WavePreRenderer.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java`
+
+### Existing tests to extend
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/util/WavePanelThreadFocusContractTest.java`
+
+### New files that are expected only after `#964` stabilizes the Lit shell conventions
+
+- a new J2CL read-surface package under `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/`
+  for Lit-backed read components and semantic helpers
+- either:
+  - co-located behavioral coverage in `J2clSelectedWaveControllerTest` / `J2clSelectedWaveProjectorTest`, or
+  - new J2CL tests under `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/`
+    for semantic DOM/provider, focus, collapse, thread navigation, and root-shell upgrade behavior
+
+Do **not** create those package names or filenames in a speculative prep-only change before `#964` lands; the exact boundary should follow the shell/component conventions that PR establishes.
+
+## 5. Dependency Gate And Readiness
+
+### Already ready on `origin/main`
+
+- `#961` parity matrix is merged.
+- `#962` Lit design packet is merged.
+- `#963` bootstrap JSON contract is merged.
+- `#931` selected-wave unread/read state is merged.
+
+### Still blocking `#966` implementation
+
+- `#964` must land the shared Lit shell/chrome primitives and freeze the read-surface's surrounding shell/component conventions.
+- `#965` must land the server-first selected-wave HTML / shell-swap seam so `#966` upgrades server output instead of bypassing it.
+
+### Readiness rule
+
+`#966` becomes implementation-ready only when all of the following are true on the working branch:
+
+- the branch includes merged `#964` code, not just the design packet from `#962`
+- the branch includes merged `#965` code, not just a reviewed prep plan
+- the root shell exposes a stable mount / upgrade host for the read surface
+- the rebased `#965` server HTML exposes enough stable IDs / semantics for a DOM-as-view provider, or the team explicitly records the alternative client-upgrade strategy before coding
+- the rebased read path makes the collapse-state persistence seam explicit: either existing supplement-backed state is consumable, or `#966` is narrowed to in-session collapse semantics and that deferral is recorded before implementation
+- browser and Jakarta tests already covering the root shell continue to pass after rebasing onto those merges
+
+As of `2026-04-23`, this lane is **plan-ready but not implementation-ready**.
+
+## 6. Task Breakdown
+
+### Task 1: Pass The Dependency Gate
+
+- [ ] Wait until `#964` merges to `main`, then rebase this worktree and confirm the actual Lit shell/chrome files and exported component seams.
+- [ ] Wait until `#965` implementation merges to `main`, then rebase again and confirm the actual server-first selected-wave HTML / shell-swap host inside the root shell.
+- [ ] Audit the rebased selected-wave payload shape (`documents`, `fragments`, IDs, anchors, parentage) and record whether it is sufficient to build a semantic tree without widening transport.
+- [ ] Audit read-state granularity before promising unread-aware thread navigation parity:
+  - confirm whether the post-`#931` read-state seam is only wave-level aggregate unread state or whether rebased inputs expose per-blip / per-thread unread state,
+  - if it is aggregate-only, record whether `#966` narrows `R-3.4` unread-awareness to the currently available granularity or blocks on a follow-up seam first.
+- [ ] Make one written implementation decision in the issue comment before coding:
+  - preferred path: adapt `#965` server HTML directly as the upgraded DOM-as-view source, then patch that DOM in place from live updates, or
+  - fallback path: use `#965` server HTML only for first paint, then replace it once with an isomorphic client-owned DOM that the provider adapts after upgrade.
+- [ ] Record in the same decision whether the Lit read surface hydrates existing server nodes in place or performs a single controlled client-side swap after first paint; Task 7 verification must assert that exact mode.
+- [ ] Make one written collapse-state decision in the same issue comment before coding:
+  - use an already-available supplement / submit seam for persisted collapse state, or
+  - narrow `#966` to in-session collapse semantics and explicitly defer cross-session persistence.
+- [ ] Add an issue comment before any code implementation summarizing the exact merged commits or PR numbers from `#964` / `#965`, the chosen DOM/provider strategy, the collapse-state decision, and whether transport remains unchanged.
+- [ ] Do not start Tasks 2-8 until this gate is complete.
+
+### Task 2: Freeze The J2CL Read-Surface Composition Boundary
+
+- [ ] Keep `J2clSelectedWaveController`, `J2clSelectedWaveModel`, and `J2clSelectedWaveProjector` as the authoritative transport / projection seam unless the merged `#964` shell introduces a clearly better boundary.
+- [ ] Replace the current imperative `J2clSelectedWaveView` card with a dedicated Lit-backed read surface that mounts inside the root-shell workflow host without changing route, transport, or compose ownership.
+- [ ] Keep the write/compose host integration intact so the read surface does not regress the post-`#931` write-session coupling.
+- [ ] Preserve the existing route contract: `/?view=j2cl-root&wave=<waveId>` remains the explicit J2CL route; `/` stays on GWT.
+
+### Task 3: Port Open-Wave Rendering And Semantic DOM
+
+- [ ] Replace the current flat `pre`-block rendering with a semantic blip/thread tree only after Task 1 proves whether the structure comes from rebased payload data, rebased server HTML, or the agreed first-paint-upgrade handoff.
+- [ ] Introduce only the semantic DOM/provider queries this slice needs for `FocusFramePresenter`, `CollapsePresenter`, and `ThreadNavigationPresenter`; explicitly defer unrelated `FullStructure` surface area (menus, tags, participants, other StageTwo features) unless a merged dependency already requires them.
+- [ ] Preserve stable DOM identity per blip/thread so incremental updates, focus, and collapse state survive rerenders.
+- [ ] Keep the current server/client data seam narrow: no auth changes and no new socket message types unless Task 1 explicitly proves the rebased inputs are insufficient and the lane is re-scoped first.
+
+### Task 4: Port Focus Framing
+
+- [ ] Mirror `FocusFramePresenter` behavior for focus movement, scroll-into-view, and active-blip changes.
+- [ ] Preserve the keyboard contract called out by the parity matrix and GWT StageOne:
+  - arrow-key movement between blips,
+  - `j` / `k`-style movement where it exists today,
+  - `shift+tab` / reverse traversal behavior where it exists today,
+  - no focus theft during rerender, collapse, expand, or server-first upgrade.
+- [ ] Ensure focus survives incremental render and collapse / expand transitions.
+- [ ] Extend test coverage so the new focus seam proves ordering and preservation behavior instead of relying on manual inspection only.
+
+### Task 5: Port Collapse / Expand Behavior
+
+- [ ] Reproduce inline-thread collapse / expand behavior with the exact persistence contract chosen in Task 1:
+  - if an existing supplement-backed seam is available, match `CollapsePresenter` + `FullDomRenderer`, or
+  - if not, keep `#966` to in-session collapse semantics and document the persistence follow-up explicitly.
+- [ ] Preserve scroll anchor and focused-thread behavior across collapse / expand.
+- [ ] Reuse the existing read-state transport from `#931`; do not reinvent unread state inside the view layer.
+- [ ] Keep keyboard toggle semantics (`space` / `enter`) and visible collapsed / expanded state exposed to assistive technology.
+
+### Task 6: Port Thread Navigation
+
+- [ ] Port the deep-thread navigation behavior from `ThreadNavigationPresenter`, including stack depth behavior and unread-aware navigation expectations from parity row `R-3.4`.
+- [ ] Keep navigation and collapse coordinated so entering a deep thread never silently loses focus or un-hides the wrong siblings.
+- [ ] Preserve browser-history / route expectations only if the merged `#964` / `#965` shell still needs them; otherwise keep the same user-facing behavior without widening the routing surface.
+- [ ] Extend the existing thread-focus contract tests or add targeted J2CL equivalents for the migrated logic.
+
+### Task 7: Integrate With The `#965` Server-First Upgrade Path
+
+- [ ] Consume the server-rendered selected-wave HTML contract from `#965` according to the DOM/provider strategy chosen in Task 1; do not leave that decision to implementation-time guesswork.
+- [ ] Upgrade the read surface in place with no duplicate-root flash and no route / chrome reset.
+- [ ] Preserve rollback safety: the explicit J2CL route can be disabled or backed out without breaking the legacy GWT root.
+- [ ] Keep legacy bootstrap globals and current root-shell auth / return-target behavior intact unless the upstream dependencies deliberately replace them.
+
+### Task 8: Verification, Issue Traceability, And PR Prep
+
+- [ ] Record the dependency-ready rebase point in issue `#966` before implementation starts.
+- [ ] Run the targeted J2CL tests for controller / projector / transport changes.
+- [ ] Run the dedicated read-surface behavior coverage chosen in Task 1:
+  - either expanded cases in `J2clSelectedWaveControllerTest` / `J2clSelectedWaveProjectorTest`, or
+  - the concrete `j2cl.read` test suite created after `#964` lands.
+- [ ] Re-run or extend `J2clSidecarComposeControllerTest` (or the replacement integration seam) so replacing `J2clSelectedWaveView` cannot silently break compose-host mounting or write-session handoff.
+- [ ] Run the targeted root-shell Jakarta tests covering the root shell and return-target/auth-link behavior.
+- [ ] Add at least one automated upgrade invariant for Task 7 that proves the server-first read surface does not duplicate or tear down the root-shell mount unexpectedly during client upgrade.
+- [ ] Run a browser verification pass against `/?view=j2cl-root` with a real selected wave, covering render, focus, collapse, thread navigation, and upgrade behavior.
+- [ ] Record the exact local verification commands and outcomes in `journal/local-verification/<date>-issue-966-stageone-read-parity.md` and mirror the important results into the issue comment and PR body.
+
+## 7. Verification Matrix
+
+All commands run from `/Users/vega/devroot/worktrees/issue-966-stageone-read-parity` once Tasks 1-7 are complete.
+
+### Targeted automated verification
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+# If Task 1 created a dedicated read-surface suite instead of co-locating
+# coverage in the existing controller/projector tests, run it explicitly too.
+sbt -batch "testOnly org.waveprotocol.box.j2cl.read.*"
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.server.util.WavePanelThreadFocusContractTest"
+sbt -batch j2clSearchBuild j2clSearchTest
+sbt -batch compileGwt Universal/stage
+```
+
+Expected:
+
+- J2CL selected-wave controller/projector/codec tests stay green after the read-surface port
+- dedicated read-surface behavior tests cover focus, collapse, thread navigation, semantic DOM/provider queries, and root-shell upgrade invariants
+- compose-host / write-session tests prove the Lit read-surface swap did not break reply mounting
+- root-shell Jakarta coverage stays green and proves the route / auth / return-target shell still works
+- J2CL search build remains green
+- legacy GWT compile/stage remains green
+
+### Local runtime / browser verification
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+bash scripts/worktree-boot.sh --port 9926
+PORT=9926 bash scripts/wave-smoke.sh start
+PORT=9926 bash scripts/wave-smoke.sh check
+PORT=9926 bash scripts/wave-smoke.sh stop
+```
+
+Manual browser verification on `http://localhost:9926/?view=j2cl-root&wave=<known-wave-id>`:
+
+- selected wave upgrades from the server-first shell without a duplicate root
+- blips and inline replies render as a semantic thread tree, not a flat debug list
+- focus framing moves predictably and survives rerender
+- collapse / expand preserves anchor and does not lose focus
+- thread navigation reaches deep replies and preserves unread-aware ordering when unread state exists
+- compose still mounts into the selected-wave read surface after upgrade and accepts input without losing the current write session
+- legacy `/` still boots GWT unchanged
+
+## 8. Review / Rollback Notes
+
+- Keep `#966` behind the existing explicit J2CL route and whatever feature seam `#964` / `#965` establish; this slice does **not** authorize default-root cutover.
+- If the Lit read-surface port regresses root-shell upgrade, route state, or GWT coexistence, rollback is to disable the J2CL route/shell seam and fall back to the legacy GWT root plus the pre-`#966` J2CL read path.
+- Issue comments and the eventual PR must explicitly call out:
+  - which merged `#964` / `#965` commits this branch built on
+  - which GWT seams were ported vs intentionally deferred
+  - which verification commands proved parity and rollback safety

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -1,0 +1,19 @@
+package org.waveprotocol.box.j2cl.read;
+
+public final class J2clReadBlip {
+  private final String blipId;
+  private final String text;
+
+  public J2clReadBlip(String blipId, String text) {
+    this.blipId = blipId == null ? "" : blipId;
+    this.text = text == null ? "" : text;
+  }
+
+  public String getBlipId() {
+    return blipId;
+  }
+
+  public String getText() {
+    return text;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -388,9 +388,6 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private String currentFocusedBlipId() {
-    if (focusedBlip != null && focusedBlip.hasAttribute("data-blip-id")) {
-      return focusedBlip.getAttribute("data-blip-id");
-    }
     if (DomGlobal.document == null || !(DomGlobal.document.activeElement instanceof HTMLElement)) {
       return null;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -349,6 +349,7 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void ensureSingleTabStop() {
+    List<HTMLElement> visible = visibleBlips();
     HTMLElement tabStop = null;
     for (HTMLElement blip : renderedBlips) {
       if (!isHiddenByCollapsedThread(blip) && "0".equals(blip.getAttribute("tabindex"))) {
@@ -356,8 +357,8 @@ public final class J2clReadSurfaceDomRenderer {
         break;
       }
     }
-    if (tabStop == null && !visibleBlips().isEmpty()) {
-      tabStop = visibleBlips().get(0);
+    if (tabStop == null && !visible.isEmpty()) {
+      tabStop = visible.get(0);
     }
     for (HTMLElement blip : renderedBlips) {
       blip.setAttribute("tabindex", blip == tabStop ? "0" : "-1");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1,10 +1,12 @@
 package org.waveprotocol.box.j2cl.read;
 
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.KeyboardEvent;
+import elemental2.dom.NodeList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +46,19 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     host.appendChild(surface);
+    enhanceSurface(surface);
     return true;
+  }
+
+  public boolean enhanceExistingSurface() {
+    renderedBlips.clear();
+    focusedBlip = null;
+    HTMLElement surface = findExistingSurface();
+    if (surface == null) {
+      return false;
+    }
+    enhanceSurface(surface);
+    return !renderedBlips.isEmpty();
   }
 
   private HTMLElement renderBlip(J2clReadBlip blip, int index) {
@@ -54,8 +68,6 @@ public final class J2clReadSurfaceDomRenderer {
     article.setAttribute("data-blip-id", blip.getBlipId());
     article.setAttribute("role", "listitem");
     article.setAttribute("tabindex", index == 0 ? "0" : "-1");
-    article.addEventListener("focus", this::onBlipFocus);
-    article.addEventListener("keydown", this::onBlipKeyDown);
 
     HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
     meta.className = "blip-meta j2cl-read-blip-meta";
@@ -66,9 +78,90 @@ public final class J2clReadSurfaceDomRenderer {
     content.className = "blip-content j2cl-read-blip-content";
     content.textContent = blip.getText();
     article.appendChild(content);
-
-    renderedBlips.add(article);
     return article;
+  }
+
+  private HTMLElement findExistingSurface() {
+    HTMLElement surface = (HTMLElement) host.querySelector(".wave-content");
+    if (surface != null) {
+      return surface;
+    }
+    return (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+  }
+
+  private void enhanceSurface(HTMLElement surface) {
+    surface.classList.add("j2cl-read-surface");
+    surface.setAttribute("data-j2cl-read-surface", "true");
+    if (!surface.hasAttribute("aria-label")) {
+      surface.setAttribute("aria-label", "Selected wave read surface");
+    }
+    enhanceThreads(surface);
+    enhanceBlips(surface);
+  }
+
+  private void enhanceThreads(HTMLElement surface) {
+    NodeList<Element> threads = surface.querySelectorAll("[data-thread-id]");
+    for (int index = 0; index < threads.length; index++) {
+      HTMLElement thread = (HTMLElement) threads.item(index);
+      if (thread == null) {
+        continue;
+      }
+      thread.classList.add("j2cl-read-thread");
+      thread.setAttribute("role", "list");
+      if (thread.classList.contains("inline-thread")) {
+        enhanceInlineThread(thread, index);
+      }
+    }
+  }
+
+  private void enhanceInlineThread(HTMLElement thread, int index) {
+    if (thread.hasAttribute("data-j2cl-collapse-ready")) {
+      return;
+    }
+    thread.setAttribute("data-j2cl-collapse-ready", "true");
+    if (!thread.hasAttribute("id")) {
+      thread.setAttribute("id", "j2cl-read-thread-" + index);
+    }
+    HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
+    button.className = "j2cl-read-thread-toggle";
+    button.setAttribute("type", "button");
+    button.setAttribute("aria-controls", thread.getAttribute("id"));
+    button.setAttribute("aria-expanded", "true");
+    button.textContent = "Collapse thread";
+    button.addEventListener("click", event -> toggleThread(thread, button));
+    thread.insertBefore(button, thread.firstChild);
+  }
+
+  private void enhanceBlips(HTMLElement surface) {
+    NodeList<Element> blips = surface.querySelectorAll("[data-blip-id]");
+    for (int index = 0; index < blips.length; index++) {
+      HTMLElement blip = (HTMLElement) blips.item(index);
+      if (blip == null) {
+        continue;
+      }
+      blip.classList.add("j2cl-read-blip");
+      blip.setAttribute("data-j2cl-read-blip", "true");
+      blip.setAttribute("role", "listitem");
+      blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
+      blip.addEventListener("focus", this::onBlipFocus);
+      blip.addEventListener("keydown", this::onBlipKeyDown);
+      renderedBlips.add(blip);
+    }
+  }
+
+  private void toggleThread(HTMLElement thread, HTMLElement button) {
+    boolean collapsed = !thread.classList.contains("j2cl-read-thread-collapsed");
+    if (collapsed) {
+      thread.classList.add("j2cl-read-thread-collapsed");
+      thread.setAttribute("data-j2cl-thread-collapsed", "true");
+      button.setAttribute("aria-expanded", "false");
+      button.textContent = "Expand thread";
+    } else {
+      thread.classList.remove("j2cl-read-thread-collapsed");
+      thread.removeAttribute("data-j2cl-thread-collapsed");
+      button.setAttribute("aria-expanded", "true");
+      button.textContent = "Collapse thread";
+    }
   }
 
   private void onBlipFocus(Event event) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -98,20 +98,6 @@ public final class J2clReadSurfaceDomRenderer {
     }
   }
 
-  private void restoreFocusedBlipById(String blipId) {
-    if (blipId == null) {
-      ensureSingleTabStop();
-      return;
-    }
-    for (HTMLElement blip : renderedBlips) {
-      if (blipId.equals(blip.getAttribute("data-blip-id")) && !isHiddenByCollapsedThread(blip)) {
-        focusBlip(blip);
-        return;
-      }
-    }
-    ensureSingleTabStop();
-  }
-
   public boolean enhanceExistingSurface() {
     HTMLElement surface = findExistingSurface();
     if (surface == null) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -15,6 +15,7 @@ public final class J2clReadSurfaceDomRenderer {
   private final HTMLDivElement host;
   private final List<HTMLElement> renderedBlips = new ArrayList<HTMLElement>();
   private HTMLElement focusedBlip;
+  private int generatedThreadIdCounter;
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this.host = host;
@@ -58,6 +59,8 @@ public final class J2clReadSurfaceDomRenderer {
       return false;
     }
     enhanceSurface(surface);
+    // A zero-blip surface is still valid no-wave/empty markup, but callers use
+    // the boolean to know whether focusable read content was found.
     return !renderedBlips.isEmpty();
   }
 
@@ -120,7 +123,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
     thread.setAttribute("data-j2cl-collapse-ready", "true");
     if (!thread.hasAttribute("id")) {
-      thread.setAttribute("id", "j2cl-read-thread-" + index);
+      thread.setAttribute("id", generatedThreadId(thread, index));
     }
     HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
     button.className = "j2cl-read-thread-toggle";
@@ -142,8 +145,9 @@ public final class J2clReadSurfaceDomRenderer {
       blip.classList.add("j2cl-read-blip");
       blip.setAttribute("data-j2cl-read-blip", "true");
       blip.setAttribute("role", "listitem");
-      blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
-      if (!blip.hasAttribute("data-j2cl-read-blip-bound")) {
+      boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
+      if (!alreadyBound) {
+        blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
         blip.setAttribute("data-j2cl-read-blip-bound", "true");
         blip.addEventListener("focus", this::onBlipFocus);
         blip.addEventListener("keydown", this::onBlipKeyDown);
@@ -199,7 +203,8 @@ public final class J2clReadSurfaceDomRenderer {
     List<HTMLElement> visibleBlips = visibleBlips();
     int current = focusedBlip == null ? -1 : visibleBlips.indexOf(focusedBlip);
     if (current < 0) {
-      current = 0;
+      focusVisibleByIndex(offset > 0 ? 0 : visibleBlips.size() - 1);
+      return;
     }
     focusVisibleByIndex(current + offset);
   }
@@ -265,6 +270,31 @@ public final class J2clReadSurfaceDomRenderer {
       parent = (HTMLElement) parent.parentElement;
     }
     return false;
+  }
+
+  private String generatedThreadId(HTMLElement thread, int index) {
+    String threadId = thread.getAttribute("data-thread-id");
+    if (threadId == null || threadId.isEmpty()) {
+      threadId = "thread-" + index;
+    }
+    return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + (++generatedThreadIdCounter);
+  }
+
+  private static String sanitizeDomId(String value) {
+    StringBuilder sanitized = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if ((c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_') {
+        sanitized.append(c);
+      } else {
+        sanitized.append('-');
+      }
+    }
+    return sanitized.length() == 0 ? "thread" : sanitized.toString();
   }
 
   private static List<J2clReadBlip> normalizeBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -76,7 +76,8 @@ public final class J2clReadSurfaceDomRenderer {
 
     HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
     meta.className = "blip-meta j2cl-read-blip-meta";
-    meta.textContent = "Blip";
+    meta.textContent = blip.getBlipId().isEmpty() ? "Blip" : blip.getBlipId();
+    meta.setAttribute("aria-hidden", "true");
     article.appendChild(meta);
 
     HTMLElement content = (HTMLElement) DomGlobal.document.createElement("div");
@@ -102,6 +103,7 @@ public final class J2clReadSurfaceDomRenderer {
     if (!surface.hasAttribute("aria-label")) {
       surface.setAttribute("aria-label", "Selected wave read surface");
     }
+    surface.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
     enhanceThreads(surface);
     enhanceBlips(surface);
   }
@@ -116,6 +118,7 @@ public final class J2clReadSurfaceDomRenderer {
       thread.classList.add("j2cl-read-thread");
       if (thread.classList.contains("inline-thread")) {
         thread.setAttribute("role", "group");
+        thread.setAttribute("aria-label", threadLabel(thread));
         enhanceInlineThread(thread, index);
       } else {
         thread.setAttribute("role", "list");
@@ -136,6 +139,7 @@ public final class J2clReadSurfaceDomRenderer {
     button.setAttribute("type", "button");
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     button.setAttribute("aria-expanded", "true");
+    button.setAttribute("aria-label", "Collapse " + threadLabel(thread));
     button.textContent = "Collapse thread";
     button.addEventListener("click", event -> toggleThread(thread, button));
     thread.insertBefore(button, thread.firstChild);
@@ -152,7 +156,6 @@ public final class J2clReadSurfaceDomRenderer {
       blip.classList.add("j2cl-read-blip");
       blip.setAttribute("data-j2cl-read-blip", "true");
       blip.setAttribute("role", "listitem");
-      blip.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
       boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
       if (!alreadyBound) {
         boolean visible = !isHiddenByCollapsedThread(blip);
@@ -174,11 +177,13 @@ public final class J2clReadSurfaceDomRenderer {
       thread.classList.add("j2cl-read-thread-collapsed");
       thread.setAttribute("data-j2cl-thread-collapsed", "true");
       button.setAttribute("aria-expanded", "false");
+      button.setAttribute("aria-label", "Expand " + threadLabel(thread));
       button.textContent = "Expand thread";
     } else {
       thread.classList.remove("j2cl-read-thread-collapsed");
       thread.removeAttribute("data-j2cl-thread-collapsed");
       button.setAttribute("aria-expanded", "true");
+      button.setAttribute("aria-label", "Collapse " + threadLabel(thread));
       button.textContent = "Collapse thread";
     }
     if (collapsed && isHiddenByCollapsedThread(focusedBlip)) {
@@ -369,7 +374,16 @@ public final class J2clReadSurfaceDomRenderer {
       threadId = "thread-" + index;
     }
     generatedThreadIdCounter++;
+    // The counter preserves uniqueness even when sanitized thread ids collide.
     return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + generatedThreadIdCounter;
+  }
+
+  private static String threadLabel(HTMLElement thread) {
+    String threadId = thread.getAttribute("data-thread-id");
+    if (threadId == null || threadId.isEmpty()) {
+      return "inline reply thread";
+    }
+    return "inline reply thread " + threadId;
   }
 
   private static String sanitizeDomId(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1,0 +1,148 @@
+package org.waveprotocol.box.j2cl.read;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.KeyboardEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clReadSurfaceDomRenderer {
+  private final HTMLDivElement host;
+  private final List<HTMLElement> renderedBlips = new ArrayList<HTMLElement>();
+  private HTMLElement focusedBlip;
+
+  public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
+    this.host = host;
+  }
+
+  public boolean render(List<J2clReadBlip> blips, List<String> fallbackEntries) {
+    host.innerHTML = "";
+    renderedBlips.clear();
+    focusedBlip = null;
+
+    List<J2clReadBlip> effectiveBlips = normalizeBlips(blips, fallbackEntries);
+    if (effectiveBlips.isEmpty()) {
+      return false;
+    }
+
+    HTMLElement surface = (HTMLElement) DomGlobal.document.createElement("section");
+    surface.className = "j2cl-read-surface wave-content";
+    surface.setAttribute("data-j2cl-read-surface", "true");
+    surface.setAttribute("aria-label", "Selected wave read surface");
+
+    HTMLElement rootThread = (HTMLElement) DomGlobal.document.createElement("div");
+    rootThread.className = "thread j2cl-read-thread";
+    rootThread.setAttribute("data-thread-id", "root");
+    rootThread.setAttribute("role", "list");
+    surface.appendChild(rootThread);
+
+    for (int i = 0; i < effectiveBlips.size(); i++) {
+      rootThread.appendChild(renderBlip(effectiveBlips.get(i), i));
+    }
+
+    host.appendChild(surface);
+    return true;
+  }
+
+  private HTMLElement renderBlip(J2clReadBlip blip, int index) {
+    HTMLElement article = (HTMLElement) DomGlobal.document.createElement("article");
+    article.className = "blip j2cl-read-blip";
+    article.setAttribute("data-j2cl-read-blip", "true");
+    article.setAttribute("data-blip-id", blip.getBlipId());
+    article.setAttribute("role", "listitem");
+    article.setAttribute("tabindex", index == 0 ? "0" : "-1");
+    article.addEventListener("focus", this::onBlipFocus);
+    article.addEventListener("keydown", this::onBlipKeyDown);
+
+    HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
+    meta.className = "blip-meta j2cl-read-blip-meta";
+    meta.textContent = blip.getBlipId().isEmpty() ? "Blip" : blip.getBlipId();
+    article.appendChild(meta);
+
+    HTMLElement content = (HTMLElement) DomGlobal.document.createElement("div");
+    content.className = "blip-content j2cl-read-blip-content";
+    content.textContent = blip.getText();
+    article.appendChild(content);
+
+    renderedBlips.add(article);
+    return article;
+  }
+
+  private void onBlipFocus(Event event) {
+    if (event == null || event.currentTarget == null) {
+      return;
+    }
+    focusBlip((HTMLElement) event.currentTarget);
+  }
+
+  private void onBlipKeyDown(Event event) {
+    KeyboardEvent keyEvent = (KeyboardEvent) event;
+    String key = keyEvent.key;
+    if ("ArrowDown".equals(key) || "j".equals(key)) {
+      focusByOffset(1);
+      keyEvent.preventDefault();
+    } else if ("ArrowUp".equals(key) || "k".equals(key)) {
+      focusByOffset(-1);
+      keyEvent.preventDefault();
+    } else if ("Home".equals(key)) {
+      focusByIndex(0);
+      keyEvent.preventDefault();
+    } else if ("End".equals(key)) {
+      focusByIndex(renderedBlips.size() - 1);
+      keyEvent.preventDefault();
+    }
+  }
+
+  private void focusByOffset(int offset) {
+    int current = focusedBlip == null ? -1 : renderedBlips.indexOf(focusedBlip);
+    if (current < 0) {
+      current = 0;
+    }
+    focusByIndex(current + offset);
+  }
+
+  private void focusByIndex(int index) {
+    if (renderedBlips.isEmpty()) {
+      return;
+    }
+    int boundedIndex = Math.max(0, Math.min(index, renderedBlips.size() - 1));
+    HTMLElement next = renderedBlips.get(boundedIndex);
+    focusBlip(next);
+    next.focus();
+  }
+
+  private void focusBlip(HTMLElement next) {
+    if (focusedBlip == next) {
+      return;
+    }
+    if (focusedBlip != null) {
+      focusedBlip.classList.remove("j2cl-read-blip-focused");
+      focusedBlip.removeAttribute("aria-current");
+      focusedBlip.setAttribute("tabindex", "-1");
+    }
+    focusedBlip = next;
+    if (focusedBlip != null) {
+      focusedBlip.classList.add("j2cl-read-blip-focused");
+      focusedBlip.setAttribute("aria-current", "true");
+      focusedBlip.setAttribute("tabindex", "0");
+    }
+  }
+
+  private static List<J2clReadBlip> normalizeBlips(
+      List<J2clReadBlip> blips, List<String> fallbackEntries) {
+    if (blips != null && !blips.isEmpty()) {
+      return blips;
+    }
+    if (fallbackEntries == null || fallbackEntries.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clReadBlip> fallbackBlips = new ArrayList<J2clReadBlip>();
+    for (int i = 0; i < fallbackEntries.size(); i++) {
+      fallbackBlips.add(new J2clReadBlip("entry-" + (i + 1), fallbackEntries.get(i)));
+    }
+    return fallbackBlips;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -82,11 +82,11 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private HTMLElement findExistingSurface() {
-    HTMLElement surface = (HTMLElement) host.querySelector(".wave-content");
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
     if (surface != null) {
       return surface;
     }
-    return (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    return (HTMLElement) host.querySelector(".wave-content");
   }
 
   private void enhanceSurface(HTMLElement surface) {
@@ -143,8 +143,11 @@ public final class J2clReadSurfaceDomRenderer {
       blip.setAttribute("data-j2cl-read-blip", "true");
       blip.setAttribute("role", "listitem");
       blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
-      blip.addEventListener("focus", this::onBlipFocus);
-      blip.addEventListener("keydown", this::onBlipKeyDown);
+      if (!blip.hasAttribute("data-j2cl-read-blip-bound")) {
+        blip.setAttribute("data-j2cl-read-blip-bound", "true");
+        blip.addEventListener("focus", this::onBlipFocus);
+        blip.addEventListener("keydown", this::onBlipKeyDown);
+      }
       renderedBlips.add(blip);
     }
   }
@@ -161,6 +164,9 @@ public final class J2clReadSurfaceDomRenderer {
       thread.removeAttribute("data-j2cl-thread-collapsed");
       button.setAttribute("aria-expanded", "true");
       button.textContent = "Collapse thread";
+    }
+    if (isHiddenByCollapsedThread(focusedBlip)) {
+      focusVisibleByIndex(0);
     }
   }
 
@@ -190,38 +196,75 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void focusByOffset(int offset) {
-    int current = focusedBlip == null ? -1 : renderedBlips.indexOf(focusedBlip);
+    List<HTMLElement> visibleBlips = visibleBlips();
+    int current = focusedBlip == null ? -1 : visibleBlips.indexOf(focusedBlip);
     if (current < 0) {
       current = 0;
     }
-    focusByIndex(current + offset);
+    focusVisibleByIndex(current + offset);
   }
 
   private void focusByIndex(int index) {
-    if (renderedBlips.isEmpty()) {
+    focusVisibleByIndex(index);
+  }
+
+  private void focusVisibleByIndex(int index) {
+    List<HTMLElement> visibleBlips = visibleBlips();
+    if (visibleBlips.isEmpty()) {
       return;
     }
-    int boundedIndex = Math.max(0, Math.min(index, renderedBlips.size() - 1));
-    HTMLElement next = renderedBlips.get(boundedIndex);
+    int boundedIndex = Math.max(0, Math.min(index, visibleBlips.size() - 1));
+    HTMLElement next = visibleBlips.get(boundedIndex);
     focusBlip(next);
     next.focus();
   }
 
   private void focusBlip(HTMLElement next) {
+    if (next == null) {
+      clearFocusedBlip();
+      return;
+    }
     if (focusedBlip == next) {
       return;
     }
+    clearFocusedBlip();
+    focusedBlip = next;
+    focusedBlip.classList.add("j2cl-read-blip-focused");
+    focusedBlip.setAttribute("aria-current", "true");
+    focusedBlip.setAttribute("tabindex", "0");
+  }
+
+  private void clearFocusedBlip() {
     if (focusedBlip != null) {
       focusedBlip.classList.remove("j2cl-read-blip-focused");
       focusedBlip.removeAttribute("aria-current");
       focusedBlip.setAttribute("tabindex", "-1");
+      focusedBlip = null;
     }
-    focusedBlip = next;
-    if (focusedBlip != null) {
-      focusedBlip.classList.add("j2cl-read-blip-focused");
-      focusedBlip.setAttribute("aria-current", "true");
-      focusedBlip.setAttribute("tabindex", "0");
+  }
+
+  private List<HTMLElement> visibleBlips() {
+    List<HTMLElement> visible = new ArrayList<HTMLElement>();
+    for (HTMLElement blip : renderedBlips) {
+      if (!isHiddenByCollapsedThread(blip)) {
+        visible.add(blip);
+      }
     }
+    return visible;
+  }
+
+  private boolean isHiddenByCollapsedThread(HTMLElement blip) {
+    if (blip == null) {
+      return false;
+    }
+    HTMLElement parent = (HTMLElement) blip.parentElement;
+    while (parent != null && parent != host) {
+      if (parent.classList.contains("j2cl-read-thread-collapsed")) {
+        return true;
+      }
+      parent = (HTMLElement) parent.parentElement;
+    }
+    return false;
   }
 
   private static List<J2clReadBlip> normalizeBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -52,6 +52,7 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   public boolean enhanceExistingSurface() {
+    HTMLElement previousFocusedBlip = focusedBlip;
     renderedBlips.clear();
     focusedBlip = null;
     HTMLElement surface = findExistingSurface();
@@ -59,6 +60,7 @@ public final class J2clReadSurfaceDomRenderer {
       return false;
     }
     enhanceSurface(surface);
+    restoreFocusedBlip(previousFocusedBlip);
     // A zero-blip surface is still valid no-wave/empty markup, but callers use
     // the boolean to know whether focusable read content was found.
     return !renderedBlips.isEmpty();
@@ -74,7 +76,7 @@ public final class J2clReadSurfaceDomRenderer {
 
     HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
     meta.className = "blip-meta j2cl-read-blip-meta";
-    meta.textContent = blip.getBlipId().isEmpty() ? "Blip" : blip.getBlipId();
+    meta.textContent = "Blip";
     article.appendChild(meta);
 
     HTMLElement content = (HTMLElement) DomGlobal.document.createElement("div");
@@ -89,6 +91,8 @@ public final class J2clReadSurfaceDomRenderer {
     if (surface != null) {
       return surface;
     }
+    // The server-selected card from WavePreRenderer uses the legacy
+    // `.wave-content` class before the J2CL client marks it as enhanced.
     return (HTMLElement) host.querySelector(".wave-content");
   }
 
@@ -145,6 +149,7 @@ public final class J2clReadSurfaceDomRenderer {
       blip.classList.add("j2cl-read-blip");
       blip.setAttribute("data-j2cl-read-blip", "true");
       blip.setAttribute("role", "listitem");
+      blip.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
       boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
       if (!alreadyBound) {
         blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
@@ -169,8 +174,8 @@ public final class J2clReadSurfaceDomRenderer {
       button.setAttribute("aria-expanded", "true");
       button.textContent = "Collapse thread";
     }
-    if (isHiddenByCollapsedThread(focusedBlip)) {
-      focusVisibleByIndex(0);
+    if (collapsed && isHiddenByCollapsedThread(focusedBlip)) {
+      focusNearestVisibleFrom(focusedBlip);
     }
   }
 
@@ -183,11 +188,14 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void onBlipKeyDown(Event event) {
     KeyboardEvent keyEvent = (KeyboardEvent) event;
+    if (event.currentTarget != null) {
+      focusBlip((HTMLElement) event.currentTarget);
+    }
     String key = keyEvent.key;
-    if ("ArrowDown".equals(key) || "j".equals(key)) {
+    if ("ArrowDown".equals(key)) {
       focusByOffset(1);
       keyEvent.preventDefault();
-    } else if ("ArrowUp".equals(key) || "k".equals(key)) {
+    } else if ("ArrowUp".equals(key)) {
       focusByOffset(-1);
       keyEvent.preventDefault();
     } else if ("Home".equals(key)) {
@@ -240,12 +248,12 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void clearFocusedBlip() {
-    if (focusedBlip != null) {
-      focusedBlip.classList.remove("j2cl-read-blip-focused");
-      focusedBlip.removeAttribute("aria-current");
-      focusedBlip.setAttribute("tabindex", "-1");
-      focusedBlip = null;
+    for (HTMLElement blip : renderedBlips) {
+      blip.classList.remove("j2cl-read-blip-focused");
+      blip.removeAttribute("aria-current");
+      blip.setAttribute("tabindex", "-1");
     }
+    focusedBlip = null;
   }
 
   private List<HTMLElement> visibleBlips() {
@@ -270,6 +278,82 @@ public final class J2clReadSurfaceDomRenderer {
       parent = (HTMLElement) parent.parentElement;
     }
     return false;
+  }
+
+  private void restoreFocusedBlip(HTMLElement previousFocusedBlip) {
+    HTMLElement restored = visibleRenderedBlip(previousFocusedBlip);
+    if (restored == null) {
+      restored = visibleRenderedBlip((HTMLElement) DomGlobal.document.activeElement);
+    }
+    if (restored == null) {
+      restored = firstVisibleFocusedMarker();
+    }
+    if (restored != null) {
+      focusBlip(restored);
+    } else {
+      ensureSingleTabStop();
+    }
+  }
+
+  private HTMLElement visibleRenderedBlip(HTMLElement blip) {
+    if (blip != null && renderedBlips.contains(blip) && !isHiddenByCollapsedThread(blip)) {
+      return blip;
+    }
+    return null;
+  }
+
+  private HTMLElement firstVisibleFocusedMarker() {
+    for (HTMLElement blip : renderedBlips) {
+      if (!isHiddenByCollapsedThread(blip)
+          && (blip.classList.contains("j2cl-read-blip-focused")
+              || "true".equals(blip.getAttribute("aria-current")))) {
+        return blip;
+      }
+    }
+    return null;
+  }
+
+  private void ensureSingleTabStop() {
+    HTMLElement tabStop = null;
+    for (HTMLElement blip : renderedBlips) {
+      if (!isHiddenByCollapsedThread(blip) && "0".equals(blip.getAttribute("tabindex"))) {
+        tabStop = blip;
+        break;
+      }
+    }
+    if (tabStop == null && !visibleBlips().isEmpty()) {
+      tabStop = visibleBlips().get(0);
+    }
+    for (HTMLElement blip : renderedBlips) {
+      blip.setAttribute("tabindex", blip == tabStop ? "0" : "-1");
+      blip.classList.remove("j2cl-read-blip-focused");
+      blip.removeAttribute("aria-current");
+    }
+  }
+
+  private void focusNearestVisibleFrom(HTMLElement origin) {
+    int originIndex = renderedBlips.indexOf(origin);
+    if (originIndex < 0) {
+      focusVisibleByIndex(0);
+      return;
+    }
+    for (int index = originIndex + 1; index < renderedBlips.size(); index++) {
+      HTMLElement candidate = renderedBlips.get(index);
+      if (!isHiddenByCollapsedThread(candidate)) {
+        focusBlip(candidate);
+        candidate.focus();
+        return;
+      }
+    }
+    for (int index = originIndex - 1; index >= 0; index--) {
+      HTMLElement candidate = renderedBlips.get(index);
+      if (!isHiddenByCollapsedThread(candidate)) {
+        focusBlip(candidate);
+        candidate.focus();
+        return;
+      }
+    }
+    focusBlip(null);
   }
 
   private String generatedThreadId(HTMLElement thread, int index) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -22,14 +22,23 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   public boolean render(List<J2clReadBlip> blips, List<String> fallbackEntries) {
+    List<J2clReadBlip> effectiveBlips = normalizeBlips(blips, fallbackEntries);
+    if (effectiveBlips.isEmpty()) {
+      host.innerHTML = "";
+      renderedBlips.clear();
+      focusedBlip = null;
+      return false;
+    }
+
+    String focusedBlipId = currentFocusedBlipId();
+    if (matchesRenderedBlips(effectiveBlips)) {
+      restoreFocusedBlipById(focusedBlipId);
+      return true;
+    }
+
     host.innerHTML = "";
     renderedBlips.clear();
     focusedBlip = null;
-
-    List<J2clReadBlip> effectiveBlips = normalizeBlips(blips, fallbackEntries);
-    if (effectiveBlips.isEmpty()) {
-      return false;
-    }
 
     HTMLElement surface = (HTMLElement) DomGlobal.document.createElement("section");
     surface.className = "j2cl-read-surface wave-content";
@@ -48,6 +57,7 @@ public final class J2clReadSurfaceDomRenderer {
 
     host.appendChild(surface);
     enhanceSurface(surface);
+    restoreFocusedBlipById(focusedBlipId);
     return true;
   }
 
@@ -328,6 +338,66 @@ public final class J2clReadSurfaceDomRenderer {
     } else {
       ensureSingleTabStop();
     }
+  }
+
+  private void restoreFocusedBlipById(String blipId) {
+    HTMLElement restored = visibleRenderedBlip(renderedBlipById(blipId));
+    if (restored != null) {
+      focusBlip(restored);
+      restored.focus();
+      return;
+    }
+    restoreFocusedBlip(null);
+  }
+
+  private String currentFocusedBlipId() {
+    if (focusedBlip != null && focusedBlip.hasAttribute("data-blip-id")) {
+      return focusedBlip.getAttribute("data-blip-id");
+    }
+    if (DomGlobal.document == null || !(DomGlobal.document.activeElement instanceof HTMLElement)) {
+      return null;
+    }
+    HTMLElement active = (HTMLElement) DomGlobal.document.activeElement;
+    HTMLElement rendered = visibleRenderedBlip(active);
+    return rendered == null ? null : rendered.getAttribute("data-blip-id");
+  }
+
+  private boolean matchesRenderedBlips(List<J2clReadBlip> blips) {
+    if (renderedBlips.size() != blips.size()) {
+      return false;
+    }
+    for (int i = 0; i < blips.size(); i++) {
+      J2clReadBlip expected = blips.get(i);
+      HTMLElement actual = renderedBlips.get(i);
+      if (!expected.getBlipId().equals(actual.getAttribute("data-blip-id"))) {
+        return false;
+      }
+      if (!expected.getText().equals(renderedBlipText(actual))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private HTMLElement renderedBlipById(String blipId) {
+    if (blipId == null || blipId.isEmpty()) {
+      return null;
+    }
+    for (HTMLElement blip : renderedBlips) {
+      if (blipId.equals(blip.getAttribute("data-blip-id"))) {
+        return blip;
+      }
+    }
+    return null;
+  }
+
+  private static String renderedBlipText(HTMLElement blip) {
+    if (blip == null) {
+      return "";
+    }
+    HTMLElement content =
+        (HTMLElement) blip.querySelector(".j2cl-read-blip-content, .blip-content");
+    return content == null || content.textContent == null ? "" : content.textContent;
   }
 
   private HTMLElement visibleRenderedBlip(HTMLElement blip) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -76,7 +76,7 @@ public final class J2clReadSurfaceDomRenderer {
 
     HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
     meta.className = "blip-meta j2cl-read-blip-meta";
-    meta.textContent = blip.getBlipId().isEmpty() ? "Blip" : blip.getBlipId();
+    meta.textContent = blipLabel(blip.getBlipId());
     meta.setAttribute("aria-hidden", "true");
     article.appendChild(meta);
 
@@ -103,7 +103,6 @@ public final class J2clReadSurfaceDomRenderer {
     if (!surface.hasAttribute("aria-label")) {
       surface.setAttribute("aria-label", "Selected wave read surface");
     }
-    surface.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
     enhanceThreads(surface);
     enhanceBlips(surface);
   }
@@ -156,6 +155,7 @@ public final class J2clReadSurfaceDomRenderer {
       blip.classList.add("j2cl-read-blip");
       blip.setAttribute("data-j2cl-read-blip", "true");
       blip.setAttribute("role", "listitem");
+      blip.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
       boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
       if (!alreadyBound) {
         boolean visible = !isHiddenByCollapsedThread(blip);
@@ -374,7 +374,8 @@ public final class J2clReadSurfaceDomRenderer {
       threadId = "thread-" + index;
     }
     generatedThreadIdCounter++;
-    // The counter preserves uniqueness even when sanitized thread ids collide.
+    // Keep incrementing across the renderer lifetime so new controls remain
+    // unique even if sanitized thread ids collide or the DOM is re-rendered.
     return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + generatedThreadIdCounter;
   }
 
@@ -383,7 +384,21 @@ public final class J2clReadSurfaceDomRenderer {
     if (threadId == null || threadId.isEmpty()) {
       return "inline reply thread";
     }
-    return "inline reply thread " + threadId;
+    return "inline reply thread " + readableId(threadId, "t+");
+  }
+
+  private static String blipLabel(String blipId) {
+    if (blipId == null || blipId.isEmpty()) {
+      return "Blip";
+    }
+    return "Blip " + readableId(blipId, "b+");
+  }
+
+  private static String readableId(String id, String prefix) {
+    if (id.startsWith(prefix) && id.length() > prefix.length()) {
+      return id.substring(prefix.length());
+    }
+    return id;
   }
 
   private static String sanitizeDomId(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -31,6 +31,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     String focusedBlipId = currentFocusedBlipId();
+    List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
     if (matchesRenderedBlips(effectiveBlips)) {
       restoreFocusedBlipById(focusedBlipId);
       return true;
@@ -57,8 +58,58 @@ public final class J2clReadSurfaceDomRenderer {
 
     host.appendChild(surface);
     enhanceSurface(surface);
+    restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
     return true;
+  }
+
+  private List<String> captureCollapsedThreadIds() {
+    List<String> ids = new ArrayList<String>();
+    NodeList<Element> collapsed = host.querySelectorAll("[data-j2cl-thread-collapsed='true']");
+    for (int i = 0; i < collapsed.length; i++) {
+      Element thread = collapsed.item(i);
+      if (thread != null) {
+        String id = thread.getAttribute("data-thread-id");
+        if (id != null && !id.isEmpty()) {
+          ids.add(id);
+        }
+      }
+    }
+    return ids;
+  }
+
+  private void restoreCollapsedThreads(List<String> collapsedIds) {
+    if (collapsedIds.isEmpty()) {
+      return;
+    }
+    NodeList<Element> threads = host.querySelectorAll("[data-j2cl-collapse-ready]");
+    for (int i = 0; i < threads.length; i++) {
+      HTMLElement thread = (HTMLElement) threads.item(i);
+      if (thread == null) {
+        continue;
+      }
+      String threadId = thread.getAttribute("data-thread-id");
+      if (threadId != null && collapsedIds.contains(threadId)) {
+        HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+        if (button != null) {
+          toggleThread(thread, button);
+        }
+      }
+    }
+  }
+
+  private void restoreFocusedBlipById(String blipId) {
+    if (blipId == null) {
+      ensureSingleTabStop();
+      return;
+    }
+    for (HTMLElement blip : renderedBlips) {
+      if (blipId.equals(blip.getAttribute("data-blip-id")) && !isHiddenByCollapsedThread(blip)) {
+        focusBlip(blip);
+        return;
+      }
+    }
+    ensureSingleTabStop();
   }
 
   public boolean enhanceExistingSurface() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -109,6 +109,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void enhanceThreads(HTMLElement surface) {
     NodeList<Element> threads = surface.querySelectorAll("[data-thread-id]");
+    int inlineThreadOrdinal = 1;
     for (int index = 0; index < threads.length; index++) {
       HTMLElement thread = (HTMLElement) threads.item(index);
       if (thread == null) {
@@ -117,28 +118,37 @@ public final class J2clReadSurfaceDomRenderer {
       thread.classList.add("j2cl-read-thread");
       if (thread.classList.contains("inline-thread")) {
         thread.setAttribute("role", "group");
-        thread.setAttribute("aria-label", threadLabel(thread));
-        enhanceInlineThread(thread, index);
+        enhanceInlineThread(thread, index, inlineThreadOrdinal++);
       } else {
         thread.setAttribute("role", "list");
       }
     }
   }
 
-  private void enhanceInlineThread(HTMLElement thread, int index) {
-    if (thread.hasAttribute("data-j2cl-collapse-ready")) {
-      return;
-    }
-    thread.setAttribute("data-j2cl-collapse-ready", "true");
+  private void enhanceInlineThread(HTMLElement thread, int index, int ordinal) {
     if (!thread.hasAttribute("id")) {
       thread.setAttribute("id", generatedThreadId(thread, index));
     }
+    String label = threadLabel(thread, ordinal);
+    thread.setAttribute("aria-label", label);
+    thread.setAttribute("data-j2cl-thread-label", label);
+    if (thread.hasAttribute("data-j2cl-collapse-ready")) {
+      HTMLElement existingButton = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+      if (existingButton != null) {
+        existingButton.setAttribute(
+            "aria-label",
+            (thread.classList.contains("j2cl-read-thread-collapsed") ? "Expand " : "Collapse ")
+                + label);
+      }
+      return;
+    }
+    thread.setAttribute("data-j2cl-collapse-ready", "true");
     HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
     button.className = "j2cl-read-thread-toggle";
     button.setAttribute("type", "button");
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     button.setAttribute("aria-expanded", "true");
-    button.setAttribute("aria-label", "Collapse " + threadLabel(thread));
+    button.setAttribute("aria-label", "Collapse " + label);
     button.textContent = "Collapse thread";
     button.addEventListener("click", event -> toggleThread(thread, button));
     thread.insertBefore(button, thread.firstChild);
@@ -154,7 +164,7 @@ public final class J2clReadSurfaceDomRenderer {
       }
       blip.classList.add("j2cl-read-blip");
       blip.setAttribute("data-j2cl-read-blip", "true");
-      blip.setAttribute("role", "listitem");
+      blip.setAttribute("role", isInsideInlineThread(blip) ? "article" : "listitem");
       blip.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
       boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
       if (!alreadyBound) {
@@ -292,6 +302,17 @@ public final class J2clReadSurfaceDomRenderer {
     return false;
   }
 
+  private boolean isInsideInlineThread(HTMLElement blip) {
+    HTMLElement parent = (HTMLElement) blip.parentElement;
+    while (parent != null && parent != host) {
+      if (parent.classList.contains("inline-thread")) {
+        return true;
+      }
+      parent = (HTMLElement) parent.parentElement;
+    }
+    return false;
+  }
+
   private void restoreFocusedBlip(HTMLElement previousFocusedBlip) {
     HTMLElement restored = visibleRenderedBlip(previousFocusedBlip);
     if (restored == null) {
@@ -379,12 +400,17 @@ public final class J2clReadSurfaceDomRenderer {
     return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + generatedThreadIdCounter;
   }
 
-  private static String threadLabel(HTMLElement thread) {
+  private static String threadLabel(HTMLElement thread, int ordinal) {
     String threadId = thread.getAttribute("data-thread-id");
     if (threadId == null || threadId.isEmpty()) {
-      return "inline reply thread";
+      return "inline reply thread " + ordinal;
     }
-    return "inline reply thread " + readableId(threadId, "t+");
+    return "inline reply thread " + readableId(threadId, "t+") + " " + ordinal;
+  }
+
+  private static String threadLabel(HTMLElement thread) {
+    String label = thread.getAttribute("data-j2cl-thread-label");
+    return label == null || label.isEmpty() ? "inline reply thread" : label;
   }
 
   private static String blipLabel(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -52,13 +52,13 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   public boolean enhanceExistingSurface() {
-    HTMLElement previousFocusedBlip = focusedBlip;
-    renderedBlips.clear();
-    focusedBlip = null;
     HTMLElement surface = findExistingSurface();
     if (surface == null) {
       return false;
     }
+    HTMLElement previousFocusedBlip = focusedBlip;
+    renderedBlips.clear();
+    focusedBlip = null;
     enhanceSurface(surface);
     restoreFocusedBlip(previousFocusedBlip);
     // A zero-blip surface is still valid no-wave/empty markup, but callers use
@@ -114,9 +114,11 @@ public final class J2clReadSurfaceDomRenderer {
         continue;
       }
       thread.classList.add("j2cl-read-thread");
-      thread.setAttribute("role", "list");
       if (thread.classList.contains("inline-thread")) {
+        thread.setAttribute("role", "group");
         enhanceInlineThread(thread, index);
+      } else {
+        thread.setAttribute("role", "list");
       }
     }
   }
@@ -141,6 +143,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void enhanceBlips(HTMLElement surface) {
     NodeList<Element> blips = surface.querySelectorAll("[data-blip-id]");
+    boolean tabStopAssigned = false;
     for (int index = 0; index < blips.length; index++) {
       HTMLElement blip = (HTMLElement) blips.item(index);
       if (blip == null) {
@@ -152,10 +155,14 @@ public final class J2clReadSurfaceDomRenderer {
       blip.setAttribute("aria-keyshortcuts", "ArrowUp ArrowDown Home End");
       boolean alreadyBound = blip.hasAttribute("data-j2cl-read-blip-bound");
       if (!alreadyBound) {
-        blip.setAttribute("tabindex", index == 0 ? "0" : "-1");
+        boolean visible = !isHiddenByCollapsedThread(blip);
+        blip.setAttribute("tabindex", visible && !tabStopAssigned ? "0" : "-1");
+        tabStopAssigned = tabStopAssigned || visible;
         blip.setAttribute("data-j2cl-read-blip-bound", "true");
         blip.addEventListener("focus", this::onBlipFocus);
         blip.addEventListener("keydown", this::onBlipKeyDown);
+      } else if (!isHiddenByCollapsedThread(blip) && "0".equals(blip.getAttribute("tabindex"))) {
+        tabStopAssigned = true;
       }
       renderedBlips.add(blip);
     }
@@ -361,7 +368,8 @@ public final class J2clReadSurfaceDomRenderer {
     if (threadId == null || threadId.isEmpty()) {
       threadId = "thread-" + index;
     }
-    return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + (++generatedThreadIdCounter);
+    generatedThreadIdCounter++;
+    return "j2cl-read-thread-" + sanitizeDomId(threadId) + "-" + generatedThreadIdCounter;
   }
 
   private static String sanitizeDomId(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -198,6 +198,8 @@ public final class J2clReadSurfaceDomRenderer {
     }
     if (collapsed && isHiddenByCollapsedThread(focusedBlip)) {
       focusNearestVisibleFrom(focusedBlip);
+    } else if (collapsed && focusedBlip == null) {
+      ensureSingleTabStop();
     }
   }
 
@@ -405,7 +407,7 @@ public final class J2clReadSurfaceDomRenderer {
     if (threadId == null || threadId.isEmpty()) {
       return "inline reply thread " + ordinal;
     }
-    return "inline reply thread " + readableId(threadId, "t+") + " " + ordinal;
+    return "inline reply thread " + ordinal + " (" + readableId(threadId, "t+") + ")";
   }
 
   private static String threadLabel(HTMLElement thread) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.search;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 
 public final class J2clSelectedWaveModel {
   public static final int UNKNOWN_UNREAD_COUNT = -1;
@@ -19,6 +20,7 @@ public final class J2clSelectedWaveModel {
   private final int reconnectCount;
   private final List<String> participantIds;
   private final List<String> contentEntries;
+  private final List<J2clReadBlip> readBlips;
   private final J2clSidecarWriteSession writeSession;
   private final int unreadCount;
   private final boolean read;
@@ -43,6 +45,46 @@ public final class J2clSelectedWaveModel {
       boolean read,
       boolean readStateKnown,
       boolean readStateStale) {
+    this(
+        hasSelection,
+        loading,
+        error,
+        selectedWaveId,
+        titleText,
+        snippetText,
+        unreadText,
+        statusText,
+        detailText,
+        reconnectCount,
+        participantIds,
+        contentEntries,
+        Collections.<J2clReadBlip>emptyList(),
+        writeSession,
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateStale);
+  }
+
+  J2clSelectedWaveModel(
+      boolean hasSelection,
+      boolean loading,
+      boolean error,
+      String selectedWaveId,
+      String titleText,
+      String snippetText,
+      String unreadText,
+      String statusText,
+      String detailText,
+      int reconnectCount,
+      List<String> participantIds,
+      List<String> contentEntries,
+      List<J2clReadBlip> readBlips,
+      J2clSidecarWriteSession writeSession,
+      int unreadCount,
+      boolean read,
+      boolean readStateKnown,
+      boolean readStateStale) {
     this.hasSelection = hasSelection;
     this.loading = loading;
     this.error = error;
@@ -61,6 +103,10 @@ public final class J2clSelectedWaveModel {
         contentEntries == null
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(contentEntries));
+    this.readBlips =
+        readBlips == null
+            ? Collections.<J2clReadBlip>emptyList()
+            : Collections.unmodifiableList(new ArrayList<J2clReadBlip>(readBlips));
     this.writeSession = writeSession;
     this.unreadCount = unreadCount;
     this.read = read;
@@ -243,6 +289,10 @@ public final class J2clSelectedWaveModel {
 
   public List<String> getContentEntries() {
     return contentEntries;
+  }
+
+  public List<J2clReadBlip> getReadBlips() {
+    return readBlips;
   }
 
   public J2clSidecarWriteSession getWriteSession() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.search;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
@@ -49,6 +50,13 @@ public final class J2clSelectedWaveProjector {
     }
     if (contentEntries.isEmpty() && previous != null && !previous.getContentEntries().isEmpty()) {
       contentEntries = previous.getContentEntries();
+    }
+    List<J2clReadBlip> readBlips = extractReadBlips(update.getFragments());
+    if (readBlips.isEmpty()) {
+      readBlips = extractDocumentReadBlips(update.getDocuments());
+    }
+    if (readBlips.isEmpty() && previous != null && !previous.getReadBlips().isEmpty()) {
+      readBlips = previous.getReadBlips();
     }
 
     String detailText = buildDetailText(update);
@@ -99,6 +107,7 @@ public final class J2clSelectedWaveProjector {
         reconnectCount,
         participantIds,
         contentEntries,
+        readBlips,
         buildWriteSession(selectedWaveId, update, previous),
         unreadCount,
         read,
@@ -157,6 +166,7 @@ public final class J2clSelectedWaveProjector {
         previous.getReconnectCount(),
         previous.getParticipantIds(),
         previous.getContentEntries(),
+        previous.getReadBlips(),
         previous.getWriteSession(),
         unreadCount,
         read,
@@ -276,6 +286,22 @@ public final class J2clSelectedWaveProjector {
     return blipSnapshots.isEmpty() ? fallbackSnapshots : blipSnapshots;
   }
 
+  private static List<J2clReadBlip> extractReadBlips(SidecarSelectedWaveFragments fragments) {
+    if (fragments == null) {
+      return Collections.emptyList();
+    }
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
+      String rawSnapshot = fragment.getRawSnapshot();
+      String blipId = blipIdFromSegment(fragment.getSegment());
+      if (rawSnapshot == null || rawSnapshot.isEmpty() || blipId == null) {
+        continue;
+      }
+      blips.add(new J2clReadBlip(blipId, rawSnapshot));
+    }
+    return blips;
+  }
+
   private static List<String> extractDocumentEntries(List<SidecarSelectedWaveDocument> documents) {
     if (documents == null || documents.isEmpty()) {
       return Collections.emptyList();
@@ -294,6 +320,32 @@ public final class J2clSelectedWaveProjector {
       }
     }
     return blipEntries.isEmpty() ? fallbackEntries : blipEntries;
+  }
+
+  private static List<J2clReadBlip> extractDocumentReadBlips(
+      List<SidecarSelectedWaveDocument> documents) {
+    if (documents == null || documents.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    for (SidecarSelectedWaveDocument document : documents) {
+      String documentId = document.getDocumentId();
+      String textContent = document.getTextContent();
+      if (documentId == null || !documentId.startsWith("b+")
+          || textContent == null || textContent.isEmpty()) {
+        continue;
+      }
+      blips.add(new J2clReadBlip(documentId, textContent));
+    }
+    return blips;
+  }
+
+  private static String blipIdFromSegment(String segment) {
+    if (segment == null || !segment.startsWith("blip:")) {
+      return null;
+    }
+    String blipId = segment.substring("blip:".length());
+    return blipId.isEmpty() ? null : blipId;
   }
 
   private static String buildDetailText(SidecarSelectedWaveUpdate update) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -231,11 +231,10 @@ public final class J2clSelectedWaveProjector {
     }
     String fallback = null;
     for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
-      String segment = fragment.getSegment();
-      if (segment == null || !segment.startsWith("blip:")) {
+      String blipId = blipIdFromSegment(fragment.getSegment());
+      if (blipId == null) {
         continue;
       }
-      String blipId = segment.substring("blip:".length());
       if ("b+root".equals(blipId)) {
         return blipId;
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -37,6 +37,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       composeHost = queryRequired(existingCard, ".sidecar-selected-compose");
       contentList = queryRequired(existingCard, ".sidecar-selected-content");
       readSurface = new J2clReadSurfaceDomRenderer(contentList);
+      readSurface.enhanceExistingSurface();
       emptyState = queryRequired(existingCard, ".sidecar-empty-state");
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -5,6 +5,7 @@ import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
+import org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer;
 import org.waveprotocol.box.j2cl.root.J2clServerFirstRootShellDom;
 
 public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
@@ -16,6 +17,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLElement snippet;
   private final HTMLElement composeHost;
   private final HTMLDivElement contentList;
+  private final J2clReadSurfaceDomRenderer readSurface;
   private final HTMLElement emptyState;
   private boolean serverFirstActive;
   private boolean serverFirstSwapRecorded;
@@ -34,6 +36,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       snippet = queryRequired(existingCard, ".sidecar-selected-snippet");
       composeHost = queryRequired(existingCard, ".sidecar-selected-compose");
       contentList = queryRequired(existingCard, ".sidecar-selected-content");
+      readSurface = new J2clReadSurfaceDomRenderer(contentList);
       emptyState = queryRequired(existingCard, ".sidecar-empty-state");
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
@@ -84,6 +87,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     contentList = (HTMLDivElement) DomGlobal.document.createElement("div");
     contentList.className = "sidecar-selected-content";
     card.appendChild(contentList);
+    readSurface = new J2clReadSurfaceDomRenderer(contentList);
 
     emptyState = (HTMLElement) DomGlobal.document.createElement("div");
     emptyState.className = "sidecar-empty-state";
@@ -124,15 +128,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     snippet.textContent = model.getSnippetText();
     snippet.hidden = model.getSnippetText().isEmpty();
 
-    contentList.innerHTML = "";
-    for (String entry : model.getContentEntries()) {
-      HTMLElement block = (HTMLElement) DomGlobal.document.createElement("pre");
-      block.className = "sidecar-selected-entry";
-      block.textContent = entry;
-      contentList.appendChild(block);
-    }
+    boolean hasRenderedReadSurface = readSurface.render(model.getReadBlips(), model.getContentEntries());
 
-    emptyState.hidden = model.isError() || (model.hasSelection() && !model.getContentEntries().isEmpty());
+    emptyState.hidden = model.isError() || (model.hasSelection() && hasRenderedReadSurface);
     emptyState.textContent =
         model.hasSelection()
             ? (model.isLoading()
@@ -171,7 +169,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (model.isLoading() || model.isError()) {
       return true;
     }
-    return model.getContentEntries().isEmpty();
+    return model.getContentEntries().isEmpty() && model.getReadBlips().isEmpty();
   }
 
   private boolean shouldPreserveServerFirstCard(J2clSelectedWaveModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -38,7 +38,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       contentList = queryRequired(existingCard, ".sidecar-selected-content");
       readSurface = new J2clReadSurfaceDomRenderer(contentList);
       readSurface.enhanceExistingSurface();
-      emptyState = queryRequired(existingCard, ".sidecar-empty-state");
+      emptyState = queryOrCreate(existingCard, ".sidecar-empty-state", "div", "sidecar-empty-state");
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
       serverFirstMode = J2clServerFirstRootShellDom.serverFirstMode(host);
@@ -236,6 +236,19 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
           "Missing required DOM element for selector '" + selector + "'");
     }
     return (T) element;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends HTMLElement> T queryOrCreate(
+      HTMLElement root, String selector, String tagName, String className) {
+    Object element = root.querySelector(selector);
+    if (element != null) {
+      return (T) element;
+    }
+    HTMLElement created = (HTMLElement) DomGlobal.document.createElement(tagName);
+    created.className = className;
+    root.appendChild(created);
+    return (T) created;
   }
 
   @JsFunction

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -201,6 +201,43 @@ body {
   white-space: pre-wrap;
 }
 
+.j2cl-read-surface {
+  display: block;
+}
+
+.j2cl-read-thread {
+  display: grid;
+  gap: 12px;
+}
+
+.j2cl-read-blip {
+  background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
+  border: 1px solid #d8e2f0;
+  border-radius: 18px;
+  color: #173355;
+  margin: 0;
+  outline: none;
+  padding: 16px;
+}
+
+.j2cl-read-blip-focused {
+  border-color: #3567c8;
+  box-shadow: 0 0 0 3px rgba(53, 103, 200, 0.16);
+}
+
+.j2cl-read-blip-meta {
+  color: #4f6480;
+  font-size: 0.82rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.j2cl-read-blip-content {
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .sidecar-search-session {
   margin: 16px 0 0;
   color: #3567c8;

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -210,6 +210,34 @@ body {
   gap: 12px;
 }
 
+.j2cl-read-thread-toggle {
+  align-self: start;
+  background: #eef5ff;
+  border: 1px solid #bfcef5;
+  border-radius: 999px;
+  color: #173355;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 700;
+  margin: 0 0 10px;
+  padding: 6px 12px;
+}
+
+.j2cl-read-thread-toggle:hover,
+.j2cl-read-thread-toggle:focus-visible {
+  background: #dce9ff;
+  outline: 2px solid rgba(53, 103, 200, 0.24);
+  outline-offset: 2px;
+}
+
+.j2cl-read-thread-collapsed > .blip,
+.j2cl-read-thread-collapsed > .j2cl-read-blip,
+.j2cl-read-thread-collapsed > .inline-thread,
+.j2cl-read-thread-collapsed > .j2cl-read-thread {
+  display: none;
+}
+
 .j2cl-read-blip {
   background: linear-gradient(180deg, #f8fbff 0%, #ffffff 100%);
   border: 1px solid #d8e2f0;

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -253,6 +253,11 @@ body {
   box-shadow: 0 0 0 3px rgba(53, 103, 200, 0.16);
 }
 
+.j2cl-read-blip:focus-visible {
+  outline: 2px solid rgba(53, 103, 200, 0.55);
+  outline-offset: 3px;
+}
+
 .j2cl-read-blip-meta {
   color: #4f6480;
   font-size: 0.82rem;

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -265,7 +265,8 @@ body {
 .j2cl-read-blip-content {
   line-height: 1.65;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 .sidecar-search-session {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -231,10 +231,7 @@ body {
   outline-offset: 2px;
 }
 
-.j2cl-read-thread-collapsed > .blip,
-.j2cl-read-thread-collapsed > .j2cl-read-blip,
-.j2cl-read-thread-collapsed > .inline-thread,
-.j2cl-read-thread-collapsed > .j2cl-read-thread {
+.j2cl-read-thread-collapsed > :not(.j2cl-read-thread-toggle) {
   display: none;
 }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -47,6 +47,24 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void enhanceExistingSurfaceIsIdempotentForThreadToggles() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div></div>";
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+
+    Assert.assertEquals(1, host.querySelectorAll(".j2cl-read-thread-toggle").length);
+    Assert.assertEquals(1, host.querySelectorAll("[data-j2cl-read-blip-bound='true']").length);
+  }
+
+  @Test
   public void renderLiveBlipsCreatesSemanticReadSurface() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -64,6 +82,22 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
     Assert.assertEquals("b+root", firstBlip(host).getAttribute("data-blip-id"));
     Assert.assertEquals("0", firstBlip(host).getAttribute("tabindex"));
+  }
+
+  @Test
+  public void renderFallbackEntriesSynthesizesStableEntryIds() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    boolean rendered =
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Collections.<J2clReadBlip>emptyList(),
+                Arrays.asList("First fallback", "Second fallback"));
+
+    Assert.assertTrue(rendered);
+    Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
+    Assert.assertEquals("entry-1", firstBlip(host).getAttribute("data-blip-id"));
   }
 
   private static HTMLDivElement createHost() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -359,6 +359,44 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void rerenderingWithExternalFocusDoesNotStealFocusBack() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root text"),
+                new J2clReadBlip("b+reply", "Reply text")),
+            Collections.<String>emptyList()));
+    HTMLElement reply = blip(host, "b+reply");
+    reply.focus();
+
+    HTMLButtonElement external =
+        (HTMLButtonElement) DomGlobal.document.createElement("button");
+    DomGlobal.document.body.appendChild(external);
+    try {
+      external.focus();
+      Assert.assertEquals(external, DomGlobal.document.activeElement);
+
+      Assert.assertTrue(
+          renderer.render(
+              Arrays.asList(
+                  new J2clReadBlip("b+root", "Root text updated"),
+                  new J2clReadBlip("b+reply", "Reply text updated")),
+              Collections.<String>emptyList()));
+
+      Assert.assertEquals(external, DomGlobal.document.activeElement);
+      Assert.assertNull(blip(host, "b+reply").getAttribute("aria-current"));
+    } finally {
+      if (external.parentElement != null) {
+        external.parentElement.removeChild(external);
+      }
+    }
+  }
+
+  @Test
   public void renderLiveBlipsHandlesKeyboardBranchesAndBounds() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -9,12 +9,23 @@ import elemental2.dom.KeyboardEvent;
 import elemental2.dom.KeyboardEventInit;
 import java.util.Arrays;
 import java.util.Collections;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
 @J2clTestInput(J2clReadSurfaceDomRendererTest.class)
 public class J2clReadSurfaceDomRendererTest {
+  private HTMLDivElement currentHost;
+
+  @After
+  public void tearDown() {
+    if (currentHost != null && currentHost.parentElement != null) {
+      currentHost.parentElement.removeChild(currentHost);
+    }
+    currentHost = null;
+  }
+
   @Test
   public void enhanceExistingSurfaceWiresServerRenderedBlipsAndInlineThreads() {
     assumeBrowserDom();
@@ -401,13 +412,13 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertFalse(first.getAttribute("aria-label").equals(second.getAttribute("aria-label")));
   }
 
-  private static HTMLDivElement createHost() {
-    HTMLDivElement host = (HTMLDivElement) DomGlobal.document.createElement("div");
-    DomGlobal.document.body.appendChild(host);
-    return host;
+  private HTMLDivElement createHost() {
+    currentHost = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(currentHost);
+    return currentHost;
   }
 
-  private static HTMLDivElement createDuplicateThreadIdHost() {
+  private HTMLDivElement createDuplicateThreadIdHost() {
     HTMLDivElement host = createHost();
     host.innerHTML =
         "<div class=\"wave-content\">"
@@ -422,7 +433,7 @@ public class J2clReadSurfaceDomRendererTest {
     return host;
   }
 
-  private static HTMLDivElement createThreadedHost() {
+  private HTMLDivElement createThreadedHost() {
     HTMLDivElement host = createHost();
     host.innerHTML =
         "<div class=\"wave-content\">"
@@ -436,7 +447,7 @@ public class J2clReadSurfaceDomRendererTest {
     return host;
   }
 
-  private static HTMLDivElement createThreadedHostWithoutFollowingBlip() {
+  private HTMLDivElement createThreadedHostWithoutFollowingBlip() {
     HTMLDivElement host = createHost();
     host.innerHTML =
         "<div class=\"wave-content\">"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -39,13 +39,22 @@ public class J2clReadSurfaceDomRendererTest {
         (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
     Assert.assertNotNull(toggle);
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
-
-    toggle.click();
+    Assert.assertEquals(
+        "Collapse inline reply thread t+inline", toggle.getAttribute("aria-label"));
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
+    HTMLElement rootThread =
+        (HTMLElement) host.querySelector(".thread[data-thread-id='t+root']");
+    Assert.assertEquals("list", rootThread.getAttribute("role"));
+    Assert.assertEquals("group", inlineThread.getAttribute("role"));
+    Assert.assertEquals("inline reply thread t+inline", inlineThread.getAttribute("aria-label"));
+
+    toggle.click();
+
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
+    Assert.assertEquals("Expand inline reply thread t+inline", toggle.getAttribute("aria-label"));
   }
 
   @Test
@@ -64,6 +73,50 @@ public class J2clReadSurfaceDomRendererTest {
 
     Assert.assertEquals(1, host.querySelectorAll(".j2cl-read-thread-toggle").length);
     Assert.assertEquals(1, host.querySelectorAll("[data-j2cl-read-blip-bound='true']").length);
+  }
+
+  @Test
+  public void failedReEnhancementPreservesFocusedCollapseState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    HTMLElement reply = blip(host, "b+reply");
+    HTMLElement after = blip(host, "b+after");
+
+    reply.focus();
+    surface.removeAttribute("data-j2cl-read-surface");
+    surface.classList.remove("wave-content");
+
+    Assert.assertFalse(renderer.enhanceExistingSurface());
+    toggle.click();
+
+    Assert.assertEquals("-1", reply.getAttribute("tabindex"));
+    Assert.assertEquals("0", after.getAttribute("tabindex"));
+    Assert.assertEquals("true", after.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void reEnhancementPrefersAlreadyMarkedSurfaceOverSiblingWaveContent() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\" data-j2cl-read-surface=\"true\">"
+            + "<div class=\"blip\" data-blip-id=\"b+current\">Current</div>"
+            + "</div>"
+            + "<div class=\"wave-content\">"
+            + "<div class=\"blip\" data-blip-id=\"b+sibling\">Sibling</div>"
+            + "</div>";
+
+    Assert.assertTrue(new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface());
+
+    Assert.assertEquals(
+        "true", blip(host, "b+current").getAttribute("data-j2cl-read-blip"));
+    Assert.assertNull(blip(host, "b+sibling").getAttribute("data-j2cl-read-blip"));
   }
 
   @Test
@@ -172,6 +225,29 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderLiveBlipsWiresKeyboardTraversal() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip("b+root", "Root text"),
+                    new J2clReadBlip("b+reply", "Reply text")),
+                Collections.<String>emptyList()));
+
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+    root.focus();
+    dispatchKey(root, "ArrowDown");
+
+    Assert.assertEquals("-1", root.getAttribute("tabindex"));
+    Assert.assertEquals("0", reply.getAttribute("tabindex"));
+    Assert.assertEquals("true", reply.getAttribute("aria-current"));
+  }
+
+  @Test
   public void renderFallbackEntriesSynthesizesStableEntryIds() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -187,9 +263,41 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("entry-1", firstBlip(host).getAttribute("data-blip-id"));
   }
 
+  @Test
+  public void duplicateThreadIdsStillGenerateDistinctControlTargets() {
+    assumeBrowserDom();
+    HTMLDivElement host = createDuplicateThreadIdHost();
+
+    Assert.assertTrue(new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface());
+
+    HTMLButtonElement first =
+        (HTMLButtonElement) host.querySelectorAll(".j2cl-read-thread-toggle").item(0);
+    HTMLButtonElement second =
+        (HTMLButtonElement) host.querySelectorAll(".j2cl-read-thread-toggle").item(1);
+    Assert.assertNotNull(first);
+    Assert.assertNotNull(second);
+    Assert.assertFalse(
+        first.getAttribute("aria-controls").equals(second.getAttribute("aria-controls")));
+  }
+
   private static HTMLDivElement createHost() {
     HTMLDivElement host = (HTMLDivElement) DomGlobal.document.createElement("div");
     DomGlobal.document.body.appendChild(host);
+    return host;
+  }
+
+  private static HTMLDivElement createDuplicateThreadIdHost() {
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+duplicate\">"
+            + "<div class=\"blip\" data-blip-id=\"b+one\">One</div>"
+            + "</div>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+duplicate\">"
+            + "<div class=\"blip\" data-blip-id=\"b+two\">Two</div>"
+            + "</div>"
+            + "</div></div>";
     return host;
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -40,7 +40,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(toggle);
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
-        "Collapse inline reply thread inline", toggle.getAttribute("aria-label"));
+        "Collapse inline reply thread inline 1", toggle.getAttribute("aria-label"));
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
@@ -48,13 +48,15 @@ public class J2clReadSurfaceDomRendererTest {
         (HTMLElement) host.querySelector(".thread[data-thread-id='t+root']");
     Assert.assertEquals("list", rootThread.getAttribute("role"));
     Assert.assertEquals("group", inlineThread.getAttribute("role"));
-    Assert.assertEquals("inline reply thread inline", inlineThread.getAttribute("aria-label"));
+    Assert.assertEquals("listitem", blip(host, "b+root").getAttribute("role"));
+    Assert.assertEquals("article", blip(host, "b+reply").getAttribute("role"));
+    Assert.assertEquals("inline reply thread inline 1", inlineThread.getAttribute("aria-label"));
 
     toggle.click();
 
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
-    Assert.assertEquals("Expand inline reply thread inline", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("Expand inline reply thread inline 1", toggle.getAttribute("aria-label"));
   }
 
   @Test
@@ -222,6 +224,26 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
     Assert.assertEquals("b+root", firstBlip(host).getAttribute("data-blip-id"));
     Assert.assertEquals("0", firstBlip(host).getAttribute("tabindex"));
+    Assert.assertEquals(
+        "ArrowUp ArrowDown Home End", firstBlip(host).getAttribute("aria-keyshortcuts"));
+  }
+
+  @Test
+  public void focusedBlipReceivesCurrentMarker() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(new J2clReadBlip("b+root", "Root text")),
+                Collections.<String>emptyList()));
+
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+
+    Assert.assertEquals("true", root.getAttribute("aria-current"));
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
   }
 
   @Test
@@ -339,6 +361,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(second);
     Assert.assertFalse(
         first.getAttribute("aria-controls").equals(second.getAttribute("aria-controls")));
+    Assert.assertFalse(first.getAttribute("aria-label").equals(second.getAttribute("aria-label")));
   }
 
   private static HTMLDivElement createHost() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -67,6 +67,27 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void reEnhancementPreservesFocusedRovingTabStop() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+    HTMLElement after = blip(host, "b+after");
+
+    reply.focus();
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+
+    Assert.assertEquals("-1", root.getAttribute("tabindex"));
+    Assert.assertEquals("0", reply.getAttribute("tabindex"));
+    Assert.assertEquals("true", reply.getAttribute("aria-current"));
+    Assert.assertEquals("-1", after.getAttribute("tabindex"));
+    Assert.assertEquals(1, host.querySelectorAll("[tabindex='0']").length);
+  }
+
+  @Test
   public void keyboardNavigationSkipsCollapsedThreadBlips() {
     assumeBrowserDom();
     HTMLDivElement host = createThreadedHost();
@@ -108,6 +129,26 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("-1", reply.getAttribute("tabindex"));
     Assert.assertEquals("0", after.getAttribute("tabindex"));
     Assert.assertEquals("true", after.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void collapsingFocusedLastThreadFallsBackToPreviousVisibleBlip() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHostWithoutFollowingBlip();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+
+    reply.focus();
+    toggle.click();
+
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
+    Assert.assertEquals("true", root.getAttribute("aria-current"));
+    Assert.assertEquals("-1", reply.getAttribute("tabindex"));
   }
 
   @Test
@@ -162,6 +203,19 @@ public class J2clReadSurfaceDomRendererTest {
             + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
             + "</div>"
             + "<div class=\"blip\" data-blip-id=\"b+after\">After</div>"
+            + "</div></div>";
+    return host;
+  }
+
+  private static HTMLDivElement createThreadedHostWithoutFollowingBlip() {
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div>"
             + "</div></div>";
     return host;
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -5,6 +5,8 @@ import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.KeyboardEvent;
+import elemental2.dom.KeyboardEventInit;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
@@ -65,6 +67,50 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void keyboardNavigationSkipsCollapsedThreadBlips() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+    HTMLElement after = blip(host, "b+after");
+
+    toggle.click();
+    root.focus();
+    dispatchKey(root, "ArrowDown");
+
+    Assert.assertEquals("0", after.getAttribute("tabindex"));
+    Assert.assertEquals("true", after.getAttribute("aria-current"));
+    Assert.assertEquals("-1", reply.getAttribute("tabindex"));
+  }
+
+  @Test
+  public void collapsingFocusedThreadMovesToNearestFollowingVisibleBlip() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+    HTMLElement after = blip(host, "b+after");
+
+    reply.focus();
+    toggle.click();
+
+    Assert.assertEquals("-1", root.getAttribute("tabindex"));
+    Assert.assertEquals("-1", reply.getAttribute("tabindex"));
+    Assert.assertEquals("0", after.getAttribute("tabindex"));
+    Assert.assertEquals("true", after.getAttribute("aria-current"));
+  }
+
+  @Test
   public void renderLiveBlipsCreatesSemanticReadSurface() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -106,11 +152,35 @@ public class J2clReadSurfaceDomRendererTest {
     return host;
   }
 
+  private static HTMLDivElement createThreadedHost() {
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+after\">After</div>"
+            + "</div></div>";
+    return host;
+  }
+
   private static void assumeBrowserDom() {
     Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
   }
 
   private static HTMLElement firstBlip(HTMLDivElement host) {
     return (HTMLElement) host.querySelector("[data-j2cl-read-blip='true']");
+  }
+
+  private static HTMLElement blip(HTMLDivElement host, String blipId) {
+    return (HTMLElement) host.querySelector("[data-blip-id='" + blipId + "']");
+  }
+
+  private static void dispatchKey(HTMLElement target, String key) {
+    KeyboardEventInit init = KeyboardEventInit.create();
+    init.setKey(key);
+    target.dispatchEvent(new KeyboardEvent("keydown", init));
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1,0 +1,82 @@
+package org.waveprotocol.box.j2cl.read;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLButtonElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+@J2clTestInput(J2clReadSurfaceDomRendererTest.class)
+public class J2clReadSurfaceDomRendererTest {
+  @Test
+  public void enhanceExistingSurfaceWiresServerRenderedBlipsAndInlineThreads() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\" data-wave-id=\"example.com/w+1\">"
+            + "<div class=\"conversation\" data-conv-id=\"c+root\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div></div></div></div>";
+
+    Assert.assertTrue(new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface());
+
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    Assert.assertNotNull(surface);
+    Assert.assertEquals(
+        2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
+
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    Assert.assertNotNull(toggle);
+    Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
+
+    toggle.click();
+
+    HTMLElement inlineThread =
+        (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
+    Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
+    Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
+  }
+
+  @Test
+  public void renderLiveBlipsCreatesSemanticReadSurface() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    boolean rendered =
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip("b+root", "Root text"),
+                    new J2clReadBlip("b+reply", "Reply text")),
+                Collections.<String>emptyList());
+
+    Assert.assertTrue(rendered);
+    Assert.assertNotNull(host.querySelector("[data-j2cl-read-surface='true']"));
+    Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
+    Assert.assertEquals("b+root", firstBlip(host).getAttribute("data-blip-id"));
+    Assert.assertEquals("0", firstBlip(host).getAttribute("tabindex"));
+  }
+
+  private static HTMLDivElement createHost() {
+    HTMLDivElement host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    return host;
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+
+  private static HTMLElement firstBlip(HTMLDivElement host) {
+    return (HTMLElement) host.querySelector("[data-j2cl-read-blip='true']");
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -40,7 +40,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(toggle);
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
-        "Collapse inline reply thread inline 1", toggle.getAttribute("aria-label"));
+        "Collapse inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
@@ -50,13 +50,13 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("group", inlineThread.getAttribute("role"));
     Assert.assertEquals("listitem", blip(host, "b+root").getAttribute("role"));
     Assert.assertEquals("article", blip(host, "b+reply").getAttribute("role"));
-    Assert.assertEquals("inline reply thread inline 1", inlineThread.getAttribute("aria-label"));
+    Assert.assertEquals("inline reply thread 1 (inline)", inlineThread.getAttribute("aria-label"));
 
     toggle.click();
 
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
-    Assert.assertEquals("Expand inline reply thread inline 1", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
   }
 
   @Test
@@ -100,6 +100,32 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("-1", reply.getAttribute("tabindex"));
     Assert.assertEquals("0", after.getAttribute("tabindex"));
     Assert.assertEquals("true", after.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void enhanceExistingSurfaceReturnsFalseForEmptyHost() {
+    assumeBrowserDom();
+    Assert.assertFalse(new J2clReadSurfaceDomRenderer(createHost()).enhanceExistingSurface());
+  }
+
+  @Test
+  public void collapsingWithoutFocusedBlipSanitizesHiddenTabStop() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement reply = blip(host, "b+reply");
+    root.setAttribute("tabindex", "-1");
+    reply.setAttribute("tabindex", "0");
+
+    toggle.click();
+
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
+    Assert.assertEquals("-1", reply.getAttribute("tabindex"));
   }
 
   @Test
@@ -344,6 +370,17 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertTrue(rendered);
     Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-read-blip='true']").length);
     Assert.assertEquals("entry-1", firstBlip(host).getAttribute("data-blip-id"));
+  }
+
+  @Test
+  public void renderEmptyContentReturnsFalseAndLeavesHostEmpty() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertFalse(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(Collections.<J2clReadBlip>emptyList(), Collections.<String>emptyList()));
+    Assert.assertEquals("", host.innerHTML);
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -9,6 +9,7 @@ import elemental2.dom.KeyboardEvent;
 import elemental2.dom.KeyboardEventInit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -304,6 +305,57 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("-1", root.getAttribute("tabindex"));
     Assert.assertEquals("0", reply.getAttribute("tabindex"));
     Assert.assertEquals("true", reply.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void rerenderingSameLiveBlipsPreservesFocusedNode() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+root", "Root text"),
+            new J2clReadBlip("b+reply", "Reply text"));
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+    HTMLElement reply = blip(host, "b+reply");
+    reply.focus();
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+
+    Assert.assertSame(reply, blip(host, "b+reply"));
+    Assert.assertEquals(reply, DomGlobal.document.activeElement);
+    Assert.assertEquals("0", reply.getAttribute("tabindex"));
+    Assert.assertEquals("true", reply.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void rerenderingUpdatedLiveBlipsRestoresFocusByBlipId() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root text"),
+                new J2clReadBlip("b+reply", "Reply text")),
+            Collections.<String>emptyList()));
+    HTMLElement originalReply = blip(host, "b+reply");
+    originalReply.focus();
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root text updated"),
+                new J2clReadBlip("b+reply", "Reply text updated")),
+            Collections.<String>emptyList()));
+
+    HTMLElement updatedReply = blip(host, "b+reply");
+    Assert.assertNotSame(originalReply, updatedReply);
+    Assert.assertEquals(updatedReply, DomGlobal.document.activeElement);
+    Assert.assertEquals("0", updatedReply.getAttribute("tabindex"));
+    Assert.assertEquals("true", updatedReply.getAttribute("aria-current"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -40,7 +40,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(toggle);
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
-        "Collapse inline reply thread t+inline", toggle.getAttribute("aria-label"));
+        "Collapse inline reply thread inline", toggle.getAttribute("aria-label"));
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
@@ -48,13 +48,13 @@ public class J2clReadSurfaceDomRendererTest {
         (HTMLElement) host.querySelector(".thread[data-thread-id='t+root']");
     Assert.assertEquals("list", rootThread.getAttribute("role"));
     Assert.assertEquals("group", inlineThread.getAttribute("role"));
-    Assert.assertEquals("inline reply thread t+inline", inlineThread.getAttribute("aria-label"));
+    Assert.assertEquals("inline reply thread inline", inlineThread.getAttribute("aria-label"));
 
     toggle.click();
 
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
-    Assert.assertEquals("Expand inline reply thread t+inline", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("Expand inline reply thread inline", toggle.getAttribute("aria-label"));
   }
 
   @Test
@@ -245,6 +245,67 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("-1", root.getAttribute("tabindex"));
     Assert.assertEquals("0", reply.getAttribute("tabindex"));
     Assert.assertEquals("true", reply.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void renderLiveBlipsHandlesKeyboardBranchesAndBounds() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip("b+root", "Root text"),
+                    new J2clReadBlip("b+middle", "Middle text"),
+                    new J2clReadBlip("b+last", "Last text")),
+                Collections.<String>emptyList()));
+
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement middle = blip(host, "b+middle");
+    HTMLElement last = blip(host, "b+last");
+
+    last.focus();
+    dispatchKey(last, "ArrowDown");
+    Assert.assertEquals("0", last.getAttribute("tabindex"));
+
+    dispatchKey(last, "Home");
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
+
+    dispatchKey(root, "ArrowUp");
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
+
+    dispatchKey(root, "End");
+    Assert.assertEquals("0", last.getAttribute("tabindex"));
+
+    dispatchKey(last, "ArrowUp");
+    Assert.assertEquals("0", middle.getAttribute("tabindex"));
+  }
+
+  @Test
+  public void renderAfterEnhancementRebuildsAndWiresFreshLiveBlips() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+live-root", "Root text"),
+                new J2clReadBlip("b+live-reply", "Reply text")),
+            Collections.<String>emptyList()));
+
+    Assert.assertNull(blip(host, "b+reply"));
+    HTMLElement liveRoot = blip(host, "b+live-root");
+    HTMLElement liveReply = blip(host, "b+live-reply");
+
+    liveRoot.focus();
+    dispatchKey(liveRoot, "ArrowDown");
+
+    Assert.assertEquals("-1", liveRoot.getAttribute("tabindex"));
+    Assert.assertEquals("0", liveReply.getAttribute("tabindex"));
+    Assert.assertEquals("true", liveReply.getAttribute("aria-current"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -420,6 +420,36 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void rerenderPreservesFocusedBlipAndTabStop() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    renderer.render(
+        Arrays.asList(
+            new J2clReadBlip("b+root", "Root text"),
+            new J2clReadBlip("b+reply", "Reply text")),
+        Collections.<String>emptyList());
+
+    HTMLElement reply = blip(host, "b+reply");
+    reply.focus();
+    Assert.assertEquals("true", reply.getAttribute("aria-current"));
+
+    // Re-render with the same blip IDs (simulating a read-state-only reprojet).
+    renderer.render(
+        Arrays.asList(
+            new J2clReadBlip("b+root", "Root text updated"),
+            new J2clReadBlip("b+reply", "Reply text updated")),
+        Collections.<String>emptyList());
+
+    HTMLElement restoredReply = blip(host, "b+reply");
+    Assert.assertNotNull(restoredReply);
+    Assert.assertEquals("true", restoredReply.getAttribute("aria-current"));
+    Assert.assertEquals("0", restoredReply.getAttribute("tabindex"));
+    Assert.assertEquals("-1", blip(host, "b+root").getAttribute("tabindex"));
+  }
+
+  @Test
   public void renderFallbackEntriesSynthesizesStableEntryIds() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
@@ -129,6 +130,70 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertFalse(projected.isReadStateKnown());
     Assert.assertFalse(projected.isReadStateStale());
     Assert.assertEquals("Live updates connected.", projected.getStatusText());
+  }
+
+  @Test
+  public void projectKeepsStableReadBlipIdsFromFragmentSegments() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    9L,
+                    0L,
+                    9L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+reply", 0L, 9L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0),
+                        new SidecarSelectedWaveFragment("blip:b+reply", "Reply text", 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(2, projected.getReadBlips().size());
+    Assert.assertEquals("b+root", projected.getReadBlips().get(0).getBlipId());
+    Assert.assertEquals("Root text", projected.getReadBlips().get(0).getText());
+    Assert.assertEquals("b+reply", projected.getReadBlips().get(1).getBlipId());
+    Assert.assertEquals("Reply text", projected.getReadBlips().get(1).getText());
+  }
+
+  @Test
+  public void projectFallsBackToDocumentBlipsWhenFragmentsAreAbsent() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, "Document text"),
+                    new SidecarSelectedWaveDocument(
+                        "conversation", "user@example.com", 7L, 8L, "metadata")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("b+root", blip.getBlipId());
+    Assert.assertEquals("Document text", blip.getText());
   }
 
   // -- Write-session coupling (pre-existing) ----------------------------------

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -196,6 +196,40 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("Document text", blip.getText());
   }
 
+  @Test
+  public void projectPrefersFragmentReadBlipsOverDocumentFallbacks() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, "Document text")),
+                new SidecarSelectedWaveFragments(
+                    9L,
+                    0L,
+                    9L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Fragment text", 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("b+root", blip.getBlipId());
+    Assert.assertEquals("Fragment text", blip.getText());
+  }
+
   // -- Write-session coupling (pre-existing) ----------------------------------
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 
 @J2clTestInput(J2clSelectedWaveViewServerFirstLogicTest.class)
 public class J2clSelectedWaveViewServerFirstLogicTest {
@@ -43,6 +44,33 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
             0,
             Collections.<String>emptyList(),
             Arrays.asList("Live content"),
+            null,
+            J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+            false,
+            false,
+            false);
+
+    Assert.assertFalse(
+        J2clSelectedWaveView.shouldPreserveServerSnapshot("example.com/w+1", liveModel, false));
+  }
+
+  @Test
+  public void firstLiveReadBlipSwapsServerSnapshotOut() {
+    J2clSelectedWaveModel liveModel =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            false,
+            "example.com/w+1",
+            "Selected wave",
+            "",
+            "",
+            "Live updates connected.",
+            "",
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            Arrays.asList(new J2clReadBlip("b+root", "Live content")),
             null,
             J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
             false,

--- a/wave/config/changelog.d/2026-04-23-j2cl-stageone-read-surface.json
+++ b/wave/config/changelog.d/2026-04-23-j2cl-stageone-read-surface.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-23-j2cl-stageone-read-surface",
+  "version": "Issue #966",
+  "date": "2026-04-23",
+  "title": "J2CL selected-wave reading gains a semantic StageOne-style read surface",
+  "summary": "The opt-in J2CL root shell now upgrades selected-wave content into stable blip/thread DOM instead of flat text blocks, preserving server-first selected-wave HTML while the live client attaches read-surface behavior.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Selected-wave live updates render as semantic blip nodes with stable `data-blip-id` attributes for focus and later StageOne parity work",
+        "Server-rendered selected-wave snapshots are enhanced in place with keyboard focus traversal and in-session inline-thread collapse controls",
+        "The existing J2CL route and sidecar transport remain unchanged while the read surface moves toward GWT StageOne parity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Port the selected-wave J2CL read surface from flat content entries to semantic `data-blip-id` read blip DOM.
- Enhance server-first selected-wave HTML in place so the initial snapshot stays visible and gains keyboard focus, inline-thread collapse, ARIA labels, and stable read-surface markers.
- Keep route/root-shell/sidecar transport unchanged; live updates remain a flat `J2clReadBlip` projection until the follow-up viewport/thread-structure slices.

## Issue / Plan
- Closes #966
- Plan: `docs/superpowers/plans/2026-04-23-issue-966-stageone-read-parity.md`
- Worktree: `/Users/vega/devroot/worktrees/issue-966-stageone-read-parity`

## Verification
- `sbt -batch j2clSearchBuild j2clSearchTest` -> PASS
- `python3 scripts/assemble-changelog.py` -> PASS
- `python3 scripts/validate-changelog.py` -> PASS
- `git diff --check` -> PASS

## Review
- Self-review completed across renderer/model/projector/view/tests.
- Claude Opus review loop completed through final isolated review: `/tmp/claude-review-966-final.out`.
- Final verdict: ready for PR, no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected-wave view now renders semantic blip/thread structure with stable data-blip IDs and opt-in J2CL read-surface rendering; server-rendered snapshots are enhanced in place.
* **Accessibility**
  * Improved ARIA roles, roving focus/tabindex, and keyboard navigation (Arrow/Home/End) with focus preservation across enhancements and inline-thread collapse/expand.
* **Styles**
  * New styles for read threads, collapse toggles, blips, and focused states.
* **Tests**
  * Added browser/DOM tests validating rendering, enhancement, navigation, collapse behavior, focus restoration, and projection logic.
* **Documentation**
  * Added rollout plan and changelog entry for the read-surface migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->