### PR TITLE
test(j2cl): harden viewport metadata edge cases

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -55,6 +55,8 @@ public final class J2clSelectedWaveProjector {
         hasViewportWindow
             ? viewportState.getLoadedContentEntries()
             : extractDocumentEntries(update.getDocuments());
+    // TODO(#904): keep the legacy document projection fallback for non-viewport updates until all
+    // selected-wave surfaces consume J2clSelectedWaveViewportState directly.
     if (contentEntries.isEmpty()
         && !hasViewportWindow
         && previousMatchesWave

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -15,6 +15,7 @@ import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveViewportState {
   static final String BLIP_SEGMENT_PREFIX = "blip:";
+  private static final String BLIP_DOCUMENT_PREFIX = "b+";
 
   private static final long UNKNOWN_VERSION = -1L;
   private static final J2clSelectedWaveViewportState EMPTY =
@@ -95,9 +96,13 @@ public final class J2clSelectedWaveViewportState {
       if (documentId == null || documentId.isEmpty()) {
         continue;
       }
-      // Documents do not carry fragment segment ids; blip documents use the
-      // same segment convention emitted by SidecarSelectedWaveFragments.
-      String segment = documentId.startsWith("b+") ? BLIP_SEGMENT_PREFIX + documentId : documentId;
+      // Documents do not carry fragment segment ids. Generated conversational blip ids use
+      // IdGenerator's "b+" token; other document ids remain non-read metadata entries until the
+      // sidecar transport can send explicit segment ids for documents too.
+      String segment =
+          documentId.startsWith(BLIP_DOCUMENT_PREFIX)
+              ? BLIP_SEGMENT_PREFIX + documentId
+              : documentId;
       long version = document.getLastModifiedVersion();
       minVersion = Math.min(minVersion, version);
       maxVersion = Math.max(maxVersion, version);
@@ -198,6 +203,9 @@ public final class J2clSelectedWaveViewportState {
         }
         long mergedToVersion =
             Math.max(existing.getToVersion(), documentEntry.getToVersion());
+        // Fragment fetches can expand the window through mergeFragments/minKnown; document-only
+        // updates refresh content inside the current viewport and must not widen a known fragment
+        // window backward just because a document has an older modified version.
         long mergedFromVersion =
             knownOrFallback(existing.getFromVersion(), documentEntry.getFromVersion());
         merged.set(
@@ -240,7 +248,12 @@ public final class J2clSelectedWaveViewportState {
     return entries.isEmpty();
   }
 
-  // Metadata-only fragment deltas are state updates, not selected-wave read windows.
+  /**
+   * Returns true only for fragment payloads that can define a selected-wave read window.
+   *
+   * <p>Metadata/index-only fragment deltas are state updates; the projector must route them to the
+   * previous viewport or document fallback path instead of replacing visible blips.
+   */
   boolean hasBlipEntries() {
     for (Entry entry : entries) {
       if (entry.isBlip()) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -13,12 +13,14 @@ import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
+import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 @J2clTestInput(J2clSelectedWaveProjectorTest.class)
 public class J2clSelectedWaveProjectorTest {
   private static final String WAVE_ID = "example.com/w+1";
   private static final String WAVELET_NAME = "example.com!w+1/example.com!conv+root";
   private static final String CHANNEL_ID = "chan-1";
+  private static final String INDEX_SEGMENT = "index";
   private static final String MANIFEST_SEGMENT = "manifest";
 
   // -- Read-state projection (issue #931) -------------------------------------
@@ -349,23 +351,7 @@ public class J2clSelectedWaveProjectorTest {
         J2clSelectedWaveProjector.project(
             WAVE_ID,
             digest("Wave A", "snippet", 0),
-            new SidecarSelectedWaveUpdate(
-                1,
-                WAVELET_NAME,
-                true,
-                CHANNEL_ID,
-                40L,
-                "HASH",
-                Arrays.asList("user@example.com"),
-                Collections.<SidecarSelectedWaveDocument>emptyList(),
-                new SidecarSelectedWaveFragments(
-                    40L,
-                    30L,
-                    40L,
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 40L)),
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            rootFragmentUpdate(1, 40L, "HASH", "Root text"),
             null,
             0);
 
@@ -382,14 +368,7 @@ public class J2clSelectedWaveProjectorTest {
                 "HASH2",
                 Arrays.asList("user@example.com"),
                 Collections.<SidecarSelectedWaveDocument>emptyList(),
-                new SidecarSelectedWaveFragments(
-                    44L,
-                    40L,
-                    44L,
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 40L, 44L)),
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)))),
+                metadataOnlyFragments(44L, 40L, 44L)),
             first,
             0);
 
@@ -416,20 +395,143 @@ public class J2clSelectedWaveProjectorTest {
                 Arrays.asList(
                     new SidecarSelectedWaveDocument(
                         "b+root", "user@example.com", 44L, 45L, "Document text")),
-                new SidecarSelectedWaveFragments(
-                    44L,
-                    40L,
-                    44L,
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 40L, 44L)),
-                    Arrays.asList(
-                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)))),
+                metadataOnlyFragments(44L, 40L, 44L)),
             null,
             0);
 
     Assert.assertEquals(1, projected.getViewportState().getEntries().size());
     Assert.assertEquals("b+root", projected.getViewportState().getEntries().get(0).getBlipId());
     Assert.assertEquals("Document text", projected.getViewportState().getEntries().get(0).getRawSnapshot());
