### PR TITLE
Fix Android IME Done ghost text recovery

### DIFF
--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-followup-plan.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-followup-plan.md
@@ -32,7 +32,7 @@ The missing character therefore must be captured as an initial ghost at activati
 
 - Add pure `GhostTextReconciler` regression tests for:
   - empty model + captured previous sibling `n` + current previous sibling empty + scratch `ew` -> `new`
-  - model `new` + captured previous sibling `new b` + current previous sibling `new` + scratch `lip` -> ` blip`
+  - model `new` + captured previous sibling `new b` + current previous sibling `new` + scratch `lip` -> `<space>blip`
   - initial ghost still present at flush is not double-counted
   - old post-capture ghost growth still works
   - symmetric next-sibling captured ghosts survive Done and post-capture growth

--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-followup-plan.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-followup-plan.md
@@ -1,0 +1,46 @@
+# Issue 828 Android IME Done Follow-up Plan
+
+## Current Symptom
+
+After PR #998, real Android Chrome on a phone became worse:
+
+- typing into a blip and pressing the keyboard Done action leaves the editor visually empty
+- after reload, some text is persisted, but the first character is still missing
+
+## Updated Root Cause
+
+PR #998 made the adjacent DOM baseline model-aware, but it still only recovered ghost text by comparing the adjacent DOM sibling at flush time.
+
+That is insufficient for the Done path. On Android, the first character can already be in the adjacent DOM sibling when the IME scratch activates, then disappear or move before `compositionend` / blur-driven flush. In that ordering:
+
+- activation can see the missing `n`
+- flush no longer sees the `n`
+- the model-aware baseline has no later DOM delta to recover
+- teardown can restore the visible DOM sibling before the model insert renders, producing the blank-after-Done symptom
+
+The missing character therefore must be captured as an initial ghost at activation time, not rediscovered at flush time.
+
+## Fix
+
+- Keep the captured DOM sibling text and the model sibling text as separate facts.
+- At activation, compute any initial ghost text already present in captured DOM over the model baseline.
+- At flush, always include that initial ghost text, even if Android removed it from the sibling before Done.
+- Continue detecting later sibling growth after activation for the ordering the earlier ghost-text recovery handled.
+- Restore visible DOM from model baselines only for recognized ghost text.
+
+## Tests
+
+- Add pure `GhostTextReconciler` regression tests for:
+  - empty model + captured previous sibling `n` + current previous sibling empty + scratch `ew` -> `new`
+  - model `new` + captured previous sibling `new b` + current previous sibling `new` + scratch `lip` -> ` blip`
+  - initial ghost still present at flush is not double-counted
+  - old post-capture ghost growth still works
+  - symmetric next-sibling captured ghosts survive Done and post-capture growth
+  - mismatched captured DOM still falls back to scratch
+
+## Verification
+
+- Run `python3 scripts/assemble-changelog.py` before sbt if generated changelog is missing.
+- Run focused `GhostTextReconcilerTest`.
+- Run changelog validation.
+- Run worktree boot plus a narrow local root/health sanity probe.

