### PR TITLE
J2CL root live surface status

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-968-root-live-surface.md
+++ b/docs/superpowers/plans/2026-04-23-issue-968-root-live-surface.md
@@ -1,0 +1,560 @@
+# Issue #968 Root-Shell Live Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote the current J2CL sidecar workflow into a durable StageTwo-like live surface inside the J2CL root shell, covering route/history continuity, reconnect, selected-wave/open-state continuity, read-state/live-state wiring, and root-level integration with the existing shell/bootstrap seams, without widening into StageThree compose parity or a default-root cutover.
+
+**Architecture:** Keep J2CL authoritative for the live-runtime state machine. The root shell should stop behaving like "the sidecar widget mounted in a different div" and instead gain a root-scoped live-runtime coordinator that owns bootstrap/session state, route state, reconnect status, selected-wave continuity, and fragment-policy inputs. The existing search, selected-wave, and compose controllers remain the narrowest reusable seams, but they should be composed under a root-runtime owner rather than each independently reacquiring bootstrap and lifecycle state. Lit stays visual-only for this slice: existing shell primitives and status-strip slots render state that J2CL publishes.
+
+**Tech Stack:** J2CL Java under `j2cl/src/main/java`, Jakarta servlet/rendering seams under `wave/src/jakarta-overrides/java`, generated protocol models under `gen/messages/`, existing root-shell Lit primitives under `j2cl/lit/`, the explicit `/bootstrap.json` contract from `#963`, the unread/read-state path from `#931`, server-side viewport-hint support under `WaveClientRpcImpl`, and targeted J2CL/server unit tests plus local browser verification on `/?view=j2cl-root`.
+
+---
+
+## 1. Goal / Baseline / Root Cause
+
+### 1.1 Current baseline in this worktree
+
+The current repo state already provides several of the prerequisites `#968` must consume rather than recreate:
+
+- `#933` is closed: J2CL sidecar/root-shell sockets now rely on the WebSocket upgrade handshake and host-match guard instead of a client-side auth frame. The current outbound frame contract is covered by `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`.
+- `#931` is closed: the selected-wave panel already has real unread/read-state fetching, debounce, reconnect persistence, and visibility-based refresh inside `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`.
+- `#963` is closed: root/session/socket metadata now come from `/bootstrap.json`, served by `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`, with the contract pinned in `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`.
+- `#964` is closed: the root shell already exposes Lit shell primitives such as `shell-main-region` and `shell-status-strip`, and `HtmlRenderer.renderJ2clRootShellPage(...)` mounts the J2CL bundle into the existing shell page.
+
+### 1.2 Exact current seams
+
+These seams are the actual starting point for `#968`:
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java:21-69`
+  - The root shell currently just instantiates the existing `J2clSearchPanelController`, `J2clSelectedWaveController`, `J2clSidecarComposeController`, and `J2clSidecarRouteController` directly.
+  - There is no root-scoped live-runtime owner. The root shell is still a composition wrapper around the sidecar controllers.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java:102-138`
+  - Route/history state is still the sidecar route model: query + selected-wave id, optionally pinned behind `view=j2cl-root`.
+  - The controller is already root-shell aware enough to preserve the explicit selector, but it is still named and scoped as sidecar route state, not a root-runtime route contract.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:238-500`
+  - Reconnect, read-state refresh, and visibility-refresh logic already exist, but they are owned entirely by the selected-wave controller.
+  - Bootstrap is refetched on open/reconnect from inside this controller, which keeps session/bootstrap lifecycle controller-local instead of root-scoped.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:45-115`
+  - Selected-wave open still creates a socket per opened wave and sends a manual `ProtocolOpenRequest` frame.
+  - The gateway fetches bootstrap and opens sockets, but it does not own a shared root session/bootstrap snapshot or any root-runtime continuity.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java:7-31`
+  - The sidecar open request carries only participant id, wave id, and wavelet prefixes.
+  - It has no fields for `viewportStartBlipId`, `viewportDirection`, or `viewportLimit`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:13-30`
+  - The manual JSON encoder writes only fields `"1"`, `"2"`, and `"3"` into the `ProtocolOpenRequest` payload.
+  - It does not expose the viewport-hint fields the server already understands.
+- `gen/messages/org/waveprotocol/box/common/comms/proto/ProtocolOpenRequestProtoImpl.java:856-900`
+  - The generated protocol model already reserves the JSON/proto slots for viewport hints:
+    - `"5"` = `viewportStartBlipId`
+    - `"6"` = `viewportDirection`
+    - `"7"` = `viewportLimit`
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:371-427`
+  - The server already validates/clamps viewport hints and selects visible segments accordingly.
+  - This means the server-side StageTwo/fragment seam already exists; the J2CL sidecar/root-shell transport simply does not reach it yet.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3327-3415`
+  - The root-shell bootstrap script already normalizes legacy hash deep links, hooks `pushState`/`replaceState`, and keeps auth return-target links in sync.
+  - That means route-awareness is currently split between inline server JS and `J2clSidecarRouteController`.
+- `j2cl/lit/src/elements/shell-status-strip.js`
+  - The shell already has a status/live-region surface. `#968` should publish live runtime state into this existing seam, not invent a parallel root status DOM.
+
+### 1.3 Root cause
+
+The missing piece is not "more selected-wave logic." The missing piece is a durable StageTwo-like root-runtime owner.
+
+Today:
+
+- bootstrap/session state is reacquired independently by search, selected-wave open, and compose flows;
+- route/history state is split between root-shell bootstrap JS and the sidecar route controller;
+- reconnect/read-state continuity lives inside the selected-wave widget;
+- viewport-fragment policy is supported by the server but not by the J2CL open-frame encoder;
+- root-shell chrome has a live-status surface, but no root-runtime controller publishes live state into it.
+
+That is why parity docs still describe the live runtime as controller-local and sidecar-oriented. `#968` is the slice that turns those seams into one root-scoped live surface.
+
+## 2. Acceptance Criteria
+
+`#968` is complete when all of the following are true:
+
+- The J2CL root shell has a root-scoped live-runtime coordinator that owns:
+  - bootstrap/session state,
+  - route/history continuity,
+  - selected-wave continuity,
+  - reconnect state,
+  - read-state/live-state publication,
+  - fragment-policy inputs for selected-wave opens.
+- `/?view=j2cl-root` preserves query + selected-wave deep links across:
+  - initial load,
+  - back/forward,
+  - reconnect,
+  - reload,
+  - sign-in/sign-out return-target navigation.
+- Reconnect no longer behaves as an internal selected-wave widget concern only:
+  - the root shell surfaces reconnect state in its status strip,
+  - the selected wave remains logically selected during reconnect,
+  - the last known read state survives transient failures,
+  - successful recovery resets the reconnect budget.
+- The J2CL open-frame path can carry viewport hints using the existing protocol fields already supported by the server, so the root live surface can consume the `#967` fragment-window state instead of whole-wave default behavior.
+- `#931` unread/read modeling is consumed as part of the root live surface rather than treated as an isolated selected-wave label feature.
+- The shell consumes live-state visuals through existing Lit/root-shell seams only:
+  - `shell-status-strip` for reconnect and root-runtime status,
+  - existing read/unread surfaces for unread state.
+- Existing compose handoff via `J2clSidecarWriteSession` remains intact and atomic-version behavior from `#936` is not regressed.
+- No new rollout flag is introduced by default:
+  - `j2cl-root-bootstrap` remains the only rollout/coexistence seam unless implementation proves a narrower live-surface sub-flag is strictly necessary.
+- No change is made to:
+  - default `/` root routing,
+  - StageThree compose parity (`#969`),
+  - Lit read-surface parity (`#966`),
+  - fragment-window modeling itself (`#967`),
+  - server-first read HTML (`#965`),
+  - the GWT rollback seam.
+
+## 3. Scope And Non-Goals
+
+### 3.1 In scope
+
+- Root-runtime ownership of bootstrap/session lifecycle inside the J2CL root shell.
+- Root-runtime ownership of route/history continuity for the current query + selected-wave deep-link model.
+- Publishing reconnect/live-state into the root shell status surface.
+- Wiring the existing unread/read-state path from `#931` into the root live surface contract.
+- Extending the J2CL open request so it can send viewport hints already supported by the server.
+- Targeted J2CL/server tests and root-shell browser verification.
+
+### 3.2 Explicit non-goals
+
+- No StageOne read-surface implementation work from `#966`.
+- No fragment-window modeling or visible-region rendering work from `#967`.
+- No StageThree compose/editor parity from `#969`.
+- No attempt to aggregate ephemeral compose/search socket lifecycles into the root reconnect-status strip in `#968`; root reconnect publication is limited to the selected-wave live surface plus bootstrap refresh continuity.
+- No new server protocol beyond exposing existing `ProtocolOpenRequest` viewport fields already present in generated models.
+- No default-root cutover.
+- No rollback/coexistence change in `WaveClientServlet`.
+- No redesign of shell primitives or new Stitch work; `#964` and the design packet already own that.
+
+## 4. Dependency Readiness
+
+### 4.1 Closed prerequisites
+
+As of 2026-04-23 in this worktree:
+
+- `#933` — closed
+- `#931` — closed
+- `#963` — closed
+- `#964` — closed
+- `#936` — closed
+
+These closed issues mean the auth, unread/read modeling, bootstrap JSON, root-shell chrome, and atomic write-basis seams are already available.
+
+### 4.2 Open dependencies and readiness call
+
+As of 2026-04-23:
+
+- `#966` — open
+- `#967` — open
+- `#965` — open
+
+Readiness call:
+
+- Planning is ready now.
+- Full implementation is **not** ready to merge until `#966` and `#967` land, because the parity matrix ties:
+  - `R-4.6` to `#967`,
+  - `R-7.3` to `#967`,
+  - the practical root read/live handoff to the StageOne read surface from `#966`.
+- `#965` is an adjacent integration edge, not a declared hard blocker in the issue body, but the implementation lane should pull its latest root-shell host changes before coding so `#968` does not hardcode against a stale shell-swap surface.
+- If `#966` and `#967` merge before `#965`, pause and decide explicitly whether to:
+  - pull the latest `#965` branch/worktree changes into the lane for the diff-check, or
+  - wait for `#965` to merge.
+  Do not guess the host contract in that state.
+
+Implementation verdict: `#968` is **dependency-ready for planning/prep only**. The worker lane should wait for `#966` and `#967` to merge before landing code.
+
+## 5. Slice Packet For #968
+
+**Title:** Promote the J2CL sidecar into a root-shell live surface with route/history/reconnect/read-state integration
+**Stage:** live
+**Dependencies:** `#933`, `#931`, `#963`, `#966`, `#967`
+
+### Matrix rows claimed
+
+- `R-4.1` — socket/session lifecycle
+- `R-4.3` — reconnect
+- `R-4.5` — route/history integration
+- `R-4.7` — feature activation and live-update application
+
+### Matrix rows shared / coordinated
+
+- `R-4.4` — read/unread state live updates
+  - modeling was introduced by `#931`
+  - `#968` owns root-live-surface wiring and continuity consumption
+- `R-4.6` — fragment fetch policy
+  - transport/window modeling belongs to `#967`
+  - `#968` owns the live-runtime side that consumes the resulting viewport state
+- `R-7.3` — server clamp behavior
+  - server behavior already exists
+  - `#968` owns client-side visibility/telemetry surfacing once `#967` lands
+
+### Existing seams consumed
+
+- Bootstrap JSON: `J2clBootstrapServlet` + `J2clBootstrapContract`
+- Root-shell mount: `HtmlRenderer.renderJ2clRootShellPage(...)` + `WaveSandboxEntryPoint.mount(..., "root-shell")`
+- Root-shell live status surface: `shell-status-strip`
+- Route/history persistence: `J2clSidecarRouteController`
+- Selected-wave reconnect/read-state: `J2clSelectedWaveController`
+- Server viewport-hint support: `WaveClientRpcImpl` + `WaveClientRpcViewportHintsTest`
+
+### Rollout / rollback seam
+
+- Route: `/?view=j2cl-root`
+- Flag/coexistence seam: `j2cl-root-bootstrap`
+- Default `/` stays on legacy GWT unless the existing feature flag says otherwise
+- `#968` must not alter the rollback contract
+
+## 6. Exact Files Likely To Change
+
+### New J2CL files
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java`
+  - Root-scoped live-runtime owner for bootstrap/session state, route continuity, reconnect status, selected-wave continuity, and root status publication.
+  - It does not replace `J2clRootShellController` as the composition root; it owns lifecycle wiring and cross-controller coordination after the composition root instantiates the child views/controllers.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java`
+  - Immutable root-runtime snapshot published to shell/status surfaces.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java`
+  - Focused tests for root-runtime lifecycle, stale-bootstrap drops, and reconnect/route continuity.
+
+### Modified J2CL files
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+  - Becomes a thin composition root that delegates live-runtime ownership to `J2clRootLiveSurfaceController`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`
+  - Expose/set root live-status content through the existing shell status surface, not only the return-target label.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java`
+  - Preserve current URL contract, but promote root-shell route/history behavior from "sidecar route" to the root live surface's authoritative route seam.
+  - No class rename is planned in `#968`; the issue should prefer behavioral ownership changes over naming churn.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java`
+  - Expand only if additional root-runtime route metadata is strictly needed after `#966/#967` land.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java`
+  - Remains the URL codec; may need narrow extensions for root-runtime continuity only.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java`
+  - Narrow bootstrap/session wiring change only if the root coordinator becomes the single bootstrap owner. Compose/write-session semantics remain unchanged.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+  - Shift from widget-local lifecycle owner to selected-wave/live-channel controller under the root runtime.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  - Preserve last-known read/reconnect continuity under root-runtime ownership.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  - Continue to consume read-state and fragment data, but do not own root-runtime continuity decisions.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
+  - Shared bootstrap/session access, open-frame viewport hints, and any root-runtime transport helpers.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java`
+  - Add viewport-hint fields.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+  - Extend `ProtocolOpenRequest` encoding to include viewport fields `5/6/7`.
+
+### Modified tests
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+  - Existing transport test file; extend it rather than creating a duplicate transport-codec suite.
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java`
+  - Existing bootstrap JSON regression coverage; verify the signed-out contract still degrades cleanly once the root runtime becomes the single bootstrap owner.
+
+### Changelog / rollout traceability
+
+- `wave/config/changelog.d/2026-04-23-root-live-surface.json`
+  - Required when implementation lands because `#968` changes user-visible root-shell live behavior.
+
+### Inspect-only references
+
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java`
+  - Existing server-side viewport-hint + clamp logic; not expected to change for `#968`.
+- `wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java`
+  - Existing server regression coverage for viewport hints/clamps.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+  - Existing bootstrap/session/shell metadata seam.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+  - Existing root-shell bootstrap JS and history hook seam.
+- `j2cl/lit/src/elements/shell-status-strip.js`
+  - Existing root live-region/status surface.
+- `j2cl/lit/src/elements/shell-main-region.js`
+  - Existing shell primitive; `#968` should keep using the current slot/mount contract rather than introducing a new Lit surface.
+
+## 7. Task Breakdown
+
+### Task 1: Freeze the dependency gate and root-runtime boundary
+
+- [ ] Keep `#968` scoped to the root-runtime/state-machine layer only.
+- [ ] Treat `#966` and `#967` as merge gates for implementation, not as work to subsume into `#968`.
+- [ ] Record in the issue comment:
+  - worktree path,
+  - branch,
+  - plan path,
+  - closed prerequisites,
+  - open blockers (`#966`, `#967`),
+  - adjacent integration edge (`#965`).
+
+### Task 2: Introduce a root-scoped live-runtime coordinator
+
+- [ ] Add `J2clRootLiveSurfaceController` under `org.waveprotocol.box.j2cl.root`.
+- [ ] Keep `J2clRootShellController` as the composition root that instantiates the child views/controllers.
+- [ ] Move root-runtime lifecycle ownership out of `J2clRootShellController.start()` and into the new coordinator.
+- [ ] The new coordinator should own:
+  - current bootstrap snapshot,
+  - current route state,
+  - current selected-wave id,
+  - reconnect status,
+  - root status-strip publication,
+  - cross-controller coordination after the composition root has instantiated the child controllers.
+- [ ] `J2clRootShellController` should become a thin adapter:
+  - construct `J2clRootShellView`,
+  - construct the child search/selected-wave/compose views,
+  - delegate to `J2clRootLiveSurfaceController.start()`.
+- [ ] Add `J2clRootLiveSurfaceControllerTest` to lock:
+  - stale bootstrap results are ignored after route reselection,
+  - reconnect preserves the selected-wave id,
+  - root status survives transient disconnects,
+  - root-shell startup still mounts through the existing workflow host,
+  - signed-out bootstrap responses leave the root shell stable and keep auth return-target links intact.
+
+### Task 3: Make route/history authority explicitly root-scoped
+
+- [ ] Keep `J2clSidecarRouteController` as the current URL codec/controller seam rather than inventing a second router.
+- [ ] Re-scope its usage so the root live coordinator, not individual child widgets, owns the current route state.
+- [ ] Preserve the existing root-shell URL contract:
+  - `?view=j2cl-root&q=...&wave=...`
+  - legacy hash deep-link normalization still happens once during server bootstrap
+  - post-mount updates come from the J2CL route controller
+- [ ] Explicit legacy-hash handoff contract:
+  - the inline server bootstrap JS may do the one-time `replaceState(...)` normalization before J2CL mounts,
+  - `J2clRootLiveSurfaceController.start()` must treat `location.search` as authoritative when it already contains `?view=j2cl-root...` and `location.hash` no longer carries a legacy wave token,
+  - the coordinator must not re-run hash normalization or write a duplicate history entry on initial mount if the server bootstrap already normalized the URL.
+- [ ] Keep `routeUrlObserver -> J2clRootShellView.syncReturnTarget(...)` as the steady-state same-origin auth-link/return-target seam.
+- [ ] Extend route tests to cover:
+  - root-shell start after server hash normalization,
+  - the server bootstrap JS one-time normalization does not lead the coordinator to emit a second boot-time history mutation,
+  - back/forward after reconnect,
+  - no duplicate push on internal metadata/read-state refresh,
+  - deep-link restore after a reconnect-driven bootstrap refresh.
+
+### Task 4: Promote bootstrap/session lifecycle from controller-local to root-scoped
+
+- [ ] Stop treating bootstrap fetch as something each controller reacquires independently.
+- [ ] The root live coordinator should fetch `/bootstrap.json` at root-shell start and publish the current `SidecarSessionBootstrap` to child flows.
+- [ ] Only refresh bootstrap when required:
+  - initial boot,
+  - reconnect after a transport failure,
+  - explicit root-runtime invalidation.
+- [ ] Preserve current signed-out behavior from `J2clBootstrapServlet` and root-shell auth links.
+- [ ] If compose needs the shared bootstrap snapshot, make that a narrow `J2clSidecarComposeController` wiring change only:
+  - inject the root-owned bootstrap snapshot or supplier,
+  - keep compose/write-session behavior otherwise unchanged,
+  - do not widen this issue into StageThree compose work.
+- [ ] Extend tests to prove:
+  - search, selected-wave open, and compose can share one stable bootstrap snapshot,
+  - stale bootstrap responses do not overwrite a newer route selection,
+  - reconnect refreshes bootstrap only when needed,
+  - signed-out `/bootstrap.json` responses keep the root shell stable instead of throwing the runtime into a dead-end error state,
+  - stale bootstrap responses delivered through the compose bootstrap supplier path are dropped under the same route-generation guard as search/selected-wave paths.
+- [ ] Reconnect-driven bootstrap refresh failure mode:
+  - if `/bootstrap.json` returns a transient 5xx or network failure during reconnect,
+  - keep the last selected wave + route state intact,
+  - surface the failure in the root status strip,
+  - log dropped/stale bootstrap callbacks with the `[j2cl-root-live]` prefix,
+  - continue using the existing bounded reconnect/backoff path rather than clearing selection or pushing a new route.
+- [ ] Session-expired reconnect branch:
+  - if `/bootstrap.json` comes back signed out / auth-required during reconnect,
+  - keep the current route/return target intact,
+  - surface a session-expired message in the root status strip,
+  - preserve working sign-in return-target links instead of pretending the live surface recovered.
+- [ ] Use one explicit stale-bootstrap guard in the root coordinator:
+  - a monotonic `routeGeneration` (or equivalently named) counter increments on every route selection / bootstrap-invalidating transition,
+  - every async bootstrap callback carries the generation it was issued under,
+  - callbacks whose generation no longer matches are dropped.
+- [ ] Lock that guard with a dedicated `J2clRootLiveSurfaceControllerTest` case rather than leaving the stale-drop behavior as prose only.
+
+### Task 5a: Add viewport-hint transport plumbing on the J2CL sidecar/root path
+
+- [ ] Extend `SidecarOpenRequest` with:
+  - `viewportStartBlipId`
+  - `viewportDirection`
+  - `viewportLimit`
+- [ ] Extend `SidecarTransportCodec.encodeOpenEnvelope(...)` to emit fields:
+  - `"5"` for `viewportStartBlipId`
+  - `"6"` for `viewportDirection`
+  - `"7"` for `viewportLimit`
+  matching the generated `ProtocolOpenRequest` contract already used by the GWT client and server.
+- [ ] Do not hand-guess new protocol semantics; reuse the existing generated field numbering already present in `gen/messages/.../ProtocolOpenRequestProtoImpl.java`.
+- [ ] Extend `SidecarTransportCodecTest` as the canonical transport-encoding home for these assertions, and keep `J2clSearchGatewayAuthFrameTest` focused on the no-auth-envelope contract.
+- [ ] In `SidecarTransportCodecTest`, prove:
+  - open frames still begin with `ProtocolOpenRequest`,
+  - no auth envelope regresses,
+  - viewport fields are present only when explicitly set,
+  - a default-constructed / unset `SidecarOpenRequest` emits no viewport fields at all,
+  - pre-`#967` caller paths do not emit viewport fields accidentally,
+  - the JSON key set remains backward-compatible with the current GWT/ProtocolOpenRequest schema: required keys stay `1/2/3`, with `5/6/7` present only as optional additions.
+- [ ] Keep this transport plumbing in the same `#968` implementation lane; do not merge it independently before `#967`.
+
+### Task 5b: Feed real fragment-window state into the open request after `#967`
+
+- [ ] Gate the caller-side wiring on pulling `#967` once it merges.
+- [ ] Use the actual fragment-window/visible-region state from `#967` as the source of:
+  - `viewportStartBlipId`
+  - `viewportDirection`
+  - `viewportLimit`
+- [ ] Do not invent a temporary heuristic source in `#968`; if `#967` is not merged, Task 5b remains blocked and `#968` does not merge.
+
+### Task 6: Re-scope selected-wave reconnect/read-state behavior under the root live surface
+
+- [ ] Keep `J2clSelectedWaveController` as the selected-wave stream/read-state coordinator, but make it a child of the new root live controller rather than the top-level owner.
+- [ ] `J2clSelectedWaveController` should continue to own its existing socket-local behavior from `#931`:
+  - reconnect backoff scheduling,
+  - reconnect budget counting and reset on successful update,
+  - read-state debounce,
+  - visibility-refresh fetches,
+  - stale-callback / stale-generation drops,
+  - `J2clSidecarWriteSession` derivation.
+- [ ] The root live controller should own only the cross-controller continuity decisions:
+  - selected wave stays selected during reconnect,
+  - last known read state is preserved through transient failures,
+  - reconnect status is published to the root shell,
+  - successful recovery is reflected in root status text based on the child controller's published reconnect state,
+  - route state remains authoritative through reconnect/reload.
+- [ ] Ownership boundary rule:
+  - `J2clSelectedWaveController` remains the authoritative owner of reconnect budget/counter state,
+  - `J2clRootLiveSurfaceController` may only read and publish that state,
+  - the root coordinator must not increment, reset, or shadow a second reconnect counter.
+- [ ] Preserve `J2clSidecarWriteSession` handoff to compose unchanged aside from any narrow bootstrap-supplier wiring from Task 4.
+- [ ] Extend `J2clSelectedWaveControllerTest` to prove:
+  - reconnect preserves root-level selected-wave continuity,
+  - stale reopen/update callbacks are ignored after route change,
+  - root-runtime status does not regress when read-state fetches fail softly,
+  - visibility refresh still closes the UDW-only-change gap from `#931`,
+  - reconnect/bootstrap refresh preserves the current write-session `historyHash` / base-version continuity required by `#936`,
+  - compose-path submit wiring still sees the preserved write-session continuity after the root-owned bootstrap supplier path is introduced.
+- [ ] Extend `J2clRootLiveSurfaceControllerTest` to prove the reconnect-counter single-owner rule:
+  - the child `J2clSelectedWaveController` remains the only mutator of reconnect-budget state,
+  - the root coordinator only reads/publishes that state and never increments/resets a shadow counter.
+- [ ] Keep `J2clSelectedWaveModel` / `J2clSelectedWaveProjector` changes concrete and narrow:
+  - only the fields/projection needed to preserve current read-state + write-session continuity under the root-runtime owner,
+  - no new presentation semantics beyond what `#931` already introduced.
+
+### Task 7: Publish live state into the existing root shell chrome
+
+- [ ] Extend `J2clRootShellView` so it can render root live status into the existing `shell-status-strip` seam.
+- [ ] Publish:
+  - reconnect in progress / reconnected,
+  - current return target,
+  - selected-wave continuity summary when relevant.
+- [ ] Reuse design-packet visual vocabulary only:
+  - `shell-status-strip` from `#964`
+  - `live-reconnect-banner` / unread-read indicator concepts from `docs/j2cl-lit-design-packet.md` heading `### 5.3 Live-Surface Visual Indicators`
+- [ ] Existing unread/read state continues to render through the current selected-wave J2CL surface (`J2clSelectedWaveView`) unless `#966`/`#967` have already moved that rendering seam.
+- [ ] Do not introduce a new Lit custom element for `#968` by default; prefer the existing `shell-status-strip` slot/light-DOM path.
+- [ ] If that proves insufficient, pause and update the plan + issue before adding a new Lit element.
+- [ ] Do not move behavioral ownership into Lit. Lit remains slot/render-only.
+- [ ] Accessibility contract for reconnect/state publication:
+  - `shell-status-strip` already renders with `aria-live=\"polite\"`,
+  - `#968` should keep that politeness level unless the plan/issue are explicitly updated.
+- [ ] Browser verification must confirm:
+  - reconnect is announced in the status strip/live region,
+  - focus is not stolen by reconnect messaging,
+  - auth links keep the correct return target after back/forward.
+
+### Task 8: Preserve feature activation and StageTwo parity seams
+
+- [ ] Add root-runtime assertions or status hooks that confirm the active live surface still has:
+  - search controller,
+  - selected-wave controller,
+  - compose controller,
+  - read-state refresh path.
+- [ ] Keep `#936` atomic write-basis behavior intact; no reconnect or route refactor may drop `historyHash`/base-version continuity.
+- [ ] Observability decision for `#968`:
+  - no new standalone telemetry channel by default,
+  - reuse the existing shell status-strip UI seam for user-visible state,
+  - reuse existing client logging/console seams from the root bootstrap and selected-wave controller for debugging,
+  - use a consistent root-runtime console/log prefix such as `[j2cl-root-live]` for lifecycle events that browser verification may need to inspect,
+  - if a reviewer requires explicit counters, update the plan/issue before widening scope.
+- [ ] Search-panel retries/loading remain request-local; the root status strip in `#968` does not aggregate search-request retry state.
+- [ ] Record the exact verification commands and browser steps in the issue and later PR.
+- [ ] Before implementation starts, diff the merged `#965` host-surface files against this worktree and record whether the root-shell host contract moved:
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
+  - `j2cl/lit/src/elements/shell-main-region.js`
+- [ ] When `#967` is pulled into the lane for Task 5b, re-diff the fragment-window transport seam and confirm the generated `ProtocolOpenRequest` field usage still maps to the same viewport slots (`5/6/7`) before wiring caller state.
+
+## 8. Verification Commands
+
+Run these from `/Users/vega/devroot/worktrees/issue-968-root-live-surface` once implementation starts and after `#966`/`#967` are merged into the lane:
+
+### Targeted J2CL/server test gates
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSidecarRouteControllerTest org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest org.waveprotocol.box.j2cl.search.J2clSearchGatewayAuthFrameTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.rpc.J2clBootstrapServletTest"
+```
+
+### Local root-shell browser verification
+
+```bash
+bash scripts/worktree-boot.sh --port 9968
+PORT=9968 bash scripts/wave-smoke.sh start
+PORT=9968 bash scripts/wave-smoke.sh check
+```
+
+Required browser path:
+
+- Open `http://localhost:9968/?view=j2cl-root` from the worktree root after running the commands above.
+- Open the same route while signed out and confirm the signed-out `/bootstrap.json` contract still produces a stable shell with working auth return-target links.
+- Complete one signed-out -> sign-in round trip and verify the return target lands back on the same root-shell route/deep link, including after a reconnect-triggering route restore during the session.
+- Open a deep link with both query and wave:
+  - `http://localhost:9968/?view=j2cl-root&q=in%3Ainbox&wave=example.com%2Fw%2Babc`
+- Open a legacy-hash deep link that the server bootstrap JS currently normalizes, then verify the J2CL route controller remains authoritative after mount:
+  - `http://localhost:9968/?view=j2cl-root#/example.com/w+abc`
+- With a selected wave open, background the tab long enough to miss any live update, modify/read the wave from another tab, then return and verify the visibility-refresh path still updates unread/read state without a route reset.
+- While signed in after that round trip, force a transient reconnect and verify unread/read continuity survives the reconnect-driven bootstrap refresh without changing the return target.
+- Verify:
+  - selected wave stays selected across reload
+  - back/forward preserve query + selected wave
+  - reconnect messaging appears in the shell status strip and clears on recovery
+  - reconnect/session-expired messaging stays `aria-live=\"polite\"` and does not steal focus
+  - unread/read state survives reconnect and visibility refresh
+  - fragment-window opens use the `#967` path rather than regressing to eager whole-wave behavior, but only after `#967` is merged into the lane and Task 5b is enabled
+  - browser logs with the `[j2cl-root-live]` prefix tell a coherent start -> route -> reconnect -> recover story during debugging
+
+Shutdown:
+
+```bash
+PORT=9968 bash scripts/wave-smoke.sh stop
+```
+
+## 9. Review And Traceability Gates
+
+- [ ] Run Claude Opus 4.7 review on this plan before implementation starts.
+- [ ] Do not start the implementation lane until:
+  - plan review is clean,
+  - `#966` is merged or otherwise pulled as final accepted base,
+  - `#967` is merged or otherwise pulled as final accepted base.
+- [ ] After implementation, run Claude Opus 4.7 review again on the implementation diff.
+- [ ] Feature-flag decision for implementation:
+  - default plan is to reuse only the existing `j2cl-root-bootstrap` seam
+  - if a narrower `#968`-specific live-surface flag becomes necessary, pause and update the issue + plan before adding it
+- [ ] Add a changelog fragment at `wave/config/changelog.d/2026-04-23-root-live-surface.json` when implementation lands.
+- [ ] Record on issue `#968`:
+  - worktree path,
+  - branch,
+  - plan path,
+  - seam findings,
+  - dependency-readiness note,
+  - plan-review result,
+  - commit SHA(s),
+  - verification commands/results when implementation eventually happens.
+
+## 10. Dependency-Readiness Verdict
+
+Planner verdict for 2026-04-23:
+
+- `#968` has enough closed foundation to write and review the implementation plan now.
+- `#968` should **not** start product implementation yet because `#966` and `#967` are still open and own part of the live-surface contract this issue must consume.
+- The implementation lane should resume only after those two issues are merged into `main` and pulled into the worktree, with `#965` checked for any root-shell host drift.
+- The listed verification commands are current in this worktree: `build.sbt` defines both `j2clSearchBuild` and `j2clSearchTest`.