+  }
+
+  @Test
+  public void projectDoesNotCarryMetadataOnlyFragmentsAcrossWaveSwitch() {
+    J2clSelectedWaveModel previous =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            rootFragmentUpdate(1, 40L, "HASH", "Root text"),
+            null,
+            0);
+
+    J2clSelectedWaveModel switched =
+        J2clSelectedWaveProjector.project(
+            "example.com/w+2",
+            null,
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                metadataOnlyFragments(44L, 40L, 44L)),
+            previous,
+            0);
+
+    Assert.assertTrue(switched.getViewportState().isEmpty());
+    Assert.assertTrue(switched.getReadBlips().isEmpty());
+  }
+
+  @Test
+  public void projectMixedMetadataAndBlipFragmentsReplacePreviousViewportWindow() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            rootFragmentUpdate(1, 40L, "HASH", "Old root text"),
+            null,
+            0);
+
+    J2clSelectedWaveModel mixedFragments =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                50L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    50L,
+                    45L,
+                    50L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, 45L, 50L),
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 45L, 50L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0),
+                        new SidecarSelectedWaveFragment("blip:b+root", "New root text", 0, 0)))),
+            first,
+            0);
+
+    Assert.assertEquals(50L, mixedFragments.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(2, mixedFragments.getViewportState().getEntries().size());
+    Assert.assertEquals(
+        "metadata",
+        entryBySegment(mixedFragments.getViewportState(), MANIFEST_SEGMENT).getRawSnapshot());
+    Assert.assertEquals(
+        "New root text",
+        entryBySegment(mixedFragments.getViewportState(), "blip:b+root").getRawSnapshot());
+  }
+
+  @Test
+  public void projectPreservesDocumentMergedViewportAcrossMetadataOnlyFragments() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            rootFragmentUpdate(1, 40L, "HASH", "Root text"),
+            null,
+            0);
+
+    J2clSelectedWaveModel documentMerged =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 44L, 45L, "Document text")),
+                null),
+            first,
+            0);
+
+    J2clSelectedWaveModel metadataOnly =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                3,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                45L,
+                "HASH3",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                metadataOnlyFragments(45L, 44L, 45L)),
+            documentMerged,
+            0);
+
+    Assert.assertEquals(44L, metadataOnly.getViewportState().getSnapshotVersion());
+    Assert.assertEquals(1, metadataOnly.getViewportState().getEntries().size());
+    Assert.assertEquals("b+root", metadataOnly.getViewportState().getEntries().get(0).getBlipId());
+    Assert.assertEquals(
+        "Document text", metadataOnly.getViewportState().getEntries().get(0).getRawSnapshot());
   }
 
   @Test