--- a/wave/config/changelog.d/2026-04-24-android-ime-done-captured-ghost.json
+++ b/wave/config/changelog.d/2026-04-24-android-ime-done-captured-ghost.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-24-android-ime-done-captured-ghost",
+  "version": "Unreleased",
+  "date": "2026-04-24",
+  "title": "Keep Android IME text visible after Done",
+  "summary": "Android Chrome can move the first composed character into a neighboring text node before the editor snapshots the IME scratch, then remove that neighboring text again when the keyboard Done button closes composition. The editor now carries the activation-time ghost text through the final commit, so the visible blip and persisted content keep the leading characters.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Typing into a blip from Android Chrome now preserves leading characters even when the keyboard Done button removes the browser's temporary adjacent DOM text before the editor flushes the composition."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -75,9 +75,11 @@ public class ImeExtractor {
    * {@link #deactivate(LocalDocument)}.
    */
   private Node ghostPreviousSibling;
-  private String ghostPreviousSiblingBaseline;
+  private String ghostPreviousSiblingModelBaseline;
+  private String ghostPreviousSiblingCapturedText;
   private Node ghostNextSibling;
-  private String ghostNextSiblingBaseline;
+  private String ghostNextSiblingModelBaseline;
+  private String ghostNextSiblingCapturedText;
 
   private static final String WRAPPER_TAGNAME = "l:ime";
 
@@ -153,15 +155,17 @@ public class ImeExtractor {
     }
     String currentPrev = readText(ghostPreviousSibling);
     String currentNext = readText(ghostNextSibling);
-    String result = GhostTextReconciler.combine(scratchContent,
-        ghostPreviousSiblingBaseline, currentPrev,
-        ghostNextSiblingBaseline, currentNext);
+    String result = GhostTextReconciler.combineWithCapturedGhosts(scratchContent,
+        ghostPreviousSiblingModelBaseline, ghostPreviousSiblingCapturedText, currentPrev,
+        ghostNextSiblingModelBaseline, ghostNextSiblingCapturedText, currentNext);
     if (ImeDebugTracer.isEnabled()) {
       ImeDebugTracer.start("ImeExtractor.getEffectiveContent")
           .add("scratch", scratchContent)
-          .add("prevBaseline", ghostPreviousSiblingBaseline)
+          .add("prevModelBaseline", ghostPreviousSiblingModelBaseline)
+          .add("prevCaptured", ghostPreviousSiblingCapturedText)
           .add("currentPrev", currentPrev)
-          .add("nextBaseline", ghostNextSiblingBaseline)
+          .add("nextModelBaseline", ghostNextSiblingModelBaseline)
+          .add("nextCaptured", ghostNextSiblingCapturedText)
           .add("currentNext", currentNext)
           .add("result", result)
           .emit();
@@ -210,9 +214,11 @@ public class ImeExtractor {
       Element anchor = imeContainer.getParentElement();
       ImeDebugTracer.start("ImeExtractor.activate")
           .add("prevSibling", ImeDebugTracer.describe(ghostPreviousSibling))
-          .add("prevBaseline", ghostPreviousSiblingBaseline)
+          .add("prevModelBaseline", ghostPreviousSiblingModelBaseline)
+          .add("prevCaptured", ghostPreviousSiblingCapturedText)
           .add("nextSibling", ImeDebugTracer.describe(ghostNextSibling))
-          .add("nextBaseline", ghostNextSiblingBaseline)
+          .add("nextModelBaseline", ghostNextSiblingModelBaseline)
+          .add("nextCaptured", ghostNextSiblingCapturedText)
           .add("anchorParent", ImeDebugTracer.describe(anchor == null ? null : anchor.getParentElement()))
           .add("anchorInnerText", ImeDebugTracer.innerText(anchor == null ? null : anchor.getParentElement()))
           .emit();
@@ -230,17 +236,19 @@ public class ImeExtractor {
     Element scratchDomAnchor = imeContainer.getParentElement();
     if (scratchDomAnchor == null) {
       ghostPreviousSibling = null;
-      ghostPreviousSiblingBaseline = null;
+      ghostPreviousSiblingModelBaseline = null;
+      ghostPreviousSiblingCapturedText = null;
       ghostNextSibling = null;
-      ghostNextSiblingBaseline = null;
+      ghostNextSiblingModelBaseline = null;
+      ghostNextSiblingCapturedText = null;
       return;
     }
     ghostPreviousSibling = scratchDomAnchor.getPreviousSibling();
-    ghostPreviousSiblingBaseline = GhostTextReconciler.modelAwarePreviousBaseline(
-        previousModelBaseline, readText(ghostPreviousSibling));
+    ghostPreviousSiblingModelBaseline = previousModelBaseline;
+    ghostPreviousSiblingCapturedText = readText(ghostPreviousSibling);
     ghostNextSibling = scratchDomAnchor.getNextSibling();
-    ghostNextSiblingBaseline = GhostTextReconciler.modelAwareNextBaseline(
-        nextModelBaseline, readText(ghostNextSibling));
+    ghostNextSiblingModelBaseline = nextModelBaseline;
+    ghostNextSiblingCapturedText = readText(ghostNextSibling);
   }
 
   /**
@@ -255,10 +263,12 @@ public class ImeExtractor {
           .add("scratch", imeContainer.getInnerText())
           .add("prevSibling", ImeDebugTracer.describe(ghostPreviousSibling))
           .add("prevCurrent", ImeDebugTracer.readText(ghostPreviousSibling))
-          .add("prevBaseline", ghostPreviousSiblingBaseline)
+          .add("prevModelBaseline", ghostPreviousSiblingModelBaseline)
+          .add("prevCaptured", ghostPreviousSiblingCapturedText)
           .add("nextSibling", ImeDebugTracer.describe(ghostNextSibling))
           .add("nextCurrent", ImeDebugTracer.readText(ghostNextSibling))
-          .add("nextBaseline", ghostNextSiblingBaseline)
+          .add("nextModelBaseline", ghostNextSiblingModelBaseline)
+          .add("nextCaptured", ghostNextSiblingCapturedText)
           .emit();
     }
     // Restore any ghost text back to its baseline BEFORE we tear down the
@@ -275,12 +285,14 @@ public class ImeExtractor {
   }
 
   private void restoreGhostBaseline() {
-    restorePreviousTextNode(ghostPreviousSibling, ghostPreviousSiblingBaseline);
-    restoreNextTextNode(ghostNextSibling, ghostNextSiblingBaseline);
+    restorePreviousTextNode(ghostPreviousSibling, ghostPreviousSiblingModelBaseline);
+    restoreNextTextNode(ghostNextSibling, ghostNextSiblingModelBaseline);
     ghostPreviousSibling = null;
-    ghostPreviousSiblingBaseline = null;
+    ghostPreviousSiblingModelBaseline = null;
+    ghostPreviousSiblingCapturedText = null;
     ghostNextSibling = null;
-    ghostNextSiblingBaseline = null;
+    ghostNextSiblingModelBaseline = null;
+    ghostNextSiblingCapturedText = null;
   }
 
   private static void restorePreviousTextNode(Node node, String baseline) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -106,14 +106,18 @@ public final class GhostTextReconciler {
     if (scratchContent == null) {
       throw new NullPointerException("scratchContent must not be null");
     }
-    String ghostBefore = currentOrCapturedFallback(
-        extractGhostSuffix(previousModelBaseline, capturedPrevious),
-        extractGhostSuffix(previousModelBaseline, currentPrevious),
-        previousModelBaseline, currentPrevious);
-    String ghostAfter = currentOrCapturedFallback(
-        extractGhostPrefix(nextModelBaseline, capturedNext),
-        extractGhostPrefix(nextModelBaseline, currentNext),
-        nextModelBaseline, currentNext);
+    String ghostBefore = withoutSuffixAlreadyAtScratchStart(
+        currentOrCapturedFallback(
+            extractGhostSuffix(previousModelBaseline, capturedPrevious),
+            extractGhostSuffix(previousModelBaseline, currentPrevious),
+            previousModelBaseline, currentPrevious),
+        scratchContent);
+    String ghostAfter = withoutPrefixAlreadyAtScratchEnd(
+        currentOrCapturedFallback(
+            extractGhostPrefix(nextModelBaseline, capturedNext),
+            extractGhostPrefix(nextModelBaseline, currentNext),
+            nextModelBaseline, currentNext),
+        scratchContent);
 
     if (ghostBefore.isEmpty() && ghostAfter.isEmpty()) {
       return scratchContent;
@@ -131,6 +135,26 @@ public final class GhostTextReconciler {
 
   private static boolean isAtModelBaseline(String modelBaseline, String currentText) {
     return modelBaseline != null && modelBaseline.equals(currentText);
+  }
+
+  private static String withoutSuffixAlreadyAtScratchStart(String ghost, String scratchContent) {
+    int overlap = suffixPrefixOverlap(ghost, scratchContent);
+    return ghost.substring(0, ghost.length() - overlap);
+  }
+
+  private static String withoutPrefixAlreadyAtScratchEnd(String ghost, String scratchContent) {
+    int overlap = suffixPrefixOverlap(scratchContent, ghost);
+    return ghost.substring(overlap);
+  }
+
+  private static int suffixPrefixOverlap(String left, String right) {
+    int max = Math.min(left.length(), right.length());
+    for (int length = max; length > 0; length--) {
+      if (left.regionMatches(left.length() - length, right, 0, length)) {
+        return length;
+      }
+    }
+    return 0;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -39,8 +39,9 @@ package org.waveprotocol.wave.model.util;
  * unit-tested without a browser. The caller (see the
  * {@code ImeExtractor} in the editor's client package) is responsible for
  * capturing the adjacent text-node contents at {@code activate()} time and
- * feeding the before/after pairs to {@link #combine(String, String, String,
- * String, String)} at {@code compositionEnd} time.
+ * feeding the before/after pairs to {@link #combineWithCapturedGhosts(String,
+ * String, String, String, String, String, String)} at {@code compositionEnd}
+ * time.
  */
 public final class GhostTextReconciler {
 
@@ -81,6 +82,41 @@ public final class GhostTextReconciler {
       return scratchContent;
     }
     return ghostBefore + scratchContent + ghostAfter;
+  }
+
+  /**
+   * Combines scratch content with ghost text that may have existed before the
+   * activation-time DOM snapshot and ghost text that appeared after it.
+   *
+   * <p>Android Chrome's keyboard Done path can remove or relocate the first
+   * composition character from the adjacent DOM sibling before the editor
+   * flushes the IME scratch. This method therefore treats the captured DOM
+   * snapshot itself as a possible ghost carrier over the model baseline. It
+   * then compares that captured ghost with the final DOM state and keeps the
+   * longest model-relative ghost, covering both Android removing the captured
+   * text before Done and Android adding more ghost text after activation.
+   */
+  public static String combineWithCapturedGhosts(String scratchContent,
+      String previousModelBaseline, String capturedPrevious, String currentPrevious,
+      String nextModelBaseline, String capturedNext, String currentNext) {
+    if (scratchContent == null) {
+      throw new NullPointerException("scratchContent must not be null");
+    }
+    String ghostBefore = longer(
+        extractGhostSuffix(previousModelBaseline, capturedPrevious),
+        extractGhostSuffix(previousModelBaseline, currentPrevious));
+    String ghostAfter = longer(
+        extractGhostPrefix(nextModelBaseline, capturedNext),
+        extractGhostPrefix(nextModelBaseline, currentNext));
+
+    if (ghostBefore.isEmpty() && ghostAfter.isEmpty()) {
+      return scratchContent;
+    }
+    return ghostBefore + scratchContent + ghostAfter;
+  }
+
+  private static String longer(String first, String second) {
+    return second.length() > first.length() ? second : first;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -94,9 +94,11 @@ public final class GhostTextReconciler {
    * snapshot itself as a possible ghost carrier over the model baseline. It
    * then compares that captured ghost with the final DOM state. If the final
    * DOM still has a model-relative ghost, the final DOM wins because it may
-   * contain IME rewrites made after activation. If the final DOM no longer
-   * has a ghost, the captured ghost is kept so Android's Done path cannot
-   * drop the first character by deleting the temporary sibling text.
+   * contain IME rewrites made after activation. If the final DOM has returned
+   * exactly to the model baseline, the captured ghost is kept so Android's
+   * Done path cannot drop the first character by deleting the temporary
+   * sibling text. If the final DOM no longer matches the model baseline, the
+   * captured ghost is not trusted.
    */
   public static String combineWithCapturedGhosts(String scratchContent,
       String previousModelBaseline, String capturedPrevious, String currentPrevious,
@@ -106,10 +108,12 @@ public final class GhostTextReconciler {
     }
     String ghostBefore = currentOrCapturedFallback(
         extractGhostSuffix(previousModelBaseline, capturedPrevious),
-        extractGhostSuffix(previousModelBaseline, currentPrevious));
+        extractGhostSuffix(previousModelBaseline, currentPrevious),
+        previousModelBaseline, currentPrevious);
     String ghostAfter = currentOrCapturedFallback(
         extractGhostPrefix(nextModelBaseline, capturedNext),
-        extractGhostPrefix(nextModelBaseline, currentNext));
+        extractGhostPrefix(nextModelBaseline, currentNext),
+        nextModelBaseline, currentNext);
 
     if (ghostBefore.isEmpty() && ghostAfter.isEmpty()) {
       return scratchContent;
@@ -117,8 +121,16 @@ public final class GhostTextReconciler {
     return ghostBefore + scratchContent + ghostAfter;
   }
 
-  private static String currentOrCapturedFallback(String capturedGhost, String currentGhost) {
-    return currentGhost.isEmpty() ? capturedGhost : currentGhost;
+  private static String currentOrCapturedFallback(String capturedGhost, String currentGhost,
+      String modelBaseline, String currentText) {
+    if (!currentGhost.isEmpty()) {
+      return currentGhost;
+    }
+    return isAtModelBaseline(modelBaseline, currentText) ? capturedGhost : "";
+  }
+
+  private static boolean isAtModelBaseline(String modelBaseline, String currentText) {
+    return modelBaseline != null && modelBaseline.equals(currentText);
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -92,9 +92,11 @@ public final class GhostTextReconciler {
    * composition character from the adjacent DOM sibling before the editor
    * flushes the IME scratch. This method therefore treats the captured DOM
    * snapshot itself as a possible ghost carrier over the model baseline. It
-   * then compares that captured ghost with the final DOM state and keeps the
-   * longest model-relative ghost, covering both Android removing the captured
-   * text before Done and Android adding more ghost text after activation.
+   * then compares that captured ghost with the final DOM state. If the final
+   * DOM still has a model-relative ghost, the final DOM wins because it may
+   * contain IME rewrites made after activation. If the final DOM no longer
+   * has a ghost, the captured ghost is kept so Android's Done path cannot
+   * drop the first character by deleting the temporary sibling text.
    */
   public static String combineWithCapturedGhosts(String scratchContent,
       String previousModelBaseline, String capturedPrevious, String currentPrevious,
@@ -102,10 +104,10 @@ public final class GhostTextReconciler {
     if (scratchContent == null) {
       throw new NullPointerException("scratchContent must not be null");
     }
-    String ghostBefore = longerOrCurrentOnTie(
+    String ghostBefore = currentOrCapturedFallback(
         extractGhostSuffix(previousModelBaseline, capturedPrevious),
         extractGhostSuffix(previousModelBaseline, currentPrevious));
-    String ghostAfter = longerOrCurrentOnTie(
+    String ghostAfter = currentOrCapturedFallback(
         extractGhostPrefix(nextModelBaseline, capturedNext),
         extractGhostPrefix(nextModelBaseline, currentNext));
 
@@ -115,8 +117,8 @@ public final class GhostTextReconciler {
     return ghostBefore + scratchContent + ghostAfter;
   }
 
-  private static String longerOrCurrentOnTie(String capturedGhost, String currentGhost) {
-    return currentGhost.length() >= capturedGhost.length() ? currentGhost : capturedGhost;
+  private static String currentOrCapturedFallback(String capturedGhost, String currentGhost) {
+    return currentGhost.isEmpty() ? capturedGhost : currentGhost;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -102,10 +102,10 @@ public final class GhostTextReconciler {
     if (scratchContent == null) {
       throw new NullPointerException("scratchContent must not be null");
     }
-    String ghostBefore = longer(
+    String ghostBefore = longerOrCurrentOnTie(
         extractGhostSuffix(previousModelBaseline, capturedPrevious),
         extractGhostSuffix(previousModelBaseline, currentPrevious));
-    String ghostAfter = longer(
+    String ghostAfter = longerOrCurrentOnTie(
         extractGhostPrefix(nextModelBaseline, capturedNext),
         extractGhostPrefix(nextModelBaseline, currentNext));
 
@@ -115,8 +115,8 @@ public final class GhostTextReconciler {
     return ghostBefore + scratchContent + ghostAfter;
   }
 
-  private static String longer(String first, String second) {
-    return second.length() > first.length() ? second : first;
+  private static String longerOrCurrentOnTie(String capturedGhost, String currentGhost) {
+    return currentGhost.length() >= capturedGhost.length() ? currentGhost : capturedGhost;
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -236,6 +236,16 @@ public class GhostTextReconcilerTest extends TestCase {
     }
   }
 
+  public void testCombineWithCapturedGhostsNullScratchThrows() {
+    try {
+      GhostTextReconciler.combineWithCapturedGhosts(
+          null, null, null, null, null, null, null);
+      fail("Expected NullPointerException for null scratchContent");
+    } catch (NullPointerException expected) {
+      // pass
+    }
+  }
+
   public void testExtractGhostSuffixHandlesNulls() {
     assertEquals("", GhostTextReconciler.extractGhostSuffix(null, null));
     assertEquals("", GhostTextReconciler.extractGhostSuffix("", null));

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -147,6 +147,16 @@ public class GhostTextReconcilerTest extends TestCase {
         "ew", "", "n", "", null, null, null));
   }
 
+  public void testCapturedPreviousGhostDoesNotDuplicateWhenMovedIntoScratch() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "new", "", "n", "", null, null, null));
+  }
+
+  public void testCapturedPreviousGhostOnlyAddsPartNotMovedIntoScratch() {
+    assertEquals("abc", GhostTextReconciler.combineWithCapturedGhosts(
+        "bc", "", "ab", "", null, null, null));
+  }
+
   public void testCapturedPreviousGhostIsNotDoubleCountedWhenStillPresent() {
     assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
         "ew", "", "n", "n", null, null, null));
@@ -180,6 +190,16 @@ public class GhostTextReconcilerTest extends TestCase {
   public void testCapturedNextGhostSurvivesDoneWhenDomNoLongerHasIt() {
     assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
         "ne", null, null, null, "world", "wworld", "world"));
+  }
+
+  public void testCapturedNextGhostDoesNotDuplicateWhenMovedIntoScratch() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "new", null, null, null, "world", "wworld", "world"));
+  }
+
+  public void testCapturedNextGhostOnlyAddsPartNotMovedIntoScratch() {
+    assertEquals("abc", GhostTextReconciler.combineWithCapturedGhosts(
+        "ab", null, null, null, "world", "bcworld", "world"));
   }
 
   public void testCapturedNextGhostKeepsPostCaptureGrowthSupport() {

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -152,6 +152,11 @@ public class GhostTextReconcilerTest extends TestCase {
         "ew", "", "n", "n", null, null, null));
   }
 
+  public void testCapturedPreviousGhostTiePrefersCurrentDomText() {
+    assertEquals("mew", GhostTextReconciler.combineWithCapturedGhosts(
+        "ew", "", "n", "m", null, null, null));
+  }
+
   public void testCapturedSecondWordGhostSurvivesDoneWhenDomNoLongerHasIt() {
     assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
         "lip", "new", "new b", "new", null, null, null));
@@ -170,6 +175,11 @@ public class GhostTextReconcilerTest extends TestCase {
   public void testCapturedNextGhostKeepsPostCaptureGrowthSupport() {
     assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
         "n", null, null, null, "world", "eworld", "ewworld"));
+  }
+
+  public void testCapturedNextGhostTiePrefersCurrentDomText() {
+    assertEquals("nem", GhostTextReconciler.combineWithCapturedGhosts(
+        "ne", null, null, null, "world", "wworld", "mworld"));
   }
 
   public void testCapturedGhostFallsBackWhenCapturedDomDoesNotContainModel() {

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -142,6 +142,41 @@ public class GhostTextReconcilerTest extends TestCase {
         "new", "bNEW"));
   }
 
+  public void testCapturedPreviousGhostSurvivesDoneWhenDomNoLongerHasIt() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "ew", "", "n", "", null, null, null));
+  }
+
+  public void testCapturedPreviousGhostIsNotDoubleCountedWhenStillPresent() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "ew", "", "n", "n", null, null, null));
+  }
+
+  public void testCapturedSecondWordGhostSurvivesDoneWhenDomNoLongerHasIt() {
+    assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
+        "lip", "new", "new b", "new", null, null, null));
+  }
+
+  public void testCapturedGhostKeepsPostCaptureGrowthSupport() {
+    assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
+        "lip", "new", "new", "new b", null, null, null));
+  }
+
+  public void testCapturedNextGhostSurvivesDoneWhenDomNoLongerHasIt() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "ne", null, null, null, "world", "wworld", "world"));
+  }
+
+  public void testCapturedNextGhostKeepsPostCaptureGrowthSupport() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "n", null, null, null, "world", "eworld", "ewworld"));
+  }
+
+  public void testCapturedGhostFallsBackWhenCapturedDomDoesNotContainModel() {
+    assertEquals("lip", GhostTextReconciler.combineWithCapturedGhosts(
+        "lip", "new", "NEW b", "NEW b", null, null, null));
+  }
+
   public void testNullScratchThrows() {
     try {
       GhostTextReconciler.combine(null, null, null, null, null);

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -162,6 +162,11 @@ public class GhostTextReconcilerTest extends TestCase {
         "x", "", "ab", "c", null, null, null));
   }
 
