### PR TITLE
J2CL viewport fragment growth parity

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Drive the J2CL/Lit selected-wave read surface from explicit viewport-scoped fragment windows instead of the current coarse whole-wave selected-wave payload assumptions, while preserving the existing server clamp contract and leaving broader StageOne/read-surface behavior to `#966`.
+**Goal:** Drive the J2CL/Lit selected-wave read surface from explicit viewport-scoped fragment windows instead of the current coarse whole-wave selected-wave payload assumptions, while preserving the existing server clamp contract and consuming the merged StageOne/read-surface container from `#966`.
 
 **Architecture:** Reuse the existing repo split rather than inventing a new transport. Initial selected-wave open continues to go through the sidecar `ProtocolOpenRequest`, but the J2CL open envelope must grow to carry the same viewport hints the GWT client already sends. Scroll growth does not reopen the selected-wave socket; it uses the existing `/fragments` JSON endpoint to fetch additional windows and merges them into a J2CL-owned visible-region model. To satisfy parity row `R-7.4`, the server path must stop treating viewport fragments as additive-on-top-of-a-full-snapshot when viewport mode is active, otherwise the client can render a windowed container while still paying whole-wave bootstrap cost on the wire.
 
@@ -66,14 +66,15 @@ The current J2CL selected-wave path is still fundamentally sidecar-demo shaped:
 - J2CL open envelope cannot carry viewport hints:
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java:7-31`
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:13-31`
-  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:231-238`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:44-65,231-238`
   - `SidecarOpenRequest` only contains participant id, wave id, and wavelet prefixes; `encodeOpenEnvelope(...)` only writes numeric keys `1`, `2`, and `3`; `buildSelectedWaveOpenFrame(...)` hardcodes the minimal request.
-- J2CL preserves fragment payloads only long enough to flatten them:
+- J2CL preserves fragment payloads only long enough to project blip text, not a window model:
   - decode seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:86-149`
-  - projection seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:46-54,259-317`
-  - model seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:20-68`
-  - view seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:68-105`
-  - the transport decoder already preserves ranges and fragment entries, but the projector reduces them to `List<String> contentEntries`; the model stores only those flattened strings; the view renders them as `<pre>` blocks. That discards:
+  - projection seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:47-60,268-340`
+  - model seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:21-24,69-115,290-295`
+  - view seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:28-40,104-132,152-174`
+  - read-surface seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java:24-64,101-154,204-229`
+  - the transport decoder already preserves ranges and fragment entries, and `#966` now projects `J2clReadBlip` instances into the StageOne read surface. The model still lacks a typed viewport/window state, and the read-surface renderer currently receives only a complete list of loaded blips plus fallback strings. That still discards:
     - segment identity
     - loaded vs unloaded window boundaries
     - placeholder positions
@@ -81,10 +82,10 @@ The current J2CL selected-wave path is still fundamentally sidecar-demo shaped:
 - J2CL has no fragment-growth transport seam:
   - there is no `fetchFragments(...)` equivalent anywhere under `j2cl/src/main/java`
   - a repository-wide search only finds viewport-aware logic in the GWT client and server path, not in J2CL
-- The root-shell/search-selected-wave host seams were destructive before `#965`:
-  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-40`
-  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:48-152`
-  - `#965` has now landed the preserved server-first selected-wave seam. `#967` must re-audit the merged root-shell/selected-wave host behavior and consume that seam rather than reintroducing startup DOM clearing.
+- The root-shell/search-selected-wave host seam is now server-first, but `#967` must not bypass it:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clServerFirstRootShellDom.java:5-61`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:28-40,104-145`
+  - `#965/#966` have landed the preserved server-first selected-wave card and the enhanced read-surface renderer. `#967` must derive its initial viewport hint from that preserved DOM when present and attach scroll growth to the merged renderer/container rather than creating a second selected-wave surface.
 
 ### 1.4 Additional implementation risks that must be planned up front
 
@@ -176,32 +177,39 @@ These are the non-obvious seams that turn `#967` into a mixed server/client slic
 - `#933` HttpOnly-safe sidecar websocket auth: merged
 - `#936` selected-wave version/hash atomicity: merged
 
-### 4.2 Current blockers for implementation
+### 4.2 Dependency merge status
 
 As of the current issue state on 2026-04-24:
 
 - `#965` has merged and this plan branch has been rebased onto an `origin/main` containing it
-- `#966` has moved from prep into PR `#991`, but it is not merged yet
+- `#966` has merged via PR `#991` and this plan branch has been rebased onto `origin/main` at `867be56ee6dd6999e92a06d6517c72745c0a3243`
 
-That means `#967` is **plan-current and review-ready, but not implementation-ready** until `#966` lands.
+That means `#967` is implementation-ready after this Task 1 seam-audit update is reviewed and pushed.
 
 ### 4.3 Why `#965` was a hard blocker
 
 `#965` owns the preserved server-first selected-wave HTML seam. That dependency is now satisfied, but Task 1 must still re-audit the exact merged files before implementation because `#967` needs to seed viewport state from the real preserved selected-wave surface, not from the pre-`#965` placeholder assumptions.
 
-### 4.4 Why `#966` is a hard blocker
+### 4.4 Why `#966` was a hard blocker
 
 `#966` owns the practical StageOne read-surface container and DOM/provider contract. `#967` only makes sense once the read surface is no longer a flat `<pre>` list. This slice should wire viewport windows into the merged `#966` container rather than grow the current placeholder sidecar view into a second competing read-surface architecture.
 
-### 4.5 Required first implementation step once the blockers merge
+### 4.5 Completed rebase and seam-audit gate
 
-Before any code task below, after `#966` merges:
+Before any code task below, following the `#966` merge:
 
-- [ ] Run `git fetch origin && git rebase origin/main`
-- [ ] Confirm `origin/main` includes the merged implementations for `#965` and `#966`
-- [ ] Refresh the file:line citations in §1 after the rebase so review evidence points at the merged code, not the planning snapshot
-- [ ] Re-audit the actual merged file seams and update this plan in-branch if the merged file names differ from the current `J2clSelectedWave*` seams
-- [ ] If `#966` changed the selected-wave/read-surface seam enough that this task list no longer maps cleanly, stop implementation, amend this plan, and rerun the plan-review loop before code work
+- [x] Run `git fetch origin && git rebase origin/main`
+- [x] Confirm `origin/main` includes the merged implementations for `#965` and `#966`
+- [x] Refresh the file:line citations in §1 after the rebase so review evidence points at the merged code, not the planning snapshot
+- [x] Re-audit the actual merged file seams and update this plan in-branch if the merged file names differ from the current `J2clSelectedWave*` seams
+- [x] If `#966` changed the selected-wave/read-surface seam enough that this task list no longer maps cleanly, stop implementation, amend this plan, and rerun the plan-review loop before code work
+
+Task 1 audit result:
+
+- `#966` kept the expected `J2clSelectedWave*` seams and added the real read-surface container at `J2clSelectedWaveView.contentList` / `J2clReadSurfaceDomRenderer`.
+- Verified container citation: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:88-91` creates `.sidecar-selected-content` and constructs `J2clReadSurfaceDomRenderer`; `J2clSelectedWaveView.java:28-40` reuses the same selector when preserving server-first DOM.
+- The implementation can start with Task 2. Task 5 must wire scroll growth into `J2clReadSurfaceDomRenderer` through the `J2clSelectedWaveView`/`J2clSelectedWaveController` seam, not through a parallel DOM surface.
+- The initial viewport hint source is the preserved server-first card's first visible `[data-blip-id]` inside `J2clSelectedWaveView.contentList` when present. If no preserved DOM exists, the selected-wave open should send explicit `viewportLimit=0` only; Task 2 must prove this stays field-present through the JSON/protobuf boundary.
 
 ## 5. Slice Parity Packet — Issue #967
 
@@ -270,6 +278,7 @@ Before any code task below, after `#966` merges:
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
@@ -309,10 +318,10 @@ Before any code task below, after `#966` merges:
   - `docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md`
   - merged `#965` / `#966` files on `origin/main`
 
-- [ ] Rebase the worktree after `#966` merges
-- [ ] Refresh §1 file:line citations after rebase so every cited seam points at the merged `origin/main`
-- [ ] If the merged `#966` read-surface seam does not expose a stable container for viewport windows, stop and amend this plan before implementation
-- [ ] Rewrite Task 5's file list and integration assertions to name the actual merged `#966` container/controller API before Task 5 starts; do not leave the container attachment test as a generic prose assertion
+- [x] Rebase the worktree after `#966` merges
+- [x] Refresh §1 file:line citations after rebase so every cited seam points at the merged `origin/main`
+- [x] If the merged `#966` read-surface seam does not expose a stable container for viewport windows, stop and amend this plan before implementation
+- [x] Rewrite Task 5's file list and integration assertions to name the actual merged `#966` container/controller API before Task 5 starts; do not leave the container attachment test as a generic prose assertion
 
 Run:
 ```bash
@@ -325,7 +334,7 @@ Expected:
 - the branch includes the merged commits for `#965` and `#966`
 - the current selected-wave/root-shell file names still match this plan, or this plan is amended before code starts
 
-- [ ] Confirm the merged `#965` seam that exposes the initial selected-wave window source
+- [x] Confirm the merged `#965` seam that exposes the initial selected-wave window source
 
 Run:
 ```bash
@@ -337,7 +346,7 @@ Expected:
   - preserved server DOM marker from `#965`, or
   - explicit bootstrap extension from upstream merged work
 
-- [ ] Confirm the merged `#966` read-surface container seam
+- [x] Confirm the merged `#966` read-surface container seam
 
 Run:
 ```bash
@@ -348,14 +357,14 @@ Expected:
 - one concrete container/view seam is identified as the `#967` integration point
 - there is no need to invent a second read-surface architecture in this slice
 
-- [ ] Confirm the initial viewport hint source using this ordered rule:
+- [x] Confirm the initial viewport hint source using this ordered rule:
   - first choice: the preserved server-first `#966` read surface's first visible `[data-blip-id]`, sent as `viewportStartBlipId` with `viewportDirection="forward"`
   - fallback: when a selected wave is opened without preserved DOM, send `viewportLimit=0` only, using the existing server rule where an explicit non-positive limit means "use configured default" and also opts into viewport mode
   - legacy/no-selected-wave path: send no viewport hint fields, preserving current whole-snapshot behavior
-- [ ] Confirm `ProtocolOpenRequest` field-presence semantics before coding:
+- [x] Confirm `ProtocolOpenRequest` field-presence source semantics before coding:
   - server-side viewport detection must use `hasViewportLimit()` / field presence, not `viewportLimit > 0`
-  - if the protobuf/runtime cannot preserve explicit zero, introduce an explicit sentinel field/value before implementing snapshot suppression
-  - the `viewportLimit=0` fallback is invalid unless tests prove it arrives as "present and defaulted"
+  - `wave/src/proto/proto/org/waveprotocol/box/common/comms/waveclient-rpc.proto:90-95` declares `viewport_limit` as an `optional int32`, so source-level presence semantics exist
+  - Task 2 must still prove the runtime JSON/protobuf path preserves explicit zero with a boundary test; if it cannot, introduce an explicit sentinel field/value before implementing snapshot suppression
 
 ### Task 2: Extend the J2CL open contract for initial viewport hints
 
@@ -379,6 +388,7 @@ Expected:
   - preserved server DOM first visible `data-blip-id` -> `startBlipId`, `direction="forward"`, no explicit limit
   - no preserved DOM but selected wave present -> explicit `limit=0` and no `startBlipId`/`direction`
   - no selected wave / legacy call path -> no viewport fields
+- [ ] Add a narrow `J2clSelectedWaveController.View` query seam, or an equivalent injected source, so `J2clSelectedWaveView` can expose initial viewport hints without the controller depending on DOM classes directly
 - [ ] Add backwards-compatibility tests proving absent hints are not encoded and still produce the existing open envelope
 - [ ] Add a codec/server-boundary test proving a request carrying only `viewportLimit=0` is encoded/decoded as viewport-hinted via field presence
 
@@ -478,16 +488,17 @@ Expected:
 
 **Files:**
 - Modify:
-  - the concrete merged selected-wave/read-surface controller/view files from `#966`
-  - if `#966` retains the current seam names, expect:
-    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
-    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
-    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
-  - the concrete merged root-shell host seam from `#965`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clServerFirstRootShellDom.java` only if the initial hint source needs another server-first marker helper
 - Test:
   - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
 
-- [ ] Add scroll-edge callbacks from the merged read-surface container to the selected-wave controller
+- [ ] Add scroll-edge callbacks from `J2clReadSurfaceDomRenderer` / `J2clSelectedWaveView.contentList` to the selected-wave controller
 - [ ] Request growth only when the user approaches an unloaded edge; coalesce repeated scroll triggers
 - [ ] Preserve scroll anchor and focus when new windows merge in
 - [ ] Surface loading placeholders with the existing `visible-region-placeholder` visual vocabulary
@@ -499,7 +510,7 @@ Expected:
   - stale responses whose version/hash no longer matches the selected-wave state are dropped
   - a later scroll or retry can request the edge again
 - [ ] Add tests for timeout/error display, stale-response drop, duplicate-request suppression, and retry after failure
-- [ ] Add a direct assertion that the implementation attaches to the merged `#966` read-surface container rather than introducing a second competing selected-wave surface
+- [ ] Add a direct assertion that the implementation attaches to the merged `#966` `J2clReadSurfaceDomRenderer` / `.sidecar-selected-content` container rather than introducing a second competing selected-wave surface
 
 Run:
 ```bash
@@ -606,10 +617,5 @@ Before implementation starts, the worker should be able to answer these review q
 
 ## 9. Ready-To-Start Call
 
-- `#967` is **not** ready for implementation on the current checkout.
-- `#967` becomes implementation-ready only after:
-  - `#966` merges
-  - this worktree rebases onto the merged `origin/main`
-  - Task 1 confirms the actual merged read-surface and server-first seams
-
-At that point the implementation should start with Task 2, not with view work first. The transport and server no-whole-wave-bootstrap seam are the hard constraints; if those do not land first, the container work will only paper over a transport regression.
+- `#967` is ready for implementation on this rebased checkout once this seam-audit plan update has passed the review loop.
+- Implementation should start with Task 2, not with view work first. The transport and server no-whole-wave-bootstrap seam are the hard constraints; if those do not land first, the container work will only paper over a transport regression.

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -517,23 +517,32 @@ Expected:
 - Test:
   - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
 
-- [ ] Add scroll-edge callbacks from `J2clReadSurfaceDomRenderer` / `J2clSelectedWaveView.contentList` to the selected-wave controller
-- [ ] Request growth only when the user approaches an unloaded edge; coalesce repeated scroll triggers
-- [ ] Preserve scroll anchor and focus when new windows merge in
-- [ ] Surface loading placeholders with the existing `visible-region-placeholder` visual vocabulary
-- [ ] Keep the container shape compatible with the `#966` DOM-as-view provider path
-- [ ] Define `/fragments` growth failure behavior:
+- [x] Add scroll-edge callbacks from `J2clReadSurfaceDomRenderer` / `J2clSelectedWaveView.contentList` to the selected-wave controller
+- [x] Request growth only when the user approaches an unloaded edge; coalesce repeated scroll triggers
+- [x] Preserve scroll anchor and focus when new windows merge in
+- [x] Surface loading placeholders with the existing `visible-region-placeholder` visual vocabulary
+- [x] Keep the container shape compatible with the `#966` DOM-as-view provider path
+- [x] Define `/fragments` growth failure behavior:
   - timeout/error keeps the existing window visible
   - edge placeholder switches to retry/error state without clearing loaded blips
   - duplicate requests for the same edge are coalesced while one is in flight
   - stale responses whose version/hash no longer matches the selected-wave state are dropped
   - a later scroll or retry can request the edge again
-- [ ] Add tests for timeout/error display, stale-response drop, duplicate-request suppression, and retry after failure
-- [ ] Add a direct assertion that the implementation attaches to the merged `#966` `J2clReadSurfaceDomRenderer` / `.sidecar-selected-content` container rather than introducing a second competing selected-wave surface
+- [x] Add tests for timeout/error display, stale-response drop, duplicate-request suppression, and retry after failure
+- [x] Add a direct assertion that the implementation attaches to the merged `#966` `J2clReadSurfaceDomRenderer` / `.sidecar-selected-content` container rather than introducing a second competing selected-wave surface
+
+Task 5 result:
+- Added scroll-edge callback plumbing from `J2clReadSurfaceDomRenderer` through `J2clSelectedWaveView` into `J2clSelectedWaveController`, using the existing `.sidecar-selected-content` / `#966` read-surface container instead of creating a parallel selected-wave surface.
+- Added `J2clViewportGrowthDirection` and routed renderer, controller, viewport-state, view, and gateway direction handling through the shared forward/backward normalizer.
+- Added keyed in-flight fragment-growth coalescing by `direction:anchor`; both success and error callbacks retain the in-flight key through `view.render(...)` so synchronous same-edge render re-entry is coalesced, then clear it to allow later retry/growth.
+- Merged successful `/fragments` responses into `J2clSelectedWaveViewportState`, using loaded blips only for null-anchor fallback. Stale growth responses are dropped when write-session version/hash changes; null-to-present write-session transitions remain accepted, while present-to-null is documented as stale.
+- Added scroll-anchor preservation for full `renderWindow(...)` rebuilds, one-shot edge auto-triggering when the user remains near an unloaded edge, and wave/classic transitions that clear stale viewport scroll memory while flat no-op renders preserve it.
+- Added soft failure behavior: failures keep loaded content visible, surface a non-blocking status, allow retry after render, and successful retry clears the fragment-growth banner with `"More selected-wave content loaded."`.
+- Claude Opus 4.7 review loop cleared in round 9 with no blockers or important required comments. Non-blocking notes were limited to follow-up considerations such as future copy/a11y polish and no-op-path micro-optimizations.
 
 Run:
 ```bash
-sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest"
+sbt -batch j2clSearchBuild j2clSearchTest && git diff --check && python3 scripts/validate-changelog.py
 ```
 
 Expected:
@@ -543,6 +552,11 @@ Expected:
   - duplicate-request suppression
   - stale-response drop behavior
   - failure placeholder/retry behavior
+- renderer tests cover:
+  - forward/backward edge callbacks on unloaded placeholders
+  - flat no-op scroll-memory preservation
+  - one-shot post-render edge auto-triggering
+  - backward prepend scroll-anchor preservation
 
 ### Task 6: Remove whole-wave bootstrap when viewport mode is active
 

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -613,15 +613,15 @@ Task 6 result:
 - Update issue comment(s)
 - Add journal verification note if the lane policy requires one
 
-- [ ] Boot the rebased `#965/#966/#967` stack on a local port
-- [ ] Verify the scripts in this section exist after rebase; if any are absent, substitute the repo's current worktree boot/smoke equivalent and record the substitution in the issue
-- [ ] Open a large-wave path in the J2CL root shell
-- [ ] Confirm:
+- [x] Boot the rebased `#965/#966/#967` stack on a local port
+- [x] Verify the scripts in this section exist after rebase; if any are absent, substitute the repo's current worktree boot/smoke equivalent and record the substitution in the issue
+- [x] Open a large-wave path in the J2CL root shell
+- [x] Confirm:
   - initial render shows only the visible fragment window
   - scrolling grows the window
   - focus and scroll anchor stay stable
   - network / logs show fragment-window fetches instead of a whole-wave bootstrap
-- [ ] Capture issue evidence:
+- [x] Capture issue evidence:
   - exact local route and selected wave id
   - requested/effective initial window size
   - browser network entry or log line for at least one `/fragments` extension fetch
@@ -644,6 +644,20 @@ http://localhost:9967/?view=j2cl-root
 
 Expected:
 - the issue log can cite the exact large-wave route used, the observed initial window size, and at least one successful extension fetch
+
+Task 7 result:
+
+- Fresh staged server booted on `127.0.0.1:9967`; boot log line at `2026-04-24T05:06:56.313561+03:00` confirmed `Configured WaveClientRpc fragments handler: enabled=true`.
+- Smoke verification passed with `ROOT_STATUS=200`, `J2CL_ROOT_STATUS=200`, `SIDECAR_STATUS=200`, and `WEBCLIENT_STATUS=200`.
+- Browser verification used the reproducible large-wave fixture created with `WAVE_PERF_BASE_URL=http://localhost:9967 sbt --batch 'GatlingTest / runMain org.waveprotocol.wave.perf.WaveDataSeeder 1 80'`: user `perfuser@local.net`, wave `local.net/w+perf0001`, 80 seeded blips.
+- Exact route verified: `http://127.0.0.1:9967/?view=j2cl-root&q=in%3Ainbox&wave=local.net%2Fw%2Bperf0001`.
+- Initial J2CL selected-wave render loaded only `b+perf0001b1` through `b+perf0001b5`, rendered one viewport placeholder, and used `.sidecar-selected-content` as the scroll surface with `overflow-y: auto`.
+- Selected-wave websocket open included explicit viewport mode: `{"1":"perfuser@local.net","2":"local.net/w+perf0001","3":["conv+root"],"7":0}`.
+- Selected-wave websocket update for `local.net/w+perf0001/~/conv+root` had `hasSnapshot=false`, `hasFragments=true`, `fragmentRangeCount=8`, and `fragmentEntryCount=6`, so the initial open did not send a full-wave bootstrap snapshot.
+- Scroll growth requested `GET /fragments?waveId=local.net%2Fw%2Bperf0001&waveletId=local.net%2Fconv%2Broot&client=j2cl&direction=forward&limit=5&startVersion=81&endVersion=81&startBlipId=b%2Bperf0001b6`, returned HTTP 200, and expanded the rendered blips to `b+perf0001b1` through `b+perf0001b10` while keeping focus on `b+perf0001b1`.
+- Server logs after the fresh restart emitted fragments for `local.net/w+perf0001/local.net/conv+root` with `ranges=8 snapshotVersion=81 endVersion=81` and had zero `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` entries.
+- Final verification after review follow-ups passed: `sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.rpc.FragmentsServletViewportLimitTest org.waveprotocol.box.server.ServerMainStructuredLoggingTest org.waveprotocol.box.server.frontend.WaveClientRpcFragmentsTest org.waveprotocol.box.server.frontend.ViewportLimitPolicyTest" j2clSearchBuild j2clSearchTest` (`35` targeted server tests plus J2CL build/tests), `sbt -batch Universal/stage`, `git diff --check`, and `python3 scripts/validate-changelog.py`.
+- Claude Opus 4.7 implementation review cleared in round 7 with no remaining blockers, important concerns, minor nits, coverage gaps, UX/a11y concerns, or performance pitfalls. Final output: `/tmp/claude-review-967-task7-r7.out`.
 
 ## 8. Review Plan
 

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -1,0 +1,539 @@
+# Issue #967 Viewport-Scoped Fragment Windows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drive the J2CL/Lit selected-wave read surface from explicit viewport-scoped fragment windows instead of the current coarse whole-wave selected-wave payload assumptions, while preserving the existing server clamp contract and leaving broader StageOne/read-surface behavior to `#966`.
+
+**Architecture:** Reuse the existing repo split rather than inventing a new transport. Initial selected-wave open continues to go through the sidecar `ProtocolOpenRequest`, but the J2CL open envelope must grow to carry the same viewport hints the GWT client already sends. Scroll growth does not reopen the selected-wave socket; it uses the existing `/fragments` JSON endpoint to fetch additional windows and merges them into a J2CL-owned visible-region model. To satisfy parity row `R-7.4`, the server path must stop treating viewport fragments as additive-on-top-of-a-full-snapshot when viewport mode is active, otherwise the client can render a windowed container while still paying whole-wave bootstrap cost on the wire.
+
+**Tech Stack:** J2CL Java client (`j2cl/src/main/java/...`), existing sidecar websocket transport, existing `/fragments` HTTP JSON endpoint, existing server-side `WaveClientRpcImpl` fragments attachment path, current root-shell/search/selected-wave J2CL surfaces, `sbt`-driven repo tasks (`j2clSearchBuild`, `j2clSearchTest`, targeted `testOnly`), and existing JUnit/J2CL test suites under `j2cl/src/test/java` and `wave/src/test/java`.
+
+---
+
+## 1. Goal / Baseline / Root Cause
+
+### 1.1 Parity contract for `#967`
+
+This plan is scoped to the rows already assigned to `#967`:
+
+- `docs/j2cl-parity-issue-map.md:307-340` defines the issue scope as:
+  - initial visible window
+  - J2CL open-contract viewport hints
+  - fragment expansion / scroll growth
+  - read-surface container updates
+  - explicit server limits / clamps
+- `docs/j2cl-gwt-parity-matrix.md:102-103` assigns `R-3.5` and `R-3.6` to `#967`:
+  - visible-region container model
+  - DOM-as-view provider compatibility for the new container
+- `docs/j2cl-gwt-parity-matrix.md:119` assigns `R-4.6` to `#967`:
+  - fragment-fetch policy must honour existing hints/clamps
+- `docs/j2cl-gwt-parity-matrix.md:168-171` assigns `R-7.1`–`R-7.4` to `#967`:
+  - initial visible window
+  - extension on scroll
+  - server clamp behavior
+  - no regression to whole-wave bootstrap
+- `docs/j2cl-lit-design-packet.md:265-272,384-389,496` says `#967` consumes only the read-surface `visible-region-placeholder` visual primitive; Stitch is **Prohibited** for fragment viewport logic itself.
+
+### 1.2 Current repo seams that already exist
+
+The repo is not starting from zero. The existing GWT/server path already has the pieces `#967` must reuse:
+
+- GWT initial open hint seam:
+  - `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteWaveViewService.java:327-340`
+  - `wave/src/main/java/org/waveprotocol/box/webclient/client/RemoteViewServiceMultiplexer.java:183-224`
+  - `RemoteWaveViewService` reads `initialViewportStartBlipId`, `initialViewportDirection`, and `initialViewportLimit` from client flags, then calls the multiplexer overload that sets `viewportStartBlipId`, `viewportDirection`, and `viewportLimit` on `ProtocolOpenRequest`.
+- GWT dynamic growth seam:
+  - `wave/src/main/java/org/waveprotocol/wave/client/StageTwo.java:1091-1185`
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/DynamicRendererImpl.java:755-813`
+  - `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/render/FragmentRequester.java:29-103`
+  - `DynamicRendererImpl` builds `RequestContext` from the visible blips and current versions, then uses either `ViewChannelFragmentRequester` or `ClientFragmentRequester` based on the existing `fragmentFetchMode` / `enableFragmentFetchViewChannel` / `enableFragmentFetchForceLayer` flags.
+- Server fragments/window seam:
+  - `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:371-428`
+  - `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java:62-127`
+  - `WaveClientRpcImpl` already reads `viewportStartBlipId`, `viewportDirection`, and `viewportLimit`; the current tests cover defaulting, max clamping, and invalid-direction tolerance.
+- HTTP `/fragments` seam:
+  - `wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java:69-277`
+  - the servlet already accepts `waveId`, `waveletId`, `startBlipId`, `direction`, `limit`, `startVersion`, and `endVersion`, and returns JSON containing:
+    - `version.snapshot`, `version.start`, `version.end`
+    - `ranges`
+    - `fragments`
+    - per-blip metadata
+
+### 1.3 Current J2CL gaps that block `#967`
+
+The current J2CL selected-wave path is still fundamentally sidecar-demo shaped:
+
+- J2CL open envelope cannot carry viewport hints:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java:7-31`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:13-31`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:231-238`
+  - `SidecarOpenRequest` only contains participant id, wave id, and wavelet prefixes; `encodeOpenEnvelope(...)` only writes numeric keys `1`, `2`, and `3`; `buildSelectedWaveOpenFrame(...)` hardcodes the minimal request.
+- J2CL preserves fragment payloads only long enough to flatten them:
+  - decode seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:86-149`
+  - projection seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:46-54,259-317`
+  - model seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:20-68`
+  - view seam: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:68-105`
+  - the transport decoder already preserves ranges and fragment entries, but the projector reduces them to `List<String> contentEntries`; the model stores only those flattened strings; the view renders them as `<pre>` blocks. That discards:
+    - segment identity
+    - loaded vs unloaded window boundaries
+    - placeholder positions
+    - enough structure to implement `R-3.6` DOM-as-view compatibility
+- J2CL has no fragment-growth transport seam:
+  - there is no `fetchFragments(...)` equivalent anywhere under `j2cl/src/main/java`
+  - a repository-wide search only finds viewport-aware logic in the GWT client and server path, not in J2CL
+- The root-shell/search-selected-wave host seams are still destructive:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-40`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:48-152`
+  - `J2clRootShellView` and `J2clSearchPanelView` clear `host.innerHTML`; that is exactly the kind of startup behavior `#965` must change before `#967` can safely consume preserved server-rendered fragment HTML.
+
+### 1.4 Additional implementation risks that must be planned up front
+
+These are the non-obvious seams that turn `#967` into a mixed server/client slice rather than a pure J2CL UI task:
+
+- Current bootstrap JSON does **not** carry visible-window hints:
+  - `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java:43-60`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java:103-136`
+  - the current bootstrap contract is limited to `session`, `socket.address`, and shell metadata. There is no current typed source of initial viewport anchor/limit for the J2CL read surface.
+- Current initial fragments still ride alongside full snapshot payloads:
+  - `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:192-218`
+  - `docs/fragments-viewport-behavior.md:213-217`
+  - `docs/migrate-conversation-renderer-to-apache-wave.md:21-31`
+  - the server still emits a full snapshot on initial open when fragments are present, which means a client-only change cannot meet `R-7.4`.
+- Current clamp semantics diverge between initial-open and `/fragments` growth:
+  - open path: `WaveClientRpcImpl.resolveViewportLimit(...)` clamps to `wave.fragments.defaultViewportLimit` / `wave.fragments.maxViewportLimit`
+  - HTTP growth path: `FragmentsServlet.clampLimit(...)` hardcodes default `50` and max `200`
+  - if J2CL uses `/fragments` for growth without server cleanup, extension windows will not match initial-open limits.
+
+### 1.5 Narrow root-cause summary
+
+`#967` is blocked by three concrete gaps:
+
+1. the J2CL sidecar open request cannot express viewport intent;
+2. the J2CL selected-wave model/view cannot preserve or render a fragment-window container;
+3. the current server transport still sends full-snapshot bootstrap data even when a viewport window exists, so a client-only fix cannot satisfy `R-7.4`.
+
+## 2. Acceptance Criteria
+
+`#967` is complete when all of the following are true:
+
+- J2CL selected-wave open frames carry the same viewport hint fields the GWT client already uses (`start blip`, `direction`, `limit`), encoded in the numeric `ProtocolOpenRequest` shape.
+- The J2CL selected-wave controller owns a typed viewport state (anchor, direction, limit, loaded ranges) instead of treating fragment payloads as raw display text.
+- The selected-wave model/view can render:
+  - loaded fragment sections
+  - unloaded placeholder sections
+  - a scrollable visible-region container that requests extension windows when the user enters an unloaded edge
+- Scroll growth uses a dedicated J2CL fetch path that keeps the live selected-wave socket open; it must not “refresh the whole selected wave” just to grow the window.
+- The server clamp rules used by initial open and by extension fetches are aligned and explicitly test-covered.
+- When viewport mode is active and fragments are available, the server no longer boots the selected-wave read surface with a whole-wave snapshot payload; large-wave open remains windowed on the wire as well as in the DOM.
+- The implementation records/uses the existing parity telemetry shape:
+  - initial-window size/clamp
+  - extension fetch counts/outcomes
+  - clamp applied/rejected
+  - whole-wave fallback warning if it still occurs
+- The implementation stays inside `#967` scope:
+  - no full StageOne parity work from `#966`
+  - no live-surface promotion from `#968`
+  - no new Stitch/design-system work beyond consuming the existing placeholder family
+- Verification passes:
+  - targeted J2CL tests
+  - targeted server fragments/open tests
+  - narrow local browser verification on a large-wave path against the merged `#965/#966` baseline
+
+## 3. Scope And Non-Goals
+
+### 3.1 In scope
+
+- J2CL sidecar open-envelope viewport hints
+- initial-window state derivation for selected-wave open
+- J2CL fragment-window model + projector + view/container changes
+- J2CL scroll-growth fetch path
+- server clamp normalization between initial open and growth fetch
+- server-side no-whole-wave-bootstrap behavior needed for `R-7.4`
+- tests and issue evidence for the above
+
+### 3.2 Explicit non-goals
+
+- No full StageOne keyboard/focus/collapse/thread-navigation parity. Those remain `#966`.
+- No live reconnect / route-history / shell-wide state work. Those remain `#968`.
+- No compose/edit/reaction/task work.
+- No visual redesign beyond consuming the already-approved `visible-region-placeholder`.
+- No PR creation in this prep lane.
+
+## 4. Dependency Readiness
+
+### 4.1 Already merged and available on this branch
+
+- `#961` parity matrix: merged
+- `#962` Lit design packet: merged
+- `#963` bootstrap JSON contract: merged
+- `#964` Lit root shell/chrome primitives: merged
+- `#931` unread/read selected-wave state: merged
+- `#933` HttpOnly-safe sidecar websocket auth: merged
+- `#936` selected-wave version/hash atomicity: merged
+
+### 4.2 Current blockers for implementation
+
+As of the current issue state on 2026-04-23:
+
+- `#965` is in active implementation, not merged
+- `#966` is still prep-only / not merged
+
+That means `#967` is **plan-ready but not implementation-ready**.
+
+### 4.3 Why `#965` is a hard blocker
+
+`#965` owns the preserved server-first selected-wave HTML seam. Until that lands, the J2CL root-shell/search-selected-wave path still clears host DOM on startup (`J2clRootShellView`, `J2clSearchPanelView`), which means `#967` has no stable preserved server fragment container to upgrade or inspect for initial visible-window state.
+
+### 4.4 Why `#966` is a hard blocker
+
+`#966` owns the practical StageOne read-surface container and DOM/provider contract. `#967` only makes sense once the read surface is no longer a flat `<pre>` list. This slice should wire viewport windows into the merged `#966` container rather than grow the current placeholder sidecar view into a second competing read-surface architecture.
+
+### 4.5 Required first implementation step once the blockers merge
+
+Before any code task below:
+
+- [ ] Run `git fetch origin && git rebase origin/main`
+- [ ] Confirm `origin/main` includes the merged implementations for `#965` and `#966`
+- [ ] Re-audit the actual merged file seams and update this plan in-branch if the merged file names differ from the current `J2clSelectedWave*` seams
+
+## 5. Slice Parity Packet — Issue #967
+
+**Title:** Drive the Lit read surface from viewport-scoped fragment windows instead of whole-wave payloads
+**Dependencies:** `#965`, `#966`
+
+### Parity matrix rows claimed
+
+- `R-3.5` — visible-region container model
+- `R-3.6` — DOM-as-view provider compatibility for the new container
+- `R-4.6` — fragment-fetch policy
+- `R-7.1` — initial visible window
+- `R-7.2` — extension on scroll
+- `R-7.3` — server clamp behavior
+- `R-7.4` — no regression to whole-wave bootstrap for large waves
+
+### Design-packet consumption
+
+- Consume §5.2 `visible-region-placeholder`
+- Do **not** open new Stitch work; `docs/j2cl-lit-design-packet.md:389` marks fragment viewport logic as design-tool-prohibited
+
+### Existing seams to reuse
+
+- Initial viewport flags / open transport:
+  - `RemoteWaveViewService`
+  - `RemoteViewServiceMultiplexer`
+- Dynamic growth request context:
+  - `FragmentRequester.RequestContext`
+  - `DynamicRendererImpl.maybeRequestFragments(...)`
+- Server viewport hints + clamp:
+  - `WaveClientRpcImpl`
+  - `WaveClientRpcViewportHintsTest`
+- HTTP growth JSON:
+  - `FragmentsServlet`
+
+### J2CL seams to replace or extend
+
+- `SidecarOpenRequest`
+- `SidecarTransportCodec`
+- `J2clSearchGateway`
+- `J2clSelectedWaveController`
+- `J2clSelectedWaveProjector`
+- `J2clSelectedWaveModel`
+- `J2clSelectedWaveView`
+- root-shell / selected-wave host wiring touched by `#965/#966`
+
+### Telemetry / observability checkpoints
+
+- initial open records the requested and effective viewport limit
+- extension fetches record request count, success/failure, and clamp-used
+- a warning metric/log fires if the selected-wave open path still receives a full snapshot while viewport mode is active
+
+### Verification shape
+
+- smoke + browser + harness, consistent with `R-3.5`, `R-4.6`, `R-7.1`–`R-7.4`
+
+## 6. File Structure
+
+### 6.1 Existing files expected to change
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java`
+
+### 6.2 New files recommended by this plan
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarViewportHints.java`
+  - tiny immutable holder for `startBlipId`, `direction`, and `limit`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java`
+  - DTO for `/fragments` JSON (`version`, `ranges`, `fragments`, `blips`)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+  - typed selected-wave window state preserved across projection and scroll growth
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java`
+  - shared config-backed clamp/default helper used by both `WaveClientRpcImpl` and `FragmentsServlet`
+
+### 6.3 Existing tests expected to grow
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java`
+
+### 6.4 New tests recommended by this plan
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java`
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java`
+
+## 7. Task Breakdown
+
+### Task 1: Rebase gate and merged seam audit
+
+**Files:**
+- Read / confirm only:
+  - `docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md`
+  - merged `#965` / `#966` files on `origin/main`
+
+- [ ] Rebase the worktree after `#965` and `#966` merge
+
+Run:
+```bash
+git fetch origin
+git rebase origin/main
+git log --oneline --max-count=8
+```
+
+Expected:
+- the branch includes the merged commits for `#965` and `#966`
+- the current selected-wave/root-shell file names still match this plan, or this plan is amended before code starts
+
+- [ ] Confirm the merged `#965` seam that exposes the initial selected-wave window source
+
+Run:
+```bash
+rg -n "selected-wave|fragment|visible|data-" j2cl/src/main/java wave/src/jakarta-overrides/java
+```
+
+Expected:
+- one concrete merged seam exists for the initial visible-window seed:
+  - preserved server DOM marker from `#965`, or
+  - explicit bootstrap extension from upstream merged work
+
+- [ ] Confirm the merged `#966` read-surface container seam
+
+Run:
+```bash
+rg -n "selected-wave|wave-panel|thread-container|view provider|placeholder" j2cl/src/main/java
+```
+
+Expected:
+- one concrete container/view seam is identified as the `#967` integration point
+- there is no need to invent a second read-surface architecture in this slice
+
+### Task 2: Extend the J2CL open contract for initial viewport hints
+
+**Files:**
+- Modify:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- Create:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarViewportHints.java`
+- Test:
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
+
+- [ ] Add a typed viewport-hints value object and thread it through the selected-wave open path
+- [ ] Extend `SidecarOpenRequest` to carry optional `startBlipId`, `direction`, and `limit`
+- [ ] Extend `encodeOpenEnvelope(...)` to emit the viewport numeric fields only when present
+- [ ] Keep the message type `ProtocolOpenRequest`; do not reintroduce any sidecar auth frame
+- [ ] Update the selected-wave controller/gateway seam so the initial open call accepts viewport hints derived from merged `#965/#966` state
+
+Run:
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest org.waveprotocol.box.j2cl.search.J2clSearchGatewayAuthFrameTest"
+```
+
+Expected:
+- open-envelope tests assert the numeric hint fields are present when supplied
+- auth-frame tests still prove the first outbound frame is `ProtocolOpenRequest`
+
+### Task 3: Preserve fragment-window structure in the J2CL model instead of flattening it away
+
+**Files:**
+- Modify:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- Create:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+- Test:
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+
+- [ ] Replace `List<String> contentEntries` as the primary rendering model with a typed window model that preserves:
+  - segment id
+  - range
+  - loaded vs placeholder state
+  - ordering
+- [ ] Keep enough compatibility in the projector/model for existing status/read/write-session assertions to keep passing
+- [ ] Teach the view to render loaded entries and placeholders without losing the eventual `#966` DOM/view-provider seam
+- [ ] Preserve fragment metadata even when snapshot documents are absent
+
+Run:
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest"
+```
+
+Expected:
+- projector tests prove fragment ranges survive projection
+- projector no longer depends on flattening raw snapshots into standalone `<pre>` blocks
+
+### Task 4: Add J2CL fragment-growth fetches and align server clamp policy
+
+**Files:**
+- Modify:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`
+- Create:
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java`
+  - `wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java`
+- Test:
+  - `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java`
+  - `wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java`
+  - new J2CL decoder test for `/fragments` response
+
+- [ ] Add a J2CL `/fragments` fetch method that decodes the existing servlet JSON shape into typed window data
+- [ ] Keep the selected-wave websocket subscription open for live updates; do not close/reopen the wave just to extend the viewport
+- [ ] Extract shared clamp/default behavior so the initial-open path and `/fragments` path honour the same limits
+- [ ] Make the extension request carry the current anchor/direction/limit plus version bounds
+
+Run:
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.rpc.FragmentsServletViewportLimitTest"
+sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponseTest"
+```
+
+Expected:
+- the same configured limits are applied in both paths
+- J2CL can decode and merge `/fragments` growth windows without using GWT-only code
+
+### Task 5: Wire scroll growth into the merged read-surface container
+
+**Files:**
+- Modify:
+  - the concrete merged selected-wave/read-surface controller/view files from `#966`
+  - if `#966` retains the current seam names, expect:
+    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+    - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+  - the concrete merged root-shell host seam from `#965`
+- Test:
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+
+- [ ] Add scroll-edge callbacks from the merged read-surface container to the selected-wave controller
+- [ ] Request growth only when the user approaches an unloaded edge; coalesce repeated scroll triggers
+- [ ] Preserve scroll anchor and focus when new windows merge in
+- [ ] Surface loading placeholders with the existing `visible-region-placeholder` visual vocabulary
+- [ ] Keep the container shape compatible with the `#966` DOM-as-view provider path
+
+Run:
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest"
+```
+
+Expected:
+- controller tests cover:
+  - initial open with viewport hints
+  - extension request scheduling
+  - duplicate-request suppression
+  - stale-response drop behavior
+
+### Task 6: Remove whole-wave bootstrap when viewport mode is active
+
+**Files:**
+- Modify:
+  - `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`
+  - the concrete merged selected-wave/root-shell server-first seam from `#965` if that merge owns the final selected-wave bootstrap markup or metadata boundary
+- Test:
+  - `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java`
+  - existing fragments/open tests that inspect the initial `ProtocolWaveletUpdate`
+
+- [ ] Gate initial selected-wave snapshot emission when viewport hints are active and fragments are available
+- [ ] Preserve the fields the J2CL selected-wave path still needs on initial open:
+  - wavelet name
+  - channel id
+  - resulting version / hash
+  - fragments payload
+- [ ] Add a regression assertion that a viewport-hinted selected-wave open no longer includes a whole-wave snapshot payload
+- [ ] Record a warning/metric only when the server truly has to fall back to full snapshot bootstrap
+
+Run:
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.frontend.WaveClientRpcFragmentsTest"
+```
+
+Expected:
+- viewport-hinted initial open is fragment-window-first on the wire
+- tests prove `R-7.4` instead of only rendering-level virtualization
+
+### Task 7: Browser verification and issue evidence
+
+**Files:**
+- Update issue comment(s)
+- Add journal verification note if the lane policy requires one
+
+- [ ] Boot the rebased `#965/#966/#967` stack on a local port
+- [ ] Open a large-wave path in the J2CL root shell
+- [ ] Confirm:
+  - initial render shows only the visible fragment window
+  - scrolling grows the window
+  - focus and scroll anchor stay stable
+  - network / logs show fragment-window fetches instead of a whole-wave bootstrap
+
+Run:
+```bash
+bash scripts/worktree-boot.sh --port 9967
+PORT=9967 bash scripts/wave-smoke.sh start
+PORT=9967 bash scripts/wave-smoke.sh check
+PORT=9967 bash scripts/wave-smoke.sh stop
+```
+
+Plus browser verification on:
+```text
+http://localhost:9967/?view=j2cl-root
+```
+
+Expected:
+- the issue log can cite the exact large-wave route used, the observed initial window size, and at least one successful extension fetch
+
+## 8. Review Plan
+
+Before implementation starts, the worker should be able to answer these review questions directly from the code and tests:
+
+- Where does the initial viewport hint source come from after `#965` and `#966` merge?
+- Does the J2CL open envelope match the existing GWT/server field contract exactly?
+- Does the J2CL model still flatten fragment data anywhere after decode?
+- What exact path performs scroll-growth fetches?
+- Do initial open and `/fragments` growth share the same clamp/default logic?
+- Is whole-wave snapshot bootstrap actually gone when viewport mode is active, or did the change only virtualize rendering?
+
+## 9. Ready-To-Start Call
+
+- `#967` is **not** ready for implementation on the current checkout.
+- `#967` becomes implementation-ready only after:
+  - `#965` merges
+  - `#966` merges
+  - this worktree rebases onto the merged `origin/main`
+  - Task 1 confirms the actual merged read-surface and server-first seams
+
+At that point the implementation should start with Task 2, not with view work first. The transport and server no-whole-wave-bootstrap seam are the hard constraints; if those do not land first, the container work will only paper over a transport regression.

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -312,6 +312,7 @@ Before any code task below, after `#966` merges:
 - [ ] Rebase the worktree after `#966` merges
 - [ ] Refresh §1 file:line citations after rebase so every cited seam points at the merged `origin/main`
 - [ ] If the merged `#966` read-surface seam does not expose a stable container for viewport windows, stop and amend this plan before implementation