--- a/docs/superpowers/plans/2026-04-23-issue-968-root-live-surface.md
+++ b/docs/superpowers/plans/2026-04-23-issue-968-root-live-surface.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Keep J2CL authoritative for the live-runtime state machine. The root shell should stop behaving like "the sidecar widget mounted in a different div" and instead gain a root-scoped live-runtime coordinator that owns bootstrap/session state, route state, reconnect status, selected-wave continuity, and fragment-policy inputs. The existing search, selected-wave, and compose controllers remain the narrowest reusable seams, but they should be composed under a root-runtime owner rather than each independently reacquiring bootstrap and lifecycle state. Lit stays visual-only for this slice: existing shell primitives and status-strip slots render state that J2CL publishes.
 
-**Tech Stack:** J2CL Java under `j2cl/src/main/java`, Jakarta servlet/rendering seams under `wave/src/jakarta-overrides/java`, generated protocol models under `gen/messages/`, existing root-shell Lit primitives under `j2cl/lit/`, the explicit `/bootstrap.json` contract from `#963`, the unread/read-state path from `#931`, server-side viewport-hint support under `WaveClientRpcImpl`, and targeted J2CL/server unit tests plus local browser verification on `/?view=j2cl-root`.
+**Tech Stack:** J2CL Java under `j2cl/src/main/java`, Jakarta servlet/rendering seams under `wave/src/jakarta-overrides/java`, generated protocol models under `gen/messages/`, existing root-shell Lit primitives under `j2cl/lit/`, the explicit `/bootstrap.json` contract from `#963`, the unread/read-state path from `#931`, the StageOne read surface from `#966`, viewport-hint/fragment-window support from `#967` plus `#993`, server-side viewport-hint support under `WaveClientRpcImpl`, and targeted J2CL/server unit tests plus local browser verification on `/?view=j2cl-root`.
 
 ---
 