+  public void testCapturedPreviousGhostFallsBackOnlyWhenCurrentReturnedToModel() {
+    assertEquals("lip", GhostTextReconciler.combineWithCapturedGhosts(
+        "lip", "new", "new b", "NEW b", null, null, null));
+  }
+
   public void testCapturedSecondWordGhostSurvivesDoneWhenDomNoLongerHasIt() {
     assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
         "lip", "new", "new b", "new", null, null, null));
@@ -190,6 +195,11 @@ public class GhostTextReconcilerTest extends TestCase {
   public void testCapturedNextGhostShrinkPrefersCurrentDomText() {
     assertEquals("xc", GhostTextReconciler.combineWithCapturedGhosts(
         "x", null, null, null, "world", "abworld", "cworld"));
+  }
+
+  public void testCapturedNextGhostFallsBackOnlyWhenCurrentReturnedToModel() {
+    assertEquals("x", GhostTextReconciler.combineWithCapturedGhosts(
+        "x", null, null, null, "world", "bworld", "bWORLD"));
   }
 
   public void testCapturedGhostFallsBackWhenCapturedDomDoesNotContainModel() {

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -157,6 +157,11 @@ public class GhostTextReconcilerTest extends TestCase {
         "ew", "", "n", "m", null, null, null));
   }
 
