### PR TITLE
Fix blocking callback null validation

### DIFF
--- a/wave/src/main/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallback.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallback.java
@@ -26,14 +26,15 @@ import org.waveprotocol.wave.util.logging.Log;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A {@code SuccessFailCallback} which supports blocking for a response.  Note that neither
- * {@link #onSuccess} not {@link #onFailure} will accept a null argument.
- *
- * TODO: the behaviour for unexpected conditions is a bit harsh, should log not crash (but it
- * requires more work, currently unwarranted).
+ * {@link #onSuccess} nor {@link #onFailure} will accept a null argument.
+ * This helper is intended for tests and blocking bridge code that must fail fast when a callback is
+ * used incorrectly: duplicate callbacks, mixed success/failure callbacks, and null callback values
+ * are programmer errors and are rejected immediately.
  */
 public class BlockingSuccessFailCallback<S, F> implements SuccessFailCallback<S, F> {
 
@@ -41,6 +42,7 @@ public class BlockingSuccessFailCallback<S, F> implements SuccessFailCallback<S,
 
   private final AtomicReference<S> successResult = new AtomicReference<S>(null);
   private final AtomicReference<F> failureResult = new AtomicReference<F>(null);
+  private final AtomicBoolean completed = new AtomicBoolean(false);
   private final CountDownLatch awaitLatch = new CountDownLatch(1);
   private final String description;
 
@@ -86,17 +88,17 @@ public class BlockingSuccessFailCallback<S, F> implements SuccessFailCallback<S,
   public void onFailure(F failureValue) {
     LOG.warning(description + ": onFailure(" + failureValue + ")");
     Preconditions.checkArgument(failureValue != null);
-    Preconditions.checkState(failureResult.getAndSet(failureValue) == null);
-    Preconditions.checkState(successResult.get() == null);
+    Preconditions.checkState(completed.compareAndSet(false, true));
+    failureResult.set(failureValue);
     awaitLatch.countDown();
   }
 
   @Override
   public void onSuccess(S successValue) {
     LOG.fine(description + ": onSuccess(" + successValue + ")");
-    Preconditions.checkArgument(successResult != null);
-    Preconditions.checkState(successResult.getAndSet(successValue) == null);
-    Preconditions.checkState(failureResult.get() == null);
+    Preconditions.checkArgument(successValue != null);
+    Preconditions.checkState(completed.compareAndSet(false, true));
+    successResult.set(successValue);
     awaitLatch.countDown();
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallback.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallback.java
@@ -86,18 +86,22 @@ public class BlockingSuccessFailCallback<S, F> implements SuccessFailCallback<S,
 
   @Override
   public void onFailure(F failureValue) {
-    LOG.warning(description + ": onFailure(" + failureValue + ")");
-    Preconditions.checkArgument(failureValue != null);
-    Preconditions.checkState(completed.compareAndSet(false, true));
+    Preconditions.checkArgument(failureValue != null,
+        description + ": onFailure requires a non-null failure value");
+    Preconditions.checkState(completed.compareAndSet(false, true),
+        description + ": callback already completed before onFailure");
     failureResult.set(failureValue);
+    LOG.warning(description + ": onFailure(" + failureValue + ")");
     awaitLatch.countDown();
   }
 
   @Override
   public void onSuccess(S successValue) {
+    Preconditions.checkArgument(successValue != null,
+        description + ": onSuccess requires a non-null success value");
+    Preconditions.checkState(completed.compareAndSet(false, true),
+        description + ": callback already completed before onSuccess");
     LOG.fine(description + ": onSuccess(" + successValue + ")");
-    Preconditions.checkArgument(successValue != null);
-    Preconditions.checkState(completed.compareAndSet(false, true));
     successResult.set(successValue);
     awaitLatch.countDown();
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallbackTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallbackTest.java
@@ -181,7 +181,7 @@ public class BlockingSuccessFailCallbackTest extends TestCase {
     successThread.start();
     failureThread.start();
     start.countDown();
-    assertTrue(done.await(1, TimeUnit.SECONDS));
+    assertTrue("Timed out waiting for concurrent callbacks", done.await(5, TimeUnit.SECONDS));
 
     assertEquals(1, completed.get());
     assertEquals(1, rejected.get());

--- a/wave/src/test/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallbackTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/BlockingSuccessFailCallbackTest.java
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.wave.model.util.Pair;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests {@link BlockingSuccessFailCallback}.
+ */
+public class BlockingSuccessFailCallbackTest extends TestCase {
+
+  public void testAwaitReturnsSuccessResult() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    callback.onSuccess("ok");
+    Pair<String, Exception> result = callback.await(0, TimeUnit.MILLISECONDS);
+
+    assertNotNull(result);
+    assertEquals("ok", result.first);
+    assertNull(result.second);
+  }
+
+  public void testAwaitReturnsFailureResult() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+    Exception failure = new Exception("failed");
+
+    callback.onFailure(failure);
+    Pair<String, Exception> result = callback.await(0, TimeUnit.MILLISECONDS);
+
+    assertNotNull(result);
+    assertNull(result.first);
+    assertSame(failure, result.second);
+  }
+
+  public void testAwaitReturnsNullOnTimeout() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    assertNull(callback.await(0, TimeUnit.MILLISECONDS));
+  }
+
+  public void testOnSuccessRejectsNullValue() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    assertThrowsIllegalArgument(new Runnable() {
+      @Override
+      public void run() {
+        callback.onSuccess(null);
+      }
+    });
+  }
+
+  public void testOnFailureRejectsNullValue() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    assertThrowsIllegalArgument(new Runnable() {
+      @Override
+      public void run() {
+        callback.onFailure(null);
+      }
+    });
+  }
+
+  public void testDuplicateSuccessCallbackIsRejected() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    callback.onSuccess("first");
+
+    assertThrowsIllegalState(new Runnable() {
+      @Override
+      public void run() {
+        callback.onSuccess("second");
+      }
+    });
+  }
+
+  public void testDuplicateFailureCallbackIsRejected() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    callback.onFailure(new Exception("first"));
+
+    assertThrowsIllegalState(new Runnable() {
+      @Override
+      public void run() {
+        callback.onFailure(new Exception("second"));
+      }
+    });
+  }
+
+  public void testFailureAfterSuccessIsRejected() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    callback.onSuccess("ok");
+
+    assertThrowsIllegalState(new Runnable() {
+      @Override
+      public void run() {
+        callback.onFailure(new Exception("failed"));
+      }
+    });
+  }
+
+  public void testSuccessAfterFailureIsRejected() {
+    BlockingSuccessFailCallback<String, Exception> callback = BlockingSuccessFailCallback.create();
+
+    callback.onFailure(new Exception("failed"));
+
+    assertThrowsIllegalState(new Runnable() {
+      @Override
+      public void run() {
+        callback.onSuccess("ok");
+      }
+    });
+  }
+
+  public void testConcurrentMixedCallbacksOnlyOneCompletes() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      assertConcurrentMixedCallbackOnlyOneCompletes();
+    }
+  }
+
+  private static void assertConcurrentMixedCallbackOnlyOneCompletes() throws Exception {
+    final BlockingSuccessFailCallback<String, Exception> callback =
+        BlockingSuccessFailCallback.create();
+    final CountDownLatch start = new CountDownLatch(1);
+    final CountDownLatch done = new CountDownLatch(2);
+    final AtomicInteger completed = new AtomicInteger();
+    final AtomicInteger rejected = new AtomicInteger();
+
+    Thread successThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        awaitUninterruptibly(start);
+        try {
+          callback.onSuccess("ok");
+          completed.incrementAndGet();
+        } catch (IllegalStateException expected) {
+          rejected.incrementAndGet();
+        } finally {
+          done.countDown();
+        }
+      }
+    });
+    Thread failureThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        awaitUninterruptibly(start);
+        try {
+          callback.onFailure(new Exception("failed"));
+          completed.incrementAndGet();
+        } catch (IllegalStateException expected) {
+          rejected.incrementAndGet();
+        } finally {
+          done.countDown();
+        }
+      }
+    });
+
+    successThread.start();
+    failureThread.start();
+    start.countDown();
+    assertTrue(done.await(1, TimeUnit.SECONDS));
+
+    assertEquals(1, completed.get());
+    assertEquals(1, rejected.get());
+    Pair<String, Exception> result = callback.await(0, TimeUnit.MILLISECONDS);
+    assertNotNull(result);
+    assertTrue((result.first == null) != (result.second == null));
+  }
+
+  private static void awaitUninterruptibly(CountDownLatch latch) {
+    boolean interrupted = false;
+    while (true) {
+      try {
+        latch.await();
+        if (interrupted) {
+          Thread.currentThread().interrupt();
+        }
+        return;
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+  }
+
+  private static void assertThrowsIllegalArgument(Runnable action) {
+    try {
+      action.run();
+      fail("Expected IllegalArgumentException");
+    } catch (IllegalArgumentException expected) {
+      // Expected.
+    }
+  }
+
+  private static void assertThrowsIllegalState(Runnable action) {
+    try {
+      action.run();
+      fail("Expected IllegalStateException");
+    } catch (IllegalStateException expected) {
+      // Expected.
+    }
+  }
+}


### PR DESCRIPTION
Refs #990

## Summary
- fix `BlockingSuccessFailCallback.onSuccess` so null success values are rejected
- replace the stale crash-vs-log TODO with an explicit fail-fast contract for invalid callback use
- use a single atomic completion gate so concurrent mixed callbacks cannot publish both success and failure
- add focused tests for success, failure, timeout, null callbacks, sequential duplicate/mixed callbacks, and concurrent mixed callbacks

## Verification
- `python3 scripts/assemble-changelog.py` -> assembled 233 entries into ignored local `wave/config/changelog.json`
- red check before fix: `sbt "testOnly org.waveprotocol.box.server.util.BlockingSuccessFailCallbackTest"` failed on null success validation as expected
- `sbt "testOnly org.waveprotocol.box.server.util.BlockingSuccessFailCallbackTest"` -> Passed 10 tests, 0 failed after the concurrency fix and rebase onto current `origin/main`
- `git diff --check HEAD~1..HEAD` -> passed
- `git status --short --branch` -> clean, ahead by this PR commit

## Reviews
- Internal spec review initially found the concurrent mixed-callback race; fixed with a single atomic terminal state
- Internal code-quality review initially found the same race; fixed
- Internal spec re-review: no findings
- Internal code-quality re-review: no findings; reran the focused callback test successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved callback completion enforcement to prevent duplicate completion attempts and invalid state transitions.
  * Enhanced validation with immediate error feedback for incorrect usage patterns.

* **Tests**
  * Added comprehensive test coverage validating callback terminal semantics and input validation requirements.
  * Included concurrency testing to ensure correct behavior under concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->