### PR TITLE
Handle generic update maps in doc op utilities

### DIFF
--- a/wave/src/main/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverter.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverter.java
@@ -26,6 +26,10 @@ import org.waveprotocol.wave.model.document.operation.DocOp;
 import org.waveprotocol.wave.model.document.operation.EvaluatingDocOpCursor;
 import org.waveprotocol.wave.model.document.operation.impl.AttributesUpdateImpl;
 import org.waveprotocol.wave.model.document.operation.impl.DocOpBuffer;
+import org.waveprotocol.wave.model.document.operation.util.ImmutableUpdateMap.AttributeUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A reverser of document operations.
@@ -87,13 +91,12 @@ public final class DocOpInverter<T> implements EvaluatingDocOpCursor<T> {
 
   @Override
   public void updateAttributes(AttributesUpdate attrUpdate) {
-    AttributesUpdate update = new AttributesUpdateImpl();
-    // TODO: This is a little silly. We should do this a better way.
+    List<AttributeUpdate> updates = new ArrayList<AttributeUpdate>(attrUpdate.changeSize());
     for (int i = 0; i < attrUpdate.changeSize(); ++i) {
-      update = update.composeWith(new AttributesUpdateImpl(attrUpdate.getChangeKey(i),
+      updates.add(new AttributeUpdate(attrUpdate.getChangeKey(i),
           attrUpdate.getNewValue(i), attrUpdate.getOldValue(i)));
     }
-    target.updateAttributes(update);
+    target.updateAttributes(AttributesUpdateImpl.fromUnsortedUpdates(updates));
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverter.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverter.java
@@ -91,8 +91,9 @@ public final class DocOpInverter<T> implements EvaluatingDocOpCursor<T> {
 
   @Override
   public void updateAttributes(AttributesUpdate attrUpdate) {
-    List<AttributeUpdate> updates = new ArrayList<AttributeUpdate>(attrUpdate.changeSize());
-    for (int i = 0; i < attrUpdate.changeSize(); ++i) {
+    int changeSize = attrUpdate.changeSize();
+    List<AttributeUpdate> updates = new ArrayList<AttributeUpdate>(changeSize);
+    for (int i = 0; i < changeSize; ++i) {
       updates.add(new AttributeUpdate(attrUpdate.getChangeKey(i),
           attrUpdate.getNewValue(i), attrUpdate.getOldValue(i)));
     }

--- a/wave/src/main/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMap.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMap.java
@@ -140,8 +140,7 @@ public abstract class ImmutableUpdateMap<T extends ImmutableUpdateMap<T, U>, U e
     List<AttributeUpdate> newAttributes = new ArrayList<AttributeUpdate>();
     Iterator<AttributeUpdate> iterator = updates.iterator();
     AttributeUpdate nextAttribute = iterator.hasNext() ? iterator.next() : null;
-    // TODO: Have a slow path when the cast would fail.
-    List<AttributeUpdate> mutationAttributes = ((ImmutableUpdateMap<?,?>) mutation).updates;
+    List<AttributeUpdate> mutationAttributes = attributeUpdatesFrom(mutation);
     loop: for (AttributeUpdate attribute : mutationAttributes) {
       while (nextAttribute != null) {
         int comparison = comparator.compare(attribute, nextAttribute);
@@ -172,9 +171,25 @@ public abstract class ImmutableUpdateMap<T extends ImmutableUpdateMap<T, U>, U e
     return createFromList(newAttributes);
   }
 
+  private static List<AttributeUpdate> attributeUpdatesFrom(UpdateMap mutation) {
+    if (mutation instanceof ImmutableUpdateMap<?,?>) {
+      return ((ImmutableUpdateMap<?,?>) mutation).updates;
+    }
+    List<AttributeUpdate> mutationAttributes =
+        new ArrayList<AttributeUpdate>(mutation.changeSize());
+    for (int i = 0; i < mutation.changeSize(); i++) {
+      mutationAttributes.add(new AttributeUpdate(mutation.getChangeKey(i),
+          mutation.getOldValue(i), mutation.getNewValue(i)));
+    }
+    Collections.sort(mutationAttributes, comparator);
+    checkUpdatesSorted(mutationAttributes);
+    return mutationAttributes;
+  }
+
   protected abstract T createFromList(List<AttributeUpdate> attributes);
 
-  // TODO: Is there a utility method for this somewhere?
+  // Keep this local: model document-operation code is GWT-compiled and nearby code avoids
+  // java.util.Objects for null-safe equality.
   private boolean areEqual(Object a, Object b) {
     return (a == null) ? b == null : a.equals(b);
   }

--- a/wave/src/main/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMap.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMap.java
@@ -175,9 +175,10 @@ public abstract class ImmutableUpdateMap<T extends ImmutableUpdateMap<T, U>, U e
     if (mutation instanceof ImmutableUpdateMap<?,?>) {
       return ((ImmutableUpdateMap<?,?>) mutation).updates;
     }
+    int changeSize = mutation.changeSize();
     List<AttributeUpdate> mutationAttributes =
-        new ArrayList<AttributeUpdate>(mutation.changeSize());
-    for (int i = 0; i < mutation.changeSize(); i++) {
+        new ArrayList<AttributeUpdate>(changeSize);
+    for (int i = 0; i < changeSize; i++) {
       mutationAttributes.add(new AttributeUpdate(mutation.getChangeKey(i),
           mutation.getOldValue(i), mutation.getNewValue(i)));
     }

--- a/wave/src/test/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverterTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverterTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.document.operation.algorithm;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.wave.model.document.operation.AttributesUpdate;
+import org.waveprotocol.wave.model.document.operation.DocOp;
+import org.waveprotocol.wave.model.document.operation.impl.AttributesUpdateImpl;
+import org.waveprotocol.wave.model.document.operation.impl.DocOpBuffer;
+import org.waveprotocol.wave.model.document.operation.impl.DocOpBuilder;
+import org.waveprotocol.wave.model.operation.OpComparators;
+
+import java.util.Collection;
+
+public class DocOpInverterTest extends TestCase {
+
+  public void testUpdateAttributesInversionReversesValues() {
+    DocOpInverter<DocOp> inverter = new DocOpInverter<DocOp>(new DocOpBuffer());
+
+    inverter.updateAttributes(new NonImmutableAttributesUpdate(
+        "b", "oldB", null,
+        "a", null, "newA"));
+
+    DocOp expected = new DocOpBuilder()
+        .updateAttributes(new AttributesUpdateImpl(
+            "a", "newA", null,
+            "b", null, "oldB"))
+        .build();
+    assertTrue(OpComparators.SYNTACTIC_IDENTITY.equal(expected, inverter.finish()));
+  }
+
+  private static final class NonImmutableAttributesUpdate implements AttributesUpdate {
+    private final String[] triples;
+
+    NonImmutableAttributesUpdate(String ... triples) {
+      this.triples = triples;
+    }
+
+    @Override
+    public int changeSize() {
+      return triples.length / 3;
+    }
+
+    @Override
+    public String getChangeKey(int changeIndex) {
+      return triples[3 * changeIndex];
+    }
+
+    @Override
+    public String getOldValue(int changeIndex) {
+      return triples[3 * changeIndex + 1];
+    }
+
+    @Override
+    public String getNewValue(int changeIndex) {
+      return triples[3 * changeIndex + 2];
+    }
+
+    @Override
+    public AttributesUpdate composeWith(AttributesUpdate mutation) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AttributesUpdate exclude(Collection<String> keys) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverterTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/document/operation/algorithm/DocOpInverterTest.java
@@ -51,7 +51,11 @@ public class DocOpInverterTest extends TestCase {
     private final String[] triples;
 
     NonImmutableAttributesUpdate(String ... triples) {
-      this.triples = triples;
+      if (triples.length % 3 != 0) {
+        throw new IllegalArgumentException(
+            "Attributes updates must be supplied as key/old/new triples");
+      }
+      this.triples = triples.clone();
     }
 
     @Override

--- a/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
@@ -21,14 +21,34 @@ package org.waveprotocol.wave.model.document.operation.util;
 
 import junit.framework.TestCase;
 
+import org.waveprotocol.wave.model.document.operation.AttributesUpdate;
+import org.waveprotocol.wave.model.document.operation.impl.AttributesUpdateImpl;
 import org.waveprotocol.wave.model.document.operation.util.ImmutableUpdateMap.AttributeUpdate;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * @author ohler@google.com (Christian Ohler)
  */
 public class ImmutableUpdateMapTest extends TestCase {
+
+  public void testComposeWithNonImmutableUpdateMap() {
+    AttributesUpdateImpl base = new AttributesUpdateImpl(
+        "b", "oldB", "midB",
+        "d", "oldD", "midD");
+
+    AttributesUpdate result = base.composeWith(new NonImmutableAttributesUpdate(
+        "c", null, "newC",
+        "a", null, "newA",
+        "b", "midB", "newB"));
+
+    assertUpdate(result,
+        "a", null, "newA",
+        "b", "oldB", "newB",
+        "c", null, "newC",
+        "d", "oldD", "midD");
+  }
 
   public void testCheckUpdatesSorted() {
     // see also the corresponding tests in ImmutableStateMapTest.
@@ -127,6 +147,53 @@ public class ImmutableUpdateMapTest extends TestCase {
       fail();
     } catch (IllegalArgumentException e) {
       // ok
+    }
+  }
+
+  private static void assertUpdate(UpdateMap update, String ... triples) {
+    assertEquals(triples.length / 3, update.changeSize());
+    for (int i = 0; i < update.changeSize(); i++) {
+      assertEquals(triples[3 * i], update.getChangeKey(i));
+      assertEquals(triples[3 * i + 1], update.getOldValue(i));
+      assertEquals(triples[3 * i + 2], update.getNewValue(i));
+    }
+  }
+
+  private static final class NonImmutableAttributesUpdate implements AttributesUpdate {
+    private final String[] triples;
+
+    NonImmutableAttributesUpdate(String ... triples) {
+      this.triples = triples;
+    }
+
+    @Override
+    public int changeSize() {
+      return triples.length / 3;
+    }
+
+    @Override
+    public String getChangeKey(int changeIndex) {
+      return triples[3 * changeIndex];
+    }
+
+    @Override
+    public String getOldValue(int changeIndex) {
+      return triples[3 * changeIndex + 1];
+    }
+
+    @Override
+    public String getNewValue(int changeIndex) {
+      return triples[3 * changeIndex + 2];
+    }
+
+    @Override
+    public AttributesUpdate composeWith(AttributesUpdate mutation) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AttributesUpdate exclude(Collection<String> keys) {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
@@ -50,6 +50,31 @@ public class ImmutableUpdateMapTest extends TestCase {
         "d", "oldD", "midD");
   }
 
+  public void testComposeWithNonImmutableUpdateMapRejectsDuplicateKeys() {
+    AttributesUpdateImpl base = new AttributesUpdateImpl("a", "oldA", "midA");
+
+    try {
+      base.composeWith(new NonImmutableAttributesUpdate(
+          "b", null, "v1",
+          "b", "v1", "v2"));
+      fail();
+    } catch (IllegalArgumentException e) {
+      // ok
+    }
+  }
+
+  public void testComposeWithNonImmutableUpdateMapRejectsMismatchedOldValue() {
+    AttributesUpdateImpl base = new AttributesUpdateImpl("a", "oldA", "midA");
+
+    try {
+      base.composeWith(new NonImmutableAttributesUpdate(
+          "a", "wrongMid", "newA"));
+      fail();
+    } catch (IllegalArgumentException e) {
+      // ok
+    }
+  }
+
   public void testCheckUpdatesSorted() {
     // see also the corresponding tests in ImmutableStateMapTest.
     ImmutableUpdateMap.checkUpdatesSorted(Arrays.asList(new AttributeUpdate[] {}));

--- a/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/document/operation/util/ImmutableUpdateMapTest.java
@@ -163,7 +163,11 @@ public class ImmutableUpdateMapTest extends TestCase {
     private final String[] triples;
 
     NonImmutableAttributesUpdate(String ... triples) {
-      this.triples = triples;
+      if (triples.length % 3 != 0) {
+        throw new IllegalArgumentException(
+            "triples length must be a multiple of 3: " + triples.length);
+      }
+      this.triples = Arrays.copyOf(triples, triples.length);
     }
 
     @Override


### PR DESCRIPTION
Refs #990

## Summary
- add a generic `UpdateMap` slow path to `ImmutableUpdateMap.composeWith`
- keep the null-safe equality helper local with a GWT-compatibility note
- simplify `DocOpInverter.updateAttributes` by constructing reversed `AttributeUpdate` values directly
- add focused tests for non-immutable update composition and attribute inversion

## Verification
- `python3 scripts/assemble-changelog.py` -> assembled 233 entries into ignored local `wave/config/changelog.json`
- `sbt "testOnly org.waveprotocol.wave.model.document.operation.util.ImmutableUpdateMapTest org.waveprotocol.wave.model.document.operation.util.ImmutableStateMapTest" "testOnly org.waveprotocol.wave.model.document.operation.algorithm.DocOpInverterTest"` -> Passed 6 utility tests and 1 DocOp inverter test, 0 failed
- `git diff --check HEAD~1..HEAD` -> passed
- `git status --short` -> clean

## Reviews
- Internal spec review: no findings
- Internal code-quality review: no findings
- External Copilot review: default model used after local CLI rejected `claude-opus-4.5`; no blockers
- Residual risk: duplicate-key and mismatched-old-value failure paths for the new non-immutable slow path are not separately pinned


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying that attribute update inversion operations correctly reverse values.
  * Added test coverage for attribute update composition when working with different attribute update implementations.

* **Refactor**
  * Improved internal attribute update handling by refactoring accumulation and composition logic to use batch processing instead of iterative composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->