+  public void testCapturedPreviousGhostShrinkPrefersCurrentDomText() {
+    assertEquals("cx", GhostTextReconciler.combineWithCapturedGhosts(
+        "x", "", "ab", "c", null, null, null));
+  }
+
   public void testCapturedSecondWordGhostSurvivesDoneWhenDomNoLongerHasIt() {
     assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
         "lip", "new", "new b", "new", null, null, null));
@@ -180,6 +185,11 @@ public class GhostTextReconcilerTest extends TestCase {
   public void testCapturedNextGhostTiePrefersCurrentDomText() {
     assertEquals("nem", GhostTextReconciler.combineWithCapturedGhosts(
         "ne", null, null, null, "world", "wworld", "mworld"));
+  }
+
+  public void testCapturedNextGhostShrinkPrefersCurrentDomText() {
+    assertEquals("xc", GhostTextReconciler.combineWithCapturedGhosts(
+        "x", null, null, null, "world", "abworld", "cworld"));
   }
 
   public void testCapturedGhostFallsBackWhenCapturedDomDoesNotContainModel() {


### PR DESCRIPTION
## Summary

- Captures Android IME ghost text from adjacent DOM siblings at scratch activation separately from the model baseline.
- Uses the final model-relative DOM ghost when it is still present, so Android rewrites, shrink, and tie cases win over stale activation text.
- Falls back to the activation-time ghost only when the final DOM returned exactly to the model baseline, so keyboard Done can remove the temporary sibling text without dropping the first character while baseline-mismatch rewrites do not reuse stale captured text.
- Trims any captured/current ghost text already present at the scratch edge, so Android relocating ghost text into the scratch before `compositionend` does not duplicate characters.
- Restores recognized sibling ghost text back to model baselines and adds focused regression coverage plus a changelog fragment.

Closes #828

## Verification

- `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"` — passed, 36 tests.
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` — passed.
- `git diff --check` — passed.
- `bash scripts/worktree-boot.sh --port 9920` — passed; staged app and generated port-specific runtime config.
- `PORT=9920 JAVA_OPTS='...' bash scripts/wave-smoke.sh start` — passed initial readiness with `PROBE_HTTP=200` and `READY`.
- `PORT=9920 bash scripts/wave-smoke.sh check` — later check saw no listener after the command session returned (`ROOT_STATUS=000`); diagnostics captured Jetty bound to `127.0.0.1:9920` and serving the readiness request first.
- Inline staged-server probe from `target/universal/stage/bin/wave` on port 9920 — passed with `INLINE_ROOT_STATUS=200`, `INLINE_HEALTH_STATUS=200`, `INLINE_LANDING_STATUS=200`, `INLINE_WEBCLIENT_STATUS=200`, `INLINE_ROOT_GWT=present`, `INLINE_ROOT_J2CL_SHELL=missing`.