@@ -542,6 +644,58 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals(2, second.getViewportState().getEntries().size());
     Assert.assertEquals("b+reply", second.getViewportState().getEntries().get(1).getBlipId());
     Assert.assertEquals(44L, second.getViewportState().getEntries().get(1).getToVersion());
+  }
+
+  @Test
+  public void projectMergesDocumentOnlyUpdateWithoutWideningKnownFragmentStart() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                50L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    50L,
+                    30L,
+                    50L,
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragmentRange("blip:b+root", 30L, 50L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0)))),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                20L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 20L, 21L, "Older document text")),
+                null),
+            first,
+            0);
+
+    J2clSelectedWaveViewportState.Entry root = second.getViewportState().getEntries().get(0);
+    Assert.assertEquals(30L, second.getViewportState().getStartVersion());
+    Assert.assertEquals(30L, root.getFromVersion());
+    Assert.assertEquals(50L, root.getToVersion());
+    Assert.assertEquals("Older document text", root.getRawSnapshot());
   }
 
   @Test
@@ -741,6 +895,34 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectKeepsNonBlipDocumentsAsNonReadViewportEntries() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "conversation", "user@example.com", 7L, 8L, "metadata")),
+                null),
+            null,
+            0);
+
+    J2clSelectedWaveViewportState.Entry entry = projected.getViewportState().getEntries().get(0);
+    Assert.assertEquals("conversation", entry.getSegment());
+    Assert.assertFalse(entry.isBlip());
+    Assert.assertTrue(entry.isLoaded());
+    Assert.assertTrue(projected.getViewportState().getReadWindowEntries().isEmpty());
+  }
+
+  @Test
   public void mergeFragmentsDoesNotDowngradeLoadedEntryWithPlaceholderOverlap() {
     J2clSelectedWaveViewportState initial =
         J2clSelectedWaveViewportState.fromFragments(
@@ -759,13 +941,40 @@ public class J2clSelectedWaveProjectorTest {
                 48L,
                 Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 44L, 48L)),
                 Arrays.asList(new SidecarSelectedWaveFragment("blip:b+root", null, 0, 0))),
-            "forward");
+            J2clViewportGrowthDirection.FORWARD);
 
     J2clSelectedWaveViewportState.Entry root = merged.getEntries().get(0);
     Assert.assertTrue(root.isLoaded());
     Assert.assertEquals("Root text", root.getRawSnapshot());
     Assert.assertEquals(40L, root.getFromVersion());
     Assert.assertEquals(48L, root.getToVersion());
+  }
+
+  @Test
+  public void mergeFragmentsPrependsMissingEntriesForBackwardGrowth() {
+    J2clSelectedWaveViewportState initial =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                44L,
+                40L,
+                44L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 40L, 44L)),
+                Arrays.asList(new SidecarSelectedWaveFragment("blip:b+root", "Root text", 0, 0))));
+
+    J2clSelectedWaveViewportState merged =
+        initial.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                48L,
+                36L,
+                40L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+before", 36L, 40L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment("blip:b+before", "Before text", 0, 0))),
+            J2clViewportGrowthDirection.BACKWARD);
+
+    Assert.assertEquals(2, merged.getEntries().size());
+    Assert.assertEquals("b+before", merged.getEntries().get(0).getBlipId());
+    Assert.assertEquals("b+root", merged.getEntries().get(1).getBlipId());
   }
 
   @Test
@@ -1015,6 +1224,53 @@ public class J2clSelectedWaveProjectorTest {
         Arrays.asList("user@example.com"),
         new ArrayList<SidecarSelectedWaveDocument>(),
         null);