+- [ ] Rewrite Task 5's file list and integration assertions to name the actual merged `#966` container/controller API before Task 5 starts; do not leave the container attachment test as a generic prose assertion
 
 Run:
 ```bash
@@ -351,6 +352,10 @@ Expected:
   - first choice: the preserved server-first `#966` read surface's first visible `[data-blip-id]`, sent as `viewportStartBlipId` with `viewportDirection="forward"`
   - fallback: when a selected wave is opened without preserved DOM, send `viewportLimit=0` only, using the existing server rule where an explicit non-positive limit means "use configured default" and also opts into viewport mode
   - legacy/no-selected-wave path: send no viewport hint fields, preserving current whole-snapshot behavior
+- [ ] Confirm `ProtocolOpenRequest` field-presence semantics before coding:
+  - server-side viewport detection must use `hasViewportLimit()` / field presence, not `viewportLimit > 0`
+  - if the protobuf/runtime cannot preserve explicit zero, introduce an explicit sentinel field/value before implementing snapshot suppression
+  - the `viewportLimit=0` fallback is invalid unless tests prove it arrives as "present and defaulted"
 
 ### Task 2: Extend the J2CL open contract for initial viewport hints
 
@@ -375,6 +380,7 @@ Expected:
   - no preserved DOM but selected wave present -> explicit `limit=0` and no `startBlipId`/`direction`
   - no selected wave / legacy call path -> no viewport fields
 - [ ] Add backwards-compatibility tests proving absent hints are not encoded and still produce the existing open envelope
+- [ ] Add a codec/server-boundary test proving a request carrying only `viewportLimit=0` is encoded/decoded as viewport-hinted via field presence
 
 Run:
 ```bash
@@ -384,6 +390,7 @@ sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTe
 Expected:
 - open-envelope tests assert the numeric hint fields are present when supplied
 - open-envelope tests assert no-hint requests omit the viewport fields entirely
+- open-envelope tests assert `viewportLimit=0` is still present on the wire and detectable by `hasViewportLimit()`
 - auth-frame tests still prove the first outbound frame is `ProtocolOpenRequest`
 
 ### Task 3: Preserve fragment-window structure in the J2CL model instead of flattening it away
@@ -445,6 +452,7 @@ Expected:
   - do not introduce new config keys in this slice
   - replace `FragmentsServlet`'s hardcoded `50/200` only with the same effective defaults already used by `WaveClientRpcImpl`
   - add a regression note/test for the GWT `DynamicRendererImpl`/`/fragments` path so shared servlet behavior does not unexpectedly change for non-J2CL callers
+  - add an explicit baseline test for current `FragmentsServlet` default/max behavior before the refactor, then update it to prove the shared policy preserves the same effective defaults unless config overrides them
 - [ ] Make the extension request carry the current anchor/direction/limit plus version bounds
 - [ ] Add concrete telemetry counters to `FragmentsMetrics`:
   - `j2clViewportInitialWindows`
@@ -464,6 +472,7 @@ Expected:
 - the same configured limits are applied in both paths
 - J2CL can decode and merge `/fragments` growth windows without using GWT-only code
 - non-J2CL `/fragments` callers keep the same default/max behavior unless config explicitly changes it
+- the FragmentsServlet baseline/default test prevents accidental `50/200` drift for GWT or other non-J2CL callers
 
 ### Task 5: Wire scroll growth into the merged read-surface container
 
@@ -517,6 +526,7 @@ Expected:
 
 - [ ] Gate initial selected-wave snapshot emission when viewport hints are active and fragments are available
   - the gate must be conditional on request-level viewport hints (`viewportStartBlipId`, `viewportDirection`, or `viewportLimit`)
+  - hint detection must use field presence (`hasViewportStartBlipId()`, `hasViewportDirection()`, `hasViewportLimit()`), not positive numeric values
   - no-hint open requests, including existing GWT/legacy callers, must continue receiving the current whole-wave snapshot payload
 - [ ] Preserve the fields the J2CL selected-wave path still needs on initial open:
   - wavelet name
@@ -528,6 +538,11 @@ Expected:
 - [ ] Record a warning/metric only when the server truly has to fall back to full snapshot bootstrap
   - metric: `FragmentsMetrics.j2clViewportSnapshotFallbacks`
   - warning marker: `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
+  - this counter is incremented server-side at the snapshot gate decision only; the client must not double-count it
+- [ ] Add a regression test for viewport-hinted open with fragments unavailable:
+  - server falls back to the whole-wave snapshot
+  - `FragmentsMetrics.j2clViewportSnapshotFallbacks` increments exactly once
+  - one `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` warning is emitted
 
 Run:
 ```bash
@@ -537,6 +552,7 @@ sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportH
 Expected:
 - viewport-hinted initial open is fragment-window-first on the wire
 - no-hint GWT/legacy open remains snapshot-compatible
+- viewport-hinted no-fragments fallback is observable through the named metric/log marker
 - tests prove `R-7.4` instead of only rendering-level virtualization
 
 ### Task 7: Browser verification and issue evidence
@@ -546,6 +562,7 @@ Expected:
 - Add journal verification note if the lane policy requires one
 
 - [ ] Boot the rebased `#965/#966/#967` stack on a local port
+- [ ] Verify the scripts in this section exist after rebase; if any are absent, substitute the repo's current worktree boot/smoke equivalent and record the substitution in the issue
 - [ ] Open a large-wave path in the J2CL root shell
 - [ ] Confirm:
   - initial render shows only the visible fragment window
@@ -558,6 +575,7 @@ Expected:
   - browser network entry or log line for at least one `/fragments` extension fetch
   - server/client log evidence that no full-wave snapshot was sent for the viewport-hinted open
   - value of `FragmentsMetrics.j2clViewportSnapshotFallbacks` or the absence of `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
+  - method used to create or identify the large-wave fixture so the verification is reproducible
 
 Run:
 ```bash

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -410,29 +410,40 @@ Expected:
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+  - `j2cl/src/main/webapp/assets/sidecar.css`
 - Create:
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+  - `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java`
 - Test:
   - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
 
-- [ ] Replace `List<String> contentEntries` as the primary rendering model with a typed window model that preserves:
+- [x] Replace `List<String> contentEntries` as the primary rendering model with a typed window model that preserves:
   - segment id
   - range
   - loaded vs placeholder state
   - ordering
-- [ ] Keep enough compatibility in the projector/model for existing status/read/write-session assertions to keep passing
-- [ ] Teach the view to render loaded entries and placeholders without losing the eventual `#966` DOM/view-provider seam
-- [ ] Preserve fragment metadata even when snapshot documents are absent
-- [ ] Keep compatibility coverage for existing selected-wave tests most likely to churn:
+- [x] Keep enough compatibility in the projector/model for existing status/read/write-session assertions to keep passing
+- [x] Teach the view to render loaded entries and placeholders without losing the eventual `#966` DOM/view-provider seam
+- [x] Preserve fragment metadata even when snapshot documents are absent
+- [x] Keep compatibility coverage for existing selected-wave tests most likely to churn:
   - `J2clSelectedWaveProjectorTest`
   - `J2clSelectedWaveViewServerFirstLogicTest`
   - `J2clReadSurfaceDomRendererTest`
   - any existing selected-wave model/view tests added by `#966`
-- [ ] Preserve `#936` version/hash atomicity when a live selected-wave update races a `/fragments` growth response; stale growth windows must be dropped or re-anchored based on version/hash
+- [x] Preserve `#936` version/hash atomicity when a live selected-wave update races a `/fragments` growth response; stale growth windows must be dropped or re-anchored based on version/hash
+
+Task 3 result:
+- Added `J2clSelectedWaveViewportState` with ordered segment/range entries, loaded/placeholder state, raw snapshots, operation counts, and snapshot/start/end versions.
+- Kept legacy `contentEntries` and `readBlips` as compatibility projections while moving the primary selected-wave read model to typed viewport state.
+- Added `J2clReadWindowEntry` plus read-surface rendering for loaded viewport blips and non-focusable placeholders, with stable no-op rerenders and safe transitions back to the classic renderer.
+- Document-only updates merge into prior viewport state, same-update documents append missing segments or fill unloaded placeholders, and loaded fragment snapshots continue to win over same-update document fallbacks.
+- No `/fragments` growth transport was added in Task 3; the state now preserves the version fields needed for Task 4/5 stale-growth handling, while the existing #936 write-session version/hash coupling remains covered by the selected-wave projector tests.
 
 Run:
 ```bash
-sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest"
+sbt -batch j2clSearchBuild j2clSearchTest
 ```
 
 Expected:

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -81,10 +81,10 @@ The current J2CL selected-wave path is still fundamentally sidecar-demo shaped:
 - J2CL has no fragment-growth transport seam:
   - there is no `fetchFragments(...)` equivalent anywhere under `j2cl/src/main/java`
   - a repository-wide search only finds viewport-aware logic in the GWT client and server path, not in J2CL
-- The root-shell/search-selected-wave host seams are still destructive:
+- The root-shell/search-selected-wave host seams were destructive before `#965`:
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-40`
   - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java:48-152`
-  - `J2clRootShellView` and `J2clSearchPanelView` clear `host.innerHTML`; that is exactly the kind of startup behavior `#965` must change before `#967` can safely consume preserved server-rendered fragment HTML.
+  - `#965` has now landed the preserved server-first selected-wave seam. `#967` must re-audit the merged root-shell/selected-wave host behavior and consume that seam rather than reintroducing startup DOM clearing.
 
 ### 1.4 Additional implementation risks that must be planned up front
 
@@ -167,22 +167,23 @@ These are the non-obvious seams that turn `#967` into a mixed server/client slic
 - `#962` Lit design packet: merged
 - `#963` bootstrap JSON contract: merged
 - `#964` Lit root shell/chrome primitives: merged
+- `#965` server-first selected-wave HTML / shell-swap seam: merged via PR `#989`
 - `#931` unread/read selected-wave state: merged
 - `#933` HttpOnly-safe sidecar websocket auth: merged
 - `#936` selected-wave version/hash atomicity: merged
 
 ### 4.2 Current blockers for implementation
 
-As of the current issue state on 2026-04-23:
+As of the current issue state on 2026-04-24:
 
-- `#965` is in active implementation, not merged
-- `#966` is still prep-only / not merged
+- `#965` has merged and this plan branch has been rebased onto an `origin/main` containing it
+- `#966` has moved from prep into PR `#991`, but it is not merged yet
 
-That means `#967` is **plan-ready but not implementation-ready**.
+That means `#967` is **plan-current and review-ready, but not implementation-ready** until `#966` lands.
 
-### 4.3 Why `#965` is a hard blocker
+### 4.3 Why `#965` was a hard blocker
 
-`#965` owns the preserved server-first selected-wave HTML seam. Until that lands, the J2CL root-shell/search-selected-wave path still clears host DOM on startup (`J2clRootShellView`, `J2clSearchPanelView`), which means `#967` has no stable preserved server fragment container to upgrade or inspect for initial visible-window state.
+`#965` owns the preserved server-first selected-wave HTML seam. That dependency is now satisfied, but Task 1 must still re-audit the exact merged files before implementation because `#967` needs to seed viewport state from the real preserved selected-wave surface, not from the pre-`#965` placeholder assumptions.
 
 ### 4.4 Why `#966` is a hard blocker
 
@@ -190,7 +191,7 @@ That means `#967` is **plan-ready but not implementation-ready**.
 
 ### 4.5 Required first implementation step once the blockers merge
 
-Before any code task below:
+Before any code task below, after `#966` merges:
 
 - [ ] Run `git fetch origin && git rebase origin/main`
 - [ ] Confirm `origin/main` includes the merged implementations for `#965` and `#966`
@@ -301,7 +302,7 @@ Before any code task below:
   - `docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md`
   - merged `#965` / `#966` files on `origin/main`
 
-- [ ] Rebase the worktree after `#965` and `#966` merge
+- [ ] Rebase the worktree after `#966` merges
 
 Run:
 ```bash
@@ -531,7 +532,6 @@ Before implementation starts, the worker should be able to answer these review q
 
 - `#967` is **not** ready for implementation on the current checkout.
 - `#967` becomes implementation-ready only after:
-  - `#965` merges
   - `#966` merges
   - this worktree rebases onto the merged `origin/main`
   - Task 1 confirms the actual merged read-surface and server-first seams

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -466,22 +466,30 @@ Expected:
   - `wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java`
   - new J2CL decoder test for `/fragments` response
 
-- [ ] Add a J2CL `/fragments` fetch method that decodes the existing servlet JSON shape into typed window data
-- [ ] Keep the selected-wave websocket subscription open for live updates; do not close/reopen the wave just to extend the viewport
-- [ ] Extract shared clamp/default behavior so the initial-open path and `/fragments` path honour the same limits
+- [x] Add a J2CL `/fragments` fetch method that decodes the existing servlet JSON shape into typed window data
+- [x] Keep the selected-wave websocket subscription open for live updates; do not close/reopen the wave just to extend the viewport
+- [x] Extract shared clamp/default behavior so the initial-open path and `/fragments` path honour the same limits
   - existing `wave.fragments.defaultViewportLimit` and `wave.fragments.maxViewportLimit` config keys are the source of truth
   - do not introduce new config keys in this slice
   - replace `FragmentsServlet`'s hardcoded `50/200` only with the same effective defaults already used by `WaveClientRpcImpl`
-  - add a regression note/test for the GWT `DynamicRendererImpl`/`/fragments` path so shared servlet behavior does not unexpectedly change for non-J2CL callers
-  - add an explicit baseline test for current `FragmentsServlet` default/max behavior before the refactor, then update it to prove the shared policy preserves the same effective defaults unless config overrides them
-- [ ] Make the extension request carry the current anchor/direction/limit plus version bounds
-- [ ] Add concrete telemetry counters to `FragmentsMetrics`:
+  - add a regression note/test for the GWT `DynamicRendererImpl`/`/fragments` path so the shared servlet behavior change is explicit for non-J2CL callers
+  - add an explicit baseline/default test proving the servlet uses the shared policy and does not drift back to an HTTP-only `50/200` clamp
+- [x] Make the extension request carry the current anchor/direction/limit plus version bounds
+- [x] Add concrete telemetry counters to `FragmentsMetrics`:
   - `j2clViewportInitialWindows`
   - `j2clViewportClampApplied`
   - `j2clViewportExtensionRequests`
   - `j2clViewportExtensionOk`
   - `j2clViewportExtensionErrors`
   - `j2clViewportSnapshotFallbacks`
+
+Task 4 result:
+- Added `ViewportLimitPolicy` and routed both `WaveClientRpcImpl` initial-open limit resolution and `FragmentsServlet` `/fragments` limit resolution through the same default/max policy (`5/50` unless startup config overrides it).
+- Replaced the servlet's legacy `50/200` hardcoded clamp with the shared policy. This intentionally means legacy non-J2CL `/fragments` callers now use the same effective max (`50`) as initial open instead of the old HTTP-only max (`200`); the changelog fragment calls out this bounded-window change.
+- Added `J2clSearchGateway.fetchFragments(...)` plus a deterministic `/fragments` URL builder that carries `waveId`, root `waveletId`, `client=j2cl`, anchor, direction, limit, and version bounds without closing or reopening the selected-wave websocket.
+- Added `SidecarFragmentsResponse` to decode the existing servlet JSON shape into `SidecarSelectedWaveFragments`, with deterministic failures for non-`ok` status, missing `version`, and malformed range entries. Operation bodies remain intentionally deferred to Task 5; this slice preserves operation counts only.
+- Added the required `FragmentsMetrics.j2clViewport*` counters. The extension and clamp metrics are scoped to J2CL-marked HTTP growth fetches (`client=j2cl`) so legacy `/fragments` callers are not counted as J2CL; the initial-window and snapshot-fallback counters are declared for the later Task 5/6 seams that can identify and gate those events correctly.
+- Review note: Claude Opus 4.7 round 2b passed with no blockers. It flagged the legacy `/fragments` max reduction and the deferred initial-window metric as notes to document, not code blockers.
 
 Run:
 ```bash
@@ -492,8 +500,8 @@ sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarFragmentsRespons
 Expected:
 - the same configured limits are applied in both paths
 - J2CL can decode and merge `/fragments` growth windows without using GWT-only code
-- non-J2CL `/fragments` callers keep the same default/max behavior unless config explicitly changes it
-- the FragmentsServlet baseline/default test prevents accidental `50/200` drift for GWT or other non-J2CL callers
+- non-J2CL `/fragments` callers use the same configured default/max policy as initial open; the former HTTP-only `50/200` clamp is intentionally removed and documented
+- the FragmentsServlet baseline/default test prevents accidental divergence between GWT, J2CL, and other `/fragments` callers
 
 ### Task 5: Wire scroll growth into the merged read-surface container
 

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -125,11 +125,15 @@ These are the non-obvious seams that turn `#967` into a mixed server/client slic
 - Scroll growth uses a dedicated J2CL fetch path that keeps the live selected-wave socket open; it must not “refresh the whole selected wave” just to grow the window.
 - The server clamp rules used by initial open and by extension fetches are aligned and explicitly test-covered.
 - When viewport mode is active and fragments are available, the server no longer boots the selected-wave read surface with a whole-wave snapshot payload; large-wave open remains windowed on the wire as well as in the DOM.
+- Snapshot suppression is request-scoped: only `ProtocolOpenRequest`s with at least one viewport hint field (`viewportStartBlipId`, `viewportDirection`, or `viewportLimit`) may skip the whole-wave snapshot. No-hint GWT/legacy opens must keep their current snapshot behavior.
 - The implementation records/uses the existing parity telemetry shape:
-  - initial-window size/clamp
-  - extension fetch counts/outcomes
-  - clamp applied/rejected
-  - whole-wave fallback warning if it still occurs
+  - `FragmentsMetrics.j2clViewportInitialWindows`
+  - `FragmentsMetrics.j2clViewportClampApplied`
+  - `FragmentsMetrics.j2clViewportExtensionRequests`
+  - `FragmentsMetrics.j2clViewportExtensionOk`
+  - `FragmentsMetrics.j2clViewportExtensionErrors`
+  - `FragmentsMetrics.j2clViewportSnapshotFallbacks`
+  - warning log marker `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` if a viewport-hinted open still has to send a whole-wave snapshot
 - The implementation stays inside `#967` scope:
   - no full StageOne parity work from `#966`
   - no live-surface promotion from `#968`
@@ -195,7 +199,9 @@ Before any code task below, after `#966` merges:
 
 - [ ] Run `git fetch origin && git rebase origin/main`
 - [ ] Confirm `origin/main` includes the merged implementations for `#965` and `#966`
+- [ ] Refresh the file:line citations in §1 after the rebase so review evidence points at the merged code, not the planning snapshot
 - [ ] Re-audit the actual merged file seams and update this plan in-branch if the merged file names differ from the current `J2clSelectedWave*` seams
+- [ ] If `#966` changed the selected-wave/read-surface seam enough that this task list no longer maps cleanly, stop implementation, amend this plan, and rerun the plan-review loop before code work
 
 ## 5. Slice Parity Packet — Issue #967
 
@@ -244,9 +250,10 @@ Before any code task below, after `#966` merges:
 
 ### Telemetry / observability checkpoints
 
-- initial open records the requested and effective viewport limit
-- extension fetches record request count, success/failure, and clamp-used
-- a warning metric/log fires if the selected-wave open path still receives a full snapshot while viewport mode is active
+- initial open increments `FragmentsMetrics.j2clViewportInitialWindows` and records requested/effective viewport limit in a sampled log line
+- clamp changes increment `FragmentsMetrics.j2clViewportClampApplied`
+- extension fetches increment `FragmentsMetrics.j2clViewportExtensionRequests`, `j2clViewportExtensionOk`, or `j2clViewportExtensionErrors`
+- a warning metric/log fires if the selected-wave open path still receives a full snapshot while viewport mode is active: `FragmentsMetrics.j2clViewportSnapshotFallbacks` plus `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
 
 ### Verification shape
 
@@ -303,6 +310,8 @@ Before any code task below, after `#966` merges:
   - merged `#965` / `#966` files on `origin/main`
 
 - [ ] Rebase the worktree after `#966` merges
+- [ ] Refresh §1 file:line citations after rebase so every cited seam points at the merged `origin/main`
+- [ ] If the merged `#966` read-surface seam does not expose a stable container for viewport windows, stop and amend this plan before implementation
 
 Run:
 ```bash
@@ -338,6 +347,11 @@ Expected:
 - one concrete container/view seam is identified as the `#967` integration point
 - there is no need to invent a second read-surface architecture in this slice
 
+- [ ] Confirm the initial viewport hint source using this ordered rule:
+  - first choice: the preserved server-first `#966` read surface's first visible `[data-blip-id]`, sent as `viewportStartBlipId` with `viewportDirection="forward"`
+  - fallback: when a selected wave is opened without preserved DOM, send `viewportLimit=0` only, using the existing server rule where an explicit non-positive limit means "use configured default" and also opts into viewport mode
+  - legacy/no-selected-wave path: send no viewport hint fields, preserving current whole-snapshot behavior
+
 ### Task 2: Extend the J2CL open contract for initial viewport hints
 
 **Files:**
@@ -356,7 +370,11 @@ Expected:
 - [ ] Extend `SidecarOpenRequest` to carry optional `startBlipId`, `direction`, and `limit`
 - [ ] Extend `encodeOpenEnvelope(...)` to emit the viewport numeric fields only when present
 - [ ] Keep the message type `ProtocolOpenRequest`; do not reintroduce any sidecar auth frame
-- [ ] Update the selected-wave controller/gateway seam so the initial open call accepts viewport hints derived from merged `#965/#966` state
+- [ ] Update the selected-wave controller/gateway seam so the initial open call accepts viewport hints derived from the Task 1 source decision:
+  - preserved server DOM first visible `data-blip-id` -> `startBlipId`, `direction="forward"`, no explicit limit
+  - no preserved DOM but selected wave present -> explicit `limit=0` and no `startBlipId`/`direction`
+  - no selected wave / legacy call path -> no viewport fields
+- [ ] Add backwards-compatibility tests proving absent hints are not encoded and still produce the existing open envelope
 
 Run:
 ```bash
@@ -365,6 +383,7 @@ sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTe
 
 Expected:
 - open-envelope tests assert the numeric hint fields are present when supplied
+- open-envelope tests assert no-hint requests omit the viewport fields entirely
 - auth-frame tests still prove the first outbound frame is `ProtocolOpenRequest`
 
 ### Task 3: Preserve fragment-window structure in the J2CL model instead of flattening it away
@@ -387,6 +406,12 @@ Expected:
 - [ ] Keep enough compatibility in the projector/model for existing status/read/write-session assertions to keep passing
 - [ ] Teach the view to render loaded entries and placeholders without losing the eventual `#966` DOM/view-provider seam
 - [ ] Preserve fragment metadata even when snapshot documents are absent
+- [ ] Keep compatibility coverage for existing selected-wave tests most likely to churn:
+  - `J2clSelectedWaveProjectorTest`
+  - `J2clSelectedWaveViewServerFirstLogicTest`
+  - `J2clReadSurfaceDomRendererTest`
+  - any existing selected-wave model/view tests added by `#966`
+- [ ] Preserve `#936` version/hash atomicity when a live selected-wave update races a `/fragments` growth response; stale growth windows must be dropped or re-anchored based on version/hash
 
 Run:
 ```bash
@@ -416,7 +441,18 @@ Expected:
 - [ ] Add a J2CL `/fragments` fetch method that decodes the existing servlet JSON shape into typed window data
 - [ ] Keep the selected-wave websocket subscription open for live updates; do not close/reopen the wave just to extend the viewport
 - [ ] Extract shared clamp/default behavior so the initial-open path and `/fragments` path honour the same limits
+  - existing `wave.fragments.defaultViewportLimit` and `wave.fragments.maxViewportLimit` config keys are the source of truth
+  - do not introduce new config keys in this slice
+  - replace `FragmentsServlet`'s hardcoded `50/200` only with the same effective defaults already used by `WaveClientRpcImpl`
+  - add a regression note/test for the GWT `DynamicRendererImpl`/`/fragments` path so shared servlet behavior does not unexpectedly change for non-J2CL callers
 - [ ] Make the extension request carry the current anchor/direction/limit plus version bounds
+- [ ] Add concrete telemetry counters to `FragmentsMetrics`:
+  - `j2clViewportInitialWindows`
+  - `j2clViewportClampApplied`
+  - `j2clViewportExtensionRequests`
+  - `j2clViewportExtensionOk`
+  - `j2clViewportExtensionErrors`
+  - `j2clViewportSnapshotFallbacks`
 
 Run:
 ```bash
@@ -427,6 +463,7 @@ sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarFragmentsRespons
 Expected:
 - the same configured limits are applied in both paths
 - J2CL can decode and merge `/fragments` growth windows without using GWT-only code
+- non-J2CL `/fragments` callers keep the same default/max behavior unless config explicitly changes it
 
 ### Task 5: Wire scroll growth into the merged read-surface container
 
@@ -446,6 +483,14 @@ Expected:
 - [ ] Preserve scroll anchor and focus when new windows merge in
 - [ ] Surface loading placeholders with the existing `visible-region-placeholder` visual vocabulary
 - [ ] Keep the container shape compatible with the `#966` DOM-as-view provider path
+- [ ] Define `/fragments` growth failure behavior:
+  - timeout/error keeps the existing window visible
+  - edge placeholder switches to retry/error state without clearing loaded blips
+  - duplicate requests for the same edge are coalesced while one is in flight
+  - stale responses whose version/hash no longer matches the selected-wave state are dropped
+  - a later scroll or retry can request the edge again
+- [ ] Add tests for timeout/error display, stale-response drop, duplicate-request suppression, and retry after failure
+- [ ] Add a direct assertion that the implementation attaches to the merged `#966` read-surface container rather than introducing a second competing selected-wave surface
 
 Run:
 ```bash
@@ -458,6 +503,7 @@ Expected:
   - extension request scheduling
   - duplicate-request suppression
   - stale-response drop behavior
+  - failure placeholder/retry behavior
 
 ### Task 6: Remove whole-wave bootstrap when viewport mode is active
 
@@ -470,13 +516,18 @@ Expected:
   - existing fragments/open tests that inspect the initial `ProtocolWaveletUpdate`
 
 - [ ] Gate initial selected-wave snapshot emission when viewport hints are active and fragments are available
+  - the gate must be conditional on request-level viewport hints (`viewportStartBlipId`, `viewportDirection`, or `viewportLimit`)
+  - no-hint open requests, including existing GWT/legacy callers, must continue receiving the current whole-wave snapshot payload
 - [ ] Preserve the fields the J2CL selected-wave path still needs on initial open:
   - wavelet name
   - channel id
   - resulting version / hash
   - fragments payload
 - [ ] Add a regression assertion that a viewport-hinted selected-wave open no longer includes a whole-wave snapshot payload
+- [ ] Add a regression assertion that a no-hint selected-wave open still includes the current whole-wave snapshot payload
 - [ ] Record a warning/metric only when the server truly has to fall back to full snapshot bootstrap
+  - metric: `FragmentsMetrics.j2clViewportSnapshotFallbacks`
+  - warning marker: `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
 
 Run:
 ```bash
@@ -485,6 +536,7 @@ sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportH
 
 Expected:
 - viewport-hinted initial open is fragment-window-first on the wire
+- no-hint GWT/legacy open remains snapshot-compatible
 - tests prove `R-7.4` instead of only rendering-level virtualization
 
 ### Task 7: Browser verification and issue evidence
@@ -500,6 +552,12 @@ Expected:
   - scrolling grows the window
   - focus and scroll anchor stay stable
   - network / logs show fragment-window fetches instead of a whole-wave bootstrap
+- [ ] Capture issue evidence:
+  - exact local route and selected wave id
+  - requested/effective initial window size
+  - browser network entry or log line for at least one `/fragments` extension fetch
+  - server/client log evidence that no full-wave snapshot was sent for the viewport-hinted open
+  - value of `FragmentsMetrics.j2clViewportSnapshotFallbacks` or the absence of `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
 
 Run:
 ```bash

--- a/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-967-viewport-fragments.md
@@ -568,25 +568,25 @@ Expected:
   - `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java`
   - existing fragments/open tests that inspect the initial `ProtocolWaveletUpdate`
 
-- [ ] Gate initial selected-wave snapshot emission when viewport hints are active and fragments are available
+- [x] Gate initial selected-wave snapshot emission when viewport hints are active and fragments are available
   - the gate must be conditional on request-level viewport hints (`viewportStartBlipId`, `viewportDirection`, or `viewportLimit`)
   - hint detection must use field presence (`hasViewportStartBlipId()`, `hasViewportDirection()`, `hasViewportLimit()`), not positive numeric values
   - no-hint open requests, including existing GWT/legacy callers, must continue receiving the current whole-wave snapshot payload
-- [ ] Preserve the fields the J2CL selected-wave path still needs on initial open:
+- [x] Preserve the fields the J2CL selected-wave path still needs on initial open:
   - wavelet name
   - channel id
   - resulting version / hash
   - fragments payload
-- [ ] Add a regression assertion that a viewport-hinted selected-wave open no longer includes a whole-wave snapshot payload
-- [ ] Add a regression assertion that a no-hint selected-wave open still includes the current whole-wave snapshot payload
-- [ ] Record a warning/metric only when the server truly has to fall back to full snapshot bootstrap
+- [x] Add a regression assertion that a viewport-hinted selected-wave open no longer includes a whole-wave snapshot payload
+- [x] Add a regression assertion that a no-hint selected-wave open still includes the current whole-wave snapshot payload
+- [x] Record a warning/metric only when the server truly has to fall back to full snapshot bootstrap
   - metric: `FragmentsMetrics.j2clViewportSnapshotFallbacks`
   - warning marker: `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK`
-  - this counter is incremented server-side at the snapshot gate decision only; the client must not double-count it
-- [ ] Add a regression test for viewport-hinted open with fragments unavailable:
+  - this counter is incremented server-side once per wavelet after attempted callback delivery; the client must not double-count it
+- [x] Add a regression test for viewport-hinted open with fragments unavailable:
   - server falls back to the whole-wave snapshot
   - `FragmentsMetrics.j2clViewportSnapshotFallbacks` increments exactly once
-  - one `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` warning is emitted
+  - one `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` warning is emitted with an operator-facing reason
 
 Run:
 ```bash
@@ -598,6 +598,14 @@ Expected:
 - no-hint GWT/legacy open remains snapshot-compatible
 - viewport-hinted no-fragments fallback is observable through the named metric/log marker
 - tests prove `R-7.4` instead of only rendering-level virtualization
