### PR TITLE
Clean up ContextResolver context handling

### DIFF
--- a/wave/src/main/java/com/google/wave/api/data/converter/ContextResolver.java
+++ b/wave/src/main/java/com/google/wave/api/data/converter/ContextResolver.java
@@ -76,13 +76,13 @@ public class ContextResolver {
       Conversation conversation, Wavelet wavelet, EventDataConverter eventDataConverter,
       Map.Entry<String, Set<Context>> entry) {
     Set<Context> contextSet = entry.getValue();
-    ConversationBlip requiredBlip = conversation.getBlip(entry.getKey());
     if (contextSet.contains(Context.ALL)) {
       ContextResolver.addAllBlipsToEventMessages(
           eventMessageBundle, conversation, wavelet, eventDataConverter);
       return true;
     }
 
+    ConversationBlip requiredBlip = conversation.getBlip(entry.getKey());
     addRootBlipToEventMessages(
         eventMessageBundle, conversation, requiredBlip, wavelet, eventDataConverter, contextSet);
 

--- a/wave/src/main/java/com/google/wave/api/data/converter/ContextResolver.java
+++ b/wave/src/main/java/com/google/wave/api/data/converter/ContextResolver.java
@@ -27,7 +27,6 @@ import com.google.wave.api.impl.WaveletData;
 
 import org.waveprotocol.wave.model.conversation.Conversation;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
-import org.waveprotocol.wave.model.conversation.ConversationBlip.LocatedReplyThread;
 import org.waveprotocol.wave.model.conversation.ConversationThread;
 import org.waveprotocol.wave.model.wave.Wavelet;
 
@@ -57,54 +56,96 @@ public class ContextResolver {
    */
   public static void resolveContext(EventMessageBundle eventMessageBundle, Wavelet wavelet,
       Conversation conversation, EventDataConverter eventDataConverter) {
-    // TODO(user): Refactor.
     WaveletData waveletData =
         eventDataConverter.toWaveletData(wavelet, conversation, eventMessageBundle);
     eventMessageBundle.setWaveletData(waveletData);
     for (Map.Entry<String, Set<Context>> entry : eventMessageBundle.getRequiredBlips().entrySet()) {
-      Set<Context> contextSet = entry.getValue();
-      ConversationBlip requiredBlip = conversation.getBlip(entry.getKey());
-      if (contextSet.contains(Context.ALL)) {
-        ContextResolver.addAllBlipsToEventMessages(
-            eventMessageBundle, conversation, wavelet, eventDataConverter);
-        // We now have all blips so we're done.
+      if (resolveRequiredBlipContext(
+          eventMessageBundle, conversation, wavelet, eventDataConverter, entry)) {
         break;
       }
-      if (contextSet.contains(Context.ROOT)) {
-        ConversationBlip rootBlip = conversation.getRootThread().getFirstBlip();
-        if (rootBlip != requiredBlip) {
-          ContextResolver.addBlipToEventMessages(
-              eventMessageBundle, rootBlip, wavelet, eventDataConverter);
-        }
-      }
+    }
+  }
 
-      // Required blip might be null, for example, in a blip deleted event.
-      if (requiredBlip == null) {
-        continue;
-      }
+  /**
+   * Resolves context for a single required blip entry.
+   *
+   * @return true when all blips were added and no more entries need resolving
+   */
+  private static boolean resolveRequiredBlipContext(EventMessageBundle eventMessageBundle,
+      Conversation conversation, Wavelet wavelet, EventDataConverter eventDataConverter,
+      Map.Entry<String, Set<Context>> entry) {
+    Set<Context> contextSet = entry.getValue();
+    ConversationBlip requiredBlip = conversation.getBlip(entry.getKey());
+    if (contextSet.contains(Context.ALL)) {
+      ContextResolver.addAllBlipsToEventMessages(
+          eventMessageBundle, conversation, wavelet, eventDataConverter);
+      return true;
+    }
 
-      ContextResolver.addBlipToEventMessages(
-          eventMessageBundle, requiredBlip, wavelet, eventDataConverter);
-      if (contextSet.contains(Context.CHILDREN)) {
-        for (ConversationBlip child : eventDataConverter.findBlipChildren(requiredBlip)) {
-          ContextResolver.addBlipToEventMessages(
-              eventMessageBundle, child, wavelet, eventDataConverter);
-        }
+    addRootBlipToEventMessages(
+        eventMessageBundle, conversation, requiredBlip, wavelet, eventDataConverter, contextSet);
+
+    // Required blip might be null, for example, in a blip deleted event.
+    if (requiredBlip == null) {
+      return false;
+    }
+
+    ContextResolver.addBlipToEventMessages(
+        eventMessageBundle, requiredBlip, wavelet, eventDataConverter);
+    addChildBlipsToEventMessages(eventMessageBundle, requiredBlip, wavelet,
+        eventDataConverter, contextSet);
+    ConversationThread containingThread = requiredBlip.getThread();
+    addParentBlipToEventMessages(eventMessageBundle, requiredBlip, wavelet,
+        eventDataConverter, contextSet);
+    addSiblingBlipsToEventMessages(eventMessageBundle, requiredBlip, containingThread, wavelet,
+        eventDataConverter, contextSet);
+    return false;
+  }
+
+  private static void addRootBlipToEventMessages(EventMessageBundle eventMessageBundle,
+      Conversation conversation, ConversationBlip requiredBlip, Wavelet wavelet,
+      EventDataConverter eventDataConverter, Set<Context> contextSet) {
+    if (contextSet.contains(Context.ROOT)) {
+      ConversationBlip rootBlip = conversation.getRootThread().getFirstBlip();
+      if (rootBlip != requiredBlip) {
+        ContextResolver.addBlipToEventMessages(
+            eventMessageBundle, rootBlip, wavelet, eventDataConverter);
       }
-      ConversationThread containingThread = requiredBlip.getThread();
-      if (contextSet.contains(Context.PARENT)) {
-        ConversationBlip parent = eventDataConverter.findBlipParent(requiredBlip);
-        if (parent != null) {
-          ContextResolver.addBlipToEventMessages(
-              eventMessageBundle, parent, wavelet, eventDataConverter);
-        }
+    }
+  }
+
+  private static void addChildBlipsToEventMessages(EventMessageBundle eventMessageBundle,
+      ConversationBlip requiredBlip, Wavelet wavelet, EventDataConverter eventDataConverter,
+      Set<Context> contextSet) {
+    if (contextSet.contains(Context.CHILDREN)) {
+      for (ConversationBlip child : eventDataConverter.findBlipChildren(requiredBlip)) {
+        ContextResolver.addBlipToEventMessages(
+            eventMessageBundle, child, wavelet, eventDataConverter);
       }
-      if (contextSet.contains(Context.SIBLINGS)) {
-        for (ConversationBlip blip : containingThread.getBlips()) {
-          if (blip != requiredBlip) {
-            ContextResolver.addBlipToEventMessages(
-                eventMessageBundle, blip, wavelet, eventDataConverter);
-          }
+    }
+  }
+
+  private static void addParentBlipToEventMessages(EventMessageBundle eventMessageBundle,
+      ConversationBlip requiredBlip, Wavelet wavelet, EventDataConverter eventDataConverter,
+      Set<Context> contextSet) {
+    if (contextSet.contains(Context.PARENT)) {
+      ConversationBlip parent = eventDataConverter.findBlipParent(requiredBlip);
+      if (parent != null) {
+        ContextResolver.addBlipToEventMessages(
+            eventMessageBundle, parent, wavelet, eventDataConverter);
+      }
+    }
+  }
+
+  private static void addSiblingBlipsToEventMessages(EventMessageBundle eventMessageBundle,
+      ConversationBlip requiredBlip, ConversationThread containingThread, Wavelet wavelet,
+      EventDataConverter eventDataConverter, Set<Context> contextSet) {
+    if (contextSet.contains(Context.SIBLINGS)) {
+      for (ConversationBlip blip : containingThread.getBlips()) {
+        if (blip != requiredBlip) {
+          ContextResolver.addBlipToEventMessages(
+              eventMessageBundle, blip, wavelet, eventDataConverter);
         }
       }
     }

--- a/wave/src/test/java/com/google/wave/api/data/converter/ContextResolverTest.java
+++ b/wave/src/test/java/com/google/wave/api/data/converter/ContextResolverTest.java
@@ -155,7 +155,9 @@ public class ContextResolverTest extends TestCase {
 
   private ConversationBlip getSecondRootBlip() {
     Iterator<? extends ConversationBlip> blips = conversation.getRootThread().getBlips().iterator();
+    assertTrue("Expected at least one root blip", blips.hasNext());
     blips.next();
+    assertTrue("Expected at least two root blips", blips.hasNext());
     return blips.next();
   }
 

--- a/wave/src/test/java/com/google/wave/api/data/converter/ContextResolverTest.java
+++ b/wave/src/test/java/com/google/wave/api/data/converter/ContextResolverTest.java
@@ -44,6 +44,7 @@ import org.waveprotocol.wave.model.wave.Wavelet;
 import org.waveprotocol.wave.model.wave.opbased.ObservableWaveView;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 
 /**
@@ -93,6 +94,69 @@ public class ContextResolverTest extends TestCase {
     assertEquals(2, blips.size());
     assertTrue(blips.contains(conversation.getRootThread().getFirstBlip().getId()));
     assertTrue(blips.contains(newBlip.getId()));
+  }
+
+  public void testResolveAllContextAddsRootAndReplyThreadBlips() throws Exception {
+    ConversationBlip rootBlip = conversation.getRootThread().getFirstBlip();
+    ConversationBlip secondRootBlip = getSecondRootBlip();
+    ConversationBlip replyBlip = rootBlip.addReplyThread().appendBlip();
+    ConversationBlip secondReplyBlip = replyBlip.getThread().appendBlip();
+    eventMessages.requireBlip(rootBlip.getId(), Lists.newArrayList(Context.ALL));
+
+    ContextResolver.resolveContext(
+        eventMessages, wavelet, conversation, new EventDataConverterV21());
+
+    assertBlipDataContainsExactly(rootBlip, secondRootBlip, replyBlip, secondReplyBlip);
+  }
+
+  public void testResolveContextSkipsDeletedRequiredBlip() throws Exception {
+    ConversationBlip deletedBlip = conversation.getRootThread().appendBlip();
+    String deletedBlipId = deletedBlip.getId();
+    deletedBlip.delete();
+    eventMessages.requireBlip(
+        deletedBlipId, Lists.newArrayList(Context.PARENT, Context.CHILDREN, Context.SIBLINGS));
+
+    ContextResolver.resolveContext(
+        eventMessages, wavelet, conversation, new EventDataConverterV21());
+
+    assertTrue(eventMessages.getBlipData().isEmpty());
+  }
+
+  public void testResolveParentContextAddsRequiredBlipAndParent() throws Exception {
+    ConversationBlip rootBlip = conversation.getRootThread().getFirstBlip();
+    ConversationBlip secondRootBlip = getSecondRootBlip();
+    eventMessages.requireBlip(secondRootBlip.getId(), Lists.newArrayList(Context.PARENT));
+
+    ContextResolver.resolveContext(
+        eventMessages, wavelet, conversation, new EventDataConverterV21());
+
+    assertBlipDataContainsExactly(rootBlip, secondRootBlip);
+  }
+
+  public void testResolveSiblingsContextAddsRequiredBlipAndSiblings() throws Exception {
+    ConversationBlip rootBlip = conversation.getRootThread().getFirstBlip();
+    ConversationBlip secondRootBlip = getSecondRootBlip();
+    ConversationBlip thirdRootBlip = conversation.getRootThread().appendBlip();
+    eventMessages.requireBlip(secondRootBlip.getId(), Lists.newArrayList(Context.SIBLINGS));
+
+    ContextResolver.resolveContext(
+        eventMessages, wavelet, conversation, new EventDataConverterV21());
+
+    assertBlipDataContainsExactly(rootBlip, secondRootBlip, thirdRootBlip);
+  }
+
+  private void assertBlipDataContainsExactly(ConversationBlip... expectedBlips) {
+    Set<String> blips = eventMessages.getBlipData().keySet();
+    assertEquals(expectedBlips.length, blips.size());
+    for (ConversationBlip blip : expectedBlips) {
+      assertTrue(blips.contains(blip.getId()));
+    }
+  }
+
+  private ConversationBlip getSecondRootBlip() {
+    Iterator<? extends ConversationBlip> blips = conversation.getRootThread().getBlips().iterator();
+    blips.next();
+    return blips.next();
   }
 
   private Wavelet createMockWavelet(Conversation forConversation) {


### PR DESCRIPTION
Refs #990

## Summary
- remove the unused `LocatedReplyThread` import
- split `ContextResolver.resolveContext` into focused helper methods
- add focused coverage for ALL, deleted required blip, PARENT, and SIBLINGS context handling

## Verification
- `python3 scripts/assemble-changelog.py` -> assembled 233 entries into ignored local `wave/config/changelog.json`
- `sbt "testOnly com.google.wave.api.data.converter.ContextResolverTest"` -> Passed 6 tests, 0 failed
- `git diff --check HEAD~1..HEAD` -> passed
- `git status --short` -> clean

## Reviews
- Internal spec review: no findings
- Internal code-quality review: no findings
- External Copilot review: default model used after local CLI rejected `claude-opus-4.5`; no actionable findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for context resolution logic.

* **Tests**
  * Expanded test coverage for context-resolution functionality including edge cases and additional resolution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->