### PR TITLE
Fix Android IME first-character loss

### DIFF
--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-first-char-plan.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-first-char-plan.md
@@ -1,0 +1,37 @@
+# Issue 828 Android IME First-Character Recovery Plan
+
+## Problem
+
+On real Android Chrome on a Galaxy phone, typing `new blip` in an empty blip can persist as `ewlip`: the first character of each composed segment, and the inter-word space, are dropped.
+
+Prior recovery in `ImeExtractor` captures the DOM text siblings around the IME scratch span and treats later sibling growth as ghost composition text. That fixes the ordering where the browser inserts ghost text after baseline capture. The remaining phone-only ordering is the inverse: Chrome can insert the first character into the regular editor DOM before `compositionstart` handling creates the scratch and captures the baseline. In that case the baseline already contains the ghost text, so DOM-to-DOM comparison sees no delta and commits only the scratch contents.
+
+## Root-Cause Evidence
+
+- Android IME key events return to browser default handling when composition events are enabled, so no typing-extractor state is created before the browser default insertion.
+- `compositionStart` calls `forceFlush()`, but `forceFlush()` only drains existing typing-extractor state.
+- `ImeExtractor.activate()` currently captures adjacent DOM sibling text after creating the scratch and moving selection into it.
+- If the adjacent DOM text node already contains the browser-inserted `n` or ` b`, `GhostTextReconciler.combine()` treats that text as baseline and cannot recover it.
+
+## Fix
+
+Use model-informed baselines for the adjacent IME scratch siblings:
+
+- Record the model text immediately before and after the scratch insertion point.
+- When the captured DOM sibling is a strict extension of that model text, use the model text as the ghost baseline instead of the already-mutated DOM snapshot.
+- Keep the existing DOM-to-DOM behavior as the fallback when model and DOM do not align.
+
+This preserves the old recovery path and adds the missing ordering where ghost text exists before `activate()` snapshots the DOM.
+
+## Tests
+
+- Add pure `GhostTextReconciler` tests showing that a previous sibling whose captured DOM is already `n` over model baseline empty recovers `new` from scratch `ew`.
+- Add a second-word test where model baseline `new` and captured DOM `new b` recovers ` blip` from scratch `lip`.
+- Add symmetric next-sibling and mismatch fallback tests.
+- Run the focused model-util test before and after implementation.
+
+## Verification
+
+- Focused unit test: `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
+- Changelog assembly and validation because this changes user-facing editor behavior.
+- Local server sanity check before PR, with exact command and result mirrored to issue #828 and the PR body.

--- a/wave/config/changelog.d/2026-04-24-android-ime-model-baseline.json
+++ b/wave/config/changelog.d/2026-04-24-android-ime-model-baseline.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-24-android-ime-model-baseline",
+  "version": "Unreleased",
+  "date": "2026-04-24",
+  "title": "Android IME preserves first characters on real phones",
+  "summary": "Android Chrome IME composition now recovers first characters and inter-word spaces even when the browser inserts them into the editor DOM before the IME scratch baseline is captured.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Mobile Chrome editing now uses the document model to recover IME ghost text that already exists in adjacent DOM nodes when composition starts"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -181,11 +181,12 @@ public class ImeExtractor {
       DocumentContext<ContentNode, ContentElement, ContentTextNode> cxt,
       Point<ContentNode> location) {
 
-    clearWrapper(cxt.annotatableContent());
+    LocalDocument<ContentNode, ContentElement, ContentTextNode> doc = cxt.annotatableContent();
+    clearWrapper(doc);
 
     Point<ContentNode> point = DocHelper.ensureNodeBoundary(
         DocHelper.transparentSlice(location, cxt),
-        cxt.annotatableContent(), cxt.textNodeOrganiser());
+        doc, cxt.textNodeOrganiser());
 
     // NOTE(danilatos): Needed as a workaround to bug 2152316
     ContentElement container = point.getContainer().asElement();
@@ -195,13 +196,16 @@ public class ImeExtractor {
     }
     ////
 
-    wrapper = cxt.annotatableContent().transparentCreate(
+    String previousModelBaseline = readModelText(previousContentSibling(doc, container, nodeAfter));
+    String nextModelBaseline = readModelText(nodeAfter);
+
+    wrapper = doc.transparentCreate(
         WRAPPER_TAGNAME, Collections.<String, String>emptyMap(),
         container, nodeAfter);
 
     wrapper.getContainerNodelet().appendChild(imeContainer);
     NativeSelectionUtil.setCaret(inContainer);
-    captureGhostBaseline();
+    captureGhostBaseline(previousModelBaseline, nextModelBaseline);
     if (ImeDebugTracer.isEnabled()) {
       Element anchor = imeContainer.getParentElement();
       ImeDebugTracer.start("ImeExtractor.activate")
@@ -221,7 +225,8 @@ public class ImeExtractor {
    * #getEffectiveContent()} can later recover any composition characters the
    * browser steered into those siblings instead of the scratch.
    */
-  private void captureGhostBaseline() {
+  private void captureGhostBaseline(String previousModelBaseline,
+      String nextModelBaseline) {
     Element scratchDomAnchor = imeContainer.getParentElement();
     if (scratchDomAnchor == null) {
       ghostPreviousSibling = null;
@@ -231,9 +236,11 @@ public class ImeExtractor {
       return;
     }
     ghostPreviousSibling = scratchDomAnchor.getPreviousSibling();
-    ghostPreviousSiblingBaseline = readText(ghostPreviousSibling);
+    ghostPreviousSiblingBaseline = GhostTextReconciler.modelAwarePreviousBaseline(
+        previousModelBaseline, readText(ghostPreviousSibling));
     ghostNextSibling = scratchDomAnchor.getNextSibling();
-    ghostNextSiblingBaseline = readText(ghostNextSibling);
+    ghostNextSiblingBaseline = GhostTextReconciler.modelAwareNextBaseline(
+        nextModelBaseline, readText(ghostNextSibling));
   }
 
   /**
@@ -307,6 +314,22 @@ public class ImeExtractor {
       return null;
     }
     return Text.as(node).getData();
+  }
+
+  private static ContentNode previousContentSibling(
+      LocalDocument<ContentNode, ContentElement, ContentTextNode> doc,
+      ContentElement container, ContentNode nodeAfter) {
+    return nodeAfter == null
+        ? doc.getLastChild(container)
+        : doc.getPreviousSibling(nodeAfter);
+  }
+
+  private static String readModelText(ContentNode node) {
+    if (node == null) {
+      return "";
+    }
+    ContentTextNode text = node.asText();
+    return text == null ? "" : text.getData();
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -84,6 +84,41 @@ public final class GhostTextReconciler {
   }
 
   /**
+   * Returns the baseline to use for a previous-sibling DOM text node when the
+   * content model's adjacent text is known.
+   *
+   * <p>If Android inserted composition text before the DOM snapshot was taken,
+   * the captured DOM text is already ahead of the model. In that case the
+   * model text is the correct baseline, otherwise the old DOM snapshot remains
+   * the safest fallback.
+   */
+  public static String modelAwarePreviousBaseline(String modelText,
+      String capturedDomText) {
+    if (capturedDomText == null) {
+      return null;
+    }
+    if (modelText == null) {
+      return capturedDomText;
+    }
+    return capturedDomText.startsWith(modelText) ? modelText : capturedDomText;
+  }
+
+  /**
+   * Returns the baseline to use for a next-sibling DOM text node when the
+   * content model's adjacent text is known.
+   */
+  public static String modelAwareNextBaseline(String modelText,
+      String capturedDomText) {
+    if (capturedDomText == null) {
+      return null;
+    }
+    if (modelText == null) {
+      return capturedDomText;
+    }
+    return capturedDomText.endsWith(modelText) ? modelText : capturedDomText;
+  }
+
+  /**
    * Returns the trailing substring of {@code current} that was added since the
    * {@code baseline} snapshot. Returns an empty string if the baseline is
    * absent, if {@code current} is not a strict extension of {@code baseline},

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -109,6 +109,39 @@ public class GhostTextReconcilerTest extends TestCase {
         "lip", "new", "new b", null, null));
   }
 
+  public void testPreviousModelBaselineRecoversGhostPresentBeforeSnapshot() {
+    String baseline = GhostTextReconciler.modelAwarePreviousBaseline("", "n");
+
+    assertEquals("", baseline);
+    assertEquals("new", GhostTextReconciler.combine(
+        "ew", baseline, "n", null, null));
+  }
+
+  public void testPreviousModelBaselineRecoversSecondWordBeforeSnapshot() {
+    String baseline = GhostTextReconciler.modelAwarePreviousBaseline(
+        "new", "new b");
+
+    assertEquals("new", baseline);
+    assertEquals(" blip", GhostTextReconciler.combine(
+        "lip", baseline, "new b", null, null));
+  }
+
+  public void testNextModelBaselineRecoversGhostPresentBeforeSnapshot() {
+    String baseline = GhostTextReconciler.modelAwareNextBaseline(
+        "world", "wworld");
+
+    assertEquals("world", baseline);
+    assertEquals("new", GhostTextReconciler.combine(
+        "ne", null, null, baseline, "wworld"));
+  }
+
+  public void testModelBaselineFallsBackWhenCapturedDomDoesNotContainModel() {
+    assertEquals("NEW b", GhostTextReconciler.modelAwarePreviousBaseline(
+        "new", "NEW b"));
+    assertEquals("bNEW", GhostTextReconciler.modelAwareNextBaseline(
+        "new", "bNEW"));
+  }
+
   public void testNullScratchThrows() {
     try {
       GhostTextReconciler.combine(null, null, null, null, null);


### PR DESCRIPTION
Closes #828.

## Summary
- Recover Android IME ghost text even when Chrome inserts it into adjacent DOM before the IME scratch baseline is captured.
- Use the document model as the adjacent-sibling baseline when the captured DOM text is already ahead of the model; keep the existing DOM snapshot fallback for mismatches.
- Add regression coverage for the `new blip` -> `ewlip` ordering and a changelog fragment.

## Verification
- `python3 scripts/assemble-changelog.py` -> assembled 234 entries.
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` -> passed.
- `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"` -> 19 tests passed.
- `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest org.waveprotocol.wave.client.editor.event.CompositionEventHandlerTest org.waveprotocol.wave.client.editor.event.DelayedCompositionMutationGuardTest"` -> GhostTextReconciler suite passed; adjacent event-handler patterns did not run additional tests in this sbt setup.
- `bash scripts/worktree-boot.sh --port 9918` -> staged app successfully.
- `PORT=9918 JAVA_OPTS=... bash scripts/wave-smoke.sh start` -> `PROBE_HTTP=200`, `READY`.
- Staged-server boot-time probe -> `ROOT_STATUS=200`, `HEALTH_STATUS=200`, `ROOT_GWT=present`.

Note: the standard post-start `PORT=9918 bash scripts/wave-smoke.sh check` failed after the local server process exited before the follow-up probe (`ROOT_STATUS=000`). Diagnostics showed Jetty had started and served the initial root request with no IME/editor errors in the startup log tail; I did not fold that unrelated server-lifetime behavior into this IME patch.