+
+Task 6 result:
+
+- `WaveClientRpcImpl` now defers full snapshot serialization until after the fragments decision and suppresses the full snapshot only for viewport-hinted opens that attach a non-empty fragments payload.
+- Viewport initial-window metrics count any viewport-window delivery once per wavelet, including snapshot-less synthetic/dev fragments; snapshot fallback metrics count full-snapshot fallback once per wavelet after attempted callback delivery.
+- `WaveClientRpcViewportHintsTest` covers success suppression, no-hint compatibility, snapshot fallback, snapshot-less no-fragments behavior, snapshot-less fragments metrics, repeated same-wavelet metric de-duplication, multi-wavelet metric counting, and fallback reason labels.
+- Verification passed: `sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.frontend.WaveClientRpcFragmentsTest" && git diff --check && python3 scripts/validate-changelog.py`.
+- Claude Opus 4.7 implementation review cleared in round 7 with no blockers, important concerns, required nits, or required coverage gaps. Final output: `/tmp/claude-review-967-task6-r7.out`.
 
 ### Task 7: Browser verification and issue evidence
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -42,6 +42,9 @@ public final class J2clReadSurfaceDomRenderer {
    */
   public void setViewportEdgeListener(ViewportEdgeListener viewportEdgeListener) {
     this.viewportEdgeListener = viewportEdgeListener;
+    if (viewportEdgeListener == null) {
+      lastScrollDirection = null;
+    }
     if (!scrollListenerBound) {
       host.addEventListener("scroll", this::onHostScroll);
       scrollListenerBound = true;
@@ -161,11 +164,7 @@ public final class J2clReadSurfaceDomRenderer {
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
     restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
-    if (lastScrollDirection != null && isNearEdge(lastScrollDirection)) {
-      String pendingDirection = lastScrollDirection;
-      lastScrollDirection = null;
-      requestEdgeIfPlaceholder(pendingDirection);
-    }
+    requestReachablePlaceholderAfterRender();
     return true;
   }
 
@@ -433,7 +432,31 @@ public final class J2clReadSurfaceDomRenderer {
     return distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX;
   }
 
+  private void requestReachablePlaceholderAfterRender() {
+    if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
+      return;
+    }
+    if (lastScrollDirection != null && isNearEdge(lastScrollDirection)) {
+      String pendingDirection = lastScrollDirection;
+      lastScrollDirection = null;
+      requestEdgeIfPlaceholder(pendingDirection);
+      return;
+    }
+    if (edgePlaceholder(J2clViewportGrowthDirection.FORWARD) != null
+        && isNearEdge(J2clViewportGrowthDirection.FORWARD)) {
+      requestEdgeIfPlaceholder(J2clViewportGrowthDirection.FORWARD);
+      return;
+    }
+    if (edgePlaceholder(J2clViewportGrowthDirection.BACKWARD) != null
+        && isNearEdge(J2clViewportGrowthDirection.BACKWARD)) {
+      requestEdgeIfPlaceholder(J2clViewportGrowthDirection.BACKWARD);
+    }
+  }
+
   private void requestEdgeIfPlaceholder(String direction) {
+    if (viewportEdgeListener == null) {
+      return;
+    }
     J2clReadWindowEntry placeholder = edgePlaceholder(direction);
     if (placeholder != null) {
       viewportEdgeListener.onViewportEdge(placeholder.getBlipId(), direction);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -14,6 +14,9 @@ import java.util.List;
 public final class J2clReadSurfaceDomRenderer {
   private final HTMLDivElement host;
   private final List<HTMLElement> renderedBlips = new ArrayList<HTMLElement>();
+  private List<J2clReadWindowEntry> renderedWindowEntries =
+      Collections.<J2clReadWindowEntry>emptyList();
+  private HTMLElement renderedSurface;
   private HTMLElement focusedBlip;
   private int generatedThreadIdCounter;
 
@@ -26,6 +29,8 @@ public final class J2clReadSurfaceDomRenderer {
     if (effectiveBlips.isEmpty()) {
       host.innerHTML = "";
       renderedBlips.clear();
+      renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+      renderedSurface = null;
       focusedBlip = null;
       return false;
     }
@@ -39,6 +44,8 @@ public final class J2clReadSurfaceDomRenderer {
 
     host.innerHTML = "";
     renderedBlips.clear();
+    renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+    renderedSurface = null;
     focusedBlip = null;
 
     HTMLElement surface = (HTMLElement) DomGlobal.document.createElement("section");
@@ -57,6 +64,67 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     host.appendChild(surface);
+    renderedSurface = surface;
+    enhanceSurface(surface);
+    restoreCollapsedThreads(previouslyCollapsedThreadIds);
+    restoreFocusedBlipById(focusedBlipId);
+    return true;
+  }
+
+  public boolean renderWindow(List<J2clReadWindowEntry> entries) {
+    if (entries == null || entries.isEmpty()) {
+      host.innerHTML = "";
+      renderedBlips.clear();
+      renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+      renderedSurface = null;
+      focusedBlip = null;
+      return false;
+    }
+
+    String focusedBlipId = currentFocusedBlipId();
+    List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
+    if (matchesRenderedWindowEntries(entries)) {
+      restoreFocusedBlipById(focusedBlipId);
+      return true;
+    }
+
+    host.innerHTML = "";
+    renderedBlips.clear();
+    renderedSurface = null;
+    focusedBlip = null;
+
+    HTMLElement surface = (HTMLElement) DomGlobal.document.createElement("section");
+    surface.className = "j2cl-read-surface wave-content";
+    surface.setAttribute("data-j2cl-read-surface", "true");
+    surface.setAttribute("aria-label", "Selected wave read surface");
+
+    HTMLElement rootThread = (HTMLElement) DomGlobal.document.createElement("div");
+    rootThread.className = "thread j2cl-read-thread";
+    rootThread.setAttribute("data-thread-id", "root");
+    rootThread.setAttribute("role", "list");
+    surface.appendChild(rootThread);
+
+    int blipIndex = 0;
+    boolean hasPlaceholder = false;
+    for (int i = 0; i < entries.size(); i++) {
+      J2clReadWindowEntry entry = entries.get(i);
+      if (entry.isLoaded()) {
+        rootThread.appendChild(
+            renderBlip(new J2clReadBlip(entry.getBlipId(), entry.getText()), blipIndex++));
+      } else {
+        hasPlaceholder = true;
+        rootThread.appendChild(renderPlaceholder(entry));
+      }
+    }
+    if (hasPlaceholder) {
+      surface.setAttribute("aria-live", "polite");
+      rootThread.setAttribute("aria-busy", "true");
+    }
+
+    host.appendChild(surface);
+    renderedWindowEntries =
+        Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
+    renderedSurface = surface;
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
@@ -101,10 +169,13 @@ public final class J2clReadSurfaceDomRenderer {
   public boolean enhanceExistingSurface() {
     HTMLElement surface = findExistingSurface();
     if (surface == null) {
+      renderedSurface = null;
       return false;
     }
     HTMLElement previousFocusedBlip = focusedBlip;
     renderedBlips.clear();
+    renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+    renderedSurface = surface;
     focusedBlip = null;
     enhanceSurface(surface);
     restoreFocusedBlip(previousFocusedBlip);
@@ -132,6 +203,26 @@ public final class J2clReadSurfaceDomRenderer {
     content.textContent = blip.getText();
     article.appendChild(content);
     return article;
+  }
+
+  private HTMLElement renderPlaceholder(J2clReadWindowEntry entry) {
+    HTMLElement placeholder = (HTMLElement) DomGlobal.document.createElement("div");
+    placeholder.className = "j2cl-read-viewport-placeholder visible-region-placeholder";
+    placeholder.setAttribute("data-j2cl-viewport-placeholder", "true");
+    placeholder.setAttribute("data-segment", entry.getSegment());
+    if (entry.getFromVersion() >= 0) {
+      placeholder.setAttribute("data-range-from", Long.toString(entry.getFromVersion()));
+    }
+    if (entry.getToVersion() >= 0) {
+      placeholder.setAttribute("data-range-to", Long.toString(entry.getToVersion()));
+    }
+    if (!entry.getBlipId().isEmpty()) {
+      placeholder.setAttribute("data-placeholder-blip-id", entry.getBlipId());
+    }
+    placeholder.setAttribute("role", "listitem");
+    placeholder.setAttribute("aria-busy", "true");
+    placeholder.textContent = placeholderText();
+    return placeholder;
   }
 
   private HTMLElement findExistingSurface() {
@@ -397,6 +488,12 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private boolean matchesRenderedBlips(List<J2clReadBlip> blips) {
+    if (!renderedWindowEntries.isEmpty()) {
+      return false;
+    }
+    if (host.querySelector("[data-j2cl-viewport-placeholder='true']") != null) {
+      return false;
+    }
     if (renderedBlips.size() != blips.size()) {
       return false;
     }
@@ -411,6 +508,31 @@ public final class J2clReadSurfaceDomRenderer {
       }
     }
     return true;
+  }
+
+  private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
+    if (renderedSurface == null || renderedSurface.parentElement != host) {
+      return false;
+    }
+    if (renderedWindowEntries.size() != entries.size()) {
+      return false;
+    }
+    for (int i = 0; i < entries.size(); i++) {
+      if (!sameWindowEntry(renderedWindowEntries.get(i), entries.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean sameWindowEntry(
+      J2clReadWindowEntry left, J2clReadWindowEntry right) {
+    return left.isLoaded() == right.isLoaded()
+        && left.getFromVersion() == right.getFromVersion()
+        && left.getToVersion() == right.getToVersion()
+        && left.getSegment().equals(right.getSegment())
+        && left.getBlipId().equals(right.getBlipId())
+        && left.getText().equals(right.getText());
   }
 
   private HTMLElement renderedBlipById(String blipId) {
@@ -525,6 +647,10 @@ public final class J2clReadSurfaceDomRenderer {
       return "Blip";
     }
     return "Blip " + readableId(blipId, "b+");
+  }
+
+  private static String placeholderText() {
+    return "Loading wave content.";
   }
 
   private static String readableId(String id, String prefix) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -10,8 +10,17 @@ import elemental2.dom.NodeList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clReadSurfaceDomRenderer {
+  // Roughly one compact blip of lead time before a viewport edge reaches the exact scroll boundary.
+  private static final double EDGE_SCROLL_THRESHOLD_PX = 64;
+
+  @FunctionalInterface
+  public interface ViewportEdgeListener {
+    void onViewportEdge(String anchorBlipId, String direction);
+  }
+
   private final HTMLDivElement host;
   private final List<HTMLElement> renderedBlips = new ArrayList<HTMLElement>();
   private List<J2clReadWindowEntry> renderedWindowEntries =
@@ -19,14 +28,34 @@ public final class J2clReadSurfaceDomRenderer {
   private HTMLElement renderedSurface;
   private HTMLElement focusedBlip;
   private int generatedThreadIdCounter;
+  private ViewportEdgeListener viewportEdgeListener;
+  private boolean scrollListenerBound;
+  private String lastScrollDirection;
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this.host = host;
   }
 
+  /**
+   * Installs the viewport edge callback once for this renderer. Passing null
+   * disables callback delivery but intentionally keeps the cheap scroll listener bound.
+   */
+  public void setViewportEdgeListener(ViewportEdgeListener viewportEdgeListener) {
+    this.viewportEdgeListener = viewportEdgeListener;
+    if (!scrollListenerBound) {
+      host.addEventListener("scroll", this::onHostScroll);
+      scrollListenerBound = true;
+    }
+  }
+
+  public void clearViewportScrollMemory() {
+    lastScrollDirection = null;
+  }
+
   public boolean render(List<J2clReadBlip> blips, List<String> fallbackEntries) {
     List<J2clReadBlip> effectiveBlips = normalizeBlips(blips, fallbackEntries);
     if (effectiveBlips.isEmpty()) {
+      clearViewportScrollMemory();
       host.innerHTML = "";
       renderedBlips.clear();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
@@ -42,6 +71,7 @@ public final class J2clReadSurfaceDomRenderer {
       return true;
     }
 
+    clearViewportScrollMemory();
     host.innerHTML = "";
     renderedBlips.clear();
     renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
@@ -82,6 +112,8 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     String focusedBlipId = currentFocusedBlipId();
+    String scrollAnchorBlipId = firstRenderedBlipId();
+    double scrollAnchorTop = renderedBlipTop(scrollAnchorBlipId);
     List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
     if (matchesRenderedWindowEntries(entries)) {
       restoreFocusedBlipById(focusedBlipId);
@@ -128,6 +160,12 @@ public final class J2clReadSurfaceDomRenderer {
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
+    restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
+    if (lastScrollDirection != null && isNearEdge(lastScrollDirection)) {
+      String pendingDirection = lastScrollDirection;
+      lastScrollDirection = null;
+      requestEdgeIfPlaceholder(pendingDirection);
+    }
     return true;
   }
 
@@ -367,6 +405,75 @@ public final class J2clReadSurfaceDomRenderer {
       focusByIndex(renderedBlips.size() - 1);
       keyEvent.preventDefault();
     }
+  }
+
+  private void onHostScroll(Event event) {
+    if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
+      return;
+    }
+    if (host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX) {
+      lastScrollDirection = J2clViewportGrowthDirection.BACKWARD;
+      requestEdgeIfPlaceholder(J2clViewportGrowthDirection.BACKWARD);
+      return;
+    }
+    double distanceFromBottom = host.scrollHeight - host.clientHeight - host.scrollTop;
+    if (distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX) {
+      lastScrollDirection = J2clViewportGrowthDirection.FORWARD;
+      requestEdgeIfPlaceholder(J2clViewportGrowthDirection.FORWARD);
+      return;
+    }
+    lastScrollDirection = null;
+  }
+
+  private boolean isNearEdge(String direction) {
+    if (J2clViewportGrowthDirection.isBackward(direction)) {
+      return host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
+    }
+    double distanceFromBottom = host.scrollHeight - host.clientHeight - host.scrollTop;
+    return distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX;
+  }
+
+  private void requestEdgeIfPlaceholder(String direction) {
+    J2clReadWindowEntry placeholder = edgePlaceholder(direction);
+    if (placeholder != null) {
+      viewportEdgeListener.onViewportEdge(placeholder.getBlipId(), direction);
+    }
+  }
+
+  private J2clReadWindowEntry edgePlaceholder(String direction) {
+    if (J2clViewportGrowthDirection.isBackward(direction)) {
+      J2clReadWindowEntry first = renderedWindowEntries.get(0);
+      return first.isLoaded() ? null : first;
+    }
+    J2clReadWindowEntry last = renderedWindowEntries.get(renderedWindowEntries.size() - 1);
+    return last.isLoaded() ? null : last;
+  }
+
+  private String firstRenderedBlipId() {
+    for (HTMLElement blip : renderedBlips) {
+      String blipId = blip.getAttribute("data-blip-id");
+      if (blipId != null && !blipId.isEmpty()) {
+        return blipId;
+      }
+    }
+    return "";
+  }
+
+  private double renderedBlipTop(String blipId) {
+    HTMLElement blip = renderedBlipById(blipId);
+    return blip == null ? 0 : blip.getBoundingClientRect().top;
+  }
+
+  private void restoreScrollAnchor(String blipId, double previousTop) {
+    HTMLElement blip = renderedBlipById(blipId);
+    if (blip == null || blipId == null || blipId.isEmpty()) {
+      return;
+    }
+    double delta = blip.getBoundingClientRect().top - previousTop;
+    // Apply the layout delta to the browser's current scrollTop. This stays
+    // correct whether the browser preserved scrollTop through the rebuild or
+    // reset it while the old surface was detached.
+    host.scrollTop = Math.max(0, host.scrollTop + delta);
   }
 
   private void focusByOffset(int offset) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -106,6 +106,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   public boolean renderWindow(List<J2clReadWindowEntry> entries) {
     if (entries == null || entries.isEmpty()) {
+      clearViewportScrollMemory();
       host.innerHTML = "";
       renderedBlips.clear();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
@@ -207,6 +208,9 @@ public final class J2clReadSurfaceDomRenderer {
     HTMLElement surface = findExistingSurface();
     if (surface == null) {
       renderedSurface = null;
+      renderedBlips.clear();
+      renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+      focusedBlip = null;
       return false;
     }
     HTMLElement previousFocusedBlip = focusedBlip;
@@ -618,6 +622,9 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private boolean matchesRenderedBlips(List<J2clReadBlip> blips) {
+    if (renderedSurface == null || renderedSurface.parentElement != host) {
+      return false;
+    }
     if (!renderedWindowEntries.isEmpty()) {
       return false;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -1,0 +1,59 @@
+package org.waveprotocol.box.j2cl.read;
+
+public final class J2clReadWindowEntry {
+  private final String segment;
+  private final long fromVersion;
+  private final long toVersion;
+  private final String blipId;
+  private final String text;
+  private final boolean loaded;
+
+  private J2clReadWindowEntry(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      boolean loaded) {
+    this.segment = segment == null ? "" : segment;
+    this.fromVersion = fromVersion;
+    this.toVersion = toVersion;
+    this.blipId = blipId == null ? "" : blipId;
+    this.text = text == null ? "" : text;
+    this.loaded = loaded;
+  }
+
+  public static J2clReadWindowEntry loaded(
+      String segment, long fromVersion, long toVersion, String blipId, String text) {
+    return new J2clReadWindowEntry(segment, fromVersion, toVersion, blipId, text, true);
+  }
+
+  public static J2clReadWindowEntry placeholder(
+      String segment, long fromVersion, long toVersion, String blipId) {
+    return new J2clReadWindowEntry(segment, fromVersion, toVersion, blipId, "", false);
+  }
+
+  public String getSegment() {
+    return segment;
+  }
+
+  public long getFromVersion() {
+    return fromVersion;
+  }
+
+  public long getToVersion() {
+    return toVersion;
+  }
+
+  public String getBlipId() {
+    return blipId;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public boolean isLoaded() {
+    return loaded;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -15,6 +15,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
 import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSearchGateway
     implements
@@ -290,7 +291,11 @@ public final class J2clSearchGateway
         .append(encodeQueryComponent(defaultWaveletId(waveId)))
         .append("&client=j2cl")
         .append("&direction=")
-        .append(encodeQueryComponent(direction == null ? "forward" : direction))
+        .append(
+            encodeQueryComponent(
+                direction == null
+                    ? J2clViewportGrowthDirection.FORWARD
+                    : J2clViewportGrowthDirection.normalize(direction)))
         .append("&limit=")
         .append(limit)
         .append("&startVersion=")

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -13,6 +13,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 public final class J2clSearchGateway
     implements
@@ -45,6 +46,7 @@ public final class J2clSearchGateway
   public J2clSelectedWaveController.Subscription openSelectedWave(
       SidecarSessionBootstrap bootstrap,
       String waveId,
+      SidecarViewportHints viewportHints,
       J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
       J2clSearchPanelController.ErrorCallback onError,
       Runnable onDisconnect) {
@@ -61,7 +63,7 @@ public final class J2clSearchGateway
           if (closedByClient[0]) {
             return;
           }
-          socket.send(buildSelectedWaveOpenFrame(bootstrap, waveId));
+          socket.send(buildSelectedWaveOpenFrame(bootstrap, waveId, viewportHints));
         };
     socket.onmessage =
         event -> {
@@ -229,12 +231,18 @@ public final class J2clSearchGateway
   }
 
   static String buildSelectedWaveOpenFrame(SidecarSessionBootstrap bootstrap, String waveId) {
+    return buildSelectedWaveOpenFrame(bootstrap, waveId, SidecarViewportHints.none());
+  }
+
+  static String buildSelectedWaveOpenFrame(
+      SidecarSessionBootstrap bootstrap, String waveId, SidecarViewportHints viewportHints) {
     return SidecarTransportCodec.encodeOpenEnvelope(
         1,
         new SidecarOpenRequest(
             bootstrap.getAddress(),
             waveId,
-            java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX)));
+            java.util.Collections.singletonList(DEFAULT_WAVELET_PREFIX),
+            viewportHints));
   }
 
   static String buildSubmitFrame(SidecarSubmitRequest request) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -6,6 +6,7 @@ import elemental2.dom.XMLHttpRequest;
 import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
+import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
@@ -138,6 +139,32 @@ public final class J2clSearchGateway
   }
 
   @Override
+  public void fetchFragments(
+      String waveId,
+      String startBlipId,
+      String direction,
+      int limit,
+      long startVersion,
+      long endVersion,
+      J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    if (waveId == null || waveId.isEmpty()) {
+      onError.accept("Wave id is required for the fragments fetch.");
+      return;
+    }
+    requestText(
+        buildFragmentsUrl(waveId, startBlipId, direction, limit, startVersion, endVersion),
+        text -> {
+          try {
+            onSuccess.accept(SidecarFragmentsResponse.fromJson(text));
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to decode selected-wave fragments."));
+          }
+        },
+        onError);
+  }
+
+  @Override
   public void search(
       String query,
       int index,
@@ -247,6 +274,70 @@ public final class J2clSearchGateway
 
   static String buildSubmitFrame(SidecarSubmitRequest request) {
     return SidecarTransportCodec.encodeSubmitEnvelope(1, request);
+  }
+
+  static String buildFragmentsUrl(
+      String waveId,
+      String startBlipId,
+      String direction,
+      int limit,
+      long startVersion,
+      long endVersion) {
+    // J2CL selected-wave parity currently targets the root conversation wavelet.
+    StringBuilder url = new StringBuilder("/fragments?waveId=");
+    url.append(encodeQueryComponent(waveId))
+        .append("&waveletId=")
+        .append(encodeQueryComponent(defaultWaveletId(waveId)))
+        .append("&client=j2cl")
+        .append("&direction=")
+        .append(encodeQueryComponent(direction == null ? "forward" : direction))
+        .append("&limit=")
+        .append(limit)
+        .append("&startVersion=")
+        .append(startVersion)
+        .append("&endVersion=")
+        .append(endVersion);
+    if (startBlipId != null && !startBlipId.isEmpty()) {
+      url.append("&startBlipId=").append(encodeQueryComponent(startBlipId));
+    }
+    return url.toString();
+  }
+
+  private static String defaultWaveletId(String waveId) {
+    int separator = waveId == null ? -1 : waveId.indexOf('/');
+    String domain = separator <= 0 ? "" : waveId.substring(0, separator);
+    return domain.isEmpty() ? DEFAULT_WAVELET_PREFIX : domain + "/" + DEFAULT_WAVELET_PREFIX;
+  }
+
+  private static String encodeQueryComponent(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    // Keep this JVM-testable; encodeURIComponent is native and unavailable in JUnit.
+    // Wave ids, wavelet ids, blip ids, and directions use the ASCII-safe Wave id alphabet.
+    StringBuilder encoded = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_'
+          || c == '.'
+          || c == '~') {
+        encoded.append(c);
+      } else {
+        encoded.append('%');
+        appendHex(encoded, c >> 4);
+        appendHex(encoded, c);
+      }
+    }
+    return encoded.toString();
+  }
+
+  private static void appendHex(StringBuilder target, int value) {
+    int nibble = value & 0x0F;
+    target.append((char) (nibble < 10 ? '0' + nibble : 'A' + (nibble - 10)));
   }
 
   private static void requestText(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,11 +1,14 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import java.util.HashSet;
+import java.util.Set;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveController
     implements J2clSidecarRouteController.SelectedWaveController {
@@ -13,6 +16,12 @@ public final class J2clSelectedWaveController
   // Keep retries bounded, but leave enough budget for a local WIAB restart on the same port.
   private static final int MAX_RECONNECT_DELAY_MS = 2000;
   private static final int MAX_RECONNECT_ATTEMPTS = 8;
+  // Matches the current server default viewport window until growth-size config is exposed to J2CL.
+  private static final int FRAGMENT_GROWTH_LIMIT = 5;
+  private static final String FRAGMENT_GROWTH_FAILURE_STATUS =
+      "Could not load more selected-wave content.";
+  private static final String FRAGMENT_GROWTH_RECOVERED_STATUS =
+      "More selected-wave content loaded.";
   // Trailing-edge debounce for per-update read-state fetches. Short enough to
   // feel live, long enough to coalesce server-initiated flurries without
   // amplifying HTTP pressure.
@@ -58,6 +67,14 @@ public final class J2clSelectedWaveController
     default SidecarViewportHints initialViewportHints(String selectedWaveId) {
       return SidecarViewportHints.defaultLimit();
     }
+
+    default void setViewportEdgeHandler(ViewportEdgeHandler handler) {
+    }
+  }
+
+  @FunctionalInterface
+  public interface ViewportEdgeHandler {
+    void onViewportEdge(String anchorBlipId, String direction);
   }
 
   public interface RetryScheduler {
@@ -105,6 +122,7 @@ public final class J2clSelectedWaveController
   private int readStateFetchSeq;
   private int latestReadStateApplied;
   private int pendingDebounceToken;
+  private final Set<String> fragmentFetchesInFlight = new HashSet<String>();
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
     this(
@@ -180,6 +198,7 @@ public final class J2clSelectedWaveController
     this.writeSessionListener = writeSessionListener;
     this.currentModel = J2clSelectedWaveModel.empty();
     this.view.render(currentModel);
+    this.view.setViewportEdgeHandler(this::onViewportEdge);
     publishWriteSession();
     if (visibilitySource != null) {
       visibilitySource.addVisibilityListener(this::onVisible);
@@ -196,6 +215,7 @@ public final class J2clSelectedWaveController
     }
     int generation = ++requestGeneration;
     closeSubscription();
+    resetFragmentFetchTracking();
     reconnectCount = 0;
     // A refresh happens after the reply already committed on the server, so transient bootstrap or
     // open failures should recover like a reconnect instead of strand the panel on stale content.
@@ -228,6 +248,7 @@ public final class J2clSelectedWaveController
     int generation = ++requestGeneration;
     closeSubscription();
     resetReadStateFetchTracking();
+    resetFragmentFetchTracking();
 
     if (waveId == null || waveId.isEmpty()) {
       selectedWaveId = null;
@@ -368,6 +389,106 @@ public final class J2clSelectedWaveController
     return hints == null || !hints.hasHints() ? SidecarViewportHints.defaultLimit() : hints;
   }
 
+  void onViewportEdge(String anchorBlipId, String direction) {
+    if (selectedWaveId == null || selectedWaveId.isEmpty() || currentModel == null) {
+      return;
+    }
+    J2clSelectedWaveViewportState viewportState = currentModel.getViewportState();
+    if (viewportState == null || viewportState.isEmpty()) {
+      return;
+    }
+    String normalizedDirection = normalizeGrowthDirection(direction);
+    String anchor = normalizeAnchor(anchorBlipId, viewportState, normalizedDirection);
+    if (anchor.isEmpty()) {
+      return;
+    }
+    String edgeKey = normalizedDirection + ":" + anchor;
+    if (fragmentFetchesInFlight.contains(edgeKey)) {
+      return;
+    }
+    fragmentFetchesInFlight.add(edgeKey);
+    int generation = requestGeneration;
+    String waveId = selectedWaveId;
+    long startVersion = viewportState.getStartVersion();
+    long endVersion = viewportState.getEndVersion();
+    J2clSidecarWriteSession writeSession = currentModel.getWriteSession();
+    boolean hadWriteSession = writeSession != null;
+    long baseVersion = writeSession == null ? -1L : writeSession.getBaseVersion();
+    String historyHash = writeSession == null ? "" : nullToEmpty(writeSession.getHistoryHash());
+    gateway.fetchFragments(
+        waveId,
+        anchor,
+        normalizedDirection,
+        FRAGMENT_GROWTH_LIMIT,
+        startVersion,
+        endVersion,
+        response -> {
+          if (!isCurrentGeneration(generation) || !waveId.equals(selectedWaveId)) {
+            return;
+          }
+          if (isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash)) {
+            fragmentFetchesInFlight.remove(edgeKey);
+            return;
+          }
+          J2clSelectedWaveViewportState mergedState =
+              currentModel
+                  .getViewportState()
+                  .mergeFragments(response.getFragments(), normalizedDirection);
+          currentModel = currentModel.withViewportState(mergedState);
+          // Only clear the soft fragment-growth banner owned by this controller.
+          // Live-update statuses are left intact because they represent fresher stream state.
+          if (FRAGMENT_GROWTH_FAILURE_STATUS.equals(currentModel.getStatusText())) {
+            currentModel = currentModel.withStatus(FRAGMENT_GROWTH_RECOVERED_STATUS, "");
+          }
+          view.render(currentModel);
+          publishWriteSession();
+          fragmentFetchesInFlight.remove(edgeKey);
+        },
+        error -> {
+          if (!isCurrentGeneration(generation) || !waveId.equals(selectedWaveId)) {
+            return;
+          }
+          // Soft failure: keep loaded blips visible while surfacing retry context.
+          currentModel =
+              currentModel.withStatus(
+                  FRAGMENT_GROWTH_FAILURE_STATUS,
+                  error == null ? "" : error);
+          view.render(currentModel);
+          publishWriteSession();
+          fragmentFetchesInFlight.remove(edgeKey);
+        });
+  }
+
+  private boolean isStaleFragmentResponse(
+      boolean hadWriteSession, long baseVersion, String historyHash) {
+    if (!hadWriteSession) {
+      return false;
+    }
+    J2clSidecarWriteSession writeSession = currentModel.getWriteSession();
+    // If a write session disappears before the fragment response returns, the controller can no
+    // longer prove the response belongs to the same live selected-wave stream, so treat it as stale.
+    long currentBaseVersion = writeSession == null ? -1L : writeSession.getBaseVersion();
+    String currentHistoryHash =
+        writeSession == null ? "" : nullToEmpty(writeSession.getHistoryHash());
+    return baseVersion != currentBaseVersion || !historyHash.equals(currentHistoryHash);
+  }
+
+  private static String normalizeGrowthDirection(String direction) {
+    return J2clViewportGrowthDirection.normalize(direction);
+  }
+
+  private static String normalizeAnchor(
+      String anchorBlipId, J2clSelectedWaveViewportState viewportState, String direction) {
+    if (anchorBlipId != null && !anchorBlipId.isEmpty()) {
+      return anchorBlipId;
+    }
+    return viewportState.edgeBlipId(direction);
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
   private void scheduleReconnectOrFail(int generation, int reconnectCount) {
     if (reconnectCount >= MAX_RECONNECT_ATTEMPTS) {
       currentModel =
@@ -426,6 +547,10 @@ public final class J2clSelectedWaveController
     if (writeSessionListener != null) {
       writeSessionListener.onWriteSessionChanged(currentModel.getWriteSession());
     }
+  }
+
+  private void resetFragmentFetchTracking() {
+    fragmentFetchesInFlight.clear();
   }
 
   // --- Read-state fetch orchestration ----------------------------------------

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
@@ -38,6 +39,16 @@ public final class J2clSelectedWaveController
     void fetchSelectedWaveReadState(
         String waveId,
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+
+    void fetchFragments(
+        String waveId,
+        String startBlipId,
+        String direction,
+        int limit,
+        long startVersion,
+        long endVersion,
+        J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> onSuccess,
         J2clSearchPanelController.ErrorCallback onError);
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -4,6 +4,7 @@ import elemental2.dom.DomGlobal;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 public final class J2clSelectedWaveController
     implements J2clSidecarRouteController.SelectedWaveController {
@@ -24,6 +25,7 @@ public final class J2clSelectedWaveController
     Subscription openSelectedWave(
         SidecarSessionBootstrap bootstrap,
         String waveId,
+        SidecarViewportHints viewportHints,
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> onUpdate,
         J2clSearchPanelController.ErrorCallback onError,
         Runnable onDisconnect);
@@ -41,6 +43,10 @@ public final class J2clSelectedWaveController
 
   public interface View {
     void render(J2clSelectedWaveModel model);
+
+    default SidecarViewportHints initialViewportHints(String selectedWaveId) {
+      return SidecarViewportHints.defaultLimit();
+    }
   }
 
   public interface RetryScheduler {
@@ -286,6 +292,7 @@ public final class J2clSelectedWaveController
         gateway.openSelectedWave(
             currentBootstrap,
             selectedWaveId,
+            resolveInitialViewportHints(),
             update -> {
               if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
                 return;
@@ -341,6 +348,13 @@ public final class J2clSelectedWaveController
               clearActiveSubscription();
               scheduleReconnectOrFail(generation, activeReconnectCount[0]);
             });
+  }
+
+  private SidecarViewportHints resolveInitialViewportHints() {
+    SidecarViewportHints hints = view.initialViewportHints(selectedWaveId);
+    // Defensive fallback for tests and alternate views: a selected-wave open without a
+    // preserved DOM anchor still opts into viewport mode with the configured server default.
+    return hints == null || !hints.hasHints() ? SidecarViewportHints.defaultLimit() : hints;
   }
 
   private void scheduleReconnectOrFail(int generation, int reconnectCount) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -21,6 +21,7 @@ public final class J2clSelectedWaveModel {
   private final List<String> participantIds;
   private final List<String> contentEntries;
   private final List<J2clReadBlip> readBlips;
+  private final J2clSelectedWaveViewportState viewportState;
   private final J2clSidecarWriteSession writeSession;
   private final int unreadCount;
   private final boolean read;
@@ -59,6 +60,7 @@ public final class J2clSelectedWaveModel {
         participantIds,
         contentEntries,
         Collections.<J2clReadBlip>emptyList(),
+        J2clSelectedWaveViewportState.empty(),
         writeSession,
         unreadCount,
         read,
@@ -80,6 +82,48 @@ public final class J2clSelectedWaveModel {
       List<String> participantIds,
       List<String> contentEntries,
       List<J2clReadBlip> readBlips,
+      J2clSidecarWriteSession writeSession,
+      int unreadCount,
+      boolean read,
+      boolean readStateKnown,
+      boolean readStateStale) {
+    this(
+        hasSelection,
+        loading,
+        error,
+        selectedWaveId,
+        titleText,
+        snippetText,
+        unreadText,
+        statusText,
+        detailText,
+        reconnectCount,
+        participantIds,
+        contentEntries,
+        readBlips,
+        J2clSelectedWaveViewportState.empty(),
+        writeSession,
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateStale);
+  }
+
+  J2clSelectedWaveModel(
+      boolean hasSelection,
+      boolean loading,
+      boolean error,
+      String selectedWaveId,
+      String titleText,
+      String snippetText,
+      String unreadText,
+      String statusText,
+      String detailText,
+      int reconnectCount,
+      List<String> participantIds,
+      List<String> contentEntries,
+      List<J2clReadBlip> readBlips,
+      J2clSelectedWaveViewportState viewportState,
       J2clSidecarWriteSession writeSession,
       int unreadCount,
       boolean read,
@@ -107,6 +151,8 @@ public final class J2clSelectedWaveModel {
         readBlips == null
             ? Collections.<J2clReadBlip>emptyList()
             : Collections.unmodifiableList(new ArrayList<J2clReadBlip>(readBlips));
+    this.viewportState =
+        viewportState == null ? J2clSelectedWaveViewportState.empty() : viewportState;
     this.writeSession = writeSession;
     this.unreadCount = unreadCount;
     this.read = read;
@@ -293,6 +339,10 @@ public final class J2clSelectedWaveModel {
 
   public List<J2clReadBlip> getReadBlips() {
     return readBlips;
+  }
+
+  public J2clSelectedWaveViewportState getViewportState() {
+    return viewportState;
   }
 
   public J2clSidecarWriteSession getWriteSession() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -349,6 +349,58 @@ public final class J2clSelectedWaveModel {
     return writeSession;
   }
 
+  J2clSelectedWaveModel withViewportState(J2clSelectedWaveViewportState nextViewportState) {
+    return new J2clSelectedWaveModel(
+        hasSelection,
+        loading,
+        error,
+        selectedWaveId,
+        titleText,
+        snippetText,
+        unreadText,
+        statusText,
+        detailText,
+        reconnectCount,
+        participantIds,
+        nextViewportState == null
+            ? contentEntries
+            : nextViewportState.getLoadedContentEntries(),
+        nextViewportState == null
+            ? readBlips
+            : nextViewportState.getLoadedReadBlips(),
+        nextViewportState == null ? viewportState : nextViewportState,
+        writeSession,
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateStale);
+  }
+
+  J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
+    // Soft status updates keep the selected-wave card interactive and avoid the blocking error
+    // presentation used for bootstrap/stream failures.
+    return new J2clSelectedWaveModel(
+        hasSelection,
+        loading,
+        false,
+        selectedWaveId,
+        titleText,
+        snippetText,
+        unreadText,
+        nextStatusText,
+        nextDetailText,
+        reconnectCount,
+        participantIds,
+        contentEntries,
+        readBlips,
+        viewportState,
+        writeSession,
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateStale);
+  }
+
   public int getUnreadCount() {
     return unreadCount;
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -44,18 +44,31 @@ public final class J2clSelectedWaveProjector {
       participantIds = previous.getParticipantIds();
     }
 
-    List<String> contentEntries = extractContentEntries(update.getFragments());
-    if (contentEntries.isEmpty()) {
-      contentEntries = extractDocumentEntries(update.getDocuments());
-    }
-    if (contentEntries.isEmpty() && previous != null && !previous.getContentEntries().isEmpty()) {
+    boolean previousMatchesWave =
+        previous != null
+            && selectedWaveId != null
+            && selectedWaveId.equals(previous.getSelectedWaveId());
+    J2clSelectedWaveViewportState viewportState =
+        projectViewportState(update, previousMatchesWave, previous);
+    boolean hasViewportWindow = !viewportState.isEmpty();
+    List<String> contentEntries =
+        hasViewportWindow
+            ? viewportState.getLoadedContentEntries()
+            : extractDocumentEntries(update.getDocuments());
+    if (contentEntries.isEmpty()
+        && !hasViewportWindow
+        && previousMatchesWave
+        && !previous.getContentEntries().isEmpty()) {
       contentEntries = previous.getContentEntries();
     }
-    List<J2clReadBlip> readBlips = extractReadBlips(update.getFragments());
-    if (readBlips.isEmpty()) {
-      readBlips = extractDocumentReadBlips(update.getDocuments());
-    }
-    if (readBlips.isEmpty() && previous != null && !previous.getReadBlips().isEmpty()) {
+    List<J2clReadBlip> readBlips =
+        hasViewportWindow
+            ? viewportState.getLoadedReadBlips()
+            : extractDocumentReadBlips(update.getDocuments());
+    if (readBlips.isEmpty()
+        && !hasViewportWindow
+        && previousMatchesWave
+        && !previous.getReadBlips().isEmpty()) {
       readBlips = previous.getReadBlips();
     }
 
@@ -66,10 +79,6 @@ public final class J2clSelectedWaveProjector {
     int unreadCount;
     boolean read;
     boolean readStateKnown;
-    boolean previousMatchesWave =
-        previous != null
-            && selectedWaveId != null
-            && selectedWaveId.equals(previous.getSelectedWaveId());
     boolean readStateMatchesWave = readState != null
         && selectedWaveId != null
         && selectedWaveId.equals(readState.getWaveId());
@@ -108,6 +117,7 @@ public final class J2clSelectedWaveProjector {
         participantIds,
         contentEntries,
         readBlips,
+        viewportState,
         buildWriteSession(selectedWaveId, update, previous),
         unreadCount,
         read,
@@ -167,6 +177,7 @@ public final class J2clSelectedWaveProjector {
         previous.getParticipantIds(),
         previous.getContentEntries(),
         previous.getReadBlips(),
+        previous.getViewportState(),
         previous.getWriteSession(),
         unreadCount,
         read,
@@ -220,6 +231,30 @@ public final class J2clSelectedWaveProjector {
         selectedWaveId, channelId, baseVersion, historyHash, replyTargetBlipId);
   }
 
+  private static J2clSelectedWaveViewportState projectViewportState(
+      SidecarSelectedWaveUpdate update,
+      boolean previousMatchesWave,
+      J2clSelectedWaveModel previous) {
+    J2clSelectedWaveViewportState fragmentState =
+        J2clSelectedWaveViewportState.fromFragments(update.getFragments());
+    if (!fragmentState.isEmpty()) {
+      return fragmentState.appendMissingDocuments(update.getDocuments());
+    }
+    if (previousMatchesWave && previous != null && !previous.getViewportState().isEmpty()) {
+      J2clSelectedWaveViewportState mergedState =
+          previous.getViewportState().mergeDocuments(update.getDocuments());
+      if (!mergedState.isEmpty()) {
+        return mergedState;
+      }
+    }
+    J2clSelectedWaveViewportState documentState =
+        J2clSelectedWaveViewportState.fromDocuments(update.getDocuments());
+    if (!documentState.isEmpty()) {
+      return documentState;
+    }
+    return J2clSelectedWaveViewportState.empty();
+  }
+
   private static String resolveReplyTargetBlipId(SidecarSelectedWaveUpdate update) {
     String preferred = findPreferredDocumentId(update.getDocuments());
     if (preferred != null) {
@@ -231,7 +266,7 @@ public final class J2clSelectedWaveProjector {
     }
     String fallback = null;
     for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
-      String blipId = blipIdFromSegment(fragment.getSegment());
+      String blipId = J2clSelectedWaveViewportState.blipIdOrNull(fragment.getSegment());
       if (blipId == null) {
         continue;
       }
@@ -263,42 +298,6 @@ public final class J2clSelectedWaveProjector {
       }
     }
     return fallback;
-  }
-
-  private static List<String> extractContentEntries(SidecarSelectedWaveFragments fragments) {
-    if (fragments == null) {
-      return Collections.emptyList();
-    }
-    List<String> blipSnapshots = new ArrayList<String>();
-    List<String> fallbackSnapshots = new ArrayList<String>();
-    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
-      String rawSnapshot = fragment.getRawSnapshot();
-      if (rawSnapshot == null || rawSnapshot.isEmpty()) {
-        continue;
-      }
-      if (fragment.getSegment() != null && fragment.getSegment().startsWith("blip:")) {
-        blipSnapshots.add(rawSnapshot);
-      } else {
-        fallbackSnapshots.add(rawSnapshot);
-      }
-    }
-    return blipSnapshots.isEmpty() ? fallbackSnapshots : blipSnapshots;
-  }
-
-  private static List<J2clReadBlip> extractReadBlips(SidecarSelectedWaveFragments fragments) {
-    if (fragments == null) {
-      return Collections.emptyList();
-    }
-    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
-    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
-      String rawSnapshot = fragment.getRawSnapshot();
-      String blipId = blipIdFromSegment(fragment.getSegment());
-      if (rawSnapshot == null || rawSnapshot.isEmpty() || blipId == null) {
-        continue;
-      }
-      blips.add(new J2clReadBlip(blipId, rawSnapshot));
-    }
-    return blips;
   }
 
   private static List<String> extractDocumentEntries(List<SidecarSelectedWaveDocument> documents) {
@@ -337,14 +336,6 @@ public final class J2clSelectedWaveProjector {
       blips.add(new J2clReadBlip(documentId, textContent));
     }
     return blips;
-  }
-
-  private static String blipIdFromSegment(String segment) {
-    if (segment == null || !segment.startsWith("blip:")) {
-      return null;
-    }
-    String blipId = segment.substring("blip:".length());
-    return blipId.isEmpty() ? null : blipId;
   }
 
   private static String buildDetailText(SidecarSelectedWaveUpdate update) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -237,7 +237,7 @@ public final class J2clSelectedWaveProjector {
       J2clSelectedWaveModel previous) {
     J2clSelectedWaveViewportState fragmentState =
         J2clSelectedWaveViewportState.fromFragments(update.getFragments());
-    if (!fragmentState.isEmpty()) {
+    if (fragmentState.hasBlipEntries()) {
       return fragmentState.appendMissingDocuments(update.getDocuments());
     }
     if (previousMatchesWave && previous != null && !previous.getViewportState().isEmpty()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -3,9 +3,11 @@ package org.waveprotocol.box.j2cl.search;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
+import java.util.List;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer;
+import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
 import org.waveprotocol.box.j2cl.root.J2clServerFirstRootShellDom;
 import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
@@ -130,7 +132,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     snippet.textContent = model.getSnippetText();
     snippet.hidden = model.getSnippetText().isEmpty();
 
-    boolean hasRenderedReadSurface = readSurface.render(model.getReadBlips(), model.getContentEntries());
+    List<J2clReadWindowEntry> readWindowEntries = model.getViewportState().getReadWindowEntries();
+    boolean hasViewportReadWindow = !readWindowEntries.isEmpty();
+    boolean hasRenderedReadSurface =
+        hasViewportReadWindow
+            ? readSurface.renderWindow(readWindowEntries)
+            : readSurface.render(model.getReadBlips(), model.getContentEntries());
 
     emptyState.hidden = model.isError() || (model.hasSelection() && hasRenderedReadSurface);
     emptyState.textContent =
@@ -177,7 +184,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (model.isLoading() || model.isError()) {
       return true;
     }
-    return model.getContentEntries().isEmpty() && model.getReadBlips().isEmpty();
+    return model.getContentEntries().isEmpty()
+        && model.getReadBlips().isEmpty()
+        && model.getViewportState().getReadWindowEntries().isEmpty();
   }
 
   private boolean shouldPreserveServerFirstCard(J2clSelectedWaveModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -10,6 +10,7 @@ import org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
 import org.waveprotocol.box.j2cl.root.J2clServerFirstRootShellDom;
 import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
   private final HTMLElement title;
@@ -27,6 +28,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private String serverFirstWaveId;
   private String serverFirstMode;
   private double serverFirstMountedAtMs;
+  private String lastRenderedWaveId = "";
 
   public J2clSelectedWaveView(HTMLElement host) {
     HTMLElement existingCard = J2clServerFirstRootShellDom.findSelectedWaveCard(host);
@@ -106,6 +108,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   @Override
   public void render(J2clSelectedWaveModel model) {
+    String renderedWaveId = model.getSelectedWaveId() == null ? "" : model.getSelectedWaveId();
+    if (!renderedWaveId.equals(lastRenderedWaveId)) {
+      readSurface.clearViewportScrollMemory();
+      lastRenderedWaveId = renderedWaveId;
+    }
     if (shouldPreserveServerFirstCard(model)) {
       renderPreservedServerFirstState(model);
       return;
@@ -155,6 +162,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   public HTMLElement getComposeHost() {
     return composeHost;
+  }
+
+  @Override
+  public void setViewportEdgeHandler(J2clSelectedWaveController.ViewportEdgeHandler handler) {
+    readSurface.setViewportEdgeListener(
+        handler == null ? null : handler::onViewportEdge);
   }
 
   @Override
@@ -210,7 +223,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             || serverFirstWaveId.equals(selectedWaveId))
         && anchor != null
         && !anchor.isEmpty()) {
-      return new SidecarViewportHints(anchor, "forward", null);
+      return new SidecarViewportHints(anchor, J2clViewportGrowthDirection.FORWARD, null);
     }
     return SidecarViewportHints.defaultLimit();
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -249,7 +249,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (!serverFirstActive) {
       return null;
     }
-    HTMLElement firstBlip = (HTMLElement) contentList.querySelector("[data-blip-id]");
+    HTMLElement firstBlip =
+        (HTMLElement) contentList.querySelector("[data-j2cl-read-blip='true'][tabindex='0']");
+    if (firstBlip == null) {
+      firstBlip = (HTMLElement) contentList.querySelector("[data-j2cl-read-blip='true']");
+    }
     if (firstBlip == null) {
       return null;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -41,6 +41,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       snippet = queryRequired(existingCard, ".sidecar-selected-snippet");
       composeHost = queryRequired(existingCard, ".sidecar-selected-compose");
       contentList = queryRequired(existingCard, ".sidecar-selected-content");
+      configureContentList(contentList);
       readSurface = new J2clReadSurfaceDomRenderer(contentList);
       readSurface.enhanceExistingSurface();
       emptyState = queryOrCreate(existingCard, ".sidecar-empty-state", "div", "sidecar-empty-state");
@@ -92,6 +93,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     contentList = (HTMLDivElement) DomGlobal.document.createElement("div");
     contentList.className = "sidecar-selected-content";
+    configureContentList(contentList);
     card.appendChild(contentList);
     readSurface = new J2clReadSurfaceDomRenderer(contentList);
 
@@ -104,6 +106,21 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     serverFirstWaveId = "";
     serverFirstMode = "";
     serverFirstMountedAtMs = 0;
+  }
+
+  static void configureContentList(HTMLElement contentList) {
+    configureContentListAttributes(
+        (name, value) -> contentList.setAttribute(name, value));
+  }
+
+  static void configureContentListAttributes(AttributeWriter attributes) {
+    attributes.setAttribute("role", "region");
+    attributes.setAttribute("aria-label", "Selected wave content");
+    attributes.setAttribute("tabindex", "0");
+  }
+
+  interface AttributeWriter {
+    void setAttribute(String name, String value);
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -7,6 +7,7 @@ import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer;
 import org.waveprotocol.box.j2cl.root.J2clServerFirstRootShellDom;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
   private final HTMLElement title;
@@ -149,6 +150,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     return composeHost;
   }
 
+  @Override
+  public SidecarViewportHints initialViewportHints(String selectedWaveId) {
+    return resolveInitialViewportHints(
+        serverFirstActive, serverFirstWaveId, selectedWaveId, serverFirstBlipAnchor());
+  }
+
   public static boolean shouldPreserveServerSnapshot(
       String serverSnapshotWaveId, J2clSelectedWaveModel model, boolean serverFirstAlreadySwapped) {
     if (serverFirstAlreadySwapped || model == null) {
@@ -181,6 +188,34 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       return shouldPreserveServerSnapshot(serverFirstWaveId, model, serverFirstSwapRecorded);
     }
     return !model.hasSelection() && !serverFirstMode.isEmpty();
+  }
+
+  static SidecarViewportHints resolveInitialViewportHints(
+      boolean serverFirstActive, String serverFirstWaveId, String selectedWaveId, String anchor) {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return SidecarViewportHints.none();
+    }
+    if (serverFirstActive
+        && (serverFirstWaveId == null
+            || serverFirstWaveId.isEmpty()
+            || serverFirstWaveId.equals(selectedWaveId))
+        && anchor != null
+        && !anchor.isEmpty()) {
+      return new SidecarViewportHints(anchor, "forward", null);
+    }
+    return SidecarViewportHints.defaultLimit();
+  }
+
+  private String serverFirstBlipAnchor() {
+    if (!serverFirstActive) {
+      return null;
+    }
+    HTMLElement firstBlip = (HTMLElement) contentList.querySelector("[data-blip-id]");
+    if (firstBlip == null) {
+      return null;
+    }
+    String blipId = firstBlip.getAttribute("data-blip-id");
+    return blipId == null || blipId.isEmpty() ? null : blipId;
   }
 
   private void renderPreservedServerFirstState(J2clSelectedWaveModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -11,6 +11,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveViewportState {
   static final String BLIP_SEGMENT_PREFIX = "blip:";
@@ -117,6 +118,55 @@ public final class J2clSelectedWaveViewportState {
   J2clSelectedWaveViewportState appendMissingDocuments(
       List<SidecarSelectedWaveDocument> documents) {
     return mergeDocuments(documents, false);
+  }
+
+  J2clSelectedWaveViewportState mergeFragments(
+      SidecarSelectedWaveFragments fragments, String direction) {
+    J2clSelectedWaveViewportState fragmentState = fromFragments(fragments);
+    if (fragmentState.isEmpty()) {
+      return this;
+    }
+    if (isEmpty()) {
+      return fragmentState;
+    }
+    List<Entry> merged = new ArrayList<Entry>(entries);
+    List<Entry> missing = new ArrayList<Entry>();
+    for (Entry fragmentEntry : fragmentState.getEntries()) {
+      int existingIndex = indexOfSegment(merged, fragmentEntry.getSegment());
+      if (existingIndex >= 0) {
+        merged.set(existingIndex, fragmentEntry);
+      } else {
+        missing.add(fragmentEntry);
+      }
+    }
+    if (J2clViewportGrowthDirection.isBackward(direction)) {
+      merged.addAll(0, missing);
+    } else {
+      merged.addAll(missing);
+    }
+    return new J2clSelectedWaveViewportState(
+        Math.max(snapshotVersion, fragmentState.getSnapshotVersion()),
+        minKnown(startVersion, fragmentState.getStartVersion()),
+        Math.max(endVersion, fragmentState.getEndVersion()),
+        merged);
+  }
+
+  String edgeBlipId(String direction) {
+    if (J2clViewportGrowthDirection.isBackward(direction)) {
+      for (Entry entry : entries) {
+        if (entry.isLoaded() && entry.isBlip()) {
+          return entry.getBlipId();
+        }
+      }
+      return "";
+    }
+    for (int i = entries.size() - 1; i >= 0; i--) {
+      Entry entry = entries.get(i);
+      if (entry.isLoaded() && entry.isBlip()) {
+        return entry.getBlipId();
+      }
+    }
+    return "";
   }
 
   private J2clSelectedWaveViewportState mergeDocuments(
@@ -235,6 +285,16 @@ public final class J2clSelectedWaveViewportState {
       }
     }
     return -1;
+  }
+
+  private static long minKnown(long left, long right) {
+    if (left < 0) {
+      return right;
+    }
+    if (right < 0) {
+      return left;
+    }
+    return Math.min(left, right);
   }
 
   private static SidecarSelectedWaveFragment findFragment(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -185,11 +185,13 @@ public final class J2clSelectedWaveViewportState {
         }
         long mergedToVersion =
             Math.max(existing.getToVersion(), documentEntry.getToVersion());
+        long mergedFromVersion =
+            minKnown(existing.getFromVersion(), documentEntry.getFromVersion());
         merged.set(
             existingIndex,
             Entry.loaded(
                 existing.getSegment(),
-                existing.getFromVersion(),
+                mergedFromVersion,
                 mergedToVersion,
                 documentEntry.getRawSnapshot(),
                 existing.getAdjustOperationCount(),
@@ -200,7 +202,7 @@ public final class J2clSelectedWaveViewportState {
     }
     return new J2clSelectedWaveViewportState(
         Math.max(snapshotVersion, documentState.getSnapshotVersion()),
-        startVersion,
+        minKnown(startVersion, documentState.getStartVersion()),
         Math.max(endVersion, documentState.getEndVersion()),
         merged);
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -1,0 +1,378 @@
+package org.waveprotocol.box.j2cl.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
+
+public final class J2clSelectedWaveViewportState {
+  static final String BLIP_SEGMENT_PREFIX = "blip:";
+
+  private static final long UNKNOWN_VERSION = -1L;
+  private static final J2clSelectedWaveViewportState EMPTY =
+      new J2clSelectedWaveViewportState(
+          UNKNOWN_VERSION,
+          UNKNOWN_VERSION,
+          UNKNOWN_VERSION,
+          Collections.<Entry>emptyList());
+
+  private final long snapshotVersion;
+  private final long startVersion;
+  private final long endVersion;
+  private final List<Entry> entries;
+
+  private J2clSelectedWaveViewportState(
+      long snapshotVersion, long startVersion, long endVersion, List<Entry> entries) {
+    this.snapshotVersion = snapshotVersion;
+    this.startVersion = startVersion;
+    this.endVersion = endVersion;
+    this.entries =
+        entries == null
+            ? Collections.<Entry>emptyList()
+            : Collections.unmodifiableList(new ArrayList<Entry>(entries));
+  }
+
+  public static J2clSelectedWaveViewportState empty() {
+    return EMPTY;
+  }
+
+  static J2clSelectedWaveViewportState fromFragments(SidecarSelectedWaveFragments fragments) {
+    if (fragments == null) {
+      return empty();
+    }
+    List<Entry> entries = new ArrayList<Entry>();
+    Set<String> seenSegments = new HashSet<String>();
+    for (SidecarSelectedWaveFragmentRange range : fragments.getRanges()) {
+      if (range == null) {
+        continue;
+      }
+      SidecarSelectedWaveFragment fragment =
+          findFragment(fragments.getEntries(), range.getSegment());
+      entries.add(Entry.fromRange(range, fragment));
+      seenSegments.add(range.getSegment());
+    }
+    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
+      if (fragment == null || seenSegments.contains(fragment.getSegment())) {
+        continue;
+      }
+      entries.add(Entry.fromFragment(fragment));
+    }
+    if (entries.isEmpty()) {
+      return empty();
+    }
+    return new J2clSelectedWaveViewportState(
+        fragments.getSnapshotVersion(),
+        fragments.getStartVersion(),
+        fragments.getEndVersion(),
+        entries);
+  }
+
+  static J2clSelectedWaveViewportState fromDocuments(
+      List<SidecarSelectedWaveDocument> documents) {
+    if (documents == null || documents.isEmpty()) {
+      return empty();
+    }
+    List<Entry> entries = new ArrayList<Entry>();
+    long minVersion = Long.MAX_VALUE;
+    long maxVersion = UNKNOWN_VERSION;
+    for (SidecarSelectedWaveDocument document : documents) {
+      if (document == null) {
+        continue;
+      }
+      String textContent = document.getTextContent();
+      if (textContent == null || textContent.isEmpty()) {
+        continue;
+      }
+      String documentId = document.getDocumentId();
+      if (documentId == null || documentId.isEmpty()) {
+        continue;
+      }
+      // Documents do not carry fragment segment ids; blip documents use the
+      // same segment convention emitted by SidecarSelectedWaveFragments.
+      String segment = documentId.startsWith("b+") ? BLIP_SEGMENT_PREFIX + documentId : documentId;
+      long version = document.getLastModifiedVersion();
+      minVersion = Math.min(minVersion, version);
+      maxVersion = Math.max(maxVersion, version);
+      entries.add(Entry.loaded(segment, version, version, textContent, 0, 0));
+    }
+    if (entries.isEmpty()) {
+      return empty();
+    }
+    long start = minVersion == Long.MAX_VALUE ? UNKNOWN_VERSION : minVersion;
+    return new J2clSelectedWaveViewportState(maxVersion, start, maxVersion, entries);
+  }
+
+  J2clSelectedWaveViewportState mergeDocuments(
+      List<SidecarSelectedWaveDocument> documents) {
+    return mergeDocuments(documents, true);
+  }
+
+  J2clSelectedWaveViewportState appendMissingDocuments(
+      List<SidecarSelectedWaveDocument> documents) {
+    return mergeDocuments(documents, false);
+  }
+
+  private J2clSelectedWaveViewportState mergeDocuments(
+      List<SidecarSelectedWaveDocument> documents, boolean replaceExisting) {
+    J2clSelectedWaveViewportState documentState = fromDocuments(documents);
+    if (documentState.isEmpty()) {
+      return this;
+    }
+    List<Entry> merged = new ArrayList<Entry>(entries);
+    for (Entry documentEntry : documentState.getEntries()) {
+      int existingIndex = indexOfSegment(merged, documentEntry.getSegment());
+      if (existingIndex >= 0) {
+        Entry existing = merged.get(existingIndex);
+        if (!replaceExisting && existing.isLoaded()) {
+          continue;
+        }
+        long mergedToVersion =
+            Math.max(existing.getToVersion(), documentEntry.getToVersion());
+        merged.set(
+            existingIndex,
+            Entry.loaded(
+                existing.getSegment(),
+                existing.getFromVersion(),
+                mergedToVersion,
+                documentEntry.getRawSnapshot(),
+                existing.getAdjustOperationCount(),
+                existing.getDiffOperationCount()));
+      } else {
+        merged.add(documentEntry);
+      }
+    }
+    return new J2clSelectedWaveViewportState(
+        Math.max(snapshotVersion, documentState.getSnapshotVersion()),
+        startVersion,
+        Math.max(endVersion, documentState.getEndVersion()),
+        merged);
+  }
+
+  public long getSnapshotVersion() {
+    return snapshotVersion;
+  }
+
+  public long getStartVersion() {
+    return startVersion;
+  }
+
+  public long getEndVersion() {
+    return endVersion;
+  }
+
+  public List<Entry> getEntries() {
+    return entries;
+  }
+
+  public boolean isEmpty() {
+    return entries.isEmpty();
+  }
+
+  public List<String> getLoadedContentEntries() {
+    List<String> contentEntries = new ArrayList<String>();
+    List<String> fallbackEntries = new ArrayList<String>();
+    for (Entry entry : entries) {
+      if (!entry.isLoaded()) {
+        continue;
+      }
+      if (entry.isBlip()) {
+        contentEntries.add(entry.getRawSnapshot());
+      } else {
+        fallbackEntries.add(entry.getRawSnapshot());
+      }
+    }
+    return contentEntries.isEmpty() ? fallbackEntries : contentEntries;
+  }
+
+  public List<J2clReadBlip> getLoadedReadBlips() {
+    List<J2clReadBlip> readBlips = new ArrayList<J2clReadBlip>();
+    for (Entry entry : entries) {
+      if (!entry.isLoaded() || !entry.isBlip()) {
+        continue;
+      }
+      readBlips.add(new J2clReadBlip(entry.getBlipId(), entry.getRawSnapshot()));
+    }
+    return readBlips;
+  }
+
+  public List<J2clReadWindowEntry> getReadWindowEntries() {
+    List<J2clReadWindowEntry> windowEntries = new ArrayList<J2clReadWindowEntry>();
+    for (Entry entry : entries) {
+      if (!entry.isBlip()) {
+        continue;
+      }
+      if (entry.isLoaded()) {
+        windowEntries.add(
+            J2clReadWindowEntry.loaded(
+                entry.getSegment(),
+                entry.getFromVersion(),
+                entry.getToVersion(),
+                entry.getBlipId(),
+                entry.getRawSnapshot()));
+      } else {
+        windowEntries.add(
+            J2clReadWindowEntry.placeholder(
+                entry.getSegment(),
+                entry.getFromVersion(),
+                entry.getToVersion(),
+                entry.getBlipId()));
+      }
+    }
+    return windowEntries;
+  }
+
+  private static int indexOfSegment(List<Entry> entries, String segment) {
+    for (int i = 0; i < entries.size(); i++) {
+      if (equals(segment, entries.get(i).getSegment())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static SidecarSelectedWaveFragment findFragment(
+      List<SidecarSelectedWaveFragment> fragments, String segment) {
+    if (fragments == null) {
+      return null;
+    }
+    for (SidecarSelectedWaveFragment fragment : fragments) {
+      if (fragment != null && equals(segment, fragment.getSegment())) {
+        return fragment;
+      }
+    }
+    return null;
+  }
+
+  private static boolean equals(String left, String right) {
+    return left == null ? right == null : left.equals(right);
+  }
+
+  static String blipIdOrNull(String segment) {
+    if (segment == null || !segment.startsWith(BLIP_SEGMENT_PREFIX)) {
+      return null;
+    }
+    String blipId = segment.substring(BLIP_SEGMENT_PREFIX.length());
+    return blipId.isEmpty() ? null : blipId;
+  }
+
+  public static final class Entry {
+    private final String segment;
+    private final long fromVersion;
+    private final long toVersion;
+    private final String rawSnapshot;
+    private final int adjustOperationCount;
+    private final int diffOperationCount;
+    private final boolean loaded;
+
+    private Entry(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        boolean loaded) {
+      this.segment = segment == null ? "" : segment;
+      this.fromVersion = fromVersion;
+      this.toVersion = toVersion;
+      this.rawSnapshot = rawSnapshot == null ? "" : rawSnapshot;
+      this.adjustOperationCount = adjustOperationCount;
+      this.diffOperationCount = diffOperationCount;
+      this.loaded = loaded;
+    }
+
+    static Entry fromRange(
+        SidecarSelectedWaveFragmentRange range, SidecarSelectedWaveFragment fragment) {
+      if (fragment == null || fragment.getRawSnapshot() == null) {
+        return placeholder(range.getSegment(), range.getFromVersion(), range.getToVersion());
+      }
+      return new Entry(
+          range.getSegment(),
+          range.getFromVersion(),
+          range.getToVersion(),
+          fragment.getRawSnapshot(),
+          fragment.getAdjustOperationCount(),
+          fragment.getDiffOperationCount(),
+          true);
+    }
+
+    static Entry fromFragment(SidecarSelectedWaveFragment fragment) {
+      if (fragment.getRawSnapshot() == null) {
+        return placeholder(fragment.getSegment(), UNKNOWN_VERSION, UNKNOWN_VERSION);
+      }
+      return new Entry(
+          fragment.getSegment(),
+          UNKNOWN_VERSION,
+          UNKNOWN_VERSION,
+          fragment.getRawSnapshot(),
+          fragment.getAdjustOperationCount(),
+          fragment.getDiffOperationCount(),
+          true);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount) {
+      return new Entry(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          true);
+    }
+
+    static Entry placeholder(String segment, long fromVersion, long toVersion) {
+      return new Entry(segment, fromVersion, toVersion, "", 0, 0, false);
+    }
+
+    public String getSegment() {
+      return segment;
+    }
+
+    public long getFromVersion() {
+      return fromVersion;
+    }
+
+    public long getToVersion() {
+      return toVersion;
+    }
+
+    public String getRawSnapshot() {
+      return rawSnapshot;
+    }
+
+    public int getAdjustOperationCount() {
+      return adjustOperationCount;
+    }
+
+    public int getDiffOperationCount() {
+      return diffOperationCount;
+    }
+
+    public boolean isLoaded() {
+      return loaded;
+    }
+
+    public boolean isBlip() {
+      return !getBlipId().isEmpty();
+    }
+
+    public String getBlipId() {
+      String blipId = blipIdOrNull(segment);
+      return blipId == null ? "" : blipId;
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -240,6 +240,16 @@ public final class J2clSelectedWaveViewportState {
     return entries.isEmpty();
   }
 
+  // Metadata-only fragment deltas are state updates, not selected-wave read windows.
+  boolean hasBlipEntries() {
+    for (Entry entry : entries) {
+      if (entry.isBlip()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public List<String> getLoadedContentEntries() {
     List<String> contentEntries = new ArrayList<String>();
     List<String> fallbackEntries = new ArrayList<String>();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -88,8 +88,8 @@ public final class J2clSelectedWaveViewportState {
         continue;
       }
       String textContent = document.getTextContent();
-      if (textContent == null || textContent.isEmpty()) {
-        continue;
+      if (textContent == null) {
+        textContent = "";
       }
       String documentId = document.getDocumentId();
       if (documentId == null || documentId.isEmpty()) {
@@ -134,7 +134,20 @@ public final class J2clSelectedWaveViewportState {
     for (Entry fragmentEntry : fragmentState.getEntries()) {
       int existingIndex = indexOfSegment(merged, fragmentEntry.getSegment());
       if (existingIndex >= 0) {
-        merged.set(existingIndex, fragmentEntry);
+        Entry existing = merged.get(existingIndex);
+        if (existing.isLoaded() && !fragmentEntry.isLoaded()) {
+          merged.set(
+              existingIndex,
+              Entry.loaded(
+                  existing.getSegment(),
+                  minKnown(existing.getFromVersion(), fragmentEntry.getFromVersion()),
+                  Math.max(existing.getToVersion(), fragmentEntry.getToVersion()),
+                  existing.getRawSnapshot(),
+                  existing.getAdjustOperationCount(),
+                  existing.getDiffOperationCount()));
+        } else {
+          merged.set(existingIndex, fragmentEntry);
+        }
       } else {
         missing.add(fragmentEntry);
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -186,7 +186,7 @@ public final class J2clSelectedWaveViewportState {
         long mergedToVersion =
             Math.max(existing.getToVersion(), documentEntry.getToVersion());
         long mergedFromVersion =
-            minKnown(existing.getFromVersion(), documentEntry.getFromVersion());
+            knownOrFallback(existing.getFromVersion(), documentEntry.getFromVersion());
         merged.set(
             existingIndex,
             Entry.loaded(
@@ -202,7 +202,7 @@ public final class J2clSelectedWaveViewportState {
     }
     return new J2clSelectedWaveViewportState(
         Math.max(snapshotVersion, documentState.getSnapshotVersion()),
-        minKnown(startVersion, documentState.getStartVersion()),
+        knownOrFallback(startVersion, documentState.getStartVersion()),
         Math.max(endVersion, documentState.getEndVersion()),
         merged);
   }
@@ -297,6 +297,10 @@ public final class J2clSelectedWaveViewportState {
       return left;
     }
     return Math.min(left, right);
+  }
+
+  private static long knownOrFallback(long value, long fallback) {
+    return value < 0 ? fallback : value;
   }
 
   private static SidecarSelectedWaveFragment findFragment(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
@@ -39,7 +39,7 @@ public final class SidecarFragmentsResponse {
         Map<String, Object> range = getObject(rawRange);
         ranges.add(
             new SidecarSelectedWaveFragmentRange(
-                getString(range, "segment"),
+                getRequiredString(range, "segment"),
                 getLong(range, "from"),
                 getLong(range, "to")));
       }
@@ -53,7 +53,7 @@ public final class SidecarFragmentsResponse {
         Map<String, Object> fragment = getObject(rawFragment);
         entries.add(
             new SidecarSelectedWaveFragment(
-                getString(fragment, "segment"),
+                getRequiredString(fragment, "segment"),
                 getNullableString(fragment, "rawSnapshot"),
                 // TODO(#967 Task 5): decode operation bodies when growth windows apply deltas.
                 getArrayLength(fragment.get("adjust")),
@@ -105,6 +105,14 @@ public final class SidecarFragmentsResponse {
   private static String getString(Map<String, Object> object, String key) {
     Object value = object.get(key);
     return value == null ? "" : String.valueOf(value);
+  }
+
+  private static String getRequiredString(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (value == null) {
+      throw new IllegalArgumentException("Missing required field: " + key);
+    }
+    return String.valueOf(value);
   }
 
   private static String getNullableString(Map<String, Object> object, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
@@ -54,7 +54,7 @@ public final class SidecarFragmentsResponse {
         entries.add(
             new SidecarSelectedWaveFragment(
                 getString(fragment, "segment"),
-                getString(fragment, "rawSnapshot"),
+                getNullableString(fragment, "rawSnapshot"),
                 // TODO(#967 Task 5): decode operation bodies when growth windows apply deltas.
                 getArrayLength(fragment.get("adjust")),
                 getArrayLength(fragment.get("diff"))));
@@ -105,6 +105,14 @@ public final class SidecarFragmentsResponse {
   private static String getString(Map<String, Object> object, String key) {
     Object value = object.get(key);
     return value == null ? "" : String.valueOf(value);
+  }
+
+  private static String getNullableString(Map<String, Object> object, String key) {
+    if (!object.containsKey(key)) {
+      return null;
+    }
+    Object value = object.get(key);
+    return value == null ? null : String.valueOf(value);
   }
 
   private static long getLong(Map<String, Object> object, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
@@ -117,7 +117,10 @@ public final class SidecarFragmentsResponse {
 
   private static long getLong(Map<String, Object> object, String key) {
     Object value = object.get(key);
-    return value instanceof Number ? ((Number) value).longValue() : 0L;
+    if (!(value instanceof Number)) {
+      throw new IllegalArgumentException("Expected numeric '" + key + "' but got " + value);
+    }
+    return ((Number) value).longValue();
   }
 
   private static int getArrayLength(Object value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
@@ -1,0 +1,118 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class SidecarFragmentsResponse {
+  private final String status;
+  private final String waveRefPath;
+  private final SidecarSelectedWaveFragments fragments;
+
+  private SidecarFragmentsResponse(
+      String status, String waveRefPath, SidecarSelectedWaveFragments fragments) {
+    this.status = status == null ? "" : status;
+    this.waveRefPath = waveRefPath == null ? "" : waveRefPath;
+    this.fragments = fragments == null
+        ? new SidecarSelectedWaveFragments(
+            -1L,
+            0L,
+            0L,
+            Collections.<SidecarSelectedWaveFragmentRange>emptyList(),
+            Collections.<SidecarSelectedWaveFragment>emptyList())
+        : fragments;
+  }
+
+  public static SidecarFragmentsResponse fromJson(String json) {
+    Map<String, Object> root = SidecarTransportCodec.parseJsonObject(json);
+    String status = getString(root, "status");
+    if (!"ok".equals(status)) {
+      throw new IllegalArgumentException("Unexpected fragments response status: " + status);
+    }
+    Map<String, Object> version = getObject(root.get("version"));
+    List<SidecarSelectedWaveFragmentRange> ranges =
+        new ArrayList<SidecarSelectedWaveFragmentRange>();
+    Object rawRanges = root.get("ranges");
+    if (rawRanges != null) {
+      for (Object rawRange : asList(rawRanges)) {
+        Map<String, Object> range = getObject(rawRange);
+        ranges.add(
+            new SidecarSelectedWaveFragmentRange(
+                getString(range, "segment"),
+                getLong(range, "from"),
+                getLong(range, "to")));
+      }
+    }
+
+    List<SidecarSelectedWaveFragment> entries =
+        new ArrayList<SidecarSelectedWaveFragment>();
+    Object rawFragments = root.get("fragments");
+    if (rawFragments != null) {
+      for (Object rawFragment : asList(rawFragments)) {
+        Map<String, Object> fragment = getObject(rawFragment);
+        entries.add(
+            new SidecarSelectedWaveFragment(
+                getString(fragment, "segment"),
+                getString(fragment, "rawSnapshot"),
+                // TODO(#967 Task 5): decode operation bodies when growth windows apply deltas.
+                getArrayLength(fragment.get("adjust")),
+                getArrayLength(fragment.get("diff"))));
+      }
+    }
+
+    return new SidecarFragmentsResponse(
+        status,
+        getString(root, "waveRef"),
+        new SidecarSelectedWaveFragments(
+            getLong(version, "snapshot"),
+            getLong(version, "start"),
+            getLong(version, "end"),
+            ranges,
+            entries));
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getWaveRefPath() {
+    return waveRefPath;
+  }
+
+  public SidecarSelectedWaveFragments getFragments() {
+    return fragments;
+  }
+
+  private static Map<String, Object> getObject(Object value) {
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException("Expected object but got " + value);
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> object = (Map<String, Object>) value;
+    return object;
+  }
+
+  private static List<Object> asList(Object value) {
+    if (!(value instanceof List)) {
+      throw new IllegalArgumentException("Expected array but got " + value);
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) value;
+    return list;
+  }
+
+  private static String getString(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value == null ? "" : String.valueOf(value);
+  }
+
+  private static long getLong(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    return value instanceof Number ? ((Number) value).longValue() : 0L;
+  }
+
+  private static int getArrayLength(Object value) {
+    return value instanceof List ? ((List<?>) value).size() : 0;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java
@@ -8,14 +8,25 @@ public final class SidecarOpenRequest {
   private final String participantId;
   private final String waveId;
   private final List<String> waveletIdPrefixes;
+  private final SidecarViewportHints viewportHints;
 
+  /** No-hint convenience constructor retained for legacy selected-wave and test callers. */
   public SidecarOpenRequest(String participantId, String waveId, List<String> waveletIdPrefixes) {
+    this(participantId, waveId, waveletIdPrefixes, null);
+  }
+
+  public SidecarOpenRequest(
+      String participantId,
+      String waveId,
+      List<String> waveletIdPrefixes,
+      SidecarViewportHints viewportHints) {
     this.participantId = participantId;
     this.waveId = waveId;
     this.waveletIdPrefixes =
         waveletIdPrefixes == null
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<>(waveletIdPrefixes));
+    this.viewportHints = viewportHints == null ? SidecarViewportHints.none() : viewportHints;
   }
 
   public String getParticipantId() {
@@ -28,5 +39,9 @@ public final class SidecarOpenRequest {
 
   public List<String> getWaveletIdPrefixes() {
     return waveletIdPrefixes;
+  }
+
+  public SidecarViewportHints getViewportHints() {
+    return viewportHints;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -26,7 +26,18 @@ public final class SidecarTransportCodec {
       }
       json.append('"').append(escapeJson(prefixes.get(i))).append('"');
     }
-    json.append("]}}");
+    json.append(']');
+    SidecarViewportHints hints = request.getViewportHints();
+    if (hints.getStartBlipId() != null) {
+      json.append(",\"5\":\"").append(escapeJson(hints.getStartBlipId())).append('"');
+    }
+    if (hints.getDirection() != null) {
+      json.append(",\"6\":\"").append(escapeJson(hints.getDirection())).append('"');
+    }
+    if (hints.getLimit() != null) {
+      json.append(",\"7\":").append(hints.getLimit().intValue());
+    }
+    json.append("}}");
     return json.toString();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarViewportHints.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarViewportHints.java
@@ -1,0 +1,51 @@
+package org.waveprotocol.box.j2cl.transport;
+
+/** Optional viewport hints for selected-wave ProtocolOpenRequest frames. */
+public final class SidecarViewportHints {
+  private static final SidecarViewportHints NONE = new SidecarViewportHints(null, null, null);
+  // Explicit zero means "viewport mode requested; server should apply its configured default limit".
+  private static final SidecarViewportHints DEFAULT_LIMIT =
+      new SidecarViewportHints(null, null, Integer.valueOf(0));
+
+  private final String startBlipId;
+  private final String direction;
+  private final Integer limit;
+
+  public SidecarViewportHints(String startBlipId, String direction, Integer limit) {
+    this.startBlipId = normalize(startBlipId);
+    this.direction = normalize(direction);
+    this.limit = limit;
+  }
+
+  public static SidecarViewportHints none() {
+    return NONE;
+  }
+
+  public static SidecarViewportHints defaultLimit() {
+    return DEFAULT_LIMIT;
+  }
+
+  public boolean hasHints() {
+    return startBlipId != null || direction != null || limit != null;
+  }
+
+  public String getStartBlipId() {
+    return startBlipId;
+  }
+
+  public String getDirection() {
+    return direction;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  private static String normalize(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirection.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirection.java
@@ -1,0 +1,18 @@
+package org.waveprotocol.box.j2cl.viewport;
+
+public final class J2clViewportGrowthDirection {
+  public static final String FORWARD = "forward";
+  public static final String BACKWARD = "backward";
+
+  private J2clViewportGrowthDirection() {
+  }
+
+  /** Defaults unknown or missing directions to forward growth, matching the server API default. */
+  public static String normalize(String direction) {
+    return BACKWARD.equals(direction) ? BACKWARD : FORWARD;
+  }
+
+  public static boolean isBackward(String direction) {
+    return BACKWARD.equals(direction);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirection.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirection.java
@@ -1,5 +1,7 @@
 package org.waveprotocol.box.j2cl.viewport;
 
+import java.util.Locale;
+
 public final class J2clViewportGrowthDirection {
   public static final String FORWARD = "forward";
   public static final String BACKWARD = "backward";
@@ -9,7 +11,11 @@ public final class J2clViewportGrowthDirection {
 
   /** Defaults unknown or missing directions to forward growth, matching the server API default. */
   public static String normalize(String direction) {
-    return BACKWARD.equals(direction) ? BACKWARD : FORWARD;
+    if (direction == null) {
+      return FORWARD;
+    }
+    String normalized = direction.trim().toLowerCase(Locale.ROOT);
+    return BACKWARD.equals(normalized) ? BACKWARD : FORWARD;
   }
 
   public static boolean isBackward(String direction) {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -187,6 +187,15 @@ body {
   display: grid;
   gap: 12px;
   margin-top: 18px;
+  max-height: min(68vh, 720px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+}
+
+.sidecar-selected-content:focus-visible {
+  outline: 3px solid #1f6feb;
+  outline-offset: 4px;
 }
 
 .sidecar-selected-entry {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -269,6 +269,47 @@ body {
   word-break: normal;
 }
 
+.j2cl-read-viewport-placeholder,
+.visible-region-placeholder {
+  background:
+    linear-gradient(
+      90deg,
+      rgba(220, 233, 255, 0.65),
+      rgba(248, 251, 255, 0.35),
+      rgba(220, 233, 255, 0.65)
+    );
+  border: 1px dashed #bfcef5;
+  border-radius: 18px;
+  background-size: 220% 100%;
+  color: #4f6480;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  animation: j2cl-viewport-placeholder-shimmer 1.8s ease-in-out 6;
+  padding: 14px 16px;
+}
+
+@keyframes j2cl-viewport-placeholder-shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .j2cl-read-viewport-placeholder,
+  .visible-region-placeholder {
+    animation: none;
+  }
+}
+
 .sidecar-search-session {
   margin: 16px 0 0;
   color: #3567c8;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -504,6 +504,226 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderWindowEntriesKeepsPlaceholderMetadataInOrder() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    boolean rendered =
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.loaded(
+                        "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+missing", 36L, 40L, "b+missing")));
+
+    Assert.assertTrue(rendered);
+    Assert.assertEquals("b+root", firstBlip(host).getAttribute("data-blip-id"));
+    HTMLElement placeholder =
+        (HTMLElement) host.querySelector("[data-j2cl-viewport-placeholder='true']");
+    Assert.assertNotNull(placeholder);
+    Assert.assertEquals("blip:b+missing", placeholder.getAttribute("data-segment"));
+    Assert.assertEquals("36", placeholder.getAttribute("data-range-from"));
+    Assert.assertEquals("40", placeholder.getAttribute("data-range-to"));
+    Assert.assertEquals("b+missing", placeholder.getAttribute("data-placeholder-blip-id"));
+    Assert.assertEquals(
+        firstBlip(host).nextSibling,
+        placeholder);
+  }
+
+  @Test
+  public void rerenderingSameWindowEntriesPreservesFocusedNode() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    List<J2clReadWindowEntry> entries =
+        Arrays.asList(
+            J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+            J2clReadWindowEntry.placeholder("blip:b+missing", 36L, 40L, "b+missing"));
+
+    Assert.assertTrue(renderer.renderWindow(entries));
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+
+    Assert.assertTrue(renderer.renderWindow(entries));
+
+    Assert.assertSame(root, blip(host, "b+root"));
+    Assert.assertEquals(root, DomGlobal.document.activeElement);
+    Assert.assertEquals("0", root.getAttribute("tabindex"));
+    Assert.assertEquals("true", root.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void renderWindowPlaceholderOmitsUnknownRangeAttributes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+pending", -1L, -1L, "b+pending"))));
+
+    HTMLElement placeholder =
+        (HTMLElement) host.querySelector("[data-j2cl-viewport-placeholder='true']");
+    Assert.assertNotNull(placeholder);
+    Assert.assertNull(placeholder.getAttribute("data-range-from"));
+    Assert.assertNull(placeholder.getAttribute("data-range-to"));
+    Assert.assertEquals(
+        "polite", host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+  }
+
+  @Test
+  public void renderWindowPlaceholderCanCarryOneSidedRangeMetadata() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+pending", 12L, -1L, "b+pending"))));
+
+    HTMLElement placeholder =
+        (HTMLElement) host.querySelector("[data-j2cl-viewport-placeholder='true']");
+    Assert.assertNotNull(placeholder);
+    Assert.assertEquals("12", placeholder.getAttribute("data-range-from"));
+    Assert.assertNull(placeholder.getAttribute("data-range-to"));
+  }
+
+  @Test
+  public void renderWindowAllPlaceholdersKeepsSurfaceBusyWithoutTabStops() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+before", 10L, 12L, "b+before"),
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+after", 12L, 14L, "b+after"))));
+
+    Assert.assertNull(firstBlip(host));
+    Assert.assertEquals(2, host.querySelectorAll("[data-j2cl-viewport-placeholder='true']").length);
+    Assert.assertEquals(
+        "true", host.querySelector("[data-thread-id='root']").getAttribute("aria-busy"));
+    Assert.assertEquals(
+        0, host.querySelectorAll("[data-j2cl-viewport-placeholder='true'][tabindex]").length);
+  }
+
+  @Test
+  public void renderWindowAndClassicRenderTransitionsClearStaleState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder("blip:b+missing", 36L, 40L, "b+missing"))));
+    Assert.assertNotNull(host.querySelector("[data-j2cl-viewport-placeholder='true']"));
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(new J2clReadBlip("b+root", "Root text updated")),
+            Collections.<String>emptyList()));
+    Assert.assertNull(host.querySelector("[data-j2cl-viewport-placeholder='true']"));
+    Assert.assertEquals("Root text updated", renderedText(blip(host, "b+root")));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text window"))));
+    Assert.assertEquals("Root text window", renderedText(blip(host, "b+root")));
+  }
+
+  @Test
+  public void allPlaceholderWindowThenClassicRenderClearsBusySurfaceState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.placeholder("blip:b+before", 10L, 12L, "b+before"),
+                J2clReadWindowEntry.placeholder("blip:b+after", 12L, 14L, "b+after"))));
+    Assert.assertNotNull(host.querySelector("[data-j2cl-viewport-placeholder='true']"));
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(new J2clReadBlip("b+root", "Root text")),
+            Collections.<String>emptyList()));
+
+    Assert.assertNull(host.querySelector("[data-j2cl-viewport-placeholder='true']"));
+    Assert.assertNull(host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+    Assert.assertNull(host.querySelector("[data-thread-id='root']").getAttribute("aria-busy"));
+    Assert.assertEquals("Root text", renderedText(blip(host, "b+root")));
+  }
+
+  @Test
+  public void classicRenderAfterWindowNoOpClearsViewportSurfaceState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"))));
+    HTMLElement windowRoot = blip(host, "b+root");
+    Assert.assertNull(host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(new J2clReadBlip("b+root", "Root text")),
+            Collections.<String>emptyList()));
+
+    HTMLElement classicRoot = blip(host, "b+root");
+    Assert.assertNotSame(windowRoot, classicRoot);
+    Assert.assertNull(host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"))));
+    Assert.assertNotSame(classicRoot, blip(host, "b+root"));
+    Assert.assertNull(host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+  }
+
+  @Test
+  public void renderWindowPlaceholderUpgradePreservesFocusedLoadedBlip() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder("blip:b+reply", 36L, 40L, "b+reply"))));
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+reply", 36L, 40L, "b+reply", "Reply text"))));
+
+    HTMLElement restoredRoot = blip(host, "b+root");
+    Assert.assertEquals(restoredRoot, DomGlobal.document.activeElement);
+    Assert.assertEquals("true", restoredRoot.getAttribute("aria-current"));
+    Assert.assertEquals("Reply text", renderedText(blip(host, "b+reply")));
+  }
+
+  @Test
   public void renderEmptyContentReturnsFalseAndLeavesHostEmpty() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -590,6 +810,11 @@ public class J2clReadSurfaceDomRendererTest {
 
   private static HTMLElement blip(HTMLDivElement host, String blipId) {
     return (HTMLElement) host.querySelector("[data-blip-id='" + blipId + "']");
+  }
+
+  private static String renderedText(HTMLElement blip) {
+    HTMLElement content = (HTMLElement) blip.querySelector(".j2cl-read-blip-content");
+    return content == null ? "" : content.textContent;
   }
 
   private static void dispatchKey(HTMLElement target, String key) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -2,11 +2,13 @@ package org.waveprotocol.box.j2cl.read;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.KeyboardEvent;
 import elemental2.dom.KeyboardEventInit;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -14,17 +16,23 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 @J2clTestInput(J2clReadSurfaceDomRendererTest.class)
 public class J2clReadSurfaceDomRendererTest {
   private HTMLDivElement currentHost;
+  private HTMLElement currentStyle;
 
   @After
   public void tearDown() {
     if (currentHost != null && currentHost.parentElement != null) {
       currentHost.parentElement.removeChild(currentHost);
     }
+    if (currentStyle != null && currentStyle.parentElement != null) {
+      currentStyle.parentElement.removeChild(currentStyle);
+    }
     currentHost = null;
+    currentStyle = null;
   }
 
   @Test
@@ -594,6 +602,179 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderWindowRequestsForwardGrowthWhenScrolledToTrailingPlaceholder() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    host.scrollTop = 100;
+    host.dispatchEvent(new Event("scroll"));
+
+    Assert.assertEquals("b+missing", requested[0]);
+    Assert.assertEquals("forward", requested[1]);
+  }
+
+  @Test
+  public void renderWindowRequestsBackwardGrowthWhenScrolledToLeadingPlaceholder() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+before", 24L, 30L, "b+before"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"))));
+
+    host.scrollTop = 0;
+    host.dispatchEvent(new Event("scroll"));
+
+    Assert.assertEquals("b+before", requested[0]);
+    Assert.assertEquals("backward", requested[1]);
+  }
+
+  @Test
+  public void renderWindowDoesNotRequestGrowthWhenScrolledToLoadedEdges() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final int[] requestCount = new int[1];
+    renderer.setViewportEdgeListener((anchorBlipId, direction) -> requestCount[0]++);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+tail", 36L, 40L, "b+tail", "Tail text"))));
+
+    host.scrollTop = 0;
+    host.dispatchEvent(new Event("scroll"));
+    host.scrollTop = 100;
+    host.dispatchEvent(new Event("scroll"));
+
+    Assert.assertEquals(0, requestCount[0]);
+  }
+
+  @Test
+  public void flatRenderNoOpPreservesPendingViewportEdgeMemory() throws Exception {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+    List<J2clReadBlip> blips = Arrays.asList(new J2clReadBlip("b+root", "Root text"));
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+    setLastScrollDirection(renderer, J2clViewportGrowthDirection.FORWARD);
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+    host.scrollTop = 100;
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals("b+missing", requested[0]);
+    Assert.assertEquals(J2clViewportGrowthDirection.FORWARD, requested[1]);
+  }
+
+  @Test
+  public void renderWindowPostRenderGrowthRequestIsOneShot() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final int[] requestCount = new int[1];
+    renderer.setViewportEdgeListener((anchorBlipId, direction) -> requestCount[0]++);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+    host.scrollTop = 100;
+    host.dispatchEvent(new Event("scroll"));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text updated once"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text updated twice"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals(2, requestCount[0]);
+  }
+
+  @Test
+  public void backwardGrowthPreservesScrollAnchorAcrossPrependRebuild() {
+    assumeBrowserDom();
+    installFixedBlipLayout();
+    HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 80px; overflow-y: auto;");
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+tail", 36L, 40L, "b+tail", "Tail text"))));
+    host.scrollTop = 0;
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+before", 24L, 30L, "b+before", "Before text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+tail", 36L, 40L, "b+tail", "Tail text"))));
+
+    Assert.assertTrue(host.scrollTop > 0);
+  }
+
+  @Test
   public void renderWindowAllPlaceholdersKeepsSurfaceBusyWithoutTabStops() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -758,6 +939,13 @@ public class J2clReadSurfaceDomRendererTest {
     return currentHost;
   }
 
+  private void installFixedBlipLayout() {
+    currentStyle = (HTMLElement) DomGlobal.document.createElement("style");
+    currentStyle.textContent =
+        ".j2cl-read-blip,.j2cl-read-viewport-placeholder{display:block;height:40px;}";
+    DomGlobal.document.head.appendChild(currentStyle);
+  }
+
   private HTMLDivElement createDuplicateThreadIdHost() {
     HTMLDivElement host = createHost();
     host.innerHTML =
@@ -815,6 +1003,13 @@ public class J2clReadSurfaceDomRendererTest {
   private static String renderedText(HTMLElement blip) {
     HTMLElement content = (HTMLElement) blip.querySelector(".j2cl-read-blip-content");
     return content == null ? "" : content.textContent;
+  }
+
+  private static void setLastScrollDirection(
+      J2clReadSurfaceDomRenderer renderer, String direction) throws Exception {
+    Field field = J2clReadSurfaceDomRenderer.class.getDeclaredField("lastScrollDirection");
+    field.setAccessible(true);
+    field.set(renderer, direction);
   }
 
   private static void dispatchKey(HTMLElement target, String key) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -604,7 +604,9 @@ public class J2clReadSurfaceDomRendererTest {
   @Test
   public void renderWindowRequestsForwardGrowthWhenScrolledToTrailingPlaceholder() {
     assumeBrowserDom();
+    installFixedBlipLayout();
     HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 40px; overflow-y: auto;");
     J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
     final String[] requested = new String[2];
     renderer.setViewportEdgeListener(
@@ -631,7 +633,9 @@ public class J2clReadSurfaceDomRendererTest {
   @Test
   public void renderWindowRequestsBackwardGrowthWhenScrolledToLeadingPlaceholder() {
     assumeBrowserDom();
+    installFixedBlipLayout();
     HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 40px; overflow-y: auto;");
     J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
     final String[] requested = new String[2];
     renderer.setViewportEdgeListener(
@@ -653,6 +657,79 @@ public class J2clReadSurfaceDomRendererTest {
 
     Assert.assertEquals("b+before", requested[0]);
     Assert.assertEquals("backward", requested[1]);
+  }
+
+  @Test
+  public void renderWindowAutoRequestsForwardGrowthWhenTrailingPlaceholderAlreadyVisible() {
+    assumeBrowserDom();
+    installFixedBlipLayout();
+    HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 400px; overflow-y: auto;");
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals("b+missing", requested[0]);
+    Assert.assertEquals(J2clViewportGrowthDirection.FORWARD, requested[1]);
+  }
+
+  @Test
+  public void renderWindowAutoRequestsBackwardGrowthWhenLeadingPlaceholderAlreadyVisible() {
+    assumeBrowserDom();
+    installFixedBlipLayout();
+    HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 400px; overflow-y: auto;");
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+before", 24L, 30L, "b+before"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"))));
+
+    Assert.assertEquals("b+before", requested[0]);
+    Assert.assertEquals(J2clViewportGrowthDirection.BACKWARD, requested[1]);
+  }
+
+  @Test
+  public void renderWindowSkipsPendingGrowthReplayWhenListenerIsCleared() throws Exception {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final int[] requestCount = new int[1];
+    renderer.setViewportEdgeListener((anchorBlipId, direction) -> requestCount[0]++);
+    setLastScrollDirection(renderer, J2clViewportGrowthDirection.FORWARD);
+    renderer.setViewportEdgeListener(null);
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals(0, requestCount[0]);
   }
 
   @Test
@@ -741,7 +818,7 @@ public class J2clReadSurfaceDomRendererTest {
                 J2clReadWindowEntry.placeholder(
                     "blip:b+missing", 36L, 40L, "b+missing"))));
 
-    Assert.assertEquals(2, requestCount[0]);
+    Assert.assertEquals(3, requestCount[0]);
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -123,6 +123,23 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderAfterFailedReEnhancementRebuildsDetachedHost() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    List<J2clReadBlip> blips = Arrays.asList(new J2clReadBlip("b+root", "Root text"));
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+    host.innerHTML = "";
+    Assert.assertFalse(renderer.enhanceExistingSurface());
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+
+    Assert.assertNotNull(host.querySelector("[data-j2cl-read-surface='true']"));
+    Assert.assertEquals("Root text", renderedText(blip(host, "b+root")));
+  }
+
+  @Test
   public void enhanceExistingSurfaceReturnsFalseForEmptyHost() {
     assumeBrowserDom();
     Assert.assertFalse(new J2clReadSurfaceDomRenderer(createHost()).enhanceExistingSurface());
@@ -733,6 +750,18 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderWindowEmptyEntriesClearPendingViewportEdgeMemory() throws Exception {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    setLastScrollDirection(renderer, J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertFalse(renderer.renderWindow(Collections.<J2clReadWindowEntry>emptyList()));
+
+    Assert.assertNull(getLastScrollDirection(renderer));
+  }
+
+  @Test
   public void renderWindowDoesNotRequestGrowthWhenScrolledToLoadedEdges() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -1087,6 +1116,13 @@ public class J2clReadSurfaceDomRendererTest {
     Field field = J2clReadSurfaceDomRenderer.class.getDeclaredField("lastScrollDirection");
     field.setAccessible(true);
     field.set(renderer, direction);
+  }
+
+  private static String getLastScrollDirection(J2clReadSurfaceDomRenderer renderer)
+      throws Exception {
+    Field field = J2clReadSurfaceDomRenderer.class.getDeclaredField("lastScrollDirection");
+    field.setAccessible(true);
+    return (String) field.get(renderer);
   }
 
   private static void dispatchKey(HTMLElement target, String key) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 /**
  * Issue #933 regression coverage for the first outbound J2CL sidecar frames.
@@ -34,6 +35,32 @@ public class J2clSearchGatewayAuthFrameTest {
 
     Assert.assertEquals("ProtocolOpenRequest", SidecarTransportCodec.decodeMessageType(frame));
     Assert.assertFalse(frame.contains("ProtocolAuthenticate"));
+  }
+
+  @Test
+  public void selectedWaveOpenFrameCanCarryExplicitDefaultViewportLimit() {
+    String frame =
+        J2clSearchGateway.buildSelectedWaveOpenFrame(
+            new SidecarSessionBootstrap("rose@example.com", "socket.example.test"),
+            "example.com/w+abc",
+            new SidecarViewportHints(null, null, Integer.valueOf(0)));
+
+    Assert.assertEquals("ProtocolOpenRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertTrue(frame.contains("\"7\":0"));
+  }
+
+  @Test
+  public void selectedWaveOpenFrameCanCarryServerFirstViewportAnchor() {
+    String frame =
+        J2clSearchGateway.buildSelectedWaveOpenFrame(
+            new SidecarSessionBootstrap("rose@example.com", "socket.example.test"),
+            "example.com/w+abc",
+            new SidecarViewportHints("b+root", "forward", null));
+
+    Assert.assertEquals("ProtocolOpenRequest", SidecarTransportCodec.decodeMessageType(frame));
+    Assert.assertTrue(frame.contains("\"5\":\"b+root\""));
+    Assert.assertTrue(frame.contains("\"6\":\"forward\""));
+    Assert.assertFalse(frame.contains("\"7\""));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java
@@ -77,6 +77,44 @@ public class J2clSearchGatewayAuthFrameTest {
   }
 
   @Test
+  public void fragmentsFetchUrlCarriesViewportWindowAndDefaultWavelet() {
+    String url =
+        J2clSearchGateway.buildFragmentsUrl(
+            "example.com/w+abc", "b+root", "backward", 12, 40L, 44L);
+
+    Assert.assertTrue(url.startsWith("/fragments?"));
+    Assert.assertTrue(url.contains("waveId=example.com%2Fw%2Babc"));
+    Assert.assertTrue(url.contains("waveletId=example.com%2Fconv%2Broot"));
+    Assert.assertTrue(url.contains("client=j2cl"));
+    Assert.assertTrue(url.contains("startBlipId=b%2Broot"));
+    Assert.assertTrue(url.contains("direction=backward"));
+    Assert.assertTrue(url.contains("limit=12"));
+    Assert.assertTrue(url.contains("startVersion=40"));
+    Assert.assertTrue(url.contains("endVersion=44"));
+  }
+
+  @Test
+  public void fragmentsFetchUrlOmitsEmptyAnchorAndDefaultsDirection() {
+    String url =
+        J2clSearchGateway.buildFragmentsUrl(
+            "example.com/w+abc", "", null, 5, 40L, 44L);
+
+    Assert.assertFalse(url.contains("startBlipId="));
+    Assert.assertTrue(url.contains("direction=forward"));
+    Assert.assertTrue(url.contains("client=j2cl"));
+  }
+
+  @Test
+  public void fragmentsFetchUrlFallsBackToRootWaveletForDomainlessWaveId() {
+    String url =
+        J2clSearchGateway.buildFragmentsUrl(
+            "w+abc", "b+root", "forward", 5, 40L, 44L);
+
+    Assert.assertTrue(url.contains("waveId=w%2Babc"));
+    Assert.assertTrue(url.contains("waveletId=conv%2Broot"));
+  }
+
+  @Test
   public void websocketCookieHostMustMatchCurrentPageHost() {
     Assert.assertTrue(
         SidecarSessionBootstrap.usesCompatibleCookieHost(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -6,9 +6,11 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
@@ -550,6 +552,335 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(1, harness.readStateAttempts.size());
   }
 
+  @Test
+  public void viewportEdgeDispatchesFragmentsFetchWithCurrentVersionWindow() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+    FragmentFetchAttempt attempt = harness.fragmentFetchAttempts.get(0);
+    Assert.assertEquals("example.com/w+1", attempt.waveId);
+    Assert.assertEquals("b+next", attempt.startBlipId);
+    Assert.assertEquals("forward", attempt.direction);
+    Assert.assertEquals(5, attempt.limit);
+    Assert.assertEquals(40L, attempt.startVersion);
+    Assert.assertEquals(44L, attempt.endVersion);
+  }
+
+  @Test
+  public void viewportEdgeFetchMergesGrowthWindowWithoutReopeningSocket() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+
+    Assert.assertEquals(1, harness.openCount);
+    Assert.assertEquals(0, harness.closedCount);
+    Assert.assertEquals(
+        Arrays.asList("Root already loaded", "Next loaded", "Tail loaded"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void duplicateViewportEdgeRequestsAreCoalescedWhileFetchInFlight()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void oppositeViewportEdgesCanFetchConcurrently() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.requestViewportEdge(controller, "b+before", "backward");
+
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("forward", harness.fragmentFetchAttempts.get(0).direction);
+    Assert.assertEquals("backward", harness.fragmentFetchAttempts.get(1).direction);
+  }
+
+  @Test
+  public void viewportEdgeBeforeAnyViewportStateDoesNotFetchFragments() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    Assert.assertEquals(0, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void viewportEdgeCanUseTrailingAnchorFallback() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, null, "forward");
+
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+root", harness.fragmentFetchAttempts.get(0).startBlipId);
+  }
+
+  @Test
+  public void viewportEdgeWithoutAnchorOrLoadedBlipDoesNotFetchFragments() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithOnlyPlaceholder());
+
+    harness.requestViewportEdge(controller, null, "forward");
+
+    Assert.assertEquals(0, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void backwardViewportGrowthPrependsLoadedWindow() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+before", "backward");
+    harness.resolveFragmentFetch(
+        0, fragmentsResponseForBlips("b+before", "Before loaded", null, null));
+
+    Assert.assertEquals(
+        Arrays.asList("Before loaded", "Root already loaded"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void viewportEdgeCanFetchAgainAfterSuccessfulGrowth() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+    harness.requestViewportEdge(controller, "b+tail", "forward");
+
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void sameViewportEdgeCanFetchAgainAfterSuccessfulGrowth() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void staleViewportGrowthResponseIsDroppedAfterLiveUpdateChangesVersion()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    harness.deliverRawUpdate(
+        0,
+        update(
+            "example.com!w+1/example.com!conv+root",
+            "Live update changed base version",
+            45L,
+            "EFGH"));
+    harness.resolveFragmentFetch(0, fragmentsResponse("Stale next", "Stale tail"));
+
+    Assert.assertEquals(
+        Arrays.asList("Live update changed base version"), harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void staleViewportGrowthResponseIsDroppedAfterLiveUpdateChangesHashOnly()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    harness.deliverRawUpdate(
+        0,
+        update(
+            "example.com!w+1/example.com!conv+root",
+            "Live update changed history hash",
+            44L,
+            "EFGH"));
+    harness.resolveFragmentFetch(0, fragmentsResponse("Stale next", "Stale tail"));
+
+    Assert.assertEquals(
+        Arrays.asList("Live update changed history hash"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void viewportGrowthResponseSurvivesNullToPresentWriteSessionTransition()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholderWithoutWriteSession("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root refreshed with write session"));
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+
+    Assert.assertEquals(
+        Arrays.asList("Root refreshed with write session", "Next loaded", "Tail loaded"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void viewportGrowthFailureKeepsLoadedWindowAndAllowsRetry() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.rejectFragmentFetch(0, "fragment timeout");
+
+    Assert.assertEquals(
+        Arrays.asList("Root already loaded"), harness.modelValue("getContentEntries"));
+    Assert.assertTrue(
+        String.valueOf(harness.modelValue("getDetailText")).contains("fragment timeout"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+    harness.resolveFragmentFetch(1, fragmentsResponse("Recovered next", "Recovered tail"));
+
+    Assert.assertEquals("More selected-wave content loaded.", harness.modelValue("getStatusText"));
+    Assert.assertEquals("", harness.modelValue("getDetailText"));
+    Assert.assertEquals(
+        Arrays.asList("Root already loaded", "Recovered next", "Recovered tail"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void viewportGrowthFailureCoalescesSameEdgeReentryDuringRender() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.onNextRender =
+        () -> {
+          try {
+            harness.requestViewportEdge(controller, "b+next", "forward");
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    harness.rejectFragmentFetch(0, "fragment timeout");
+
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void viewportGrowthSuccessCoalescesSameEdgeReentryDuringRender() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.onNextRender =
+        () -> {
+          try {
+            harness.requestViewportEdge(controller, "b+next", "forward");
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
+
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
+  public void refreshClearsInFlightViewportEdgeTracking() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    harness.refreshSelectedWave(controller);
+    harness.resolveBootstrap(1);
+    harness.deliverRawUpdate(1, updateWithPlaceholder("Root reopened"));
+    harness.requestViewportEdge(controller, "b+next", "forward");
+
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
@@ -563,10 +894,13 @@ public class J2clSelectedWaveControllerTest {
     private final List<BootstrapAttempt> bootstrapAttempts = new ArrayList<BootstrapAttempt>();
     private final List<OpenAttempt> openAttempts = new ArrayList<OpenAttempt>();
     private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
+    private final List<FragmentFetchAttempt> fragmentFetchAttempts =
+        new ArrayList<FragmentFetchAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
     private SidecarViewportHints initialViewportHints;
     private Object lastModel;
+    private Runnable onNextRender;
     private Method onWaveSelectedMethod;
     private Method onWaveSelectedWithDigestMethod;
 
@@ -640,6 +974,24 @@ public class J2clSelectedWaveControllerTest {
                   readStateAttempts.add(new ReadStateFetchAttempt((String) args[0], success, error));
                   return null;
                 }
+                if ("fetchFragments".equals(method.getName())) {
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> success =
+                      (J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse>) args[6];
+                  J2clSearchPanelController.ErrorCallback error =
+                      (J2clSearchPanelController.ErrorCallback) args[7];
+                  fragmentFetchAttempts.add(
+                      new FragmentFetchAttempt(
+                          (String) args[0],
+                          (String) args[1],
+                          (String) args[2],
+                          ((Number) args[3]).intValue(),
+                          ((Number) args[4]).longValue(),
+                          ((Number) args[5]).longValue(),
+                          success,
+                          error));
+                  return null;
+                }
                 return null;
               });
 
@@ -650,6 +1002,11 @@ public class J2clSelectedWaveControllerTest {
               (proxy, method, args) -> {
                 if ("render".equals(method.getName())) {
                   lastModel = args[0];
+                  Runnable callback = onNextRender;
+                  onNextRender = null;
+                  if (callback != null) {
+                    callback.run();
+                  }
                 }
                 if ("initialViewportHints".equals(method.getName())) {
                   return initialViewportHints;
@@ -743,6 +1100,14 @@ public class J2clSelectedWaveControllerTest {
       refreshSelectedWaveMethod.invoke(controller);
     }
 
+    private void requestViewportEdge(Object controller, String anchorBlipId, String direction)
+        throws Exception {
+      Method requestViewportEdgeMethod =
+          controller.getClass().getDeclaredMethod("onViewportEdge", String.class, String.class);
+      requestViewportEdgeMethod.setAccessible(true);
+      requestViewportEdgeMethod.invoke(controller, anchorBlipId, direction);
+    }
+
     private void resolveBootstrap(int index) {
       bootstrapAttempts.get(index)
           .success
@@ -782,6 +1147,14 @@ public class J2clSelectedWaveControllerTest {
       readStateAttempts.get(index).error.accept(message);
     }
 
+    private void resolveFragmentFetch(int index, SidecarFragmentsResponse response) {
+      fragmentFetchAttempts.get(index).success.accept(response);
+    }
+
+    private void rejectFragmentFetch(int index, String message) {
+      fragmentFetchAttempts.get(index).error.accept(message);
+    }
+
     private void deliverUpdate(int index, String rawSnapshot) {
       deliverRawUpdate(index, update("example.com!w+1/example.com!conv+root", rawSnapshot));
     }
@@ -801,13 +1174,18 @@ public class J2clSelectedWaveControllerTest {
   }
 
   private static SidecarSelectedWaveUpdate update(String waveletName, String rawSnapshot) {
+    return update(waveletName, rawSnapshot, 44L, "ABCD");
+  }
+
+  private static SidecarSelectedWaveUpdate update(
+      String waveletName, String rawSnapshot, long resultingVersion, String historyHash) {
     return new SidecarSelectedWaveUpdate(
         1,
         waveletName,
         true,
         "chan-1",
-        44L,
-        "ABCD",
+        resultingVersion,
+        historyHash,
         Arrays.asList("user@example.com", "teammate@example.com"),
         Arrays.asList(
             new SidecarSelectedWaveDocument(
@@ -822,6 +1200,98 @@ public class J2clSelectedWaveControllerTest {
             Arrays.asList(
                 new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
                 new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
+  }
+
+  private static SidecarSelectedWaveUpdate updateWithPlaceholder(String rootSnapshot) {
+    return updateWithPlaceholder(rootSnapshot, 44L, "ABCD");
+  }
+
+  private static SidecarSelectedWaveUpdate updateWithPlaceholderWithoutWriteSession(
+      String rootSnapshot) {
+    return updateWithPlaceholder(rootSnapshot, -1L, null);
+  }
+
+  private static SidecarSelectedWaveUpdate updateWithPlaceholder(
+      String rootSnapshot, long resultingVersion, String historyHash) {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        "example.com!w+1/example.com!conv+root",
+        true,
+        "chan-1",
+        resultingVersion,
+        historyHash,
+        Arrays.asList("user@example.com", "teammate@example.com"),
+        Arrays.asList(
+            new SidecarSelectedWaveDocument(
+                "b+root", "user@example.com", 33L, 44L, rootSnapshot)),
+        new SidecarSelectedWaveFragments(
+            44L,
+            40L,
+            44L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
+                new SidecarSelectedWaveFragmentRange("blip:b+root", 41L, 44L),
+                new SidecarSelectedWaveFragmentRange("blip:b+next", 41L, 44L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
+                new SidecarSelectedWaveFragment("blip:b+root", rootSnapshot, 0, 0))));
+  }
+
+  private static SidecarSelectedWaveUpdate updateWithOnlyPlaceholder() {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        "example.com!w+1/example.com!conv+root",
+        true,
+        "chan-1",
+        44L,
+        "ABCD",
+        Arrays.asList("user@example.com", "teammate@example.com"),
+        Collections.<SidecarSelectedWaveDocument>emptyList(),
+        new SidecarSelectedWaveFragments(
+            44L,
+            40L,
+            44L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
+                new SidecarSelectedWaveFragmentRange("blip:b+missing", 41L, 44L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0))));
+  }
+
+  private static SidecarFragmentsResponse fragmentsResponse(
+      String nextSnapshot, String tailSnapshot) {
+    return fragmentsResponseForBlips("b+next", nextSnapshot, "b+tail", tailSnapshot);
+  }
+
+  private static SidecarFragmentsResponse fragmentsResponseForBlips(
+      String firstBlipId, String firstSnapshot, String secondBlipId, String secondSnapshot) {
+    StringBuilder json =
+        new StringBuilder(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+1/~/conv+root\","
+                + "\"version\":{\"snapshot\":48,\"start\":44,\"end\":48},"
+                + "\"ranges\":[{\"segment\":\"blip:");
+    json.append(firstBlipId)
+        .append("\",\"from\":44,\"to\":48}");
+    if (secondBlipId != null) {
+      json.append(",{\"segment\":\"blip:")
+          .append(secondBlipId)
+          .append("\",\"from\":44,\"to\":48}");
+    }
+    json.append("],\"fragments\":[{\"segment\":\"blip:")
+        .append(firstBlipId)
+        .append("\",\"rawSnapshot\":\"")
+        .append(firstSnapshot)
+        .append("\",\"adjust\":[],\"diff\":[]}");
+    if (secondBlipId != null) {
+      json.append(",{\"segment\":\"blip:")
+          .append(secondBlipId)
+          .append("\",\"rawSnapshot\":\"")
+          .append(secondSnapshot)
+          .append("\",\"adjust\":[],\"diff\":[]}");
+    }
+    json.append("]}");
+    return SidecarFragmentsResponse.fromJson(
+        json.toString());
   }
 
   private static SidecarSelectedWaveUpdate snapshotOnlyUpdate(String textContent) {
@@ -860,6 +1330,36 @@ public class J2clSelectedWaveControllerTest {
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> success,
         J2clSearchPanelController.ErrorCallback error) {
       this.waveId = waveId;
+      this.success = success;
+      this.error = error;
+    }
+  }
+
+  private static final class FragmentFetchAttempt {
+    private final String waveId;
+    private final String startBlipId;
+    private final String direction;
+    private final int limit;
+    private final long startVersion;
+    private final long endVersion;
+    private final J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> success;
+    private final J2clSearchPanelController.ErrorCallback error;
+
+    private FragmentFetchAttempt(
+        String waveId,
+        String startBlipId,
+        String direction,
+        int limit,
+        long startVersion,
+        long endVersion,
+        J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> success,
+        J2clSearchPanelController.ErrorCallback error) {
+      this.waveId = waveId;
+      this.startBlipId = startBlipId;
+      this.direction = direction;
+      this.limit = limit;
+      this.startVersion = startVersion;
+      this.endVersion = endVersion;
       this.success = success;
       this.error = error;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -16,6 +16,7 @@ import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 @J2clTestInput(J2clSelectedWaveControllerTest.class)
 public class J2clSelectedWaveControllerTest {
@@ -181,6 +182,52 @@ public class J2clSelectedWaveControllerTest {
     harness.resolveBootstrap(1);
     Assert.assertEquals(1, harness.openCount);
     Assert.assertEquals("example.com/w+b", harness.openAttempts.get(0).waveId);
+  }
+
+  @Test
+  public void selectingWaveDefaultsToExplicitViewportLimitHintWhenViewHasNoAnchor()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    SidecarViewportHints hints = harness.openAttempts.get(0).viewportHints;
+    Assert.assertNull(hints.getStartBlipId());
+    Assert.assertNull(hints.getDirection());
+    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+  }
+
+  @Test
+  public void selectingWaveDefaultsToExplicitViewportLimitHintWhenViewReturnsNoHints()
+      throws Exception {
+    Harness harness = new Harness();
+    harness.initialViewportHints = SidecarViewportHints.none();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    SidecarViewportHints hints = harness.openAttempts.get(0).viewportHints;
+    Assert.assertNull(hints.getStartBlipId());
+    Assert.assertNull(hints.getDirection());
+    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+  }
+
+  @Test
+  public void selectingWaveUsesViewProvidedServerFirstViewportAnchor() throws Exception {
+    Harness harness = new Harness();
+    harness.initialViewportHints = new SidecarViewportHints("b+server", "forward", null);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    SidecarViewportHints hints = harness.openAttempts.get(0).viewportHints;
+    Assert.assertEquals("b+server", hints.getStartBlipId());
+    Assert.assertEquals("forward", hints.getDirection());
+    Assert.assertNull(hints.getLimit());
   }
 
   @Test
@@ -518,6 +565,7 @@ public class J2clSelectedWaveControllerTest {
     private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
+    private SidecarViewportHints initialViewportHints;
     private Object lastModel;
     private Method onWaveSelectedMethod;
     private Method onWaveSelectedWithDigestMethod;
@@ -563,13 +611,15 @@ public class J2clSelectedWaveControllerTest {
                 }
                 if ("openSelectedWave".equals(method.getName())) {
                   openCount++;
+                  SidecarViewportHints viewportHints = (SidecarViewportHints) args[2];
                   @SuppressWarnings("unchecked")
                   J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success =
-                      (J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate>) args[2];
+                      (J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate>) args[3];
                   J2clSearchPanelController.ErrorCallback error =
-                      (J2clSearchPanelController.ErrorCallback) args[3];
-                  Runnable disconnect = (Runnable) args[4];
-                  OpenAttempt attempt = new OpenAttempt((String) args[1], success, error, disconnect);
+                      (J2clSearchPanelController.ErrorCallback) args[4];
+                  Runnable disconnect = (Runnable) args[5];
+                  OpenAttempt attempt =
+                      new OpenAttempt((String) args[1], viewportHints, success, error, disconnect);
                   openAttempts.add(attempt);
                   return Proxy.newProxyInstance(
                       subscriptionClass.getClassLoader(),
@@ -600,6 +650,9 @@ public class J2clSelectedWaveControllerTest {
               (proxy, method, args) -> {
                 if ("render".equals(method.getName())) {
                   lastModel = args[0];
+                }
+                if ("initialViewportHints".equals(method.getName())) {
+                  return initialViewportHints;
                 }
                 return null;
               });
@@ -814,16 +867,19 @@ public class J2clSelectedWaveControllerTest {
 
   private static final class OpenAttempt {
     private final String waveId;
+    private final SidecarViewportHints viewportHints;
     private final J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success;
     private final J2clSearchPanelController.ErrorCallback error;
     private final Runnable disconnect;
 
     private OpenAttempt(
         String waveId,
+        SidecarViewportHints viewportHints,
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveUpdate> success,
         J2clSearchPanelController.ErrorCallback error,
         Runnable disconnect) {
       this.waveId = waveId;
+      this.viewportHints = viewportHints;
       this.success = success;
       this.error = error;
       this.disconnect = disconnect;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
@@ -87,4 +87,62 @@ public class J2clSelectedWaveModelCopyTest {
     Assert.assertFalse(model.isRead());
     Assert.assertFalse(model.isReadStateKnown());
   }
+
+  @Test
+  public void viewportStateCopyPreservesLoadingAndErrorFlags() {
+    J2clSelectedWaveModel model =
+        new J2clSelectedWaveModel(
+            true,
+            true,
+            true,
+            "example.com/w+1",
+            "Title",
+            "",
+            "",
+            "Opening selected wave.",
+            "Waiting for content.",
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            null,
+            J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+            false,
+            false,
+            false);
+
+    J2clSelectedWaveModel copied =
+        model.withViewportState(J2clSelectedWaveViewportState.empty());
+
+    Assert.assertTrue(copied.isLoading());
+    Assert.assertTrue(copied.isError());
+  }
+
+  @Test
+  public void softStatusCopyKeepsSelectionOutOfBlockingErrorState() {
+    J2clSelectedWaveModel model =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            true,
+            "example.com/w+1",
+            "Title",
+            "",
+            "",
+            "Selected wave stream failed.",
+            "detail",
+            0,
+            Collections.<String>emptyList(),
+            Collections.<String>emptyList(),
+            null,
+            J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+            false,
+            false,
+            false);
+
+    J2clSelectedWaveModel copied =
+        model.withStatus("Could not load more selected-wave content.", "fragment timeout");
+
+    Assert.assertFalse(copied.isError());
+    Assert.assertEquals("Could not load more selected-wave content.", copied.getStatusText());
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -230,6 +230,481 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("Fragment text", blip.getText());
   }
 
+  @Test
+  public void projectPreservesFragmentWindowRangesAndPlaceholders() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("manifest", 30L, 40L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 36L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+missing", 36L, 38L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+empty", 38L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("manifest", "metadata", 0, 0),
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 2, 3),
+                        new SidecarSelectedWaveFragment("blip:b+empty", null, 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveViewportState viewport = projected.getViewportState();
+
+    Assert.assertEquals(40L, viewport.getSnapshotVersion());
+    Assert.assertEquals(30L, viewport.getStartVersion());
+    Assert.assertEquals(40L, viewport.getEndVersion());
+    Assert.assertEquals(4, viewport.getEntries().size());
+
+    J2clSelectedWaveViewportState.Entry manifest = viewport.getEntries().get(0);
+    Assert.assertEquals("manifest", manifest.getSegment());
+    Assert.assertEquals(30L, manifest.getFromVersion());
+    Assert.assertEquals(40L, manifest.getToVersion());
+    Assert.assertFalse(manifest.isBlip());
+    Assert.assertTrue(manifest.isLoaded());
+    Assert.assertEquals("metadata", manifest.getRawSnapshot());
+
+    J2clSelectedWaveViewportState.Entry root = viewport.getEntries().get(1);
+    Assert.assertEquals("blip:b+root", root.getSegment());
+    Assert.assertEquals(30L, root.getFromVersion());
+    Assert.assertEquals(36L, root.getToVersion());
+    Assert.assertTrue(root.isBlip());
+    Assert.assertEquals("b+root", root.getBlipId());
+    Assert.assertTrue(root.isLoaded());
+    Assert.assertEquals("Root text", root.getRawSnapshot());
+    Assert.assertEquals(2, root.getAdjustOperationCount());
+    Assert.assertEquals(3, root.getDiffOperationCount());
+
+    J2clSelectedWaveViewportState.Entry placeholder = viewport.getEntries().get(2);
+    Assert.assertEquals("blip:b+missing", placeholder.getSegment());
+    Assert.assertEquals(36L, placeholder.getFromVersion());
+    Assert.assertEquals(38L, placeholder.getToVersion());
+    Assert.assertTrue(placeholder.isBlip());
+    Assert.assertEquals("b+missing", placeholder.getBlipId());
+    Assert.assertFalse(placeholder.isLoaded());
+
+    J2clSelectedWaveViewportState.Entry empty = viewport.getEntries().get(3);
+    Assert.assertEquals("blip:b+empty", empty.getSegment());
+    Assert.assertEquals(38L, empty.getFromVersion());
+    Assert.assertEquals(40L, empty.getToVersion());
+    Assert.assertEquals("b+empty", empty.getBlipId());
+    Assert.assertFalse(empty.isLoaded());
+  }
+
+  @Test
+  public void projectCarriesPreviousViewportWindowWhenUpdateOmitsFragments() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            first,
+            0);
+
+    Assert.assertEquals(40L, second.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(1, second.getViewportState().getEntries().size());
+    Assert.assertEquals("b+root", second.getViewportState().getEntries().get(0).getBlipId());
+  }
+
+  @Test
+  public void projectMergesDocumentOnlyUpdateIntoPreviousViewportWindow() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 36L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+missing", 36L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Root text updated")),
+                null),
+            first,
+            0);
+
+    Assert.assertEquals(2, second.getViewportState().getEntries().size());
+    J2clSelectedWaveViewportState.Entry root = second.getViewportState().getEntries().get(0);
+    Assert.assertEquals("blip:b+root", root.getSegment());
+    Assert.assertEquals(30L, root.getFromVersion());
+    Assert.assertEquals(44L, root.getToVersion());
+    Assert.assertTrue(root.isLoaded());
+    Assert.assertEquals("Root text updated", root.getRawSnapshot());
+    J2clSelectedWaveViewportState.Entry missing = second.getViewportState().getEntries().get(1);
+    Assert.assertEquals("blip:b+missing", missing.getSegment());
+    Assert.assertEquals(36L, missing.getFromVersion());
+    Assert.assertEquals(40L, missing.getToVersion());
+    Assert.assertFalse(missing.isLoaded());
+  }
+
+  @Test
+  public void projectMergesDocumentOnlyUpdateWithoutDowngradingViewportVersion() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                50L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    50L,
+                    30L,
+                    50L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 50L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+reply", "user@example.com", 44L, 45L, "Reply text")),
+                null),
+            first,
+            0);
+
+    Assert.assertEquals(50L, second.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(50L, second.getViewportState().getEndVersion());
+    Assert.assertEquals(2, second.getViewportState().getEntries().size());
+    Assert.assertEquals("b+reply", second.getViewportState().getEntries().get(1).getBlipId());
+    Assert.assertEquals(44L, second.getViewportState().getEntries().get(1).getToVersion());
+  }
+
+  @Test
+  public void projectMergesDocumentsIntoFragmentUpdate() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+reply", "user@example.com", 42L, 43L, "Reply text")),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(2, projected.getViewportState().getEntries().size());
+    Assert.assertEquals("b+root", projected.getViewportState().getEntries().get(0).getBlipId());
+    Assert.assertEquals("b+reply", projected.getViewportState().getEntries().get(1).getBlipId());
+    Assert.assertEquals(
+        "Reply text", projected.getViewportState().getEntries().get(1).getRawSnapshot());
+  }
+
+  @Test
+  public void projectUpgradesFragmentPlaceholderFromDocumentInSameUpdate() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Root text from document")),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", null, 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getViewportState().getEntries().size());
+    J2clSelectedWaveViewportState.Entry root = projected.getViewportState().getEntries().get(0);
+    Assert.assertTrue(root.isLoaded());
+    Assert.assertEquals("Root text from document", root.getRawSnapshot());
+    Assert.assertEquals(44L, root.getToVersion());
+  }
+
+  @Test
+  public void projectKeepsLoadedFragmentWhenSameUpdateDocumentAlsoExists() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Document text")),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(
+                            "blip:b+root", "Fragment text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveViewportState.Entry root =
+        projected.getViewportState().getEntries().get(0);
+    Assert.assertEquals("Fragment text", root.getRawSnapshot());
+    Assert.assertEquals(40L, root.getToVersion());
+  }
+
+  @Test
+  public void projectBuildsViewportWindowFromDocumentOnlyUpdate() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, "Document text")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getViewportState().getReadWindowEntries().size());
+    Assert.assertEquals(
+        "b+root", projected.getViewportState().getReadWindowEntries().get(0).getBlipId());
+    Assert.assertEquals(
+        "Document text",
+        projected.getViewportState().getReadWindowEntries().get(0).getText());
+  }
+
+  @Test
+  public void projectBuildsDocumentOnlyViewportAtVersionZero() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                0L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 0L, 8L, "Bootstrap text")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(0L, projected.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(0L, projected.getViewportState().getStartVersion());
+    Assert.assertEquals(0L, projected.getViewportState().getEndVersion());
+  }
+
+  @Test
+  public void projectSkipsDocumentViewportEntriesWithoutDocumentIds() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                0L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        null, "user@example.com", 0L, 8L, "No id"),
+                    new SidecarSelectedWaveDocument(
+                        "", "user@example.com", 1L, 9L, "Empty id")),
+                null),
+            null,
+            0);
+
+    Assert.assertTrue(projected.getViewportState().isEmpty());
+  }
+
+  @Test
+  public void projectSkipsDocumentViewportEntriesWithoutText() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                0L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+empty", "user@example.com", 0L, 8L, ""),
+                    new SidecarSelectedWaveDocument(
+                        "b+null", "user@example.com", 1L, 9L, null)),
+                null),
+            null,
+            0);
+
+    Assert.assertTrue(projected.getViewportState().isEmpty());
+  }
+
+  @Test
+  public void reprojectReadStatePreservesViewportWindow() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel reprojected =
+        J2clSelectedWaveProjector.reprojectReadState(
+            projected,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveReadState(WAVE_ID, 0, true),
+            false);
+
+    Assert.assertEquals(40L, reprojected.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(1, reprojected.getViewportState().getEntries().size());
+    Assert.assertEquals(
+        "Root text", reprojected.getViewportState().getEntries().get(0).getRawSnapshot());
+  }
+
   // -- Write-session coupling (pre-existing) ----------------------------------
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -624,6 +624,61 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectKeepsEmptyTextDocumentAsLoadedViewportAnchor() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+empty", "user@example.com", 7L, 8L, "")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getViewportState().getReadWindowEntries().size());
+    Assert.assertEquals(
+        "b+empty", projected.getViewportState().getReadWindowEntries().get(0).getBlipId());
+    Assert.assertEquals("", projected.getViewportState().getReadWindowEntries().get(0).getText());
+  }
+
+  @Test
+  public void mergeFragmentsDoesNotDowngradeLoadedEntryWithPlaceholderOverlap() {
+    J2clSelectedWaveViewportState initial =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                44L,
+                40L,
+                44L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 40L, 44L)),
+                Arrays.asList(new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0))));
+
+    J2clSelectedWaveViewportState merged =
+        initial.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                48L,
+                44L,
+                48L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 44L, 48L)),
+                Arrays.asList(new SidecarSelectedWaveFragment("blip:b+root", null, 0, 0))),
+            "forward");
+
+    J2clSelectedWaveViewportState.Entry root = merged.getEntries().get(0);
+    Assert.assertTrue(root.isLoaded());
+    Assert.assertEquals("Root text", root.getRawSnapshot());
+    Assert.assertEquals(40L, root.getFromVersion());
+    Assert.assertEquals(48L, root.getToVersion());
+  }
+
+  @Test
   public void projectBuildsDocumentOnlyViewportAtVersionZero() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(
@@ -676,7 +731,7 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
-  public void projectSkipsDocumentViewportEntriesWithoutText() {
+  public void projectSkipsDocumentViewportEntriesWithNullText() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(
             WAVE_ID,
@@ -690,8 +745,6 @@ public class J2clSelectedWaveProjectorTest {
                 "HASH",
                 Arrays.asList("user@example.com"),
                 Arrays.asList(
-                    new SidecarSelectedWaveDocument(
-                        "b+empty", "user@example.com", 0L, 8L, ""),
                     new SidecarSelectedWaveDocument(
                         "b+null", "user@example.com", 1L, 9L, null)),
                 null),

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -19,6 +19,7 @@ public class J2clSelectedWaveProjectorTest {
   private static final String WAVE_ID = "example.com/w+1";
   private static final String WAVELET_NAME = "example.com!w+1/example.com!conv+root";
   private static final String CHANNEL_ID = "chan-1";
+  private static final String MANIFEST_SEGMENT = "manifest";
 
   // -- Read-state projection (issue #931) -------------------------------------
 
@@ -250,12 +251,12 @@ public class J2clSelectedWaveProjectorTest {
                     30L,
                     40L,
                     Arrays.asList(
-                        new SidecarSelectedWaveFragmentRange("manifest", 30L, 40L),
+                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 30L, 40L),
                         new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 36L),
                         new SidecarSelectedWaveFragmentRange("blip:b+missing", 36L, 38L),
                         new SidecarSelectedWaveFragmentRange("blip:b+empty", 38L, 40L)),
                     Arrays.asList(
-                        new SidecarSelectedWaveFragment("manifest", "metadata", 0, 0),
+                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0),
                         new SidecarSelectedWaveFragment("blip:b+root", "Root text", 2, 3),
                         new SidecarSelectedWaveFragment("blip:b+empty", null, 0, 0)))),
             null,
@@ -269,7 +270,7 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals(4, viewport.getEntries().size());
 
     J2clSelectedWaveViewportState.Entry manifest = viewport.getEntries().get(0);
-    Assert.assertEquals("manifest", manifest.getSegment());
+    Assert.assertEquals(MANIFEST_SEGMENT, manifest.getSegment());
     Assert.assertEquals(30L, manifest.getFromVersion());
     Assert.assertEquals(40L, manifest.getToVersion());
     Assert.assertFalse(manifest.isBlip());
@@ -340,6 +341,95 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals(40L, second.getViewportState().getSnapshotVersion());
     Assert.assertEquals(1, second.getViewportState().getEntries().size());
     Assert.assertEquals("b+root", second.getViewportState().getEntries().get(0).getBlipId());
+  }
+
+  @Test
+  public void projectCarriesPreviousViewportWindowWhenFragmentsOnlyContainMetadata() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                40L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    40L,
+                    30L,
+                    40L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    44L,
+                    40L,
+                    44L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 40L, 44L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)))),
+            first,
+            0);
+
+    Assert.assertEquals(40L, second.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(1, second.getViewportState().getEntries().size());
+    Assert.assertEquals("b+root", second.getViewportState().getEntries().get(0).getBlipId());
+    Assert.assertEquals("Root text", second.getViewportState().getEntries().get(0).getRawSnapshot());
+  }
+
+  @Test
+  public void projectFallsThroughToDocumentsWhenMetadataOnlyFragmentsHaveNoPreviousViewport() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Document text")),
+                new SidecarSelectedWaveFragments(
+                    44L,
+                    40L,
+                    44L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 40L, 44L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getViewportState().getEntries().size());
+    Assert.assertEquals("b+root", projected.getViewportState().getEntries().get(0).getBlipId());
+    Assert.assertEquals("Document text", projected.getViewportState().getEntries().get(0).getRawSnapshot());
   }
 
   @Test
@@ -731,7 +821,7 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
-  public void projectSkipsDocumentViewportEntriesWithNullText() {
+  public void projectNormalizesNullDocumentTextToLoadedEmptyViewportAnchor() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(
             WAVE_ID,
@@ -751,7 +841,10 @@ public class J2clSelectedWaveProjectorTest {
             null,
             0);
 
-    Assert.assertTrue(projected.getViewportState().isEmpty());
+    Assert.assertEquals(1, projected.getViewportState().getReadWindowEntries().size());
+    Assert.assertEquals(
+        "b+null", projected.getViewportState().getReadWindowEntries().get(0).getBlipId());
+    Assert.assertEquals("", projected.getViewportState().getReadWindowEntries().get(0).getText());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -525,6 +525,41 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectResolvesUnknownFragmentStartFromDocumentMerge() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Root text from document")),
+                new SidecarSelectedWaveFragments(
+                    44L,
+                    -1L,
+                    44L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", -1L, -1L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", null, 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveViewportState viewport = projected.getViewportState();
+    J2clSelectedWaveViewportState.Entry root = viewport.getEntries().get(0);
+    Assert.assertEquals(44L, viewport.getStartVersion());
+    Assert.assertEquals(44L, root.getFromVersion());
+    Assert.assertEquals(44L, root.getToVersion());
+  }
+
+  @Test
   public void projectKeepsLoadedFragmentWhenSameUpdateDocumentAlsoExists() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
@@ -3,6 +3,8 @@ package org.waveprotocol.box.j2cl.search;
 import com.google.j2cl.junit.apt.J2clTestInput;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
@@ -139,5 +141,16 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
     Assert.assertNull(hints.getStartBlipId());
     Assert.assertNull(hints.getDirection());
     Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+  }
+
+  @Test
+  public void configureContentListAddsScrollableRegionA11yAttributes() {
+    Map<String, String> attributes = new LinkedHashMap<String, String>();
+
+    J2clSelectedWaveView.configureContentListAttributes(attributes::put);
+
+    Assert.assertEquals("region", attributes.get("role"));
+    Assert.assertEquals("Selected wave content", attributes.get("aria-label"));
+    Assert.assertEquals("0", attributes.get("tabindex"));
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 
 @J2clTestInput(J2clSelectedWaveViewServerFirstLogicTest.class)
 public class J2clSelectedWaveViewServerFirstLogicTest {
@@ -105,5 +106,38 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
     Assert.assertFalse(
         J2clSelectedWaveView.shouldPreserveServerSnapshot(
             "example.com/w+1", J2clSelectedWaveModel.clearedSelection(), false));
+  }
+
+  @Test
+  public void initialViewportHintsUseServerFirstBlipAnchor() {
+    SidecarViewportHints hints =
+        J2clSelectedWaveView.resolveInitialViewportHints(
+            true, "example.com/w+1", "example.com/w+1", "b+root");
+
+    Assert.assertEquals("b+root", hints.getStartBlipId());
+    Assert.assertEquals("forward", hints.getDirection());
+    Assert.assertNull(hints.getLimit());
+  }
+
+  @Test
+  public void initialViewportHintsIgnoreMismatchedServerFirstWave() {
+    SidecarViewportHints hints =
+        J2clSelectedWaveView.resolveInitialViewportHints(
+            true, "example.com/w+old", "example.com/w+new", "b+root");
+
+    Assert.assertNull(hints.getStartBlipId());
+    Assert.assertNull(hints.getDirection());
+    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+  }
+
+  @Test
+  public void initialViewportHintsFallbackToDefaultLimitWhenServerFirstHasNoBlipAnchor() {
+    SidecarViewportHints hints =
+        J2clSelectedWaveView.resolveInitialViewportHints(
+            true, "example.com/w+1", "example.com/w+1", null);
+
+    Assert.assertNull(hints.getStartBlipId());
+    Assert.assertNull(hints.getDirection());
+    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
@@ -55,6 +55,17 @@ public class SidecarFragmentsResponseTest {
   }
 
   @Test
+  public void decodeFragmentsServletResponsePreservesMissingRawSnapshotAsNull() {
+    SidecarFragmentsResponse response =
+        SidecarFragmentsResponse.fromJson(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+                + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44},"
+                + "\"fragments\":[{\"segment\":\"blip:b+pending\"}]}");
+
+    Assert.assertNull(response.getFragments().getEntries().get(0).getRawSnapshot());
+  }
+
+  @Test
   public void decodeFragmentsServletResponseRequiresVersionObject() {
     try {
       SidecarFragmentsResponse.fromJson(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
@@ -1,0 +1,80 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(SidecarFragmentsResponseTest.class)
+public class SidecarFragmentsResponseTest {
+  @Test
+  public void decodeFragmentsServletResponsePreservesRangesAndRawSnapshots() {
+    SidecarFragmentsResponse response =
+        SidecarFragmentsResponse.fromJson(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+                + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44},"
+                + "\"ranges\":[{\"segment\":\"manifest\",\"from\":40,\"to\":44},"
+                + "{\"segment\":\"blip:b+root\",\"from\":41,\"to\":44}],"
+                + "\"fragments\":[{\"segment\":\"manifest\",\"rawSnapshot\":\"metadata\","
+                + "\"adjust\":[],\"diff\":[]},"
+                + "{\"segment\":\"blip:b+root\",\"rawSnapshot\":\"Root text\","
+                + "\"adjust\":[{}],\"diff\":[{},{}]}]}");
+
+    Assert.assertEquals("ok", response.getStatus());
+    Assert.assertEquals("example.com/w+abc/~/conv+root", response.getWaveRefPath());
+    Assert.assertEquals(44L, response.getFragments().getSnapshotVersion());
+    Assert.assertEquals(40L, response.getFragments().getStartVersion());
+    Assert.assertEquals(44L, response.getFragments().getEndVersion());
+    Assert.assertEquals(2, response.getFragments().getRanges().size());
+    Assert.assertEquals(2, response.getFragments().getEntries().size());
+    Assert.assertEquals(
+        "blip:b+root", response.getFragments().getEntries().get(1).getSegment());
+    Assert.assertEquals("Root text", response.getFragments().getEntries().get(1).getRawSnapshot());
+    Assert.assertEquals(1, response.getFragments().getEntries().get(1).getAdjustOperationCount());
+    Assert.assertEquals(2, response.getFragments().getEntries().get(1).getDiffOperationCount());
+  }
+
+  @Test
+  public void decodeFragmentsServletResponseRejectsErrorStatus() {
+    try {
+      SidecarFragmentsResponse.fromJson("{\"status\":\"error\"}");
+      Assert.fail("Expected error status to be rejected");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("status"));
+    }
+  }
+
+  @Test
+  public void decodeFragmentsServletResponseAllowsMissingRangesAndFragments() {
+    SidecarFragmentsResponse response =
+        SidecarFragmentsResponse.fromJson(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+                + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44}}");
+
+    Assert.assertTrue(response.getFragments().getRanges().isEmpty());
+    Assert.assertTrue(response.getFragments().getEntries().isEmpty());
+  }
+
+  @Test
+  public void decodeFragmentsServletResponseRequiresVersionObject() {
+    try {
+      SidecarFragmentsResponse.fromJson(
+          "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\"}");
+      Assert.fail("Expected missing version to be rejected");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("Expected object"));
+    }
+  }
+
+  @Test
+  public void decodeFragmentsServletResponseRejectsMalformedRangeEntry() {
+    try {
+      SidecarFragmentsResponse.fromJson(
+          "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+              + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44},"
+              + "\"ranges\":[\"not-an-object\"]}");
+      Assert.fail("Expected malformed range entry to be rejected");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("Expected object"));
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -48,6 +48,52 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void encodeOpenEnvelopeOmitsViewportHintsWhenAbsent() {
+    SidecarOpenRequest request =
+        new SidecarOpenRequest(
+            "user@example.com", "example.com/w+abc123", Arrays.asList("conv+root"));
+
+    String json = SidecarTransportCodec.encodeOpenEnvelope(8, request);
+    Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(json);
+    Map<String, Object> message = asObject(envelope.get("message"));
+
+    Assert.assertFalse(message.containsKey("5"));
+    Assert.assertFalse(message.containsKey("6"));
+    Assert.assertFalse(message.containsKey("7"));
+  }
+
+  @Test
+  public void encodeOpenEnvelopeIncludesViewportHintsWhenPresent() {
+    SidecarOpenRequest request =
+        new SidecarOpenRequest(
+            "user@example.com",
+            "example.com/w+abc123",
+            Arrays.asList("conv+root"),
+            new SidecarViewportHints("b+root", "forward", Integer.valueOf(0)));
+
+    String json = SidecarTransportCodec.encodeOpenEnvelope(8, request);
+    Map<String, Object> envelope = SidecarTransportCodec.parseJsonObject(json);
+    Map<String, Object> message = asObject(envelope.get("message"));
+
+    Assert.assertEquals("b+root", message.get("5"));
+    Assert.assertEquals("forward", message.get("6"));
+    Assert.assertEquals(0, ((Number) message.get("7")).intValue());
+  }
+
+  @Test
+  public void parseOpenEnvelopePreservesExplicitZeroViewportLimitField() {
+    Map<String, Object> envelope =
+        SidecarTransportCodec.parseJsonObject(
+            "{\"sequenceNumber\":8,\"messageType\":\"ProtocolOpenRequest\","
+                + "\"message\":{\"1\":\"user@example.com\",\"2\":\"example.com/w+abc123\","
+                + "\"3\":[\"conv+root\"],\"7\":0}}");
+    Map<String, Object> message = asObject(envelope.get("message"));
+
+    Assert.assertTrue(message.containsKey("7"));
+    Assert.assertEquals(0, ((Number) message.get("7")).intValue());
+  }
+
+  @Test
   public void decodeSearchResponseReadsNumericKeysAndLongWords() {
     String json =
         "{\"1\":\"in:inbox\",\"2\":1,\"3\":[{\"1\":\"Inbox wave\",\"2\":\"Snippet\","
@@ -353,5 +399,10 @@ public class SidecarTransportCodecTest {
           "Expected message to contain \"" + substring + "\" but was: " + expected.getMessage(),
           expected.getMessage().contains(substring));
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asObject(Object value) {
+    return (Map<String, Object>) value;
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirectionTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/viewport/J2clViewportGrowthDirectionTest.java
@@ -1,0 +1,25 @@
+package org.waveprotocol.box.j2cl.viewport;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clViewportGrowthDirectionTest.class)
+public final class J2clViewportGrowthDirectionTest {
+  @Test
+  public void normalizeTrimsAndCaseNormalizesBackwardDirection() {
+    Assert.assertEquals(
+        J2clViewportGrowthDirection.BACKWARD,
+        J2clViewportGrowthDirection.normalize(" Backward "));
+  }
+
+  @Test
+  public void normalizeFallsBackToForwardForMissingOrUnknownDirection() {
+    Assert.assertEquals(
+        J2clViewportGrowthDirection.FORWARD,
+        J2clViewportGrowthDirection.normalize(null));
+    Assert.assertEquals(
+        J2clViewportGrowthDirection.FORWARD,
+        J2clViewportGrowthDirection.normalize("sideways"));
+  }
+}

--- a/wave/config/changelog.d/2026-04-24-j2cl-viewport-fragment-policy.json
+++ b/wave/config/changelog.d/2026-04-24-j2cl-viewport-fragment-policy.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-24-j2cl-viewport-fragment-policy",
+  "version": "Issue #967",
+  "date": "2026-04-24",
+  "title": "Align viewport fragment limits for J2CL window growth",
+  "summary": "J2CL selected-wave fragment growth now uses the existing /fragments endpoint with the same bounded viewport policy as initial open, so fragment windows stay small and predictable while the full GWT UI remains available.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a J2CL /fragments fetch path that carries the selected wave, root wavelet, anchor, direction, limit, and version bounds for future scroll-window growth",
+        "Aligned /fragments limit clamping with the configured viewport policy used by initial open, reducing the legacy HTTP-only maximum from 200 to the shared default maximum of 50 unless deployment config overrides it",
+        "Added scoped J2CL viewport fragment metrics so marked J2CL growth requests can be tracked without counting legacy /fragments callers as J2CL traffic"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-24-j2cl-viewport-window-bootstrap.json
+++ b/wave/config/changelog.d/2026-04-24-j2cl-viewport-window-bootstrap.json
@@ -3,12 +3,16 @@
   "version": "Issue #967",
   "date": "2026-04-24",
   "title": "Avoid whole-wave bootstrap for J2CL viewport opens",
-  "summary": "Viewport-hinted selected-wave opens now keep the J2CL read surface windowed on the wire when fragment windows are available, while legacy no-hint opens still receive the full snapshot bootstrap.",
+  "summary": "Viewport-hinted selected-wave opens now install the server fragment handler, keep the J2CL read surface windowed on the wire, and expose scroll-edge placeholders for fragment growth while legacy no-hint opens still receive the full snapshot bootstrap.",
   "sections": [
     {
       "type": "feature",
       "items": [
+        "Installed the configured server fragment handler for the selected-wave RPC path so live J2CL viewport opens can attach fragment windows",
         "Suppressed the full selected-wave snapshot payload for viewport-hinted opens that successfully attach a fragment window",
+        "Sorted snapshot blip ids naturally for deterministic viewport windows on large waves",
+        "Added placeholder-only edge ranges to J2CL viewport fragment windows so the read surface can grow through /fragments instead of stopping at the initial window",
+        "Made the J2CL selected-wave content region the scroll surface that owns viewport-growth callbacks",
         "Preserved snapshot bootstrap compatibility for no-hint GWT and legacy opens",
         "Added J2CL viewport initial-window and snapshot-fallback metrics, plus a fallback warning marker, so operators can distinguish windowed opens from full-snapshot fallback"
       ]

--- a/wave/config/changelog.d/2026-04-24-j2cl-viewport-window-bootstrap.json
+++ b/wave/config/changelog.d/2026-04-24-j2cl-viewport-window-bootstrap.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-24-j2cl-viewport-window-bootstrap",
+  "version": "Issue #967",
+  "date": "2026-04-24",
+  "title": "Avoid whole-wave bootstrap for J2CL viewport opens",
+  "summary": "Viewport-hinted selected-wave opens now keep the J2CL read surface windowed on the wire when fragment windows are available, while legacy no-hint opens still receive the full snapshot bootstrap.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Suppressed the full selected-wave snapshot payload for viewport-hinted opens that successfully attach a fragment window",
+        "Preserved snapshot bootstrap compatibility for no-hint GWT and legacy opens",
+        "Added J2CL viewport initial-window and snapshot-fallback metrics, plus a fallback warning marker, so operators can distinguish windowed opens from full-snapshot fallback"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -19,6 +19,7 @@ import org.waveprotocol.box.server.authentication.AccountStoreHolder;
 import org.waveprotocol.box.server.executor.ExecutorsModule;
 import org.waveprotocol.box.server.frontend.ClientFrontend;
 import org.waveprotocol.box.server.frontend.ClientFrontendImpl;
+import org.waveprotocol.box.server.frontend.FragmentsViewChannelHandler;
 import org.waveprotocol.box.server.frontend.SearchWaveletDispatcher;
 import org.waveprotocol.box.server.frontend.WaveClientRpcImpl;
 import org.waveprotocol.box.server.frontend.WaveletInfo;
@@ -513,10 +514,19 @@ public class ServerMain {
             waveletInfo,
             injector.getInstance(SearchProvider.class),
             injector.getInstance(SearchWaveletSnapshotPublisher.class));
+    installFragmentsHandlerForFrontend(provider, injector.getInstance(Config.class));
     org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.Interface rpcImpl =
         WaveClientRpcImpl.create(frontend, false, injector.getInstance(SearchWaveletManager.class));
     server.registerService(org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveClientRpc.newReflectiveService(rpcImpl));
     new StaleAnnotationSweeper(provider).start();
+  }
+
+  static FragmentsViewChannelHandler installFragmentsHandlerForFrontend(
+      WaveletProvider provider, Config config) {
+    FragmentsViewChannelHandler handler = new FragmentsViewChannelHandler(provider, config);
+    WaveClientRpcImpl.setFragmentsHandler(handler);
+    LOG.info("Configured WaveClientRpc fragments handler: enabled=" + handler.isEnabled());
+    return handler;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
@@ -34,7 +34,7 @@ public final class ViewportLimitPolicy {
       return defaultLimit;
     }
     try {
-      return resolveLimit(Integer.parseInt(rawLimit));
+      return resolveLimit(Integer.parseInt(rawLimit.trim()));
     } catch (NumberFormatException e) {
       return defaultLimit;
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
@@ -1,7 +1,12 @@
 package org.waveprotocol.box.server.frontend;
 
+import java.util.Locale;
+
 /** Shared limit policy for viewport-scoped fragment windows. */
 public final class ViewportLimitPolicy {
+  public static final String DIRECTION_FORWARD = "forward";
+  public static final String DIRECTION_BACKWARD = "backward";
+
   private static volatile int defaultLimit = 5;
   private static volatile int maxLimit = 50;
 
@@ -40,5 +45,13 @@ public final class ViewportLimitPolicy {
       return defaultLimit;
     }
     return Math.min(requestedLimit, maxLimit);
+  }
+
+  public static String normalizeDirection(String rawDirection) {
+    if (rawDirection == null) {
+      return DIRECTION_FORWARD;
+    }
+    String normalized = rawDirection.trim().toLowerCase(Locale.ROOT);
+    return DIRECTION_BACKWARD.equals(normalized) ? DIRECTION_BACKWARD : DIRECTION_FORWARD;
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
@@ -1,0 +1,44 @@
+package org.waveprotocol.box.server.frontend;
+
+/** Shared limit policy for viewport-scoped fragment windows. */
+public final class ViewportLimitPolicy {
+  private static volatile int defaultLimit = 5;
+  private static volatile int maxLimit = 50;
+
+  private ViewportLimitPolicy() {
+  }
+
+  public static void setLimits(int configuredDefaultLimit, int configuredMaxLimit) {
+    int normalizedDefault = configuredDefaultLimit <= 0 ? 1 : configuredDefaultLimit;
+    int normalizedMax =
+        configuredMaxLimit < normalizedDefault ? normalizedDefault : configuredMaxLimit;
+    maxLimit = normalizedMax;
+    defaultLimit = normalizedDefault;
+  }
+
+  public static int getDefaultLimit() {
+    return defaultLimit;
+  }
+
+  public static int getMaxLimit() {
+    return maxLimit;
+  }
+
+  public static int resolveLimit(String rawLimit) {
+    if (rawLimit == null) {
+      return defaultLimit;
+    }
+    try {
+      return resolveLimit(Integer.parseInt(rawLimit));
+    } catch (NumberFormatException e) {
+      return defaultLimit;
+    }
+  }
+
+  public static int resolveLimit(int requestedLimit) {
+    if (requestedLimit <= 0) {
+      return defaultLimit;
+    }
+    return Math.min(requestedLimit, maxLimit);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicy.java
@@ -7,8 +7,7 @@ public final class ViewportLimitPolicy {
   public static final String DIRECTION_FORWARD = "forward";
   public static final String DIRECTION_BACKWARD = "backward";
 
-  private static volatile int defaultLimit = 5;
-  private static volatile int maxLimit = 50;
+  private static volatile Limits limits = new Limits(5, 50);
 
   private ViewportLimitPolicy() {
   }
@@ -17,34 +16,38 @@ public final class ViewportLimitPolicy {
     int normalizedDefault = configuredDefaultLimit <= 0 ? 1 : configuredDefaultLimit;
     int normalizedMax =
         configuredMaxLimit < normalizedDefault ? normalizedDefault : configuredMaxLimit;
-    maxLimit = normalizedMax;
-    defaultLimit = normalizedDefault;
+    limits = new Limits(normalizedDefault, normalizedMax);
   }
 
   public static int getDefaultLimit() {
-    return defaultLimit;
+    return limits.defaultLimit;
   }
 
   public static int getMaxLimit() {
-    return maxLimit;
+    return limits.maxLimit;
   }
 
   public static int resolveLimit(String rawLimit) {
+    Limits snapshot = limits;
     if (rawLimit == null) {
-      return defaultLimit;
+      return snapshot.defaultLimit;
     }
     try {
-      return resolveLimit(Integer.parseInt(rawLimit.trim()));
+      return resolveLimit(Integer.parseInt(rawLimit.trim()), snapshot);
     } catch (NumberFormatException e) {
-      return defaultLimit;
+      return snapshot.defaultLimit;
     }
   }
 
   public static int resolveLimit(int requestedLimit) {
+    return resolveLimit(requestedLimit, limits);
+  }
+
+  private static int resolveLimit(int requestedLimit, Limits snapshot) {
     if (requestedLimit <= 0) {
-      return defaultLimit;
+      return snapshot.defaultLimit;
     }
-    return Math.min(requestedLimit, maxLimit);
+    return Math.min(requestedLimit, snapshot.maxLimit);
   }
 
   public static String normalizeDirection(String rawDirection) {
@@ -53,5 +56,15 @@ public final class ViewportLimitPolicy {
     }
     String normalized = rawDirection.trim().toLowerCase(Locale.ROOT);
     return DIRECTION_BACKWARD.equals(normalized) ? DIRECTION_BACKWARD : DIRECTION_FORWARD;
+  }
+
+  private static final class Limits {
+    private final int defaultLimit;
+    private final int maxLimit;
+
+    private Limits(int defaultLimit, int maxLimit) {
+      this.defaultLimit = defaultLimit;
+      this.maxLimit = maxLimit;
+    }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -20,6 +20,7 @@
 package org.waveprotocol.box.server.frontend;
 
 import com.google.common.base.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.RpcCallback;
 import com.google.protobuf.RpcController;
 
@@ -53,7 +54,10 @@ import org.slf4j.MDC;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -100,6 +104,11 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   public static void setFragmentsHandler(FragmentsViewChannelHandler handler) {
     fragmentsHandler = handler;
+  }
+
+  @VisibleForTesting
+  public static FragmentsViewChannelHandler getFragmentsHandlerForTesting() {
+    return fragmentsHandler;
   }
 
   public static void setForceClientFragments(boolean force) {
@@ -223,10 +232,12 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
                 long startV = computeStartVersion(snapshot, committedVersion);
                 long endV = startV;
 
-                List<SegmentId> segs = selectVisibleSegments(fh, waveletName, snapshot, request);
+                ViewportSegments selectedSegments =
+                    selectVisibleSegments(fh, waveletName, snapshot, request);
+                List<SegmentId> segs = selectedSegments.getRangeSegments();
 
                 try {
-                  java.util.Map<SegmentId, VersionRange> ranges =
+                  Map<SegmentId, VersionRange> ranges =
                       fh.fetchFragments(waveletName, segs, startV, endV);
                   org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.Builder fb =
                       org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.newBuilder()
@@ -234,7 +245,7 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
                           .setStartVersion(startV)
                           .setEndVersion(endV);
                   int emitted = 0;
-                  for (java.util.Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
+                  for (Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
                     long from = e.getValue().from();
                     long to = e.getValue().to();
                     if (from > to) {
@@ -271,7 +282,7 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
                   if (fragmentsAttached) {
                     ReadableWaveletData fragmentData = (snapshot != null) ? snapshot.snapshot : null;
                     List<FragmentsPayload.Fragment> rawFragments =
-                        RawFragmentsBuilder.build(fragmentData, ranges);
+                        RawFragmentsBuilder.build(fragmentData, selectedSegments.rawRanges(ranges));
                     for (FragmentsPayload.Fragment fragment : rawFragments) {
                       org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.Builder fragmentBuilder =
                           org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.newBuilder()
@@ -468,23 +479,29 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
    * Selects the set of segments to attach as a fragments window.
    *
    * Rules:
-   * - Use viewport-aware selection only when a snapshot is available.
-   * - Otherwise, prefer blips from the snapshot; if none, fall back to INDEX/MANIFEST.
-   * - If still empty and snapshot exists, use heuristic manifest/time-based selection.
+   * - Viewport-hinted opens get deterministic natural blip ordering plus one
+   *   placeholder range for scroll growth when another blip exists.
+   * - Legacy no-hint opens preserve snapshot document iteration order and never
+   *   receive placeholder-only growth ranges.
+   * - If no snapshot blips exist, only INDEX/MANIFEST ranges are attached.
    */
-  private List<SegmentId> selectVisibleSegments(FragmentsViewChannelHandler fh,
+  private ViewportSegments selectVisibleSegments(FragmentsViewChannelHandler fh,
                                                 WaveletName waveletName,
                                                 @Nullable CommittedWaveletSnapshot snapshot,
                                                 ProtocolOpenRequest request) {
     List<SegmentId> segs = new ArrayList<>();
+    Set<SegmentId> rawSegments = new HashSet<SegmentId>();
     segs.add(SegmentId.INDEX_ID);
+    rawSegments.add(SegmentId.INDEX_ID);
     segs.add(SegmentId.MANIFEST_ID);
+    rawSegments.add(SegmentId.MANIFEST_ID);
 
     final String vpStart = request.hasViewportStartBlipId() ? request.getViewportStartBlipId() : null;
     final String vpDir = request.hasViewportDirection() ? request.getViewportDirection() : null;
     final int vpLimit = resolveViewportLimit(request);
+    boolean viewportHints = hasViewportHints(request);
 
-    if (hasViewportHints(request)) {
+    if (viewportHints) {
       if ((vpStart == null || vpStart.isEmpty()) && (vpDir != null && !vpDir.isEmpty()) && !request.hasViewportLimit()) {
         if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
           org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.viewportAmbiguity.incrementAndGet();
@@ -495,17 +512,172 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
     }
 
     if (segs.size() <= 2 && snapshot != null) {
-      int added = 0;
-      for (String docId : snapshot.snapshot.getDocumentIds()) {
-        if (docId != null && docId.startsWith("b+")) {
-          segs.add(SegmentId.ofBlipId(docId));
-          if (++added >= vpLimit) break;
+      BlipWindow window =
+          selectBlipWindow(
+              snapshotBlipOrder(snapshot, viewportHints), vpStart, vpDir, vpLimit, viewportHints);
+      for (String blipId : window.getRangeBlipIds()) {
+        SegmentId segment = SegmentId.ofBlipId(blipId);
+        segs.add(segment);
+        if (window.isLoaded(blipId)) {
+          rawSegments.add(segment);
         }
       }
     }
 
     // Avoid computeVisibleSegments fallback to prevent snapshot reads from commit thread.
-    return segs;
+    return new ViewportSegments(segs, rawSegments);
+  }
+
+  private static List<String> snapshotBlipOrder(
+      @Nullable CommittedWaveletSnapshot snapshot, boolean naturalOrder) {
+    if (snapshot == null || snapshot.snapshot == null) {
+      return Collections.emptyList();
+    }
+    List<String> blips = new ArrayList<String>();
+    for (String docId : snapshot.snapshot.getDocumentIds()) {
+      if (docId != null && docId.startsWith("b+")) {
+        blips.add(docId);
+      }
+    }
+    if (naturalOrder) {
+      blips.sort(WaveClientRpcImpl::compareBlipIdsNaturally);
+    }
+    return blips;
+  }
+
+  private static int compareBlipIdsNaturally(String left, String right) {
+    String leftPrefix = trailingNumberPrefix(left);
+    String rightPrefix = trailingNumberPrefix(right);
+    if (leftPrefix.equals(rightPrefix)) {
+      long leftNumber = trailingNumber(left, -1L);
+      long rightNumber = trailingNumber(right, -1L);
+      if (leftNumber >= 0 && rightNumber >= 0 && leftNumber != rightNumber) {
+        return leftNumber < rightNumber ? -1 : 1;
+      }
+    }
+    return left.compareTo(right);
+  }
+
+  private static String trailingNumberPrefix(String value) {
+    int start = trailingNumberStart(value);
+    return start >= 0 ? value.substring(0, start) : value;
+  }
+
+  private static long trailingNumber(String value, long fallback) {
+    int start = trailingNumberStart(value);
+    if (start < 0) {
+      return fallback;
+    }
+    try {
+      return Long.parseLong(value.substring(start));
+    } catch (NumberFormatException e) {
+      return fallback;
+    }
+  }
+
+  private static int trailingNumberStart(String value) {
+    if (value == null || value.isEmpty()) {
+      return -1;
+    }
+    int index = value.length() - 1;
+    while (index >= 0 && value.charAt(index) >= '0' && value.charAt(index) <= '9') {
+      index--;
+    }
+    return index == value.length() - 1 ? -1 : index + 1;
+  }
+
+  private static BlipWindow selectBlipWindow(
+      List<String> blipOrder,
+      @Nullable String startBlipId,
+      @Nullable String direction,
+      int limit,
+      boolean includeEdgePlaceholder) {
+    if (blipOrder == null || blipOrder.isEmpty() || limit <= 0) {
+      return BlipWindow.empty();
+    }
+    String normalizedDirection = ViewportLimitPolicy.normalizeDirection(direction);
+    int startIndex = 0;
+    if (startBlipId != null && !startBlipId.isEmpty()) {
+      int found = blipOrder.indexOf(startBlipId);
+      if (found >= 0) {
+        startIndex = found;
+      }
+    }
+    int rangeLimit = limit + (includeEdgePlaceholder ? 1 : 0);
+    int fromIndex;
+    int toIndexExclusive;
+    if (ViewportLimitPolicy.DIRECTION_BACKWARD.equals(normalizedDirection)) {
+      toIndexExclusive = Math.min(blipOrder.size(), startIndex + 1);
+      fromIndex = Math.max(0, toIndexExclusive - rangeLimit);
+    } else {
+      fromIndex = Math.max(0, startIndex);
+      toIndexExclusive = Math.min(blipOrder.size(), fromIndex + rangeLimit);
+    }
+    List<String> rangeBlipIds =
+        new ArrayList<String>(blipOrder.subList(fromIndex, toIndexExclusive));
+    if (rangeBlipIds.isEmpty()) {
+      return BlipWindow.empty();
+    }
+    List<String> loadedBlipIds = new ArrayList<String>(rangeBlipIds);
+    if (includeEdgePlaceholder && rangeBlipIds.size() > limit) {
+      if (ViewportLimitPolicy.DIRECTION_BACKWARD.equals(normalizedDirection)) {
+        loadedBlipIds = new ArrayList<String>(rangeBlipIds.subList(1, rangeBlipIds.size()));
+      } else {
+        loadedBlipIds = new ArrayList<String>(rangeBlipIds.subList(0, limit));
+      }
+    }
+    return new BlipWindow(rangeBlipIds, loadedBlipIds);
+  }
+
+  private static final class BlipWindow {
+    private static final BlipWindow EMPTY =
+        new BlipWindow(Collections.<String>emptyList(), Collections.<String>emptyList());
+
+    private final List<String> rangeBlipIds;
+    private final Set<String> loadedBlipIds;
+
+    private BlipWindow(List<String> rangeBlipIds, List<String> loadedBlipIds) {
+      this.rangeBlipIds =
+          Collections.unmodifiableList(new ArrayList<String>(rangeBlipIds));
+      this.loadedBlipIds = new HashSet<String>(loadedBlipIds);
+    }
+
+    static BlipWindow empty() {
+      return EMPTY;
+    }
+
+    List<String> getRangeBlipIds() {
+      return rangeBlipIds;
+    }
+
+    boolean isLoaded(String blipId) {
+      return loadedBlipIds.contains(blipId);
+    }
+  }
+
+  private static final class ViewportSegments {
+    private final List<SegmentId> rangeSegments;
+    private final Set<SegmentId> rawSegments;
+
+    private ViewportSegments(List<SegmentId> rangeSegments, Set<SegmentId> rawSegments) {
+      this.rangeSegments =
+          Collections.unmodifiableList(new ArrayList<SegmentId>(rangeSegments));
+      this.rawSegments = new HashSet<SegmentId>(rawSegments);
+    }
+
+    List<SegmentId> getRangeSegments() {
+      return rangeSegments;
+    }
+
+    Map<SegmentId, VersionRange> rawRanges(Map<SegmentId, VersionRange> ranges) {
+      Map<SegmentId, VersionRange> filtered = new LinkedHashMap<SegmentId, VersionRange>();
+      for (Map.Entry<SegmentId, VersionRange> entry : ranges.entrySet()) {
+        if (rawSegments.contains(entry.getKey())) {
+          filtered.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return filtered;
+    }
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -66,24 +66,24 @@ import javax.annotation.Nullable;
 public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   private static final Log LOG = Log.get(WaveClientRpcImpl.class);
-  /** Default and maximum number of blip segments to include when the client
-   * supplies viewport hints but omits or provides an out-of-range limit.
-   * Values are configurable; see {@link #setViewportLimits(int, int)}. */
-  private static volatile int DEFAULT_VIEWPORT_LIMIT = 5;
-  private static volatile int MAX_VIEWPORT_LIMIT = 50;
-
   /** Config hook to adjust viewport limits at runtime (eager-read at startup). */
   public static void setViewportLimits(int defaultLimit, int maxLimit) {
-    if (defaultLimit <= 0) defaultLimit = 1;
-    if (maxLimit < defaultLimit) maxLimit = defaultLimit;
-    DEFAULT_VIEWPORT_LIMIT = defaultLimit;
-    MAX_VIEWPORT_LIMIT = maxLimit;
-    LOG.info("Configured viewport limits: default=" + DEFAULT_VIEWPORT_LIMIT + ", max=" + MAX_VIEWPORT_LIMIT);
+    ViewportLimitPolicy.setLimits(defaultLimit, maxLimit);
+    LOG.info(
+        "Configured viewport limits: default="
+            + ViewportLimitPolicy.getDefaultLimit()
+            + ", max="
+            + ViewportLimitPolicy.getMaxLimit());
   }
 
   // Visible for tests
-  public static int getDefaultViewportLimit() { return DEFAULT_VIEWPORT_LIMIT; }
-  public static int getMaxViewportLimit() { return MAX_VIEWPORT_LIMIT; }
+  public static int getDefaultViewportLimit() {
+    return ViewportLimitPolicy.getDefaultLimit();
+  }
+
+  public static int getMaxViewportLimit() {
+    return ViewportLimitPolicy.getMaxLimit();
+  }
 
   private final ClientFrontend frontend;
   private final boolean handleAuthentication;
@@ -375,12 +375,10 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   /** Resolves viewport limit with validation and clamping. */
   private static int resolveViewportLimit(ProtocolOpenRequest request) {
-    int limit = DEFAULT_VIEWPORT_LIMIT;
-    if (!request.hasViewportLimit()) return limit;
-    int requested = request.getViewportLimit();
-    if (requested <= 0) return DEFAULT_VIEWPORT_LIMIT;
-    if (requested > MAX_VIEWPORT_LIMIT) return MAX_VIEWPORT_LIMIT;
-    return requested;
+    if (!request.hasViewportLimit()) {
+      return ViewportLimitPolicy.getDefaultLimit();
+    }
+    return ViewportLimitPolicy.resolveLimit(request.getViewportLimit());
   }
 
   /**
@@ -425,13 +423,6 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
     // Avoid computeVisibleSegments fallback to prevent snapshot reads from commit thread.
     return segs;
-  }
-
-  private static List<SegmentId> baseSegments() {
-    List<SegmentId> base = new ArrayList<>();
-    base.add(SegmentId.INDEX_ID);
-    base.add(SegmentId.MANIFEST_ID);
-    return base;
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -51,9 +51,11 @@ import org.waveprotocol.wave.util.logging.Log;
 import org.waveprotocol.box.server.persistence.blocks.VersionRange;
 import org.slf4j.MDC;
 
-import java.util.Collections;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 
@@ -66,6 +68,8 @@ import javax.annotation.Nullable;
 public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   private static final Log LOG = Log.get(WaveClientRpcImpl.class);
+  private static final String J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK =
+      "J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK";
   /** Config hook to adjust viewport limits at runtime (eager-read at startup). */
   public static void setViewportLimits(int defaultLimit, int maxLimit) {
     ViewportLimitPolicy.setLimits(defaultLimit, maxLimit);
@@ -162,136 +166,197 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
           request.getKnownWaveletList(),
           searchQuery,
           new ClientFrontend.OpenListener() {
-          @Override
-          public void onFailure(String errorMessage) {
-            LOG.warning("openRequest failure: " + errorMessage);
-            controller.setFailed(errorMessage);
-          }
+            private final Set<String> viewportInitialWindowMetricWavelets =
+                newConcurrentStringSet();
+            private final Set<String> viewportSnapshotFallbackMetricWavelets =
+                newConcurrentStringSet();
 
-          @Override
-          public void onUpdate(WaveletName waveletName,
-              @Nullable CommittedWaveletSnapshot snapshot, List<TransformedWaveletDelta> deltas,
-              @Nullable HashedVersion committedVersion, Boolean hasMarker, String channel_id) {
-            ProtocolWaveletUpdate.Builder builder = ProtocolWaveletUpdate.newBuilder();
-            if (hasMarker != null) {
-              builder.setMarker(hasMarker.booleanValue());
+            @Override
+            public void onFailure(String errorMessage) {
+              LOG.warning("openRequest failure: " + errorMessage);
+              controller.setFailed(errorMessage);
             }
-            if (channel_id != null) {
-              builder.setChannelId(channel_id);
-            }
-            builder.setWaveletName(ModernIdSerialiser.INSTANCE.serialiseWaveletName(waveletName));
-            for (TransformedWaveletDelta d : deltas) {
-              // TODO(anorth): Add delta application metadata to the result
-              // when the c/s protocol supports it.
-              builder.addAppliedDelta(CoreWaveletOperationSerializer.serialize(d));
-            }
-            if (!deltas.isEmpty()) {
-              builder.setResultingVersion(CoreWaveletOperationSerializer.serialize(
-                  deltas.get((deltas.size() - 1)).getResultingVersion()));
-            }
-            boolean includeSnapshot = snapshot != null;
-            if (includeSnapshot) {
-              Preconditions.checkState(committedVersion.equals(snapshot.committedVersion),
-                  "Mismatched commit versions, snapshot: " + snapshot.committedVersion
-                      + " expected: " + committedVersion);
-              builder.setSnapshot(SnapshotSerializer.serializeWavelet(snapshot.snapshot,
-                  snapshot.committedVersion));
-              builder.setResultingVersion(CoreWaveletOperationSerializer.serialize(
-                  snapshot.snapshot.getHashedVersion()));
-              builder.setCommitNotice(CoreWaveletOperationSerializer.serialize(
-                  snapshot.committedVersion));
-            } else {
-              if (committedVersion != null) {
-                builder.setCommitNotice(
-                    CoreWaveletOperationSerializer.serialize(committedVersion));
+
+            @Override
+            public void onUpdate(WaveletName waveletName,
+                @Nullable CommittedWaveletSnapshot snapshot, List<TransformedWaveletDelta> deltas,
+                @Nullable HashedVersion committedVersion, Boolean hasMarker, String channel_id) {
+              ProtocolWaveletUpdate.Builder builder = ProtocolWaveletUpdate.newBuilder();
+              String serializedWaveletName =
+                  ModernIdSerialiser.INSTANCE.serialiseWaveletName(waveletName);
+              if (hasMarker != null) {
+                builder.setMarker(hasMarker.booleanValue());
               }
-            }
-            FragmentsViewChannelHandler fh = fragmentsHandler;
-            if (fh != null && fh.isEnabled() && !isDummyWavelet(waveletName)) {
-              long startV = computeStartVersion(snapshot, committedVersion);
-              long endV = startV;
+              if (channel_id != null) {
+                builder.setChannelId(channel_id);
+              }
+              builder.setWaveletName(serializedWaveletName);
 
-              List<SegmentId> segs = selectVisibleSegments(fh, waveletName, snapshot, request);
+              for (TransformedWaveletDelta d : deltas) {
+                // TODO(anorth): Add delta application metadata to the result
+                // when the c/s protocol supports it.
+                builder.addAppliedDelta(CoreWaveletOperationSerializer.serialize(d));
+              }
+              if (!deltas.isEmpty()) {
+                builder.setResultingVersion(CoreWaveletOperationSerializer.serialize(
+                    deltas.get((deltas.size() - 1)).getResultingVersion()));
+              }
+              boolean hasViewportHints = hasViewportHints(request);
+              boolean snapshotAvailable = snapshot != null;
+              if (snapshotAvailable) {
+                Preconditions.checkState(committedVersion.equals(snapshot.committedVersion),
+                    "Mismatched commit versions, snapshot: " + snapshot.committedVersion
+                        + " expected: " + committedVersion);
+                builder.setResultingVersion(CoreWaveletOperationSerializer.serialize(
+                    snapshot.snapshot.getHashedVersion()));
+                builder.setCommitNotice(CoreWaveletOperationSerializer.serialize(
+                    snapshot.committedVersion));
+              } else {
+                if (committedVersion != null) {
+                  builder.setCommitNotice(
+                      CoreWaveletOperationSerializer.serialize(committedVersion));
+                }
+              }
+              FragmentsViewChannelHandler fh = fragmentsHandler;
+              boolean fragmentsAttached = false;
+              if (fh != null && fh.isEnabled() && !isDummyWavelet(waveletName)) {
+                long startV = computeStartVersion(snapshot, committedVersion);
+                long endV = startV;
 
-              try {
-                java.util.Map<SegmentId, VersionRange> ranges = fh.fetchFragments(waveletName, segs, startV, endV);
-                org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.Builder fb =
-                    org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.newBuilder()
-                        .setSnapshotVersion(startV)
-                        .setStartVersion(startV)
-                        .setEndVersion(endV);
-                int emitted = 0;
-                for (java.util.Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
-                  long from = e.getValue().from(); long to = e.getValue().to();
-                  if (from > to) {
-                    LOG.warning("Skipping invalid fragment range (from>to) for " + e.getKey() + " wavelet=" + waveletName);
-                    continue;
+                List<SegmentId> segs = selectVisibleSegments(fh, waveletName, snapshot, request);
+
+                try {
+                  java.util.Map<SegmentId, VersionRange> ranges =
+                      fh.fetchFragments(waveletName, segs, startV, endV);
+                  org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.Builder fb =
+                      org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragments.newBuilder()
+                          .setSnapshotVersion(startV)
+                          .setStartVersion(startV)
+                          .setEndVersion(endV);
+                  int emitted = 0;
+                  for (java.util.Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
+                    long from = e.getValue().from();
+                    long to = e.getValue().to();
+                    if (from > to) {
+                      LOG.warning("Skipping invalid fragment range (from>to) for " + e.getKey()
+                          + " wavelet=" + waveletName);
+                      continue;
+                    }
+                    org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange r =
+                        org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange.newBuilder()
+                            .setSegment(e.getKey().asString())
+                            .setFrom(from)
+                            .setTo(to)
+                            .build();
+                    fb.addRange(r);
+                    emitted++;
                   }
-                  org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange r =
-                      org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange.newBuilder()
-                          .setSegment(e.getKey().asString())
-                          .setFrom(from)
-                          .setTo(to)
-                          .build();
-                  fb.addRange(r);
-                  emitted++;
-                }
-                if (emitted == 0 && forceFragmentsWithoutSnapshot) {
-                  long syntheticFrom = startV;
-                  long syntheticTo = (endV <= syntheticFrom) ? (syntheticFrom + 1) : endV;
-                  fb.setEndVersion(syntheticTo);
-                  fb.addRange(org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange.newBuilder()
-                      .setSegment(SegmentId.INDEX_ID.asString())
-                      .setFrom(syntheticFrom)
-                      .setTo(syntheticTo)
-                      .build());
-                  emitted = 1;
-                }
-                ReadableWaveletData fragmentData = (snapshot != null) ? snapshot.snapshot : null;
-                List<FragmentsPayload.Fragment> rawFragments = RawFragmentsBuilder.build(fragmentData, ranges);
-                for (FragmentsPayload.Fragment fragment : rawFragments) {
-                  org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.Builder fragmentBuilder =
-                      org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.newBuilder()
-                          .setSegment(fragment.segment.asString());
-                  if (fragment.rawSnapshot != null && !fragment.rawSnapshot.isEmpty()) {
-                    fragmentBuilder.setSnapshot(
-                        org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentSnapshot.newBuilder()
-                            .setRawSnapshot(fragment.rawSnapshot)
+                  if (emitted == 0 && forceFragmentsWithoutSnapshot) {
+                    // The dev/test force flag intentionally treats its synthetic INDEX range as an
+                    // attached fragments window so snapshotless bootstrap can be exercised. Production
+                    // opens reach that branch only when the operator explicitly enables the flag.
+                    long syntheticFrom = startV;
+                    long syntheticTo = (endV <= syntheticFrom) ? (syntheticFrom + 1) : endV;
+                    fb.setEndVersion(syntheticTo);
+                    fb.addRange(
+                        org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentRange
+                            .newBuilder()
+                            .setSegment(SegmentId.INDEX_ID.asString())
+                            .setFrom(syntheticFrom)
+                            .setTo(syntheticTo)
                             .build());
+                    emitted = 1;
                   }
-                  for (FragmentsPayload.Operation op : fragment.adjustOperations) {
-                    fragmentBuilder.addAdjustOperation(toProto(op));
+                  fragmentsAttached = emitted > 0;
+                  if (fragmentsAttached) {
+                    ReadableWaveletData fragmentData = (snapshot != null) ? snapshot.snapshot : null;
+                    List<FragmentsPayload.Fragment> rawFragments =
+                        RawFragmentsBuilder.build(fragmentData, ranges);
+                    for (FragmentsPayload.Fragment fragment : rawFragments) {
+                      org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.Builder fragmentBuilder =
+                          org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragment.newBuilder()
+                              .setSegment(fragment.segment.asString());
+                      if (fragment.rawSnapshot != null && !fragment.rawSnapshot.isEmpty()) {
+                        fragmentBuilder.setSnapshot(
+                            org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolFragmentSnapshot.newBuilder()
+                                .setRawSnapshot(fragment.rawSnapshot)
+                                .build());
+                      }
+                      for (FragmentsPayload.Operation op : fragment.adjustOperations) {
+                        fragmentBuilder.addAdjustOperation(toProto(op));
+                      }
+                      for (FragmentsPayload.Operation op : fragment.diffOperations) {
+                        fragmentBuilder.addDiffOperation(toProto(op));
+                      }
+                      fb.addFragment(fragmentBuilder.build());
+                    }
+                    builder.setFragments(fb.build());
+                    LOG.info("Emitting fragments for " + waveletName + ": ranges="
+                        + fb.getRangeCount() + " snapshotVersion=" + fb.getSnapshotVersion()
+                        + " endVersion=" + fb.getEndVersion());
+                    if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+                      org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                          .emissionCount.incrementAndGet();
+                      org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                          .emissionRanges.addAndGet(emitted);
+                      if (segs.size() <= 2) {
+                        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                            .emissionFallbacks.incrementAndGet();
+                      }
+                    }
                   }
-                  for (FragmentsPayload.Operation op : fragment.diffOperations) {
-                    fragmentBuilder.addDiffOperation(toProto(op));
+                } catch (org.waveprotocol.box.server.waveserver.WaveServerException wse) {
+                  LOG.warning("WaveServerException fetching fragments for " + waveletName + ": "
+                      + wse.getMessage(), wse);
+                  if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+                    org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                        .emissionErrors.incrementAndGet();
                   }
-                  fb.addFragment(fragmentBuilder.build());
+                } catch (Exception ex) {
+                  LOG.warning("Unexpected error fetching fragments for " + waveletName, ex);
+                  if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+                    org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                        .emissionErrors.incrementAndGet();
+                  }
                 }
-                builder.setFragments(fb.build());
-                LOG.info("Emitting fragments for " + waveletName + ": ranges=" + fb.getRangeCount()
-                    + " snapshotVersion=" + fb.getSnapshotVersion() + " endVersion=" + fb.getEndVersion());
+              }
+              boolean viewportWindowAttached = hasViewportHints && fragmentsAttached;
+              boolean suppressSnapshot = snapshotAvailable && viewportWindowAttached;
+              // This is set only when a whole snapshot was actually available to use as fallback.
+              // Snapshot-less updates have no full bootstrap payload to report.
+              boolean snapshotFallback = false;
+              if (suppressSnapshot) {
+                // The viewport window is already present in fragments; keep the wire payload windowed.
+              } else if (snapshotAvailable) {
+                if (hasViewportHints) {
+                  snapshotFallback = true;
+                  LOG.warning(
+                      J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK
+                          + " wavelet="
+                          + waveletName
+                          + " reason="
+                          + viewportSnapshotFallbackReason(fh, waveletName));
+                }
+                builder.setSnapshot(SnapshotSerializer.serializeWavelet(snapshot.snapshot,
+                    snapshot.committedVersion));
+              }
+              try {
+                done.run(builder.build());
+              } finally {
                 if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
-                  org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.emissionCount.incrementAndGet();
-                  org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.emissionRanges.addAndGet(emitted);
-                  if (segs.size() <= 2) {
-                    org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.emissionFallbacks.incrementAndGet();
+                  if (viewportWindowAttached
+                      && viewportInitialWindowMetricWavelets.add(serializedWaveletName)) {
+                    org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                        .j2clViewportInitialWindows.incrementAndGet();
+                  } else if (snapshotFallback
+                      && viewportSnapshotFallbackMetricWavelets.add(serializedWaveletName)) {
+                    org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+                        .j2clViewportSnapshotFallbacks.incrementAndGet();
                   }
-                }
-              } catch (org.waveprotocol.box.server.waveserver.WaveServerException wse) {
-                LOG.warning("WaveServerException fetching fragments for " + waveletName + ": " + wse.getMessage(), wse);
-                if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
-                  org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.emissionErrors.incrementAndGet();
-                }
-              } catch (Exception ex) {
-                LOG.warning("Unexpected error fetching fragments for " + waveletName, ex);
-                if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
-                  org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.emissionErrors.incrementAndGet();
                 }
               }
             }
-            done.run(builder.build());
-          }
-        });
+          });
     } finally {
       MDC.remove("waveId");
       MDC.remove("participantId");
@@ -371,6 +436,24 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
   /** Returns true if any viewport hint is present on the request. */
   private static boolean hasViewportHints(ProtocolOpenRequest request) {
     return request.hasViewportStartBlipId() || request.hasViewportDirection() || request.hasViewportLimit();
+  }
+
+  static String viewportSnapshotFallbackReason(
+      @Nullable FragmentsViewChannelHandler handler, WaveletName waveletName) {
+    if (handler == null) {
+      return "fragments-handler-absent";
+    }
+    if (!handler.isEnabled()) {
+      return "fragments-handler-disabled";
+    }
+    if (isDummyWavelet(waveletName)) {
+      return "dummy-wavelet";
+    }
+    return "no-fragments-emitted";
+  }
+
+  private static Set<String> newConcurrentStringSet() {
+    return Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
   }
 
   /** Resolves viewport limit with validation and clamping. */

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -78,10 +78,6 @@ public final class FragmentsServlet extends HttpServlet {
     boolean j2clViewportRequest = isJ2clViewportRequest(req);
     if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
       org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.httpRequests.incrementAndGet();
-      if (j2clViewportRequest) {
-        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
-            .j2clViewportExtensionRequests.incrementAndGet();
-      }
     }
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
     if (user == null) { resp.setStatus(HttpServletResponse.SC_FORBIDDEN); return; }
@@ -105,6 +101,10 @@ public final class FragmentsServlet extends HttpServlet {
       }
     }
     if (wn == null) { resp.setStatus(HttpServletResponse.SC_BAD_REQUEST); return; }
+    if (j2clViewportRequest && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+      org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+          .j2clViewportExtensionRequests.incrementAndGet();
+    }
 
     String start = req.getParameter("startBlipId");
     String dir = ViewportLimitPolicy.normalizeDirection(req.getParameter("direction"));

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -45,13 +45,17 @@ import org.waveprotocol.box.server.persistence.blocks.VersionRange;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 
 import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Fragments endpoint (compat): returns a JSON list of blip ids + metadata near viewport.
@@ -103,7 +107,7 @@ public final class FragmentsServlet extends HttpServlet {
     if (wn == null) { resp.setStatus(HttpServletResponse.SC_BAD_REQUEST); return; }
 
     String start = req.getParameter("startBlipId");
-    String dir = normalizeDirection(req.getParameter("direction"));
+    String dir = ViewportLimitPolicy.normalizeDirection(req.getParameter("direction"));
     int limit = clampLimit(req.getParameter("limit"), j2clViewportRequest);
     Long startVersion = parseLong(req.getParameter("startVersion"));
     Long endVersion = parseLong(req.getParameter("endVersion"));
@@ -119,14 +123,16 @@ public final class FragmentsServlet extends HttpServlet {
         LOG.warning("FragmentsServlet: manifestOrder failed for " + wn + ", falling back to time-based ordering", ex);
         order = null;
       }
-      List<String> slice = FragmentsFetcherCompat.sliceUsingOrder(metas, order, start, dir, limit);
+      SliceWindow sliceWindow = buildSliceWindow(metas, order, start, dir, limit);
       if (order == null) {
-        LOG.fine("FragmentsServlet: using time-based blip order for " + wn + ", slice size=" + slice.size());
+        LOG.fine("FragmentsServlet: using time-based blip order for " + wn
+            + ", loaded slice size=" + sliceWindow.getLoadedBlipIds().size());
       }
       long snapshotVersion = FragmentsFetcherCompat.getCommittedVersion(waveletProvider, wn);
       FragmentsRequest fReq = buildFragmentsRequest(snapshotVersion, startVersion, endVersion);
       com.google.common.collect.ImmutableMap<SegmentId, VersionRange> ranges =
-          FragmentsFetcherCompat.computeRangesForSegments(snapshotVersion, fReq, buildSegments(slice));
+          FragmentsFetcherCompat.computeRangesForSegments(
+              snapshotVersion, fReq, buildSegments(sliceWindow.getRangeBlipIds()));
       ReadableWaveletData data = null;
       try {
         CommittedWaveletSnapshot snap = waveletProvider.getSnapshot(wn);
@@ -136,9 +142,20 @@ public final class FragmentsServlet extends HttpServlet {
       } catch (WaveServerException ex) {
         LOG.warning("FragmentsServlet: snapshot load failed for " + wn, ex);
       }
-      List<FragmentsPayload.Fragment> rawFragments = RawFragmentsBuilder.build(data, ranges);
+      List<FragmentsPayload.Fragment> rawFragments =
+          RawFragmentsBuilder.build(
+              data,
+              filterRawRanges(ranges, buildSegments(sliceWindow.getLoadedBlipIds())));
       // Build safe JSON with proper escaping and canonical waveref encoding
-      String json = buildJson(wn, metas, slice, snapshotVersion, fReq, ranges, rawFragments);
+      String json =
+          buildJson(
+              wn,
+              metas,
+              sliceWindow.getLoadedBlipIds(),
+              snapshotVersion,
+              fReq,
+              ranges,
+              rawFragments);
       // Help browsers avoid content-type sniffing
       resp.setHeader("X-Content-Type-Options", "nosniff");
       resp.getWriter().write(json);
@@ -171,10 +188,6 @@ public final class FragmentsServlet extends HttpServlet {
       WaveRef waveref = JavaWaverefEncoder.decodeWaveRefFromPath(ref);
       return WaveletName.of(waveref.getWaveId(), waveref.getWaveletId());
     } catch (Exception e) { return null; }
-  }
-
-  private String normalizeDirection(String dir) {
-    return (dir == null || dir.isEmpty()) ? "forward" : dir;
   }
 
   @VisibleForTesting
@@ -232,99 +245,151 @@ public final class FragmentsServlet extends HttpServlet {
     return new FragmentsRequest.Builder().setStartVersion(snapshot).setEndVersion(snapshot).build();
   }
 
-  private java.util.ArrayList<SegmentId> buildSegments(List<String> slice) {
-    java.util.ArrayList<SegmentId> segs = new java.util.ArrayList<>();
+  private ArrayList<SegmentId> buildSegments(List<String> slice) {
+    ArrayList<SegmentId> segs = new ArrayList<>();
     segs.add(SegmentId.INDEX_ID);
     segs.add(SegmentId.MANIFEST_ID);
     for (String id : slice) segs.add(SegmentId.ofBlipId(id));
     return segs;
   }
 
-  private String buildJson(WaveletName wn,
+  @VisibleForTesting
+  static SliceWindow buildSliceWindow(
+      Map<String, FragmentsFetcherCompat.BlipMeta> metas,
+      List<String> order,
+      String start,
+      String direction,
+      int limit) {
+    // Keep this defensive for tests and future internal callers; HTTP doGet normalizes first.
+    String normalizedDirection = ViewportLimitPolicy.normalizeDirection(direction);
+    int boundedLimit = Math.max(1, limit);
+    List<String> rangeSlice =
+        FragmentsFetcherCompat.sliceUsingOrder(
+            metas, order, start, normalizedDirection, boundedLimit + 1);
+    if (rangeSlice.size() <= boundedLimit) {
+      return new SliceWindow(rangeSlice, rangeSlice);
+    }
+    if (ViewportLimitPolicy.DIRECTION_BACKWARD.equals(normalizedDirection)) {
+      return new SliceWindow(
+          rangeSlice,
+          rangeSlice.subList(1, rangeSlice.size()));
+    }
+    return new SliceWindow(
+        rangeSlice,
+        rangeSlice.subList(0, boundedLimit));
+  }
+
+  private Map<SegmentId, VersionRange> filterRawRanges(
+      Map<SegmentId, VersionRange> ranges,
+      List<SegmentId> rawSegments) {
+    Set<SegmentId> rawSegmentSet = new HashSet<SegmentId>(rawSegments);
+    Map<SegmentId, VersionRange> filtered = new LinkedHashMap<SegmentId, VersionRange>();
+    for (Map.Entry<SegmentId, VersionRange> entry : ranges.entrySet()) {
+      if (rawSegmentSet.contains(entry.getKey())) {
+        filtered.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return filtered;
+  }
+
+  static final class SliceWindow {
+    private final List<String> rangeBlipIds;
+    private final List<String> loadedBlipIds;
+
+    private SliceWindow(List<String> rangeBlipIds, List<String> loadedBlipIds) {
+      this.rangeBlipIds =
+          Collections.unmodifiableList(new ArrayList<String>(rangeBlipIds));
+      this.loadedBlipIds =
+          Collections.unmodifiableList(new ArrayList<String>(loadedBlipIds));
+    }
+
+    List<String> getRangeBlipIds() {
+      return rangeBlipIds;
+    }
+
+    List<String> getLoadedBlipIds() {
+      return loadedBlipIds;
+    }
+  }
+
+  @VisibleForTesting
+  static String buildJson(WaveletName wn,
       Map<String, FragmentsFetcherCompat.BlipMeta> metas,
       List<String> slice,
       long snapshotVersion,
       FragmentsRequest fReq,
-      java.util.Map<SegmentId, VersionRange> ranges,
+      Map<SegmentId, VersionRange> ranges,
       List<FragmentsPayload.Fragment> fragmentsList) {
-    class VersionInfo {
-      long snapshot; long start; long end;
-      VersionInfo(long s, long st, long en) { snapshot=s; start=st; end=en; }
-    }
-    class BlipInfo {
-      String id; String author; long lastModifiedTime;
-      BlipInfo(String i, String a, long t) { id=i; author=a; lastModifiedTime=t; }
-    }
-    class RangeInfo {
-      String segment; long from; long to;
-      RangeInfo(String s, long f, long t) { segment=s; from=f; to=t; }
-    }
-    class FragmentOp {
-      String operations;
-      String author;
-      long targetVersion;
-      long timestamp;
-      FragmentOp(String operations, String author, long targetVersion, long timestamp) {
-        this.operations = operations;
-        this.author = author;
-        this.targetVersion = targetVersion;
-        this.timestamp = timestamp;
-      }
-    }
-    class FragmentInfo {
-      String segment;
-      List<FragmentOp> adjust;
-      List<FragmentOp> diff;
-      String rawSnapshot;
-      FragmentInfo(String segment, List<FragmentOp> adjust, List<FragmentOp> diff, String rawSnapshot) {
-        this.segment = segment;
-        this.adjust = adjust;
-        this.diff = diff;
-        this.rawSnapshot = rawSnapshot;
-      }
-    }
-    class Response {
-      String status = "ok";
-      @SerializedName("waveRef") String waveRefPath;
-      VersionInfo version;
-      List<BlipInfo> blips;
-      List<RangeInfo> ranges;
-      List<FragmentInfo> fragments;
-    }
-    Response out = new Response();
+    Map<String, Object> out = new LinkedHashMap<String, Object>();
+    out.put("status", "ok");
     // Canonical, server-encoded waveref path segment
-    out.waveRefPath = JavaWaverefEncoder.encodeToUriPathSegment(
-        org.waveprotocol.wave.model.waveref.WaveRef.of(wn.waveId, wn.waveletId));
-    out.version = new VersionInfo(snapshotVersion, fReq.startVersion, fReq.endVersion);
-    out.blips = new java.util.ArrayList<>(slice.size());
+    out.put(
+        "waveRef",
+        JavaWaverefEncoder.encodeToUriPathSegment(
+            org.waveprotocol.wave.model.waveref.WaveRef.of(wn.waveId, wn.waveletId)));
+    Map<String, Object> version = new LinkedHashMap<String, Object>();
+    version.put("snapshot", snapshotVersion);
+    version.put("start", fReq.startVersion);
+    version.put("end", fReq.endVersion);
+    out.put("version", version);
+    List<Map<String, Object>> blips = new ArrayList<>(slice.size());
     for (String id : slice) {
       FragmentsFetcherCompat.BlipMeta m = metas.get(id);
-      out.blips.add(new BlipInfo(id, (m.author==null? "" : m.author.getAddress()), m.lastModifiedTime));
+      Map<String, Object> blip = new LinkedHashMap<String, Object>();
+      blip.put("id", id);
+      blip.put("author", m == null || m.author == null ? "" : m.author.getAddress());
+      blip.put("lastModifiedTime", m == null ? 0L : m.lastModifiedTime);
+      blips.add(blip);
     }
-    out.ranges = new java.util.ArrayList<>(ranges.size());
-    for (java.util.Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
-      out.ranges.add(new RangeInfo(e.getKey().asString(), e.getValue().from(), e.getValue().to()));
+    out.put("blips", blips);
+    List<Map<String, Object>> rangeList = new ArrayList<>(ranges.size());
+    for (Map.Entry<SegmentId, VersionRange> e : ranges.entrySet()) {
+      Map<String, Object> range = new LinkedHashMap<String, Object>();
+      range.put("segment", e.getKey().asString());
+      range.put("from", e.getValue().from());
+      range.put("to", e.getValue().to());
+      rangeList.add(range);
     }
+    out.put("ranges", rangeList);
     if (fragmentsList == null || fragmentsList.isEmpty()) {
-      out.fragments = java.util.Collections.emptyList();
+      out.put("fragments", Collections.emptyList());
     } else {
-      out.fragments = new java.util.ArrayList<>(fragmentsList.size());
+      List<Map<String, Object>> fragments = new ArrayList<>(fragmentsList.size());
       for (FragmentsPayload.Fragment fragment : fragmentsList) {
-        List<FragmentOp> adjust = new java.util.ArrayList<>(fragment.adjustOperations.size());
+        List<Map<String, Object>> adjust = new ArrayList<>(fragment.adjustOperations.size());
         for (FragmentsPayload.Operation op : fragment.adjustOperations) {
-          adjust.add(new FragmentOp(op.operations, op.author, op.targetVersion, op.timestamp));
+          adjust.add(fragmentOp(op));
         }
-        List<FragmentOp> diff = new java.util.ArrayList<>(fragment.diffOperations.size());
+        List<Map<String, Object>> diff = new ArrayList<>(fragment.diffOperations.size());
         for (FragmentsPayload.Operation op : fragment.diffOperations) {
-          diff.add(new FragmentOp(op.operations, op.author, op.targetVersion, op.timestamp));
+          diff.add(fragmentOp(op));
         }
-        out.fragments.add(new FragmentInfo(
-            fragment.segment.asString(),
-            adjust.isEmpty() ? java.util.Collections.<FragmentOp>emptyList() : adjust,
-            diff.isEmpty() ? java.util.Collections.<FragmentOp>emptyList() : diff,
-            fragment.rawSnapshot == null ? "" : fragment.rawSnapshot));
+        Map<String, Object> fragmentMap = new LinkedHashMap<String, Object>();
+        fragmentMap.put("segment", fragment.segment.asString());
+        fragmentMap.put(
+            "adjust",
+            adjust.isEmpty()
+                ? Collections.<Map<String, Object>>emptyList()
+                : adjust);
+        fragmentMap.put(
+            "diff",
+            diff.isEmpty()
+                ? Collections.<Map<String, Object>>emptyList()
+                : diff);
+        fragmentMap.put("rawSnapshot", fragment.rawSnapshot == null ? "" : fragment.rawSnapshot);
+        fragments.add(fragmentMap);
       }
+      out.put("fragments", fragments);
     }
     return new Gson().toJson(out);
+  }
+
+  private static Map<String, Object> fragmentOp(FragmentsPayload.Operation op) {
+    Map<String, Object> operation = new LinkedHashMap<String, Object>();
+    operation.put("operations", op.operations);
+    operation.put("author", op.author);
+    operation.put("targetVersion", op.targetVersion);
+    operation.put("timestamp", op.timestamp);
+    return operation;
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -79,9 +79,20 @@ public final class FragmentsServlet extends HttpServlet {
     boolean j2clViewportRequest = isJ2clViewportRequest(req);
     if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
       org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.httpRequests.incrementAndGet();
+      if (j2clViewportRequest) {
+        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+            .j2clViewportExtensionRequests.incrementAndGet();
+      }
     }
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
-    if (user == null) { resp.setStatus(HttpServletResponse.SC_FORBIDDEN); return; }
+    if (user == null) {
+      if (j2clViewportRequest && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+            .j2clViewportExtensionErrors.incrementAndGet();
+      }
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
 
     String ref = req.getParameter("ref");
     WaveletName wn = null;
@@ -101,10 +112,13 @@ public final class FragmentsServlet extends HttpServlet {
         }
       }
     }
-    if (wn == null) { resp.setStatus(HttpServletResponse.SC_BAD_REQUEST); return; }
-    if (j2clViewportRequest && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
-      org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
-          .j2clViewportExtensionRequests.incrementAndGet();
+    if (wn == null) {
+      if (j2clViewportRequest && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+            .j2clViewportExtensionErrors.incrementAndGet();
+      }
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
     }
 
     String start = req.getParameter("startBlipId");

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -62,6 +62,7 @@ import java.util.Set;
  */
 public final class FragmentsServlet extends HttpServlet {
   private static final Log LOG = Log.get(FragmentsServlet.class);
+  private static final Gson GSON = new Gson();
 
   private final WaveletProvider waveletProvider;
   private final SessionManager sessionManager;
@@ -381,7 +382,7 @@ public final class FragmentsServlet extends HttpServlet {
       }
       out.put("fragments", fragments);
     }
-    return new Gson().toJson(out);
+    return GSON.toJson(out);
   }
 
   private static Map<String, Object> fragmentOp(FragmentsPayload.Operation op) {

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -19,6 +19,7 @@
 
 package org.waveprotocol.box.server.rpc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.waveprotocol.box.server.waveserver.WaveServerException;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
@@ -26,6 +27,7 @@ import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.frontend.FragmentsFetcherCompat;
 import org.waveprotocol.box.server.frontend.FragmentsRequest;
 import org.waveprotocol.box.server.frontend.RawFragmentsBuilder;
+import org.waveprotocol.box.server.frontend.ViewportLimitPolicy;
 import org.waveprotocol.wave.concurrencycontrol.channel.dto.FragmentsPayload;
 import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.id.SegmentId;
@@ -69,8 +71,13 @@ public final class FragmentsServlet extends HttpServlet {
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
     resp.setContentType("application/json;charset=UTF-8");
+    boolean j2clViewportRequest = isJ2clViewportRequest(req);
     if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
       org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.httpRequests.incrementAndGet();
+      if (j2clViewportRequest) {
+        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+            .j2clViewportExtensionRequests.incrementAndGet();
+      }
     }
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
     if (user == null) { resp.setStatus(HttpServletResponse.SC_FORBIDDEN); return; }
@@ -97,7 +104,7 @@ public final class FragmentsServlet extends HttpServlet {
 
     String start = req.getParameter("startBlipId");
     String dir = normalizeDirection(req.getParameter("direction"));
-    int limit = clampLimit(req.getParameter("limit"));
+    int limit = clampLimit(req.getParameter("limit"), j2clViewportRequest);
     Long startVersion = parseLong(req.getParameter("startVersion"));
     Long endVersion = parseLong(req.getParameter("endVersion"));
 
@@ -138,6 +145,10 @@ public final class FragmentsServlet extends HttpServlet {
       resp.setStatus(HttpServletResponse.SC_OK);
       if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
         org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.httpOk.incrementAndGet();
+        if (j2clViewportRequest) {
+          org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+              .j2clViewportExtensionOk.incrementAndGet();
+        }
       }
     } catch (WaveServerException e) {
         LOG.warning("Error fetching fragments", e);
@@ -147,6 +158,10 @@ public final class FragmentsServlet extends HttpServlet {
       }
       if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
         org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.httpErrors.incrementAndGet();
+        if (j2clViewportRequest) {
+          org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+              .j2clViewportExtensionErrors.incrementAndGet();
+        }
       }
     }
   }
@@ -162,13 +177,50 @@ public final class FragmentsServlet extends HttpServlet {
     return (dir == null || dir.isEmpty()) ? "forward" : dir;
   }
 
-  private int clampLimit(String lim) {
-    int limit = 50;
-    if (lim == null) return limit;
-    try { limit = Math.max(1, Math.min(200, Integer.parseInt(lim))); } catch (Exception ex) {
+  @VisibleForTesting
+  static int resolveLimitForRequest(String rawLimit) {
+    return resolveLimitForRequest(rawLimit, false);
+  }
+
+  @VisibleForTesting
+  static int resolveLimitForRequest(String rawLimit, boolean recordJ2clMetric) {
+    Integer requestedLimit = parseInteger(rawLimit);
+    int resolvedLimit =
+        requestedLimit == null
+            ? ViewportLimitPolicy.resolveLimit(rawLimit)
+            : ViewportLimitPolicy.resolveLimit(requestedLimit.intValue());
+    if (recordJ2clMetric
+        && requestedLimit != null
+        && resolvedLimit != requestedLimit.intValue()
+        && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+      org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+          .j2clViewportClampApplied.incrementAndGet();
+    }
+    return resolvedLimit;
+  }
+
+  private int clampLimit(String lim, boolean recordJ2clMetric) {
+    int limit = resolveLimitForRequest(lim, recordJ2clMetric);
+    Integer requestedLimit = parseInteger(lim);
+    if (lim != null && requestedLimit == null) {
       LOG.fine("Invalid 'limit' parameter '" + lim + "'; using default " + limit);
     }
     return limit;
+  }
+
+  private static boolean isJ2clViewportRequest(HttpServletRequest req) {
+    return "j2cl".equals(req.getParameter("client"));
+  }
+
+  private static Integer parseInteger(String value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(value);
+    } catch (NumberFormatException ex) {
+      return null;
+    }
   }
 
   private Long parseLong(String v) { if (v == null) return null; try { return Long.parseLong(v); } catch (Exception e) { return null; } }

--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/FragmentsMetrics.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/FragmentsMetrics.java
@@ -55,6 +55,13 @@ public final class FragmentsMetrics {
   public static final AtomicLong httpRequests = new AtomicLong();
   public static final AtomicLong httpOk = new AtomicLong();
   public static final AtomicLong httpErrors = new AtomicLong();
+  // J2CL viewport counters are incremented only from request seams that identify J2CL.
+  public static final AtomicLong j2clViewportInitialWindows = new AtomicLong();
+  public static final AtomicLong j2clViewportClampApplied = new AtomicLong();
+  public static final AtomicLong j2clViewportExtensionRequests = new AtomicLong();
+  public static final AtomicLong j2clViewportExtensionOk = new AtomicLong();
+  public static final AtomicLong j2clViewportExtensionErrors = new AtomicLong();
+  public static final AtomicLong j2clViewportSnapshotFallbacks = new AtomicLong();
   // Client-side requester counters
   public static final AtomicLong requesterSends = new AtomicLong();
   public static final AtomicLong requesterCoalesced = new AtomicLong();

--- a/wave/src/test/java/org/waveprotocol/box/server/ServerMainStructuredLoggingTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/ServerMainStructuredLoggingTest.java
@@ -18,14 +18,53 @@
  */
 package org.waveprotocol.box.server;
 
+import com.typesafe.config.ConfigFactory;
+import org.junit.After;
 import org.junit.Test;
+import org.waveprotocol.box.server.frontend.FragmentsViewChannelHandler;
+import org.waveprotocol.box.server.frontend.WaveClientRpcImpl;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public final class ServerMainStructuredLoggingTest {
+
+  @After
+  public void clearFragmentsHandler() {
+    WaveClientRpcImpl.setFragmentsHandler(null);
+  }
 
   @Test
   public void structuredLoggingStatusMentionsWaveJsonLogPath() {
     assertTrue(ServerMain.structuredLoggingStatusMessage().contains("logs/wave-json.log"));
+  }
+
+  @Test
+  public void installFragmentsHandlerWiresWaveClientRpcOpenPath() {
+    WaveClientRpcImpl.setFragmentsHandler(null);
+
+    FragmentsViewChannelHandler handler =
+        ServerMain.installFragmentsHandlerForFrontend(
+            mock(WaveletProvider.class),
+            ConfigFactory.parseString("server.fragments.transport = stream"));
+
+    assertTrue(handler.isEnabled());
+    assertSame(handler, WaveClientRpcImpl.getFragmentsHandlerForTesting());
+  }
+
+  @Test
+  public void installFragmentsHandlerStillWiresDisabledHandler() {
+    WaveClientRpcImpl.setFragmentsHandler(null);
+
+    FragmentsViewChannelHandler handler =
+        ServerMain.installFragmentsHandlerForFrontend(
+            mock(WaveletProvider.class),
+            ConfigFactory.parseString("server.fragments.transport = off"));
+
+    assertFalse(handler.isEnabled());
+    assertSame(handler, WaveClientRpcImpl.getFragmentsHandlerForTesting());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicyTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicyTest.java
@@ -1,0 +1,50 @@
+package org.waveprotocol.box.server.frontend;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public final class ViewportLimitPolicyTest {
+  private int previousDefaultLimit;
+  private int previousMaxLimit;
+
+  @Before
+  public void setUp() {
+    previousDefaultLimit = ViewportLimitPolicy.getDefaultLimit();
+    previousMaxLimit = ViewportLimitPolicy.getMaxLimit();
+  }
+
+  @After
+  public void tearDown() {
+    ViewportLimitPolicy.setLimits(previousDefaultLimit, previousMaxLimit);
+  }
+
+  @Test
+  public void missingOrInvalidLimitFallsBackToConfiguredDefault() {
+    ViewportLimitPolicy.setLimits(7, 20);
+
+    assertEquals(7, ViewportLimitPolicy.resolveLimit(null));
+    assertEquals(7, ViewportLimitPolicy.resolveLimit("not-a-number"));
+    assertEquals(7, ViewportLimitPolicy.resolveLimit("-2"));
+    assertEquals(7, ViewportLimitPolicy.resolveLimit("0"));
+  }
+
+  @Test
+  public void requestedLimitIsClampedToConfiguredMax() {
+    ViewportLimitPolicy.setLimits(5, 12);
+
+    assertEquals(8, ViewportLimitPolicy.resolveLimit("8"));
+    assertEquals(12, ViewportLimitPolicy.resolveLimit("100"));
+  }
+
+  @Test
+  public void maxLimitCannotDropBelowDefaultLimit() {
+    ViewportLimitPolicy.setLimits(9, 3);
+
+    assertEquals(9, ViewportLimitPolicy.getDefaultLimit());
+    assertEquals(9, ViewportLimitPolicy.getMaxLimit());
+    assertEquals(9, ViewportLimitPolicy.resolveLimit("100"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicyTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/ViewportLimitPolicyTest.java
@@ -36,6 +36,7 @@ public final class ViewportLimitPolicyTest {
     ViewportLimitPolicy.setLimits(5, 12);
 
     assertEquals(8, ViewportLimitPolicy.resolveLimit("8"));
+    assertEquals(10, ViewportLimitPolicy.resolveLimit(" 10 "));
     assertEquals(12, ViewportLimitPolicy.resolveLimit("100"));
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
@@ -30,6 +30,7 @@ import org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolOpenRequest;
 import org.waveprotocol.box.common.comms.WaveClientRpc.ProtocolWaveletUpdate;
 import org.waveprotocol.box.server.waveserver.WaveletProvider;
 import org.waveprotocol.wave.model.id.ModernIdSerialiser;
+import org.waveprotocol.wave.model.id.SegmentId;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
@@ -37,6 +38,9 @@ import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+
+import java.util.Arrays;
+import java.util.List;
 
 /** Tests viewport limit clamping and direction normalization. */
 public final class WaveClientRpcViewportHintsTest {
@@ -77,7 +81,7 @@ public final class WaveClientRpcViewportHintsTest {
     WaveClientRpcImpl.setViewportLimits(4, 10);
     ProtocolWaveletUpdate update = openWithHints("b+1", "forward", -123);
     assertTrue(update.hasFragments());
-    int blipCount = countBlipRanges(update.getFragments());
+    int blipCount = countBlipFragments(update.getFragments());
     assertEquals(4, blipCount);
   }
 
@@ -86,8 +90,122 @@ public final class WaveClientRpcViewportHintsTest {
     WaveClientRpcImpl.setViewportLimits(3, 6);
     ProtocolWaveletUpdate update = openWithHints("b+1", "forward", 100);
     assertTrue(update.hasFragments());
-    int blipCount = countBlipRanges(update.getFragments());
+    int blipCount = countBlipFragments(update.getFragments());
     assertEquals(6, blipCount);
+  }
+
+  @Test
+  public void viewportHintsAttachEdgePlaceholderRangeForGrowth() {
+    ProtocolWaveletUpdate update = openWithHints("b+1", "forward", 5);
+
+    assertTrue(update.hasFragments());
+    assertEquals("Expected five loaded blips plus one growth placeholder range",
+        6, countBlipRanges(update.getFragments()));
+    assertEquals("Expected only the visible five blips to carry raw fragments",
+        5, countBlipFragments(update.getFragments()));
+    assertTrue(hasSegmentRange(update.getFragments(), SegmentId.INDEX_ID.asString()));
+    assertTrue(hasSegmentRange(update.getFragments(), SegmentId.MANIFEST_ID.asString()));
+    assertEquals(Arrays.asList("b+1", "b+2", "b+3", "b+4", "b+5", "b+6"),
+        blipRangeIds(update.getFragments()));
+    assertTrue(hasBlipRange(update.getFragments(), "b+6"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+6"));
+  }
+
+  @Test
+  public void viewportHintsAttachBackwardEdgePlaceholderForGrowth() {
+    ProtocolWaveletUpdate update = openWithHints("b+10", "backward", 5);
+
+    assertTrue(update.hasFragments());
+    assertEquals("Expected five loaded blips plus one backward growth placeholder range",
+        6, countBlipRanges(update.getFragments()));
+    assertEquals("Expected only the visible five blips to carry raw fragments",
+        5, countBlipFragments(update.getFragments()));
+    assertEquals(Arrays.asList("b+5", "b+6", "b+7", "b+8", "b+9", "b+10"),
+        blipRangeIds(update.getFragments()));
+    assertTrue(hasBlipRange(update.getFragments(), "b+5"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+5"));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+10"));
+  }
+
+  @Test
+  public void viewportHintsBackwardAtStartDoesNotAddPlaceholderRange() {
+    ProtocolWaveletUpdate update = openWithHints("b+1", "backward", 5);
+
+    assertTrue(update.hasFragments());
+    assertEquals(1, countBlipRanges(update.getFragments()));
+    assertEquals(1, countBlipFragments(update.getFragments()));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+1"));
+  }
+
+  @Test
+  public void viewportHintsUseNaturalBlipOrderForSnapshotWindow() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+10", "b+2", "b+1", "b+3"),
+            viewportHintRequest(null, "forward", 2));
+
+    assertTrue(update.hasFragments());
+    assertTrue(hasBlipFragment(update.getFragments(), "b+1"));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+2"));
+    assertTrue(hasBlipRange(update.getFragments(), "b+3"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+3"));
+    assertFalse(hasBlipRange(update.getFragments(), "b+10"));
+  }
+
+  @Test
+  public void viewportHintsMissingStartFallsBackToFirstWindow() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+1", "b+2", "b+3"),
+            viewportHintRequest("b+missing", "forward", 2));
+
+    assertTrue(update.hasFragments());
+    assertTrue(hasBlipFragment(update.getFragments(), "b+1"));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+2"));
+    assertTrue(hasBlipRange(update.getFragments(), "b+3"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+3"));
+  }
+
+  @Test
+  public void viewportHintsMissingStartWithBackwardDirectionFallsBackToFirstBlip() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+1", "b+2", "b+3"),
+            viewportHintRequest("b+missing", "backward", 2));
+
+    assertTrue(update.hasFragments());
+    assertEquals(Arrays.asList("b+1"), blipRangeIds(update.getFragments()));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+1"));
+  }
+
+  @Test
+  public void viewportHintsUseLexicalOrderWhenBlipsHaveNoTrailingNumbers() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+foo", "b+bar", "b+zed"),
+            viewportHintRequest(null, "forward", 2));
+
+    assertTrue(update.hasFragments());
+    assertTrue(hasBlipFragment(update.getFragments(), "b+bar"));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+foo"));
+    assertTrue(hasBlipRange(update.getFragments(), "b+zed"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+zed"));
+  }
+
+  @Test
+  public void noHintOpenKeepsSnapshotDocumentIterationOrder() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+10", "b+2", "b+1"),
+            ProtocolOpenRequest.newBuilder()
+                .setParticipantId("user@example.com")
+                .setWaveId("example.com/w+vh")
+                .addWaveletIdPrefix("conv+root")
+                .build());
+
+    assertTrue(update.hasFragments());
+    assertTrue(update.hasSnapshot());
+    assertEquals(Arrays.asList("b+10", "b+2", "b+1"), blipRangeIds(update.getFragments()));
   }
 
   @Test
@@ -117,6 +235,8 @@ public final class WaveClientRpcViewportHintsTest {
 
     assertTrue("Legacy no-hint open keeps snapshot bootstrap", update.hasSnapshot());
     assertTrue("Fragments can still be attached for legacy clients", update.hasFragments());
+    assertEquals("Legacy no-hint open should not attach viewport growth placeholders",
+        countBlipFragments(update.getFragments()), countBlipRanges(update.getFragments()));
     assertEquals(0L, FragmentsMetrics.j2clViewportInitialWindows.get());
     assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
   }
@@ -208,6 +328,43 @@ public final class WaveClientRpcViewportHintsTest {
       if (r.getSegment().startsWith("blip:")) c++;
     }
     return c;
+  }
+
+  private static int countBlipFragments(WaveClientRpc.ProtocolFragments f) {
+    int c = 0;
+    for (WaveClientRpc.ProtocolFragment fragment : f.getFragmentList()) {
+      if (fragment.getSegment().startsWith("blip:")) c++;
+    }
+    return c;
+  }
+
+  private static boolean hasBlipRange(WaveClientRpc.ProtocolFragments f, String blipId) {
+    return hasSegmentRange(f, "blip:" + blipId);
+  }
+
+  private static boolean hasSegmentRange(WaveClientRpc.ProtocolFragments f, String segment) {
+    for (WaveClientRpc.ProtocolFragmentRange range : f.getRangeList()) {
+      if (segment.equals(range.getSegment())) return true;
+    }
+    return false;
+  }
+
+  private static boolean hasBlipFragment(WaveClientRpc.ProtocolFragments f, String blipId) {
+    String segment = "blip:" + blipId;
+    for (WaveClientRpc.ProtocolFragment fragment : f.getFragmentList()) {
+      if (segment.equals(fragment.getSegment())) return true;
+    }
+    return false;
+  }
+
+  private static List<String> blipRangeIds(WaveClientRpc.ProtocolFragments f) {
+    java.util.ArrayList<String> ids = new java.util.ArrayList<String>();
+    for (WaveClientRpc.ProtocolFragmentRange range : f.getRangeList()) {
+      if (range.getSegment().startsWith("blip:")) {
+        ids.add(range.getSegment().substring("blip:".length()));
+      }
+    }
+    return ids;
   }
 
   private static ProtocolWaveletUpdate openWithHints(String startId, String dir, int limit) {
@@ -325,11 +482,36 @@ public final class WaveClientRpcViewportHintsTest {
     return WaveClientRpcImpl.create(frontend, false);
   }
 
+  private static WaveClientRpcImpl makeWaveClientRpcWithBlipIds(String... blipIds) {
+    ClientFrontend frontend = new ClientFrontend() {
+      @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
+        WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
+        WaveletName wn = WaveletName.of(waveId, wid);
+        ReadableWaveletData data = providerDataWithBlipIds(waveId, wid, blipIds);
+        CommittedWaveletSnapshot snap = new CommittedWaveletSnapshot(data, HashedVersion.unsigned(100));
+        listener.onUpdate(wn, snap, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+      }
+    };
+    return WaveClientRpcImpl.create(frontend, false);
+  }
+
   private static ReadableWaveletData providerDataWithBlips(WaveId waveId, WaveletId wid, int count) {
     ReadableWaveletDataStub stub = new ReadableWaveletDataStub(waveId, wid, HashedVersion.unsigned(1));
     for (int i = 1; i <= count; i++) {
       String id = "b+" + i;
       stub.addDoc(id, new ReadableBlipDataStub(ParticipantId.ofUnsafe("user@example.com"), i * 100L));
+    }
+    return stub;
+  }
+
+  private static ReadableWaveletData providerDataWithBlipIds(
+      WaveId waveId, WaveletId wid, String... blipIds) {
+    ReadableWaveletDataStub stub = new ReadableWaveletDataStub(waveId, wid, HashedVersion.unsigned(1));
+    for (int i = 0; i < blipIds.length; i++) {
+      stub.addDoc(
+          blipIds[i],
+          new ReadableBlipDataStub(ParticipantId.ofUnsafe("user@example.com"), (i + 1) * 100L));
     }
     return stub;
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
@@ -36,17 +36,27 @@ import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
+import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
 
 /** Tests viewport limit clamping and direction normalization. */
 public final class WaveClientRpcViewportHintsTest {
 
   private int prevDefault;
   private int prevMax;
+  private boolean prevMetricsEnabled;
+  private long prevSnapshotFallbacks;
+  private long prevInitialWindows;
 
   @Before
   public void setUp() {
     prevDefault = WaveClientRpcImpl.getDefaultViewportLimit();
     prevMax = WaveClientRpcImpl.getMaxViewportLimit();
+    prevMetricsEnabled = FragmentsMetrics.isEnabled();
+    prevSnapshotFallbacks = FragmentsMetrics.j2clViewportSnapshotFallbacks.get();
+    prevInitialWindows = FragmentsMetrics.j2clViewportInitialWindows.get();
+    FragmentsMetrics.setEnabled(true);
+    FragmentsMetrics.j2clViewportSnapshotFallbacks.set(0L);
+    FragmentsMetrics.j2clViewportInitialWindows.set(0L);
     // Enable fragments handler with RPC fetch enabled
     WaveletProvider provider = providerWithBlips(15);
     WaveClientRpcImpl.setFragmentsHandler(new FragmentsViewChannelHandler(provider,
@@ -57,6 +67,9 @@ public final class WaveClientRpcViewportHintsTest {
   public void tearDown() {
     WaveClientRpcImpl.setViewportLimits(prevDefault, prevMax);
     WaveClientRpcImpl.setFragmentsHandler(null);
+    FragmentsMetrics.j2clViewportSnapshotFallbacks.set(prevSnapshotFallbacks);
+    FragmentsMetrics.j2clViewportInitialWindows.set(prevInitialWindows);
+    FragmentsMetrics.setEnabled(prevMetricsEnabled);
   }
 
   @Test
@@ -86,6 +99,109 @@ public final class WaveClientRpcViewportHintsTest {
     assertTrue("Expected fragments payload present", update.hasFragments());
   }
 
+  @Test
+  public void viewportHintsSuppressWholeSnapshotWhenFragmentsAvailable() {
+    ProtocolWaveletUpdate update = openWithHints("b+1", "forward", 5);
+
+    assertTrue("Expected fragments payload present", update.hasFragments());
+    assertFalse("Viewport-hinted open should not include full snapshot", update.hasSnapshot());
+    assertTrue("Expected resulting version for write-session coupling", update.hasResultingVersion());
+    assertTrue("Expected commit notice for selected-wave bootstrap", update.hasCommitNotice());
+    assertEquals(1L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void noHintOpenKeepsWholeSnapshotForLegacyClients() {
+    ProtocolWaveletUpdate update = openWithoutHints();
+
+    assertTrue("Legacy no-hint open keeps snapshot bootstrap", update.hasSnapshot());
+    assertTrue("Fragments can still be attached for legacy clients", update.hasFragments());
+    assertEquals(0L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void viewportHintsFallbackToSnapshotWhenFragmentsUnavailable() {
+    WaveClientRpcImpl.setFragmentsHandler(null);
+
+    ProtocolWaveletUpdate update = openWithHints("b+1", "forward", 5);
+
+    assertFalse("No fragments should be attached without a handler", update.hasFragments());
+    assertTrue("Viewport-hinted open must fall back to snapshot if fragments are unavailable",
+        update.hasSnapshot());
+    assertEquals(0L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(1L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void viewportHintsWithoutSnapshotOrFragmentsOnlyPreserveCommitNotice() {
+    WaveClientRpcImpl.setFragmentsHandler(null);
+
+    ProtocolWaveletUpdate update =
+        openWithRpc(makeWaveClientRpcWithoutSnapshot(), viewportHintRequest("b+1", "forward", 5));
+
+    assertFalse("No snapshot should be attached when the frontend has none", update.hasSnapshot());
+    assertFalse("No fragments should be attached without a handler", update.hasFragments());
+    assertTrue("Commit notice should still preserve the update version", update.hasCommitNotice());
+    assertEquals(0L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void snapshotlessViewportFragmentsCountAsInitialWindow() {
+    WaveClientRpcImpl.setForceClientFragments(true);
+    try {
+      ProtocolWaveletUpdate update =
+          openWithRpc(makeWaveClientRpcWithoutSnapshot(), viewportHintRequest("b+1", "forward", 5));
+
+      assertFalse("No full snapshot should be attached", update.hasSnapshot());
+      assertTrue("Synthetic viewport fragments should be attached", update.hasFragments());
+      assertEquals(1L, FragmentsMetrics.j2clViewportInitialWindows.get());
+      assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+    } finally {
+      WaveClientRpcImpl.setForceClientFragments(false);
+    }
+  }
+
+  @Test
+  public void viewportInitialWindowMetricCountsOncePerOpen() {
+    openWithRpc(makeWaveClientRpcWithTwoSnapshotUpdates(),
+        viewportHintRequest("b+1", "forward", 5));
+
+    assertEquals(1L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void viewportInitialWindowMetricCountsEachWaveletOnce() {
+    openWithRpc(makeWaveClientRpcWithTwoWavelets(),
+        viewportHintRequest("b+1", "forward", 5));
+
+    assertEquals(2L, FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(0L, FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  @Test
+  public void viewportSnapshotFallbackReasonLabelsOperatorPaths() {
+    FragmentsViewChannelHandler disabledHandler = new FragmentsViewChannelHandler(
+        providerWithBlips(1), ConfigFactory.parseString("server.enableFetchFragmentsRpc=false"));
+    FragmentsViewChannelHandler enabledHandler = new FragmentsViewChannelHandler(
+        providerWithBlips(1), ConfigFactory.parseString("server.enableFetchFragmentsRpc=true"));
+
+    assertEquals("fragments-handler-absent",
+        WaveClientRpcImpl.viewportSnapshotFallbackReason(null, testWaveletName("conv+root")));
+    assertEquals("fragments-handler-disabled",
+        WaveClientRpcImpl.viewportSnapshotFallbackReason(
+            disabledHandler, testWaveletName("conv+root")));
+    assertEquals("dummy-wavelet",
+        WaveClientRpcImpl.viewportSnapshotFallbackReason(
+            enabledHandler, testWaveletName("dummy+root")));
+    assertEquals("no-fragments-emitted",
+        WaveClientRpcImpl.viewportSnapshotFallbackReason(
+            enabledHandler, testWaveletName("conv+root")));
+  }
+
   private static int countBlipRanges(WaveClientRpc.ProtocolFragments f) {
     int c = 0;
     for (WaveClientRpc.ProtocolFragmentRange r : f.getRangeList()) {
@@ -95,15 +211,38 @@ public final class WaveClientRpcViewportHintsTest {
   }
 
   private static ProtocolWaveletUpdate openWithHints(String startId, String dir, int limit) {
-    WaveClientRpcImpl rpc = makeWaveClientRpc();
-    ProtocolOpenRequest.Builder b = ProtocolOpenRequest.newBuilder()
+    return openWithRequest(viewportHintRequest(startId, dir, limit));
+  }
+
+  private static ProtocolWaveletUpdate openWithoutHints() {
+    return openWithRequest(baseOpenRequestBuilder().build());
+  }
+
+  private static ProtocolOpenRequest.Builder baseOpenRequestBuilder() {
+    return ProtocolOpenRequest.newBuilder()
         .setParticipantId("user@example.com")
         .setWaveId(ModernIdSerialiser.INSTANCE.serialiseWaveId(WaveId.of("example.com", "w+vh")));
+  }
+
+  private static WaveletName testWaveletName(String waveletId) {
+    WaveId waveId = WaveId.of("example.com", "w+vh");
+    return WaveletName.of(waveId, WaveletId.of(waveId.getDomain(), waveletId));
+  }
+
+  private static ProtocolOpenRequest viewportHintRequest(String startId, String dir, int limit) {
+    ProtocolOpenRequest.Builder b = baseOpenRequestBuilder();
     if (startId != null) b.setViewportStartBlipId(startId);
     if (dir != null) b.setViewportDirection(dir);
     b.setViewportLimit(limit);
-    ProtocolOpenRequest request = b.build();
+    return b.build();
+  }
 
+  private static ProtocolWaveletUpdate openWithRequest(ProtocolOpenRequest request) {
+    return openWithRpc(makeWaveClientRpc(), request);
+  }
+
+  private static ProtocolWaveletUpdate openWithRpc(
+      WaveClientRpcImpl rpc, ProtocolOpenRequest request) {
     final ProtocolWaveletUpdate[] holder = new ProtocolWaveletUpdate[1];
     RpcCallback<ProtocolWaveletUpdate> cb = update -> {
       holder[0] = update;
@@ -135,6 +274,52 @@ public final class WaveClientRpcViewportHintsTest {
         ReadableWaveletData data = providerDataWithBlips(waveId, wid, 20);
         CommittedWaveletSnapshot snap = new CommittedWaveletSnapshot(data, HashedVersion.unsigned(100));
         listener.onUpdate(wn, snap, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+      }
+    };
+    return WaveClientRpcImpl.create(frontend, false);
+  }
+
+  private static WaveClientRpcImpl makeWaveClientRpcWithoutSnapshot() {
+    ClientFrontend frontend = new ClientFrontend() {
+      @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
+        WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
+        WaveletName wn = WaveletName.of(waveId, wid);
+        listener.onUpdate(wn, null, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+      }
+    };
+    return WaveClientRpcImpl.create(frontend, false);
+  }
+
+  private static WaveClientRpcImpl makeWaveClientRpcWithTwoSnapshotUpdates() {
+    ClientFrontend frontend = new ClientFrontend() {
+      @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
+        WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
+        WaveletName wn = WaveletName.of(waveId, wid);
+        ReadableWaveletData data = providerDataWithBlips(waveId, wid, 20);
+        CommittedWaveletSnapshot snap = new CommittedWaveletSnapshot(data, HashedVersion.unsigned(100));
+        listener.onUpdate(wn, snap, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+        listener.onUpdate(wn, snap, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+      }
+    };
+    return WaveClientRpcImpl.create(frontend, false);
+  }
+
+  private static WaveClientRpcImpl makeWaveClientRpcWithTwoWavelets() {
+    ClientFrontend frontend = new ClientFrontend() {
+      @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
+        WaveletId first = WaveletId.of(waveId.getDomain(), "conv+root");
+        WaveletId second = WaveletId.of(waveId.getDomain(), "conv+thread");
+        listener.onUpdate(WaveletName.of(waveId, first),
+            new CommittedWaveletSnapshot(providerDataWithBlips(waveId, first, 20),
+                HashedVersion.unsigned(100)),
+            java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh-1");
+        listener.onUpdate(WaveletName.of(waveId, second),
+            new CommittedWaveletSnapshot(providerDataWithBlips(waveId, second, 20),
+                HashedVersion.unsigned(100)),
+            java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh-2");
       }
     };
     return WaveClientRpcImpl.create(frontend, false);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
@@ -5,8 +5,22 @@ import static org.junit.Assert.assertEquals;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.waveprotocol.box.server.frontend.FragmentsFetcherCompat;
+import org.waveprotocol.box.server.frontend.FragmentsRequest;
 import org.waveprotocol.box.server.frontend.ViewportLimitPolicy;
+import org.waveprotocol.box.server.persistence.blocks.VersionRange;
 import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+import org.waveprotocol.wave.concurrencycontrol.channel.dto.FragmentsPayload;
+import org.waveprotocol.wave.model.id.SegmentId;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public final class FragmentsServletViewportLimitTest {
   private int previousDefaultLimit;
@@ -55,5 +69,167 @@ public final class FragmentsServletViewportLimitTest {
 
     assertEquals(6, FragmentsServlet.resolveLimitForRequest("invalid", true));
     assertEquals(1L, FragmentsMetrics.j2clViewportClampApplied.get());
+  }
+
+  @Test
+  public void servletJsonPayloadIsDecodableByJ2clFragmentsResponse() {
+    WaveId waveId = WaveId.of("example.com", "w+json");
+    WaveletName waveletName =
+        WaveletName.of(waveId, WaveletId.of(waveId.getDomain(), "conv+root"));
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    Map<SegmentId, VersionRange> ranges = new LinkedHashMap<SegmentId, VersionRange>();
+    ranges.put(SegmentId.ofBlipId("b+1"), VersionRange.of(7L, 9L));
+    ranges.put(SegmentId.ofBlipId("b+2"), VersionRange.of(7L, 9L));
+    ranges.put(SegmentId.ofBlipId("b+missing"), VersionRange.of(7L, 9L));
+
+    String json =
+        FragmentsServlet.buildJson(
+            waveletName,
+            metas,
+            Arrays.asList("b+1", "b+missing"),
+            9L,
+            new FragmentsRequest.Builder().setStartVersion(7L).setEndVersion(9L).build(),
+            ranges,
+            Arrays.asList(
+                new FragmentsPayload.Fragment(
+                    SegmentId.ofBlipId("b+1"),
+                    "raw one",
+                    Collections.<FragmentsPayload.Operation>emptyList(),
+                    Collections.<FragmentsPayload.Operation>emptyList())));
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> decoded = new com.google.gson.Gson().fromJson(json, Map.class);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> version = (Map<String, Object>) decoded.get("version");
+    @SuppressWarnings("unchecked")
+    java.util.List<Map<String, Object>> blips =
+        (java.util.List<Map<String, Object>>) decoded.get("blips");
+    @SuppressWarnings("unchecked")
+    java.util.List<Map<String, Object>> fragments =
+        (java.util.List<Map<String, Object>>) decoded.get("fragments");
+    Map<String, Object> missingMetaBlip = blips.get(1);
+    Map<String, Object> fragment = fragments.get(0);
+
+    assertEquals("ok", decoded.get("status"));
+    assertEquals(9.0, version.get("snapshot"));
+    assertEquals(2, blips.size());
+    assertEquals("b+missing", missingMetaBlip.get("id"));
+    assertEquals("", missingMetaBlip.get("author"));
+    assertEquals(0.0, missingMetaBlip.get("lastModifiedTime"));
+    assertEquals(3, ((java.util.List<?>) decoded.get("ranges")).size());
+    assertEquals(1, fragments.size());
+    assertEquals("raw one", fragment.get("rawSnapshot"));
+    assertEquals(Collections.emptyList(), fragment.get("adjust"));
+    assertEquals(Collections.emptyList(), fragment.get("diff"));
+  }
+
+  @Test
+  public void servletLimitOneStillAddsGrowthPlaceholderRange() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2"),
+            "b+1",
+            "FORWARD",
+            1);
+
+    assertEquals(Arrays.asList("b+1", "b+2"), window.getRangeBlipIds());
+    assertEquals(Collections.singletonList("b+1"), window.getLoadedBlipIds());
+  }
+
+  @Test
+  public void servletNonPositiveLimitStillAddsSingleLoadedBlipAndPlaceholder() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2"),
+            "b+1",
+            "forward",
+            0);
+
+    assertEquals(Arrays.asList("b+1", "b+2"), window.getRangeBlipIds());
+    assertEquals(Collections.singletonList("b+1"), window.getLoadedBlipIds());
+  }
+
+  @Test
+  public void servletBackwardWindowUsesLeadingPlaceholderRange() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+    metas.put("b+3", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 30L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2", "b+3"),
+            "b+3",
+            "backward",
+            2);
+
+    assertEquals(Arrays.asList("b+1", "b+2", "b+3"), window.getRangeBlipIds());
+    assertEquals(Arrays.asList("b+2", "b+3"), window.getLoadedBlipIds());
+  }
+
+  @Test
+  public void servletBackwardAtStartDoesNotAddPlaceholderRange() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2"),
+            "b+1",
+            "backward",
+            5);
+
+    assertEquals(Collections.singletonList("b+1"), window.getRangeBlipIds());
+    assertEquals(Collections.singletonList("b+1"), window.getLoadedBlipIds());
+  }
+
+  @Test
+  public void servletEndOfWaveDoesNotAddPlaceholderRange() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2"),
+            "b+2",
+            "forward",
+            5);
+
+    assertEquals(Collections.singletonList("b+2"), window.getRangeBlipIds());
+    assertEquals(Collections.singletonList("b+2"), window.getLoadedBlipIds());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
@@ -1,0 +1,59 @@
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.waveprotocol.box.server.frontend.ViewportLimitPolicy;
+import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+
+public final class FragmentsServletViewportLimitTest {
+  private int previousDefaultLimit;
+  private int previousMaxLimit;
+  private boolean previousMetricsEnabled;
+  private long previousClampApplied;
+
+  @Before
+  public void setUp() {
+    previousDefaultLimit = ViewportLimitPolicy.getDefaultLimit();
+    previousMaxLimit = ViewportLimitPolicy.getMaxLimit();
+    previousMetricsEnabled = FragmentsMetrics.isEnabled();
+    previousClampApplied = FragmentsMetrics.j2clViewportClampApplied.get();
+    FragmentsMetrics.setEnabled(false);
+    FragmentsMetrics.j2clViewportClampApplied.set(0L);
+  }
+
+  @After
+  public void tearDown() {
+    ViewportLimitPolicy.setLimits(previousDefaultLimit, previousMaxLimit);
+    FragmentsMetrics.j2clViewportClampApplied.set(previousClampApplied);
+    FragmentsMetrics.setEnabled(previousMetricsEnabled);
+  }
+
+  @Test
+  public void servletUsesSharedViewportLimitPolicy() {
+    ViewportLimitPolicy.setLimits(6, 11);
+
+    assertEquals(6, FragmentsServlet.resolveLimitForRequest(null));
+    assertEquals(6, FragmentsServlet.resolveLimitForRequest("invalid"));
+    assertEquals(6, FragmentsServlet.resolveLimitForRequest("0"));
+    assertEquals(9, FragmentsServlet.resolveLimitForRequest("9"));
+    assertEquals(11, FragmentsServlet.resolveLimitForRequest("90"));
+  }
+
+  @Test
+  public void servletClampMetricIsScopedToJ2clMarkedRequests() {
+    ViewportLimitPolicy.setLimits(6, 11);
+    FragmentsMetrics.setEnabled(true);
+
+    assertEquals(11, FragmentsServlet.resolveLimitForRequest("90", false));
+    assertEquals(0L, FragmentsMetrics.j2clViewportClampApplied.get());
+
+    assertEquals(11, FragmentsServlet.resolveLimitForRequest("90", true));
+    assertEquals(1L, FragmentsMetrics.j2clViewportClampApplied.get());
+
+    assertEquals(6, FragmentsServlet.resolveLimitForRequest("invalid", true));
+    assertEquals(1L, FragmentsMetrics.j2clViewportClampApplied.get());
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WebSocketChannelTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WebSocketChannelTest.java
@@ -77,6 +77,18 @@ public class WebSocketChannelTest extends TestCase {
     checkRoundtripping(sourceBuilder);
   }
 
+  public void testRoundTrippingJsonPreservesExplicitZeroViewportLimit() throws Exception {
+    WaveClientRpc.ProtocolOpenRequest.Builder sourceBuilder = buildProtocolOpenRequest();
+    sourceBuilder.setViewportLimit(0);
+
+    checkRoundtripping(sourceBuilder);
+
+    WaveClientRpc.ProtocolOpenRequest decoded =
+        (WaveClientRpc.ProtocolOpenRequest) callback.savedMessage;
+    assertTrue(decoded.hasViewportLimit());
+    assertEquals(0, decoded.getViewportLimit());
+  }
+
   private void checkRoundtripping(final WaveClientRpc.ProtocolOpenRequest.Builder sourceBuilder) {
     WaveClientRpc.ProtocolOpenRequest sourceRequest = sourceBuilder.build();
     channel.sendMessage(SEQUENCE_NUMBER, sourceRequest);


### PR DESCRIPTION
## Summary

Closes #967. Refs #904.

This completes the J2CL viewport-fragment parity lane by wiring the live selected-wave RPC path to fragment windows, keeping viewport-hinted opens off the whole-wave snapshot bootstrap, and proving browser-visible scroll growth against an 80-blip fixture.

## Changes

- Install the configured `FragmentsViewChannelHandler` during Jakarta `ServerMain` frontend initialization so live J2CL opens can attach fragments.
- Split viewport range announcements from raw loaded fragments so the initial window and `/fragments` growth can include one placeholder-only edge range.
- Keep legacy/GWT no-hint opens snapshot-compatible, without viewport growth placeholders, while preserving their snapshot document iteration order.
- Share viewport direction normalization through `ViewportLimitPolicy` and harden forward/backward/window edge cases.
- Make `.sidecar-selected-content` the keyboard-focusable selected-wave scroll surface with `role`, `aria-label`, `tabindex`, and `:focus-visible` styling.
- Record Task 7 browser evidence in the plan doc and changelog.

## Verification

- `sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.rpc.FragmentsServletViewportLimitTest org.waveprotocol.box.server.ServerMainStructuredLoggingTest org.waveprotocol.box.server.frontend.WaveClientRpcFragmentsTest org.waveprotocol.box.server.frontend.ViewportLimitPolicyTest" j2clSearchBuild j2clSearchTest` -> PASS (`35` targeted server tests plus J2CL build/tests).
- `sbt -batch Universal/stage` -> PASS.
- `PORT=9967 bash scripts/wave-smoke.sh check` -> PASS (`ROOT_STATUS=200`, `J2CL_ROOT_STATUS=200`, `SIDECAR_STATUS=200`, `WEBCLIENT_STATUS=200`).
- Playwright browser verification on `http://127.0.0.1:9967/?view=j2cl-root&q=in%3Ainbox&wave=local.net%2Fw%2Bperf0001` -> PASS.
- Browser evidence: initial render loaded `b+perf0001b1` through `b+perf0001b5` plus one placeholder; scroll fetched `/fragments?...startBlipId=b%2Bperf0001b6`; rendered window grew to `b+perf0001b1` through `b+perf0001b10`; focus stayed on `b+perf0001b1`.
- WebSocket evidence: selected open sent `"7":0`; selected `conv+root` update had `hasSnapshot=false`, `hasFragments=true`, `fragmentRangeCount=8`, `fragmentEntryCount=6`.
- Log evidence after fresh restart: handler configured enabled, fragment emission logged for `local.net/w+perf0001/local.net/conv+root`, and zero `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` entries.
- `git diff --check` -> PASS.
- `python3 scripts/validate-changelog.py` -> PASS.

## Review

- Self-review completed.
- Claude Opus 4.7 implementation review loop cleared in round 7 with no remaining blockers, important concerns, nits, coverage gaps, UX/a11y concerns, or performance pitfalls.
- Final review output: `/tmp/claude-review-967-task7-r7.out`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental fragment loading as users scroll (forward/backward) with viewport-scoped windows, server-aligned clamping, preserved scroll-anchor/focus, and viewport-edge callbacks.
  * Placeholder shimmer UI for pending content with reduced-motion support and accessible selected-wave content region.
  * Partial bootstrap preferring small viewport windows over full snapshots with explicit fallback behavior and initial viewport hints.

* **Documentation**
  * Added planning and changelog entries describing viewport fragment behavior, rollout, and metrics.

* **Tests**
  * Extensive unit and integration tests covering viewport windows, merging, encoding, metrics, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->