@@ -20,6 +20,10 @@ The current repo state already provides several of the prerequisites `#968` must
 - `#931` is closed: the selected-wave panel already has real unread/read-state fetching, debounce, reconnect persistence, and visibility-based refresh inside `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`.
 - `#963` is closed: root/session/socket metadata now come from `/bootstrap.json`, served by `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`, with the contract pinned in `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`.
 - `#964` is closed: the root shell already exposes Lit shell primitives such as `shell-main-region` and `shell-status-strip`, and `HtmlRenderer.renderJ2clRootShellPage(...)` mounts the J2CL bundle into the existing shell page.
+- `#965` is merged: the root-shell host can serve selected-wave HTML before J2CL boot; `#968` should preserve that server-first host contract rather than reimplement it.
+- `#966` is merged: StageOne read-surface parity exists; `#968` consumes it only through the current selected-wave/read-state seams.
+- `#967` is merged: viewport-hint transport, selected-wave fragment fetching, viewport growth, and `J2clSelectedWaveViewportState` are present in the J2CL selected-wave path.
+- `#993` is merged: viewport metadata edge cases have additional hardening on top of `#967`.
 
 ### 1.2 Exact current seams
 
@@ -35,14 +39,17 @@ These seams are the actual starting point for `#968`:
   - Reconnect, read-state refresh, and visibility-refresh logic already exist, but they are owned entirely by the selected-wave controller.
   - Bootstrap is refetched on open/reconnect from inside this controller, which keeps session/bootstrap lifecycle controller-local instead of root-scoped.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:45-115`
-  - Selected-wave open still creates a socket per opened wave and sends a manual `ProtocolOpenRequest` frame.
-  - The gateway fetches bootstrap and opens sockets, but it does not own a shared root session/bootstrap snapshot or any root-runtime continuity.
+  - Selected-wave open still creates a socket per opened wave and sends a manual `ProtocolOpenRequest` frame, now with optional `SidecarViewportHints`.
+  - The gateway fetches bootstrap, opens sockets, and fetches fragment windows, but it does not own a shared root session/bootstrap snapshot or any root-runtime continuity.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java:7-31`
-  - The sidecar open request carries only participant id, wave id, and wavelet prefixes.
-  - It has no fields for `viewportStartBlipId`, `viewportDirection`, or `viewportLimit`.
+  - The sidecar open request carries participant id, wave id, wavelet prefixes, and `SidecarViewportHints`.
+  - This is now a consumed seam, not an implementation gap for `#968`.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java:13-30`
-  - The manual JSON encoder writes only fields `"1"`, `"2"`, and `"3"` into the `ProtocolOpenRequest` payload.
-  - It does not expose the viewport-hint fields the server already understands.
+  - The manual JSON encoder writes required fields `"1"`, `"2"`, and `"3"` plus optional viewport fields `"5"`, `"6"`, and `"7"`.
+  - Transport-codec behavior is already covered by existing J2CL tests from the merged viewport work.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+  - The selected-wave path now has an explicit viewport-window model from `#967`.
+  - `#968` should consume this model through existing selected-wave controller behavior, not duplicate fragment growth logic in the root coordinator.
 - `gen/messages/org/waveprotocol/box/common/comms/proto/ProtocolOpenRequestProtoImpl.java:856-900`
   - The generated protocol model already reserves the JSON/proto slots for viewport hints:
     - `"5"` = `viewportStartBlipId`
@@ -66,7 +73,7 @@ Today:
 - bootstrap/session state is reacquired independently by search, selected-wave open, and compose flows;
 - route/history state is split between root-shell bootstrap JS and the sidecar route controller;
 - reconnect/read-state continuity lives inside the selected-wave widget;
-- viewport-fragment policy is supported by the server but not by the J2CL open-frame encoder;
+- viewport-fragment policy is now available in the selected-wave path, but root-runtime ownership still does not coordinate or publish that live-state continuity;
 - root-shell chrome has a live-status surface, but no root-runtime controller publishes live state into it.
 
 That is why parity docs still describe the live runtime as controller-local and sidecar-oriented. `#968` is the slice that turns those seams into one root-scoped live surface.
@@ -93,7 +100,7 @@ That is why parity docs still describe the live runtime as controller-local and 
   - the selected wave remains logically selected during reconnect,
   - the last known read state survives transient failures,
   - successful recovery resets the reconnect budget.
-- The J2CL open-frame path can carry viewport hints using the existing protocol fields already supported by the server, so the root live surface can consume the `#967` fragment-window state instead of whole-wave default behavior.
+- The root live surface consumes the existing `#967`/`#993` viewport-hint and fragment-window path without changing server protocol or duplicating selected-wave fragment growth behavior.
 - `#931` unread/read modeling is consumed as part of the root live surface rather than treated as an isolated selected-wave label feature.
 - The shell consumes live-state visuals through existing Lit/root-shell seams only:
   - `shell-status-strip` for reconnect and root-runtime status,
@@ -117,13 +124,13 @@ That is why parity docs still describe the live runtime as controller-local and 
 - Root-runtime ownership of route/history continuity for the current query + selected-wave deep-link model.
 - Publishing reconnect/live-state into the root shell status surface.
 - Wiring the existing unread/read-state path from `#931` into the root live surface contract.
-- Extending the J2CL open request so it can send viewport hints already supported by the server.
+- Consuming the existing J2CL viewport-hint and fragment-window path when coordinating selected-wave opens.
 - Targeted J2CL/server tests and root-shell browser verification.
 
 ### 3.2 Explicit non-goals
 
-- No StageOne read-surface implementation work from `#966`.
-- No fragment-window modeling or visible-region rendering work from `#967`.
+- No StageOne read-surface reimplementation or visual redesign from `#966`.
+- No fragment-window modeling, visible-region rendering, or viewport metadata hardening rework from `#967` / `#993`.
 - No StageThree compose/editor parity from `#969`.
 - No attempt to aggregate ephemeral compose/search socket lifecycles into the root reconnect-status strip in `#968`; root reconnect publication is limited to the selected-wave live surface plus bootstrap refresh continuity.
 - No new server protocol beyond exposing existing `ProtocolOpenRequest` viewport fields already present in generated models.
@@ -133,46 +140,39 @@ That is why parity docs still describe the live runtime as controller-local and 
 
 ## 4. Dependency Readiness
 
-### 4.1 Closed prerequisites
+### 4.1 Merged prerequisites
 
-As of 2026-04-23 in this worktree:
+As of 2026-04-24 in this worktree after `git fetch origin main`:
 
 - `#933` — closed
 - `#931` — closed
 - `#963` — closed
 - `#964` — closed
 - `#936` — closed
+- `#965` — merged into `origin/main`
+- `#966` — merged into `origin/main`
+- `#967` — merged into `origin/main`
+- `#993` — merged into `origin/main`
 
-These closed issues mean the auth, unread/read modeling, bootstrap JSON, root-shell chrome, and atomic write-basis seams are already available.
+These merged issues mean the auth, unread/read modeling, bootstrap JSON, root-shell chrome, server-first selected-wave host, StageOne read surface, viewport transport, fragment-window growth, and atomic write-basis seams are already available.
 
-### 4.2 Open dependencies and readiness call
+### 4.2 Dependency readiness call
 
-As of 2026-04-23:
+As of 2026-04-24:
 
-- `#966` — open
-- `#967` — open
-- `#965` — open
+- There are no dependency blockers for starting `#968` implementation on `issue-968-root-live-surface`.
+- The lane must consume, not recreate, the now-merged work from `#965`, `#966`, `#967`, and `#993`.
+- The first implementation slice is intentionally narrower than the full plan: refresh this plan, then add the root-scoped live-surface model/controller and root-shell status publication wiring only.
+- Keep compose/write path changes, default-root routing, server protocol changes, and StageThree parity out of this first slice.
+- Before future larger slices, re-diff root-shell host and selected-wave viewport seams against `origin/main` because adjacent lanes continue to merge into the same surfaces.
 
-Readiness call:
-
-- Planning is ready now.
-- Full implementation is **not** ready to merge until `#966` and `#967` land, because the parity matrix ties:
-  - `R-4.6` to `#967`,
-  - `R-7.3` to `#967`,
-  - the practical root read/live handoff to the StageOne read surface from `#966`.
-- `#965` is an adjacent integration edge, not a declared hard blocker in the issue body, but the implementation lane should pull its latest root-shell host changes before coding so `#968` does not hardcode against a stale shell-swap surface.
-- If `#966` and `#967` merge before `#965`, pause and decide explicitly whether to:
-  - pull the latest `#965` branch/worktree changes into the lane for the diff-check, or
-  - wait for `#965` to merge.
-  Do not guess the host contract in that state.
-
-Implementation verdict: `#968` is **dependency-ready for planning/prep only**. The worker lane should wait for `#966` and `#967` to merge before landing code.
+Implementation verdict: `#968` is dependency-ready for the first narrow implementation slice.
 
 ## 5. Slice Packet For #968
 
 **Title:** Promote the J2CL sidecar into a root-shell live surface with route/history/reconnect/read-state integration
 **Stage:** live
-**Dependencies:** `#933`, `#931`, `#963`, `#966`, `#967`
+**Dependencies:** `#933`, `#931`, `#963`, `#965`, `#966`, `#967`, `#993`
 
 ### Matrix rows claimed
 
@@ -201,6 +201,7 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
 - Route/history persistence: `J2clSidecarRouteController`
 - Selected-wave reconnect/read-state: `J2clSelectedWaveController`
 - Server viewport-hint support: `WaveClientRpcImpl` + `WaveClientRpcViewportHintsTest`
+- J2CL viewport-hint transport and fragment growth: `SidecarViewportHints`, `SidecarOpenRequest`, `SidecarTransportCodec`, `J2clSelectedWaveViewportState`, `J2clSelectedWaveController.fetchFragments(...)`
 
 ### Rollout / rollback seam
 
@@ -243,11 +244,7 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
   - Continue to consume read-state and fragment data, but do not own root-runtime continuity decisions.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java`
-  - Shared bootstrap/session access, open-frame viewport hints, and any root-runtime transport helpers.
-- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java`
-  - Add viewport-hint fields.
-- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
-  - Extend `ProtocolOpenRequest` encoding to include viewport fields `5/6/7`.
+  - Future shared bootstrap/session access if a later slice makes the root coordinator the single bootstrap owner. Do not change transport semantics in the first slice.
 
 ### Modified tests
 
@@ -255,7 +252,7 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchGatewayAuthFrameTest.java`
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
-  - Existing transport test file; extend it rather than creating a duplicate transport-codec suite.
+  - Inspect-only for the first slice unless root-live wiring reveals a transport regression. Viewport transport assertions already exist after `#967` / `#993`.
 - `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java`
   - Existing bootstrap JSON regression coverage; verify the signed-out contract still degrades cleanly once the root runtime becomes the single bootstrap owner.
 
@@ -284,14 +281,16 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
 ### Task 1: Freeze the dependency gate and root-runtime boundary
 
 - [ ] Keep `#968` scoped to the root-runtime/state-machine layer only.
-- [ ] Treat `#966` and `#967` as merge gates for implementation, not as work to subsume into `#968`.
+- [ ] Treat `#965`, `#966`, `#967`, and `#993` as merged prerequisites to consume, not work to subsume into `#968`.
+- [ ] For the first worker slice, touch only root live-surface model/controller wiring, root-shell status publication, focused J2CL tests, and any required changelog fragment.
+- [ ] Keep compose/write path, default root routing, server protocol, and StageThree parity out of the first worker slice.
 - [ ] Record in the issue comment:
   - worktree path,
   - branch,
   - plan path,
   - closed prerequisites,
-  - open blockers (`#966`, `#967`),
-  - adjacent integration edge (`#965`).
+  - merged dependency refresh note for `#965`, `#966`, `#967`, and `#993`,
+  - first-slice scope.
 
 ### Task 2: Introduce a root-scoped live-runtime coordinator
 
@@ -372,36 +371,12 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
   - callbacks whose generation no longer matches are dropped.
 - [ ] Lock that guard with a dedicated `J2clRootLiveSurfaceControllerTest` case rather than leaving the stale-drop behavior as prose only.
 
-### Task 5a: Add viewport-hint transport plumbing on the J2CL sidecar/root path
+### Task 5: Consume the merged viewport-hint and fragment-window path
 
