### PR TITLE
Add feature-flagged social sign-in

### DIFF
--- a/docs/runbooks/social-auth-oauth.md
+++ b/docs/runbooks/social-auth-oauth.md
@@ -1,0 +1,150 @@
+# Social Sign-In OAuth Setup
+
+Status: Current
+Owner: Project Maintainers
+Updated: 2026-04-24
+
+This runbook configures feature-flagged Google and GitHub sign-in/sign-up for
+SupaWave.
+
+Social auth does not replace Wave usernames. A first-time social user must still
+choose a SupaWave username, which becomes their participant address such as
+`yuri@supawave.ai`. Google or GitHub only verifies the provider identity and
+email used to create or later sign in to that SupaWave account.
+
+## Callback URLs
+
+Use the production public base URL for the OAuth redirect/callback URLs:
+
+```text
+https://<public-supawave-host>/auth/social/callback/google
+https://<public-supawave-host>/auth/social/callback/github
+```
+
+Set `WAVE_PUBLIC_URL=https://<public-supawave-host>` unless you set explicit
+provider redirect URI env vars. Production callbacks must be HTTPS.
+
+## Google
+
+Official setup references:
+
+- Google OpenID Connect: https://developers.google.com/identity/openid-connect/openid-connect
+- Google OAuth web server flow: https://developers.google.com/identity/protocols/oauth2/web-server
+
+Steps:
+
+1. Open Google Cloud Console.
+2. Select or create the project that owns SupaWave auth.
+3. Configure the OAuth consent screen for the SupaWave domain.
+4. Create OAuth client credentials with application type `Web application`.
+5. Add the authorized redirect URI:
+
+   ```text
+   https://<public-supawave-host>/auth/social/callback/google
+   ```
+
+6. Record the client ID and client secret.
+7. Configure the runtime:
+
+   ```bash
+   export WAVE_GOOGLE_OAUTH_CLIENT_ID='...apps.googleusercontent.com'
+   export WAVE_GOOGLE_OAUTH_CLIENT_SECRET='...'
+   export WAVE_GOOGLE_OAUTH_REDIRECT_URI='https://<public-supawave-host>/auth/social/callback/google'
+   ```
+
+The server requests `openid email profile`, validates the Google ID token
+signature, issuer, audience, expiry, nonce, and requires `email_verified=true`.
+
+## GitHub
+
+Official setup references:
+
+- Creating an OAuth App: https://docs.github.com/en/developers/apps/creating-an-oauth-app
+- Authorizing OAuth Apps: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+- User emails API: https://docs.github.com/en/rest/users/emails
+
+Steps:
+
+1. In GitHub, go to Developer settings -> OAuth Apps -> New OAuth App.
+2. Set the application name to SupaWave or the deployment-specific name.
+3. Set Homepage URL to the SupaWave public URL.
+4. Set Authorization callback URL:
+
+   ```text
+   https://<public-supawave-host>/auth/social/callback/github
+   ```
+
+5. Register the app and generate a client secret.
+6. Configure the runtime:
+
+   ```bash
+   export WAVE_GITHUB_OAUTH_CLIENT_ID='...'
+   export WAVE_GITHUB_OAUTH_CLIENT_SECRET='...'
+   export WAVE_GITHUB_OAUTH_REDIRECT_URI='https://<public-supawave-host>/auth/social/callback/github'
+   ```
+
+The server requests `read:user user:email`, uses PKCE S256, and requires a
+verified primary email from GitHub. If GitHub has no verified primary email, the
+user must verify one in GitHub before using social sign-in.
+
+## Shared Config
+
+Optional:
+
+```bash
+export WAVE_SOCIAL_AUTH_HTTP_TIMEOUT_SECONDS=10
+```
+
+Do not commit provider secrets. Configure them through the deployment secret
+manager or process environment.
+
+## Feature Flag
+
+The OAuth buttons are hidden until the provider secrets are configured and the
+`social-auth` feature flag is globally enabled.
+
+Enable for global rollout:
+
+```bash
+scripts/feature-flag.sh set social-auth \
+  "Enable Google and GitHub social sign-in and sign-up" \
+  --enabled true
+```
+
+For a fresh environment, operators can seed the initial value through config:
+
+```bash
+export WAVE_SOCIAL_AUTH_ENABLED=true
+```
+
+If the flag already exists in the feature-flag store, the admin/API value is
+preserved.
+
+Per-user allowlist entries can test authenticated account-linking direct
+`/auth/social/<provider>` links, but unauthenticated social sign-in and
+first-time social signup require the flag to be globally enabled because the
+SupaWave participant does not exist until the user chooses a username.
+
+## Rollout Notes
+
+- Keep `social-auth` disabled until every runtime has the new binary.
+- File-backed deployments must do a full stop/start rollout before enabling the
+  flag; mixed-version file-store rollout is not supported for social auth.
+- Mongo-backed deployments run a Mongock migration that adds a unique index for
+  provider/subject identity lookup.
+- Existing password accounts are not silently auto-linked by email. A social
+  provider email matching an existing account gets a generic failure page.
+- OAuth start, callback, and username-completion endpoints have a small
+  per-process rate limit keyed by `HttpServletRequest.getRemoteAddr()`. If the
+  server sits behind a reverse proxy, configure the proxy/container so remote
+  addresses reflect clients rather than a single load-balancer address.
+
+## Troubleshooting
+
+- No buttons on `/auth/signin`: confirm the global flag is enabled and the
+  selected provider has both client ID and client secret.
+- Provider says redirect URI mismatch: compare the configured provider callback
+  with `WAVE_*_OAUTH_REDIRECT_URI` and `WAVE_PUBLIC_URL`.
+- GitHub rejects login: verify the GitHub account has a primary, verified email.
+- Google rejects login: verify the Google OAuth client ID matches the deployment
+  config and the callback URL is registered on the web application client.