+  }
+
+  private static SidecarSelectedWaveUpdate rootFragmentUpdate(
+      int sequence, long version, String historyHash, String rawSnapshot) {
+    // Keep the helper window non-zero so tests catch accidental range downgrades.
+    long fromVersion = version - 10L;
+    return new SidecarSelectedWaveUpdate(
+        sequence,
+        WAVELET_NAME,
+        true,
+        CHANNEL_ID,
+        version,
+        historyHash,
+        Arrays.asList("user@example.com"),
+        Collections.<SidecarSelectedWaveDocument>emptyList(),
+        new SidecarSelectedWaveFragments(
+            version,
+            fromVersion,
+            version,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("blip:b+root", fromVersion, version)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
+  }
+
+  private static SidecarSelectedWaveFragments metadataOnlyFragments(
+      long snapshotVersion, long fromVersion, long toVersion) {
+    return new SidecarSelectedWaveFragments(
+        snapshotVersion,
+        fromVersion,
+        toVersion,
+        Arrays.asList(
+            new SidecarSelectedWaveFragmentRange(INDEX_SEGMENT, fromVersion, toVersion),
+            new SidecarSelectedWaveFragmentRange(MANIFEST_SEGMENT, fromVersion, toVersion)),
+        Arrays.asList(
+            new SidecarSelectedWaveFragment(INDEX_SEGMENT, "index", 0, 0),
+            new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)));
+  }
+
+  private static J2clSelectedWaveViewportState.Entry entryBySegment(
+      J2clSelectedWaveViewportState viewport, String segment) {
+    for (J2clSelectedWaveViewportState.Entry entry : viewport.getEntries()) {
+      if (segment.equals(entry.getSegment())) {
+        return entry;
+      }
+    }
+    throw new AssertionError("Missing segment: " + segment);
   }
 
   private static SidecarSelectedWaveUpdate updateWithVersionAndHash(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -19,6 +19,7 @@ import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 public class J2clSelectedWaveProjectorTest {
   private static final String WAVE_ID = "example.com/w+1";
   private static final String WAVELET_NAME = "example.com!w+1/example.com!conv+root";
+  private static final String WAVELET_NAME_2 = "example.com!w+2/example.com!conv+root";
   private static final String CHANNEL_ID = "chan-1";
   private static final String INDEX_SEGMENT = "index";
   private static final String MANIFEST_SEGMENT = "manifest";
@@ -420,7 +421,7 @@ public class J2clSelectedWaveProjectorTest {
             null,
             new SidecarSelectedWaveUpdate(
                 2,
-                WAVELET_NAME,
+                WAVELET_NAME_2,
                 true,
                 CHANNEL_ID,
                 44L,
@@ -1229,7 +1230,7 @@ public class J2clSelectedWaveProjectorTest {
   private static SidecarSelectedWaveUpdate rootFragmentUpdate(
       int sequence, long version, String historyHash, String rawSnapshot) {
     // Keep the helper window non-zero so tests catch accidental range downgrades.
-    long fromVersion = version - 10L;
+    long fromVersion = Math.max(0L, version - 10L);
     return new SidecarSelectedWaveUpdate(
         sequence,
         WAVELET_NAME,


### PR DESCRIPTION
## Summary
- Adds focused J2CL selected-wave viewport regression coverage for metadata-only fragment deltas, wave switches, mixed metadata+blip replacement, non-blip documents, backward growth, and document merge version bounds.
- Documents the `b+` document-id convention, metadata-only routing, legacy fallback TODO under #904, and why document-only updates do not widen known fragment windows.
- Follow-up to merged PR #992 for issue #967 after the review loop completed after the merge race.

## Verification
- `sbt -batch "testOnly org.waveprotocol.box.server.frontend.ViewportLimitPolicyTest org.waveprotocol.box.server.rpc.FragmentsServletViewportLimitTest org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest" j2clSearchBuild j2clSearchTest`
- `rg "extractContentEntries|extractReadBlips|blipIdFromSegment" -n j2cl/src/main/java j2cl/src/test/java` returned no matches
- `git diff --check`
- `python3 scripts/validate-changelog.py`

Claude review: final focused Opus review returned `conclusion: pass`; remaining notes were non-blocking follow-up suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Clarified viewport/fragment behavior and centralized internal identifiers for conversational documents; documented fallback handling with a temporary TODO note.

* **Tests**
  * Expanded tests for fragment handling, including metadata-only scenarios, viewport merge directions, document-merge regressions, and segment-specific assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->