-- [ ] Extend `SidecarOpenRequest` with:
-  - `viewportStartBlipId`
-  - `viewportDirection`
-  - `viewportLimit`
-- [ ] Extend `SidecarTransportCodec.encodeOpenEnvelope(...)` to emit fields:
-  - `"5"` for `viewportStartBlipId`
-  - `"6"` for `viewportDirection`
-  - `"7"` for `viewportLimit`
-  matching the generated `ProtocolOpenRequest` contract already used by the GWT client and server.
-- [ ] Do not hand-guess new protocol semantics; reuse the existing generated field numbering already present in `gen/messages/.../ProtocolOpenRequestProtoImpl.java`.
-- [ ] Extend `SidecarTransportCodecTest` as the canonical transport-encoding home for these assertions, and keep `J2clSearchGatewayAuthFrameTest` focused on the no-auth-envelope contract.
-- [ ] In `SidecarTransportCodecTest`, prove:
-  - open frames still begin with `ProtocolOpenRequest`,
-  - no auth envelope regresses,
-  - viewport fields are present only when explicitly set,
-  - a default-constructed / unset `SidecarOpenRequest` emits no viewport fields at all,
-  - pre-`#967` caller paths do not emit viewport fields accidentally,
-  - the JSON key set remains backward-compatible with the current GWT/ProtocolOpenRequest schema: required keys stay `1/2/3`, with `5/6/7` present only as optional additions.
-- [ ] Keep this transport plumbing in the same `#968` implementation lane; do not merge it independently before `#967`.
-
-### Task 5b: Feed real fragment-window state into the open request after `#967`
-
-- [ ] Gate the caller-side wiring on pulling `#967` once it merges.
-- [ ] Use the actual fragment-window/visible-region state from `#967` as the source of:
-  - `viewportStartBlipId`
-  - `viewportDirection`
-  - `viewportLimit`
-- [ ] Do not invent a temporary heuristic source in `#968`; if `#967` is not merged, Task 5b remains blocked and `#968` does not merge.
+- [ ] Treat `SidecarViewportHints`, `SidecarOpenRequest` viewport fields, `SidecarTransportCodec` fields `5/6/7`, `J2clSearchGateway.openSelectedWave(... SidecarViewportHints ...)`, `fetchFragments(...)`, `J2clSelectedWaveController` viewport growth, and `J2clSelectedWaveViewportState` as existing seams.
+- [ ] Do not alter the server protocol or transport codec in the first worker slice.
+- [ ] Do not invent a second root-level fragment-window model; root-live coordination should observe or preserve selected-wave state through existing selected-wave controller seams.
+- [ ] If a later `#968` slice needs to route viewport status into shell chrome, add it as a root-status/model projection only after proving the selected-wave controller remains the single owner of fragment growth.
 
 ### Task 6: Re-scope selected-wave reconnect/read-state behavior under the root live surface
 
@@ -480,16 +455,17 @@ Implementation verdict: `#968` is **dependency-ready for planning/prep only**. T
   - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
   - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`
   - `j2cl/lit/src/elements/shell-main-region.js`
-- [ ] When `#967` is pulled into the lane for Task 5b, re-diff the fragment-window transport seam and confirm the generated `ProtocolOpenRequest` field usage still maps to the same viewport slots (`5/6/7`) before wiring caller state.
+- [ ] Confirm the merged fragment-window transport seam still maps to generated `ProtocolOpenRequest` viewport slots (`5/6/7`) before any future caller-state wiring changes.
 
 ## 8. Verification Commands
 
-Run these from `/Users/vega/devroot/worktrees/issue-968-root-live-surface` once implementation starts and after `#966`/`#967` are merged into the lane:
+Run these from `/Users/vega/devroot/worktrees/issue-968-root-live-surface` once implementation starts:
 
 ### Targeted J2CL/server test gates
 
 ```bash
 sbt -batch j2clSearchBuild j2clSearchTest
+j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.root.J2clRootLiveSurfaceControllerTest,org.waveprotocol.box.j2cl.root.J2clRootShellViewTest test
 sbt -batch "testOnly org.waveprotocol.box.j2cl.search.J2clSidecarRouteControllerTest org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest org.waveprotocol.box.j2cl.search.J2clSearchGatewayAuthFrameTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
 sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest org.waveprotocol.box.server.rpc.J2clBootstrapServletTest"
 ```
@@ -531,10 +507,7 @@ PORT=9968 bash scripts/wave-smoke.sh stop
 ## 9. Review And Traceability Gates
 
 - [ ] Run Claude Opus 4.7 review on this plan before implementation starts.
-- [ ] Do not start the implementation lane until:
-  - plan review is clean,
-  - `#966` is merged or otherwise pulled as final accepted base,
-  - `#967` is merged or otherwise pulled as final accepted base.
+- [ ] Implementation may start after this dependency refresh because `#965`, `#966`, `#967`, and `#993` are present on `origin/main` in this worktree.
 - [ ] After implementation, run Claude Opus 4.7 review again on the implementation diff.
 - [ ] Feature-flag decision for implementation:
   - default plan is to reuse only the existing `j2cl-root-bootstrap` seam
@@ -552,9 +525,9 @@ PORT=9968 bash scripts/wave-smoke.sh stop
 
 ## 10. Dependency-Readiness Verdict
 
-Planner verdict for 2026-04-23:
+Planner verdict refreshed for 2026-04-24:
 