--- a/docs/superpowers/plans/2026-04-24-social-oauth-auth.md
+++ b/docs/superpowers/plans/2026-04-24-social-oauth-auth.md
@@ -1,0 +1,235 @@
+# Feature-Flagged Social Sign-In Plan
+
+Issue: https://github.com/vega113/supawave/issues/995
+Branch: `codex/social-oauth-auth-20260424`
+Worktree: `/Users/vega/devroot/worktrees/codex-social-oauth-auth-20260424`
+Date: 2026-04-24
+
+## Goal
+
+Add Google and GitHub sign-in/sign-up support so operators can enable it by adding OAuth secrets and turning on a feature flag. First-time social users must still choose a SupaWave username; the provider identity only proves email/profile ownership and links to the chosen Wave participant.
+
+## Current Seams
+
+- Runtime-active auth servlets are Jakarta overrides:
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java`
+  - `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java`
+- Account data is persisted through `HumanAccountData`, `HumanAccountDataImpl`, proto serialization, `FileAccountStore`, and `Mongo4AccountStore`.
+- Feature flags live in `FeatureFlagService` and `KnownFeatureFlags`; unauthenticated pages currently need a global-style visibility decision before a participant exists.
+- `PublicBaseUrlResolver` already derives a public base URL from `core.public_url` or frontend address. OAuth callback URLs should prefer explicit configured redirect URIs and otherwise use that resolver.
+- `SocialAuthServlet` must live under `wave/src/jakarta-overrides/java/...` beside the active auth servlets.
+- First-user owner assignment, timestamps, welcome-wave creation, analytics, and email-confirmation defaults currently live inside `UserRegistrationServlet`; move this into a shared `AccountCreationSupport` helper and use it from password and social registration paths.
+
+## Implementation
+
+1. Add account-level social identity data.
+   - Create `SocialIdentity` under `org.waveprotocol.box.server.account`.
+   - Fields: `provider`, `subject`, `email`, `displayName`, `linkedAtMillis`.
+   - Add `getSocialIdentities`, `setSocialIdentities`, and `addOrReplaceSocialIdentity` to `HumanAccountData` and `HumanAccountDataImpl`.
+   - Update proto schema and serializer with a repeated `ProtoSocialIdentity` field.
+   - Update file and Mongo stores to preserve identities and add lookup by `(provider, subject)`.
+   - Add `AccountStore.getAccountBySocialIdentity(provider, subject)`; the default implementation may scan with a warning for non-Mongo stores, while Mongo must use an indexed lookup.
+   - Add `AccountStore.linkSocialIdentity(participantId, identity)` so social-link writes can be field-targeted where the backend supports it.
+   - Add a Mongo Mongock change unit for a unique partial compound multikey index:
+     - keys: `human.socialIdentities.provider: 1`, `human.socialIdentities.subject: 1`
+     - name: `human_social_identity_provider_subject_unique`
+     - `unique(true)`, `background(true)`
+     - `partialFilterExpression` requiring both `human.socialIdentities.provider` and `human.socialIdentities.subject` to exist
+   - `Mongo4AccountStore.getAccountBySocialIdentity` must query with `$elemMatch`.
+   - `Mongo4AccountStore.linkSocialIdentity` must use field-level update semantics, not a full account read-modify-write.
+
+2. Add the feature flag.
+   - Register `social-auth` in `KnownFeatureFlags`, default disabled.
+   - Add `FeatureFlagService.isGloballyEnabled(flagName)` or equivalent snapshot helper for unauthenticated UI; contract: it returns only the flag's global `enabled` field and must return false when the flag only has allowed-user entries.
+   - Render social buttons on the sign-in page only when `social-auth` is globally enabled and the provider is configured. Per-user allowlist rollout can still be tested through direct `/auth/social/<provider>` links, but the generic unauthenticated sign-in page will not advertise social login until global rollout is on.
+   - Enforce `FeatureFlagService.isEnabled("social-auth", participantId)` after a provider callback resolves a participant:
+     - existing linked account: check the linked account id
+     - existing unlinked password account with matching email: do not auto-link; show a safe account-exists message telling the user to sign in with password until an authenticated account-linking flow exists
+     - new social sign-up: require `social-auth` to be globally enabled because no account exists yet
+
+3. Add OAuth provider support.
+   - New package `org.waveprotocol.box.server.authentication.oauth`.
+   - Support Google OpenID Connect with `openid email profile`.
+   - Support GitHub OAuth with `read:user user:email`, fetching the verified primary email from `/user/emails`.
+   - Do not persist access tokens, refresh tokens, ID tokens, or raw provider responses.
+   - Use authorization-code PKCE (`S256`) for Google and GitHub. Store `code_verifier` in the server session and submit it during token exchange.
+   - Generate a Google OIDC `nonce` alongside `state`, store it in the server session, and verify it against the ID token nonce claim.
+   - Verify Google ID tokens locally:
+     - parse JWS header/payload
+     - require `alg=RS256`
+     - fetch/cache Google JWKS and verify signature by `kid`
+     - validate issuer, audience/client id, expiry, and nonce
+     - allowed issuers: `https://accounts.google.com` and `accounts.google.com`
+     - accept scalar `aud` only when it equals the configured Google client id exactly
+     - accept array `aud` only when it contains the configured client id and `azp` equals the configured client id
+     - allow at most 60 seconds of clock skew for `exp` and `iat`; reject `iat` values more than 60 seconds in the future
+     - use the ID token claims as source of truth for `sub`, `email`, `name`, and `email_verified`
+   - Require Google `email_verified=true`.
+   - GitHub is OAuth 2.0, not OIDC: no ID token and no nonce validation on that path.
+   - Require PKCE S256 on GitHub OAuth Apps too; fail closed if the provider rejects the PKCE-protected authorization-code exchange.
+   - Require GitHub verified primary email from `/user/emails`; primary without verified is not enough. If no verified primary email is returned, reject with a generic provider-verification message that directs the user to verify their GitHub email without revealing local account existence.
+   - Provider HTTP hardening:
+     - strict platform TLS only; no custom trust manager
+     - do not follow redirects on token/userinfo/JWKS endpoints
+     - enforce connect/read timeout config
+     - bound response-size reads
+     - JWKS cache must be bounded, respect `Cache-Control` where available, and enforce a minimum refresh interval on unknown-`kid` misses
+   - Config keys in `reference.conf`:
+     - `core.social_auth.google.client_id`, `client_secret`, `redirect_uri`
+     - `core.social_auth.github.client_id`, `client_secret`, `redirect_uri`
+     - env overrides for the same secrets/redirects
+     - provider HTTP timeout
+   - Treat a provider as available only when client id and secret are configured.
+
+4. Add `SocialAuthServlet`.
+   - Register `/auth/social/*` in `ServerMain`.
+   - `GET /auth/social/google` and `/auth/social/github`:
+     - require `social-auth` global enable or an already authenticated participant with the flag enabled
+     - require provider config
+     - generate cryptographic `state`, `nonce` where applicable, and PKCE verifier with `SecureRandom`
+     - save pending state, nonce/verifier, created-at timestamp, one-shot CSRF token, and sanitized local `r` redirect in the server session
+     - redirect to the provider authorization endpoint
+   - `GET /auth/social/callback/<provider>`:
+     - validate and clear state
+     - exchange code for profile
+     - require provider subject; require verified email for account creation/linking
+     - find existing linked identity and sign it in if allowed/active
+     - if the request started from an already-authenticated account, link the provider only after provider email verification and only when the verified provider email matches that account's confirmed email, then keep the user signed in
+     - if an already-authenticated user's provider email does not match their confirmed account email, reject the link and preserve the existing session
+     - otherwise, if the provider email matches an existing unlinked account, do not auto-link; render a generic social-auth failure page instead
+     - otherwise rotate the HTTP session id, store a small pending profile in session, and render username-completion page
+     - clear `state`, `nonce`, `code_verifier`, and pending profile on every terminal callback outcome so state is one-shot even after failures
+   - `POST /auth/social/complete`:
+     - require a pending profile in session
+     - require the one-shot CSRF token from the pending profile
+     - reject expired pending profiles; default TTL 10 minutes
+     - require registration enabled
+     - validate username through `RegistrationSupport.checkNewUsername`
+     - require `social-auth` globally enabled
+     - create a no-password human account with verified email, social identity, timestamps, first-user owner role, analytics, and welcome wave
+     - rotate the HTTP session id, clear the pending profile, then sign in with `SessionManager` and browser-session JWT cookie
+   - Preserve existing suspended-account and email-confirmation blocking behavior.
+   - Keep local redirect validation aligned with `AuthenticationServlet`; extract a small shared `AuthRedirects` helper rather than duplicating the whole redirect parser.
+   - Use the same `AuthRedirects` helper on social entry and callback; reject open-redirect probes before storing `r` in the session.
+   - Add session-id rotation to the existing password sign-in path too, via a shared helper, so password and social sign-in do not diverge.
+   - Never log provider authorization codes, state values, tokens, raw responses, or authorization headers.
+   - Add a small in-memory rate limiter for callback/complete failures and new social-account creation keyed by client IP and provider subject. Before a provider subject is known, fall back to `client IP + provider + callback stage` so invalid-state, invalid-code, JWKS, and oversized-response probing is bounded. Keep it conservative and testable; document that it is per-JVM/per-process and production edge rate limiting can layer on top.
+
+5. Update server-rendered auth UI.
+   - Add a `SocialProviderLink` DTO for the renderer.
+   - Extend `renderAuthenticationPage` with an overload that accepts provider links; existing callers keep the empty-provider behavior.
+   - Render Google/GitHub buttons only when configured and feature-flag-visible.
+   - Add `renderSocialUsernamePage` for first-time social sign-up. It must clearly require a SupaWave username and show the provider/email context.
+   - Add `renderSocialFailurePage` for provider verification failures and the account-exists path. The page must not echo the probed provider email, local participant id, or matched provider name in a way that reveals whether a local account exists.
+
+6. Add operator documentation.
+   - Add `docs/runbooks/social-auth-oauth.md`.
+   - Include Google Cloud OAuth client setup, GitHub OAuth App setup, callback URLs, required scopes, environment variables, feature-flag rollout commands, and troubleshooting.
+   - Explicit environment variables:
+     - `WAVE_GOOGLE_OAUTH_CLIENT_ID`
+     - `WAVE_GOOGLE_OAUTH_CLIENT_SECRET`
+     - `WAVE_GOOGLE_OAUTH_REDIRECT_URI`
+     - `WAVE_GITHUB_OAUTH_CLIENT_ID`
+     - `WAVE_GITHUB_OAUTH_CLIENT_SECRET`
+     - `WAVE_GITHUB_OAUTH_REDIRECT_URI`
+     - `WAVE_SOCIAL_AUTH_HTTP_TIMEOUT_SECONDS`
+   - Explicitly state that first-time social users still choose a SupaWave username.
+   - Link to official Google and GitHub docs used for the setup steps.
+
+7. Add changelog.
+   - Add a changelog fragment under `wave/config/changelog.d/`.
+   - Run the changelog assemble/validate workflow before PR.
+
+## Tests First
+
+Add focused failing tests before implementation. The final implementation keeps
+the test scope focused on the behavior that can be exercised without live
+provider credentials:
+
+- `FeatureFlagServiceTest`
+  - `social-auth` is known and disabled by default.
+  - unauthenticated/global helper is true only for global enable.
+  - allowlist populated with global off still makes unauthenticated/global helper false.
+  - participant-specific allowlist still works for existing linked-account callbacks.
+- `AccountStoreTestBase`
+  - social identity round-trips and can be found by `(provider, subject)`.
+  - replacing an account removes stale social identity lookup mappings.
+  - existing mixed-case email addresses are found case-insensitively before
+    social signup can claim the same provider email.
+- `ProtoAccountDataSerializerTest`
+  - human account social identities survive serialization/deserialization.
+- `HtmlRendererAuthStateTest`
+  - sign-in page omits social buttons by default.
+  - sign-in page renders configured social links.
+  - username-completion page requires a SupaWave username.
+- `SocialAuthServletTest`
+  - launch is forbidden when flag/config is missing.
+  - callback rejects invalid state.
+  - callback state is one-shot and cleared on failure.
+  - username completion rejects invalid CSRF token.
+  - callback success that leads to username completion rotates the HTTP session id before pending profile storage.
+  - unmatched provider profile requires username completion.
+  - username completion creates a no-password account with chosen Wave participant and linked social identity.
+  - matching existing unlinked email does not auto-link and renders a generic failure page.
+  - rate limiter applies to repeated callback attempts before provider subject is known.
+- `GoogleIdTokenVerifierTest`
+  - accepts valid RS256 ID token with matching issuer, audience, expiry, and nonce.
+  - rejects wrong signature, wrong audience, expired token, wrong nonce, and `email_verified=false`.
+  - accepts token within the configured clock-skew window and rejects beyond it.
+  - accepts array `aud` only when it contains the client id and `azp` equals the client id.
+  - rejects `iat` more than 60 seconds in the future.
+- `SocialAuthServiceTest`
+  - rejects GitHub primary email when `verified=false`.
+  - includes PKCE verifier during token exchange.
+  - wraps malformed provider JSON as a social-auth failure rather than a server error.
+- Mongo persistence is covered by compile-time integration with the existing
+  `Mongo4AccountStore` and Mongock migration wiring in this PR. Mixed-version
+  old-binary preservation is explicitly not promised for file storage; the
+  rollout notes below require a full runtime rollout before enabling the flag.
+- `AuthenticationServletTest`
+  - password sign-in rotates the HTTP session id after successful login.
+
+## Verification
+
+Run at least:
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.server.persistence.protos.ProtoAccountDataSerializerTest org.waveprotocol.box.server.persistence.memory.AccountStoreTest org.waveprotocol.box.server.persistence.file.AccountStoreTest org.waveprotocol.box.server.rpc.HtmlRendererAuthStateTest org.waveprotocol.box.server.rpc.SocialAuthServletTest"
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+sbt -batch wave/compile
+sbt -batch compileGwt
+```
+
+Then run a local server sanity check from the worktree. Because this is auth UI work, verify:
+
+- `/auth/signin` renders without social buttons when `social-auth` is off or provider secrets are absent.
+- With a local config override that enables `social-auth` and supplies dummy provider ids/secrets, `/auth/signin` renders Google and GitHub entry links.
+- `/auth/social/google` refuses to proceed if the flag is disabled.
+
+Integration test, not manual local sanity:
+
+- A mocked-provider callback test exercises `/auth/social/callback/<provider>` end-to-end without external network calls.
+
+## Operational Notes
+
+- Keep `social-auth` disabled until the new version is fully rolled out. Older binaries do not know about social identity fields and may drop them if they deserialize accounts into the old model and rewrite them. The new Mongo social-link path uses field-targeted updates to avoid dropping fields from new binaries, but it cannot protect writes from old binaries.
+- File-store operators must complete a full stop/start rollout to the new binary before enabling `social-auth`; file storage has no field-targeted update primitive, so mixed-version file-backed deployments are not supported for social-auth enablement.
+- Provider client secrets must be supplied through environment/config, not committed.
+- OAuth callbacks must use configured HTTPS public URLs in production.
+- Provider authorization codes, state values, tokens, authorization headers, and raw responses must not be logged or persisted.
+- Per-user social-auth rollout is useful for authenticated account-linking
+  direct-link tests, but unauthenticated social sign-in and first-time social
+  signup require global enable because the chosen account does not exist before
+  completion.
+- The in-memory rate limiter is per-process and is not a cluster-wide abuse boundary.
+
+## Self-Review
+
+- The plan uses Jakarta override files for runtime auth paths.
+- The social sign-up path still requires `RegistrationSupport.checkNewUsername`, so users choose a SupaWave participant.
+- The feature flag gates both UI discovery and account-level authorization.
+- The persistence plan covers file, proto, and Mongo-backed runtime paths.
+- The docs plan includes acquisition of Google/GitHub secrets and operator rollout.
+- The verification plan includes focused tests, compile, GWT compile, changelog validation, and local auth UI sanity.

--- a/docs/superpowers/plans/2026-04-24-social-oauth-auth.md
+++ b/docs/superpowers/plans/2026-04-24-social-oauth-auth.md
@@ -74,7 +74,7 @@ Add Google and GitHub sign-in/sign-up support so operators can enable it by addi
      - do not follow redirects on token/userinfo/JWKS endpoints
      - enforce connect/read timeout config
      - bound response-size reads
-     - JWKS cache must be bounded, respect `Cache-Control` where available, and enforce a minimum refresh interval on unknown-`kid` misses
+     - JWKS cache must be bounded with a fixed TTL and enforce a minimum refresh interval on unknown-`kid` misses
    - Config keys in `reference.conf`:
      - `core.social_auth.google.client_id`, `client_secret`, `redirect_uri`
      - `core.social_auth.github.client_id`, `client_secret`, `redirect_uri`

--- a/wave/config/changelog.d/2026-04-24-social-auth.json
+++ b/wave/config/changelog.d/2026-04-24-social-auth.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-24-social-auth",
-  "version": "PR #995",
+  "version": "PR #1000",
   "date": "2026-04-24",
   "title": "Social Sign-In",
   "summary": "Google and GitHub sign-in can now be enabled behind the social-auth feature flag.",

--- a/wave/config/changelog.d/2026-04-24-social-auth.json
+++ b/wave/config/changelog.d/2026-04-24-social-auth.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-social-auth",
+  "version": "PR #995",
+  "date": "2026-04-24",
+  "title": "Social Sign-In",
+  "summary": "Google and GitHub sign-in can now be enabled behind the social-auth feature flag.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added feature-flagged Google and GitHub social sign-in and sign-up",
+        "First-time social users still choose a SupaWave username before the account is created"
+      ]
+    }
+  ]
+}

--- a/wave/config/reference.conf
+++ b/wave/config/reference.conf
@@ -209,6 +209,34 @@ core {
   # login page, allowing passwordless login via a time-limited email link.
   magic_link_enabled = false
 
+  # Google/GitHub social sign-in. The feature stays disabled until the
+  # `social-auth` feature flag is enabled. Callback defaults use public_url.
+  social_auth {
+    enabled = false
+    enabled = ${?WAVE_SOCIAL_AUTH_ENABLED}
+
+    http_timeout_seconds = 10
+    http_timeout_seconds = ${?WAVE_SOCIAL_AUTH_HTTP_TIMEOUT_SECONDS}
+
+    google {
+      client_id = ""
+      client_id = ${?WAVE_GOOGLE_OAUTH_CLIENT_ID}
+      client_secret = ""
+      client_secret = ${?WAVE_GOOGLE_OAUTH_CLIENT_SECRET}
+      redirect_uri = ""
+      redirect_uri = ${?WAVE_GOOGLE_OAUTH_REDIRECT_URI}
+    }
+
+    github {
+      client_id = ""
+      client_id = ${?WAVE_GITHUB_OAUTH_CLIENT_ID}
+      client_secret = ""
+      client_secret = ${?WAVE_GITHUB_OAUTH_CLIENT_SECRET}
+      redirect_uri = ""
+      redirect_uri = ${?WAVE_GITHUB_OAUTH_REDIRECT_URI}
+    }
+  }
+
   # Support email shown on the Contact Us page (defaults to support@<domain>).
   support_email : ""
   support_email : ${?WAVE_SUPPORT_EMAIL}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -225,6 +225,7 @@ public class ServerMain {
       FeatureFlagStore featureFlagStore = injector.getInstance(FeatureFlagStore.class);
       FeatureFlagSeeder.seedSearchFeatureFlags(featureFlagStore, config);
       FeatureFlagSeeder.seedJ2clRootBootstrapFeatureFlags(featureFlagStore, config);
+      FeatureFlagSeeder.seedSocialAuthFeatureFlag(featureFlagStore, config);
       FeatureFlagSeeder.reconcileJ2clRootBootstrapFeatureFlag(
           featureFlagStore, applicationOverrideConfig);
       injector.getInstance(FeatureFlagService.class).refreshCache();
@@ -368,6 +369,7 @@ public class ServerMain {
     server.addServlet("/auth/signin", AuthenticationServlet.class);
     server.addServlet("/auth/signout", SignOutServlet.class);
     server.addServlet("/auth/register", UserRegistrationServlet.class);
+    server.addServlet("/auth/social/*", SocialAuthServlet.class);
     server.addServlet("/auth/confirm-email", EmailConfirmServlet.class);
     server.addServlet("/auth/password-reset", PasswordResetServlet.class);
     server.addServlet("/auth/magic-link", MagicLinkServlet.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
@@ -106,6 +106,9 @@ public class ServerModule extends AbstractModule {
   @Provides @Singleton
   public SecureRandom provideSecureRandom() { return new SecureRandom(); }
 
+  @Provides @Singleton @com.google.inject.name.Named("accountCreationLock")
+  public Object provideAccountCreationLock() { return new Object(); }
+
   @Provides @Singleton
   public Clock provideClock() { return Clock.systemUTC(); }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
@@ -39,6 +39,8 @@ import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.SessionManagerImpl;
 import org.waveprotocol.box.server.authentication.jwt.JwtKeyRingPersistence;
 import org.waveprotocol.box.server.authentication.jwt.JwtKeyRing;
+import org.waveprotocol.box.server.authentication.oauth.DefaultSocialAuthHttpClient;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthHttpClient;
 import org.waveprotocol.box.server.jakarta.ServerRpcProviderJakartaProvider;
 import org.waveprotocol.box.server.rpc.ChangelogProvider;
 import org.waveprotocol.box.server.rpc.ChangelogServlet;
@@ -82,6 +84,7 @@ public class ServerModule extends AbstractModule {
     bind(ChangelogServlet.class).in(Singleton.class);
     bind(Configuration.class).toInstance(Configuration.getConfiguration());
     bind(SessionManager.class).to(SessionManagerImpl.class).in(Singleton.class);
+    bind(SocialAuthHttpClient.class).to(DefaultSocialAuthHttpClient.class).in(Singleton.class);
     // Bind via Provider to avoid Guice eagerly reflecting over ServerRpcProvider's methods
     // (which reference EE10 types) during injector creation.
     bind(ServerRpcProvider.class).toProvider(ServerRpcProviderJakartaProvider.class).in(Singleton.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerModule.java
@@ -106,9 +106,6 @@ public class ServerModule extends AbstractModule {
   @Provides @Singleton
   public SecureRandom provideSecureRandom() { return new SecureRandom(); }
 
-  @Provides @Singleton @com.google.inject.name.Named("accountCreationLock")
-  public Object provideAccountCreationLock() { return new Object(); }
-
   @Provides @Singleton
   public Clock provideClock() { return Clock.systemUTC(); }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthRedirects.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthRedirects.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 
 final class AuthRedirects {
   private static final String DEFAULT_REDIRECT_URL = "/";
+  static final String SOCIAL_AUTH_RETURN_SESSION_ATTR = "socialAuth.returnTarget";
 
   private AuthRedirects() {
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthRedirects.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthRedirects.java
@@ -1,0 +1,37 @@
+package org.waveprotocol.box.server.rpc;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+final class AuthRedirects {
+  private static final String DEFAULT_REDIRECT_URL = "/";
+
+  private AuthRedirects() {
+  }
+
+  static String sanitizeLocalRedirect(String candidate) {
+    if (candidate == null || candidate.isEmpty()) {
+      return DEFAULT_REDIRECT_URL;
+    }
+    if (candidate.length() > 2048 || candidate.indexOf('\r') >= 0 || candidate.indexOf('\n') >= 0
+        || candidate.indexOf('\\') >= 0) {
+      return DEFAULT_REDIRECT_URL;
+    }
+    try {
+      URI uri = new URI(candidate).normalize();
+      boolean hasAuthority = (uri.getRawAuthority() != null) || (uri.getHost() != null);
+      boolean hasScheme = uri.getScheme() != null;
+      String raw = uri.toString();
+      boolean startsWithSlash = uri.getPath() != null && uri.getPath().startsWith("/");
+      boolean containsTraversal =
+          uri.getPath() != null && (uri.getPath().contains("/../") || uri.getPath().contains("/./"));
+      if (hasScheme || hasAuthority || raw.startsWith("//") || !startsWithSlash
+          || containsTraversal) {
+        return DEFAULT_REDIRECT_URL;
+      }
+      return raw;
+    } catch (URISyntaxException e) {
+      return DEFAULT_REDIRECT_URL;
+    }
+  }
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -69,12 +69,14 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -491,20 +493,30 @@ public class AuthenticationServlet extends HttpServlet {
       }
       resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, initMessage,
           initResponseType, isLoginPageDisabled, analyticsAccount,
-          passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
+          passwordResetEnabled, magicLinkEnabled, socialProviderLinks(req.getParameter("r"))));
     }
   }
 
   private List<HtmlRenderer.SocialProviderLink> socialProviderLinks() {
+    return socialProviderLinks(null);
+  }
+
+  private List<HtmlRenderer.SocialProviderLink> socialProviderLinks(String returnTarget) {
     if (featureFlagService == null || socialAuthConfig == null
+        || isLoginPageDisabled
         || !featureFlagService.isGloballyEnabled(SocialAuthServlet.SOCIAL_AUTH_FLAG)) {
       return java.util.Collections.emptyList();
     }
     List<HtmlRenderer.SocialProviderLink> links = new ArrayList<>();
     for (SocialAuthProvider provider : SocialAuthProvider.values()) {
       if (socialAuthConfig.isConfigured(provider)) {
+        String url = "/auth/social/" + provider.id();
+        if (!Strings.isNullOrEmpty(returnTarget)) {
+          url += "?r=" + URLEncoder.encode(
+              AuthRedirects.sanitizeLocalRedirect(returnTarget), StandardCharsets.UTF_8);
+        }
         links.add(new HtmlRenderer.SocialProviderLink(
-            provider.label(), "/auth/social/" + provider.id()));
+            provider.label(), url));
       }
     }
     return links;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -37,9 +37,12 @@ import org.waveprotocol.box.server.authentication.email.AuthEmailService.Dispatc
 import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwt;
 import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtCookie;
 import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtIssuer;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthConfig;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthProvider;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
 import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.waveserver.AnalyticsRecorder;
 import org.waveprotocol.box.server.util.RegistrationSupport;
@@ -74,6 +77,8 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Jakarta variant of AuthenticationServlet.
@@ -110,6 +115,8 @@ public class AuthenticationServlet extends HttpServlet {
   private final boolean passwordResetEnabled;
   private final boolean magicLinkEnabled;
   private final boolean emailConfirmationEnabled;
+  private final FeatureFlagService featureFlagService;
+  private final SocialAuthConfig socialAuthConfig;
 
   @Inject
   public AuthenticationServlet(AccountStore accountStore,
@@ -119,7 +126,36 @@ public class AuthenticationServlet extends HttpServlet {
                                Config config,
                                BrowserSessionJwtIssuer browserSessionJwtIssuer,
                                AuthEmailService authEmailService,
+                               AnalyticsRecorder analyticsRecorder,
+                               FeatureFlagService featureFlagService,
+                               SocialAuthConfig socialAuthConfig) {
+    this(accountStore, configuration, sessionManager, domain, config, browserSessionJwtIssuer,
+        authEmailService, analyticsRecorder, featureFlagService, socialAuthConfig, true);
+  }
+
+  public AuthenticationServlet(AccountStore accountStore,
+                               Configuration configuration,
+                               SessionManager sessionManager,
+                               @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
+                               Config config,
+                               BrowserSessionJwtIssuer browserSessionJwtIssuer,
+                               AuthEmailService authEmailService,
                                AnalyticsRecorder analyticsRecorder) {
+    this(accountStore, configuration, sessionManager, domain, config, browserSessionJwtIssuer,
+        authEmailService, analyticsRecorder, null, null, true);
+  }
+
+  private AuthenticationServlet(AccountStore accountStore,
+                               Configuration configuration,
+                               SessionManager sessionManager,
+                               String domain,
+                               Config config,
+                               BrowserSessionJwtIssuer browserSessionJwtIssuer,
+                               AuthEmailService authEmailService,
+                               AnalyticsRecorder analyticsRecorder,
+                               FeatureFlagService featureFlagService,
+                               SocialAuthConfig socialAuthConfig,
+                               boolean ignored) {
     Preconditions.checkNotNull(accountStore, "AccountStore is null");
     Preconditions.checkNotNull(configuration, "Configuration is null");
     Preconditions.checkNotNull(sessionManager, "Session manager is null");
@@ -144,6 +180,8 @@ public class AuthenticationServlet extends HttpServlet {
         && config.getBoolean("core.magic_link_enabled");
     this.emailConfirmationEnabled = config.hasPath("core.email_confirmation_enabled")
         && config.getBoolean("core.email_confirmation_enabled");
+    this.featureFlagService = featureFlagService;
+    this.socialAuthConfig = socialAuthConfig;
   }
 
   private static X509Certificate[] getClientCerts(HttpServletRequest req) {
@@ -232,7 +270,7 @@ public class AuthenticationServlet extends HttpServlet {
         resp.setContentType("text/html;charset=utf-8");
         resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, message,
             responseType, isLoginPageDisabled, analyticsAccount,
-            passwordResetEnabled, magicLinkEnabled));
+            passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
         return;
       }
 
@@ -302,11 +340,20 @@ public class AuthenticationServlet extends HttpServlet {
       }
     }
 
+    rotateSession(req);
     WebSession session = WebSessions.from(req, true);
     sessionManager.setLoggedInUser(session, loggedInAddress);
     issueBrowserSessionJwtCookie(req, resp, loggedInAddress);
     LOG.info("Authenticated user " + loggedInAddress);
     redirectLoggedInUser(req, resp);
+  }
+
+  private void rotateSession(HttpServletRequest req) {
+    try {
+      req.getSession(true);
+      req.changeSessionId();
+    } catch (IllegalStateException ignored) {
+    }
   }
 
   private void issueBrowserSessionJwtCookie(HttpServletRequest req,
@@ -335,7 +382,7 @@ public class AuthenticationServlet extends HttpServlet {
     resp.setContentType("text/html;charset=utf-8");
     resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, message,
         RESPONSE_STATUS_FAILED, isLoginPageDisabled, analyticsAccount,
-        passwordResetEnabled, magicLinkEnabled));
+        passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
   }
 
   private ParticipantId getLoggedInUser(Subject subject) throws InvalidParticipantAddress {
@@ -434,8 +481,23 @@ public class AuthenticationServlet extends HttpServlet {
       }
       resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, initMessage,
           initResponseType, isLoginPageDisabled, analyticsAccount,
-          passwordResetEnabled, magicLinkEnabled));
+          passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
     }
+  }
+
+  private List<HtmlRenderer.SocialProviderLink> socialProviderLinks() {
+    if (featureFlagService == null || socialAuthConfig == null
+        || !featureFlagService.isGloballyEnabled(SocialAuthServlet.SOCIAL_AUTH_FLAG)) {
+      return java.util.Collections.emptyList();
+    }
+    List<HtmlRenderer.SocialProviderLink> links = new ArrayList<>();
+    for (SocialAuthProvider provider : SocialAuthProvider.values()) {
+      if (socialAuthConfig.isConfigured(provider)) {
+        links.add(new HtmlRenderer.SocialProviderLink(
+            provider.label(), "/auth/social/" + provider.id()));
+      }
+    }
+    return links;
   }
 
   private void redirectLoggedInUser(HttpServletRequest req, HttpServletResponse resp)

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -291,8 +291,18 @@ public class AuthenticationServlet extends HttpServlet {
       }
     }
 
+    if (loggedInAddress == null) {
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      resp.setContentType("text/html;charset=utf-8");
+      resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain,
+          "Sign in is not available for this deployment.",
+          RESPONSE_STATUS_FAILED, isLoginPageDisabled, analyticsAccount,
+          passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
+      return;
+    }
+
     // Check email confirmation if enabled
-    if (emailConfirmationEnabled && loggedInAddress != null) {
+    if (emailConfirmationEnabled) {
       try {
         AccountData acct = accountStore.getAccount(loggedInAddress);
         if (acct != null && acct.isHuman()) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -54,6 +54,7 @@ import org.waveprotocol.wave.util.logging.Log;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
@@ -69,14 +70,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -491,17 +490,14 @@ public class AuthenticationServlet extends HttpServlet {
         initMessage = "Account created! Sign in to get started.";
         initResponseType = RESPONSE_STATUS_SUCCESS;
       }
+      rememberSocialReturnTarget(req);
       resp.getWriter().write(HtmlRenderer.renderAuthenticationPage(domain, initMessage,
           initResponseType, isLoginPageDisabled, analyticsAccount,
-          passwordResetEnabled, magicLinkEnabled, socialProviderLinks(req.getParameter("r"))));
+          passwordResetEnabled, magicLinkEnabled, socialProviderLinks()));
     }
   }
 
   private List<HtmlRenderer.SocialProviderLink> socialProviderLinks() {
-    return socialProviderLinks(null);
-  }
-
-  private List<HtmlRenderer.SocialProviderLink> socialProviderLinks(String returnTarget) {
     if (featureFlagService == null || socialAuthConfig == null
         || isLoginPageDisabled
         || !featureFlagService.isGloballyEnabled(SocialAuthServlet.SOCIAL_AUTH_FLAG)) {
@@ -510,16 +506,25 @@ public class AuthenticationServlet extends HttpServlet {
     List<HtmlRenderer.SocialProviderLink> links = new ArrayList<>();
     for (SocialAuthProvider provider : SocialAuthProvider.values()) {
       if (socialAuthConfig.isConfigured(provider)) {
-        String url = "/auth/social/" + provider.id();
-        if (!Strings.isNullOrEmpty(returnTarget)) {
-          url += "?r=" + URLEncoder.encode(
-              AuthRedirects.sanitizeLocalRedirect(returnTarget), StandardCharsets.UTF_8);
-        }
         links.add(new HtmlRenderer.SocialProviderLink(
-            provider.label(), url));
+            provider.label(), "/auth/social/" + provider.id()));
       }
     }
     return links;
+  }
+
+  private void rememberSocialReturnTarget(HttpServletRequest req) {
+    String returnTarget = req.getParameter("r");
+    if (Strings.isNullOrEmpty(returnTarget)) {
+      HttpSession session = req.getSession(false);
+      if (session != null) {
+        session.removeAttribute(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR);
+      }
+      return;
+    }
+    req.getSession(true).setAttribute(
+        AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR,
+        AuthRedirects.sanitizeLocalRedirect(returnTarget));
   }
 
   private void redirectLoggedInUser(HttpServletRequest req, HttpServletResponse resp)

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2101,10 +2101,14 @@ public final class HtmlRenderer {
     sb.append("  </div>\n");
     sb.append("  <div class=\"card\">\n");
     sb.append("    <h1>Choose your SupaWave username</h1>\n");
-    sb.append("    <div class=\"subtitle\">")
-        .append(escapeHtml(providerLabel == null ? "Social" : providerLabel))
-        .append(" verified ").append(escapeHtml(email == null ? "" : email))
-        .append("</div>\n");
+    sb.append("    <div class=\"subtitle\">");
+    sb.append(escapeHtml(providerLabel == null ? "Social" : providerLabel));
+    if (email == null || email.isBlank()) {
+      sb.append(" verified your identity");
+    } else {
+      sb.append(" verified ").append(escapeHtml(email));
+    }
+    sb.append("</div>\n");
     sb.append("    <div class=\"msg\" id=\"messageLbl\"></div>\n");
     sb.append("    <form id=\"socialUserForm\" method=\"post\" action=\"/auth/social/complete\">\n");
     sb.append("      <input type=\"hidden\" name=\"csrf\" value=\"")

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -1534,6 +1534,10 @@ public final class HtmlRenderer {
       + ".msg { font-size: 13px; min-height: 18px; margin-bottom: 10px; }\n"
       + ".msg.error { color: #d93025; }\n"
       + ".msg.success { color: #188038; }\n"
+      + ".social-auth-options { margin-top: 18px; }\n"
+      + ".social-auth-divider { display: flex; align-items: center; gap: 10px; margin: 14px 0; color: #8a94a6; font-size: 12px; }\n"
+      + ".social-auth-divider::before, .social-auth-divider::after { content: ''; flex: 1; height: 1px; background: #e5e9f0; }\n"
+      + ".social-auth-button { display: block; width: 100%; margin: 8px 0 0; text-align: center; text-decoration: none; }\n"
       + ".footer-link { font-size: 13px; margin-top: 16px; text-align: center; }\n"
       + ".footer-link a { color: " + WAVE_PRIMARY + "; text-decoration: none; font-weight: 500; }\n"
       + ".footer-link a:hover { text-decoration: underline; }\n"
@@ -1929,6 +1933,24 @@ public final class HtmlRenderer {
         analyticsAccount, false, false);
   }
 
+  public static final class SocialProviderLink {
+    private final String label;
+    private final String url;
+
+    public SocialProviderLink(String label, String url) {
+      this.label = label;
+      this.url = url;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public String getUrl() {
+      return url;
+    }
+  }
+
   /**
    * Renders the login page with optional email auth links.
    *
@@ -1943,6 +1965,14 @@ public final class HtmlRenderer {
   public static String renderAuthenticationPage(String domain, String message,
       String responseType, boolean disableLoginPage, String analyticsAccount,
       boolean passwordResetEnabled, boolean magicLinkEnabled) {
+    return renderAuthenticationPage(domain, message, responseType, disableLoginPage,
+        analyticsAccount, passwordResetEnabled, magicLinkEnabled, java.util.Collections.emptyList());
+  }
+
+  public static String renderAuthenticationPage(String domain, String message,
+      String responseType, boolean disableLoginPage, String analyticsAccount,
+      boolean passwordResetEnabled, boolean magicLinkEnabled,
+      java.util.List<SocialProviderLink> socialProviderLinks) {
     StringBuilder sb = new StringBuilder(8192);
     sb.append("<!DOCTYPE html>\n<html dir=\"ltr\">\n<head>\n");
     sb.append("<meta charset=\"UTF-8\">\n");
@@ -1984,6 +2014,19 @@ public final class HtmlRenderer {
       sb.append("      <div class=\"msg\" id=\"messageLbl\"></div>\n");
       sb.append("      <input type=\"submit\" class=\"btn-primary\" name=\"signIn\" id=\"signIn\" value=\"Sign in\" style=\"width:100%;\">\n");
       sb.append("    </form>\n");
+      if (socialProviderLinks != null && !socialProviderLinks.isEmpty()) {
+        sb.append("    <div class=\"social-auth-options\" aria-label=\"Social sign in options\">\n");
+        sb.append("      <div class=\"social-auth-divider\"><span>or</span></div>\n");
+        for (SocialProviderLink link : socialProviderLinks) {
+          if (link == null || link.getLabel() == null || link.getUrl() == null) {
+            continue;
+          }
+          sb.append("      <a class=\"btn-secondary social-auth-button\" href=\"")
+              .append(escapeHtml(link.getUrl())).append("\">Continue with ")
+              .append(escapeHtml(link.getLabel())).append("</a>\n");
+        }
+        sb.append("    </div>\n");
+      }
       if (passwordResetEnabled) {
         sb.append("    <div class=\"footer-link\">\n");
         sb.append("      <a href=\"/auth/password-reset\">Forgot password?</a>\n");
@@ -2035,6 +2078,69 @@ public final class HtmlRenderer {
     sb.append("</script>\n");
     sb.append("</body>\n</html>\n");
     return sb.toString();
+  }
+
+  public static String renderSocialUsernamePage(String domain, String providerLabel,
+      String email, String message, String responseType, String csrfToken,
+      String analyticsAccount) {
+    StringBuilder sb = new StringBuilder(8192);
+    sb.append("<!DOCTYPE html>\n<html dir=\"ltr\">\n<head>\n");
+    sb.append("<meta charset=\"UTF-8\">\n");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
+    sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
+    sb.append("<title>Choose Username - SupaWave</title>\n");
+    sb.append(AUTH_CSS);
+    appendAnalyticsFragment(sb, analyticsAccount, null);
+    sb.append("</head>\n<body onload=\"init()\">\n");
+    sb.append(WAVE_SVG);
+    sb.append("<div class=\"page-wrapper\">\n");
+    sb.append("  <div class=\"brand\">\n");
+    sb.append("    ").append(WAVE_LOGO_SVG);
+    sb.append("    <div class=\"brand-name\">SupaWave</div>\n");
+    sb.append("  </div>\n");
+    sb.append("  <div class=\"card\">\n");
+    sb.append("    <h1>Choose your SupaWave username</h1>\n");
+    sb.append("    <div class=\"subtitle\">")
+        .append(escapeHtml(providerLabel == null ? "Social" : providerLabel))
+        .append(" verified ").append(escapeHtml(email == null ? "" : email))
+        .append("</div>\n");
+    sb.append("    <div class=\"msg\" id=\"messageLbl\"></div>\n");
+    sb.append("    <form id=\"socialUserForm\" method=\"post\" action=\"/auth/social/complete\">\n");
+    sb.append("      <input type=\"hidden\" name=\"csrf\" value=\"")
+        .append(escapeHtml(csrfToken == null ? "" : csrfToken)).append("\">\n");
+    sb.append("      <label for=\"address\">Username</label>\n");
+    sb.append("      <div class=\"input-group\">\n");
+    sb.append("        <input type=\"text\" name=\"address\" id=\"address\" autocomplete=\"username\" placeholder=\"your.name\">\n");
+    sb.append("        <span class=\"domain-suffix\">@").append(escapeHtml(domain)).append("</span>\n");
+    sb.append("      </div>\n");
+    sb.append("      <input type=\"submit\" class=\"btn-primary\" value=\"Create account\" style=\"width:100%;\">\n");
+    sb.append("    </form>\n");
+    sb.append("    <div class=\"footer-link\"><a href=\"/auth/signin\">Back to sign in</a></div>\n");
+    sb.append("  </div>\n");
+    sb.append("</div>\n");
+    sb.append("<script>\n");
+    sb.append("var RESPONSE_STATUS_NONE = \"NONE\";\n");
+    sb.append("var RESPONSE_STATUS_FAILED = \"FAILED\";\n");
+    sb.append("var message = ").append(escapeJsonString(message == null ? "" : message)).append(";\n");
+    sb.append("var responseType = ").append(escapeJsonString(responseType == null ? "NONE" : responseType)).append(";\n");
+    sb.append("function init(){ var el=document.getElementById('address'); if(el) el.focus(); var lbl=document.getElementById('messageLbl'); if(responseType==RESPONSE_STATUS_FAILED && lbl){ lbl.style.display='block'; lbl.className='msg error'; lbl.textContent=message; }}\n");
+    sb.append("</script>\n");
+    sb.append("</body>\n</html>\n");
+    return sb.toString();
+  }
+
+  public static String renderSocialFailurePage(String domain, String message,
+      String analyticsAccount) {
+    return renderSocialFailurePage(domain, message, analyticsAccount, false, true, false);
+  }
+
+  public static String renderSocialFailurePage(String domain, String message,
+      String analyticsAccount, boolean disableLoginPage, boolean passwordResetEnabled,
+      boolean magicLinkEnabled) {
+    return renderAuthenticationPage(domain, message,
+        AuthenticationServlet.RESPONSE_STATUS_FAILED, disableLoginPage, analyticsAccount,
+        passwordResetEnabled, magicLinkEnabled);
   }
 
   // =========================================================================

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -25,6 +25,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.security.MessageDigest;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.text.StringEscapeUtils;
@@ -2014,13 +2015,20 @@ public final class HtmlRenderer {
       sb.append("      <div class=\"msg\" id=\"messageLbl\"></div>\n");
       sb.append("      <input type=\"submit\" class=\"btn-primary\" name=\"signIn\" id=\"signIn\" value=\"Sign in\" style=\"width:100%;\">\n");
       sb.append("    </form>\n");
-      if (socialProviderLinks != null && !socialProviderLinks.isEmpty()) {
-        sb.append("    <div class=\"social-auth-options\" aria-label=\"Social sign in options\">\n");
-        sb.append("      <div class=\"social-auth-divider\"><span>or</span></div>\n");
+      List<SocialProviderLink> validSocialProviderLinks = new ArrayList<>();
+      if (socialProviderLinks != null) {
         for (SocialProviderLink link : socialProviderLinks) {
-          if (link == null || link.getLabel() == null || link.getUrl() == null) {
+          if (link == null || link.getLabel() == null || link.getUrl() == null
+              || link.getLabel().trim().isEmpty() || link.getUrl().trim().isEmpty()) {
             continue;
           }
+          validSocialProviderLinks.add(link);
+        }
+      }
+      if (!validSocialProviderLinks.isEmpty()) {
+        sb.append("    <div class=\"social-auth-options\" aria-label=\"Social sign in options\">\n");
+        sb.append("      <div class=\"social-auth-divider\"><span>or</span></div>\n");
+        for (SocialProviderLink link : validSocialProviderLinks) {
           sb.append("      <a class=\"btn-secondary social-auth-button\" href=\"")
               .append(escapeHtml(link.getUrl())).append("\">Continue with ")
               .append(escapeHtml(link.getLabel())).append("</a>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -74,7 +74,7 @@ public final class SocialAuthServlet extends HttpServlet {
   private final boolean passwordResetEnabled;
   private final boolean magicLinkEnabled;
   private final String analyticsAccount;
-  private final Object accountCreationLock = new Object();
+  private final Object accountCreationLock;
   private final Object startRateLimitLock = new Object();
   // Per-instance in-memory rate-limit store. Effective only in single-instance deployments;
   // clustered deployments should replace this with a centralized store (e.g. Redis) so the
@@ -92,8 +92,10 @@ public final class SocialAuthServlet extends HttpServlet {
       AnalyticsRecorder analyticsRecorder,
       SecureRandom secureRandom,
       @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
-      Config config) {
+      Config config,
+      @Named("accountCreationLock") Object accountCreationLock) {
     this.accountStore = accountStore;
+    this.accountCreationLock = accountCreationLock;
     this.featureFlagService = featureFlagService;
     this.sessionManager = sessionManager;
     this.browserSessionJwtIssuer = browserSessionJwtIssuer;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -146,7 +146,7 @@ public final class SocialAuthServlet extends HttpServlet {
     ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
     boolean enabled = featureFlagService.isGloballyEnabled(SOCIAL_AUTH_FLAG)
         || (user != null && featureFlagService.isEnabled(SOCIAL_AUTH_FLAG, user.getAddress()));
-    if (!enabled || !socialAuthConfig.isConfigured(provider)) {
+    if (loginPageDisabled || !enabled || !socialAuthConfig.isConfigured(provider)) {
       renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
       return;
     }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -74,6 +74,7 @@ public final class SocialAuthServlet extends HttpServlet {
   private final boolean passwordResetEnabled;
   private final boolean magicLinkEnabled;
   private final String analyticsAccount;
+  private final Object accountCreationLock = new Object();
   private final Object startRateLimitLock = new Object();
   private final Map<String, RateLimitBucket> startRateLimits = new HashMap<>();
 
@@ -303,10 +304,7 @@ public final class SocialAuthServlet extends HttpServlet {
           pending.provider, pending.subject, pending.email, pending.displayName,
           System.currentTimeMillis());
       account.addOrReplaceSocialIdentity(socialIdentity);
-      if (accountStore.getAccountCount() == 0) {
-        account.setRole(HumanAccountData.ROLE_OWNER);
-      }
-      accountStore.putAccountWithUniqueSocialIdentity(account, socialIdentity);
+      persistSocialAccountWithOwnerAssignment(account, socialIdentity);
       try {
         analyticsRecorder.incrementUsersRegistered(System.currentTimeMillis());
       } catch (RuntimeException e) {
@@ -321,6 +319,16 @@ public final class SocialAuthServlet extends HttpServlet {
     } catch (PersistenceException e) {
       LOG.warning("Failed to create social account: " + e.getClass().getName());
       renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+    }
+  }
+
+  private void persistSocialAccountWithOwnerAssignment(HumanAccountDataImpl account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    synchronized (accountCreationLock) {
+      if (accountStore.getAccountCount() == 0) {
+        account.setRole(HumanAccountData.ROLE_OWNER);
+      }
+      accountStore.putAccountWithUniqueSocialIdentity(account, socialIdentity);
     }
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -53,6 +53,8 @@ public final class SocialAuthServlet extends HttpServlet {
   private static final String PROFILE_SESSION_ATTR = "socialAuth.pendingProfile";
   private static final String DEFAULT_FAILURE =
       "Social sign-in could not be completed. Check your provider account and try again.";
+  private static final String INVALID_USERNAME_MESSAGE =
+      "Choose a username using letters, numbers, underscores, and periods.";
 
   private static final Log LOG = Log.get(SocialAuthServlet.class);
 
@@ -245,7 +247,7 @@ public final class SocialAuthServlet extends HttpServlet {
           profile.getProvider(), provider.label(), profile.getSubject(),
           normalizeEmail(profile.getEmail()), profile.getDisplayName(), csrf,
           pending.redirect, System.currentTimeMillis()));
-      writeUsernamePage(resp, provider.label(), profile.getEmail(), "", 
+      writeUsernamePage(resp, provider.label(), "",
           AuthenticationServlet.RESPONSE_STATUS_NONE, csrf);
     } catch (Exception e) {
       LOG.warning("Social sign-in failed: " + e.getClass().getName());
@@ -278,12 +280,12 @@ public final class SocialAuthServlet extends HttpServlet {
     try {
       id = RegistrationSupport.checkNewUsername(domain, req.getParameter("address"));
     } catch (InvalidParticipantAddress e) {
-      writeUsernamePage(resp, pending.providerLabel, pending.email, e.getMessage(),
+      writeUsernamePage(resp, pending.providerLabel, INVALID_USERNAME_MESSAGE,
           AuthenticationServlet.RESPONSE_STATUS_FAILED, pending.csrf);
       return;
     }
     if (RegistrationSupport.doesAccountExist(accountStore, id)) {
-      writeUsernamePage(resp, pending.providerLabel, pending.email, "Account already exists",
+      writeUsernamePage(resp, pending.providerLabel, "Account already exists",
           AuthenticationServlet.RESPONSE_STATUS_FAILED, pending.csrf);
       return;
     }
@@ -369,11 +371,11 @@ public final class SocialAuthServlet extends HttpServlet {
         normalizeEmail(profile.getEmail()), profile.getDisplayName(), System.currentTimeMillis());
   }
 
-  private void writeUsernamePage(HttpServletResponse resp, String providerLabel, String email,
+  private void writeUsernamePage(HttpServletResponse resp, String providerLabel,
       String message, String responseType, String csrf) throws IOException {
     resp.setContentType("text/html;charset=utf-8");
     resp.getWriter().write(HtmlRenderer.renderSocialUsernamePage(
-        domain, providerLabel, email, message, responseType, csrf, analyticsAccount));
+        domain, providerLabel, "", message, responseType, csrf, analyticsAccount));
   }
 
   private void renderFailure(HttpServletResponse resp, int status, String message)

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -76,6 +76,9 @@ public final class SocialAuthServlet extends HttpServlet {
   private final String analyticsAccount;
   private final Object accountCreationLock = new Object();
   private final Object startRateLimitLock = new Object();
+  // Per-instance in-memory rate-limit store. Effective only in single-instance deployments;
+  // clustered deployments should replace this with a centralized store (e.g. Redis) so the
+  // window is shared across all nodes.
   private final Map<String, RateLimitBucket> startRateLimits = new HashMap<>();
 
   @Inject
@@ -427,10 +430,9 @@ public final class SocialAuthServlet extends HttpServlet {
     String key = scope + ":" + address;
     long now = System.currentTimeMillis();
     synchronized (startRateLimitLock) {
-      if (startRateLimits.size() >= START_RATE_LIMIT_MAX_BUCKETS) {
-        startRateLimits.entrySet().removeIf(
-            entry -> now - entry.getValue().windowStartedAtMillis >= START_RATE_LIMIT_WINDOW_MILLIS);
-      }
+      // Always evict expired buckets so the map doesn't grow unboundedly between capacity events.
+      startRateLimits.entrySet().removeIf(
+          entry -> now - entry.getValue().windowStartedAtMillis >= START_RATE_LIMIT_WINDOW_MILLIS);
       if (!startRateLimits.containsKey(key)
           && startRateLimits.size() >= START_RATE_LIMIT_MAX_BUCKETS) {
         return false;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -224,6 +224,11 @@ public final class SocialAuthServlet extends HttpServlet {
       }
       if (pending.loggedInUser != null) {
         ParticipantId id = ParticipantId.ofUnsafe(pending.loggedInUser);
+        if (!featureFlagService.isEnabled(SOCIAL_AUTH_FLAG, id.getAddress())) {
+          clearSocialSession(session);
+          renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+          return;
+        }
         AccountData account = accountStore.getAccount(id);
         if (account != null && account.isHuman() && verifiedEmailMatches(account.asHuman(), profile)) {
           accountStore.linkSocialIdentity(id, toSocialIdentity(profile));
@@ -290,22 +295,18 @@ public final class SocialAuthServlet extends HttpServlet {
       return;
     }
     try {
-      if (accountStore.getAccountBySocialIdentity(pending.provider, pending.subject) != null) {
-        clearSocialSession(session);
-        renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
-        return;
-      }
       HumanAccountDataImpl account = new HumanAccountDataImpl(id);
       account.setEmail(pending.email);
       account.setEmailConfirmed(true);
       account.setRegistrationTime(System.currentTimeMillis());
-      account.addOrReplaceSocialIdentity(new SocialIdentity(
+      SocialIdentity socialIdentity = new SocialIdentity(
           pending.provider, pending.subject, pending.email, pending.displayName,
-          System.currentTimeMillis()));
+          System.currentTimeMillis());
+      account.addOrReplaceSocialIdentity(socialIdentity);
       if (accountStore.getAccountCount() == 0) {
         account.setRole(HumanAccountData.ROLE_OWNER);
       }
-      accountStore.putAccount(account);
+      accountStore.putAccountWithUniqueSocialIdentity(account, socialIdentity);
       try {
         analyticsRecorder.incrementUsersRegistered(System.currentTimeMillis());
       } catch (RuntimeException e) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -157,13 +157,28 @@ public final class SocialAuthServlet extends HttpServlet {
     String state = newToken();
     String nonce = newToken();
     String verifier = PkceUtil.newVerifier(secureRandom);
-    String redirect = AuthRedirects.sanitizeLocalRedirect(req.getParameter("r"));
+    String redirect = socialReturnTarget(req);
     HttpSession session = req.getSession(true);
+    session.removeAttribute(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR);
     session.setAttribute(AUTH_SESSION_ATTR, new PendingAuthorization(
         provider.id(), state, nonce, verifier, redirect, user != null ? user.getAddress() : null,
         System.currentTimeMillis()));
     resp.sendRedirect(socialAuthService.authorizationUrl(provider, state, nonce,
         PkceUtil.challenge(verifier)));
+  }
+
+  private String socialReturnTarget(HttpServletRequest req) {
+    String queryReturnTarget = req.getParameter("r");
+    if (queryReturnTarget != null && !queryReturnTarget.isEmpty()) {
+      return AuthRedirects.sanitizeLocalRedirect(queryReturnTarget);
+    }
+    HttpSession session = req.getSession(false);
+    Object sessionReturnTarget = session == null
+        ? null : session.getAttribute(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR);
+    if (sessionReturnTarget instanceof String) {
+      return AuthRedirects.sanitizeLocalRedirect((String) sessionReturnTarget);
+    }
+    return AuthRedirects.sanitizeLocalRedirect(null);
   }
 
   private void handleCallback(HttpServletRequest req, HttpServletResponse resp)

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -1,0 +1,502 @@
+package org.waveprotocol.box.server.rpc;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.typesafe.config.Config;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.io.Serializable;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.waveprotocol.box.server.CoreSettingsNames;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.account.HumanAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtCookie;
+import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtIssuer;
+import org.waveprotocol.box.server.authentication.oauth.PkceUtil;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthConfig;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthException;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthProfile;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthProvider;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthService;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.PersistenceException;
+import org.waveprotocol.box.server.util.RegistrationSupport;
+import org.waveprotocol.box.server.waveserver.AnalyticsRecorder;
+import org.waveprotocol.wave.model.wave.InvalidParticipantAddress;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.util.logging.Log;
+
+@SuppressWarnings("serial")
+@Singleton
+public final class SocialAuthServlet extends HttpServlet {
+  public static final String SOCIAL_AUTH_FLAG = "social-auth";
+  private static final long PENDING_TTL_MILLIS = 10L * 60L * 1000L;
+  private static final long START_RATE_LIMIT_WINDOW_MILLIS = 10L * 60L * 1000L;
+  private static final int START_RATE_LIMIT_MAX_ATTEMPTS = 30;
+  private static final int START_RATE_LIMIT_MAX_BUCKETS = 4096;
+  private static final String AUTH_SESSION_ATTR = "socialAuth.pendingAuthorization";
+  private static final String PROFILE_SESSION_ATTR = "socialAuth.pendingProfile";
+  private static final String DEFAULT_FAILURE =
+      "Social sign-in could not be completed. Check your provider account and try again.";
+
+  private static final Log LOG = Log.get(SocialAuthServlet.class);
+
+  private final AccountStore accountStore;
+  private final FeatureFlagService featureFlagService;
+  private final SessionManager sessionManager;
+  private final BrowserSessionJwtIssuer browserSessionJwtIssuer;
+  private final SocialAuthConfig socialAuthConfig;
+  private final SocialAuthService socialAuthService;
+  private final WelcomeWaveCreator welcomeWaveCreator;
+  private final AnalyticsRecorder analyticsRecorder;
+  private final SecureRandom secureRandom;
+  private final String domain;
+  private final boolean secureCookiesByDefault;
+  private final boolean registrationDisabled;
+  private final boolean loginPageDisabled;
+  private final boolean passwordResetEnabled;
+  private final boolean magicLinkEnabled;
+  private final String analyticsAccount;
+  private final Object startRateLimitLock = new Object();
+  private final Map<String, RateLimitBucket> startRateLimits = new HashMap<>();
+
+  @Inject
+  public SocialAuthServlet(AccountStore accountStore,
+      FeatureFlagService featureFlagService,
+      SessionManager sessionManager,
+      BrowserSessionJwtIssuer browserSessionJwtIssuer,
+      SocialAuthConfig socialAuthConfig,
+      SocialAuthService socialAuthService,
+      WelcomeWaveCreator welcomeWaveCreator,
+      AnalyticsRecorder analyticsRecorder,
+      SecureRandom secureRandom,
+      @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
+      Config config) {
+    this.accountStore = accountStore;
+    this.featureFlagService = featureFlagService;
+    this.sessionManager = sessionManager;
+    this.browserSessionJwtIssuer = browserSessionJwtIssuer;
+    this.socialAuthConfig = socialAuthConfig;
+    this.socialAuthService = socialAuthService;
+    this.welcomeWaveCreator = welcomeWaveCreator;
+    this.analyticsRecorder = analyticsRecorder;
+    this.secureRandom = secureRandom;
+    this.domain = domain.toLowerCase(Locale.ROOT);
+    this.secureCookiesByDefault = config.getBoolean("security.enable_ssl");
+    this.registrationDisabled = config.getBoolean("administration.disable_registration");
+    this.loginPageDisabled = config.getBoolean("administration.disable_loginpage");
+    this.passwordResetEnabled = !config.hasPath("core.password_reset_enabled")
+        || config.getBoolean("core.password_reset_enabled");
+    this.magicLinkEnabled = config.hasPath("core.magic_link_enabled")
+        && config.getBoolean("core.magic_link_enabled");
+    this.analyticsAccount = config.hasPath("core.analytics_account")
+        ? config.getString("core.analytics_account") : "";
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    req.setCharacterEncoding("UTF-8");
+    resp.setCharacterEncoding("UTF-8");
+    String path = req.getPathInfo();
+    if (path != null && path.startsWith("/callback/")) {
+      handleCallback(req, resp);
+      return;
+    }
+    SocialAuthProvider provider = SocialAuthProvider.fromPath(path);
+    if (provider == null) {
+      renderFailure(resp, HttpServletResponse.SC_NOT_FOUND, DEFAULT_FAILURE);
+      return;
+    }
+    startAuthorization(provider, req, resp);
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    req.setCharacterEncoding("UTF-8");
+    if (!"/complete".equals(req.getPathInfo())) {
+      renderFailure(resp, HttpServletResponse.SC_NOT_FOUND, DEFAULT_FAILURE);
+      return;
+    }
+    completeSignup(req, resp);
+  }
+
+  private void startAuthorization(SocialAuthProvider provider, HttpServletRequest req,
+      HttpServletResponse resp) throws IOException {
+    ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
+    boolean enabled = featureFlagService.isGloballyEnabled(SOCIAL_AUTH_FLAG)
+        || (user != null && featureFlagService.isEnabled(SOCIAL_AUTH_FLAG, user.getAddress()));
+    if (!enabled || !socialAuthConfig.isConfigured(provider)) {
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    if (!allowRateLimitedRequest("start", req.getRemoteAddr())) {
+      renderFailure(resp, 429, DEFAULT_FAILURE);
+      return;
+    }
+    String state = newToken();
+    String nonce = newToken();
+    String verifier = PkceUtil.newVerifier(secureRandom);
+    String redirect = AuthRedirects.sanitizeLocalRedirect(req.getParameter("r"));
+    HttpSession session = req.getSession(true);
+    session.setAttribute(AUTH_SESSION_ATTR, new PendingAuthorization(
+        provider.id(), state, nonce, verifier, redirect, user != null ? user.getAddress() : null,
+        System.currentTimeMillis()));
+    resp.sendRedirect(socialAuthService.authorizationUrl(provider, state, nonce,
+        PkceUtil.challenge(verifier)));
+  }
+
+  private void handleCallback(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
+    if (!allowRateLimitedRequest("callback", req.getRemoteAddr())) {
+      renderFailure(resp, 429, DEFAULT_FAILURE);
+      return;
+    }
+    SocialAuthProvider provider = SocialAuthProvider.fromPath(req.getPathInfo());
+    HttpSession session = req.getSession(false);
+    PendingAuthorization pending = session == null
+        ? null : (PendingAuthorization) session.getAttribute(AUTH_SESSION_ATTR);
+    if (pending == null || provider == null || !pending.provider.equals(provider.id())
+        || !constantTimeEquals(pending.state, req.getParameter("state")) || pending.isExpired()) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    session.removeAttribute(AUTH_SESSION_ATTR);
+    String code = req.getParameter("code");
+    if (code == null || code.isBlank() || req.getParameter("error") != null) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    SocialAuthProfile profile;
+    try {
+      profile = socialAuthService.fetchProfile(provider, code, pending.codeVerifier, pending.nonce);
+    } catch (SocialAuthException e) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    if (!profile.isEmailVerified() || normalizeEmail(profile.getEmail()).isBlank()) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    try {
+      AccountData linked = accountStore.getAccountBySocialIdentity(
+          profile.getProvider(), profile.getSubject());
+      if (linked != null && linked.isHuman()) {
+        ParticipantId id = linked.getId();
+        if (pending.loggedInUser != null && !id.getAddress().equals(pending.loggedInUser)) {
+          clearSocialSession(session);
+          renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+          return;
+        }
+        if (!featureFlagService.isEnabled(SOCIAL_AUTH_FLAG, id.getAddress())) {
+          clearSocialSession(session);
+          renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+          return;
+        }
+        if (!canSignIn(linked.asHuman())) {
+          clearSocialSession(session);
+          renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+          return;
+        }
+        updateLoginTimestamps(linked);
+        signInAndRedirect(req, resp, id, pending.redirect);
+        return;
+      }
+      if (pending.loggedInUser != null) {
+        ParticipantId id = ParticipantId.ofUnsafe(pending.loggedInUser);
+        AccountData account = accountStore.getAccount(id);
+        if (account != null && account.isHuman() && verifiedEmailMatches(account.asHuman(), profile)) {
+          accountStore.linkSocialIdentity(id, toSocialIdentity(profile));
+          signInAndRedirect(req, resp, id, pending.redirect);
+          return;
+        }
+        clearSocialSession(session);
+        renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+        return;
+      }
+      AccountData existingEmail = accountStore.getAccountByEmail(normalizeEmail(profile.getEmail()));
+      if (existingEmail != null) {
+        clearSocialSession(session);
+        renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+        return;
+      }
+      rotateSession(req);
+      HttpSession rotated = req.getSession(true);
+      String csrf = newToken();
+      rotated.setAttribute(PROFILE_SESSION_ATTR, new PendingProfile(
+          profile.getProvider(), provider.label(), profile.getSubject(),
+          normalizeEmail(profile.getEmail()), profile.getDisplayName(), csrf,
+          pending.redirect, System.currentTimeMillis()));
+      writeUsernamePage(resp, provider.label(), profile.getEmail(), "", 
+          AuthenticationServlet.RESPONSE_STATUS_NONE, csrf);
+    } catch (Exception e) {
+      LOG.warning("Social sign-in failed: " + e.getClass().getName());
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, DEFAULT_FAILURE);
+    }
+  }
+
+  private void completeSignup(HttpServletRequest req, HttpServletResponse resp)
+      throws IOException {
+    if (!allowRateLimitedRequest("complete", req.getRemoteAddr())) {
+      renderFailure(resp, 429, DEFAULT_FAILURE);
+      return;
+    }
+    HttpSession session = req.getSession(false);
+    PendingProfile pending = session == null
+        ? null : (PendingProfile) session.getAttribute(PROFILE_SESSION_ATTR);
+    if (pending == null || pending.isExpired()
+        || !constantTimeEquals(pending.csrf, req.getParameter("csrf"))) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    if (registrationDisabled || !featureFlagService.isGloballyEnabled(SOCIAL_AUTH_FLAG)) {
+      clearSocialSession(session);
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+      return;
+    }
+    ParticipantId id;
+    try {
+      id = RegistrationSupport.checkNewUsername(domain, req.getParameter("address"));
+    } catch (InvalidParticipantAddress e) {
+      writeUsernamePage(resp, pending.providerLabel, pending.email, e.getMessage(),
+          AuthenticationServlet.RESPONSE_STATUS_FAILED, pending.csrf);
+      return;
+    }
+    if (RegistrationSupport.doesAccountExist(accountStore, id)) {
+      writeUsernamePage(resp, pending.providerLabel, pending.email, "Account already exists",
+          AuthenticationServlet.RESPONSE_STATUS_FAILED, pending.csrf);
+      return;
+    }
+    try {
+      if (accountStore.getAccountBySocialIdentity(pending.provider, pending.subject) != null) {
+        clearSocialSession(session);
+        renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+        return;
+      }
+      HumanAccountDataImpl account = new HumanAccountDataImpl(id);
+      account.setEmail(pending.email);
+      account.setEmailConfirmed(true);
+      account.setRegistrationTime(System.currentTimeMillis());
+      account.addOrReplaceSocialIdentity(new SocialIdentity(
+          pending.provider, pending.subject, pending.email, pending.displayName,
+          System.currentTimeMillis()));
+      if (accountStore.getAccountCount() == 0) {
+        account.setRole(HumanAccountData.ROLE_OWNER);
+      }
+      accountStore.putAccount(account);
+      try {
+        analyticsRecorder.incrementUsersRegistered(System.currentTimeMillis());
+      } catch (RuntimeException e) {
+        LOG.warning("Failed to record usersRegistered analytics", e);
+      }
+      try {
+        welcomeWaveCreator.createWelcomeWave(id);
+      } catch (Exception ignored) {
+      }
+      clearSocialSession(session);
+      signInAndRedirect(req, resp, id, pending.redirect);
+    } catch (PersistenceException e) {
+      LOG.warning("Failed to create social account: " + e.getClass().getName());
+      renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+    }
+  }
+
+  private void signInAndRedirect(HttpServletRequest req, HttpServletResponse resp, ParticipantId id,
+      String redirect) throws IOException {
+    rotateSession(req);
+    WebSession session = WebSessions.from(req, true);
+    sessionManager.setLoggedInUser(session, id);
+    issueBrowserSessionJwtCookie(req, resp, id);
+    resp.sendRedirect(AuthRedirects.sanitizeLocalRedirect(redirect));
+  }
+
+  private void issueBrowserSessionJwtCookie(HttpServletRequest req, HttpServletResponse resp,
+      ParticipantId subject) {
+    String token = browserSessionJwtIssuer.issue(subject);
+    boolean secureCookie = BrowserSessionJwtCookie.shouldUseSecureCookie(
+        req.isSecure(), req.getHeader("X-Forwarded-Proto"), secureCookiesByDefault);
+    resp.addHeader("Set-Cookie",
+        BrowserSessionJwtCookie.headerValue(token, browserSessionJwtIssuer.tokenLifetimeSeconds(),
+            secureCookie));
+  }
+
+  private void rotateSession(HttpServletRequest req) {
+    try {
+      req.getSession(true);
+      req.changeSessionId();
+    } catch (IllegalStateException ignored) {
+    }
+  }
+
+  private void updateLoginTimestamps(AccountData account) throws PersistenceException {
+    long now = System.currentTimeMillis();
+    accountStore.updateHumanLoginTimestamps(account.getId(), now, now);
+  }
+
+  private boolean canSignIn(HumanAccountData human) {
+    return !HumanAccountData.STATUS_SUSPENDED.equals(human.getStatus())
+        && human.isEmailConfirmed();
+  }
+
+  private boolean verifiedEmailMatches(HumanAccountData human, SocialAuthProfile profile) {
+    String localEmail = normalizeEmail(human.getEmail());
+    String providerEmail = normalizeEmail(profile.getEmail());
+    return human.isEmailConfirmed() && !localEmail.isBlank() && localEmail.equals(providerEmail);
+  }
+
+  private SocialIdentity toSocialIdentity(SocialAuthProfile profile) {
+    return new SocialIdentity(profile.getProvider(), profile.getSubject(),
+        normalizeEmail(profile.getEmail()), profile.getDisplayName(), System.currentTimeMillis());
+  }
+
+  private void writeUsernamePage(HttpServletResponse resp, String providerLabel, String email,
+      String message, String responseType, String csrf) throws IOException {
+    resp.setContentType("text/html;charset=utf-8");
+    resp.getWriter().write(HtmlRenderer.renderSocialUsernamePage(
+        domain, providerLabel, email, message, responseType, csrf, analyticsAccount));
+  }
+
+  private void renderFailure(HttpServletResponse resp, int status, String message)
+      throws IOException {
+    resp.setStatus(status);
+    resp.setContentType("text/html;charset=utf-8");
+    resp.getWriter().write(HtmlRenderer.renderSocialFailurePage(
+        domain, message, analyticsAccount, loginPageDisabled, passwordResetEnabled,
+        magicLinkEnabled));
+  }
+
+  private void clearSocialSession(HttpSession session) {
+    if (session == null) {
+      return;
+    }
+    session.removeAttribute(AUTH_SESSION_ATTR);
+    session.removeAttribute(PROFILE_SESSION_ATTR);
+  }
+
+  private String newToken() {
+    byte[] bytes = new byte[32];
+    secureRandom.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private static String normalizeEmail(String email) {
+    return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+  }
+
+  private static boolean constantTimeEquals(String expected, String actual) {
+    if (expected == null || actual == null) {
+      return false;
+    }
+    return MessageDigest.isEqual(expected.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+        actual.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+  }
+
+  private boolean allowRateLimitedRequest(String scope, String remoteAddress) {
+    String address = remoteAddress == null || remoteAddress.isBlank() ? "unknown" : remoteAddress;
+    String key = scope + ":" + address;
+    long now = System.currentTimeMillis();
+    synchronized (startRateLimitLock) {
+      if (startRateLimits.size() >= START_RATE_LIMIT_MAX_BUCKETS) {
+        startRateLimits.entrySet().removeIf(
+            entry -> now - entry.getValue().windowStartedAtMillis >= START_RATE_LIMIT_WINDOW_MILLIS);
+      }
+      if (!startRateLimits.containsKey(key)
+          && startRateLimits.size() >= START_RATE_LIMIT_MAX_BUCKETS) {
+        return false;
+      }
+      RateLimitBucket bucket = startRateLimits.get(key);
+      if (bucket == null
+          || now - bucket.windowStartedAtMillis >= START_RATE_LIMIT_WINDOW_MILLIS) {
+        startRateLimits.put(key, new RateLimitBucket(now, 1));
+        return true;
+      }
+      if (bucket.attempts >= START_RATE_LIMIT_MAX_ATTEMPTS) {
+        return false;
+      }
+      bucket.attempts++;
+      return true;
+    }
+  }
+
+  private static final class PendingAuthorization implements Serializable {
+    final String provider;
+    final String state;
+    final String nonce;
+    final String codeVerifier;
+    final String redirect;
+    final String loggedInUser;
+    final long createdAtMillis;
+
+    PendingAuthorization(String provider, String state, String nonce, String codeVerifier,
+        String redirect, String loggedInUser, long createdAtMillis) {
+      this.provider = provider;
+      this.state = state;
+      this.nonce = nonce;
+      this.codeVerifier = codeVerifier;
+      this.redirect = redirect;
+      this.loggedInUser = loggedInUser;
+      this.createdAtMillis = createdAtMillis;
+    }
+
+    boolean isExpired() {
+      return System.currentTimeMillis() - createdAtMillis > PENDING_TTL_MILLIS;
+    }
+  }
+
+  private static final class PendingProfile implements Serializable {
+    final String provider;
+    final String providerLabel;
+    final String subject;
+    final String email;
+    final String displayName;
+    final String csrf;
+    final String redirect;
+    final long createdAtMillis;
+
+    PendingProfile(String provider, String providerLabel, String subject, String email,
+        String displayName, String csrf, String redirect, long createdAtMillis) {
+      this.provider = provider;
+      this.providerLabel = providerLabel;
+      this.subject = subject;
+      this.email = email;
+      this.displayName = displayName;
+      this.csrf = csrf;
+      this.redirect = redirect;
+      this.createdAtMillis = createdAtMillis;
+    }
+
+    boolean isExpired() {
+      return System.currentTimeMillis() - createdAtMillis > PENDING_TTL_MILLIS;
+    }
+  }
+
+  private static final class RateLimitBucket {
+    final long windowStartedAtMillis;
+    int attempts;
+
+    RateLimitBucket(long windowStartedAtMillis, int attempts) {
+      this.windowStartedAtMillis = windowStartedAtMillis;
+      this.attempts = attempts;
+    }
+  }
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SocialAuthServlet.java
@@ -74,7 +74,6 @@ public final class SocialAuthServlet extends HttpServlet {
   private final boolean passwordResetEnabled;
   private final boolean magicLinkEnabled;
   private final String analyticsAccount;
-  private final Object accountCreationLock;
   private final Object startRateLimitLock = new Object();
   // Per-instance in-memory rate-limit store. Effective only in single-instance deployments;
   // clustered deployments should replace this with a centralized store (e.g. Redis) so the
@@ -92,10 +91,8 @@ public final class SocialAuthServlet extends HttpServlet {
       AnalyticsRecorder analyticsRecorder,
       SecureRandom secureRandom,
       @Named(CoreSettingsNames.WAVE_SERVER_DOMAIN) String domain,
-      Config config,
-      @Named("accountCreationLock") Object accountCreationLock) {
+      Config config) {
     this.accountStore = accountStore;
-    this.accountCreationLock = accountCreationLock;
     this.featureFlagService = featureFlagService;
     this.sessionManager = sessionManager;
     this.browserSessionJwtIssuer = browserSessionJwtIssuer;
@@ -324,7 +321,19 @@ public final class SocialAuthServlet extends HttpServlet {
           pending.provider, pending.subject, pending.email, pending.displayName,
           System.currentTimeMillis());
       account.addOrReplaceSocialIdentity(socialIdentity);
-      persistSocialAccountWithOwnerAssignment(account, socialIdentity);
+      AccountStore.AccountCreationResult accountCreated =
+          persistSocialAccountWithOwnerAssignment(account, socialIdentity);
+      if (accountCreated != AccountStore.AccountCreationResult.CREATED) {
+        if (accountCreated == AccountStore.AccountCreationResult.SOCIAL_IDENTITY_EXISTS) {
+          clearSocialSession(session);
+          renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
+          return;
+        }
+        writeUsernamePage(resp, pending.providerLabel, "Account already exists",
+            AuthenticationServlet.RESPONSE_STATUS_FAILED, pending.csrf);
+        return;
+      }
+      logOwnerAssignment(account);
       try {
         analyticsRecorder.incrementUsersRegistered(System.currentTimeMillis());
       } catch (RuntimeException e) {
@@ -338,17 +347,20 @@ public final class SocialAuthServlet extends HttpServlet {
       signInAndRedirect(req, resp, id, pending.redirect);
     } catch (PersistenceException e) {
       LOG.warning("Failed to create social account: " + e.getClass().getName());
+      clearSocialSession(session);
       renderFailure(resp, HttpServletResponse.SC_FORBIDDEN, DEFAULT_FAILURE);
     }
   }
 
-  private void persistSocialAccountWithOwnerAssignment(HumanAccountDataImpl account,
+  private AccountStore.AccountCreationResult persistSocialAccountWithOwnerAssignment(
+      HumanAccountDataImpl account,
       SocialIdentity socialIdentity) throws PersistenceException {
-    synchronized (accountCreationLock) {
-      if (accountStore.getAccountCount() == 0) {
-        account.setRole(HumanAccountData.ROLE_OWNER);
-      }
-      accountStore.putAccountWithUniqueSocialIdentity(account, socialIdentity);
+    return accountStore.putNewAccountWithOwnerAssignmentResult(account, socialIdentity);
+  }
+
+  private void logOwnerAssignment(HumanAccountDataImpl account) {
+    if (HumanAccountData.ROLE_OWNER.equals(account.getRole())) {
+      LOG.info("First registration — assigning owner role to " + account.getId());
     }
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
@@ -58,7 +58,7 @@ public final class UserRegistrationServlet extends HttpServlet {
       java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
 
   private final AccountStore accountStore;
-  private final Object accountCreationLock = new Object();
+  private final Object accountCreationLock;
   private final String domain;
   private final boolean registrationDisabled;
   private final String analyticsAccount;
@@ -74,8 +74,10 @@ public final class UserRegistrationServlet extends HttpServlet {
                                  Config config,
                                  AuthEmailService authEmailService,
                                  WelcomeWaveCreator welcomeWaveCreator,
-                                 AnalyticsRecorder analyticsRecorder) {
+                                 AnalyticsRecorder analyticsRecorder,
+                                 @Named("accountCreationLock") Object accountCreationLock) {
     this.accountStore = accountStore;
+    this.accountCreationLock = accountCreationLock;
     this.domain = domain;
     this.registrationDisabled = config.getBoolean("administration.disable_registration");
     this.analyticsAccount = config.hasPath("administration.analytics_account")
@@ -222,6 +224,9 @@ public final class UserRegistrationServlet extends HttpServlet {
   private boolean persistAccountWithOwnerAssignment(HumanAccountDataImpl account) {
     try {
       synchronized (accountCreationLock) {
+        if (RegistrationSupport.doesAccountExist(accountStore, account.getId())) {
+          return false;
+        }
         assignOwnerIfFirst(account);
         accountStore.putAccount(account);
       }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/UserRegistrationServlet.java
@@ -58,7 +58,6 @@ public final class UserRegistrationServlet extends HttpServlet {
       java.util.regex.Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
 
   private final AccountStore accountStore;
-  private final Object accountCreationLock;
   private final String domain;
   private final boolean registrationDisabled;
   private final String analyticsAccount;
@@ -74,10 +73,8 @@ public final class UserRegistrationServlet extends HttpServlet {
                                  Config config,
                                  AuthEmailService authEmailService,
                                  WelcomeWaveCreator welcomeWaveCreator,
-                                 AnalyticsRecorder analyticsRecorder,
-                                 @Named("accountCreationLock") Object accountCreationLock) {
+                                 AnalyticsRecorder analyticsRecorder) {
     this.accountStore = accountStore;
-    this.accountCreationLock = accountCreationLock;
     this.domain = domain;
     this.registrationDisabled = config.getBoolean("administration.disable_registration");
     this.analyticsAccount = config.hasPath("administration.analytics_account")
@@ -185,9 +182,9 @@ public final class UserRegistrationServlet extends HttpServlet {
         account.setEmail(normalizedEmail);
       }
       account.setRegistrationTime(System.currentTimeMillis());
-      boolean accountCreated = persistAccountWithOwnerAssignment(account);
-      if (!accountCreated) {
-        return "An unexpected error occurred while trying to create the account";
+      String creationError = persistAccountWithOwnerAssignment(account);
+      if (creationError != null) {
+        return creationError;
       }
       recordUsersRegisteredAnalytics();
 
@@ -202,9 +199,9 @@ public final class UserRegistrationServlet extends HttpServlet {
         account.setEmail(normalizedEmail);
       }
       account.setRegistrationTime(System.currentTimeMillis());
-      boolean accountCreated = persistAccountWithOwnerAssignment(account);
-      if (!accountCreated) {
-        return "An unexpected error occurred while trying to create the account";
+      String creationError = persistAccountWithOwnerAssignment(account);
+      if (creationError != null) {
+        return creationError;
       }
       recordUsersRegisteredAnalytics();
 
@@ -221,26 +218,25 @@ public final class UserRegistrationServlet extends HttpServlet {
   /**
    * If no other accounts exist yet, promote this account to "owner".
    */
-  private boolean persistAccountWithOwnerAssignment(HumanAccountDataImpl account) {
+  private String persistAccountWithOwnerAssignment(HumanAccountDataImpl account) {
     try {
-      synchronized (accountCreationLock) {
-        if (RegistrationSupport.doesAccountExist(accountStore, account.getId())) {
-          return false;
-        }
-        assignOwnerIfFirst(account);
-        accountStore.putAccount(account);
+      AccountStore.AccountCreationResult accountCreated =
+          accountStore.putNewAccountWithOwnerAssignmentResult(account, null);
+      if (accountCreated != AccountStore.AccountCreationResult.CREATED) {
+        // Password registration never supplies a social identity, so ACCOUNT_EXISTS is the only
+        // expected non-created result.
+        return "Account already exists";
       }
-      return true;
+      logOwnerAssignment(account);
+      return null;
     } catch (PersistenceException e) {
       LOG.severe("Failed to create account for " + account.getId(), e);
-      return false;
+      return "An unexpected error occurred while trying to create the account";
     }
   }
 
-  private void assignOwnerIfFirst(HumanAccountDataImpl account) throws PersistenceException {
-    long count = accountStore.getAccountCount();
-    if (count == 0) {
-      account.setRole(HumanAccountData.ROLE_OWNER);
+  private void logOwnerAssignment(HumanAccountDataImpl account) {
+    if (HumanAccountData.ROLE_OWNER.equals(account.getRole())) {
       LOG.info("First registration — assigning owner role to " + account.getId());
     }
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountData.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountData.java
@@ -102,6 +102,21 @@ public interface HumanAccountData extends AccountData {
    */
   void setSearches(List<SearchesItem> searches);
 
+  /**
+   * Returns provider identities linked to this user.
+   */
+  List<SocialIdentity> getSocialIdentities();
+
+  /**
+   * Replaces provider identities linked to this user.
+   */
+  void setSocialIdentities(List<SocialIdentity> socialIdentities);
+
+  /**
+   * Adds or replaces a provider identity by provider and subject.
+   */
+  void addOrReplaceSocialIdentity(SocialIdentity socialIdentity);
+
   // =========================================================================
   // Admin / role / status fields
   // =========================================================================

--- a/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountDataImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountDataImpl.java
@@ -26,6 +26,8 @@ import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Human Account. Expected to be expanded when authentication is implemented.
@@ -40,6 +42,7 @@ public final class HumanAccountDataImpl implements HumanAccountData {
   private String locale;
   private boolean emailConfirmed = true;
   private List<SearchesItem> searches;
+  private List<SocialIdentity> socialIdentities = Collections.emptyList();
 
   // Admin / role / status fields
   private String role = ROLE_USER;
@@ -131,6 +134,33 @@ public final class HumanAccountDataImpl implements HumanAccountData {
   @Override
   public void setSearches(List<SearchesItem> searches) {
     this.searches = searches;
+  }
+
+  @Override
+  public List<SocialIdentity> getSocialIdentities() {
+    return Collections.unmodifiableList(socialIdentities);
+  }
+
+  @Override
+  public void setSocialIdentities(List<SocialIdentity> socialIdentities) {
+    if (socialIdentities == null || socialIdentities.isEmpty()) {
+      this.socialIdentities = Collections.emptyList();
+      return;
+    }
+    this.socialIdentities = Collections.unmodifiableList(new ArrayList<>(socialIdentities));
+  }
+
+  @Override
+  public void addOrReplaceSocialIdentity(SocialIdentity socialIdentity) {
+    Preconditions.checkNotNull(socialIdentity, "Social identity can not be null");
+    List<SocialIdentity> updated = new ArrayList<>();
+    for (SocialIdentity existing : socialIdentities) {
+      if (!existing.matches(socialIdentity.getProvider(), socialIdentity.getSubject())) {
+        updated.add(existing);
+      }
+    }
+    updated.add(socialIdentity);
+    this.socialIdentities = Collections.unmodifiableList(updated);
   }
 
   @Override
@@ -280,6 +310,7 @@ public final class HumanAccountDataImpl implements HumanAccountData {
     result = prime * result + ((email == null) ? 0 : email.hashCode());
     result = prime * result + ((locale == null) ? 0 : locale.hashCode());
     result = prime * result + ((searches == null) ? 0 : searches.hashCode());
+    result = prime * result + ((socialIdentities == null) ? 0 : socialIdentities.hashCode());
     return result;
   }
 
@@ -304,6 +335,9 @@ public final class HumanAccountDataImpl implements HumanAccountData {
     if (searches == null) {
       if (other.searches != null) return false;
     } else if (!searches.equals(other.searches)) return false;
+    if (socialIdentities == null) {
+      if (other.socialIdentities != null) return false;
+    } else if (!socialIdentities.equals(other.socialIdentities)) return false;
     return true;
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/account/SocialIdentity.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/SocialIdentity.java
@@ -1,0 +1,82 @@
+package org.waveprotocol.box.server.account;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/** Provider identity linked to a human Wave account. */
+public final class SocialIdentity {
+  private final String provider;
+  private final String subject;
+  private final String email;
+  private final String displayName;
+  private final long linkedAtMillis;
+
+  public SocialIdentity(String provider, String subject, String email, String displayName,
+      long linkedAtMillis) {
+    this.provider = requireText(provider, "provider").toLowerCase(Locale.ROOT);
+    this.subject = requireText(subject, "subject");
+    this.email = normalizeOptional(email);
+    this.displayName = normalizeOptional(displayName);
+    this.linkedAtMillis = linkedAtMillis;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public long getLinkedAtMillis() {
+    return linkedAtMillis;
+  }
+
+  public boolean matches(String provider, String subject) {
+    return this.provider.equals(requireText(provider, "provider").toLowerCase(Locale.ROOT))
+        && this.subject.equals(requireText(subject, "subject"));
+  }
+
+  private static String requireText(String value, String name) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(name + " must be provided");
+    }
+    return value.trim();
+  }
+
+  private static String normalizeOptional(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    return value.trim();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof SocialIdentity)) {
+      return false;
+    }
+    SocialIdentity other = (SocialIdentity) obj;
+    return linkedAtMillis == other.linkedAtMillis
+        && Objects.equals(provider, other.provider)
+        && Objects.equals(subject, other.subject)
+        && Objects.equals(email, other.email)
+        && Objects.equals(displayName, other.displayName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(provider, subject, email, displayName, linkedAtMillis);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/DefaultSocialAuthHttpClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/DefaultSocialAuthHttpClient.java
@@ -33,12 +33,13 @@ public final class DefaultSocialAuthHttpClient implements SocialAuthHttpClient {
 
   private String request(String method, String url, Map<String, String> headers, String body)
       throws SocialAuthException {
+    HttpURLConnection connection = null;
     try {
       URI uri = URI.create(url);
       if (!"https".equalsIgnoreCase(uri.getScheme())) {
         throw new SocialAuthException("Provider request must use HTTPS");
       }
-      HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+      connection = (HttpURLConnection) uri.toURL().openConnection();
       connection.setInstanceFollowRedirects(false);
       connection.setConnectTimeout(timeoutMillis);
       connection.setReadTimeout(timeoutMillis);
@@ -65,7 +66,10 @@ public final class DefaultSocialAuthHttpClient implements SocialAuthHttpClient {
       InputStream stream = status >= 200 && status < 300
           ? connection.getInputStream()
           : connection.getErrorStream();
-      String response = readBounded(stream);
+      String response;
+      try (InputStream responseStream = stream) {
+        response = readBounded(responseStream);
+      }
       if (status < 200 || status >= 300) {
         throw new SocialAuthException("Provider request failed");
       }
@@ -74,6 +78,10 @@ public final class DefaultSocialAuthHttpClient implements SocialAuthHttpClient {
       throw e;
     } catch (Exception e) {
       throw new SocialAuthException("Provider request failed", e);
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/DefaultSocialAuthHttpClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/DefaultSocialAuthHttpClient.java
@@ -1,0 +1,113 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import com.google.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public final class DefaultSocialAuthHttpClient implements SocialAuthHttpClient {
+  private static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+  private final int timeoutMillis;
+
+  @Inject
+  public DefaultSocialAuthHttpClient(SocialAuthConfig config) {
+    this.timeoutMillis = config.timeoutSeconds() * 1000;
+  }
+
+  @Override
+  public String postForm(String url, Map<String, String> form, Map<String, String> headers)
+      throws SocialAuthException {
+    String body = encodeForm(form);
+    return request("POST", url, headers, body);
+  }
+
+  @Override
+  public String get(String url, Map<String, String> headers) throws SocialAuthException {
+    return request("GET", url, headers, null);
+  }
+
+  private String request(String method, String url, Map<String, String> headers, String body)
+      throws SocialAuthException {
+    try {
+      URI uri = URI.create(url);
+      if (!"https".equalsIgnoreCase(uri.getScheme())) {
+        throw new SocialAuthException("Provider request must use HTTPS");
+      }
+      HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+      connection.setInstanceFollowRedirects(false);
+      connection.setConnectTimeout(timeoutMillis);
+      connection.setReadTimeout(timeoutMillis);
+      connection.setRequestMethod(method);
+      connection.setRequestProperty("Accept", "application/json");
+      if (headers != null) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+          connection.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+      }
+      if (body != null) {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        connection.setRequestProperty("Content-Length", Integer.toString(bytes.length));
+        try (OutputStream out = connection.getOutputStream()) {
+          out.write(bytes);
+        }
+      }
+      int status = connection.getResponseCode();
+      if (status >= 300 && status < 400) {
+        throw new SocialAuthException("Provider redirected unexpectedly");
+      }
+      InputStream stream = status >= 200 && status < 300
+          ? connection.getInputStream()
+          : connection.getErrorStream();
+      String response = readBounded(stream);
+      if (status < 200 || status >= 300) {
+        throw new SocialAuthException("Provider request failed");
+      }
+      return response;
+    } catch (SocialAuthException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new SocialAuthException("Provider request failed", e);
+    }
+  }
+
+  private static String encodeForm(Map<String, String> form) {
+    StringBuilder body = new StringBuilder();
+    for (Map.Entry<String, String> entry : form.entrySet()) {
+      if (body.length() > 0) {
+        body.append('&');
+      }
+      body.append(urlEncode(entry.getKey())).append('=')
+          .append(urlEncode(entry.getValue()));
+    }
+    return body.toString();
+  }
+
+  private static String urlEncode(String value) {
+    return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+  }
+
+  private static String readBounded(InputStream input) throws Exception {
+    if (input == null) {
+      return "";
+    }
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    byte[] buffer = new byte[4096];
+    int total = 0;
+    int read;
+    while ((read = input.read(buffer)) != -1) {
+      total += read;
+      if (total > MAX_RESPONSE_BYTES) {
+        throw new SocialAuthException("Provider response too large");
+      }
+      output.write(buffer, 0, read);
+    }
+    return output.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
@@ -93,7 +93,7 @@ public final class GoogleIdTokenVerifier {
           break;
         }
       }
-      return contains;
+      return contains && clientId.equals(azp);
     }
     return false;
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
@@ -1,0 +1,208 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Clock;
+import java.util.Base64;
+
+public final class GoogleIdTokenVerifier {
+  private static final long CLOCK_SKEW_SECONDS = 60L;
+  private static final Base64.Decoder BASE64_URL_DECODER = Base64.getUrlDecoder();
+  private final JwksProvider jwksProvider;
+  private final Clock clock;
+
+  public GoogleIdTokenVerifier(JwksProvider jwksProvider, Clock clock) {
+    this.jwksProvider = jwksProvider;
+    this.clock = clock;
+  }
+
+  public SocialAuthProfile verify(String token, String clientId, String nonce)
+      throws SocialAuthException {
+    try {
+      TokenParts parts = split(token);
+      JsonObject header = JsonParser.parseString(parts.headerJson).getAsJsonObject();
+      JsonObject payload = JsonParser.parseString(parts.payloadJson).getAsJsonObject();
+      String kid = requiredString(header, "kid");
+      if (!"RS256".equals(requiredString(header, "alg"))) {
+        throw new SocialAuthException("Unable to verify Google ID token");
+      }
+      verifySignature(parts.signingInput, parts.signature, publicKeyFor(kid));
+      validateClaims(payload, clientId, nonce);
+      String email = requiredString(payload, "email");
+      return new SocialAuthProfile(
+          "google",
+          requiredString(payload, "sub"),
+          email,
+          optionalString(payload, "name"),
+          payload.has("email_verified") && payload.get("email_verified").getAsBoolean());
+    } catch (SocialAuthException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new SocialAuthException("Unable to verify Google ID token", e);
+    }
+  }
+
+  private void validateClaims(JsonObject payload, String clientId, String nonce)
+      throws SocialAuthException {
+    String issuer = requiredString(payload, "iss");
+    if (!"https://accounts.google.com".equals(issuer) && !"accounts.google.com".equals(issuer)) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    if (!audienceMatches(payload.get("aud"), optionalString(payload, "azp"), clientId)) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    if (!constantTimeEquals(requiredString(payload, "nonce"), nonce)) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    if (!payload.has("email_verified") || !payload.get("email_verified").getAsBoolean()) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    long now = clock.instant().getEpochSecond();
+    long exp = requiredLong(payload, "exp");
+    if (now > exp + CLOCK_SKEW_SECONDS) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    if (payload.has("iat") && payload.get("iat").getAsLong() > now + CLOCK_SKEW_SECONDS) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+  }
+
+  private boolean audienceMatches(JsonElement aud, String azp, String clientId)
+      throws SocialAuthException {
+    if (aud == null || aud.isJsonNull()) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    if (aud.isJsonPrimitive()) {
+      return clientId.equals(aud.getAsString());
+    }
+    if (aud.isJsonArray()) {
+      JsonArray array = aud.getAsJsonArray();
+      boolean contains = false;
+      for (JsonElement element : array) {
+        if (clientId.equals(element.getAsString())) {
+          contains = true;
+          break;
+        }
+      }
+      return contains && clientId.equals(azp);
+    }
+    return false;
+  }
+
+  private RSAPublicKey publicKeyFor(String kid) throws SocialAuthException {
+    RSAPublicKey key = publicKeyFor(kid, jwksProvider.jwksJson());
+    if (key != null) {
+      return key;
+    }
+    key = publicKeyFor(kid, jwksProvider.refreshJwksJson());
+    if (key != null) {
+      return key;
+    }
+    throw new SocialAuthException("Unable to verify Google ID token");
+  }
+
+  private RSAPublicKey publicKeyFor(String kid, String jwksJson) throws SocialAuthException {
+    JsonObject jwks = JsonParser.parseString(jwksJson).getAsJsonObject();
+    JsonArray keys = jwks.getAsJsonArray("keys");
+    if (keys != null) {
+      for (JsonElement element : keys) {
+        JsonObject key = element.getAsJsonObject();
+        if (kid.equals(optionalString(key, "kid"))) {
+          try {
+            BigInteger modulus = new BigInteger(1, BASE64_URL_DECODER.decode(requiredString(key, "n")));
+            BigInteger exponent = new BigInteger(1, BASE64_URL_DECODER.decode(requiredString(key, "e")));
+            return (RSAPublicKey) KeyFactory.getInstance("RSA")
+                .generatePublic(new RSAPublicKeySpec(modulus, exponent));
+          } catch (Exception e) {
+            throw new SocialAuthException("Unable to verify Google ID token", e);
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private void verifySignature(String signingInput, byte[] signatureBytes, RSAPublicKey publicKey)
+      throws SocialAuthException {
+    try {
+      Signature signature = Signature.getInstance("SHA256withRSA");
+      signature.initVerify(publicKey);
+      signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+      if (!signature.verify(signatureBytes)) {
+        throw new SocialAuthException("Unable to verify Google ID token");
+      }
+    } catch (SocialAuthException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new SocialAuthException("Unable to verify Google ID token", e);
+    }
+  }
+
+  private static TokenParts split(String token) throws SocialAuthException {
+    if (token == null) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    String[] parts = token.split("\\.", -1);
+    if (parts.length != 3 || parts[0].isEmpty() || parts[1].isEmpty() || parts[2].isEmpty()) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    return new TokenParts(
+        parts[0] + "." + parts[1],
+        new String(BASE64_URL_DECODER.decode(parts[0]), StandardCharsets.UTF_8),
+        new String(BASE64_URL_DECODER.decode(parts[1]), StandardCharsets.UTF_8),
+        BASE64_URL_DECODER.decode(parts[2]));
+  }
+
+  private static String requiredString(JsonObject object, String field) throws SocialAuthException {
+    String value = optionalString(object, field);
+    if (value == null || value.isBlank()) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    return value;
+  }
+
+  private static String optionalString(JsonObject object, String field) {
+    if (object == null || !object.has(field) || object.get(field).isJsonNull()) {
+      return null;
+    }
+    return object.get(field).getAsString();
+  }
+
+  private static boolean constantTimeEquals(String expected, String actual) {
+    if (expected == null || actual == null) {
+      return false;
+    }
+    return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8),
+        actual.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static long requiredLong(JsonObject object, String field) throws SocialAuthException {
+    if (!object.has(field) || object.get(field).isJsonNull()) {
+      throw new SocialAuthException("Unable to verify Google ID token");
+    }
+    return object.get(field).getAsLong();
+  }
+
+  private static final class TokenParts {
+    private final String signingInput;
+    private final String headerJson;
+    private final String payloadJson;
+    private final byte[] signature;
+
+    TokenParts(String signingInput, String headerJson, String payloadJson, byte[] signature) {
+      this.signingInput = signingInput;
+      this.headerJson = headerJson;
+      this.payloadJson = payloadJson;
+      this.signature = signature;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifier.java
@@ -93,7 +93,7 @@ public final class GoogleIdTokenVerifier {
           break;
         }
       }
-      return contains && clientId.equals(azp);
+      return contains;
     }
     return false;
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/JwksProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/JwksProvider.java
@@ -1,0 +1,9 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+interface JwksProvider {
+  String jwksJson() throws SocialAuthException;
+
+  default String refreshJwksJson() throws SocialAuthException {
+    return jwksJson();
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/PkceUtil.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/PkceUtil.java
@@ -1,0 +1,30 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public final class PkceUtil {
+  private static final Base64.Encoder BASE64_URL_ENCODER =
+      Base64.getUrlEncoder().withoutPadding();
+
+  private PkceUtil() {
+  }
+
+  public static String newVerifier(SecureRandom random) {
+    byte[] bytes = new byte[32];
+    random.nextBytes(bytes);
+    return BASE64_URL_ENCODER.encodeToString(bytes);
+  }
+
+  public static String challenge(String verifier) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return BASE64_URL_ENCODER.encodeToString(
+          digest.digest(verifier.getBytes(StandardCharsets.US_ASCII)));
+    } catch (Exception e) {
+      throw new IllegalStateException("Unable to create PKCE challenge", e);
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthConfig.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthConfig.java
@@ -1,0 +1,54 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import com.google.inject.Inject;
+import com.typesafe.config.Config;
+import org.waveprotocol.box.server.authentication.email.PublicBaseUrlResolver;
+
+public final class SocialAuthConfig {
+  private final Config config;
+  private final String publicBaseUrl;
+
+  @Inject
+  public SocialAuthConfig(Config config) {
+    this.config = config;
+    this.publicBaseUrl = PublicBaseUrlResolver.resolve(config);
+  }
+
+  public boolean isConfigured(SocialAuthProvider provider) {
+    return !clientId(provider).isBlank() && !clientSecret(provider).isBlank();
+  }
+
+  public String clientId(SocialAuthProvider provider) {
+    return read(provider, "client_id");
+  }
+
+  public String clientSecret(SocialAuthProvider provider) {
+    return read(provider, "client_secret");
+  }
+
+  public String redirectUri(SocialAuthProvider provider) {
+    String configured = read(provider, "redirect_uri");
+    if (!configured.isBlank()) {
+      return configured;
+    }
+    return publicBaseUrl + "/auth/social/callback/" + provider.id();
+  }
+
+  public int timeoutSeconds() {
+    String path = "core.social_auth.http_timeout_seconds";
+    if (!config.hasPath(path)) {
+      return 10;
+    }
+    int seconds = config.getInt(path);
+    return seconds > 0 ? seconds : 10;
+  }
+
+  private String read(SocialAuthProvider provider, String field) {
+    String path = "core.social_auth." + provider.id() + "." + field;
+    if (!config.hasPath(path)) {
+      return "";
+    }
+    String value = config.getString(path);
+    return value == null ? "" : value.trim();
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthException.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthException.java
@@ -1,0 +1,11 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+public class SocialAuthException extends Exception {
+  public SocialAuthException(String message) {
+    super(message);
+  }
+
+  public SocialAuthException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthHttpClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthHttpClient.java
@@ -1,0 +1,10 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import java.util.Map;
+
+public interface SocialAuthHttpClient {
+  String postForm(String url, Map<String, String> form, Map<String, String> headers)
+      throws SocialAuthException;
+
+  String get(String url, Map<String, String> headers) throws SocialAuthException;
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthProfile.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthProfile.java
@@ -1,0 +1,38 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+public final class SocialAuthProfile {
+  private final String provider;
+  private final String subject;
+  private final String email;
+  private final String displayName;
+  private final boolean emailVerified;
+
+  public SocialAuthProfile(String provider, String subject, String email, String displayName,
+      boolean emailVerified) {
+    this.provider = provider;
+    this.subject = subject;
+    this.email = email;
+    this.displayName = displayName;
+    this.emailVerified = emailVerified;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public boolean isEmailVerified() {
+    return emailVerified;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthProvider.java
@@ -1,0 +1,67 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import java.util.Locale;
+
+public enum SocialAuthProvider {
+  GOOGLE("google", "Google", "openid email profile",
+      "https://accounts.google.com/o/oauth2/v2/auth",
+      "https://oauth2.googleapis.com/token"),
+  GITHUB("github", "GitHub", "read:user user:email",
+      "https://github.com/login/oauth/authorize",
+      "https://github.com/login/oauth/access_token");
+
+  private final String id;
+  private final String label;
+  private final String scope;
+  private final String authorizationEndpoint;
+  private final String tokenEndpoint;
+
+  SocialAuthProvider(String id, String label, String scope, String authorizationEndpoint,
+      String tokenEndpoint) {
+    this.id = id;
+    this.label = label;
+    this.scope = scope;
+    this.authorizationEndpoint = authorizationEndpoint;
+    this.tokenEndpoint = tokenEndpoint;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String label() {
+    return label;
+  }
+
+  public String scope() {
+    return scope;
+  }
+
+  public String authorizationEndpoint() {
+    return authorizationEndpoint;
+  }
+
+  public String tokenEndpoint() {
+    return tokenEndpoint;
+  }
+
+  public static SocialAuthProvider fromPath(String path) {
+    if (path == null) {
+      return null;
+    }
+    String normalized = path.trim().toLowerCase(Locale.ROOT);
+    if (normalized.startsWith("/")) {
+      normalized = normalized.substring(1);
+    }
+    int slash = normalized.indexOf('/');
+    if (slash >= 0) {
+      normalized = normalized.substring(slash + 1);
+    }
+    for (SocialAuthProvider provider : values()) {
+      if (provider.id.equals(normalized)) {
+        return provider;
+      }
+    }
+    return null;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthService.java
@@ -1,0 +1,166 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.inject.Inject;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class SocialAuthService {
+  private static final String GITHUB_USER_URL = "https://api.github.com/user";
+  private static final String GITHUB_EMAILS_URL = "https://api.github.com/user/emails";
+  private static final String GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+  private static final long GOOGLE_JWKS_CACHE_MILLIS = 5L * 60L * 1000L;
+  private static final long GOOGLE_JWKS_MIN_REFRESH_MILLIS = 60L * 1000L;
+
+  private final SocialAuthConfig config;
+  private final SocialAuthHttpClient httpClient;
+  private final GoogleIdTokenVerifier googleVerifier;
+
+  @Inject
+  public SocialAuthService(SocialAuthConfig config, SocialAuthHttpClient httpClient,
+      Clock clock) {
+    this.config = config;
+    this.httpClient = httpClient;
+    this.googleVerifier = new GoogleIdTokenVerifier(
+        new CachingGoogleJwksProvider(httpClient, clock), clock);
+  }
+
+  public boolean isConfigured(SocialAuthProvider provider) {
+    return config.isConfigured(provider);
+  }
+
+  public String authorizationUrl(SocialAuthProvider provider, String state, String nonce,
+      String codeChallenge) {
+    Map<String, String> params = new LinkedHashMap<>();
+    params.put("client_id", config.clientId(provider));
+    params.put("redirect_uri", config.redirectUri(provider));
+    params.put("response_type", "code");
+    params.put("scope", provider.scope());
+    params.put("state", state);
+    params.put("code_challenge", codeChallenge);
+    params.put("code_challenge_method", "S256");
+    if (provider == SocialAuthProvider.GOOGLE) {
+      params.put("nonce", nonce);
+    }
+    return provider.authorizationEndpoint() + "?" + encodeForm(params);
+  }
+
+  public SocialAuthProfile fetchProfile(SocialAuthProvider provider, String code,
+      String codeVerifier, String nonce) throws SocialAuthException {
+    try {
+      Map<String, String> form = new LinkedHashMap<>();
+      form.put("client_id", config.clientId(provider));
+      form.put("client_secret", config.clientSecret(provider));
+      form.put("code", code);
+      form.put("redirect_uri", config.redirectUri(provider));
+      form.put("grant_type", "authorization_code");
+      form.put("code_verifier", codeVerifier);
+      String tokenJson = httpClient.postForm(provider.tokenEndpoint(), form,
+          provider == SocialAuthProvider.GITHUB ? Map.of("Accept", "application/json") : Map.of());
+      JsonObject token = JsonParser.parseString(tokenJson).getAsJsonObject();
+      if (provider == SocialAuthProvider.GOOGLE) {
+        if (!token.has("id_token")) {
+          throw new SocialAuthException("Provider did not return an ID token");
+        }
+        return googleVerifier.verify(token.get("id_token").getAsString(), config.clientId(provider),
+            nonce);
+      }
+      String accessToken = token.has("access_token") ? token.get("access_token").getAsString() : "";
+      if (accessToken.isBlank()) {
+        throw new SocialAuthException("Provider did not return an access token");
+      }
+      return fetchGitHubProfile(accessToken);
+    } catch (SocialAuthException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new SocialAuthException("Provider profile could not be verified", e);
+    }
+  }
+
+  private SocialAuthProfile fetchGitHubProfile(String accessToken) throws SocialAuthException {
+    try {
+      Map<String, String> headers = Map.of(
+          "Authorization", "Bearer " + accessToken,
+          "Accept", "application/vnd.github+json");
+      JsonObject user = JsonParser.parseString(httpClient.get(GITHUB_USER_URL, headers))
+          .getAsJsonObject();
+      String subject = user.has("id") ? user.get("id").getAsString() : "";
+      String displayName = user.has("name") && !user.get("name").isJsonNull()
+          ? user.get("name").getAsString()
+          : (user.has("login") ? user.get("login").getAsString() : null);
+      JsonArray emails = JsonParser.parseString(httpClient.get(GITHUB_EMAILS_URL, headers))
+          .getAsJsonArray();
+      String verifiedEmail = null;
+      for (var element : emails) {
+        JsonObject email = element.getAsJsonObject();
+        boolean primary = email.has("primary") && email.get("primary").getAsBoolean();
+        boolean verified = email.has("verified") && email.get("verified").getAsBoolean();
+        if (primary && verified && email.has("email")) {
+          verifiedEmail = email.get("email").getAsString();
+          break;
+        }
+      }
+      if (subject.isBlank() || verifiedEmail == null || verifiedEmail.isBlank()) {
+        throw new SocialAuthException("No verified primary email");
+      }
+      return new SocialAuthProfile("github", subject, verifiedEmail, displayName, true);
+    } catch (SocialAuthException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new SocialAuthException("Provider profile could not be verified", e);
+    }
+  }
+
+  private static String encodeForm(Map<String, String> form) {
+    StringBuilder body = new StringBuilder();
+    for (Map.Entry<String, String> entry : form.entrySet()) {
+      if (body.length() > 0) {
+        body.append('&');
+      }
+      body.append(URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8))
+          .append('=')
+          .append(URLEncoder.encode(entry.getValue() == null ? "" : entry.getValue(),
+              StandardCharsets.UTF_8));
+    }
+    return body.toString();
+  }
+
+  private static final class CachingGoogleJwksProvider implements JwksProvider {
+    private final SocialAuthHttpClient httpClient;
+    private final Clock clock;
+    private String cachedJwks;
+    private long expiresAtMillis;
+    private long lastRefreshAtMillis;
+
+    CachingGoogleJwksProvider(SocialAuthHttpClient httpClient, Clock clock) {
+      this.httpClient = httpClient;
+      this.clock = clock;
+    }
+
+    @Override
+    public synchronized String jwksJson() throws SocialAuthException {
+      long now = clock.millis();
+      if (cachedJwks != null && now < expiresAtMillis) {
+        return cachedJwks;
+      }
+      return refreshJwksJson();
+    }
+
+    @Override
+    public synchronized String refreshJwksJson() throws SocialAuthException {
+      long now = clock.millis();
+      if (cachedJwks != null && now - lastRefreshAtMillis < GOOGLE_JWKS_MIN_REFRESH_MILLIS) {
+        return cachedJwks;
+      }
+      cachedJwks = httpClient.get(GOOGLE_JWKS_URL, Map.of());
+      lastRefreshAtMillis = now;
+      expiresAtMillis = now + GOOGLE_JWKS_CACHE_MILLIS;
+      return cachedJwks;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthService.java
@@ -154,9 +154,6 @@ public final class SocialAuthService {
     @Override
     public synchronized String refreshJwksJson() throws SocialAuthException {
       long now = clock.millis();
-      if (cachedJwks != null && now - lastRefreshAtMillis < GOOGLE_JWKS_MIN_REFRESH_MILLIS) {
-        return cachedJwks;
-      }
       cachedJwks = httpClient.get(GOOGLE_JWKS_URL, Map.of());
       lastRefreshAtMillis = now;
       expiresAtMillis = now + GOOGLE_JWKS_CACHE_MILLIS;

--- a/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/StaticJwksProvider.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/authentication/oauth/StaticJwksProvider.java
@@ -1,0 +1,14 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+public final class StaticJwksProvider implements JwksProvider {
+  private final String jwksJson;
+
+  public StaticJwksProvider(String jwksJson) {
+    this.jwksJson = jwksJson;
+  }
+
+  @Override
+  public String jwksJson() {
+    return jwksJson;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
@@ -20,6 +20,7 @@
 package org.waveprotocol.box.server.persistence;
 
 import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
 import org.waveprotocol.box.server.account.SocialIdentity;
@@ -36,6 +37,13 @@ import java.util.logging.Logger;
  */
 public interface AccountStore {
   Logger ACCOUNT_STORE_LOG = Logger.getLogger(AccountStore.class.getName());
+
+  enum AccountCreationResult {
+    CREATED,
+    ACCOUNT_EXISTS,
+    SOCIAL_IDENTITY_EXISTS
+  }
+
   /**
    * Initialize the account store.
    * Implementations are expected to validate any configuration values, validate the state of the
@@ -212,6 +220,68 @@ public interface AccountStore {
         throw new PersistenceException("Social identity is already linked");
       }
       putAccount(account);
+    }
+  }
+
+  /**
+   * Persists a new account if the participant id is still unused.
+   *
+   * <p>If this creates the first human account in the store, the account is promoted to owner before
+   * it is written. The default implementation is atomic within one store instance so separate
+   * registration servlets in the same JVM cannot overwrite each other's accounts by racing through
+   * pre-checks. Implementations that run behind an external database should override this with a
+   * backend-level create-if-absent operation.
+   *
+   * <p>When owner promotion happens, the implementation mutates the supplied human account by
+   * setting its role before persisting it.
+   */
+  default boolean putNewAccountWithOwnerAssignment(AccountData account)
+      throws PersistenceException {
+    return putNewAccountWithOwnerAssignmentResult(account, null) == AccountCreationResult.CREATED;
+  }
+
+  /**
+   * Persists a new account while also reserving a social identity for that account.
+   *
+   * <p>Returns {@code false} when either the participant id or social identity is already in use.
+   */
+  default boolean putNewAccountWithOwnerAssignment(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    return putNewAccountWithOwnerAssignmentResult(account, socialIdentity)
+        == AccountCreationResult.CREATED;
+  }
+
+  /**
+   * Persists a new account and reports the reason when creation is rejected.
+   *
+   * <p>The default implementation is atomic within one store instance so separate registration
+   * servlets in the same JVM cannot overwrite each other's accounts by racing through pre-checks.
+   * Implementations backed by external databases should override this with a backend-level
+   * create-if-absent operation and map duplicate-key failures to the matching result.
+   *
+   * <p>When owner promotion happens, the implementation mutates the supplied human account by
+   * setting its role before persisting it. Database implementations may do that before an insert
+   * attempt and then return a non-created result after a duplicate-key race, so callers should
+   * discard the supplied account object on non-{@code CREATED} results.
+   */
+  default AccountCreationResult putNewAccountWithOwnerAssignmentResult(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    synchronized (this) {
+      if (getAccount(account.getId()) != null) {
+        return AccountCreationResult.ACCOUNT_EXISTS;
+      }
+      if (socialIdentity != null) {
+        AccountData existing = getAccountBySocialIdentity(
+            socialIdentity.getProvider(), socialIdentity.getSubject());
+        if (existing != null) {
+          return AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
+        }
+      }
+      if (account.isHuman() && getAccountCount() == 0) {
+        account.asHuman().setRole(HumanAccountData.ROLE_OWNER);
+      }
+      putAccount(account);
+      return AccountCreationResult.CREATED;
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
@@ -181,12 +181,38 @@ public interface AccountStore {
    */
   default void linkSocialIdentity(ParticipantId id, SocialIdentity socialIdentity)
       throws PersistenceException {
-    AccountData account = getAccount(id);
-    if (account == null || !account.isHuman()) {
-      throw new PersistenceException("No human account found for " + id);
+    synchronized (this) {
+      AccountData existing = getAccountBySocialIdentity(
+          socialIdentity.getProvider(), socialIdentity.getSubject());
+      if (existing != null && !existing.getId().equals(id)) {
+        throw new PersistenceException("Social identity is already linked");
+      }
+      AccountData account = getAccount(id);
+      if (account == null || !account.isHuman()) {
+        throw new PersistenceException("No human account found for " + id);
+      }
+      account.asHuman().addOrReplaceSocialIdentity(socialIdentity);
+      putAccount(account);
     }
-    account.asHuman().addOrReplaceSocialIdentity(socialIdentity);
-    putAccount(account);
+  }
+
+  /**
+   * Persists a new human account whose social identity must be unique.
+   *
+   * <p>The default implementation is atomic within one store instance. Stores
+   * backed by external databases should override this with backend-level
+   * uniqueness guarantees.
+   */
+  default void putAccountWithUniqueSocialIdentity(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    synchronized (this) {
+      AccountData existing = getAccountBySocialIdentity(
+          socialIdentity.getProvider(), socialIdentity.getSubject());
+      if (existing != null && !existing.getId().equals(account.getId())) {
+        throw new PersistenceException("Social identity is already linked");
+      }
+      putAccount(account);
+    }
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/AccountStore.java
@@ -22,9 +22,12 @@ package org.waveprotocol.box.server.persistence;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
 
 /**
  * Interface for the storage and retrieval of {@link AccountData}s.
@@ -32,6 +35,7 @@ import java.util.List;
  * @author ljvderijk@google.com (Lennard de Rijk)
  */
 public interface AccountStore {
+  Logger ACCOUNT_STORE_LOG = Logger.getLogger(AccountStore.class.getName());
   /**
    * Initialize the account store.
    * Implementations are expected to validate any configuration values, validate the state of the
@@ -95,6 +99,23 @@ public interface AccountStore {
   }
 
   /**
+   * Updates human login/activity timestamps.
+   *
+   * <p>The default implementation performs a read-modify-write. Database-backed
+   * stores should override this with a field-targeted update.
+   */
+  default void updateHumanLoginTimestamps(ParticipantId id, long lastLoginTime,
+      long lastActivityTime) throws PersistenceException {
+    AccountData account = getAccount(id);
+    if (account == null || !account.isHuman()) {
+      return;
+    }
+    account.asHuman().setLastLoginTime(lastLoginTime);
+    account.asHuman().setLastActivityTime(lastActivityTime);
+    putAccount(account);
+  }
+
+  /**
    * Removes an account from storage.
    *
    * @param id the participant id of the account to remove.
@@ -105,13 +126,67 @@ public interface AccountStore {
    * Returns an {@link AccountData} for the given email address, or null if
    * no account has that email.
    *
-   * <p>Default implementation returns null (backward compatible for stores
-   * that have not indexed by email).
+   * <p>Default implementation scans human accounts case-insensitively. Stores
+   * with an email index should override this method.
    *
    * @param email the email address to look up.
    */
   default AccountData getAccountByEmail(String email) throws PersistenceException {
+    String normalized = normalizeEmail(email);
+    if (normalized.isEmpty()) {
+      return null;
+    }
+    ACCOUNT_STORE_LOG.fine(
+        "Scanning accounts for email lookup; backend should override this method");
+    for (AccountData account : getAllAccounts()) {
+      if (account == null || !account.isHuman()) {
+        continue;
+      }
+      String accountEmail = normalizeEmail(account.asHuman().getEmail());
+      if (!accountEmail.isEmpty() && accountEmail.equals(normalized)) {
+        return account;
+      }
+    }
     return null;
+  }
+
+  /**
+   * Returns a human account linked to the given provider subject, or null.
+   */
+  default AccountData getAccountBySocialIdentity(String provider, String subject)
+      throws PersistenceException {
+    if (provider == null || provider.trim().isEmpty()
+        || subject == null || subject.trim().isEmpty()) {
+      return null;
+    }
+    ACCOUNT_STORE_LOG.fine(
+        "Scanning accounts for social identity lookup; backend should override this method");
+    String normalizedProvider = provider.trim().toLowerCase(Locale.ROOT);
+    String normalizedSubject = subject.trim();
+    for (AccountData account : getAllAccounts()) {
+      if (account == null || !account.isHuman()) {
+        continue;
+      }
+      for (SocialIdentity identity : account.asHuman().getSocialIdentities()) {
+        if (identity.matches(normalizedProvider, normalizedSubject)) {
+          return account;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Links a provider identity to an existing human account.
+   */
+  default void linkSocialIdentity(ParticipantId id, SocialIdentity socialIdentity)
+      throws PersistenceException {
+    AccountData account = getAccount(id);
+    if (account == null || !account.isHuman()) {
+      throw new PersistenceException("No human account found for " + id);
+    }
+    account.asHuman().addOrReplaceSocialIdentity(socialIdentity);
+    putAccount(account);
   }
 
   /**
@@ -139,5 +214,9 @@ public interface AccountStore {
    */
   default long getAccountCount() throws PersistenceException {
     return 0;
+  }
+
+  private static String normalizeEmail(String email) {
+    return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagSeeder.java
@@ -34,6 +34,10 @@ public final class FeatureFlagSeeder {
   private static final String J2CL_ROOT_BOOTSTRAP_DESCRIPTION =
       "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready";
   private static final String J2CL_ROOT_BOOTSTRAP_CONFIG_KEY = "ui.j2cl_root_bootstrap_enabled";
+  private static final String SOCIAL_AUTH_FLAG_NAME = "social-auth";
+  private static final String SOCIAL_AUTH_DESCRIPTION =
+      "Enable Google and GitHub social sign-in and sign-up";
+  private static final String SOCIAL_AUTH_CONFIG_KEY = "core.social_auth.enabled";
 
   private FeatureFlagSeeder() {
   }
@@ -76,6 +80,25 @@ public final class FeatureFlagSeeder {
     } else {
       LOG.info(
           "j2cl-root-bootstrap feature flag already present in store — preserving existing value");
+    }
+  }
+
+  public static void seedSocialAuthFeatureFlag(FeatureFlagStore store, Config config)
+      throws PersistenceException {
+    if (store == null || config == null || !config.hasPath(SOCIAL_AUTH_CONFIG_KEY)) {
+      return;
+    }
+    if (store.get(SOCIAL_AUTH_FLAG_NAME) == null) {
+      boolean enabled = config.getBoolean(SOCIAL_AUTH_CONFIG_KEY);
+      store.save(
+          new FeatureFlag(
+              SOCIAL_AUTH_FLAG_NAME,
+              SOCIAL_AUTH_DESCRIPTION,
+              enabled,
+              Collections.emptyMap()));
+      LOG.info("Seeded social-auth feature flag: enabled=" + enabled);
+    } else {
+      LOG.info("social-auth feature flag already present in store — preserving existing value");
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/FeatureFlagService.java
@@ -86,6 +86,14 @@ public final class FeatureFlagService {
   }
 
   /**
+   * Returns only the flag's global enabled state, ignoring per-user allowlist entries.
+   */
+  public boolean isGloballyEnabled(String flagName) {
+    FeatureFlag flag = cache.get(flagName);
+    return flag != null && flag.isEnabled();
+  }
+
+  /**
    * Returns the names of all flags that are enabled for the given participant.
    */
   public List<String> getEnabledFlagNames(String participantId) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -44,6 +44,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("ime-debug-tracer", "Enable IME diagnostic trace overlay and remote log upload", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("social-auth", "Enable Google and GitHub social sign-in and sign-up", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/MongoMigrationConfig.java
@@ -111,6 +111,10 @@ public final class MongoMigrationConfig {
     return isMongoStoreType(deltaStoreType);
   }
 
+  public boolean usesMongoAccountStore() {
+    return isMongoStoreType(accountStoreType) && isMongoV4Driver();
+  }
+
   public boolean usesMongoContactStore() {
     return isMongoStoreType(contactStoreType);
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/MongockMongoMigrationRunner.java
@@ -31,6 +31,7 @@ import org.waveprotocol.box.server.persistence.MongoMigrationRunner;
 import org.waveprotocol.box.server.persistence.mongodb4.Mongo4DbProvider;
 import org.waveprotocol.box.server.persistence.migrations.changesets.BaselineMongoSchema_001;
 import org.waveprotocol.box.server.persistence.migrations.changesets.DeltaAppliedVersionUniqueIndex_002;
+import org.waveprotocol.box.server.persistence.migrations.changesets.SocialIdentityUniqueIndex_003;
 
 /**
  * Runs the Mongock startup migration pass for MongoDB v4-backed deployments.
@@ -70,6 +71,7 @@ final class MongockMongoMigrationRunner implements MongoMigrationRunner {
           .setExecutionId(EXECUTION_ID)
           .addMigrationClass(BaselineMongoSchema_001.class)
           .addMigrationClass(DeltaAppliedVersionUniqueIndex_002.class)
+          .addMigrationClass(SocialIdentityUniqueIndex_003.class)
           .addDependency(MongoMigrationConfig.class, config)
           .addDependency(MongoDatabase.class, database)
           .buildRunner();

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/SocialIdentityUniqueIndex_003.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/migrations/changesets/SocialIdentityUniqueIndex_003.java
@@ -1,0 +1,52 @@
+package org.waveprotocol.box.server.persistence.migrations.changesets;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.ChangeUnitConstructor;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.waveprotocol.box.server.persistence.MongoMigrationConfig;
+
+/** Adds the indexed provider-subject lookup used by social sign-in. */
+@ChangeUnit(id = "social-identity-unique-index", order = "003", author = "codex")
+public final class SocialIdentityUniqueIndex_003 {
+  static final String INDEX_NAME = "human_social_identity_provider_subject_unique";
+  static final String PROVIDER_PATH = "human.socialIdentities.provider";
+  static final String SUBJECT_PATH = "human.socialIdentities.subject";
+
+  private final MongoDatabase database;
+  private final MongoMigrationConfig config;
+
+  @ChangeUnitConstructor
+  public SocialIdentityUniqueIndex_003(MongoDatabase database, MongoMigrationConfig config) {
+    this.database = database;
+    this.config = config;
+  }
+
+  @Execution
+  public void execution() {
+    if (!config.usesMongoAccountStore()) {
+      return;
+    }
+    MongoCollection<Document> accounts = database.getCollection("account");
+    Bson partial = Filters.and(Filters.exists(PROVIDER_PATH), Filters.exists(SUBJECT_PATH));
+    accounts.createIndex(
+        Indexes.compoundIndex(Indexes.ascending(PROVIDER_PATH), Indexes.ascending(SUBJECT_PATH)),
+        new IndexOptions()
+            .name(INDEX_NAME)
+            .unique(true)
+            .background(true)
+            .partialFilterExpression(partial));
+  }
+
+  @RollbackExecution
+  public void rollbackExecution() {
+    // Compatible additive index; do not drop automatically.
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
@@ -44,6 +44,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.AttachmentStore;
@@ -62,6 +63,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -89,9 +91,15 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
 
   private static final String HUMAN_PASSWORD_FIELD = "passwordDigest";
   private static final String HUMAN_SEARCHES_FIELD = "searches";
+  private static final String HUMAN_SOCIAL_IDENTITIES_FIELD = "socialIdentities";
   private static final String SEARCH_NAME_FIELD = "name";
   private static final String SEARCH_QUERY_FIELD = "query";
   private static final String SEARCH_PINNED_FIELD = "pinned";
+  private static final String SOCIAL_PROVIDER_FIELD = "provider";
+  private static final String SOCIAL_SUBJECT_FIELD = "subject";
+  private static final String SOCIAL_EMAIL_FIELD = "email";
+  private static final String SOCIAL_DISPLAY_NAME_FIELD = "displayName";
+  private static final String SOCIAL_LINKED_AT_FIELD = "linkedAtMillis";
 
   private static final String PASSWORD_DIGEST_FIELD = "digest";
   private static final String PASSWORD_SALT_FIELD = "salt";
@@ -310,18 +318,37 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
   }
 
   @Override
-  public void putAccount(AccountData account) {
-    DBObject object = getDBObjectForParticipant(account.getId());
-
-    if (account.isHuman()) {
-      object.put(ACCOUNT_HUMAN_DATA_FIELD, humanToObject(account.asHuman()));
-    } else if (account.isRobot()) {
-      object.put(ACCOUNT_ROBOT_DATA_FIELD, robotToObject(account.asRobot()));
-    } else {
-      throw new IllegalStateException("Account is neither a human nor a robot");
+  public AccountData getAccountBySocialIdentity(String provider, String subject)
+      throws PersistenceException {
+    if (provider == null || provider.trim().isEmpty()
+        || subject == null || subject.trim().isEmpty()) {
+      return null;
     }
+    try {
+      DBObject match = new BasicDBObject(SOCIAL_PROVIDER_FIELD,
+          provider.trim().toLowerCase(Locale.ROOT))
+          .append(SOCIAL_SUBJECT_FIELD, subject.trim());
+      DBObject query = new BasicDBObject(
+          ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_SOCIAL_IDENTITIES_FIELD,
+          new BasicDBObject("$elemMatch", match));
+      DBObject result = getAccountCollection().findOne(query);
+      if (result == null) {
+        return null;
+      }
+      String idAddress = (String) result.get("_id");
+      DBObject human = (DBObject) result.get(ACCOUNT_HUMAN_DATA_FIELD);
+      if (human == null) {
+        return null;
+      }
+      return objectToHuman(ParticipantId.ofUnsafe(idAddress), human);
+    } catch (RuntimeException e) {
+      throw new PersistenceException("Failed to look up social identity", e);
+    }
+  }
 
-    getAccountCollection().save(object);
+  @Override
+  public void putAccount(AccountData account) {
+    getAccountCollection().save(accountToDBObject(account));
   }
 
   @Override
@@ -365,10 +392,95 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
     return ownedRobots;
   }
 
+  @Override
+  public List<AccountData> getAllAccounts() throws PersistenceException {
+    try {
+      List<AccountData> result = new ArrayList<AccountData>();
+      for (DBObject object : getAccountCollection().find()) {
+        String idAddress = (String) object.get("_id");
+        DBObject human = (DBObject) object.get(ACCOUNT_HUMAN_DATA_FIELD);
+        if (human != null) {
+          result.add(objectToHuman(ParticipantId.ofUnsafe(idAddress), human));
+        }
+      }
+      return result;
+    } catch (RuntimeException e) {
+      throw new PersistenceException("Failed to list human accounts", e);
+    }
+  }
+
+  @Override
+  public long getAccountCount() throws PersistenceException {
+    try {
+      return getAccountCollection().count(
+          new BasicDBObject(ACCOUNT_HUMAN_DATA_FIELD, new BasicDBObject("$exists", true)));
+    } catch (MongoException e) {
+      throw new PersistenceException("Failed to count human accounts", e);
+    }
+  }
+
+  @Override
+  public synchronized AccountCreationResult putNewAccountWithOwnerAssignmentResult(
+      AccountData account, SocialIdentity socialIdentity) throws PersistenceException {
+    if (getAccount(account.getId()) != null) {
+      return AccountCreationResult.ACCOUNT_EXISTS;
+    }
+    if (socialIdentity != null
+        && getAccountBySocialIdentity(socialIdentity.getProvider(), socialIdentity.getSubject())
+            != null) {
+      return AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
+    }
+    if (account.isHuman() && getAccountCount() == 0) {
+      account.asHuman().setRole(HumanAccountData.ROLE_OWNER);
+    }
+    try {
+      getAccountCollection().insert(accountToDBObject(account));
+      return AccountCreationResult.CREATED;
+    } catch (MongoException e) {
+      if (isDuplicateKey(e)) {
+        return duplicateAccountCreationResult(account, socialIdentity);
+      }
+      throw new PersistenceException("Failed to create account", e);
+    }
+  }
+
+  private AccountCreationResult duplicateAccountCreationResult(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    if (getAccount(account.getId()) != null) {
+      return AccountCreationResult.ACCOUNT_EXISTS;
+    }
+    if (socialIdentity != null
+        && getAccountBySocialIdentity(socialIdentity.getProvider(), socialIdentity.getSubject())
+            != null) {
+      return AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
+    }
+    return AccountCreationResult.ACCOUNT_EXISTS;
+  }
+
+  private static boolean isDuplicateKey(MongoException e) {
+    // 11000 is the modern unique-index violation code; keep legacy duplicate-key codes for older
+    // Mongo servers still reachable through this driver.
+    int code = e.getCode();
+    return code == 11000 || code == 11001 || code == 12582;
+  }
+
   private DBObject getDBObjectForParticipant(ParticipantId id) {
     DBObject query = new BasicDBObject();
     query.put("_id", id.getAddress());
     return query;
+  }
+
+  private DBObject accountToDBObject(AccountData account) {
+    DBObject object = getDBObjectForParticipant(account.getId());
+
+    if (account.isHuman()) {
+      object.put(ACCOUNT_HUMAN_DATA_FIELD, humanToObject(account.asHuman()));
+    } else if (account.isRobot()) {
+      object.put(ACCOUNT_ROBOT_DATA_FIELD, robotToObject(account.asRobot()));
+    } else {
+      throw new IllegalStateException("Account is neither a human nor a robot");
+    }
+    return object;
   }
 
   private DBCollection getAccountCollection() {
@@ -404,6 +516,31 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
       object.put(HUMAN_SEARCHES_FIELD, searchList);
     }
 
+    List<SocialIdentity> identities = account.getSocialIdentities();
+    if (identities != null && !identities.isEmpty()) {
+      BasicBSONList identityList = new BasicBSONList();
+      for (SocialIdentity identity : identities) {
+        identityList.add(socialIdentityToObject(identity));
+      }
+      object.put(HUMAN_SOCIAL_IDENTITIES_FIELD, identityList);
+    }
+
+    return object;
+  }
+
+  private DBObject socialIdentityToObject(SocialIdentity identity) {
+    DBObject object = new BasicDBObject()
+        .append(SOCIAL_PROVIDER_FIELD, identity.getProvider())
+        .append(SOCIAL_SUBJECT_FIELD, identity.getSubject());
+    if (identity.getEmail() != null) {
+      object.put(SOCIAL_EMAIL_FIELD, identity.getEmail());
+    }
+    if (identity.getDisplayName() != null) {
+      object.put(SOCIAL_DISPLAY_NAME_FIELD, identity.getDisplayName());
+    }
+    if (identity.getLinkedAtMillis() != 0L) {
+      object.put(SOCIAL_LINKED_AT_FIELD, identity.getLinkedAtMillis());
+    }
     return object;
   }
 
@@ -435,7 +572,30 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
       account.setSearches(searches);
     }
 
+    @SuppressWarnings("unchecked")
+    List<DBObject> socialList = (List<DBObject>) object.get(HUMAN_SOCIAL_IDENTITIES_FIELD);
+    if (socialList != null && !socialList.isEmpty()) {
+      List<SocialIdentity> identities = new ArrayList<SocialIdentity>();
+      for (DBObject socialObject : socialList) {
+        String provider = (String) socialObject.get(SOCIAL_PROVIDER_FIELD);
+        String subject = (String) socialObject.get(SOCIAL_SUBJECT_FIELD);
+        if (provider != null && subject != null) {
+          identities.add(new SocialIdentity(
+              provider,
+              subject,
+              (String) socialObject.get(SOCIAL_EMAIL_FIELD),
+              (String) socialObject.get(SOCIAL_DISPLAY_NAME_FIELD),
+              longValue(socialObject.get(SOCIAL_LINKED_AT_FIELD))));
+        }
+      }
+      account.setSocialIdentities(identities);
+    }
+
     return account;
+  }
+
+  private static long longValue(Object value) {
+    return value instanceof Number ? ((Number) value).longValue() : 0L;
   }
 
   // ****** RobotAccountData serialization

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -1,5 +1,7 @@
 package org.waveprotocol.box.server.persistence.mongodb4;
 
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.result.UpdateResult;
@@ -119,14 +121,7 @@ final class Mongo4AccountStore implements AccountStore {
   @Override
   public void putAccount(AccountData account) throws PersistenceException {
     try {
-      Document doc = new Document("_id", account.getId().getAddress());
-      if (account.isHuman()) {
-        doc.append(ACCOUNT_HUMAN_DATA_FIELD, humanToObject(account.asHuman()));
-      } else if (account.isRobot()) {
-        doc.append(ACCOUNT_ROBOT_DATA_FIELD, robotToObject(account.asRobot()));
-      } else {
-        throw new IllegalStateException("Account is neither human nor robot");
-      }
+      Document doc = accountToDocument(account);
       col.replaceOne(eq("_id", account.getId().getAddress()), doc, new com.mongodb.client.model.ReplaceOptions().upsert(true));
     } catch (RuntimeException e) {
       throw new PersistenceException(e);
@@ -232,7 +227,60 @@ final class Mongo4AccountStore implements AccountStore {
   @Override
   public void putAccountWithUniqueSocialIdentity(AccountData account, SocialIdentity socialIdentity)
       throws PersistenceException {
-    putAccount(account);
+    synchronized (this) {
+      // Existing-account updates rely on the same social-identity unique index as account creation;
+      // the pre-check keeps the error path user-friendly within this store instance.
+      AccountData existing = getAccountBySocialIdentity(
+          socialIdentity.getProvider(), socialIdentity.getSubject());
+      if (existing != null && !existing.getId().equals(account.getId())) {
+        throw new PersistenceException("Social identity is already linked");
+      }
+      putAccount(account);
+    }
+  }
+
+  @Override
+  public synchronized AccountCreationResult putNewAccountWithOwnerAssignmentResult(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    try {
+      if (getAccount(account.getId()) != null) {
+        return AccountCreationResult.ACCOUNT_EXISTS;
+      }
+      if (socialIdentity != null) {
+        AccountData existing = getAccountBySocialIdentity(
+            socialIdentity.getProvider(), socialIdentity.getSubject());
+        if (existing != null) {
+          return AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
+        }
+      }
+      if (account.isHuman() && getAccountCount() == 0) {
+        account.asHuman().setRole(HumanAccountData.ROLE_OWNER);
+      }
+      col.insertOne(accountToDocument(account));
+      return AccountCreationResult.CREATED;
+    } catch (MongoWriteException e) {
+      if (e.getError() != null
+          && e.getError().getCategory() == ErrorCategory.DUPLICATE_KEY) {
+        return duplicateAccountCreationResult(account, socialIdentity);
+      }
+      throw new PersistenceException(e);
+    } catch (RuntimeException e) {
+      throw new PersistenceException(e);
+    }
+  }
+
+  private AccountCreationResult duplicateAccountCreationResult(AccountData account,
+      SocialIdentity socialIdentity) throws PersistenceException {
+    if (getAccount(account.getId()) != null) {
+      return AccountCreationResult.ACCOUNT_EXISTS;
+    }
+    if (socialIdentity != null
+        && getAccountBySocialIdentity(socialIdentity.getProvider(), socialIdentity.getSubject())
+            != null) {
+      return AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
+    }
+    // Unexpected duplicate-key source; preserve the account-collision ordering rule.
+    return AccountCreationResult.ACCOUNT_EXISTS;
   }
 
   @Override
@@ -292,6 +340,18 @@ final class Mongo4AccountStore implements AccountStore {
    */
   private static org.bson.conversions.Bson humanAccountsFilter() {
     return exists(ACCOUNT_HUMAN_DATA_FIELD);
+  }
+
+  private static Document accountToDocument(AccountData account) {
+    Document doc = new Document("_id", account.getId().getAddress());
+    if (account.isHuman()) {
+      doc.append(ACCOUNT_HUMAN_DATA_FIELD, humanToObject(account.asHuman()));
+    } else if (account.isRobot()) {
+      doc.append(ACCOUNT_ROBOT_DATA_FIELD, robotToObject(account.asRobot()));
+    } else {
+      throw new IllegalStateException("Account is neither human nor robot");
+    }
+    return doc;
   }
 
   private static Document humanToObject(HumanAccountData account) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -230,6 +230,12 @@ final class Mongo4AccountStore implements AccountStore {
   }
 
   @Override
+  public void putAccountWithUniqueSocialIdentity(AccountData account, SocialIdentity socialIdentity)
+      throws PersistenceException {
+    putAccount(account);
+  }
+
+  @Override
   public List<AccountData> getAllAccounts() throws PersistenceException {
     try {
       List<AccountData> result = new ArrayList<>();

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -2,6 +2,7 @@ package org.waveprotocol.box.server.persistence.mongodb4;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.waveprotocol.box.searches.SearchesItem;
@@ -10,6 +11,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.PersistenceException;
@@ -23,11 +25,16 @@ import com.google.wave.api.event.EventType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.elemMatch;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.exists;
+import static com.mongodb.client.model.Filters.regex;
+import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
 
 /** MongoDB 4.x AccountStore implementation (human + robot). */
@@ -53,11 +60,17 @@ final class Mongo4AccountStore implements AccountStore {
   private static final String HUMAN_PROFILE_IMAGE_FIELD = "profileImageAttachmentId";
   private static final String HUMAN_SHOW_LAST_SEEN_FIELD = "showLastSeen";
   private static final String HUMAN_SEARCHES_FIELD = "searches";
+  private static final String HUMAN_SOCIAL_IDENTITIES_FIELD = "socialIdentities";
   private static final String SEARCH_NAME_FIELD = "name";
   private static final String SEARCH_QUERY_FIELD = "query";
   private static final String SEARCH_PINNED_FIELD = "pinned";
   private static final String PASSWORD_DIGEST_FIELD = "digest";
   private static final String PASSWORD_SALT_FIELD = "salt";
+  private static final String SOCIAL_PROVIDER_FIELD = "provider";
+  private static final String SOCIAL_SUBJECT_FIELD = "subject";
+  private static final String SOCIAL_EMAIL_FIELD = "email";
+  private static final String SOCIAL_DISPLAY_NAME_FIELD = "displayName";
+  private static final String SOCIAL_LINKED_AT_FIELD = "linkedAtMillis";
 
   private static final String ROBOT_URL_FIELD = "url";
   private static final String ROBOT_SECRET_FIELD = "secret";
@@ -133,6 +146,21 @@ final class Mongo4AccountStore implements AccountStore {
   }
 
   @Override
+  public void updateHumanLoginTimestamps(ParticipantId id, long lastLoginTime,
+      long lastActivityTime) throws PersistenceException {
+    try {
+      col.updateOne(
+          and(eq("_id", id.getAddress()), exists(ACCOUNT_HUMAN_DATA_FIELD)),
+          combine(
+              set(ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_LAST_LOGIN_TIME_FIELD, lastLoginTime),
+              set(ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_LAST_ACTIVITY_TIME_FIELD,
+                  lastActivityTime)));
+    } catch (RuntimeException e) {
+      throw new PersistenceException(e);
+    }
+  }
+
+  @Override
   public void removeAccount(ParticipantId id) throws PersistenceException {
     try {
       col.deleteOne(eq("_id", id.getAddress()));
@@ -145,13 +173,57 @@ final class Mongo4AccountStore implements AccountStore {
   public AccountData getAccountByEmail(String email) throws PersistenceException {
     if (email == null || email.isEmpty()) return null;
     try {
-      Document doc = col.find(eq(ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_EMAIL_FIELD, email)).first();
+      String normalizedEmail = email.trim().toLowerCase(Locale.ROOT);
+      if (normalizedEmail.isEmpty()) return null;
+      Document doc = col.find(eq(
+          ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_EMAIL_FIELD, normalizedEmail)).first();
+      if (doc == null) {
+        doc = col.find(regex(
+            ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_EMAIL_FIELD,
+            "^" + Pattern.quote(normalizedEmail) + "$",
+            "i")).first();
+      }
       if (doc == null) return null;
       String idStr = doc.getString("_id");
       ParticipantId id = ParticipantId.ofUnsafe(idStr);
       Document human = (Document) doc.get(ACCOUNT_HUMAN_DATA_FIELD);
       if (human != null) return objectToHuman(id, human);
       return null;
+    } catch (RuntimeException e) {
+      throw new PersistenceException(e);
+    }
+  }
+
+  @Override
+  public AccountData getAccountBySocialIdentity(String provider, String subject)
+      throws PersistenceException {
+    if (provider == null || provider.isEmpty() || subject == null || subject.isEmpty()) return null;
+    try {
+      Document match = new Document(SOCIAL_PROVIDER_FIELD, provider.trim().toLowerCase(Locale.ROOT))
+          .append(SOCIAL_SUBJECT_FIELD, subject.trim());
+      Document doc = col.find(elemMatch(
+          ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_SOCIAL_IDENTITIES_FIELD, match)).first();
+      if (doc == null) return null;
+      String idStr = doc.getString("_id");
+      ParticipantId id = ParticipantId.ofUnsafe(idStr);
+      Document human = (Document) doc.get(ACCOUNT_HUMAN_DATA_FIELD);
+      if (human != null) return objectToHuman(id, human);
+      return null;
+    } catch (RuntimeException e) {
+      throw new PersistenceException(e);
+    }
+  }
+
+  @Override
+  public void linkSocialIdentity(ParticipantId id, SocialIdentity socialIdentity)
+      throws PersistenceException {
+    try {
+      UpdateResult result = col.updateOne(
+          and(eq("_id", id.getAddress()), exists(ACCOUNT_HUMAN_DATA_FIELD)),
+          List.of(replaceSocialIdentityStage(socialIdentity)));
+      if (result.getMatchedCount() == 0L) {
+        throw new PersistenceException("No human account found for " + id);
+      }
     } catch (RuntimeException e) {
       throw new PersistenceException(e);
     }
@@ -267,7 +339,45 @@ final class Mongo4AccountStore implements AccountStore {
       }
       doc.append(HUMAN_SEARCHES_FIELD, searchDocs);
     }
+    List<SocialIdentity> identities = account.getSocialIdentities();
+    if (identities != null && !identities.isEmpty()) {
+      List<Document> identityDocs = new ArrayList<>();
+      for (SocialIdentity identity : identities) {
+        identityDocs.add(socialIdentityToObject(identity));
+      }
+      doc.append(HUMAN_SOCIAL_IDENTITIES_FIELD, identityDocs);
+    }
     return doc;
+  }
+
+  private static Document socialIdentityToObject(SocialIdentity identity) {
+    Document doc = new Document()
+        .append(SOCIAL_PROVIDER_FIELD, identity.getProvider())
+        .append(SOCIAL_SUBJECT_FIELD, identity.getSubject());
+    if (identity.getEmail() != null) {
+      doc.append(SOCIAL_EMAIL_FIELD, identity.getEmail());
+    }
+    if (identity.getDisplayName() != null) {
+      doc.append(SOCIAL_DISPLAY_NAME_FIELD, identity.getDisplayName());
+    }
+    if (identity.getLinkedAtMillis() != 0L) {
+      doc.append(SOCIAL_LINKED_AT_FIELD, identity.getLinkedAtMillis());
+    }
+    return doc;
+  }
+
+  private static Document replaceSocialIdentityStage(SocialIdentity identity) {
+    String identityPath = ACCOUNT_HUMAN_DATA_FIELD + "." + HUMAN_SOCIAL_IDENTITIES_FIELD;
+    Document existingDoesNotMatch = new Document("$not", List.of(new Document("$and", List.of(
+        new Document("$eq", List.of("$$identity." + SOCIAL_PROVIDER_FIELD, identity.getProvider())),
+        new Document("$eq", List.of("$$identity." + SOCIAL_SUBJECT_FIELD, identity.getSubject()))))));
+    Document existingWithoutIdentity = new Document("$filter", new Document()
+        .append("input", new Document("$ifNull", List.of("$" + identityPath, List.of())))
+        .append("as", "identity")
+        .append("cond", existingDoesNotMatch));
+    return new Document("$set", new Document(identityPath, new Document("$concatArrays", List.of(
+        existingWithoutIdentity,
+        List.of(socialIdentityToObject(identity))))));
   }
 
   private static HumanAccountData objectToHuman(ParticipantId id, Document doc) {
@@ -347,6 +457,25 @@ final class Mongo4AccountStore implements AccountStore {
             sPinned != null && sPinned));
       }
       account.setSearches(searches);
+    }
+    List<?> socialList = (List<?>) doc.get(HUMAN_SOCIAL_IDENTITIES_FIELD);
+    if (socialList != null && !socialList.isEmpty()) {
+      List<SocialIdentity> identities = new ArrayList<>();
+      for (Object obj : socialList) {
+        Document sDoc = (Document) obj;
+        String provider = sDoc.getString(SOCIAL_PROVIDER_FIELD);
+        String subject = sDoc.getString(SOCIAL_SUBJECT_FIELD);
+        if (provider != null && subject != null) {
+          Long linkedAt = sDoc.getLong(SOCIAL_LINKED_AT_FIELD);
+          identities.add(new SocialIdentity(
+              provider,
+              subject,
+              sDoc.getString(SOCIAL_EMAIL_FIELD),
+              sDoc.getString(SOCIAL_DISPLAY_NAME_FIELD),
+              linkedAt != null ? linkedAt : 0L));
+        }
+      }
+      account.setSocialIdentities(identities);
     }
     return account;
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
@@ -34,6 +34,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoAccountData;
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoAccountData.AccountDataType;
@@ -43,6 +44,7 @@ import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.Prot
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoRobotCapabilities;
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoRobotCapability;
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoSearchesItem;
+import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoSocialIdentity;
 import org.waveprotocol.box.server.robots.RobotCapabilities;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 
@@ -107,6 +109,21 @@ public class ProtoAccountDataSerializer {
             .setPinned(item.isPinned())
             .build());
       }
+    }
+    for (SocialIdentity identity : account.getSocialIdentities()) {
+      ProtoSocialIdentity.Builder socialBuilder = ProtoSocialIdentity.newBuilder()
+          .setProvider(identity.getProvider())
+          .setSubject(identity.getSubject());
+      if (identity.getEmail() != null) {
+        socialBuilder.setEmail(identity.getEmail());
+      }
+      if (identity.getDisplayName() != null) {
+        socialBuilder.setDisplayName(identity.getDisplayName());
+      }
+      if (identity.getLinkedAtMillis() != 0L) {
+        socialBuilder.setLinkedAtMillis(identity.getLinkedAtMillis());
+      }
+      builder.addSocialIdentity(socialBuilder.build());
     }
     return builder.build();
   }
@@ -232,6 +249,18 @@ public class ProtoAccountDataSerializer {
         searches.add(new SearchesItem(item.getName(), item.getQuery(), item.getPinned()));
       }
       account.setSearches(searches);
+    }
+    if (data.getSocialIdentityCount() > 0) {
+      java.util.List<SocialIdentity> socialIdentities = new java.util.ArrayList<>();
+      for (ProtoSocialIdentity identity : data.getSocialIdentityList()) {
+        socialIdentities.add(new SocialIdentity(
+            identity.getProvider(),
+            identity.getSubject(),
+            identity.hasEmail() ? identity.getEmail() : null,
+            identity.hasDisplayName() ? identity.getDisplayName() : null,
+            identity.hasLinkedAtMillis() ? identity.getLinkedAtMillis() : 0L));
+      }
+      account.setSocialIdentities(socialIdentities);
     }
     return account;
   }

--- a/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
+++ b/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
@@ -58,6 +58,15 @@ message ProtoHumanAccountData {
 	optional int64 last_activity_time = 9;
 	// Saved searches
 	repeated ProtoSearchesItem saved_search = 10;
+	repeated ProtoSocialIdentity social_identity = 11;
+}
+
+message ProtoSocialIdentity {
+	required string provider = 1;
+	required string subject = 2;
+	optional string email = 3;
+	optional string display_name = 4;
+	optional int64 linked_at_millis = 5;
 }
 
 // A single saved search item (name + query + pinned)

--- a/wave/src/test/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifierTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/authentication/oauth/GoogleIdTokenVerifierTest.java
@@ -1,0 +1,234 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import org.junit.Test;
+
+public final class GoogleIdTokenVerifierTest {
+  private static final String CLIENT_ID = "client-123";
+  private static final String NONCE = "nonce-123";
+  private static final Clock CLOCK = Clock.fixed(Instant.ofEpochSecond(1_000L), ZoneOffset.UTC);
+
+  @Test
+  public void acceptsValidRs256Token() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    SocialAuthProfile profile = verifier.verify(
+        signedToken(keyPair.getPrivate(), "kid-1", validPayload()), CLIENT_ID, NONCE);
+
+    assertEquals("google", profile.getProvider());
+    assertEquals("subject-123", profile.getSubject());
+    assertEquals("user@example.com", profile.getEmail());
+    assertEquals("User Name", profile.getDisplayName());
+    assertEquals(true, profile.isEmailVerified());
+  }
+
+  @Test
+  public void rejectsWrongAudience() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"aud\":\"client-123\"", "\"aud\":\"other-client\"")));
+  }
+
+  @Test
+  public void acceptsArrayAudienceWhenAuthorizedPartyMatchesClient() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    SocialAuthProfile profile = verifier.verify(signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"aud\":\"client-123\"", "\"aud\":[\"other\",\"client-123\"]")),
+        CLIENT_ID, NONCE);
+
+    assertEquals("subject-123", profile.getSubject());
+  }
+
+  @Test
+  public void rejectsArrayAudienceWhenAuthorizedPartyDoesNotMatchClient() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload()
+            .replace("\"aud\":\"client-123\"", "\"aud\":[\"other\",\"client-123\"]")
+            .replace("\"azp\":\"client-123\"", "\"azp\":\"other\"")));
+  }
+
+  @Test
+  public void rejectsWrongNonce() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"nonce\":\"nonce-123\"", "\"nonce\":\"wrong\"")));
+  }
+
+  @Test
+  public void rejectsUnverifiedEmail() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"email_verified\":true", "\"email_verified\":false")));
+  }
+
+  @Test
+  public void rejectsMissingEmail() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"email\":\"user@example.com\",", "")));
+  }
+
+  @Test
+  public void rejectsExpiredTokenBeyondSkew() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"exp\":1100", "\"exp\":900")));
+  }
+
+  @Test
+  public void rejectsIssuedAtBeyondSkew() throws Exception {
+    KeyPair keyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider(jwksFor(keyPair, "kid-1")), CLOCK);
+
+    expectVerifyFailure(verifier, signedToken(keyPair.getPrivate(), "kid-1",
+        validPayload().replace("\"iat\":950", "\"iat\":1200")));
+  }
+
+  @Test
+  public void refreshesJwksWhenKidIsMissingFromCachedSet() throws Exception {
+    KeyPair oldKeyPair = rsaKeyPair();
+    KeyPair newKeyPair = rsaKeyPair();
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new RotatingJwksProvider(jwksFor(oldKeyPair, "old-kid"), jwksFor(newKeyPair, "new-kid")),
+        CLOCK);
+
+    SocialAuthProfile profile = verifier.verify(
+        signedToken(newKeyPair.getPrivate(), "new-kid", validPayload()), CLIENT_ID, NONCE);
+
+    assertEquals("subject-123", profile.getSubject());
+  }
+
+  @Test
+  public void rejectsUnsignedToken() throws Exception {
+    GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier(
+        new StaticJwksProvider("{\"keys\":[]}"), CLOCK);
+
+    expectVerifyFailure(verifier, "header.payload.signature");
+  }
+
+  private static void expectVerifyFailure(GoogleIdTokenVerifier verifier, String token)
+      throws Exception {
+    try {
+      verifier.verify(token, CLIENT_ID, NONCE);
+      fail("Expected token verification to fail");
+    } catch (SocialAuthException expected) {
+      assertEquals("Unable to verify Google ID token", expected.getMessage());
+    }
+  }
+
+  private static KeyPair rsaKeyPair() throws Exception {
+    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    return generator.generateKeyPair();
+  }
+
+  private static String validPayload() {
+    return "{"
+        + "\"iss\":\"https://accounts.google.com\","
+        + "\"aud\":\"client-123\","
+        + "\"azp\":\"client-123\","
+        + "\"sub\":\"subject-123\","
+        + "\"email\":\"user@example.com\","
+        + "\"name\":\"User Name\","
+        + "\"email_verified\":true,"
+        + "\"nonce\":\"nonce-123\","
+        + "\"exp\":1100,"
+        + "\"iat\":950"
+        + "}";
+  }
+
+  private static String signedToken(PrivateKey privateKey, String kid, String payloadJson)
+      throws Exception {
+    String headerJson = "{\"alg\":\"RS256\",\"kid\":\"" + kid + "\"}";
+    String signingInput = base64Url(headerJson.getBytes(StandardCharsets.UTF_8))
+        + "."
+        + base64Url(payloadJson.getBytes(StandardCharsets.UTF_8));
+    Signature signature = Signature.getInstance("SHA256withRSA");
+    signature.initSign(privateKey);
+    signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+    return signingInput + "." + base64Url(signature.sign());
+  }
+
+  private static String jwksFor(KeyPair keyPair, String kid) {
+    RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+    return "{\"keys\":[{\"kty\":\"RSA\",\"alg\":\"RS256\",\"use\":\"sig\",\"kid\":\""
+        + kid
+        + "\",\"n\":\""
+        + base64Url(unsignedBytes(publicKey.getModulus()))
+        + "\",\"e\":\""
+        + base64Url(unsignedBytes(publicKey.getPublicExponent()))
+        + "\"}]}";
+  }
+
+  private static byte[] unsignedBytes(BigInteger value) {
+    byte[] bytes = value.toByteArray();
+    if (bytes.length > 1 && bytes[0] == 0) {
+      byte[] trimmed = new byte[bytes.length - 1];
+      System.arraycopy(bytes, 1, trimmed, 0, trimmed.length);
+      return trimmed;
+    }
+    return bytes;
+  }
+
+  private static String base64Url(byte[] bytes) {
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  private static final class RotatingJwksProvider implements JwksProvider {
+    private final String initialJwks;
+    private final String refreshedJwks;
+
+    RotatingJwksProvider(String initialJwks, String refreshedJwks) {
+      this.initialJwks = initialJwks;
+      this.refreshedJwks = refreshedJwks;
+    }
+
+    @Override
+    public String jwksJson() {
+      return initialJwks;
+    }
+
+    @Override
+    public String refreshJwksJson() {
+      return refreshedJwks;
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/authentication/oauth/SocialAuthServiceTest.java
@@ -1,0 +1,159 @@
+package org.waveprotocol.box.server.authentication.oauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.typesafe.config.ConfigFactory;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public final class SocialAuthServiceTest {
+  @Test
+  public void googleAuthorizationUrlIncludesNonceAndPkceChallenge() {
+    SocialAuthService service = newService(new RecordingHttpClient());
+
+    String url = service.authorizationUrl(SocialAuthProvider.GOOGLE, "state value",
+        "nonce value", "challenge value");
+
+    assertTrue(url.startsWith("https://accounts.google.com/o/oauth2/v2/auth?"));
+    assertTrue(url.contains("client_id=google-client"));
+    assertTrue(url.contains("redirect_uri=https%3A%2F%2Fwave.example.com%2Fauth%2Fsocial%2Fcallback%2Fgoogle"));
+    assertTrue(url.contains("scope=openid+email+profile"));
+    assertTrue(url.contains("state=state+value"));
+    assertTrue(url.contains("nonce=nonce+value"));
+    assertTrue(url.contains("code_challenge=challenge+value"));
+    assertTrue(url.contains("code_challenge_method=S256"));
+  }
+
+  @Test
+  public void githubAuthorizationUrlDoesNotIncludeNonce() {
+    SocialAuthService service = newService(new RecordingHttpClient());
+
+    String url = service.authorizationUrl(SocialAuthProvider.GITHUB, "state value",
+        "nonce value", "challenge value");
+
+    assertTrue(url.startsWith("https://github.com/login/oauth/authorize?"));
+    assertTrue(url.contains("client_id=github-client"));
+    assertTrue(url.contains("scope=read%3Auser+user%3Aemail"));
+    assertTrue(url.contains("state=state+value"));
+    assertTrue(url.contains("code_challenge=challenge+value"));
+    assertFalse(url.contains("nonce="));
+  }
+
+  @Test
+  public void fetchGitHubProfileUsesPkceVerifierAndVerifiedPrimaryEmail()
+      throws Exception {
+    RecordingHttpClient client = new RecordingHttpClient();
+    SocialAuthService service = newService(client);
+
+    SocialAuthProfile profile = service.fetchProfile(
+        SocialAuthProvider.GITHUB, "provider-code", "verifier-123", "unused-nonce");
+
+    assertEquals("github", profile.getProvider());
+    assertEquals("12345", profile.getSubject());
+    assertEquals("octo@example.com", profile.getEmail());
+    assertEquals("Octo Cat", profile.getDisplayName());
+    assertTrue(profile.isEmailVerified());
+    assertEquals("provider-code", client.lastPostForm.get("code"));
+    assertEquals("verifier-123", client.lastPostForm.get("code_verifier"));
+    assertEquals("github-client", client.lastPostForm.get("client_id"));
+    assertEquals("github-secret", client.lastPostForm.get("client_secret"));
+    assertEquals("application/json", client.lastPostHeaders.get("Accept"));
+    assertEquals(2, client.getUrls.size());
+    assertEquals("Bearer gh-token", client.getHeaders.get(0).get("Authorization"));
+  }
+
+  @Test
+  public void fetchGitHubProfileRejectsMissingVerifiedPrimaryEmail() throws Exception {
+    RecordingHttpClient client = new RecordingHttpClient();
+    client.emailsResponse = "[{\"email\":\"octo@example.com\",\"primary\":true,\"verified\":false}]";
+    SocialAuthService service = newService(client);
+
+    try {
+      service.fetchProfile(SocialAuthProvider.GITHUB, "provider-code", "verifier-123",
+          "unused-nonce");
+      fail("Expected GitHub profile without verified primary email to be rejected");
+    } catch (SocialAuthException expected) {
+      assertEquals("No verified primary email", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void fetchProfileWrapsMalformedProviderJson() throws Exception {
+    RecordingHttpClient client = new RecordingHttpClient();
+    client.tokenResponse = "not json";
+    SocialAuthService service = newService(client);
+
+    try {
+      service.fetchProfile(SocialAuthProvider.GITHUB, "provider-code", "verifier-123",
+          "unused-nonce");
+      fail("Expected malformed provider JSON to be rejected");
+    } catch (SocialAuthException expected) {
+      assertEquals("Provider profile could not be verified", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void defaultHttpClientRejectsPlainHttpProviderUrl() throws Exception {
+    DefaultSocialAuthHttpClient client = new DefaultSocialAuthHttpClient(
+        new SocialAuthConfig(ConfigFactory.parseString("core.public_url = \"https://wave.example.com\"")));
+
+    try {
+      client.get("http://example.com/oauth/token", Map.of());
+      fail("Expected plaintext provider URL to be rejected");
+    } catch (SocialAuthException expected) {
+      assertEquals("Provider request must use HTTPS", expected.getMessage());
+    }
+  }
+
+  private static SocialAuthService newService(RecordingHttpClient client) {
+    return new SocialAuthService(new SocialAuthConfig(ConfigFactory.parseString(
+        "core.public_url = \"https://wave.example.com\"\n"
+            + "core.social_auth.google.client_id = \"google-client\"\n"
+            + "core.social_auth.google.client_secret = \"google-secret\"\n"
+            + "core.social_auth.google.redirect_uri = \"\"\n"
+            + "core.social_auth.github.client_id = \"github-client\"\n"
+            + "core.social_auth.github.client_secret = \"github-secret\"\n"
+            + "core.social_auth.github.redirect_uri = \"\"")),
+        client,
+        Clock.fixed(Instant.parse("2026-04-24T10:00:00Z"), ZoneOffset.UTC));
+  }
+
+  private static final class RecordingHttpClient implements SocialAuthHttpClient {
+    String tokenResponse = "{\"access_token\":\"gh-token\"}";
+    String userResponse = "{\"id\":12345,\"login\":\"octocat\",\"name\":\"Octo Cat\"}";
+    String emailsResponse = "["
+        + "{\"email\":\"other@example.com\",\"primary\":false,\"verified\":true},"
+        + "{\"email\":\"octo@example.com\",\"primary\":true,\"verified\":true}"
+        + "]";
+    Map<String, String> lastPostForm = Map.of();
+    Map<String, String> lastPostHeaders = Map.of();
+    List<String> getUrls = new ArrayList<>();
+    List<Map<String, String>> getHeaders = new ArrayList<>();
+
+    @Override
+    public String postForm(String url, Map<String, String> form, Map<String, String> headers) {
+      lastPostForm = new LinkedHashMap<>(form);
+      lastPostHeaders = new LinkedHashMap<>(headers);
+      return tokenResponse;
+    }
+
+    @Override
+    public String get(String url, Map<String, String> headers) {
+      getUrls.add(url);
+      getHeaders.add(new LinkedHashMap<>(headers));
+      if (url.endsWith("/user/emails")) {
+        return emailsResponse;
+      }
+      return userResponse;
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
@@ -31,6 +31,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.box.server.robots.RobotCapabilities;
 import org.waveprotocol.wave.model.util.CollectionUtils;
@@ -106,6 +107,50 @@ public abstract class AccountStoreTestBase extends TestCase {
         new HumanAccountDataImpl(HUMAN_ID, new PasswordDigest("internet".toCharArray())));
     AccountData retrievedAccount = accountStore.getAccount(HUMAN_ID);
     assertTrue(retrievedAccount.asHuman().getPasswordDigest().verify("internet".toCharArray()));
+  }
+
+  public final void testRoundtripHumanAccountWithSocialIdentityLookup() throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.addOrReplaceSocialIdentity(
+        new SocialIdentity("google", "google-sub-123", "human@example.com", "Human User", 1234L));
+
+    accountStore.putAccount(account);
+
+    AccountData retrievedAccount =
+        accountStore.getAccountBySocialIdentity("google", "google-sub-123");
+    assertNotNull(retrievedAccount);
+    assertEquals(HUMAN_ID, retrievedAccount.getId());
+    assertEquals(1, retrievedAccount.asHuman().getSocialIdentities().size());
+  }
+
+  public final void testEmailLookupMatchesLegacyMixedCaseEmail() throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.setEmail("Human@Example.COM");
+    accountStore.putAccount(account);
+
+    AccountData retrievedAccount = accountStore.getAccountByEmail("human@example.com");
+
+    assertNotNull(retrievedAccount);
+    assertEquals(HUMAN_ID, retrievedAccount.getId());
+  }
+
+  public final void testSocialIdentityLookupRemovesStaleMappingOnReplace() throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.addOrReplaceSocialIdentity(
+        new SocialIdentity("github", "old-subject", "human@example.com", "Human User", 1234L));
+    accountStore.putAccount(account);
+
+    HumanAccountDataImpl replacement = new HumanAccountDataImpl(HUMAN_ID);
+    replacement.addOrReplaceSocialIdentity(
+        new SocialIdentity("github", "new-subject", "human@example.com", "Human User", 2345L));
+    accountStore.putAccount(replacement);
+
+    assertNull(accountStore.getAccountBySocialIdentity("github", "old-subject"));
+    assertEquals(HUMAN_ID,
+        accountStore.getAccountBySocialIdentity("github", "new-subject").getId());
   }
 
   public final void testRoundtripRobotAccount() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
@@ -49,6 +49,9 @@ public abstract class AccountStoreTestBase extends TestCase {
 
   private static final ParticipantId HUMAN_ID = ParticipantId.ofUnsafe("human@example.com");
 
+  private static final ParticipantId SECOND_HUMAN_ID =
+      ParticipantId.ofUnsafe("second@example.com");
+
   private static final ParticipantId ROBOT_ID = ParticipantId.ofUnsafe("robot@example.com");
 
   private RobotAccountData robotAccount;
@@ -112,16 +115,36 @@ public abstract class AccountStoreTestBase extends TestCase {
   public final void testRoundtripHumanAccountWithSocialIdentityLookup() throws Exception {
     AccountStore accountStore = newAccountStore();
     HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
-    account.addOrReplaceSocialIdentity(
-        new SocialIdentity("google", "google-sub-123", "human@example.com", "Human User", 1234L));
+    SocialIdentity identity =
+        new SocialIdentity("google", "google-sub-123", "human@example.com", "Human User", 1234L);
+    account.addOrReplaceSocialIdentity(identity);
 
-    accountStore.putAccount(account);
+    accountStore.putAccountWithUniqueSocialIdentity(account, identity);
 
     AccountData retrievedAccount =
         accountStore.getAccountBySocialIdentity("google", "google-sub-123");
     assertNotNull(retrievedAccount);
     assertEquals(HUMAN_ID, retrievedAccount.getId());
     assertEquals(1, retrievedAccount.asHuman().getSocialIdentities().size());
+  }
+
+  public final void testPutAccountWithUniqueSocialIdentityRejectsDuplicate() throws Exception {
+    AccountStore accountStore = newAccountStore();
+    SocialIdentity identity =
+        new SocialIdentity("google", "google-sub-123", "human@example.com", "Human User", 1234L);
+    HumanAccountDataImpl first = new HumanAccountDataImpl(HUMAN_ID);
+    first.addOrReplaceSocialIdentity(identity);
+    accountStore.putAccountWithUniqueSocialIdentity(first, identity);
+
+    HumanAccountDataImpl second = new HumanAccountDataImpl(SECOND_HUMAN_ID);
+    second.addOrReplaceSocialIdentity(identity);
+    try {
+      accountStore.putAccountWithUniqueSocialIdentity(second, identity);
+      fail("Expected duplicate social identity to be rejected");
+    } catch (PersistenceException expected) {
+      assertEquals(HUMAN_ID,
+          accountStore.getAccountBySocialIdentity("google", "google-sub-123").getId());
+    }
   }
 
   public final void testEmailLookupMatchesLegacyMixedCaseEmail() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
@@ -147,6 +147,85 @@ public abstract class AccountStoreTestBase extends TestCase {
     }
   }
 
+  public final void testPutNewAccountWithOwnerAssignmentRejectsExistingAddress()
+      throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl passwordAccount =
+        new HumanAccountDataImpl(HUMAN_ID, new PasswordDigest("internet".toCharArray()));
+
+    assertEquals(AccountStore.AccountCreationResult.CREATED,
+        accountStore.putNewAccountWithOwnerAssignmentResult(passwordAccount, null));
+
+    SocialIdentity identity =
+        new SocialIdentity("github", "github-sub-123", "human@example.com", "Human User", 1234L);
+    HumanAccountDataImpl socialAccount = new HumanAccountDataImpl(HUMAN_ID);
+    socialAccount.addOrReplaceSocialIdentity(identity);
+
+    assertEquals(AccountStore.AccountCreationResult.ACCOUNT_EXISTS,
+        accountStore.putNewAccountWithOwnerAssignmentResult(socialAccount, identity));
+    AccountData stored = accountStore.getAccount(HUMAN_ID);
+    assertNotNull(stored.asHuman().getPasswordDigest());
+    assertTrue(stored.asHuman().getPasswordDigest().verify("internet".toCharArray()));
+    assertTrue(stored.asHuman().getSocialIdentities().isEmpty());
+    assertEquals(HumanAccountData.ROLE_OWNER, stored.asHuman().getRole());
+  }
+
+  public final void testPutNewAccountWithOwnerAssignmentRejectsExistingSocialIdentity()
+      throws Exception {
+    AccountStore accountStore = newAccountStore();
+    SocialIdentity identity =
+        new SocialIdentity("github", "github-sub-123", "human@example.com", "Human User", 1234L);
+    HumanAccountDataImpl first = new HumanAccountDataImpl(HUMAN_ID);
+    first.addOrReplaceSocialIdentity(identity);
+
+    assertEquals(AccountStore.AccountCreationResult.CREATED,
+        accountStore.putNewAccountWithOwnerAssignmentResult(first, identity));
+
+    HumanAccountDataImpl second = new HumanAccountDataImpl(SECOND_HUMAN_ID);
+    second.addOrReplaceSocialIdentity(identity);
+
+    assertEquals(AccountStore.AccountCreationResult.SOCIAL_IDENTITY_EXISTS,
+        accountStore.putNewAccountWithOwnerAssignmentResult(second, identity));
+    assertNull(accountStore.getAccount(SECOND_HUMAN_ID));
+    assertEquals(HUMAN_ID,
+        accountStore.getAccountBySocialIdentity("github", "github-sub-123").getId());
+  }
+
+  public final void testPutNewAccountWithOwnerAssignmentPrefersAccountCollision()
+      throws Exception {
+    AccountStore accountStore = newAccountStore();
+    SocialIdentity identity =
+        new SocialIdentity("github", "github-sub-123", "human@example.com", "Human User", 1234L);
+    HumanAccountDataImpl first = new HumanAccountDataImpl(HUMAN_ID);
+    first.addOrReplaceSocialIdentity(identity);
+
+    assertEquals(AccountStore.AccountCreationResult.CREATED,
+        accountStore.putNewAccountWithOwnerAssignmentResult(first, identity));
+
+    HumanAccountDataImpl duplicate = new HumanAccountDataImpl(HUMAN_ID);
+    duplicate.addOrReplaceSocialIdentity(identity);
+
+    assertEquals(AccountStore.AccountCreationResult.ACCOUNT_EXISTS,
+        accountStore.putNewAccountWithOwnerAssignmentResult(duplicate, identity));
+  }
+
+  public final void testPutNewAccountWithOwnerAssignmentPromotesOnlyFirstHuman()
+      throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl first = new HumanAccountDataImpl(HUMAN_ID);
+    HumanAccountDataImpl second = new HumanAccountDataImpl(SECOND_HUMAN_ID);
+
+    assertEquals(AccountStore.AccountCreationResult.CREATED,
+        accountStore.putNewAccountWithOwnerAssignmentResult(first, null));
+    assertEquals(AccountStore.AccountCreationResult.CREATED,
+        accountStore.putNewAccountWithOwnerAssignmentResult(second, null));
+
+    assertEquals(HumanAccountData.ROLE_OWNER,
+        accountStore.getAccount(HUMAN_ID).asHuman().getRole());
+    assertEquals(HumanAccountData.ROLE_USER,
+        accountStore.getAccount(SECOND_HUMAN_ID).asHuman().getRole());
+  }
+
   public final void testEmailLookupMatchesLegacyMixedCaseEmail() throws Exception {
     AccountStore accountStore = newAccountStore();
     HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagSeederTest.java
@@ -98,6 +98,34 @@ public final class FeatureFlagSeederTest {
   }
 
   @Test
+  public void seedsSocialAuthEnabledWhenConfigEnablesIt() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+
+    FeatureFlagSeeder.seedSocialAuthFeatureFlag(
+        store, ConfigFactory.parseString("core.social_auth.enabled = true"));
+
+    assertTrue(store.get("social-auth") != null);
+
+    FeatureFlagService service = new FeatureFlagService(store);
+
+    assertTrue(service.isGloballyEnabled("social-auth"));
+  }
+
+  @Test
+  public void preservesExistingSocialAuthFlagWhenConfigChanges() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(new FeatureFlag("social-auth", "Social sign-in", false, allowedUsers(true)));
+
+    FeatureFlagSeeder.seedSocialAuthFeatureFlag(
+        store, ConfigFactory.parseString("core.social_auth.enabled = true"));
+
+    FeatureFlagService service = new FeatureFlagService(store);
+
+    assertFalse(service.isGloballyEnabled("social-auth"));
+    assertTrue(service.isEnabled("social-auth", "vega@supawave.ai"));
+  }
+
+  @Test
   public void searchWaveletUpdaterIsEnabledWhenFlagHasAllowlist() throws Exception {
     MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
     store.save(

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/memory/FeatureFlagServiceTest.java
@@ -89,6 +89,36 @@ public final class FeatureFlagServiceTest {
   }
 
   @Test
+  public void socialAuthFlagIsKnownButDisabledByDefault() throws Exception {
+    assertTrue(KnownFeatureFlags.isKnownFlag("social-auth"));
+
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    service = new FeatureFlagService(store);
+
+    assertFalse(service.getEnabledFlagNames(null).contains("social-auth"));
+    assertFalse(service.isGloballyEnabled("social-auth"));
+  }
+
+  @Test
+  public void socialAuthGlobalHelperIgnoresAllowedUsers() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(new FeatureFlag("social-auth", "Social sign-in", false, allowedUsers(true)));
+    service = new FeatureFlagService(store);
+
+    assertTrue(service.isEnabled("social-auth", "vega@supawave.ai"));
+    assertFalse(service.isGloballyEnabled("social-auth"));
+  }
+
+  @Test
+  public void socialAuthGlobalHelperUsesOnlyGlobalFlag() throws Exception {
+    MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
+    store.save(new FeatureFlag("social-auth", "Social sign-in", true, allowedUsers(false)));
+    service = new FeatureFlagService(store);
+
+    assertTrue(service.isGloballyEnabled("social-auth"));
+  }
+
+  @Test
   public void storedOtSearchFlagEnablesKnownFlag() throws Exception {
     MemoryFeatureFlagStore store = new MemoryFeatureFlagStore();
     store.save(

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
@@ -189,7 +189,7 @@ public class ProtoAccountDataSerializerTest extends TestCase {
     assertEquals("Human User",
         deserialized.asHuman().getSocialIdentities().get(0).getDisplayName());
     assertEquals(1234L,
-        deserialized.asHuman().getSocialIdentities().get(0).getTimestamp());
+        deserialized.asHuman().getSocialIdentities().get(0).getLinkedAtMillis());
   }
 
   public final void testRobotAccountWithCapabilities() {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
@@ -32,6 +32,7 @@ import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.RobotAccountData;
 import org.waveprotocol.box.server.account.RobotAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.PasswordDigest;
 import org.waveprotocol.box.server.persistence.protos.ProtoAccountStoreData.ProtoAccountData;
 import org.waveprotocol.box.server.robots.RobotCapabilities;
@@ -167,6 +168,22 @@ public class ProtoAccountDataSerializerTest extends TestCase {
     assertEquals("in:inbox", human.getSearches().get(0).getQuery());
     assertEquals("Flagged", human.getSearches().get(1).getName());
     assertEquals("is:flagged", human.getSearches().get(1).getQuery());
+  }
+
+  public final void testHumanAccountWithSocialIdentity() {
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.addOrReplaceSocialIdentity(
+        new SocialIdentity("google", "google-sub-123", "human@example.com", "Human User", 1234L));
+
+    ProtoAccountData data = ProtoAccountDataSerializer.serialize(account);
+    AccountData deserialized = ProtoAccountDataSerializer.deserialize(data);
+
+    assertTrue(deserialized.isHuman());
+    assertEquals(1, deserialized.asHuman().getSocialIdentities().size());
+    assertEquals("google",
+        deserialized.asHuman().getSocialIdentities().get(0).getProvider());
+    assertEquals("google-sub-123",
+        deserialized.asHuman().getSocialIdentities().get(0).getSubject());
   }
 
   public final void testRobotAccountWithCapabilities() {

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
@@ -184,6 +184,12 @@ public class ProtoAccountDataSerializerTest extends TestCase {
         deserialized.asHuman().getSocialIdentities().get(0).getProvider());
     assertEquals("google-sub-123",
         deserialized.asHuman().getSocialIdentities().get(0).getSubject());
+    assertEquals("human@example.com",
+        deserialized.asHuman().getSocialIdentities().get(0).getEmail());
+    assertEquals("Human User",
+        deserialized.asHuman().getSocialIdentities().get(0).getDisplayName());
+    assertEquals(1234L,
+        deserialized.asHuman().getSocialIdentities().get(0).getTimestamp());
   }
 
   public final void testRobotAccountWithCapabilities() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
@@ -46,8 +46,12 @@ import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwt;
 import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtIssuer;
 import org.waveprotocol.box.server.authentication.jwt.EmailTokenIssuer;
 import org.waveprotocol.box.server.authentication.email.AuthEmailService;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthConfig;
 import org.waveprotocol.box.server.mail.MailProvider;
 import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
 import org.waveprotocol.box.server.persistence.memory.MemoryStore;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.escapers.PercentEscaper;
@@ -154,6 +158,60 @@ public class AuthenticationServletTest extends TestCase {
         bodyCaptor.getValue().contains("successBanner"));
     assertTrue("Success message should be present",
         bodyCaptor.getValue().contains("Account created!"));
+  }
+
+  public void testGetSocialLinksPreserveReturnTarget() throws Exception {
+    AccountStore store = new MemoryStore();
+    MemoryFeatureFlagStore featureFlagStore = new MemoryFeatureFlagStore();
+    FeatureFlagService socialFeatureFlags = new FeatureFlagService(featureFlagStore);
+    try {
+      featureFlagStore.save(new FeatureFlag(
+          SocialAuthServlet.SOCIAL_AUTH_FLAG, "Social sign-in", true, ImmutableMap.of()));
+      socialFeatureFlags.refreshCache();
+      Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put("administration.disable_registration", false)
+          .put("administration.analytics_account", "UA-someid")
+          .put("security.enable_clientauth", false)
+          .put("security.clientauth_cert_domain", "")
+          .put("administration.disable_loginpage", false)
+          .put("security.enable_ssl", false)
+          .put("core.email_confirmation_enabled", false)
+          .put("core.auth_email_send_cooldown_seconds", 300)
+          .put("core.auth_email_send_max_per_address_per_hour", 5)
+          .put("core.auth_email_send_max_per_ip_per_hour", 20)
+          .put("core.public_url", "https://wave.example.com")
+          .put("core.social_auth.github.client_id", "github-client")
+          .put("core.social_auth.github.client_secret", "github-secret")
+          .put("core.social_auth.github.redirect_uri", "")
+          .put("core.social_auth.google.client_id", "google-client")
+          .put("core.social_auth.google.client_secret", "google-secret")
+          .put("core.social_auth.google.redirect_uri", "")
+          .build());
+      AuthEmailService authEmailService = new AuthEmailService(
+          store,
+          emailTokenIssuer,
+          mailProvider,
+          Clock.fixed(Instant.parse("2026-03-28T08:00:00Z"), ZoneOffset.UTC),
+          config);
+      servlet = new AuthenticationServlet(store, AuthTestUtil.makeConfiguration(),
+          manager, "example.com", config, browserSessionJwtIssuer, authEmailService,
+          new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(),
+          socialFeatureFlags, new SocialAuthConfig(config));
+      StringWriter body = new StringWriter();
+      when(req.getSession(false)).thenReturn(null);
+      when(req.getParameter("r")).thenReturn("/wave/example.com/w+abc?pane=1");
+      when(req.getLocale()).thenReturn(Locale.ENGLISH);
+      when(resp.getWriter()).thenReturn(new PrintWriter(body));
+
+      servlet.doGet(req, resp);
+
+      assertTrue(body.toString().contains(
+          "href=\"/auth/social/github?r=%2Fwave%2Fexample.com%2Fw%2Babc%3Fpane%3D1\""));
+      assertTrue(body.toString().contains(
+          "href=\"/auth/social/google?r=%2Fwave%2Fexample.com%2Fw%2Babc%3Fpane%3D1\""));
+    } finally {
+      socialFeatureFlags.shutdown();
+    }
   }
 
   public void testGetRedirects() throws IOException {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
@@ -214,6 +214,43 @@ public class AuthenticationServletTest extends TestCase {
     verify(manager, never()).setLoggedInUser(Mockito.any(), Mockito.any());
   }
 
+  public void testDisabledLoginWithoutClientAuthReturnsForbidden() throws Exception {
+    AccountStore store = new MemoryStore();
+    Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+        .put("administration.disable_registration", false)
+        .put("administration.analytics_account", "UA-someid")
+        .put("security.enable_clientauth", false)
+        .put("security.clientauth_cert_domain", "")
+        .put("administration.disable_loginpage", true)
+        .put("security.enable_ssl", false)
+        .put("core.email_confirmation_enabled", false)
+        .put("core.auth_email_send_cooldown_seconds", 300)
+        .put("core.auth_email_send_max_per_address_per_hour", 5)
+        .put("core.auth_email_send_max_per_ip_per_hour", 20)
+        .put("core.public_url", "https://wave.example.com")
+        .build());
+    AuthEmailService authEmailService = new AuthEmailService(
+        store,
+        emailTokenIssuer,
+        mailProvider,
+        Clock.fixed(Instant.parse("2026-03-28T08:00:00Z"), ZoneOffset.UTC),
+        config);
+    servlet = new AuthenticationServlet(store, AuthTestUtil.makeConfiguration(),
+        manager, "example.com", config, browserSessionJwtIssuer, authEmailService,
+        new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
+    StringWriter body = new StringWriter();
+    when(resp.getWriter()).thenReturn(new PrintWriter(body));
+    when(req.getLocale()).thenReturn(Locale.ENGLISH);
+
+    servlet.doPost(req, resp);
+
+    verify(resp).setStatus(HttpServletResponse.SC_FORBIDDEN);
+    assertTrue(body.toString().contains("Sign in is not available"));
+    verify(manager, never()).setLoggedInUser(Mockito.any(), Mockito.any());
+    verify(browserSessionJwtIssuer, never()).issue(Mockito.any());
+    verify(resp, never()).sendRedirect(Mockito.anyString());
+  }
+
   public void testValidLoginForUnconfirmedAccountResendsActivationEmail() throws Exception {
     AccountStore store = new MemoryStore();
     HumanAccountDataImpl account =

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
@@ -357,6 +357,7 @@ public class AuthenticationServletTest extends TestCase {
     }
     servlet.doPost(req, resp);
     if (expectSuccess) {
+      verify(req).changeSessionId();
       verify(manager).setLoggedInUser(Mockito.any(WebSession.class), eq(USER));
       ArgumentCaptor<String> cookieCaptor = ArgumentCaptor.forClass(String.class);
       verify(resp).addHeader(eq("Set-Cookie"), cookieCaptor.capture());

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/AuthenticationServletTest.java
@@ -199,16 +199,18 @@ public class AuthenticationServletTest extends TestCase {
           socialFeatureFlags, new SocialAuthConfig(config));
       StringWriter body = new StringWriter();
       when(req.getSession(false)).thenReturn(null);
+      when(req.getSession(true)).thenReturn(session);
       when(req.getParameter("r")).thenReturn("/wave/example.com/w+abc?pane=1");
       when(req.getLocale()).thenReturn(Locale.ENGLISH);
       when(resp.getWriter()).thenReturn(new PrintWriter(body));
 
       servlet.doGet(req, resp);
 
-      assertTrue(body.toString().contains(
-          "href=\"/auth/social/github?r=%2Fwave%2Fexample.com%2Fw%2Babc%3Fpane%3D1\""));
-      assertTrue(body.toString().contains(
-          "href=\"/auth/social/google?r=%2Fwave%2Fexample.com%2Fw%2Babc%3Fpane%3D1\""));
+      verify(session).setAttribute(eq(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR),
+          eq("/wave/example.com/w+abc?pane=1"));
+      assertTrue(body.toString().contains("href=\"/auth/social/github\""));
+      assertTrue(body.toString().contains("href=\"/auth/social/google\""));
+      assertFalse(body.toString().contains("?r="));
     } finally {
       socialFeatureFlags.shutdown();
     }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -62,6 +62,24 @@ public final class HtmlRendererAuthStateTest {
   }
 
   @Test
+  public void signInPageFiltersBlankSocialButtons() {
+    String html = HtmlRenderer.renderAuthenticationPage(
+        "example.com",
+        "",
+        AuthenticationServlet.RESPONSE_STATUS_NONE,
+        false,
+        "",
+        true,
+        false,
+        List.of(
+            new HtmlRenderer.SocialProviderLink("", "/auth/social/google"),
+            new HtmlRenderer.SocialProviderLink("GitHub", "")));
+
+    assertFalse(html.contains("<div class=\"social-auth-options\""));
+    assertFalse(html.contains("Continue with"));
+  }
+
+  @Test
   public void socialUsernamePageRequiresSupaWaveUsername() {
     String html = HtmlRenderer.renderSocialUsernamePage(
         "example.com",

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererAuthStateTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
+import java.util.List;
 
 public final class HtmlRendererAuthStateTest {
   @Test
@@ -23,6 +24,89 @@ public final class HtmlRendererAuthStateTest {
     assertTrue(html.contains("aria-live=\"polite\""));
     assertTrue(html.contains("Forgot password?"));
     assertTrue(html.contains("Login with email link"));
+  }
+
+  @Test
+  public void signInPageOmitsSocialButtonsByDefault() {
+    String html = HtmlRenderer.renderAuthenticationPage(
+        "example.com",
+        "",
+        AuthenticationServlet.RESPONSE_STATUS_NONE,
+        false,
+        "",
+        true,
+        false);
+
+    assertFalse(html.contains("/auth/social/google"));
+    assertFalse(html.contains("/auth/social/github"));
+  }
+
+  @Test
+  public void signInPageShowsConfiguredSocialButtons() {
+    String html = HtmlRenderer.renderAuthenticationPage(
+        "example.com",
+        "",
+        AuthenticationServlet.RESPONSE_STATUS_NONE,
+        false,
+        "",
+        true,
+        false,
+        List.of(
+            new HtmlRenderer.SocialProviderLink("Google", "/auth/social/google"),
+            new HtmlRenderer.SocialProviderLink("GitHub", "/auth/social/github")));
+
+    assertTrue(html.contains("Continue with Google"));
+    assertTrue(html.contains("href=\"/auth/social/google\""));
+    assertTrue(html.contains("Continue with GitHub"));
+    assertTrue(html.contains("href=\"/auth/social/github\""));
+  }
+
+  @Test
+  public void socialUsernamePageRequiresSupaWaveUsername() {
+    String html = HtmlRenderer.renderSocialUsernamePage(
+        "example.com",
+        "Google",
+        "social@example.com",
+        "",
+        AuthenticationServlet.RESPONSE_STATUS_NONE,
+        "csrf-123",
+        "");
+
+    assertTrue(html.contains("Choose your SupaWave username"));
+    assertTrue(html.contains("social@example.com"));
+    assertTrue(html.contains("name=\"address\""));
+    assertTrue(html.contains("name=\"csrf\" value=\"csrf-123\""));
+  }
+
+  @Test
+  public void socialFailurePageHonorsEmailAuthFlags() {
+    String html = HtmlRenderer.renderSocialFailurePage(
+        "example.com",
+        "Social sign-in could not be completed.",
+        "",
+        false,
+        false,
+        true);
+
+    assertTrue(html.contains("Social sign-in could not be completed."));
+    assertFalse(html.contains("Forgot password?"));
+    assertTrue(html.contains("Login with email link"));
+  }
+
+  @Test
+  public void socialFailurePageHonorsDisabledLoginPage() {
+    String html = HtmlRenderer.renderSocialFailurePage(
+        "example.com",
+        "Social sign-in could not be completed.",
+        "",
+        true,
+        true,
+        true);
+
+    assertTrue(html.contains("HTTP authentication disabled by administrator."));
+    assertFalse(html.contains("id=\"wiab_loginform\""));
+    assertFalse(html.contains("Forgot password?"));
+    assertFalse(html.contains("Login with email link"));
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -437,7 +437,8 @@ public final class SocialAuthServletTest {
         new AnalyticsRecorder(),
         new SecureRandom(new byte[] {1, 2, 3, 4}),
         DOMAIN,
-        config);
+        config,
+        new Object());
     return new Fixture(servlet, accountStore, sessionManager, featureFlagStore);
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -111,6 +111,7 @@ public final class SocialAuthServletTest {
     fixture.servlet.doGet(callback.req, callbackResponse.resp);
 
     assertTrue(callbackResponse.body().contains("Choose your SupaWave username"));
+    assertFalse(callbackResponse.body().contains("octo@example.com"));
     String csrf = hiddenValue(callbackResponse.body(), "csrf");
     RequestContext complete = request("/complete",
         Map.of("csrf", csrf, "address", "octo"), session);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Test;
 import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.account.HumanAccountDataImpl;
 import org.waveprotocol.box.server.account.SocialIdentity;
 import org.waveprotocol.box.server.authentication.SessionManager;
@@ -124,12 +125,42 @@ public final class SocialAuthServletTest {
     assertEquals(null, account.asHuman().getPasswordDigest());
     assertTrue(account.asHuman().isEmailConfirmed());
     assertEquals("octo@example.com", account.asHuman().getEmail());
+    assertEquals(HumanAccountData.ROLE_OWNER, account.asHuman().getRole());
     assertEquals(1, account.asHuman().getSocialIdentities().size());
     assertEquals("github", account.asHuman().getSocialIdentities().get(0).getProvider());
     verify(fixture.sessionManager).setLoggedInUser(any(WebSession.class),
         eq(ParticipantId.ofUnsafe("octo@example.com")));
     verify(callback.req).changeSessionId();
     verify(complete.req).changeSessionId();
+  }
+
+  @Test
+  public void completeKeepsSocialAccountUserWhenAccountsAlreadyExist() throws Exception {
+    Fixture fixture = newFixture(true);
+    HumanAccountDataImpl existing =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("existing@example.com"));
+    fixture.accountStore.putAccount(existing);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of("r", "/wave/"), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+    String state = queryParam(startResponse.redirect, "state");
+    RequestContext callback = request("/callback/github",
+        Map.of("state", state, "code", "provider-code"), session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+    String csrf = hiddenValue(callbackResponse.body(), "csrf");
+
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals("/wave/", completeResponse.redirect);
+    AccountData account = fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo@example.com"));
+    assertNotNull(account);
+    assertEquals(HumanAccountData.ROLE_USER, account.asHuman().getRole());
   }
 
   @Test

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -77,6 +77,18 @@ public final class SocialAuthServletTest {
   }
 
   @Test
+  public void startAuthorizationRespectsDisabledLoginPage() throws Exception {
+    Fixture fixture = newFixture(true, new LinkedHashMap<>(), true);
+    RequestContext request = request("/github", Map.of(), newSession(new HashMap<>()));
+    ResponseContext response = response();
+
+    fixture.servlet.doGet(request.req, response.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, response.status);
+    verify(response.resp, never()).sendRedirect(anyString());
+  }
+
+  @Test
   public void callbackRejectsInvalidStateAndClearsPendingAuthorization() throws Exception {
     Fixture fixture = newFixture(true);
     Map<String, Object> sessionAttributes = new HashMap<>();
@@ -355,6 +367,11 @@ public final class SocialAuthServletTest {
 
   private Fixture newFixture(boolean socialAuthEnabled, Map<String, Boolean> allowedUsers)
       throws Exception {
+    return newFixture(socialAuthEnabled, allowedUsers, false);
+  }
+
+  private Fixture newFixture(boolean socialAuthEnabled, Map<String, Boolean> allowedUsers,
+      boolean disableLoginPage) throws Exception {
     MemoryFeatureFlagStore featureFlagStore = new MemoryFeatureFlagStore();
     featureFlagStore.save(new FeatureFlag(
         "social-auth", "Social sign-in", socialAuthEnabled, allowedUsers));
@@ -375,7 +392,7 @@ public final class SocialAuthServletTest {
             + "core.social_auth.google.redirect_uri = \"\"\n"
             + "security.enable_ssl = false\n"
             + "administration.disable_registration = false\n"
-            + "administration.disable_loginpage = false\n"
+            + "administration.disable_loginpage = " + disableLoginPage + "\n"
             + "core.password_reset_enabled = true\n"
             + "core.magic_link_enabled = false");
     SocialAuthService service = new SocialAuthService(

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.server.rpc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -46,8 +47,10 @@ import org.waveprotocol.box.server.authentication.oauth.SocialAuthConfig;
 import org.waveprotocol.box.server.authentication.oauth.SocialAuthException;
 import org.waveprotocol.box.server.authentication.oauth.SocialAuthHttpClient;
 import org.waveprotocol.box.server.authentication.oauth.SocialAuthService;
+import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.FeatureFlagService;
 import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
 import org.waveprotocol.box.server.persistence.memory.MemoryStore;
 import org.waveprotocol.box.server.waveserver.AnalyticsRecorder;
@@ -349,6 +352,70 @@ public final class SocialAuthServletTest {
   }
 
   @Test
+  public void completeKeepsPendingProfileAfterUsernameCollisionForRetry() throws Exception {
+    Fixture fixture = newFixture(true);
+    fixture.accountStore.putAccount(
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("octo@example.com")));
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    String csrf = preparePendingProfile(fixture, session);
+
+    RequestContext firstComplete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext firstResponse = response();
+    fixture.servlet.doPost(firstComplete.req, firstResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_OK, firstResponse.status);
+    assertTrue(firstResponse.body().contains("Account already exists"));
+    assertTrue(sessionAttributes.containsKey("socialAuth.pendingProfile"));
+
+    RequestContext retryComplete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo2"), session);
+    ResponseContext retryResponse = response();
+    fixture.servlet.doPost(retryComplete.req, retryResponse.resp);
+
+    assertEquals("/", retryResponse.redirect);
+    assertFalse(sessionAttributes.containsKey("socialAuth.pendingProfile"));
+    assertNotNull(fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo2@example.com")));
+  }
+
+  @Test
+  public void completeClearsPendingProfileAfterPersistenceFailure() throws Exception {
+    Fixture fixture = newFixture(true, new LinkedHashMap<>(), false,
+        new ThrowingCreateAccountStore());
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    String csrf = preparePendingProfile(fixture, session);
+
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, completeResponse.status);
+    assertFalse(sessionAttributes.containsKey("socialAuth.pendingProfile"));
+  }
+
+  @Test
+  public void completeClearsPendingProfileWhenStoreReportsSocialIdentityExists()
+      throws Exception {
+    Fixture fixture = newFixture(true, new LinkedHashMap<>(), false,
+        new SocialIdentityExistsStore());
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    String csrf = preparePendingProfile(fixture, session);
+
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, completeResponse.status);
+    assertFalse(sessionAttributes.containsKey("socialAuth.pendingProfile"));
+    assertNull(fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo@example.com")));
+  }
+
+  @Test
   public void callbackAttemptsAreRateLimited() throws Exception {
     Fixture fixture = newFixture(true);
     ResponseContext lastResponse = null;
@@ -399,11 +466,15 @@ public final class SocialAuthServletTest {
 
   private Fixture newFixture(boolean socialAuthEnabled, Map<String, Boolean> allowedUsers,
       boolean disableLoginPage) throws Exception {
+    return newFixture(socialAuthEnabled, allowedUsers, disableLoginPage, new MemoryStore());
+  }
+
+  private Fixture newFixture(boolean socialAuthEnabled, Map<String, Boolean> allowedUsers,
+      boolean disableLoginPage, MemoryStore accountStore) throws Exception {
     MemoryFeatureFlagStore featureFlagStore = new MemoryFeatureFlagStore();
     featureFlagStore.save(new FeatureFlag(
         "social-auth", "Social sign-in", socialAuthEnabled, allowedUsers));
     featureFlagService = new FeatureFlagService(featureFlagStore);
-    MemoryStore accountStore = new MemoryStore();
     SessionManager sessionManager = mock(SessionManager.class);
     BrowserSessionJwtIssuer jwtIssuer = mock(BrowserSessionJwtIssuer.class);
     when(jwtIssuer.issue(any(ParticipantId.class))).thenReturn("browser-jwt");
@@ -437,8 +508,7 @@ public final class SocialAuthServletTest {
         new AnalyticsRecorder(),
         new SecureRandom(new byte[] {1, 2, 3, 4}),
         DOMAIN,
-        config,
-        new Object());
+        config);
     return new Fixture(servlet, accountStore, sessionManager, featureFlagStore);
   }
 
@@ -564,6 +634,22 @@ public final class SocialAuthServletTest {
         return "[{\"email\":\"octo@example.com\",\"primary\":true,\"verified\":true}]";
       }
       return "{\"id\":12345,\"login\":\"octocat\",\"name\":\"Octo Cat\"}";
+    }
+  }
+
+  private static final class ThrowingCreateAccountStore extends MemoryStore {
+    @Override
+    public AccountStore.AccountCreationResult putNewAccountWithOwnerAssignmentResult(
+        AccountData account, SocialIdentity socialIdentity) throws PersistenceException {
+      throw new PersistenceException("forced failure");
+    }
+  }
+
+  private static final class SocialIdentityExistsStore extends MemoryStore {
+    @Override
+    public AccountStore.AccountCreationResult putNewAccountWithOwnerAssignmentResult(
+        AccountData account, SocialIdentity socialIdentity) {
+      return AccountStore.AccountCreationResult.SOCIAL_IDENTITY_EXISTS;
     }
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -147,6 +147,33 @@ public final class SocialAuthServletTest {
   }
 
   @Test
+  public void callbackThenCompleteUsesSessionReturnTargetFromSignInPage()
+      throws Exception {
+    Fixture fixture = newFixture(true);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    sessionAttributes.put(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR,
+        "/wave/example.com/w+abc?pane=1");
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+    String state = queryParam(startResponse.redirect, "state");
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", state, "code", "provider-code"), session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+    String csrf = hiddenValue(callbackResponse.body(), "csrf");
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals("/wave/example.com/w+abc?pane=1", completeResponse.redirect);
+    assertFalse(sessionAttributes.containsKey(AuthRedirects.SOCIAL_AUTH_RETURN_SESSION_ATTR));
+  }
+
+  @Test
   public void completeKeepsSocialAccountUserWhenAccountsAlreadyExist() throws Exception {
     Fixture fixture = newFixture(true);
     HumanAccountDataImpl existing =

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -202,6 +202,36 @@ public final class SocialAuthServletTest {
   }
 
   @Test
+  public void loggedInLinkingRechecksFeatureFlagBeforePersisting() throws Exception {
+    Fixture fixture = newFixture(true);
+    ParticipantId alice = ParticipantId.ofUnsafe("alice@example.com");
+    HumanAccountDataImpl aliceAccount = new HumanAccountDataImpl(alice);
+    aliceAccount.setEmail("octo@example.com");
+    aliceAccount.setEmailConfirmed(true);
+    fixture.accountStore.putAccount(aliceAccount);
+    when(fixture.sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(alice);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+
+    fixture.featureFlagStore.save(new FeatureFlag(
+        "social-auth", "Social sign-in", false, Map.of()));
+    featureFlagService.refreshCache();
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", queryParam(startResponse.redirect, "state"), "code", "provider-code"),
+        session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, callbackResponse.status);
+    assertEquals(0, aliceAccount.getSocialIdentities().size());
+    verify(fixture.sessionManager, never()).setLoggedInUser(any(WebSession.class), eq(alice));
+  }
+
+  @Test
   public void linkedAccountDenylistOverridesGlobalFlag() throws Exception {
     ParticipantId bob = ParticipantId.ofUnsafe("bob@example.com");
     Fixture fixture = newFixture(true, Map.of(bob.getAddress(), false));
@@ -333,7 +363,7 @@ public final class SocialAuthServletTest {
         new SecureRandom(new byte[] {1, 2, 3, 4}),
         DOMAIN,
         config);
-    return new Fixture(servlet, accountStore, sessionManager);
+    return new Fixture(servlet, accountStore, sessionManager, featureFlagStore);
   }
 
   private static HttpSession newSession(Map<String, Object> attributes) {
@@ -411,11 +441,14 @@ public final class SocialAuthServletTest {
     final SocialAuthServlet servlet;
     final MemoryStore accountStore;
     final SessionManager sessionManager;
+    final MemoryFeatureFlagStore featureFlagStore;
 
-    Fixture(SocialAuthServlet servlet, MemoryStore accountStore, SessionManager sessionManager) {
+    Fixture(SocialAuthServlet servlet, MemoryStore accountStore, SessionManager sessionManager,
+        MemoryFeatureFlagStore featureFlagStore) {
       this.servlet = servlet;
       this.accountStore = accountStore;
       this.sessionManager = sessionManager;
+      this.featureFlagStore = featureFlagStore;
     }
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SocialAuthServletTest.java
@@ -1,0 +1,459 @@
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.After;
+import org.junit.Test;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountDataImpl;
+import org.waveprotocol.box.server.account.SocialIdentity;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.authentication.jwt.BrowserSessionJwtIssuer;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthConfig;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthException;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthHttpClient;
+import org.waveprotocol.box.server.authentication.oauth.SocialAuthService;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore.FeatureFlag;
+import org.waveprotocol.box.server.persistence.memory.MemoryFeatureFlagStore;
+import org.waveprotocol.box.server.persistence.memory.MemoryStore;
+import org.waveprotocol.box.server.waveserver.AnalyticsRecorder;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class SocialAuthServletTest {
+  private static final String DOMAIN = "example.com";
+  private FeatureFlagService featureFlagService;
+
+  @After
+  public void tearDown() {
+    if (featureFlagService != null) {
+      featureFlagService.shutdown();
+    }
+  }
+
+  @Test
+  public void startAuthorizationRequiresGlobalFlag() throws Exception {
+    Fixture fixture = newFixture(false);
+    RequestContext request = request("/github", Map.of(), newSession(new HashMap<>()));
+    ResponseContext response = response();
+
+    fixture.servlet.doGet(request.req, response.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, response.status);
+    verify(response.resp, never()).sendRedirect(anyString());
+  }
+
+  @Test
+  public void callbackRejectsInvalidStateAndClearsPendingAuthorization() throws Exception {
+    Fixture fixture = newFixture(true);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+
+    assertTrue(sessionAttributes.containsKey("socialAuth.pendingAuthorization"));
+
+    RequestContext callback = request("/callback/github", Map.of("state", "wrong"), session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, callbackResponse.status);
+    assertFalse(sessionAttributes.containsKey("socialAuth.pendingAuthorization"));
+  }
+
+  @Test
+  public void callbackThenCompleteCreatesNoPasswordAccountWithChosenUsername()
+      throws Exception {
+    Fixture fixture = newFixture(true);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of("r", "/welcome"), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+    String state = queryParam(startResponse.redirect, "state");
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", state, "code", "provider-code"), session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertTrue(callbackResponse.body().contains("Choose your SupaWave username"));
+    String csrf = hiddenValue(callbackResponse.body(), "csrf");
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals("/welcome", completeResponse.redirect);
+    AccountData account = fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo@example.com"));
+    assertNotNull(account);
+    assertEquals(null, account.asHuman().getPasswordDigest());
+    assertTrue(account.asHuman().isEmailConfirmed());
+    assertEquals("octo@example.com", account.asHuman().getEmail());
+    assertEquals(1, account.asHuman().getSocialIdentities().size());
+    assertEquals("github", account.asHuman().getSocialIdentities().get(0).getProvider());
+    verify(fixture.sessionManager).setLoggedInUser(any(WebSession.class),
+        eq(ParticipantId.ofUnsafe("octo@example.com")));
+    verify(callback.req).changeSessionId();
+    verify(complete.req).changeSessionId();
+  }
+
+  @Test
+  public void completeRejectsInvalidCsrf() throws Exception {
+    Fixture fixture = newFixture(true);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    String csrf = preparePendingProfile(fixture, session);
+
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf + "-bad", "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, completeResponse.status);
+    assertEquals(null, fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo@example.com")));
+  }
+
+  @Test
+  public void callbackRejectsExistingMixedCaseEmailWithoutAutoLinking() throws Exception {
+    Fixture fixture = newFixture(true);
+    HumanAccountDataImpl existing =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("existing@example.com"));
+    existing.setEmail("Octo@Example.com");
+    existing.setEmailConfirmed(true);
+    fixture.accountStore.putAccount(existing);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", queryParam(startResponse.redirect, "state"), "code", "provider-code"),
+        session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, callbackResponse.status);
+    assertFalse(sessionAttributes.containsKey("socialAuth.pendingProfile"));
+    assertEquals(0, existing.getSocialIdentities().size());
+  }
+
+  @Test
+  public void loggedInUserCannotBeSwitchedToDifferentLinkedSocialAccount() throws Exception {
+    Fixture fixture = newFixture(true);
+    ParticipantId alice = ParticipantId.ofUnsafe("alice@example.com");
+    ParticipantId bob = ParticipantId.ofUnsafe("bob@example.com");
+    HumanAccountDataImpl bobAccount = new HumanAccountDataImpl(bob);
+    bobAccount.setEmail("octo@example.com");
+    bobAccount.setEmailConfirmed(true);
+    bobAccount.addOrReplaceSocialIdentity(
+        new SocialIdentity("github", "12345", "octo@example.com", "Octo Cat", 1234L));
+    fixture.accountStore.putAccount(bobAccount);
+    when(fixture.sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(alice);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", queryParam(startResponse.redirect, "state"), "code", "provider-code"),
+        session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, callbackResponse.status);
+    verify(fixture.sessionManager, never()).setLoggedInUser(any(WebSession.class), eq(bob));
+  }
+
+  @Test
+  public void linkedAccountDenylistOverridesGlobalFlag() throws Exception {
+    ParticipantId bob = ParticipantId.ofUnsafe("bob@example.com");
+    Fixture fixture = newFixture(true, Map.of(bob.getAddress(), false));
+    HumanAccountDataImpl bobAccount = new HumanAccountDataImpl(bob);
+    bobAccount.setEmail("octo@example.com");
+    bobAccount.setEmailConfirmed(true);
+    bobAccount.addOrReplaceSocialIdentity(
+        new SocialIdentity("github", "12345", "octo@example.com", "Octo Cat", 1234L));
+    fixture.accountStore.putAccount(bobAccount);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+
+    RequestContext callback = request("/callback/github",
+        Map.of("state", queryParam(startResponse.redirect, "state"), "code", "provider-code"),
+        session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, callbackResponse.status);
+    verify(fixture.sessionManager, never()).setLoggedInUser(any(WebSession.class), eq(bob));
+  }
+
+  @Test
+  public void completeRejectsProviderSubjectAlreadyLinkedBeforeCreate() throws Exception {
+    Fixture fixture = newFixture(true);
+    Map<String, Object> sessionAttributes = new HashMap<>();
+    HttpSession session = newSession(sessionAttributes);
+    String csrf = preparePendingProfile(fixture, session);
+    HumanAccountDataImpl existing =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("existing@example.com"));
+    existing.addOrReplaceSocialIdentity(
+        new SocialIdentity("github", "12345", "octo@example.com", "Octo Cat", 1234L));
+    fixture.accountStore.putAccount(existing);
+
+    RequestContext complete = request("/complete",
+        Map.of("csrf", csrf, "address", "octo"), session);
+    ResponseContext completeResponse = response();
+    fixture.servlet.doPost(complete.req, completeResponse.resp);
+
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, completeResponse.status);
+    assertEquals(null, fixture.accountStore.getAccount(ParticipantId.ofUnsafe("octo@example.com")));
+  }
+
+  @Test
+  public void callbackAttemptsAreRateLimited() throws Exception {
+    Fixture fixture = newFixture(true);
+    ResponseContext lastResponse = null;
+    for (int i = 0; i < 31; i++) {
+      RequestContext callback = request("/callback/github", Map.of("state", "wrong"),
+          newSession(new HashMap<>()));
+      lastResponse = response();
+      fixture.servlet.doGet(callback.req, lastResponse.resp);
+    }
+
+    assertEquals(429, lastResponse.status);
+  }
+
+  @Test
+  public void rateLimiterRejectsNewBucketsAboveGlobalCap() throws Exception {
+    Fixture fixture = newFixture(true);
+    ResponseContext lastResponse = null;
+    for (int i = 0; i < 4097; i++) {
+      RequestContext callback = request("/callback/github", Map.of("state", "wrong"),
+          newSession(new HashMap<>()), "198.51." + (i / 256) + "." + (i % 256));
+      lastResponse = response();
+      fixture.servlet.doGet(callback.req, lastResponse.resp);
+    }
+
+    assertEquals(429, lastResponse.status);
+  }
+
+  private String preparePendingProfile(Fixture fixture, HttpSession session) throws Exception {
+    RequestContext start = request("/github", Map.of(), session);
+    ResponseContext startResponse = response();
+    fixture.servlet.doGet(start.req, startResponse.resp);
+    String state = queryParam(startResponse.redirect, "state");
+    RequestContext callback = request("/callback/github",
+        Map.of("state", state, "code", "provider-code"), session);
+    ResponseContext callbackResponse = response();
+    fixture.servlet.doGet(callback.req, callbackResponse.resp);
+    return hiddenValue(callbackResponse.body(), "csrf");
+  }
+
+  private Fixture newFixture(boolean socialAuthEnabled) throws Exception {
+    return newFixture(socialAuthEnabled, new LinkedHashMap<>());
+  }
+
+  private Fixture newFixture(boolean socialAuthEnabled, Map<String, Boolean> allowedUsers)
+      throws Exception {
+    MemoryFeatureFlagStore featureFlagStore = new MemoryFeatureFlagStore();
+    featureFlagStore.save(new FeatureFlag(
+        "social-auth", "Social sign-in", socialAuthEnabled, allowedUsers));
+    featureFlagService = new FeatureFlagService(featureFlagStore);
+    MemoryStore accountStore = new MemoryStore();
+    SessionManager sessionManager = mock(SessionManager.class);
+    BrowserSessionJwtIssuer jwtIssuer = mock(BrowserSessionJwtIssuer.class);
+    when(jwtIssuer.issue(any(ParticipantId.class))).thenReturn("browser-jwt");
+    when(jwtIssuer.tokenLifetimeSeconds()).thenReturn(1209600L);
+    Config config = ConfigFactory.parseString(
+        "core.public_url = \"https://wave.example.com\"\n"
+            + "core.analytics_account = \"\"\n"
+            + "core.social_auth.github.client_id = \"github-client\"\n"
+            + "core.social_auth.github.client_secret = \"github-secret\"\n"
+            + "core.social_auth.github.redirect_uri = \"\"\n"
+            + "core.social_auth.google.client_id = \"google-client\"\n"
+            + "core.social_auth.google.client_secret = \"google-secret\"\n"
+            + "core.social_auth.google.redirect_uri = \"\"\n"
+            + "security.enable_ssl = false\n"
+            + "administration.disable_registration = false\n"
+            + "administration.disable_loginpage = false\n"
+            + "core.password_reset_enabled = true\n"
+            + "core.magic_link_enabled = false");
+    SocialAuthService service = new SocialAuthService(
+        new SocialAuthConfig(config),
+        new RecordingHttpClient(),
+        Clock.fixed(Instant.parse("2026-04-24T10:00:00Z"), ZoneOffset.UTC));
+    SocialAuthServlet servlet = new SocialAuthServlet(
+        accountStore,
+        featureFlagService,
+        sessionManager,
+        jwtIssuer,
+        new SocialAuthConfig(config),
+        service,
+        mock(WelcomeWaveCreator.class),
+        new AnalyticsRecorder(),
+        new SecureRandom(new byte[] {1, 2, 3, 4}),
+        DOMAIN,
+        config);
+    return new Fixture(servlet, accountStore, sessionManager);
+  }
+
+  private static HttpSession newSession(Map<String, Object> attributes) {
+    HttpSession session = mock(HttpSession.class);
+    when(session.getAttribute(anyString())).thenAnswer(
+        invocation -> attributes.get(invocation.getArgument(0)));
+    doAnswer(invocation -> {
+      attributes.put(invocation.getArgument(0), invocation.getArgument(1));
+      return null;
+    }).when(session).setAttribute(anyString(), any());
+    doAnswer(invocation -> {
+      attributes.remove(invocation.getArgument(0));
+      return null;
+    }).when(session).removeAttribute(anyString());
+    return session;
+  }
+
+  private static RequestContext request(String path, Map<String, String> parameters,
+      HttpSession session) {
+    return request(path, parameters, session, "198.51.100.9");
+  }
+
+  private static RequestContext request(String path, Map<String, String> parameters,
+      HttpSession session, String remoteAddr) {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    when(req.getPathInfo()).thenReturn(path);
+    when(req.getParameter(anyString())).thenAnswer(
+        invocation -> parameters.get(invocation.getArgument(0)));
+    when(req.getSession(false)).thenReturn(session);
+    when(req.getSession(true)).thenReturn(session);
+    when(req.getRemoteAddr()).thenReturn(remoteAddr);
+    when(req.getHeader("X-Forwarded-Proto")).thenReturn(null);
+    when(req.isSecure()).thenReturn(false);
+    return new RequestContext(req);
+  }
+
+  private static ResponseContext response() throws Exception {
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    ResponseContext context = new ResponseContext(resp);
+    when(resp.getWriter()).thenReturn(new PrintWriter(context.writer));
+    doAnswer(invocation -> {
+      context.status = invocation.getArgument(0);
+      return null;
+    }).when(resp).setStatus(anyInt());
+    doAnswer(invocation -> {
+      context.redirect = invocation.getArgument(0);
+      return null;
+    }).when(resp).sendRedirect(anyString());
+    return context;
+  }
+
+  private static String queryParam(String url, String name) {
+    String query = URI.create(url).getRawQuery();
+    for (String part : query.split("&")) {
+      int equals = part.indexOf('=');
+      if (equals < 0) {
+        continue;
+      }
+      String key = URLDecoder.decode(part.substring(0, equals), StandardCharsets.UTF_8);
+      if (name.equals(key)) {
+        return URLDecoder.decode(part.substring(equals + 1), StandardCharsets.UTF_8);
+      }
+    }
+    return null;
+  }
+
+  private static String hiddenValue(String html, String name) {
+    Matcher matcher = Pattern.compile("name=\"" + Pattern.quote(name)
+        + "\" value=\"([^\"]+)\"").matcher(html);
+    assertTrue("Missing hidden field " + name, matcher.find());
+    return matcher.group(1);
+  }
+
+  private static final class Fixture {
+    final SocialAuthServlet servlet;
+    final MemoryStore accountStore;
+    final SessionManager sessionManager;
+
+    Fixture(SocialAuthServlet servlet, MemoryStore accountStore, SessionManager sessionManager) {
+      this.servlet = servlet;
+      this.accountStore = accountStore;
+      this.sessionManager = sessionManager;
+    }
+  }
+
+  private static final class RequestContext {
+    final HttpServletRequest req;
+
+    RequestContext(HttpServletRequest req) {
+      this.req = req;
+    }
+  }
+
+  private static final class ResponseContext {
+    final HttpServletResponse resp;
+    final StringWriter writer = new StringWriter();
+    int status = HttpServletResponse.SC_OK;
+    String redirect;
+
+    ResponseContext(HttpServletResponse resp) {
+      this.resp = resp;
+    }
+
+    String body() {
+      return writer.toString();
+    }
+  }
+
+  private static final class RecordingHttpClient implements SocialAuthHttpClient {
+    @Override
+    public String postForm(String url, Map<String, String> form, Map<String, String> headers)
+        throws SocialAuthException {
+      return "{\"access_token\":\"gh-token\"}";
+    }
+
+    @Override
+    public String get(String url, Map<String, String> headers) throws SocialAuthException {
+      if (url.endsWith("/user/emails")) {
+        return "[{\"email\":\"octo@example.com\",\"primary\":true,\"verified\":true}]";
+      }
+      return "{\"id\":12345,\"login\":\"octocat\",\"name\":\"Octo Cat\"}";
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
@@ -163,7 +163,7 @@ public class UserRegistrationServletTest extends TestCase {
         "core.email_confirmation_enabled", true));
     UserRegistrationServlet servlet =
         new UserRegistrationServlet(store, "example.com", config, null, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
 
     when(req.getParameter("check-email")).thenReturn("1");
     when(req.getLocale()).thenReturn(Locale.ENGLISH);
@@ -225,7 +225,7 @@ public class UserRegistrationServletTest extends TestCase {
     );
     UserRegistrationServlet enabledServlet =
         new UserRegistrationServlet(store, "example.com", config1, authEmailService, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
 
     Config config2 = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
       "administration.disable_registration", true,
@@ -234,7 +234,7 @@ public class UserRegistrationServletTest extends TestCase {
     );
     UserRegistrationServlet disabledServlet =
         new UserRegistrationServlet(store, "example.com", config2, authEmailService, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
 
     when(req.getParameter("address")).thenReturn(address);
     when(req.getParameter("password")).thenReturn(password);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/UserRegistrationServletTest.java
@@ -163,7 +163,7 @@ public class UserRegistrationServletTest extends TestCase {
         "core.email_confirmation_enabled", true));
     UserRegistrationServlet servlet =
         new UserRegistrationServlet(store, "example.com", config, null, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
 
     when(req.getParameter("check-email")).thenReturn("1");
     when(req.getLocale()).thenReturn(Locale.ENGLISH);
@@ -225,7 +225,7 @@ public class UserRegistrationServletTest extends TestCase {
     );
     UserRegistrationServlet enabledServlet =
         new UserRegistrationServlet(store, "example.com", config1, authEmailService, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
 
     Config config2 = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
       "administration.disable_registration", true,
@@ -234,7 +234,7 @@ public class UserRegistrationServletTest extends TestCase {
     );
     UserRegistrationServlet disabledServlet =
         new UserRegistrationServlet(store, "example.com", config2, authEmailService, welcomeWaveCreator,
-            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder(), new Object());
+            new org.waveprotocol.box.server.waveserver.AnalyticsRecorder());
 
     when(req.getParameter("address")).thenReturn(address);
     when(req.getParameter("password")).thenReturn(password);


### PR DESCRIPTION
## Summary
- add Google and GitHub OAuth sign-in/sign-up behind the `social-auth` feature flag
- require first-time social users to choose a SupaWave username before account creation
- persist provider identities for file/Mongo stores, add Mongo unique index migration, and avoid storing provider tokens
- add OAuth setup runbook for Google/GitHub secrets, callback URLs, rollout steps, and username requirement

Fixes #995

## Security / rollout notes
- OAuth buttons render only when `social-auth` is globally enabled and the provider client id/secret are configured.
- Google ID tokens are verified locally with RS256/JWKS, issuer/audience/azp, nonce, expiry/iat skew, and verified email checks.
- GitHub login requires a verified primary email from the emails API.
- Existing password accounts are not auto-linked by email; authenticated linking requires matching confirmed account email.
- Operators should keep `social-auth` disabled until all runtimes have this binary.

## Verification
- `python3 scripts/assemble-changelog.py` -> assembled 234 entries
- `python3 scripts/validate-changelog.py` -> passed
- `sbt -batch "testOnly org.waveprotocol.box.server.rpc.SocialAuthServletTest org.waveprotocol.box.server.authentication.oauth.GoogleIdTokenVerifierTest org.waveprotocol.box.server.authentication.oauth.SocialAuthServiceTest org.waveprotocol.box.server.rpc.AuthenticationServletTest org.waveprotocol.box.server.persistence.memory.FeatureFlagSeederTest org.waveprotocol.box.server.persistence.memory.FeatureFlagServiceTest org.waveprotocol.box.server.persistence.protos.ProtoAccountDataSerializerTest org.waveprotocol.box.server.persistence.memory.AccountStoreTest org.waveprotocol.box.server.persistence.file.AccountStoreTest org.waveprotocol.box.server.rpc.HtmlRendererAuthStateTest"` -> Passed: Total 108, Failed 0, Errors 0
- `sbt -batch wave/compile` -> passed
- `sbt -batch compileGwt` -> passed; existing GWT CSS parser warnings only
- `git diff --check` -> passed
- Local staged server sanity on port 9907 recorded in `journal/local-verification/2026-04-24-branch-codex-social-oauth-auth-20260424.md`: feature-off sign-in hid social links and `/auth/social/google` returned 403; feature-on dummy-secret run rendered Google/GitHub links and `/auth/social/google` produced provider redirect with PKCE/nonce and sanitized return state.

## Review
- Self-review completed after implementation.
- Claude Code Opus 4.7 review loop was run until the final review returned `NO FINDINGS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-flagged Google and GitHub social sign-in/sign-up.
  * Login page can show “Continue with …” social buttons when enabled.
  * First-time social users must choose a SupaWave username during signup.
  * Existing accounts can be linked to social identities; safe failure and username pages added.
  * Sign-in-disabled deployments now show a clear “Sign in is not available” page.

* **Documentation**
  * Added operator runbook and implementation plan for configuring social OAuth and rollout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->