-- `#968` has enough closed foundation to write and review the implementation plan now.
-- `#968` should **not** start product implementation yet because `#966` and `#967` are still open and own part of the live-surface contract this issue must consume.
-- The implementation lane should resume only after those two issues are merged into `main` and pulled into the worktree, with `#965` checked for any root-shell host drift.
+- `#968` has the required merged foundation to start the first narrow implementation slice.
+- `#968` should consume the merged #965/#966/#967/#993 seams and avoid duplicate viewport transport, read-surface, or server-first host work.
+- The first worker slice is root-scoped live-surface model/controller plus root-shell status publication wiring and focused J2CL tests.
 - The listed verification commands are current in this worktree: `build.sbt` defines both `j2clSearchBuild` and `j2clSearchTest`.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -40,7 +40,7 @@ public final class J2clRootLiveSurfaceController {
     publishedDuringStart = false;
     try {
       routeStarter.start();
-    } catch (RuntimeException e) {
+    } catch (RuntimeException | Error e) {
       active = false;
       throw e;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -19,7 +19,7 @@ public final class J2clRootLiveSurfaceController {
   private final ShellSurface shellSurface;
   private final RouteStarter routeStarter;
   private J2clRootLiveSurfaceModel model;
-  private boolean active = true;
+  private boolean active;
   private boolean publishedDuringStart;
 
   public J2clRootLiveSurfaceController(ShellSurface shellSurface, RouteStarter routeStarter) {
@@ -78,7 +78,7 @@ public final class J2clRootLiveSurfaceController {
   }
 
   private void onRouteStateChanged(J2clSidecarRouteState state) {
-    if (state == null) {
+    if (!active || state == null) {
       return;
     }
     model = model.withRouteState(state);
@@ -86,6 +86,9 @@ public final class J2clRootLiveSurfaceController {
   }
 
   private void onSelectedWaveChanged(String waveId) {
+    if (!active) {
+      return;
+    }
     model = model.withSelectedWaveId(waveId);
     publish();
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -66,6 +66,9 @@ public final class J2clRootLiveSurfaceController {
   public J2clSearchPanelController.RouteStateHandler routeStateHandler(
       J2clSearchPanelController.RouteStateHandler delegate) {
     return (state, digestItem, userNavigation) -> {
+      if (!active) {
+        return;
+      }
       onRouteStateChanged(state);
       if (delegate != null) {
         delegate.onRouteStateChanged(state, digestItem, userNavigation);
@@ -76,6 +79,9 @@ public final class J2clRootLiveSurfaceController {
   public J2clSidecarRouteController.SelectedWaveController selectedWaveController(
       J2clSidecarRouteController.SelectedWaveController delegate) {
     return (waveId, digestItem) -> {
+      if (!active) {
+        return;
+      }
       onSelectedWaveChanged(waveId);
       if (delegate != null) {
         delegate.onWaveSelected(waveId, digestItem);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -35,6 +35,7 @@ public final class J2clRootLiveSurfaceController {
   }
 
   public void start() {
+    model = J2clRootLiveSurfaceModel.starting();
     active = true;
     publishedDuringStart = false;
     routeStarter.start();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -48,6 +48,9 @@ public final class J2clRootLiveSurfaceController {
   }
 
   public void onRouteUrlChanged(String routeUrl) {
+    if (!active) {
+      return;
+    }
     shellSurface.syncReturnTarget(routeUrl);
     model = model.withRouteUrl(routeUrl);
     publish();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -38,7 +38,12 @@ public final class J2clRootLiveSurfaceController {
     model = J2clRootLiveSurfaceModel.starting();
     active = true;
     publishedDuringStart = false;
-    routeStarter.start();
+    try {
+      routeStarter.start();
+    } catch (RuntimeException e) {
+      active = false;
+      throw e;
+    }
     if (!publishedDuringStart) {
       publish();
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -41,6 +41,7 @@ public final class J2clRootLiveSurfaceController {
     try {
       routeStarter.start();
     } catch (RuntimeException | Error e) {
+      // Reset lifecycle state before rethrowing JVM or translated JavaScript failures.
       active = false;
       throw e;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -1,0 +1,96 @@
+package org.waveprotocol.box.j2cl.root;
+
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+
+public final class J2clRootLiveSurfaceController {
+  public interface ShellSurface {
+    void syncReturnTarget(String routeUrl);
+
+    void publishLiveStatus(J2clRootLiveSurfaceModel model);
+  }
+
+  @FunctionalInterface
+  public interface RouteStarter {
+    void start();
+  }
+
+  private final ShellSurface shellSurface;
+  private final RouteStarter routeStarter;
+  private J2clRootLiveSurfaceModel model;
+  private boolean active = true;
+  private boolean publishedDuringStart;
+
+  public J2clRootLiveSurfaceController(ShellSurface shellSurface, RouteStarter routeStarter) {
+    if (shellSurface == null) {
+      throw new IllegalArgumentException("shellSurface is required");
+    }
+    if (routeStarter == null) {
+      throw new IllegalArgumentException("routeStarter is required");
+    }
+    this.shellSurface = shellSurface;
+    this.routeStarter = routeStarter;
+    this.model = J2clRootLiveSurfaceModel.starting();
+  }
+
+  public void start() {
+    active = true;
+    publishedDuringStart = false;
+    routeStarter.start();
+    if (!publishedDuringStart) {
+      publish();
+    }
+  }
+
+  public void stop() {
+    active = false;
+  }
+
+  public void onRouteUrlChanged(String routeUrl) {
+    shellSurface.syncReturnTarget(routeUrl);
+    model = model.withRouteUrl(routeUrl);
+    publish();
+  }
+
+  public J2clSearchPanelController.RouteStateHandler routeStateHandler(
+      J2clSearchPanelController.RouteStateHandler delegate) {
+    return (state, digestItem, userNavigation) -> {
+      onRouteStateChanged(state);
+      if (delegate != null) {
+        delegate.onRouteStateChanged(state, digestItem, userNavigation);
+      }
+    };
+  }
+
+  public J2clSidecarRouteController.SelectedWaveController selectedWaveController(
+      J2clSidecarRouteController.SelectedWaveController delegate) {
+    return (waveId, digestItem) -> {
+      onSelectedWaveChanged(waveId);
+      if (delegate != null) {
+        delegate.onWaveSelected(waveId, digestItem);
+      }
+    };
+  }
+
+  private void onRouteStateChanged(J2clSidecarRouteState state) {
+    if (state == null) {
+      return;
+    }
+    model = model.withRouteState(state);
+    publish();
+  }
+
+  private void onSelectedWaveChanged(String waveId) {
+    model = model.withSelectedWaveId(waveId);
+    publish();
+  }
+
+  private void publish() {
+    if (!active) {
+      return;
+    }
+    shellSurface.publishLiveStatus(model);
+    publishedDuringStart = true;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.root;
 
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
 
 public final class J2clRootLiveSurfaceModel {
   private static final String ROUTE_READY_STATUS = "Workspace is ready.";
@@ -26,11 +27,15 @@ public final class J2clRootLiveSurfaceModel {
 
   public J2clRootLiveSurfaceModel withRouteUrl(String nextRouteUrl) {
     String normalizedRouteUrl = nullToEmpty(nextRouteUrl);
+    if (normalizedRouteUrl.isEmpty()) {
+      return new J2clRootLiveSurfaceModel("", "", null, STARTING_STATUS);
+    }
+    J2clSidecarRouteState routeState = parseRouteUrl(normalizedRouteUrl);
     return new J2clRootLiveSurfaceModel(
         normalizedRouteUrl,
-        query,
-        selectedWaveId,
-        statusFor(normalizedRouteUrl, query, selectedWaveId));
+        routeState.getQuery(),
+        routeState.getSelectedWaveId(),
+        statusFor(normalizedRouteUrl, routeState.getQuery(), routeState.getSelectedWaveId()));
   }
 
   public J2clRootLiveSurfaceModel withRouteState(J2clSidecarRouteState routeState) {
@@ -88,6 +93,21 @@ public final class J2clRootLiveSurfaceModel {
 
   private static String statusFor(String routeUrl, String query, String selectedWaveId) {
     return selectedWaveId == null ? routeStatus(routeUrl, query) : selectedWaveStatus();
+  }
+
+  private static J2clSidecarRouteState parseRouteUrl(String routeUrl) {
+    String search = routeUrl;
+    String hash = "";
+    int queryStart = search.indexOf('?');
+    if (queryStart >= 0) {
+      search = search.substring(queryStart);
+    }
+    int hashStart = search.indexOf('#');
+    if (hashStart >= 0) {
+      hash = search.substring(hashStart);
+      search = search.substring(0, hashStart);
+    }
+    return J2clSidecarRouteCodec.parse(search, hash);
   }
 
   private static String nullToEmpty(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -1,0 +1,100 @@
+package org.waveprotocol.box.j2cl.root;
+
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+
+public final class J2clRootLiveSurfaceModel {
+  private static final String ROUTE_READY_STATUS = "Workspace is ready.";
+  private static final String SELECTED_WAVE_STATUS = "Selected wave is active.";
+  private static final String STARTING_STATUS = "Loading workspace.";
+
+  private final String routeUrl;
+  private final String query;
+  private final String selectedWaveId;
+  private final String statusText;
+
+  private J2clRootLiveSurfaceModel(
+      String routeUrl, String query, String selectedWaveId, String statusText) {
+    this.routeUrl = nullToEmpty(routeUrl);
+    this.query = nullToEmpty(query);
+    this.selectedWaveId = emptyToNull(selectedWaveId);
+    this.statusText = nullToEmpty(statusText);
+  }
+
+  public static J2clRootLiveSurfaceModel starting() {
+    return new J2clRootLiveSurfaceModel("", "", null, STARTING_STATUS);
+  }
+
+  public J2clRootLiveSurfaceModel withRouteUrl(String nextRouteUrl) {
+    String normalizedRouteUrl = nullToEmpty(nextRouteUrl);
+    return new J2clRootLiveSurfaceModel(
+        normalizedRouteUrl,
+        query,
+        selectedWaveId,
+        statusFor(normalizedRouteUrl, query, selectedWaveId));
+  }
+
+  public J2clRootLiveSurfaceModel withRouteState(J2clSidecarRouteState routeState) {
+    if (routeState == null) {
+      return this;
+    }
+    String nextSelectedWaveId = emptyToNull(routeState.getSelectedWaveId());
+    return new J2clRootLiveSurfaceModel(
+        routeUrl,
+        routeState.getQuery(),
+        nextSelectedWaveId,
+        statusFor(routeUrl, routeState.getQuery(), nextSelectedWaveId));
+  }
+
+  public J2clRootLiveSurfaceModel withSelectedWaveId(String nextSelectedWaveId) {
+    String normalizedSelectedWaveId = emptyToNull(nextSelectedWaveId);
+    return new J2clRootLiveSurfaceModel(
+        routeUrl,
+        query,
+        normalizedSelectedWaveId,
+        statusFor(routeUrl, query, normalizedSelectedWaveId));
+  }
+
+  public String getRouteUrl() {
+    return routeUrl;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public String getSelectedWaveId() {
+    return selectedWaveId;
+  }
+
+  public String getStatusText() {
+    return statusText;
+  }
+
+  private static String routeStatus(String routeUrl, String query) {
+    String normalizedQuery = nullToEmpty(query);
+    if (!normalizedQuery.isEmpty()) {
+      return "Showing search results for " + normalizedQuery + ".";
+    }
+    String normalizedRouteUrl = nullToEmpty(routeUrl);
+    if (normalizedRouteUrl.isEmpty()) {
+      return STARTING_STATUS;
+    }
+    return ROUTE_READY_STATUS;
+  }
+
+  private static String selectedWaveStatus() {
+    return SELECTED_WAVE_STATUS;
+  }
+
+  private static String statusFor(String routeUrl, String query, String selectedWaveId) {
+    return selectedWaveId == null ? routeStatus(routeUrl, query) : selectedWaveStatus();
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+
+  private static String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -24,6 +24,9 @@ public final class J2clRootShellController {
     final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
     final J2clSelectedWaveController[] selectedWaveControllerRef =
         new J2clSelectedWaveController[1];
+    // The route controller is wired below; the starter runs only after that assignment.
+    J2clRootLiveSurfaceController liveSurfaceController =
+        new J2clRootLiveSurfaceController(shellView, () -> routeControllerRef[0].start());
     J2clSearchPanelView searchView =
         new J2clSearchPanelView(
             shellView.getWorkflowHost(), J2clSearchPanelView.ShellPresentation.ROOT_SHELL);
@@ -52,20 +55,21 @@ public final class J2clRootShellController {
         new J2clSearchPanelController(
             gateway,
             searchView,
-            (state, digestItem, userNavigation) ->
-                routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation),
+            liveSurfaceController.routeStateHandler(
+                (state, digestItem, userNavigation) ->
+                    routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation)),
             resolveViewportWidth());
     J2clSidecarRouteController routeController =
         new J2clSidecarRouteController(
             new J2clSidecarRouteController.BrowserHistoryAdapter(),
             controller,
-            selectedWaveController,
+            liveSurfaceController.selectedWaveController(selectedWaveController),
             "view=j2cl-root",
-            shellView::syncReturnTarget);
+            liveSurfaceController::onRouteUrlChanged);
     routeControllerRef[0] = routeController;
     searchView.setSessionSummary("Mounted inside the J2CL root shell.");
     composeController.start();
-    routeController.start();
+    liveSurfaceController.start();
   }
 
   private static double resolveViewportWidth() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -67,7 +67,7 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     updateAuthHrefs(shell, "[data-j2cl-root-signout='true']", "/auth/signout", returnTarget);
 
     HTMLElement returnTargetLabel =
-        (HTMLElement) shell.querySelector("#j2cl-root-return-target-text");
+        firstElementOwnedByRootShell(shell, "#j2cl-root-return-target-text");
     if (returnTargetLabel != null) {
       returnTargetLabel.textContent = "Return target: " + returnTarget;
     }
@@ -90,28 +90,43 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
   }
 
   private HTMLElement ensureLiveStatusElement() {
-    if (liveStatus != null) {
-      return liveStatus;
-    }
-    HTMLElement statusStrip = findStatusStrip();
+    Element rootShell = findRootShell();
+    HTMLElement statusStrip = findStatusStrip(rootShell);
     if (statusStrip == null) {
       return null;
+    }
+    if (!isCurrentStatusNode(liveStatus, statusStrip, rootShell)) {
+      liveStatus = firstElementOwnedByRootShell(statusStrip, "#" + LIVE_STATUS_ID, rootShell);
+    }
+    if (!isCurrentStatusNode(liveStatusSeparator, statusStrip, rootShell)) {
+      liveStatusSeparator =
+          firstElementOwnedByRootShell(statusStrip, "#" + LIVE_STATUS_SEPARATOR_ID, rootShell);
     }
     if (liveStatusSeparator == null) {
       liveStatusSeparator = (HTMLElement) DomGlobal.document.createElement("span");
       liveStatusSeparator.id = LIVE_STATUS_SEPARATOR_ID;
       liveStatusSeparator.setAttribute("aria-hidden", "true");
       liveStatusSeparator.textContent = " | ";
-      statusStrip.appendChild(liveStatusSeparator);
+      if (liveStatus != null && liveStatus.parentElement == statusStrip) {
+        statusStrip.insertBefore(liveStatusSeparator, liveStatus);
+      } else {
+        statusStrip.appendChild(liveStatusSeparator);
+      }
     }
-    liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
-    liveStatus.id = LIVE_STATUS_ID;
-    statusStrip.appendChild(liveStatus);
+    if (liveStatus == null) {
+      liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
+      liveStatus.id = LIVE_STATUS_ID;
+      statusStrip.appendChild(liveStatus);
+    }
     return liveStatus;
   }
 
   private Element findRootShell() {
-    Element rootShell = workflowHost;
+    return findNearestRootShell(workflowHost);
+  }
+
+  private static Element findNearestRootShell(Element start) {
+    Element rootShell = start;
     // Bind to the nearest owning root shell so nested or parallel shells cannot cross-write status.
     while (rootShell != null) {
       if ("true".equals(rootShell.getAttribute("data-j2cl-root-shell"))) {
@@ -122,17 +137,16 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     return null;
   }
 
-  private HTMLElement findStatusStrip() {
-    Element rootShell = findRootShell();
+  private HTMLElement findStatusStrip(Element rootShell) {
     if (rootShell == null) {
       return null;
     }
     // shell-status-strip renders a default slot; appended light-DOM children stay visible.
-    return (HTMLElement) rootShell.querySelector("shell-status-strip[slot='status']");
+    return firstElementOwnedByRootShell(rootShell, "shell-status-strip[slot='status']");
   }
 
   private static void updateHref(Element scope, String elementId, String href) {
-    HTMLElement element = (HTMLElement) scope.querySelector("#" + elementId);
+    HTMLElement element = firstElementOwnedByRootShell(scope, "#" + elementId);
     if (element != null) {
       element.setAttribute("href", href);
     }
@@ -143,10 +157,40 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     NodeList<elemental2.dom.Element> elements = scope.querySelectorAll(selector);
     for (int index = 0; index < elements.length; index++) {
       HTMLElement element = (HTMLElement) elements.item(index);
-      if (element != null) {
+      if (element != null && isOwnedByRootShell(element, scope)) {
         element.setAttribute("href", authPath + "?r=" + encodeLocalReturnTarget(returnTarget));
       }
     }
+  }
+
+  private static HTMLElement firstElementOwnedByRootShell(Element rootShell, String selector) {
+    return firstElementOwnedByRootShell(rootShell, selector, rootShell);
+  }
+
+  private static HTMLElement firstElementOwnedByRootShell(
+      Element searchScope, String selector, Element rootShell) {
+    if (rootShell == null) {
+      return null;
+    }
+    NodeList<elemental2.dom.Element> elements = searchScope.querySelectorAll(selector);
+    for (int index = 0; index < elements.length; index++) {
+      HTMLElement element = (HTMLElement) elements.item(index);
+      if (element != null && isOwnedByRootShell(element, rootShell)) {
+        return element;
+      }
+    }
+    return null;
+  }
+
+  private static boolean isOwnedByRootShell(Element element, Element rootShell) {
+    return rootShell != null && element != null && findNearestRootShell(element) == rootShell;
+  }
+
+  private static boolean isCurrentStatusNode(
+      HTMLElement element, HTMLElement statusStrip, Element rootShell) {
+    return element != null
+        && statusStrip.contains(element)
+        && isOwnedByRootShell(element, rootShell);
   }
 
   private static String normalizeLocalReturnTarget(String routeUrl) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -56,11 +56,11 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
 
   @Override
   public void syncReturnTarget(String routeUrl) {
-    String returnTarget = normalizeLocalReturnTarget(routeUrl);
     Element shell = findRootShell();
     if (shell == null) {
       return;
     }
+    String returnTarget = resolveReturnTarget(routeUrl, shell);
     shell.setAttribute("data-j2cl-root-return-target", returnTarget);
     updateHref(shell, "j2cl-root-brand-link", returnTarget);
     updateAuthHrefs(shell, "[data-j2cl-root-signin='true']", "/auth/signin", returnTarget);
@@ -104,8 +104,12 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       liveStatus = nextLiveStatus;
     }
     if (!isCurrentStatusNode(liveStatusSeparator, statusStrip, rootShell)) {
-      liveStatusSeparator =
+      HTMLElement nextLiveStatusSeparator =
           firstElementOwnedByRootShell(statusStrip, "#" + LIVE_STATUS_SEPARATOR_ID, rootShell);
+      if (nextLiveStatusSeparator != liveStatusSeparator) {
+        lastPublishedLiveStatusText = null;
+      }
+      liveStatusSeparator = nextLiveStatusSeparator;
     }
     if (liveStatusSeparator == null) {
       liveStatusSeparator = (HTMLElement) DomGlobal.document.createElement("span");
@@ -117,6 +121,7 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       } else {
         statusStrip.appendChild(liveStatusSeparator);
       }
+      lastPublishedLiveStatusText = null;
     }
     if (liveStatus == null) {
       liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
@@ -197,6 +202,17 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     return element != null
         && statusStrip.contains(element)
         && isOwnedByRootShell(element, rootShell);
+  }
+
+  private static String resolveReturnTarget(String routeUrl, Element shell) {
+    if (routeUrl != null && !routeUrl.isEmpty() && routeUrl.charAt(0) == '?') {
+      String basePath = shell.getAttribute("data-j2cl-root-base-path");
+      if (basePath != null && !basePath.isEmpty()
+          && basePath.startsWith("/") && !basePath.startsWith("//")) {
+        return basePath + routeUrl;
+      }
+    }
+    return normalizeLocalReturnTarget(routeUrl);
   }
 
   private static String normalizeLocalReturnTarget(String routeUrl) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -57,17 +57,17 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
   @Override
   public void syncReturnTarget(String routeUrl) {
     String returnTarget = normalizeLocalReturnTarget(routeUrl);
-    HTMLElement shell =
-        (HTMLElement) DomGlobal.document.querySelector("[data-j2cl-root-shell='true']");
-    if (shell != null) {
-      shell.setAttribute("data-j2cl-root-return-target", returnTarget);
+    Element shell = findRootShell();
+    if (shell == null) {
+      return;
     }
-    updateHref("j2cl-root-brand-link", returnTarget);
-    updateAuthHrefs("[data-j2cl-root-signin='true']", "/auth/signin", returnTarget);
-    updateAuthHrefs("[data-j2cl-root-signout='true']", "/auth/signout", returnTarget);
+    shell.setAttribute("data-j2cl-root-return-target", returnTarget);
+    updateHref(shell, "j2cl-root-brand-link", returnTarget);
+    updateAuthHrefs(shell, "[data-j2cl-root-signin='true']", "/auth/signin", returnTarget);
+    updateAuthHrefs(shell, "[data-j2cl-root-signout='true']", "/auth/signout", returnTarget);
 
     HTMLElement returnTargetLabel =
-        (HTMLElement) DomGlobal.document.getElementById("j2cl-root-return-target-text");
+        (HTMLElement) shell.querySelector("#j2cl-root-return-target-text");
     if (returnTargetLabel != null) {
       returnTargetLabel.textContent = "Return target: " + returnTarget;
     }
@@ -106,38 +106,41 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     }
     liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
     liveStatus.id = LIVE_STATUS_ID;
-    liveStatus.setAttribute("role", "status");
-    liveStatus.setAttribute("aria-live", "polite");
     statusStrip.appendChild(liveStatus);
     return liveStatus;
   }
 
-  private HTMLElement findStatusStrip() {
+  private Element findRootShell() {
     Element rootShell = workflowHost;
     // Bind to the nearest owning root shell so nested or parallel shells cannot cross-write status.
     while (rootShell != null) {
       if ("true".equals(rootShell.getAttribute("data-j2cl-root-shell"))) {
-        // shell-status-strip renders a default slot; appended light-DOM children stay visible.
-        HTMLElement scopedStatusStrip =
-            (HTMLElement) rootShell.querySelector("shell-status-strip[slot='status']");
-        if (scopedStatusStrip != null) {
-          return scopedStatusStrip;
-        }
+        return rootShell;
       }
       rootShell = rootShell.parentElement;
     }
     return null;
   }
 
-  private static void updateHref(String elementId, String href) {
-    HTMLElement element = (HTMLElement) DomGlobal.document.getElementById(elementId);
+  private HTMLElement findStatusStrip() {
+    Element rootShell = findRootShell();
+    if (rootShell == null) {
+      return null;
+    }
+    // shell-status-strip renders a default slot; appended light-DOM children stay visible.
+    return (HTMLElement) rootShell.querySelector("shell-status-strip[slot='status']");
+  }
+
+  private static void updateHref(Element scope, String elementId, String href) {
+    HTMLElement element = (HTMLElement) scope.querySelector("#" + elementId);
     if (element != null) {
       element.setAttribute("href", href);
     }
   }
 
-  private static void updateAuthHrefs(String selector, String authPath, String returnTarget) {
-    NodeList<elemental2.dom.Element> elements = DomGlobal.document.querySelectorAll(selector);
+  private static void updateAuthHrefs(
+      Element scope, String selector, String authPath, String returnTarget) {
+    NodeList<elemental2.dom.Element> elements = scope.querySelectorAll(selector);
     for (int index = 0; index < elements.length; index++) {
       HTMLElement element = (HTMLElement) elements.item(index);
       if (element != null) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -1,14 +1,20 @@
 package org.waveprotocol.box.j2cl.root;
 
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.NodeList;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 
-public final class J2clRootShellView {
+public final class J2clRootShellView implements J2clRootLiveSurfaceController.ShellSurface {
   private static final String DEFAULT_RETURN_TARGET = "/?view=j2cl-root";
+  private static final String LIVE_STATUS_ID = "j2cl-root-live-status-text";
+  private static final String LIVE_STATUS_SEPARATOR_ID = "j2cl-root-live-status-separator";
   private final HTMLElement workflowHost;
+  private HTMLElement liveStatus;
+  private HTMLElement liveStatusSeparator;
+  private String lastPublishedLiveStatusText;
 
   public J2clRootShellView(HTMLElement host) {
     if (J2clServerFirstRootShellDom.hasServerFirstWorkflow(host)) {
@@ -48,9 +54,11 @@ public final class J2clRootShellView {
     return workflowHost;
   }
 
+  @Override
   public void syncReturnTarget(String routeUrl) {
     String returnTarget = normalizeLocalReturnTarget(routeUrl);
-    HTMLElement shell = (HTMLElement) DomGlobal.document.querySelector("[data-j2cl-root-shell='true']");
+    HTMLElement shell =
+        (HTMLElement) DomGlobal.document.querySelector("[data-j2cl-root-shell='true']");
     if (shell != null) {
       shell.setAttribute("data-j2cl-root-return-target", returnTarget);
     }
@@ -63,6 +71,62 @@ public final class J2clRootShellView {
     if (returnTargetLabel != null) {
       returnTargetLabel.textContent = "Return target: " + returnTarget;
     }
+  }
+
+  @Override
+  public void publishLiveStatus(J2clRootLiveSurfaceModel model) {
+    HTMLElement liveStatus = ensureLiveStatusElement();
+    if (liveStatus != null) {
+      String statusText = model == null ? "" : model.getStatusText();
+      if (statusText.equals(lastPublishedLiveStatusText)) {
+        return;
+      }
+      liveStatus.textContent = statusText;
+      if (liveStatusSeparator != null) {
+        liveStatusSeparator.style.display = statusText.isEmpty() ? "none" : "";
+      }
+      lastPublishedLiveStatusText = statusText;
+    }
+  }
+
+  private HTMLElement ensureLiveStatusElement() {
+    if (liveStatus != null) {
+      return liveStatus;
+    }
+    HTMLElement statusStrip = findStatusStrip();
+    if (statusStrip == null) {
+      return null;
+    }
+    if (liveStatusSeparator == null) {
+      liveStatusSeparator = (HTMLElement) DomGlobal.document.createElement("span");
+      liveStatusSeparator.id = LIVE_STATUS_SEPARATOR_ID;
+      liveStatusSeparator.setAttribute("aria-hidden", "true");
+      liveStatusSeparator.textContent = " | ";
+      statusStrip.appendChild(liveStatusSeparator);
+    }
+    liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
+    liveStatus.id = LIVE_STATUS_ID;
+    liveStatus.setAttribute("role", "status");
+    liveStatus.setAttribute("aria-live", "polite");
+    statusStrip.appendChild(liveStatus);
+    return liveStatus;
+  }
+
+  private HTMLElement findStatusStrip() {
+    Element rootShell = workflowHost;
+    // Bind to the nearest owning root shell so nested or parallel shells cannot cross-write status.
+    while (rootShell != null) {
+      if ("true".equals(rootShell.getAttribute("data-j2cl-root-shell"))) {
+        // shell-status-strip renders a default slot; appended light-DOM children stay visible.
+        HTMLElement scopedStatusStrip =
+            (HTMLElement) rootShell.querySelector("shell-status-strip[slot='status']");
+        if (scopedStatusStrip != null) {
+          return scopedStatusStrip;
+        }
+      }
+      rootShell = rootShell.parentElement;
+    }
+    return null;
   }
 
   private static void updateHref(String elementId, String href) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -96,7 +96,12 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       return null;
     }
     if (!isCurrentStatusNode(liveStatus, statusStrip, rootShell)) {
-      liveStatus = firstElementOwnedByRootShell(statusStrip, "#" + LIVE_STATUS_ID, rootShell);
+      HTMLElement nextLiveStatus =
+          firstElementOwnedByRootShell(statusStrip, "#" + LIVE_STATUS_ID, rootShell);
+      if (nextLiveStatus != liveStatus) {
+        lastPublishedLiveStatusText = null;
+      }
+      liveStatus = nextLiveStatus;
     }
     if (!isCurrentStatusNode(liveStatusSeparator, statusStrip, rootShell)) {
       liveStatusSeparator =
@@ -117,6 +122,7 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       liveStatus = (HTMLElement) DomGlobal.document.createElement("span");
       liveStatus.id = LIVE_STATUS_ID;
       statusStrip.appendChild(liveStatus);
+      lastPublishedLiveStatusText = null;
     }
     return liveStatus;
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -75,15 +75,18 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
 
   @Override
   public void publishLiveStatus(J2clRootLiveSurfaceModel model) {
-    HTMLElement liveStatus = ensureLiveStatusElement();
-    if (liveStatus != null) {
+    HTMLElement statusElement = ensureLiveStatusElement();
+    if (statusElement != null) {
       String statusText = model == null ? "" : model.getStatusText();
-      if (statusText.equals(lastPublishedLiveStatusText)) {
+      String desiredSeparatorDisplay = statusText.isEmpty() ? "none" : "";
+      if (statusText.equals(lastPublishedLiveStatusText)
+          && (liveStatusSeparator == null
+              || liveStatusSeparator.style.display.equals(desiredSeparatorDisplay))) {
         return;
       }
-      liveStatus.textContent = statusText;
+      statusElement.textContent = statusText;
       if (liveStatusSeparator != null) {
-        liveStatusSeparator.style.display = statusText.isEmpty() ? "none" : "";
+        liveStatusSeparator.style.display = desiredSeparatorDisplay;
       }
       lastPublishedLiveStatusText = statusText;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -47,6 +47,94 @@ public class J2clRootLiveSurfaceControllerTest {
   }
 
   @Test
+  public void startRollsBackActiveStateWhenRouteStarterFails() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(
+            shell,
+            () -> {
+              throw new RuntimeException("startup failed");
+            });
+
+    assertStartFailsAndSuppressesCallbacks(controller, shell, "startup failed");
+  }
+
+  @Test
+  public void startRollsBackActiveStateWhenRouteStarterFailsWithError() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(
+            shell,
+            () -> {
+              throw new AssertionError("startup error");
+            });
+
+    assertStartFailsAndSuppressesCallbacks(controller, shell, "startup error");
+  }
+
+  @Test
+  public void startCanRecoverAfterRouteStarterFailure() {
+    FakeShellSurface shell = new FakeShellSurface();
+    final int[] attempts = new int[1];
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(
+            shell,
+            () -> {
+              attempts[0]++;
+              if (attempts[0] == 1) {
+                throw new RuntimeException("startup failed");
+              }
+            });
+
+    assertStartFailsAndSuppressesCallbacks(controller, shell, "startup failed");
+    shell.clear();
+
+    controller.start();
+
+    Assert.assertEquals(2, attempts[0]);
+    Assert.assertEquals(1, shell.models.size());
+    Assert.assertEquals("Loading workspace.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void startCanRecoverAfterSynchronousPublishThenFailure() {
+    FakeShellSurface shell = new FakeShellSurface();
+    final int[] attempts = new int[1];
+    final J2clRootLiveSurfaceController[] controllerRef =
+        new J2clRootLiveSurfaceController[1];
+    controllerRef[0] =
+        new J2clRootLiveSurfaceController(
+            shell,
+            () -> {
+              attempts[0]++;
+              controllerRef[0].onRouteUrlChanged("?view=j2cl-root&q=partial");
+              if (attempts[0] == 1) {
+                throw new RuntimeException("startup failed");
+              }
+            });
+
+    try {
+      controllerRef[0].start();
+      Assert.fail("Expected route starter failure.");
+    } catch (RuntimeException expected) {
+      Assert.assertEquals("startup failed", expected.getMessage());
+    }
+    Assert.assertEquals(1, shell.returnTargets.size());
+    Assert.assertEquals(1, shell.models.size());
+    controllerRef[0].onRouteUrlChanged("?view=j2cl-root&q=late");
+    Assert.assertEquals(1, shell.returnTargets.size());
+    Assert.assertEquals(1, shell.models.size());
+    shell.clear();
+
+    controllerRef[0].start();
+
+    Assert.assertEquals(2, attempts[0]);
+    Assert.assertEquals(1, shell.returnTargets.size());
+    Assert.assertEquals(1, shell.models.size());
+    Assert.assertEquals("partial", shell.lastModel().getQuery());
+  }
+
+  @Test
   public void routeUrlChangedSyncsReturnTargetAndPublishesModel() {
     FakeShellSurface shell = new FakeShellSurface();
     J2clRootLiveSurfaceController controller = startedController(shell);
@@ -322,6 +410,27 @@ public class J2clRootLiveSurfaceControllerTest {
         2,
         7L,
         false);
+  }
+
+  private static void assertStartFailsAndSuppressesCallbacks(
+      J2clRootLiveSurfaceController controller, FakeShellSurface shell, String expectedMessage) {
+    try {
+      controller.start();
+      Assert.fail("Expected route starter failure.");
+    } catch (RuntimeException | Error expected) {
+      Assert.assertEquals(expectedMessage, expected.getMessage());
+    }
+    controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
+    controller
+        .routeStateHandler(null)
+        .onRouteStateChanged(
+            new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    controller
+        .selectedWaveController(null)
+        .onWaveSelected("example.com/w+456", null);
+
+    Assert.assertEquals(0, shell.returnTargets.size());
+    Assert.assertEquals(0, shell.models.size());
   }
 
   private static J2clRootLiveSurfaceController startedController(FakeShellSurface shell) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -42,7 +42,8 @@ public class J2clRootLiveSurfaceControllerTest {
 
     Assert.assertEquals(1, shell.models.size());
     Assert.assertEquals("?view=j2cl-root&q=in%3Ainbox", shell.lastModel().getRouteUrl());
-    Assert.assertEquals("Workspace is ready.", shell.lastModel().getStatusText());
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+    Assert.assertEquals("Showing search results for in:inbox.", shell.lastModel().getStatusText());
   }
 
   @Test
@@ -58,7 +59,7 @@ public class J2clRootLiveSurfaceControllerTest {
         shell.returnTargets);
     Assert.assertEquals("?view=j2cl-root&q=in%3Ainbox", shell.lastModel().getRouteUrl());
     Assert.assertEquals(
-        "Workspace is ready.",
+        "Showing search results for in:inbox.",
         shell.lastModel().getStatusText());
   }
 
@@ -165,6 +166,7 @@ public class J2clRootLiveSurfaceControllerTest {
     controller.stop();
     controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
 
+    Assert.assertEquals(0, shell.returnTargets.size());
     Assert.assertEquals(0, shell.models.size());
   }
 
@@ -182,9 +184,9 @@ public class J2clRootLiveSurfaceControllerTest {
     controller.onRouteUrlChanged("?view=j2cl-root&q=b");
 
     Assert.assertEquals("?view=j2cl-root&q=b", shell.lastModel().getRouteUrl());
-    Assert.assertEquals("a", shell.lastModel().getQuery());
+    Assert.assertEquals("b", shell.lastModel().getQuery());
     Assert.assertNull(shell.lastModel().getSelectedWaveId());
-    Assert.assertEquals("Showing search results for a.", shell.lastModel().getStatusText());
+    Assert.assertEquals("Showing search results for b.", shell.lastModel().getStatusText());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -158,6 +158,27 @@ public class J2clRootLiveSurfaceControllerTest {
   }
 
   @Test
+  public void restartResetsModelToLoadingState() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    controller.start();
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    controller.stop();
+    shell.models.clear();
+
+    controller.start();
+
+    Assert.assertEquals("Loading workspace.", shell.lastModel().getStatusText());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals("", shell.lastModel().getQuery());
+  }
+
+  @Test
   public void stopSuppressesFutureLiveStatusPublication() {
     FakeShellSurface shell = new FakeShellSurface();
     J2clRootLiveSurfaceController controller =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -381,6 +381,29 @@ public class J2clRootLiveSurfaceControllerTest {
   }
 
   @Test
+  public void callbacksAfterStopDoNotForwardToDelegates() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+    FakeRouteStateHandler routeDelegate = new FakeRouteStateHandler();
+    FakeSelectedWaveController selectedDelegate = new FakeSelectedWaveController();
+    J2clSearchPanelController.RouteStateHandler routeStateHandler =
+        controller.routeStateHandler(routeDelegate);
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(selectedDelegate);
+
+    controller.stop();
+    routeStateHandler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"),
+        digest("example.com/w+123"),
+        true);
+    selectedWaveController.onWaveSelected("example.com/w+456", digest("example.com/w+456"));
+
+    Assert.assertEquals(0, routeDelegate.events.size());
+    Assert.assertEquals(0, selectedDelegate.events.size());
+    Assert.assertEquals(0, shell.models.size());
+  }
+
+  @Test
   public void constructorRejectsNullShellSurface() {
     try {
       new J2clRootLiveSurfaceController(null, () -> {});

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -49,8 +49,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void routeUrlChangedSyncsReturnTargetAndPublishesModel() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
 
     controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
 
@@ -66,8 +65,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void routeStateHandlerPublishesSelectedWaveAndDelegates() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     FakeRouteStateHandler delegate = new FakeRouteStateHandler();
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(delegate);
@@ -89,8 +87,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void routeStateHandlerClearsSelectedWaveBackToQueryStatus() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
 
@@ -108,8 +105,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void routeStateHandlerIgnoresNullRouteState() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
 
@@ -121,8 +117,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void selectedWaveAdapterClearsToLastKnownQueryStatus() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
     J2clSidecarRouteController.SelectedWaveController selectedWaveController =
@@ -142,8 +137,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void repeatedEquivalentStatusStillPublishesModelTransitions() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
 
@@ -194,8 +188,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void interleavedRouteSelectionAndClearTransitionsRemainMonotonic() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
 
@@ -213,8 +206,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void selectedWaveAdapterPublishesContinuityAndPreservesDelegateCall() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     FakeSelectedWaveController delegate = new FakeSelectedWaveController();
     J2clSidecarRouteController.SelectedWaveController selectedWaveController =
         controller.selectedWaveController(delegate);
@@ -233,8 +225,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void selectedWaveAdapterAllowsNullDelegateForObservationOnly() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSidecarRouteController.SelectedWaveController selectedWaveController =
         controller.selectedWaveController(null);
 
@@ -247,8 +238,7 @@ public class J2clRootLiveSurfaceControllerTest {
   @Test
   public void routeStateHandlerAllowsNullDelegateForObservationOnly() {
     FakeShellSurface shell = new FakeShellSurface();
-    J2clRootLiveSurfaceController controller =
-        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clRootLiveSurfaceController controller = startedController(shell);
     J2clSearchPanelController.RouteStateHandler handler =
         controller.routeStateHandler(null);
 
@@ -256,6 +246,49 @@ public class J2clRootLiveSurfaceControllerTest {
 
     Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
     Assert.assertEquals("Showing search results for in:inbox.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void callbacksBeforeStartDoNotPublishOrSyncReturnTarget() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler routeStateHandler =
+        controller.routeStateHandler(null);
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(null);
+
+    controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
+    routeStateHandler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    selectedWaveController.onWaveSelected("example.com/w+456", null);
+
+    Assert.assertEquals(0, shell.returnTargets.size());
+    Assert.assertEquals(0, shell.models.size());
+  }
+
+  @Test
+  public void routeAndSelectionCallbacksAfterStopDoNotLeakIntoRestart() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+    J2clSearchPanelController.RouteStateHandler routeStateHandler =
+        controller.routeStateHandler(null);
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(null);
+
+    routeStateHandler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    controller.stop();
+    routeStateHandler.onRouteStateChanged(
+        new J2clSidecarRouteState("after-stop", "example.com/w+456"), null, false);
+    selectedWaveController.onWaveSelected("example.com/w+789", null);
+    shell.clear();
+
+    controller.start();
+
+    Assert.assertEquals("Loading workspace.", shell.lastModel().getStatusText());
+    Assert.assertEquals("", shell.lastModel().getQuery());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
   }
 
   @Test
@@ -290,6 +323,14 @@ public class J2clRootLiveSurfaceControllerTest {
         false);
   }
 
+  private static J2clRootLiveSurfaceController startedController(FakeShellSurface shell) {
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    controller.start();
+    shell.clear();
+    return controller;
+  }
+
   private static final class FakeShellSurface
       implements J2clRootLiveSurfaceController.ShellSurface {
     private final List<String> returnTargets = new ArrayList<String>();
@@ -308,6 +349,11 @@ public class J2clRootLiveSurfaceControllerTest {
 
     private J2clRootLiveSurfaceModel lastModel() {
       return models.get(models.size() - 1);
+    }
+
+    private void clear() {
+      returnTargets.clear();
+      models.clear();
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -1,0 +1,328 @@
+package org.waveprotocol.box.j2cl.root;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSearchDigestItem;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+
+@J2clTestInput(J2clRootLiveSurfaceControllerTest.class)
+public class J2clRootLiveSurfaceControllerTest {
+  @Test
+  public void startPublishesInitialModelAndStartsExistingRouteController() {
+    FakeShellSurface shell = new FakeShellSurface();
+    FakeRouteStarter routeStarter = new FakeRouteStarter();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, routeStarter);
+
+    controller.start();
+
+    Assert.assertEquals(1, routeStarter.startCount);
+    Assert.assertEquals(
+        "Loading workspace.",
+        shell.lastModel().getStatusText());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
+  }
+
+  @Test
+  public void startKeepsSynchronousRouteStartupAsTerminalStatus() {
+    FakeShellSurface shell = new FakeShellSurface();
+    final J2clRootLiveSurfaceController[] controllerRef =
+        new J2clRootLiveSurfaceController[1];
+    controllerRef[0] =
+        new J2clRootLiveSurfaceController(
+            shell, () -> controllerRef[0].onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox"));
+
+    controllerRef[0].start();
+
+    Assert.assertEquals(1, shell.models.size());
+    Assert.assertEquals("?view=j2cl-root&q=in%3Ainbox", shell.lastModel().getRouteUrl());
+    Assert.assertEquals("Workspace is ready.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void routeUrlChangedSyncsReturnTargetAndPublishesModel() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+
+    controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(
+        Arrays.asList("?view=j2cl-root&q=in%3Ainbox"),
+        shell.returnTargets);
+    Assert.assertEquals("?view=j2cl-root&q=in%3Ainbox", shell.lastModel().getRouteUrl());
+    Assert.assertEquals(
+        "Workspace is ready.",
+        shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void routeStateHandlerPublishesSelectedWaveAndDelegates() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    FakeRouteStateHandler delegate = new FakeRouteStateHandler();
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(delegate);
+    J2clSearchDigestItem digest = digest("example.com/w+123");
+
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), digest, true);
+
+    Assert.assertEquals(
+        Arrays.asList("in:inbox|example.com/w+123|true|example.com/w+123"),
+        delegate.events);
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+    Assert.assertEquals("example.com/w+123", shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals(
+        "Selected wave is active.",
+        shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void routeStateHandlerClearsSelectedWaveBackToQueryStatus() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, true);
+    handler.onRouteStateChanged(new J2clSidecarRouteState("in:inbox", null), null, false);
+
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals(
+        "Showing search results for in:inbox.",
+        shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void routeStateHandlerIgnoresNullRouteState() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    handler.onRouteStateChanged(null, null, false);
+
+    Assert.assertEquals(0, shell.models.size());
+  }
+
+  @Test
+  public void selectedWaveAdapterClearsToLastKnownQueryStatus() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(null);
+
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    selectedWaveController.onWaveSelected(null, null);
+
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals(
+        "Showing search results for in:inbox.",
+        shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void repeatedEquivalentStatusStillPublishesModelTransitions() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+123"), null, false);
+    handler.onRouteStateChanged(
+        new J2clSidecarRouteState("in:inbox", "example.com/w+456"), null, false);
+
+    Assert.assertEquals(2, shell.models.size());
+    Assert.assertEquals("example.com/w+456", shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals("Selected wave is active.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void stopSuppressesFutureLiveStatusPublication() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+
+    controller.stop();
+    controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(0, shell.models.size());
+  }
+
+  @Test
+  public void interleavedRouteSelectionAndClearTransitionsRemainMonotonic() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    controller.onRouteUrlChanged("?view=j2cl-root&q=a");
+    handler.onRouteStateChanged(new J2clSidecarRouteState("a", "example.com/w+1"), null, false);
+    handler.onRouteStateChanged(new J2clSidecarRouteState("a", null), null, false);
+    controller.onRouteUrlChanged("?view=j2cl-root&q=b");
+
+    Assert.assertEquals("?view=j2cl-root&q=b", shell.lastModel().getRouteUrl());
+    Assert.assertEquals("a", shell.lastModel().getQuery());
+    Assert.assertNull(shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals("Showing search results for a.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void selectedWaveAdapterPublishesContinuityAndPreservesDelegateCall() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    FakeSelectedWaveController delegate = new FakeSelectedWaveController();
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(delegate);
+
+    selectedWaveController.onWaveSelected("example.com/w+abc", digest("example.com/w+abc"));
+
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+abc|example.com/w+abc"),
+        delegate.events);
+    Assert.assertEquals("example.com/w+abc", shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals(
+        "Selected wave is active.",
+        shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void selectedWaveAdapterAllowsNullDelegateForObservationOnly() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSidecarRouteController.SelectedWaveController selectedWaveController =
+        controller.selectedWaveController(null);
+
+    selectedWaveController.onWaveSelected("example.com/w+abc", null);
+
+    Assert.assertEquals("example.com/w+abc", shell.lastModel().getSelectedWaveId());
+    Assert.assertEquals("Selected wave is active.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void routeStateHandlerAllowsNullDelegateForObservationOnly() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+    J2clSearchPanelController.RouteStateHandler handler =
+        controller.routeStateHandler(null);
+
+    handler.onRouteStateChanged(new J2clSidecarRouteState("in:inbox", null), null, false);
+
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+    Assert.assertEquals("Showing search results for in:inbox.", shell.lastModel().getStatusText());
+  }
+
+  @Test
+  public void constructorRejectsNullShellSurface() {
+    try {
+      new J2clRootLiveSurfaceController(null, () -> {});
+      Assert.fail("Expected null shell surface to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("shellSurface is required", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void constructorRejectsNullRouteStarter() {
+    try {
+      new J2clRootLiveSurfaceController(new FakeShellSurface(), null);
+      Assert.fail("Expected null route starter to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("routeStarter is required", expected.getMessage());
+    }
+  }
+
+  private static J2clSearchDigestItem digest(String waveId) {
+    return new J2clSearchDigestItem(
+        waveId,
+        "Title",
+        "Snippet",
+        "Creator",
+        1,
+        2,
+        7L,
+        false);
+  }
+
+  private static final class FakeShellSurface
+      implements J2clRootLiveSurfaceController.ShellSurface {
+    private final List<String> returnTargets = new ArrayList<String>();
+    private final List<J2clRootLiveSurfaceModel> models =
+        new ArrayList<J2clRootLiveSurfaceModel>();
+
+    @Override
+    public void syncReturnTarget(String routeUrl) {
+      returnTargets.add(routeUrl);
+    }
+
+    @Override
+    public void publishLiveStatus(J2clRootLiveSurfaceModel model) {
+      models.add(model);
+    }
+
+    private J2clRootLiveSurfaceModel lastModel() {
+      return models.get(models.size() - 1);
+    }
+  }
+
+  private static final class FakeRouteStarter
+      implements J2clRootLiveSurfaceController.RouteStarter {
+    private int startCount;
+
+    @Override
+    public void start() {
+      startCount++;
+    }
+  }
+
+  private static final class FakeRouteStateHandler
+      implements J2clSearchPanelController.RouteStateHandler {
+    private final List<String> events = new ArrayList<String>();
+
+    @Override
+    public void onRouteStateChanged(
+        J2clSidecarRouteState state, J2clSearchDigestItem digestItem, boolean userNavigation) {
+      events.add(
+          state.getQuery()
+              + "|"
+              + state.getSelectedWaveId()
+              + "|"
+              + userNavigation
+              + "|"
+              + (digestItem == null ? "null" : digestItem.getWaveId()));
+    }
+  }
+
+  private static final class FakeSelectedWaveController
+      implements J2clSidecarRouteController.SelectedWaveController {
+    private final List<String> events = new ArrayList<String>();
+
+    @Override
+    public void onWaveSelected(String waveId, J2clSearchDigestItem digestItem) {
+      events.add(waveId + "|" + (digestItem == null ? "null" : digestItem.getWaveId()));
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -282,6 +282,7 @@ public class J2clRootLiveSurfaceControllerTest {
     routeStateHandler.onRouteStateChanged(
         new J2clSidecarRouteState("after-stop", "example.com/w+456"), null, false);
     selectedWaveController.onWaveSelected("example.com/w+789", null);
+    Assert.assertEquals(1, shell.models.size());
     shell.clear();
 
     controller.start();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -261,6 +261,45 @@ public class J2clRootShellViewTest {
   }
 
   @Test
+  public void syncReturnTargetPreservesBasePathForQueryOnlyRoute() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    rootShell.setAttribute("data-j2cl-root-base-path", "/app/");
+    appendReturnTargetNodes(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(
+        "/app/?view=j2cl-root&q=in%3Ainbox",
+        rootShell.getAttribute("data-j2cl-root-return-target"));
+    Assert.assertEquals(
+        "/app/?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+  }
+
+  @Test
+  public void publishLiveStatusRepublishesWhenSeparatorRemovedWithSameStatusText() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+    HTMLElement statusStrip = statusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    HTMLElement separator =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-separator");
+    statusStrip.removeChild(separator);
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    HTMLElement restoredSeparator =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-separator");
+    Assert.assertNotNull(restoredSeparator);
+    Assert.assertEquals("", restoredSeparator.style.display);
+  }
+
+  @Test
   public void publishLiveStatusReusesExistingNodesForRecreatedView() {
     assumeBrowserDom();
     J2clRootShellView firstView = createViewWithStatusStrip();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -261,6 +261,22 @@ public class J2clRootShellViewTest {
   }
 
   @Test
+  public void publishLiveStatusRepublishesWhenSeparatorDisplayMutatedExternally() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+    HTMLElement statusStrip = statusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    HTMLElement separator =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-separator");
+    // Simulate an external mutation of the separator display while status text is unchanged.
+    separator.style.display = "none";
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertEquals("", separator.style.display);
+  }
+
+  @Test
   public void syncReturnTargetPreservesBasePathForQueryOnlyRoute() {
     assumeBrowserDom();
     host = (HTMLDivElement) DomGlobal.document.createElement("div");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -105,6 +105,35 @@ public class J2clRootShellViewTest {
   }
 
   @Test
+  public void syncReturnTargetDoesNotUpdateNestedRootShellNodes() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement outerRoot = createRootShell();
+    appendReturnTargetNodes(outerRoot);
+    HTMLElement outerWorkflowHost = appendWorkflowHost(outerRoot);
+    HTMLElement innerRoot = (HTMLElement) DomGlobal.document.createElement("shell-root");
+    innerRoot.setAttribute("data-j2cl-root-shell", "true");
+    outerRoot.appendChild(innerRoot);
+    appendReturnTargetNodes(innerRoot);
+    J2clRootShellView view = new J2clRootShellView(outerWorkflowHost);
+
+    view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(
+        "/?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) outerRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+    Assert.assertNull(
+        ((HTMLElement) innerRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+    Assert.assertEquals(
+        "Return target: /?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) outerRoot.querySelector("#j2cl-root-return-target-text")).textContent);
+    Assert.assertEquals(
+        "",
+        ((HTMLElement) innerRoot.querySelector("#j2cl-root-return-target-text")).textContent);
+  }
+
+  @Test
   public void publishLiveStatusScopesInsertionToNearestNestedRootShell() {
     assumeBrowserDom();
     host = (HTMLDivElement) DomGlobal.document.createElement("div");
@@ -200,6 +229,45 @@ public class J2clRootShellViewTest {
     view.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
 
     HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
+    Assert.assertEquals("Loading workspace.", liveStatus.textContent);
+  }
+
+  @Test
+  public void publishLiveStatusReusesExistingNodesForRecreatedView() {
+    assumeBrowserDom();
+    J2clRootShellView firstView = createViewWithStatusStrip();
+    HTMLElement workflowHost = firstView.getWorkflowHost();
+    HTMLElement statusStrip = statusStrip();
+
+    firstView.publishLiveStatus(queryStatusModel("in:inbox"));
+    J2clRootShellView secondView = new J2clRootShellView(workflowHost);
+    secondView.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
+
+    Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-separator").length);
+    Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-text").length);
+    Assert.assertEquals(
+        "Loading workspace.",
+        ((HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-text")).textContent);
+  }
+
+  @Test
+  public void publishLiveStatusRestoresMissingSeparatorBeforeExistingText() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+    HTMLElement statusStrip = statusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    HTMLElement separator =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-separator");
+    statusStrip.removeChild(separator);
+    view.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
+
+    HTMLElement restoredSeparator =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-separator");
+    HTMLElement liveStatus =
+        (HTMLElement) statusStrip.querySelector("#j2cl-root-live-status-text");
+    Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-separator").length);
+    Assert.assertEquals(restoredSeparator.nextSibling, liveStatus);
     Assert.assertEquals("Loading workspace.", liveStatus.textContent);
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -39,8 +39,8 @@ public class J2clRootShellViewTest {
     HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
     Assert.assertTrue(statusStrip.contains(separator));
     Assert.assertTrue(statusStrip.contains(liveStatus));
-    Assert.assertEquals("status", liveStatus.getAttribute("role"));
-    Assert.assertEquals("polite", liveStatus.getAttribute("aria-live"));
+    Assert.assertNull(liveStatus.getAttribute("role"));
+    Assert.assertNull(liveStatus.getAttribute("aria-live"));
     Assert.assertEquals(liveStatus, separator.nextSibling);
     Assert.assertEquals("Selected wave is active.", liveStatus.textContent);
   }
@@ -76,6 +76,32 @@ public class J2clRootShellViewTest {
 
     Assert.assertNull(firstStatusStrip.querySelector("#j2cl-root-live-status-text"));
     Assert.assertNotNull(secondStatusStrip.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void syncReturnTargetScopesUpdatesToOwningRootShell() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement firstRoot = createRootShell();
+    appendReturnTargetNodes(firstRoot);
+    HTMLElement secondRoot = createRootShell();
+    appendReturnTargetNodes(secondRoot);
+    HTMLElement secondWorkflowHost = appendWorkflowHost(secondRoot);
+    J2clRootShellView view = new J2clRootShellView(secondWorkflowHost);
+
+    view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertNull(firstRoot.getAttribute("data-j2cl-root-return-target"));
+    Assert.assertEquals(
+        "/?view=j2cl-root&q=in%3Ainbox",
+        secondRoot.getAttribute("data-j2cl-root-return-target"));
+    Assert.assertEquals(
+        "/?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) secondRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+    Assert.assertEquals(
+        "Return target: /?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) secondRoot.querySelector("#j2cl-root-return-target-text")).textContent);
   }
 
   @Test
@@ -204,6 +230,21 @@ public class J2clRootShellViewTest {
     HTMLElement workflowHost = (HTMLElement) DomGlobal.document.createElement("div");
     rootShell.appendChild(workflowHost);
     return workflowHost;
+  }
+
+  private static void appendReturnTargetNodes(HTMLElement rootShell) {
+    HTMLElement brandLink = (HTMLElement) DomGlobal.document.createElement("a");
+    brandLink.id = "j2cl-root-brand-link";
+    rootShell.appendChild(brandLink);
+    HTMLElement signIn = (HTMLElement) DomGlobal.document.createElement("a");
+    signIn.setAttribute("data-j2cl-root-signin", "true");
+    rootShell.appendChild(signIn);
+    HTMLElement signOut = (HTMLElement) DomGlobal.document.createElement("a");
+    signOut.setAttribute("data-j2cl-root-signout", "true");
+    rootShell.appendChild(signOut);
+    HTMLElement returnTargetText = (HTMLElement) DomGlobal.document.createElement("span");
+    returnTargetText.id = "j2cl-root-return-target-text";
+    rootShell.appendChild(returnTargetText);
   }
 
   private HTMLElement statusStrip() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -100,6 +100,20 @@ public class J2clRootShellViewTest {
         "/?view=j2cl-root&q=in%3Ainbox",
         ((HTMLElement) secondRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
     Assert.assertEquals(
+        "/auth/signin?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
+        ((HTMLElement) secondRoot.querySelector("[data-j2cl-root-signin='true']"))
+            .getAttribute("href"));
+    Assert.assertEquals(
+        "/auth/signout?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
+        ((HTMLElement) secondRoot.querySelector("[data-j2cl-root-signout='true']"))
+            .getAttribute("href"));
+    Assert.assertNull(
+        ((HTMLElement) firstRoot.querySelector("[data-j2cl-root-signin='true']"))
+            .getAttribute("href"));
+    Assert.assertNull(
+        ((HTMLElement) firstRoot.querySelector("[data-j2cl-root-signout='true']"))
+            .getAttribute("href"));
+    Assert.assertEquals(
         "Return target: /?view=j2cl-root&q=in%3Ainbox",
         ((HTMLElement) secondRoot.querySelector("#j2cl-root-return-target-text")).textContent);
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -282,6 +282,48 @@ public class J2clRootShellViewTest {
   }
 
   @Test
+  public void syncReturnTargetPreservesBasePathWithoutTrailingSlash() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    rootShell.setAttribute("data-j2cl-root-base-path", "/app");
+    appendReturnTargetNodes(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(
+        "/app?view=j2cl-root&q=in%3Ainbox",
+        rootShell.getAttribute("data-j2cl-root-return-target"));
+    Assert.assertEquals(
+        "/app?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+  }
+
+  @Test
+  public void syncReturnTargetIgnoresUnsafeBasePathForQueryOnlyRoute() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    rootShell.setAttribute("data-j2cl-root-base-path", "//evil.example");
+    appendReturnTargetNodes(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals(
+        "/?view=j2cl-root&q=in%3Ainbox",
+        rootShell.getAttribute("data-j2cl-root-return-target"));
+    Assert.assertEquals(
+        "/?view=j2cl-root&q=in%3Ainbox",
+        ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+  }
+
+  @Test
   public void publishLiveStatusRepublishesWhenSeparatorRemovedWithSameStatusText() {
     assumeBrowserDom();
     J2clRootShellView view = createViewWithStatusStrip();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -123,8 +123,22 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(
         "/?view=j2cl-root&q=in%3Ainbox",
         ((HTMLElement) outerRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+    Assert.assertEquals(
+        "/auth/signin?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
+        ((HTMLElement) outerRoot.querySelector("[data-j2cl-root-signin='true']"))
+            .getAttribute("href"));
+    Assert.assertEquals(
+        "/auth/signout?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
+        ((HTMLElement) outerRoot.querySelector("[data-j2cl-root-signout='true']"))
+            .getAttribute("href"));
     Assert.assertNull(
         ((HTMLElement) innerRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
+    Assert.assertNull(
+        ((HTMLElement) innerRoot.querySelector("[data-j2cl-root-signin='true']"))
+            .getAttribute("href"));
+    Assert.assertNull(
+        ((HTMLElement) innerRoot.querySelector("[data-j2cl-root-signout='true']"))
+            .getAttribute("href"));
     Assert.assertEquals(
         "Return target: /?view=j2cl-root&q=in%3Ainbox",
         ((HTMLElement) outerRoot.querySelector("#j2cl-root-return-target-text")).textContent);
@@ -243,7 +257,8 @@ public class J2clRootShellViewTest {
     J2clRootShellView secondView = new J2clRootShellView(workflowHost);
     secondView.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
 
-    Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-separator").length);
+    Assert.assertEquals(
+        1, statusStrip.querySelectorAll("#j2cl-root-live-status-separator").length);
     Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-text").length);
     Assert.assertEquals(
         "Loading workspace.",
@@ -269,6 +284,29 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(1, statusStrip.querySelectorAll("#j2cl-root-live-status-separator").length);
     Assert.assertEquals(restoredSeparator.nextSibling, liveStatus);
     Assert.assertEquals("Loading workspace.", liveStatus.textContent);
+  }
+
+  @Test
+  public void publishLiveStatusUpdatesRediscoveredNodeWhenStatusStripIsReplaced() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    HTMLElement oldStatusStrip = appendStatusStrip(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+    J2clRootLiveSurfaceModel inboxModel = queryStatusModel("in:inbox");
+
+    view.publishLiveStatus(inboxModel);
+    rootShell.removeChild(oldStatusStrip);
+    HTMLElement newStatusStrip = appendStatusStrip(rootShell);
+    HTMLElement existingLiveStatus = (HTMLElement) DomGlobal.document.createElement("span");
+    existingLiveStatus.id = "j2cl-root-live-status-text";
+    newStatusStrip.appendChild(existingLiveStatus);
+    view.publishLiveStatus(inboxModel);
+
+    Assert.assertEquals("Showing search results for in:inbox.", existingLiveStatus.textContent);
+    Assert.assertEquals(1, newStatusStrip.querySelectorAll("#j2cl-root-live-status-text").length);
   }
 
   private J2clRootShellView createViewWithStatusStrip() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -1,0 +1,221 @@
+package org.waveprotocol.box.j2cl.root;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+
+@J2clTestInput(J2clRootShellViewTest.class)
+public class J2clRootShellViewTest {
+  private HTMLDivElement host;
+
+  @After
+  public void tearDown() {
+    if (host != null && host.parentElement != null) {
+      host.parentElement.removeChild(host);
+    }
+    host = null;
+  }
+
+  @Test
+  public void publishLiveStatusCreatesSingleAriaHiddenSeparatorAndLiveText() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+    HTMLElement statusStrip = statusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    view.publishLiveStatus(J2clRootLiveSurfaceModel.starting().withSelectedWaveId("example/w+1"));
+
+    Assert.assertEquals(1, host.querySelectorAll("#j2cl-root-live-status-separator").length);
+    HTMLElement separator =
+        (HTMLElement) host.querySelector("#j2cl-root-live-status-separator");
+    Assert.assertEquals("true", separator.getAttribute("aria-hidden"));
+    Assert.assertEquals("", separator.style.display);
+    HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
+    Assert.assertTrue(statusStrip.contains(separator));
+    Assert.assertTrue(statusStrip.contains(liveStatus));
+    Assert.assertEquals("status", liveStatus.getAttribute("role"));
+    Assert.assertEquals("polite", liveStatus.getAttribute("aria-live"));
+    Assert.assertEquals(liveStatus, separator.nextSibling);
+    Assert.assertEquals("Selected wave is active.", liveStatus.textContent);
+  }
+
+  @Test
+  public void publishLiveStatusNullClearsTextAndHidesSeparator() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    view.publishLiveStatus(null);
+
+    HTMLElement separator =
+        (HTMLElement) host.querySelector("#j2cl-root-live-status-separator");
+    HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
+    Assert.assertEquals("", liveStatus.textContent);
+    Assert.assertEquals("none", separator.style.display);
+  }
+
+  @Test
+  public void publishLiveStatusScopesInsertionToOwningRootShell() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement firstRoot = createRootShell();
+    HTMLElement firstStatusStrip = appendStatusStrip(firstRoot);
+    HTMLElement secondRoot = createRootShell();
+    HTMLElement secondStatusStrip = appendStatusStrip(secondRoot);
+    HTMLElement secondWorkflowHost = appendWorkflowHost(secondRoot);
+    J2clRootShellView view = new J2clRootShellView(secondWorkflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNull(firstStatusStrip.querySelector("#j2cl-root-live-status-text"));
+    Assert.assertNotNull(secondStatusStrip.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusScopesInsertionToNearestNestedRootShell() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement outerRoot = createRootShell();
+    HTMLElement outerStatusStrip = appendStatusStrip(outerRoot);
+    HTMLElement innerRoot = (HTMLElement) DomGlobal.document.createElement("shell-root");
+    innerRoot.setAttribute("data-j2cl-root-shell", "true");
+    outerRoot.appendChild(innerRoot);
+    HTMLElement innerStatusStrip = appendStatusStrip(innerRoot);
+    HTMLElement innerWorkflowHost = appendWorkflowHost(innerRoot);
+    J2clRootShellView view = new J2clRootShellView(innerWorkflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNull(outerStatusStrip.querySelector("#j2cl-root-live-status-text"));
+    Assert.assertNotNull(innerStatusStrip.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusUsesServerFirstWorkflowHostAncestor() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    HTMLElement statusStrip = appendStatusStrip(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    HTMLElement serverFirstWorkflow =
+        (HTMLElement) DomGlobal.document.createElement("div");
+    serverFirstWorkflow.className = "sidecar-search-shell";
+    serverFirstWorkflow.setAttribute("data-j2cl-server-first-workflow", "true");
+    workflowHost.appendChild(serverFirstWorkflow);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNotNull(statusStrip.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusDoesNotUseUnrelatedStatusStripOutsideRootShell() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement unrelatedStatusStrip = appendStatusStrip(host);
+    HTMLElement workflowHost = (HTMLElement) DomGlobal.document.createElement("div");
+    host.appendChild(workflowHost);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNull(unrelatedStatusStrip.querySelector("#j2cl-root-live-status-text"));
+    Assert.assertNull(host.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusDoesNothingWithoutStatusStrip() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNull(host.querySelector("#j2cl-root-live-status-separator"));
+    Assert.assertNull(host.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusCanAttachAfterStatusStripArrives() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    HTMLElement statusStrip = appendStatusStrip(rootShell);
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+
+    Assert.assertNotNull(statusStrip.querySelector("#j2cl-root-live-status-text"));
+  }
+
+  @Test
+  public void publishLiveStatusCanReturnToStartingStatus() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+
+    view.publishLiveStatus(queryStatusModel("in:inbox"));
+    view.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
+
+    HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
+    Assert.assertEquals("Loading workspace.", liveStatus.textContent);
+  }
+
+  private J2clRootShellView createViewWithStatusStrip() {
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    appendStatusStrip(rootShell);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    return new J2clRootShellView(workflowHost);
+  }
+
+  private HTMLElement createRootShell() {
+    HTMLElement rootShell = (HTMLElement) DomGlobal.document.createElement("shell-root");
+    rootShell.setAttribute("data-j2cl-root-shell", "true");
+    host.appendChild(rootShell);
+    return rootShell;
+  }
+
+  private static HTMLElement appendStatusStrip(HTMLElement rootShell) {
+    HTMLElement statusStrip = (HTMLElement) DomGlobal.document.createElement("shell-status-strip");
+    statusStrip.setAttribute("slot", "status");
+    rootShell.appendChild(statusStrip);
+    return statusStrip;
+  }
+
+  private static HTMLElement appendWorkflowHost(HTMLElement rootShell) {
+    HTMLElement workflowHost = (HTMLElement) DomGlobal.document.createElement("div");
+    rootShell.appendChild(workflowHost);
+    return workflowHost;
+  }
+
+  private HTMLElement statusStrip() {
+    return (HTMLElement) host.querySelector("shell-status-strip[slot='status']");
+  }
+
+  private static J2clRootLiveSurfaceModel queryStatusModel(String query) {
+    return J2clRootLiveSurfaceModel.starting()
+        .withRouteState(new J2clSidecarRouteState(query, null));
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+}

--- a/wave/config/changelog.d/2026-04-24-root-live-surface.json
+++ b/wave/config/changelog.d/2026-04-24-root-live-surface.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-root-live-surface",
+  "version": "Issue #968",
+  "date": "2026-04-24",
+  "title": "J2CL root shell begins publishing live-surface status",
+  "summary": "The opt-in J2CL root shell now has a root-scoped live-surface coordinator that keeps existing search and selected-wave controllers wired through one shell status publication path.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a root live-surface model and controller for route and selected-wave continuity inside `/?view=j2cl-root`",
+        "Published root live-surface status into the existing `shell-status-strip` without changing the default GWT root route or server protocol"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3278,6 +3278,8 @@ public final class HtmlRenderer {
     if (signedIn) {
       sb.append("<shell-root data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
           .append(safeResolvedReturnTarget)
+          .append("\" data-j2cl-root-base-path=\"")
+          .append(safeResolvedBasePath)
           .append("\">\n");
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
           .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
@@ -3315,6 +3317,8 @@ public final class HtmlRenderer {
     } else {
       sb.append("<shell-root-signed-out data-j2cl-root-shell=\"true\" data-j2cl-root-return-target=\"")
           .append(safeResolvedReturnTarget)
+          .append("\" data-j2cl-root-base-path=\"")
+          .append(safeResolvedBasePath)
           .append("\">\n");
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
           .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3246,6 +3246,7 @@ public final class HtmlRenderer {
     String safeEncodedReturnTarget =
         StringEscapeUtils.escapeHtml4(encodeLocalReturnTarget(resolvedReturnTarget));
     int queryStart = resolvedReturnTarget.indexOf('?');
+    // Query-only client routes reuse this path prefix when updating return targets.
     String resolvedBasePath = queryStart >= 0 ? resolvedReturnTarget.substring(0, queryStart) : resolvedReturnTarget;
     String safeResolvedBasePath = StringEscapeUtils.escapeHtml4(resolvedBasePath);
 


### PR DESCRIPTION
## Summary
- Refreshes the #968 plan for merged #965/#966/#967/#993 dependencies and narrows this PR to the first root live-surface slice.
- Adds `J2clRootLiveSurfaceModel` and `J2clRootLiveSurfaceController` so the root shell can publish route and selected-wave continuity through one root-scoped live status path.
- Wires the existing route/search/selected-wave controllers through the root live adapter without changing default GWT routing, server protocol, read-state ownership, reconnect ownership, or #967 viewport fragment growth.
- Publishes user-facing, accessible status text into the scoped `shell-status-strip` with focused J2CL tests and a changelog fragment.

Fixes #968
Part of #904

## Verification
- `git diff --check` — passed
- `j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.root.J2clRootLiveSurfaceControllerTest,org.waveprotocol.box.j2cl.root.J2clRootShellViewTest test` — passed; 24 tests, 0 failures, 9 browser-DOM tests skipped under JVM guard
- `sbt -batch j2clSearchTest` — passed
- `sbt -batch j2clSearchBuild` — passed
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — assembled 234 entries; validation passed

## Review
- Self-review fixed plan/test command drift and scoped the slice to root live-surface status only.
- Claude Opus review loop ran through six rounds.
- Actionable findings addressed: user-facing live text, `role=status`/`aria-live=polite`, aria-hidden separator, no document-wide status-strip fallback, nearest-root scoping, controller model transition publication, view-level DOM dedupe, stop seam, server-first/nested shell coverage, and transition/clear-selection coverage.
- Final Claude verdict: approve; no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in J2CL root shell publishes a root-scoped live status into the shell status strip, preserving workspace readiness, route/query and selected-wave continuity, scoping return-target links, and announcing updates via ARIA live.

* **Tests**
  * Added comprehensive tests for lifecycle start/stop, scoped DOM insertion/cleanup, status text/separator behavior, routing-driven updates, and delegate/observation semantics.

* **Documentation**
  * Added a detailed implementation plan and changelog describing behavior, verification steps, and rollout notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->