### PR TITLE
Port StageThree compose and toolbar parity to J2CL

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-969-stage-three-compose.md
+++ b/docs/superpowers/plans/2026-04-23-issue-969-stage-three-compose.md
@@ -146,6 +146,35 @@ The `#969` implementation lane must verify these assumptions against merged code
 
 If any assumption is false after `#968` merges, update this plan before implementation and add a new issue comment explaining the adjusted handoff.
 
+### 4.1 Phase 0 Revalidation Update (2026-04-24)
+
+Post-`#968` code does include `J2clRootLiveSurfaceController` and
+`J2clRootLiveSurfaceModel`, but the merged root-live seam is narrower than the
+planning assumptions above:
+
+- `J2clRootLiveSurfaceController` owns route URL/state wrapping, selected-wave id
+  status publication, return-target sync, and the `shell-status-strip` live
+  status seam.
+- `J2clSelectedWaveController` still owns bootstrap fetch, selected-wave open,
+  reconnect/backoff, viewport-fragment loading, read-state polling, and the
+  `WriteSessionListener` publication.
+- The current stable write-session handoff for `#969` is therefore
+  `J2clSelectedWaveController.WriteSessionListener` plus the projected
+  `J2clSidecarWriteSession`, not a root-live snapshot that already includes the
+  full write basis.
+
+Adjusted implementation rule for this lane:
+
+- Compose and toolbar code must consume the existing selected-wave write-session
+  listener and root-live route/status wrappers; it must not introduce another
+  bootstrap/reconnect lifecycle.
+- If daily toolbar actions need backing behavior that root-live does not expose,
+  add small `#969` command interfaces and disabled/error states instead of
+  copying GWT toolbar/editor classes or recreating folder/edit services inside
+  the compose/toolbar layer.
+- Phase 5 verification must explicitly include the existing selected-wave
+  controller/projector tests to guard the post-`#936` atomic write-basis seam.
+
 ## 5. File Ownership
 
 ### 5.1 New Lit files

--- a/docs/superpowers/plans/2026-04-23-issue-969-stage-three-compose.md
+++ b/docs/superpowers/plans/2026-04-23-issue-969-stage-three-compose.md
@@ -1,0 +1,694 @@
+# Issue #969 StageThree Compose / Toolbar Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the practical daily compose/reply and view/edit toolbar surface into the Lit/J2CL root shell on top of the StageOne read surface and StageTwo root-live surface.
+
+**Architecture:** Treat StageThree parity as a J2CL-owned behavior layer with Lit-owned chrome. Keep write/session state in J2CL, consume the root-live selected-wave/write-basis handoff from `#968`, and render compose/toolbars through focused Lit primitives instead of growing the current manual DOM sidecar views. This issue intentionally covers daily compose/reply and daily toolbar controls only; mention/task/reaction overlays, attachments, and remaining rich-edit edge cases stay in `#970` / `#971`.
+
+**Tech Stack:** J2CL Java under `j2cl/src/main/java`, Lit elements under `j2cl/lit/src/elements`, J2CL transport models under `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport`, selected-wave/live seams from `#936` and `#968`, legacy GWT parity references under `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar`, J2CL JVM tests via `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar ... test`, Lit web component tests via `npm test -- --runInBand` from `j2cl/lit`, and local browser verification on `/?view=j2cl-root`.
+
+---
+
+## 1. Planning Status And Dependency Gates
+
+This plan is safe to write now, but product implementation is not safe to start from this lane.
+
+- `#936` is closed and available. The atomic selected-wave write-basis rule is already implemented in `J2clSelectedWaveProjector.buildWriteSession(...)`, which only advances `(baseVersion, historyHash)` when both values arrive together.
+- `#968` is the hard implementation gate. `#969` must wait until the root-shell live surface lands, because StageThree compose and toolbar state must consume root-owned route, reconnect, selected-wave, fragment, read-state, and status publication seams rather than introducing another controller-local lifecycle.
+- `#968` itself is plan-ready but implementation-gated behind `#966` and `#967`. Therefore `#969` is dependency-safe planning only until `#966`, `#967`, and `#968` merge or the team lead explicitly changes the gate.
+- Before coding, the implementation lane must rebase this plan onto the post-`#968` branch tip and refresh every file/method reference below, because several names are expected to change when `J2clRootLiveSurfaceController` lands.
+- No PR should be opened for this planning lane. The first product PR for `#969` should be opened only after the dependency gate is satisfied and this plan has been revalidated against the merged root-live surface.
+
+## 2. Acceptance Criteria
+
+`#969` is complete when all of the following are true:
+
+- The J2CL root shell exposes a daily-use compose surface for:
+  - creating a new plain-text wave,
+  - replying to the currently selected/focused daily reply target,
+  - seeing draft, submit, success, error, disabled, and stale-basis states.
+- Reply submit uses the post-`#936` atomic write basis and the post-`#968` root-live selected-wave handoff; it must not submit against a mismatched version/hash pair or against an old selected wave after route/reconnect changes.
+- Daily view toolbar controls are reachable and usable in the Lit/J2CL shell:
+  - recent / next unread / previous / next / last navigation,
+  - previous mention / next mention when mention ordering exists,
+  - archive / inbox, pin / unpin, and history visibility/toggle where the root-live surface provides the backing state.
+- Daily edit toolbar controls are reachable and usable for the practical StageThree slice:
+  - bold, italic, underline, strikethrough,
+  - heading,
+  - unordered and ordered lists,
+  - text alignment and RTL direction,
+  - link create/remove,
+  - clear formatting.
+- Toolbar controls expose labels, keyboard reachability, pressed/disabled state, and status/error feedback through Lit components and root-shell live regions.
+- During root-live reconnect/backoff, controls that require a current write basis are disabled with visible reconnect/stale-basis text; read-only navigation controls remain enabled only when the root-live surface says their target state is current.
+- The implementation adds focused unit/component tests and one local browser sanity record proving the root shell can open a wave, expose the compose surface, expose view/edit toolbar controls, and submit or simulate a daily reply path without falling back to legacy GWT.
+- No default-root cutover, GWT retirement, attachment upload, mention autocomplete, task metadata overlays, reactions, or full editor-edge-case migration is included.
+
+## 3. Current Baseline Observed In This Worktree
+
+### 3.1 J2CL root-shell composition
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java:21-69`
+  - The root controller currently instantiates `J2clSearchPanelView`, `J2clSelectedWaveView`, `J2clSidecarComposeController`, `J2clSelectedWaveController`, `J2clSearchPanelController`, and `J2clSidecarRouteController` directly.
+  - The existing compose view is mounted into both `searchView.getComposeHost()` and `selectedWaveView.getComposeHost()`.
+  - Reply success currently calls `selectedWaveController.refreshSelectedWave()`, so root-live refresh ownership is not yet separated from selected-wave controller internals.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:13-40`
+  - The root runtime still creates a manual DOM `workflowHost`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java:46-61`
+  - The only shell status integration in this file today is return-target sync.
+  - `#968` is expected to expand this into root-runtime status publication.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3283-3293`
+  - Signed-in root-shell HTML mounts the J2CL workflow into `<shell-main-region>` and exposes `<shell-status-strip>`.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3327-3419`
+  - Inline bootstrap JS owns legacy hash normalization, history hooks, return-target sync, and bundle mount timing.
+
+### 3.2 Current J2CL compose/write pilot
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:7-18`
+  - The controller depends on a gateway that can fetch `/bootstrap.json` and submit `SidecarSubmitRequest` over a short-lived socket.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:52-63`
+  - Draft, submit, status, and error state are local fields on the sidecar compose controller.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:166-178`
+  - `onWriteSessionChanged(...)` invalidates pending replies on any selected-wave, channel, version/hash, or reply-target change, preserving draft only when the selected wave is unchanged.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:180-241`
+  - Create-wave submit is plain-text only and creates a self-owned `conv+root` wave.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:253-333`
+  - Reply submit requires a non-null write session, fetches bootstrap again, builds a plain-text reply delta, and refreshes the selected wave on success.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java:21-135`
+  - The current view is manual Elemental2 DOM with two textareas and two submit buttons.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java:143-155`
+  - Rendering only toggles disabled/hidden/status on those manual DOM nodes.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java:34-71`
+  - Create/reply deltas are plain-text `conv+root` operations only.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java:3-41`
+  - The current write basis contains `selectedWaveId`, `channelId`, `baseVersion`, `historyHash`, and `replyTargetBlipId`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:174-211`
+  - The write-session basis is derived from selected-wave updates and preserves the atomic version/hash pair after `#936`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:157-220`
+  - Submit transport opens a WebSocket, sends an encoded submit frame, handles `ProtocolSubmitResponse`, and treats failed `RpcFinished` as errors.
+
+### 3.3 Current J2CL selected-wave/read surface constraints
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:18-65`
+  - The selected-wave view still creates manual DOM card sections and a compose host.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:67-105`
+  - It renders title, unread/status/detail/participants/snippet, raw content entries, and empty-state text.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:172-236`
+  - Selection changes close subscriptions, reset read-state tracking, fetch bootstrap, and open the selected wave.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:238-370`
+  - Reconnect and retry logic is currently selected-wave-controller-local; `#968` should root-scope this before `#969` consumes it.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:400-404`
+  - The selected-wave controller publishes write-session changes to the compose controller.
+
+### 3.4 GWT parity targets
+
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/ViewToolbar.java:225-350`
+  - The GWT view toolbar provides daily navigation and action groups: recent, next unread, previous, next, last, mention navigation, archive, pin, and history.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/ViewToolbar.java:356-483`
+  - Archive/inbox and pin/unpin call folder operations and update button state; history visibility is externally controlled.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/ViewToolbarFocusActions.java:46-68`
+  - Daily focus navigation delegates recent and next-unread behavior to focus/reader abstractions.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:319-362`
+  - The GWT edit toolbar initializes groups for daily formatting, headings, colors, indentation, lists, alignment, direction, links, attachments, and tasks.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:364-450`
+  - Bold/italic/underline/strikethrough, superscript/subscript, font size/family, heading, and color controls are editor-context backed.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:501-522`
+  - Clear formatting removes style annotations and clears headings.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:639-760`
+  - Direction, link create/remove, heading, indentation, lists, and alignment are backed by paragraph/text-selection controllers.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/ToolbarSwitcher.java:58-91`
+  - GWT swaps view and edit toolbars based on edit-session state.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/ReplyLocationResolver.java:49-86`
+  - GWT reply location resolution flushes the active editor before locating the reply insertion point.
+
+### 3.5 Lit design packet targets
+
+- `docs/j2cl-lit-design-packet.md` defines the compose/toolbar primitive family for `#969`: `composer-shell`, `composer-inline-reply`, `toolbar-group`, `toolbar-button`, `toolbar-overflow-menu`, and `composer-submit-affordance`.
+- `docs/j2cl-gwt-parity-matrix.md` assigns `R-5.1` compose/reply flow and `R-5.2` view/edit toolbar controls to `#969`.
+- `docs/j2cl-parity-issue-map.md:375-400` scopes `#969` to compose/reply flow, view/edit toolbar parity for daily use, and daily compose state visibility.
+
+Phase 0 must refresh every line range in this section before implementation. If any referenced file has moved or changed ownership, the worker must update this plan and the `#969` issue comment before coding.
+
+## 4. Handoff Assumptions From #968
+
+The `#969` implementation lane must verify these assumptions against merged code before editing:
+
+- A root-scoped live-runtime owner exists, expected as `J2clRootLiveSurfaceController` or an equivalent class, and owns bootstrap/session, route/history, selected-wave continuity, reconnect state, read-state/live-state publication, and fragment-policy inputs.
+- The root-live controller exposes the currently selected wave, selected digest/read metadata, selected/focused reply target, and write-session basis as one current snapshot or a stable listener contract.
+- `J2clSelectedWaveController` no longer acts as the sole owner of reconnect and bootstrap lifecycle. If it still does, `#969` must not add another lifecycle path; pause and update this plan.
+- Open-frame viewport hints from `#967` / `#968` are plumbed through selected-wave open, so compose/reply state can coexist with visible-fragment rendering without forcing whole-wave payloads.
+- Root-shell status publication uses the existing `shell-status-strip` seam, not a parallel status DOM.
+- The route/history handoff covers back/forward and signed-in/out return-target transitions, so compose draft invalidation can key off root route/selection generation rather than parsing URLs itself.
+- Signed-out root shell still does not mount the workflow bundle. Compose/toolbars must degrade to signed-out shell chrome and must not assume bootstrap JSON exists before auth.
+- The root-live surface either exposes archive/pin/history actions directly or exposes a narrow action adapter where `#969` can add those actions without recreating GWT `FolderOperationService` inside the compose/toolbar layer.
+- The root-live/edit surface exposes enough selection and paragraph context for daily edit toolbar actions. If it does not, `#969` may add only a small command interface; if a full editor-state owner is required, stop and defer that work to `#971`.
+
+If any assumption is false after `#968` merges, update this plan before implementation and add a new issue comment explaining the adjusted handoff.
+
+## 5. File Ownership
+
+### 5.1 New Lit files
+
+- Create: `j2cl/lit/src/elements/composer-shell.js`
+  - Top-level compose panel with named slots or properties for create-wave and reply regions.
+- Create: `j2cl/lit/src/elements/composer-inline-reply.js`
+  - Reply composer state surface: disabled, stale basis, submitting, error, success, reply-target label.
+- Create: `j2cl/lit/src/elements/composer-submit-affordance.js`
+  - Reusable submit button/status component with accessible busy/error labels.
+- Create: `j2cl/lit/src/elements/toolbar-group.js`
+  - Responsive grouping container for view/edit toolbar sections.
+- Create: `j2cl/lit/src/elements/toolbar-button.js`
+  - Button/toggle primitive with `label`, `pressed`, `disabled`, `danger`, and `data-action`.
+- Create: `j2cl/lit/src/elements/toolbar-overflow-menu.js`
+  - Density fallback for narrow widths; daily controls remain keyboard-reachable.
+- Modify: `j2cl/lit/src/index.js`
+  - Register the new compose/toolbar elements.
+
+### 5.2 New or modified J2CL behavior files
+
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+  - Root-shell compose coordinator. It should replace direct use of `J2clSidecarComposeController` in root-shell mode and consume the root-live snapshot/listener from `#968`.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java`
+  - Immutable create/reply state published to the Lit-backed view.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+  - Thin Elemental2 adapter that renders into the Lit compose custom elements and binds events back to J2CL.
+  - Boolean and object state must be set as DOM properties where Lit expects properties, not string attributes; string labels and action ids may be attributes.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java`
+  - View/edit toolbar coordinator that maps root-live/read/edit state to daily toolbar actions.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceModel.java`
+  - Immutable grouped toolbar model with action ids, labels, state, and visibility.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java`
+  - Thin Elemental2 adapter for `toolbar-group`, `toolbar-button`, and `toolbar-overflow-menu`.
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clDailyToolbarAction.java`
+  - Enum or value object for daily actions: recent, next unread, previous, next, last, previous mention, next mention, archive, inbox, pin, unpin, history, bold, italic, underline, strikethrough, heading, unordered list, ordered list, align left/center/right, RTL, link, unlink, clear formatting.
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+  - Stop constructing `J2clSidecarComposeController` directly for root-shell mode once the new compose/toolbar controllers exist.
+  - Wire new controllers to the merged `#968` root-live owner.
+- Modify only if sidecar compatibility requires it: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java`
+  - Preserve sidecar route behavior; do not break `/j2cl-search/index.html`.
+  - Default to no extraction. Extract shared create/reply submit logic only if both root-shell and sidecar can use it without coupling root-live state back into sidecar.
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java`
+  - Keep existing plain-text create/reply behavior.
+  - Add only the minimal operation helpers needed by the daily toolbar action subset that ships in `#969`.
+
+### 5.3 Tests
+
+- Create: `j2cl/lit/test/composer-shell.test.js`
+- Create: `j2cl/lit/test/composer-inline-reply.test.js`
+- Create: `j2cl/lit/test/composer-submit-affordance.test.js`
+- Create: `j2cl/lit/test/toolbar-group.test.js`
+- Create: `j2cl/lit/test/toolbar-button.test.js`
+- Create: `j2cl/lit/test/toolbar-overflow-menu.test.js`
+  - Must include keyboard/focus assertions for open-by-keyboard, focus moving into the opened list, arrow-key or tab-order traversal, and `Escape` close with focus returning to the trigger.
+- Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+- Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeControllerTest.java`
+  - Keep existing sidecar coverage green if shared logic is extracted.
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java`
+  - Add daily operation payload coverage only for operations implemented in this issue.
+
+### 5.4 Changelog and verification record for implementation PR
+
+- Create during implementation, not during this planning lane: `wave/config/changelog.d/2026-04-23-issue-969-stage-three-compose.json`
+- Create during implementation, not during this planning lane: `journal/local-verification/2026-04-23-issue-969-stage-three-compose.md`
+
+## 6. Phased Implementation Slices
+
+### Phase 0: Revalidate Post-#968 Baseline
+
+**Files:**
+- Read: `docs/superpowers/plans/2026-04-23-issue-968-root-live-surface.md`
+- Read: merged `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/*`
+- Read: merged `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+- Read: merged `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- Read: merged `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/*`
+
+- [ ] **Step 1: Confirm dependency state**
+
+Run:
+
+```bash
+gh repo view --json nameWithOwner
+gh issue view 966 --repo vega113/supawave --json state,title
+gh issue view 967 --repo vega113/supawave --json state,title
+gh issue view 968 --repo vega113/supawave --json state,title
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD || true
+```
+
+Expected:
+
+- `gh repo view --json nameWithOwner` reports `vega113/supawave`, or the worker updates the `gh issue view` commands to the actual remote owner/repo before continuing.
+- `#966`, `#967`, and `#968` are closed or the team lead has explicitly authorized implementation before closure.
+- The implementation branch is based on the post-`#968` integration commit.
+
+- [ ] **Step 2: Refresh the handoff map**
+
+Run:
+
+```bash
+rg -n "RootLive|LiveSurface|WriteSession|selectedWave|reconnect|viewport|shell-status|status-strip" j2cl/src/main/java wave/src/jakarta-overrides/java
+test -f j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+test -f j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+```
+
+Expected:
+
+- One root-live owner is identifiable.
+- One selected-wave/write-session publication seam is identifiable.
+- The implementation lane updates this plan if names or ownership differ from the assumptions in Section 4.
+- The worker refreshes these exact references from Section 3: root-shell composition, root-shell status sync, `HtmlRenderer` root mount/bootstrap, compose controller submit paths, compose view render contract, write-session fields, selected-wave projector write-basis creation, gateway submit transport, selected-wave reconnect/read-state ownership, GWT view-toolbar actions, GWT edit-toolbar actions, `ToolbarSwitcher`, and `ReplyLocationResolver`.
+- The selected-wave controller/projector test files still exist at the paths used by Phase 5. If either file moved or was renamed by `#968`, update the Phase 5 test command before continuing.
+
+- [ ] **Step 3: Commit nothing in Phase 0**
+
+Expected:
+
+- If the dependencies are not closed or the handoff does not exist, stop and update issue `#969` with the blocker.
+
+### Phase 1: Add Lit Compose / Toolbar Primitives
+
+**Files:**
+- Create: `j2cl/lit/src/elements/composer-shell.js`
+- Create: `j2cl/lit/src/elements/composer-inline-reply.js`
+- Create: `j2cl/lit/src/elements/composer-submit-affordance.js`
+- Create: `j2cl/lit/src/elements/toolbar-group.js`
+- Create: `j2cl/lit/src/elements/toolbar-button.js`
+- Create: `j2cl/lit/src/elements/toolbar-overflow-menu.js`
+- Modify: `j2cl/lit/src/index.js`
+- Create tests listed in Section 5.3.
+
+- [ ] **Step 1: Write Lit tests first**
+
+Run from `j2cl/lit`:
+
+```bash
+npm test -- --runInBand composer-shell.test.js composer-inline-reply.test.js composer-submit-affordance.test.js toolbar-group.test.js toolbar-button.test.js toolbar-overflow-menu.test.js
+```
+
+Expected before implementation:
+
+- FAIL because the new custom elements are not registered.
+
+- [ ] **Step 2: Implement the visual primitives**
+
+Required component behavior:
+
+- `composer-shell` exposes a labeled create section, a labeled reply section, and a root status slot.
+- `composer-inline-reply` reflects `available`, `target-label`, `draft`, `submitting`, `stale-basis`, `status`, and `error`.
+- `composer-submit-affordance` renders a real `<button>` with busy/disabled state and visible status/error text.
+- `toolbar-button` renders a real `<button>` with `aria-label`, `aria-pressed` for toggles, `disabled`, and `data-action`.
+- `toolbar-group` exposes a group label and default slot.
+- `toolbar-overflow-menu` keeps overflowed actions reachable by keyboard; use a button-triggered menu/list pattern, move focus into the opened list, support arrow-key movement or tab-order traversal consistently, and close on `Escape`.
+- Labels should come from a small J2CL message/label source that mirrors the GWT `ToolbarMessages` text where practical. Hard-coded English is acceptable only as a temporary `#969` implementation detail if a follow-up i18n issue/comment is recorded before PR.
+
+- [ ] **Step 3: Re-run Lit tests**
+
+Run:
+
+```bash
+cd j2cl/lit
+npm test -- --runInBand composer-shell.test.js composer-inline-reply.test.js composer-submit-affordance.test.js toolbar-group.test.js toolbar-button.test.js toolbar-overflow-menu.test.js
+```
+
+Expected:
+
+- PASS for the six new component suites.
+
+- [ ] **Step 4: Commit Phase 1**
+
+Commit message:
+
+```bash
+git add j2cl/lit/src j2cl/lit/test
+git commit -m "feat(j2cl): add Lit compose and toolbar primitives"
+```
+
+### Phase 2: Replace Root-Shell Compose Wiring With A Root Compose Surface
+
+**Files:**
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java`
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- Modify only if shared logic is extracted: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java`
+- Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+
+- [ ] **Step 1: Write compose-controller tests**
+
+Required test cases:
+
+- Initial model shows create enabled, reply unavailable until a root-live write session exists.
+- Selecting/opening a wave with a valid write session enables reply and publishes the target label.
+- A route/selection generation change invalidates pending reply submit callbacks.
+- Same-wave basis refresh preserves the reply draft but clears stale submit state.
+- Different-wave selection clears the reply draft.
+- Bootstrap failure preserves draft and surfaces root-shell submit error.
+- Successful reply clears draft, emits refresh/open action through the root-live handoff, and does not parse route state directly.
+- Signed-out/bootstrap-unavailable state disables compose without throwing.
+- Root-live signed-out state is a safe no-op: no bootstrap fetch, no submit socket, create/reply disabled, visible signed-out status.
+- If selection changes while a submit is in flight, the stale callback is dropped and the user-visible status becomes a stale-basis message instead of a silent success.
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest test
+```
+
+Expected before implementation:
+
+- FAIL because the new controller/model/view do not exist.
+
+- [ ] **Step 2: Implement root compose controller**
+
+Implementation constraints:
+
+- Consume root-live state from the merged `#968` seam.
+- Keep draft state in memory only.
+- Use a monotonically increasing generation token for create/reply submit suppression, matching the existing stale-callback pattern in `J2clSidecarComposeController`.
+- When a generation token invalidates a pending submit, surface "Selection changed before submit completed. Review the draft and retry." or equivalent stale-basis text while preserving the draft for same-wave changes.
+- Build create/reply requests through `J2clPlainTextDeltaFactory` unless a smaller shared submit builder has been extracted.
+- Do not introduce URL parameters for compose draft state.
+- Do not re-fetch bootstrap independently if `#968` provides a current root session snapshot; if `#968` intentionally exposes only a fetch method, call that method through the root-live owner rather than `J2clSearchGateway` directly.
+
+- [ ] **Step 3: Keep sidecar compatibility green**
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest \
+  test
+```
+
+Expected:
+
+- Existing sidecar tests pass.
+- Any shared extraction preserves `/j2cl-search/index.html` behavior.
+
+- [ ] **Step 4: Commit Phase 2**
+
+Commit message:
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/compose j2cl/src/main/java/org/waveprotocol/box/j2cl/root j2cl/src/test/java/org/waveprotocol/box/j2cl/compose j2cl/src/test/java/org/waveprotocol/box/j2cl/search
+git commit -m "feat(j2cl): wire root compose surface to live state"
+```
+
+### Phase 3: Add Daily View Toolbar Surface
+
+**Files:**
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java`
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceModel.java`
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java`
+- Create: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clDailyToolbarAction.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- Create: `j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java`
+
+- [ ] **Step 1: Write view-toolbar tests**
+
+Required test cases:
+
+- View toolbar model includes recent, next unread, previous, next, last when a selected wave/read surface exists.
+- Mention navigation actions are hidden or disabled until the post-`#966`/`#968` read surface exposes mention order.
+- Archive/inbox and pin/unpin map to root-live/folder action seams and show busy/error state.
+- History action visibility follows the root-live history permission/state.
+- Action dispatch does not call legacy GWT classes.
+- All actions have stable action ids and labels.
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest test
+```
+
+Expected before implementation:
+
+- FAIL because the toolbar package does not exist.
+
+- [ ] **Step 2: Implement view-toolbar action mapping**
+
+Implementation constraints:
+
+- Map GWT `ViewToolbar` behavior to root-live/read abstractions, not to GWT widget classes.
+- If root-live does not expose archive/pin/history actions yet, add a narrow root-live action interface in the `#969` implementation branch and document it in the issue comment.
+- Disable unavailable controls visibly instead of hiding the whole toolbar.
+- Preserve keyboard reachability; every action must be a native button through `toolbar-button`.
+
+- [ ] **Step 3: Run view-toolbar tests**
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest test
+```
+
+Expected:
+
+- PASS for view-toolbar model/action tests.
+
+- [ ] **Step 4: Commit Phase 3**
+
+Commit message:
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar j2cl/src/main/java/org/waveprotocol/box/j2cl/root j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar
+git commit -m "feat(j2cl): add root view toolbar surface"
+```
+
+### Phase 4: Add Daily Edit Toolbar Surface
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceModel.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clDailyToolbarAction.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java`
+
+- [ ] **Step 1: Write edit-toolbar tests**
+
+Required test cases:
+
+- Edit toolbar model includes the daily formatting controls listed in Section 2.
+- Toggle controls preserve `pressed`, `disabled`, and current-selection state from the root edit state model.
+- Applying bold/italic/underline/strikethrough/list/heading/link/clear-formatting creates the expected operation request or root edit command.
+- Submit is blocked with a visible stale-basis error if the selected-wave write session changes during a pending edit action.
+- Unsupported `#970`/`#971` actions are absent: mention autocomplete, task metadata overlay, reactions, and attachments.
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest \
+  test
+```
+
+Expected before implementation:
+
+- FAIL for missing edit actions/operation helpers.
+
+- [ ] **Step 2: Implement daily edit action model**
+
+Implementation constraints:
+
+- Prefer a root edit command interface over copying GWT `EditorContextAdapter`, `ButtonUpdater`, `TextSelectionController`, or `ParagraphApplicationController` into J2CL.
+- The root edit command interface must stay small: action id, current selection/write basis generation, optional value, success callback, and error callback. If the implementation needs a persistent editor-state owner, selection model, operation composer, or annotation traversal framework in this issue, stop and move that work to `#971`.
+- Keep this issue's formatting subset explicit. If implementing a daily action requires a larger editor model than `#969` owns, leave that action disabled with a documented `#971` follow-up instead of silently shipping partial behavior.
+- Do not implement attachment insertion in this phase; it belongs to `#971`.
+- Do not implement task metadata overlay in this phase; it belongs to `#970`.
+- Do not implement mention autocomplete in this phase; it belongs to `#970`.
+
+- [ ] **Step 3: Run edit-toolbar tests**
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest \
+  test
+```
+
+Expected:
+
+- PASS for implemented daily edit actions.
+- Any intentionally deferred daily-looking action has an explicit disabled state and an issue comment explaining why it is owned by `#970` or `#971`.
+
+- [ ] **Step 4: Commit Phase 4**
+
+Commit message:
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+git commit -m "feat(j2cl): add daily edit toolbar actions"
+```
+
+### Phase 5: Root-Shell Integration, Changelog, And Browser Verification
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- Modify: `j2cl/src/main/webapp/assets/sidecar.css` only for legacy sidecar/root-shell adapter spacing that affects light-DOM hosts outside the Lit shadow roots. Component styling, toolbar layout, compose state, and overflow styling must live in the Lit component CSS.
+- Create: `wave/config/changelog.d/2026-04-23-issue-969-stage-three-compose.json`
+- Create: `journal/local-verification/2026-04-23-issue-969-stage-three-compose.md`
+
+- [ ] **Step 1: Run full targeted J2CL/Lit tests**
+
+Run:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest \
+  test
+cd j2cl/lit && npm test -- --runInBand
+```
+
+Expected:
+
+- J2CL test run exits 0.
+- Lit test run exits 0.
+
+- [ ] **Step 2: Add changelog fragment**
+
+Create a user-facing changelog fragment:
+
+```json
+{
+  "releaseId": "2026-04-23-issue-969-stage-three-compose",
+  "type": "feature",
+  "title": "Add J2CL root compose and daily toolbar parity",
+  "summary": "The opt-in J2CL root shell now exposes practical compose/reply controls and daily view/edit toolbar actions on top of the live selected-wave surface.",
+  "details": [
+    "Compose and reply controls show draft, submit, success, error, disabled, and stale-basis state in the J2CL root shell",
+    "Daily view and edit toolbar controls are reachable from the Lit/J2CL shell while deeper overlays and attachments remain tracked separately"
+  ],
+  "issues": ["969"]
+}
+```
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+```
+
+Expected:
+
+- Changelog assembly and validation exit 0.
+- If validation rejects the fragment schema, inspect current files under `wave/config/changelog.d/`, update the fragment to the current schema, and record that adjustment in the issue comment.
+
+- [ ] **Step 3: Run local root-shell browser sanity**
+
+Use the repo's standard local smoke flow from the implementation worktree. If the local server requires file-store state, run:
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+```
+
+Then run the local server smoke command:
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh start
+```
+
+If either script is absent after rebasing onto post-`#968`, stop and read `docs/runbooks/worktree-lane-lifecycle.md` plus `docs/runbooks/browser-verification.md`, then update this verification step and the issue comment with the replacement command before running browser verification.
+
+Browser verification target:
+
+```text
+http://localhost:9900/?view=j2cl-root
+```
+
+Manual/browser assertions:
+
+- The signed-in root shell mounts the J2CL workflow inside `<shell-main-region>`.
+- Opening a wave shows the selected-wave read surface and root-live status.
+- Create-wave composer is visible and labeled.
+- Reply composer becomes available only after a write-session-capable selected wave opens.
+- Submitting a reply either succeeds and refreshes the selected wave or surfaces a visible error while preserving draft.
+- View toolbar controls are keyboard reachable and visibly disabled/enabled according to state.
+- Edit toolbar controls are keyboard reachable, expose labels/pressed state, and do not show attachment/task/reaction/mention-autocomplete controls as completed `#969` scope.
+- Overflow menu opens by keyboard, moves focus predictably, and closes with `Escape`.
+- Legacy `/` still serves GWT unless the existing explicit opt-in flag says otherwise.
+
+Record exact commands and results in:
+
+```text
+journal/local-verification/2026-04-23-issue-969-stage-three-compose.md
+```
+
+- [ ] **Step 4: Commit Phase 5**
+
+Commit message:
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/root j2cl/src/main/webapp/assets/sidecar.css wave/config/changelog.d/2026-04-23-issue-969-stage-three-compose.json wave/config/changelog.json journal/local-verification/2026-04-23-issue-969-stage-three-compose.md
+git commit -m "feat(j2cl): integrate compose toolbar parity in root shell"
+```
+
+## 7. Verification Commands For The Implementation Lane
+
+Run these before opening the product PR:
+
+```bash
+./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar \
+  -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest \
+  test
+```
+
+```bash
+cd j2cl/lit && npm test -- --runInBand
+```
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+```
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh start
+```
+
+Then perform browser verification against:
+
+```text
+http://localhost:9900/?view=j2cl-root
+```
+
+If tests fail because `wave/config/changelog.json` is missing or stale, run `python3 scripts/assemble-changelog.py` before assuming product code is broken.
+
+## 8. Risks And Mitigations
+
+- **Risk: #968 lands with different root-live seams than assumed.** Mitigation: Phase 0 is a hard revalidation gate; update this plan and issue `#969` before coding.
+- **Risk: toolbar parity expands into a full editor rewrite.** Mitigation: daily action list is explicit; mention/task/reaction overlays stay in `#970`; attachments and remaining rich-edit daily gaps stay in `#971`.
+- **Risk: copying GWT editor classes creates J2CL-incompatible dependencies.** Mitigation: expose root edit commands and small operation helpers instead of porting `EditorContextAdapter`, GWT widgets, or deferred-binding toolbar controllers.
+- **Risk: root compose duplicates bootstrap/reconnect ownership.** Mitigation: compose must consume the root-live session/state owner from `#968`; independent bootstrap fetch is allowed only if `#968` exposes that as the root-owned API.
+- **Risk: sidecar route regresses while root-shell compose changes.** Mitigation: keep `J2clSidecarComposeControllerTest` and sidecar search tests in the targeted suite whenever shared logic is extracted.
+- **Risk: mobile/narrow toolbar loses actions.** Mitigation: `toolbar-overflow-menu` must be keyboard reachable and tested; do not rely on hidden controls without an overflow route.
+- **Risk: local browser verification becomes too broad.** Mitigation: verify only `/?view=j2cl-root` compose/toolbar reachability and one daily reply path; leave overlay/attachment scenarios for later issues.
+- **Risk: labels ship as untracked English strings.** Mitigation: use a small J2CL label/message source that mirrors existing GWT copy where practical, or record a follow-up before PR if temporary strings are unavoidable.
+
+## 9. Explicit Non-Goals
+
+- No implementation work in this planning lane.
+- No PR from this planning lane.
+- No default `/` root cutover.
+- No legacy GWT retirement.
+- No mention autocomplete implementation.
+- No task metadata overlay implementation.
+- No reaction overlay implementation.
+- No attachment upload/download implementation.
+- No full rich-text editor parity beyond the daily toolbar subset listed in Section 2.
+- No whole-wave fallback for large waves.
+- No new rollout flag unless the `#969` implementation review proves the existing `j2cl-root-bootstrap` coexistence seam is insufficient.
+
+## 10. Self-Review Checklist For This Plan
+
+- [x] Dependency gates are explicit: `#969` implementation waits for `#968`, and `#968` waits for `#966` / `#967`, unless the team lead explicitly changes the gate in the issue trail.
+- [x] Acceptance criteria distinguish `#969` from `#970` and `#971`.
+- [x] File/method references are grounded in current code line ranges.
+- [x] The current #936 atomic write-basis seam is consumed, not replaced.
+- [x] The plan does not modify product code in this lane.
+- [x] The plan includes architecture seams, file ownership, implementation slices, test commands, local browser verification, risks, non-goals, and #968 handoff assumptions.
+- [x] The implementation plan preserves sidecar compatibility and legacy GWT default-root behavior.

--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -50,20 +50,21 @@ export class ComposerInlineReply extends LitElement {
   }
 
   render() {
-    const disabled = !this.available || this.submitting || this.staleBasis;
+    const textareaDisabled = !this.available || this.submitting;
+    const submitDisabled = textareaDisabled || this.staleBasis;
     return html`
       <div class="reply">
         <p class="target">Reply target: ${this.targetLabel || "No current wave"}</p>
         <textarea
           aria-label="Reply"
           .value=${this.draft}
-          ?disabled=${disabled}
+          ?disabled=${textareaDisabled}
           @input=${this.onInput}
         ></textarea>
         <composer-submit-affordance
           label="Send reply"
           ?busy=${this.submitting}
-          ?disabled=${disabled}
+          ?disabled=${submitDisabled}
           @submit-affordance=${this.onSubmit}
         ></composer-submit-affordance>
         ${this.status && !this.error

--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -1,0 +1,97 @@
+import { LitElement, css, html } from "lit";
+import "./composer-submit-affordance.js";
+
+export class ComposerInlineReply extends LitElement {
+  static properties = {
+    available: { type: Boolean, reflect: true },
+    targetLabel: { type: String, attribute: "target-label" },
+    draft: { type: String },
+    submitting: { type: Boolean, reflect: true },
+    staleBasis: { type: Boolean, attribute: "stale-basis", reflect: true },
+    status: { type: String },
+    error: { type: String }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .reply {
+      display: grid;
+      gap: 10px;
+    }
+
+    textarea {
+      min-height: 84px;
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font: inherit;
+      resize: vertical;
+    }
+
+    .target {
+      margin: 0;
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.9rem;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.available = false;
+    this.targetLabel = "";
+    this.draft = "";
+    this.submitting = false;
+    this.staleBasis = false;
+    this.status = "";
+    this.error = "";
+  }
+
+  render() {
+    const disabled = !this.available || this.submitting || this.staleBasis;
+    return html`
+      <div class="reply">
+        <p class="target">Reply target: ${this.targetLabel || "No current wave"}</p>
+        <textarea
+          aria-label="Reply"
+          .value=${this.draft}
+          ?disabled=${disabled}
+          @input=${this.onInput}
+        ></textarea>
+        <composer-submit-affordance
+          label="Send reply"
+          ?busy=${this.submitting}
+          ?disabled=${disabled}
+          @submit-affordance=${this.onSubmit}
+        ></composer-submit-affordance>
+        ${this.status && !this.error
+          ? html`<p class="target" role="status" aria-live="polite">${this.status}</p>`
+          : ""}
+        ${this.error
+          ? html`<p class="target" role="alert" aria-live="assertive">${this.error}</p>`
+          : ""}
+      </div>
+    `;
+  }
+
+  onInput(event) {
+    this.draft = event.target.value;
+    this.dispatchEvent(
+      new CustomEvent("draft-change", {
+        detail: { value: this.draft },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  onSubmit() {
+    this.dispatchEvent(new CustomEvent("reply-submit", { bubbles: true, composed: true }));
+  }
+}
+
+if (!customElements.get("composer-inline-reply")) {
+  customElements.define("composer-inline-reply", ComposerInlineReply);
+}

--- a/j2cl/lit/src/elements/composer-shell.js
+++ b/j2cl/lit/src/elements/composer-shell.js
@@ -1,0 +1,43 @@
+import { LitElement, css, html } from "lit";
+
+export class ComposerShell extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .shell {
+      display: grid;
+      gap: 14px;
+      padding: 14px;
+      border: 1px solid var(--shell-color-divider-subtle, #e5edf5);
+      border-radius: 16px;
+      background: var(--shell-color-surface-shell, #fff);
+    }
+
+    h2,
+    h3 {
+      margin: 0 0 8px;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="shell">
+        <section aria-labelledby="composer-create-title">
+          <h2 id="composer-create-title">New wave</h2>
+          <slot name="create"></slot>
+        </section>
+        <section aria-labelledby="composer-reply-title">
+          <h3 id="composer-reply-title">Reply</h3>
+          <slot name="reply"></slot>
+        </section>
+        <slot name="status"></slot>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("composer-shell")) {
+  customElements.define("composer-shell", ComposerShell);
+}

--- a/j2cl/lit/src/elements/composer-shell.js
+++ b/j2cl/lit/src/elements/composer-shell.js
@@ -1,6 +1,10 @@
 import { LitElement, css, html } from "lit";
 
 export class ComposerShell extends LitElement {
+  static properties = {
+    _hasReplyContent: { state: true },
+  };
+
   static styles = css`
     :host {
       display: block;
@@ -21,6 +25,15 @@ export class ComposerShell extends LitElement {
     }
   `;
 
+  constructor() {
+    super();
+    this._hasReplyContent = false;
+  }
+
+  _onReplySlotChange(e) {
+    this._hasReplyContent = e.target.assignedElements({ flatten: true }).length > 0;
+  }
+
   render() {
     return html`
       <div class="shell">
@@ -28,9 +41,12 @@ export class ComposerShell extends LitElement {
           <h2 id="composer-create-title">New wave</h2>
           <slot name="create"></slot>
         </section>
-        <section aria-labelledby="composer-reply-title">
+        <section
+          aria-labelledby="composer-reply-title"
+          ?hidden=${!this._hasReplyContent}
+        >
           <h3 id="composer-reply-title">Reply</h3>
-          <slot name="reply"></slot>
+          <slot name="reply" @slotchange=${this._onReplySlotChange}></slot>
         </section>
         <slot name="status"></slot>
       </div>

--- a/j2cl/lit/src/elements/composer-submit-affordance.js
+++ b/j2cl/lit/src/elements/composer-submit-affordance.js
@@ -1,0 +1,89 @@
+import { LitElement, css, html } from "lit";
+
+export class ComposerSubmitAffordance extends LitElement {
+  static properties = {
+    label: { type: String },
+    status: { type: String },
+    error: { type: String },
+    busy: { type: Boolean, reflect: true },
+    disabled: { type: Boolean, reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: inline-grid;
+      gap: 4px;
+    }
+
+    button {
+      border: 0;
+      border-radius: 999px;
+      padding: 9px 16px;
+      background: var(--shell-color-accent-focus, #1a73e8);
+      color: #fff;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .message {
+      margin: 0;
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.85rem;
+    }
+
+    .message.error {
+      color: #a12a16;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.label = "Submit";
+    this.status = "";
+    this.error = "";
+    this.busy = false;
+    this.disabled = false;
+  }
+
+  render() {
+    const disabled = this.disabled || this.busy;
+    const message = this.error || this.status;
+    return html`
+      <button
+        type="button"
+        aria-label=${this.label}
+        aria-busy=${this.busy ? "true" : "false"}
+        ?disabled=${disabled}
+        @click=${this.onClick}
+      >
+        ${this.label}
+      </button>
+      ${message
+        ? html`<p
+            class=${this.error ? "message error" : "message"}
+            role=${this.error ? "alert" : "status"}
+            aria-live=${this.error ? "assertive" : "polite"}
+          >
+            ${message}
+          </p>`
+        : ""}
+    `;
+  }
+
+  onClick() {
+    if (this.disabled || this.busy) {
+      return;
+    }
+    this.dispatchEvent(new CustomEvent("submit-affordance", { bubbles: true, composed: true }));
+  }
+}
+
+if (!customElements.get("composer-submit-affordance")) {
+  customElements.define("composer-submit-affordance", ComposerSubmitAffordance);
+}

--- a/j2cl/lit/src/elements/toolbar-button.js
+++ b/j2cl/lit/src/elements/toolbar-button.js
@@ -1,0 +1,81 @@
+import { LitElement, css, html, nothing } from "lit";
+
+export class ToolbarButton extends LitElement {
+  static properties = {
+    action: { type: String },
+    label: { type: String },
+    pressed: { type: Boolean, reflect: true },
+    disabled: { type: Boolean, reflect: true },
+    toggle: { type: Boolean, reflect: true },
+    danger: { type: Boolean, reflect: true }
+  };
+
+  static styles = css`
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 10px;
+      padding: 7px 10px;
+      background: #fff;
+      color: var(--shell-color-text-primary, #181c1d);
+      font: inherit;
+      cursor: pointer;
+    }
+
+    button[aria-pressed="true"] {
+      background: #123b5d;
+      border-color: #123b5d;
+      color: #fff;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    :host([danger]) button {
+      color: #a12a16;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.action = "";
+    this.label = "";
+    this.pressed = false;
+    this.disabled = false;
+    this.toggle = false;
+    this.danger = false;
+  }
+
+  render() {
+    return html`
+      <button
+        type="button"
+        aria-label=${this.label}
+        aria-pressed=${this.toggle ? String(this.pressed) : nothing}
+        data-action=${this.action}
+        ?disabled=${this.disabled}
+        @click=${this.onClick}
+      >
+        ${this.label}
+      </button>
+    `;
+  }
+
+  onClick() {
+    if (this.disabled) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("toolbar-action", {
+        detail: { action: this.action },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+}
+
+if (!customElements.get("toolbar-button")) {
+  customElements.define("toolbar-button", ToolbarButton);
+}

--- a/j2cl/lit/src/elements/toolbar-button.js
+++ b/j2cl/lit/src/elements/toolbar-button.js
@@ -63,7 +63,7 @@ export class ToolbarButton extends LitElement {
   }
 
   onClick() {
-    if (this.disabled) {
+    if (this.disabled || !this.action) {
       return;
     }
     this.dispatchEvent(

--- a/j2cl/lit/src/elements/toolbar-group.js
+++ b/j2cl/lit/src/elements/toolbar-group.js
@@ -1,0 +1,33 @@
+import { LitElement, css, html } from "lit";
+
+export class ToolbarGroup extends LitElement {
+  static properties = {
+    label: { type: String }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    div {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.label = "Toolbar group";
+  }
+
+  render() {
+    return html`<div role="group" aria-label=${this.label}><slot></slot></div>`;
+  }
+}
+
+if (!customElements.get("toolbar-group")) {
+  customElements.define("toolbar-group", ToolbarGroup);
+}

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -50,14 +50,14 @@ export class ToolbarOverflowMenu extends LitElement {
     return html`
       <button
         type="button"
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded=${this.open ? "true" : "false"}
         @click=${this.toggle}
         @keydown=${this.onTriggerKeyDown}
       >
         ${this.label}
       </button>
-      <div class="menu" role="menu"><slot></slot></div>
+      <div class="menu"><slot></slot></div>
     `;
   }
 

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -44,6 +44,7 @@ export class ToolbarOverflowMenu extends LitElement {
     this.open = false;
     this.addEventListener("keydown", this.onKeyDown);
     this.addEventListener("click", this.onLightDomClick);
+    this.addEventListener("toolbar-action", this.onToolbarAction);
   }
 
   render() {
@@ -93,10 +94,12 @@ export class ToolbarOverflowMenu extends LitElement {
   };
 
   onLightDomClick = (event) => {
-    const actionEl =
-      event.target instanceof Element ? event.target.closest("[data-action]") : null;
-    const action = actionEl ? actionEl.getAttribute("data-action") : "";
+    const action = this.actionFromEvent(event);
     if (!action) {
+      return;
+    }
+    this.closeAndFocusTrigger();
+    if (this.isToolbarButtonEvent(event)) {
       return;
     }
     this.dispatchEvent(
@@ -106,9 +109,42 @@ export class ToolbarOverflowMenu extends LitElement {
         composed: true
       })
     );
+  };
+
+  onToolbarAction = (event) => {
+    if (event.target === this) {
+      return;
+    }
+    this.closeAndFocusTrigger();
+  };
+
+  closeAndFocusTrigger() {
     this.open = false;
     this.updateComplete.then(() => this.renderRoot.querySelector("button").focus());
-  };
+  }
+
+  actionFromEvent(event) {
+    const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+    for (const item of path) {
+      if (!(item instanceof Element)) {
+        continue;
+      }
+      if (item.hasAttribute("data-action")) {
+        return item.getAttribute("data-action") || "";
+      }
+      if (item.localName === "toolbar-button") {
+        return item.action || item.getAttribute("action") || "";
+      }
+    }
+    const actionEl =
+      event.target instanceof Element ? event.target.closest("[data-action]") : null;
+    return actionEl ? actionEl.getAttribute("data-action") || "" : "";
+  }
+
+  isToolbarButtonEvent(event) {
+    const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+    return path.some(item => item instanceof Element && item.localName === "toolbar-button");
+  }
 
   focusFirstItem() {
     const items = this.items();

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -149,7 +149,7 @@ export class ToolbarOverflowMenu extends LitElement {
   focusFirstItem() {
     const items = this.items();
     if (items.length > 0) {
-      items[0].focus();
+      this.focusItem(items[0]);
     }
   }
 
@@ -158,17 +158,46 @@ export class ToolbarOverflowMenu extends LitElement {
     if (items.length === 0) {
       return;
     }
-    const currentIndex = items.indexOf(document.activeElement);
+    const currentIndex = this.activeItemIndex(items);
     const nextIndex = currentIndex < 0
       ? 0
       : (currentIndex + offset + items.length) % items.length;
-    items[nextIndex].focus();
+    this.focusItem(items[nextIndex]);
   }
 
   items() {
-    return Array.from(this.querySelectorAll("button,[href],[tabindex]")).filter(
-      item => !item.disabled
+    return Array.from(this.querySelectorAll("toolbar-button,button,[href],[tabindex]")).filter(
+      item => !this.isItemDisabled(item)
     );
+  }
+
+  activeItemIndex(items) {
+    const activeElement = document.activeElement;
+    return items.findIndex(item =>
+      item === activeElement
+        || item.contains(activeElement)
+        || item.renderRoot?.activeElement === activeElement
+        || item.shadowRoot?.activeElement === activeElement
+    );
+  }
+
+  focusItem(item) {
+    if (item.localName === "toolbar-button") {
+      const button = item.renderRoot?.querySelector("button")
+        || item.shadowRoot?.querySelector("button");
+      if (button) {
+        button.focus();
+        return;
+      }
+    }
+    item.focus();
+  }
+
+  isItemDisabled(item) {
+    if (item.localName === "toolbar-button") {
+      return Boolean(item.disabled) || item.hasAttribute("disabled");
+    }
+    return Boolean(item.disabled);
   }
 }
 

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -166,6 +166,8 @@ export class ToolbarOverflowMenu extends LitElement {
   }
 
   items() {
+    // toolbar-button keeps its native button in shadow DOM, so selecting the host
+    // adds it to the focus order without duplicating the internal control.
     return Array.from(this.querySelectorAll("toolbar-button,button,[href],[tabindex]")).filter(
       item => !this.isItemDisabled(item)
     );

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -93,9 +93,9 @@ export class ToolbarOverflowMenu extends LitElement {
   };
 
   onLightDomClick = (event) => {
-    const action = event.target && event.target.getAttribute
-      ? event.target.getAttribute("data-action")
-      : "";
+    const actionEl =
+      event.target instanceof Element ? event.target.closest("[data-action]") : null;
+    const action = actionEl ? actionEl.getAttribute("data-action") : "";
     if (!action) {
       return;
     }

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -1,0 +1,141 @@
+import { LitElement, css, html } from "lit";
+
+export class ToolbarOverflowMenu extends LitElement {
+  static properties = {
+    label: { type: String },
+    open: { type: Boolean, reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: inline-block;
+      position: relative;
+    }
+
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 10px;
+      padding: 7px 10px;
+      background: #fff;
+      font: inherit;
+    }
+
+    .menu {
+      display: none;
+      position: absolute;
+      z-index: 3;
+      min-width: 180px;
+      padding: 8px;
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 12px;
+      background: #fff;
+      box-shadow: 0 12px 32px rgb(10 38 64 / 18%);
+    }
+
+    :host([open]) .menu {
+      display: grid;
+      gap: 4px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.label = "More actions";
+    this.open = false;
+    this.addEventListener("keydown", this.onKeyDown);
+    this.addEventListener("click", this.onLightDomClick);
+  }
+
+  render() {
+    return html`
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded=${this.open ? "true" : "false"}
+        @click=${this.toggle}
+        @keydown=${this.onTriggerKeyDown}
+      >
+        ${this.label}
+      </button>
+      <div class="menu" role="menu"><slot></slot></div>
+    `;
+  }
+
+  toggle() {
+    this.open = !this.open;
+    if (this.open) {
+      this.updateComplete.then(() => this.focusFirstItem());
+    }
+  }
+
+  onTriggerKeyDown(event) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      this.open = true;
+      this.updateComplete.then(() => this.focusFirstItem());
+    }
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.open = false;
+      this.updateComplete.then(() => this.renderRoot.querySelector("button").focus());
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      this.focusByOffset(event.key === "ArrowDown" ? 1 : -1);
+    }
+  };
+
+  onLightDomClick = (event) => {
+    const action = event.target && event.target.getAttribute
+      ? event.target.getAttribute("data-action")
+      : "";
+    if (!action) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("toolbar-action", {
+        detail: { action },
+        bubbles: true,
+        composed: true
+      })
+    );
+    this.open = false;
+    this.updateComplete.then(() => this.renderRoot.querySelector("button").focus());
+  };
+
+  focusFirstItem() {
+    const items = this.items();
+    if (items.length > 0) {
+      items[0].focus();
+    }
+  }
+
+  focusByOffset(offset) {
+    const items = this.items();
+    if (items.length === 0) {
+      return;
+    }
+    const currentIndex = items.indexOf(document.activeElement);
+    const nextIndex = currentIndex < 0
+      ? 0
+      : (currentIndex + offset + items.length) % items.length;
+    items[nextIndex].focus();
+  }
+
+  items() {
+    return Array.from(this.querySelectorAll("button,[href],[tabindex]")).filter(
+      item => !item.disabled
+    );
+  }
+}
+
+if (!customElements.get("toolbar-overflow-menu")) {
+  customElements.define("toolbar-overflow-menu", ToolbarOverflowMenu);
+}

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -8,6 +8,12 @@ import "./elements/shell-main-region.js";
 import "./elements/shell-status-strip.js";
 import "./elements/shell-root.js";
 import "./elements/shell-root-signed-out.js";
+import "./elements/composer-submit-affordance.js";
+import "./elements/composer-inline-reply.js";
+import "./elements/composer-shell.js";
+import "./elements/toolbar-button.js";
+import "./elements/toolbar-group.js";
+import "./elements/toolbar-overflow-menu.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/composer-inline-reply.test.js
+++ b/j2cl/lit/test/composer-inline-reply.test.js
@@ -1,0 +1,40 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/composer-inline-reply.js";
+
+describe("<composer-inline-reply>", () => {
+  it("shows disabled stale-basis state with the reply target label", async () => {
+    const el = await fixture(html`
+      <composer-inline-reply
+        target-label="Root blip"
+        status="Selection changed before submit completed. Review the draft and retry."
+        stale-basis
+      ></composer-inline-reply>
+    `);
+
+    const textarea = el.renderRoot.querySelector("textarea");
+    const button = el.renderRoot.querySelector("composer-submit-affordance");
+    expect(el.renderRoot.textContent).to.include("Root blip");
+    expect(textarea.disabled).to.equal(true);
+    expect(button.disabled).to.equal(true);
+    expect(el.renderRoot.textContent).to.include("Selection changed");
+  });
+
+  it("emits draft-change and reply-submit events when available", async () => {
+    const el = await fixture(html`
+      <composer-inline-reply available target-label="Root blip"></composer-inline-reply>
+    `);
+    const textarea = el.renderRoot.querySelector("textarea");
+    const draftEvent = oneEvent(el, "draft-change");
+
+    textarea.value = "hello";
+    textarea.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+
+    expect((await draftEvent).detail.value).to.equal("hello");
+
+    const submitEvent = oneEvent(el, "reply-submit");
+    el.renderRoot.querySelector("composer-submit-affordance").dispatchEvent(
+      new CustomEvent("submit-affordance", { bubbles: true, composed: true })
+    );
+    expect(await submitEvent).to.exist;
+  });
+});

--- a/j2cl/lit/test/composer-shell.test.js
+++ b/j2cl/lit/test/composer-shell.test.js
@@ -1,8 +1,8 @@
-import { fixture, expect, html } from "@open-wc/testing";
+import { fixture, expect, html, nextFrame } from "@open-wc/testing";
 import "../src/elements/composer-shell.js";
 
 describe("<composer-shell>", () => {
-  it("exposes labeled create and reply sections plus a status slot", async () => {
+  it("shows reply section when reply slot has content", async () => {
     const el = await fixture(html`
       <composer-shell>
         <p slot="create">Create form</p>
@@ -11,10 +11,29 @@ describe("<composer-shell>", () => {
       </composer-shell>
     `);
 
+    await nextFrame();
+
     const sections = el.renderRoot.querySelectorAll("section");
     expect(sections.length).to.equal(2);
     expect(el.renderRoot.querySelector("slot[name='create']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='reply']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+    expect(el.renderRoot.querySelector("section[hidden]")).to.not.exist;
+  });
+
+  it("hides reply section when reply slot is empty", async () => {
+    const el = await fixture(html`
+      <composer-shell>
+        <p slot="create">Create form</p>
+      </composer-shell>
+    `);
+
+    await nextFrame();
+
+    const replySection = el.renderRoot.querySelector(
+      "section[aria-labelledby='composer-reply-title']"
+    );
+    expect(replySection).to.exist;
+    expect(replySection.hidden).to.equal(true);
   });
 });

--- a/j2cl/lit/test/composer-shell.test.js
+++ b/j2cl/lit/test/composer-shell.test.js
@@ -1,0 +1,20 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/composer-shell.js";
+
+describe("<composer-shell>", () => {
+  it("exposes labeled create and reply sections plus a status slot", async () => {
+    const el = await fixture(html`
+      <composer-shell>
+        <p slot="create">Create form</p>
+        <p slot="reply">Reply form</p>
+        <p slot="status">Ready</p>
+      </composer-shell>
+    `);
+
+    const sections = el.renderRoot.querySelectorAll("section");
+    expect(sections.length).to.equal(2);
+    expect(el.renderRoot.querySelector("slot[name='create']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='reply']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
+  });
+});

--- a/j2cl/lit/test/composer-submit-affordance.test.js
+++ b/j2cl/lit/test/composer-submit-affordance.test.js
@@ -1,0 +1,41 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/composer-submit-affordance.js";
+
+describe("<composer-submit-affordance>", () => {
+  it("renders a real submit button with visible status and error text", async () => {
+    const el = await fixture(html`
+      <composer-submit-affordance
+        label="Send reply"
+        status="Submitting the reply"
+        error="Network failed"
+      ></composer-submit-affordance>
+    `);
+
+    const button = el.renderRoot.querySelector("button");
+    expect(button).to.exist;
+    expect(button.textContent.trim()).to.equal("Send reply");
+    expect(button.getAttribute("aria-label")).to.equal("Send reply");
+    expect(el.renderRoot.textContent).to.include("Network failed");
+  });
+
+  it("disables the button while busy", async () => {
+    const el = await fixture(html`
+      <composer-submit-affordance label="Create wave" busy></composer-submit-affordance>
+    `);
+
+    const button = el.renderRoot.querySelector("button");
+    expect(button.disabled).to.equal(true);
+    expect(button.getAttribute("aria-busy")).to.equal("true");
+  });
+
+  it("dispatches submit-affordance when clicked", async () => {
+    const el = await fixture(html`
+      <composer-submit-affordance label="Create wave"></composer-submit-affordance>
+    `);
+    const eventPromise = oneEvent(el, "submit-affordance");
+
+    el.renderRoot.querySelector("button").click();
+
+    expect(await eventPromise).to.exist;
+  });
+});

--- a/j2cl/lit/test/toolbar-button.test.js
+++ b/j2cl/lit/test/toolbar-button.test.js
@@ -1,0 +1,31 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/toolbar-button.js";
+
+describe("<toolbar-button>", () => {
+  it("renders a native button with stable action id and pressed state", async () => {
+    const el = await fixture(html`
+      <toolbar-button
+        action="bold"
+        label="Bold"
+        toggle
+        pressed
+      ></toolbar-button>
+    `);
+
+    const button = el.renderRoot.querySelector("button");
+    expect(button.getAttribute("aria-label")).to.equal("Bold");
+    expect(button.getAttribute("aria-pressed")).to.equal("true");
+    expect(button.dataset.action).to.equal("bold");
+  });
+
+  it("dispatches toolbar-action with the action id", async () => {
+    const el = await fixture(html`
+      <toolbar-button action="archive" label="Archive"></toolbar-button>
+    `);
+    const eventPromise = oneEvent(el, "toolbar-action");
+
+    el.renderRoot.querySelector("button").click();
+
+    expect((await eventPromise).detail.action).to.equal("archive");
+  });
+});

--- a/j2cl/lit/test/toolbar-button.test.js
+++ b/j2cl/lit/test/toolbar-button.test.js
@@ -28,4 +28,18 @@ describe("<toolbar-button>", () => {
 
     expect((await eventPromise).detail.action).to.equal("archive");
   });
+
+  it("does not dispatch toolbar-action without an action id", async () => {
+    const el = await fixture(html`
+      <toolbar-button label="No action"></toolbar-button>
+    `);
+    let dispatched = false;
+    el.addEventListener("toolbar-action", () => {
+      dispatched = true;
+    });
+
+    el.renderRoot.querySelector("button").click();
+
+    expect(dispatched).to.equal(false);
+  });
 });

--- a/j2cl/lit/test/toolbar-group.test.js
+++ b/j2cl/lit/test/toolbar-group.test.js
@@ -1,0 +1,16 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/toolbar-group.js";
+
+describe("<toolbar-group>", () => {
+  it("uses an accessible toolbar group label and exposes the default slot", async () => {
+    const el = await fixture(html`
+      <toolbar-group label="View controls">
+        <button>Recent</button>
+      </toolbar-group>
+    `);
+
+    const group = el.renderRoot.querySelector("[role='group']");
+    expect(group.getAttribute("aria-label")).to.equal("View controls");
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+  });
+});

--- a/j2cl/lit/test/toolbar-overflow-menu.test.js
+++ b/j2cl/lit/test/toolbar-overflow-menu.test.js
@@ -44,6 +44,32 @@ describe("<toolbar-overflow-menu>", () => {
     expect((await eventPromise).detail.action).to.equal("clear-formatting");
   });
 
+  it("includes slotted toolbar-button elements in keyboard focus order", async () => {
+    const el = await fixture(html`
+      <toolbar-overflow-menu label="More toolbar actions">
+        <toolbar-button action="history" label="History"></toolbar-button>
+        <toolbar-button action="clear-formatting" label="Clear formatting"></toolbar-button>
+      </toolbar-overflow-menu>
+    `);
+    const trigger = el.renderRoot.querySelector("button[aria-haspopup='true']");
+    const historyButton = el.querySelector("toolbar-button[action='history']");
+    const clearButton = el.querySelector("toolbar-button[action='clear-formatting']");
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.open).to.equal(true);
+    expect(historyButton.renderRoot.querySelector("button")).to.equal(
+      historyButton.shadowRoot.activeElement
+    );
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+    expect(clearButton.renderRoot.querySelector("button")).to.equal(
+      clearButton.shadowRoot.activeElement
+    );
+  });
+
   it("closes and forwards actions from slotted toolbar-button elements", async () => {
     const el = await fixture(html`
       <toolbar-overflow-menu label="More toolbar actions">

--- a/j2cl/lit/test/toolbar-overflow-menu.test.js
+++ b/j2cl/lit/test/toolbar-overflow-menu.test.js
@@ -1,0 +1,45 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/toolbar-overflow-menu.js";
+
+describe("<toolbar-overflow-menu>", () => {
+  it("opens from keyboard, focuses the first item, and closes on Escape", async () => {
+    const el = await fixture(html`
+      <toolbar-overflow-menu label="More toolbar actions">
+        <button data-action="history">History</button>
+        <button data-action="clear-formatting">Clear formatting</button>
+      </toolbar-overflow-menu>
+    `);
+    const trigger = el.renderRoot.querySelector("button[aria-haspopup='menu']");
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.open).to.equal(true);
+    expect(el.querySelector("[data-action='history']")).to.equal(document.activeElement);
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.open).to.equal(false);
+    expect(trigger).to.equal(el.shadowRoot.activeElement);
+  });
+
+  it("moves focus with arrow keys and redispatches toolbar-action", async () => {
+    const el = await fixture(html`
+      <toolbar-overflow-menu label="More toolbar actions">
+        <button data-action="history">History</button>
+        <button data-action="clear-formatting">Clear formatting</button>
+      </toolbar-overflow-menu>
+    `);
+
+    el.open = true;
+    await el.updateComplete;
+    el.focusFirstItem();
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(el.querySelector("[data-action='clear-formatting']")).to.equal(document.activeElement);
+
+    const eventPromise = oneEvent(el, "toolbar-action");
+    el.querySelector("[data-action='clear-formatting']").click();
+    expect((await eventPromise).detail.action).to.equal("clear-formatting");
+  });
+});

--- a/j2cl/lit/test/toolbar-overflow-menu.test.js
+++ b/j2cl/lit/test/toolbar-overflow-menu.test.js
@@ -70,6 +70,34 @@ describe("<toolbar-overflow-menu>", () => {
     );
   });
 
+  it("skips disabled slotted toolbar-button elements during keyboard navigation", async () => {
+    const el = await fixture(html`
+      <toolbar-overflow-menu label="More toolbar actions">
+        <button data-action="history">History</button>
+        <toolbar-button action="archive" label="Archive" disabled></toolbar-button>
+        <toolbar-button action="clear-formatting" label="Clear formatting"></toolbar-button>
+      </toolbar-overflow-menu>
+    `);
+    const trigger = el.renderRoot.querySelector("button[aria-haspopup='true']");
+    const historyButton = el.querySelector("[data-action='history']");
+    const clearButton = el.querySelector("toolbar-button[action='clear-formatting']");
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    expect(historyButton).to.equal(document.activeElement);
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+
+    expect(clearButton.renderRoot.querySelector("button")).to.equal(
+      clearButton.shadowRoot.activeElement
+    );
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+
+    expect(historyButton).to.equal(document.activeElement);
+  });
+
   it("closes and forwards actions from slotted toolbar-button elements", async () => {
     const el = await fixture(html`
       <toolbar-overflow-menu label="More toolbar actions">

--- a/j2cl/lit/test/toolbar-overflow-menu.test.js
+++ b/j2cl/lit/test/toolbar-overflow-menu.test.js
@@ -1,4 +1,5 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/toolbar-button.js";
 import "../src/elements/toolbar-overflow-menu.js";
 
 describe("<toolbar-overflow-menu>", () => {
@@ -41,5 +42,31 @@ describe("<toolbar-overflow-menu>", () => {
     const eventPromise = oneEvent(el, "toolbar-action");
     el.querySelector("[data-action='clear-formatting']").click();
     expect((await eventPromise).detail.action).to.equal("clear-formatting");
+  });
+
+  it("closes and forwards actions from slotted toolbar-button elements", async () => {
+    const el = await fixture(html`
+      <toolbar-overflow-menu label="More toolbar actions">
+        <toolbar-button action="history" label="History"></toolbar-button>
+      </toolbar-overflow-menu>
+    `);
+
+    el.open = true;
+    await el.updateComplete;
+    const trigger = el.renderRoot.querySelector("button[aria-haspopup='true']");
+    let actionCount = 0;
+    // Count alongside oneEvent so this catches accidental duplicate redispatches.
+    el.addEventListener("toolbar-action", () => {
+      actionCount += 1;
+    });
+    const eventPromise = oneEvent(el, "toolbar-action");
+
+    el.querySelector("toolbar-button").renderRoot.querySelector("button").click();
+
+    expect((await eventPromise).detail.action).to.equal("history");
+    await el.updateComplete;
+    expect(actionCount).to.equal(1);
+    expect(el.open).to.equal(false);
+    expect(trigger).to.equal(el.shadowRoot.activeElement);
   });
 });

--- a/j2cl/lit/test/toolbar-overflow-menu.test.js
+++ b/j2cl/lit/test/toolbar-overflow-menu.test.js
@@ -9,7 +9,7 @@ describe("<toolbar-overflow-menu>", () => {
         <button data-action="clear-formatting">Clear formatting</button>
       </toolbar-overflow-menu>
     `);
-    const trigger = el.renderRoot.querySelector("button[aria-haspopup='menu']");
+    const trigger = el.renderRoot.querySelector("button[aria-haspopup='true']");
 
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     await el.updateComplete;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -148,6 +148,9 @@ public final class J2clComposeSurfaceController {
   }
 
   public void onWriteSessionChanged(J2clSidecarWriteSession nextWriteSession) {
+    if (signedOut) {
+      return;
+    }
     if (sessionChanged(nextWriteSession)) {
       replyGeneration++;
       if (replySubmitting) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1,0 +1,377 @@
+package org.waveprotocol.box.j2cl.compose;
+
+import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+public final class J2clComposeSurfaceController {
+  public interface Gateway {
+    void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+
+    void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError);
+  }
+
+  public interface View {
+    void bind(Listener listener);
+
+    void render(J2clComposeSurfaceModel model);
+  }
+
+  public interface Listener {
+    void onCreateDraftChanged(String draft);
+
+    void onCreateSubmitted(String draft);
+
+    void onReplyDraftChanged(String draft);
+
+    void onReplySubmitted(String draft);
+  }
+
+  @FunctionalInterface
+  public interface CreateSuccessHandler {
+    void onWaveCreated(String waveId);
+  }
+
+  @FunctionalInterface
+  public interface ReplySuccessHandler {
+    void onReplySubmitted(String waveId);
+  }
+
+  private static final String STALE_REPLY_MESSAGE =
+      "Selection changed before submit completed. Review the draft and retry.";
+
+  private final Gateway gateway;
+  private final View view;
+  private final J2clPlainTextDeltaFactory deltaFactory;
+  private final CreateSuccessHandler createSuccessHandler;
+  private final ReplySuccessHandler replySuccessHandler;
+  private String createDraft = "";
+  private boolean createSubmitting;
+  private String createStatusText = "Create a self-owned wave inside the root shell.";
+  private String createErrorText = "";
+  private J2clSidecarWriteSession writeSession;
+  private String replyDraft = "";
+  private boolean replySubmitting;
+  private boolean replyStaleBasis;
+  private String replyStatusText = "Open a wave before replying.";
+  private String replyErrorText = "";
+  private int createGeneration;
+  private int replyGeneration;
+  private boolean signedOut;
+  private boolean started;
+
+  public J2clComposeSurfaceController(
+      Gateway gateway,
+      View view,
+      J2clPlainTextDeltaFactory deltaFactory,
+      CreateSuccessHandler createSuccessHandler,
+      ReplySuccessHandler replySuccessHandler) {
+    this.gateway = gateway;
+    this.view = view;
+    this.deltaFactory = deltaFactory;
+    this.createSuccessHandler = createSuccessHandler;
+    this.replySuccessHandler = replySuccessHandler;
+  }
+
+  public void start() {
+    if (started) {
+      return;
+    }
+    started = true;
+    view.bind(
+        new Listener() {
+          @Override
+          public void onCreateDraftChanged(String draft) {
+            J2clComposeSurfaceController.this.onCreateDraftChanged(draft);
+          }
+
+          @Override
+          public void onCreateSubmitted(String draft) {
+            J2clComposeSurfaceController.this.onCreateSubmitted(draft);
+          }
+
+          @Override
+          public void onReplyDraftChanged(String draft) {
+            J2clComposeSurfaceController.this.onReplyDraftChanged(draft);
+          }
+
+          @Override
+          public void onReplySubmitted(String draft) {
+            J2clComposeSurfaceController.this.onReplySubmitted(draft);
+          }
+        });
+    render();
+  }
+
+  public void onSignedOut() {
+    signedOut = true;
+    createSubmitting = false;
+    replySubmitting = false;
+    writeSession = null;
+    createStatusText = "Sign in to create or reply in the J2CL root shell.";
+    replyStatusText = createStatusText;
+    render();
+  }
+
+  public void onCreateDraftChanged(String draft) {
+    createDraft = normalizeDraft(draft);
+    createErrorText = "";
+    render();
+  }
+
+  public void onCreateSubmitted(String draft) {
+    createDraft = normalizeDraft(draft);
+    submitCreate();
+  }
+
+  public void onReplyDraftChanged(String draft) {
+    replyDraft = normalizeDraft(draft);
+    replyErrorText = "";
+    replyStaleBasis = false;
+    render();
+  }
+
+  public void onReplySubmitted(String draft) {
+    replyDraft = normalizeDraft(draft);
+    submitReply();
+  }
+
+  public void onWriteSessionChanged(J2clSidecarWriteSession nextWriteSession) {
+    if (sessionChanged(nextWriteSession)) {
+      replyGeneration++;
+      if (replySubmitting) {
+        replyErrorText = STALE_REPLY_MESSAGE;
+        replyStaleBasis = true;
+      } else {
+        replyErrorText = "";
+        replyStaleBasis = false;
+      }
+      replySubmitting = false;
+      replyStatusText = "";
+      if (selectedWaveChanged(nextWriteSession)) {
+        replyDraft = "";
+      }
+    }
+    writeSession = nextWriteSession;
+    if (writeSession == null && replyStatusText.isEmpty()) {
+      replyStatusText = "Open a wave before replying.";
+    }
+    render();
+  }
+
+  private void submitCreate() {
+    if (signedOut || createSubmitting) {
+      render();
+      return;
+    }
+    if (createDraft.trim().isEmpty()) {
+      createStatusText = "";
+      createErrorText = "Enter some text before creating a wave.";
+      render();
+      return;
+    }
+    createSubmitting = true;
+    createStatusText = "Bootstrapping the root-shell submit session.";
+    createErrorText = "";
+    final String submittedDraft = createDraft;
+    final int generation = ++createGeneration;
+    render();
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (generation != createGeneration) {
+            return;
+          }
+          J2clPlainTextDeltaFactory.CreateWaveRequest request;
+          try {
+            request = deltaFactory.createWaveRequest(bootstrap.getAddress(), submittedDraft);
+          } catch (RuntimeException e) {
+            handleCreateFailure(generation, messageOrDefault(e, "Unable to build the create request."));
+            return;
+          }
+          createStatusText = "Submitting the new wave.";
+          render();
+          gateway.submit(
+              bootstrap,
+              request.getSubmitRequest(),
+              response -> handleCreateResponse(generation, request, response),
+              error -> handleCreateFailure(generation, error));
+        },
+        error -> handleCreateFailure(generation, error));
+  }
+
+  private void handleCreateResponse(
+      int generation,
+      J2clPlainTextDeltaFactory.CreateWaveRequest request,
+      SidecarSubmitResponse response) {
+    if (generation != createGeneration) {
+      return;
+    }
+    if (!response.getErrorMessage().isEmpty()) {
+      handleCreateFailure(generation, response.getErrorMessage());
+      return;
+    }
+    createSubmitting = false;
+    createDraft = "";
+    createStatusText = "Wave created.";
+    createErrorText = "";
+    render();
+    if (createSuccessHandler != null) {
+      createSuccessHandler.onWaveCreated(request.getCreatedWaveId());
+    }
+  }
+
+  private void handleCreateFailure(int generation, String error) {
+    if (generation != createGeneration) {
+      return;
+    }
+    createSubmitting = false;
+    createStatusText = "";
+    createErrorText = error == null || error.isEmpty() ? "Create wave failed." : error;
+    render();
+  }
+
+  private void submitReply() {
+    if (signedOut || replySubmitting) {
+      render();
+      return;
+    }
+    if (writeSession == null) {
+      replyStatusText = "";
+      replyErrorText = "Open a wave before sending a reply.";
+      render();
+      return;
+    }
+    if (replyDraft.trim().isEmpty()) {
+      replyStatusText = "";
+      replyErrorText = "Enter some text before replying.";
+      render();
+      return;
+    }
+    replySubmitting = true;
+    replyStaleBasis = false;
+    replyStatusText = "Bootstrapping the root-shell submit session.";
+    replyErrorText = "";
+    final String submittedDraft = replyDraft;
+    final int generation = ++replyGeneration;
+    final J2clSidecarWriteSession submitSession = writeSession;
+    render();
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (generation != replyGeneration) {
+            return;
+          }
+          SidecarSubmitRequest request;
+          try {
+            request =
+                deltaFactory.createReplyRequest(bootstrap.getAddress(), submitSession, submittedDraft);
+          } catch (RuntimeException e) {
+            handleReplyFailure(generation, messageOrDefault(e, "Unable to build the reply request."));
+            return;
+          }
+          replyStatusText = "Submitting the reply.";
+          render();
+          gateway.submit(
+              bootstrap,
+              request,
+              response -> handleReplyResponse(generation, submitSession, response),
+              error -> handleReplyFailure(generation, error));
+        },
+        error -> handleReplyFailure(generation, error));
+  }
+
+  private void handleReplyResponse(
+      int generation, J2clSidecarWriteSession submitSession, SidecarSubmitResponse response) {
+    if (generation != replyGeneration) {
+      return;
+    }
+    if (!response.getErrorMessage().isEmpty()) {
+      handleReplyFailure(generation, response.getErrorMessage());
+      return;
+    }
+    replySubmitting = false;
+    replyDraft = "";
+    replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
+    replyErrorText = "";
+    replyStaleBasis = false;
+    render();
+    if (replySuccessHandler != null
+        && submitSession != null
+        && submitSession.getSelectedWaveId() != null
+        && !submitSession.getSelectedWaveId().isEmpty()) {
+      replySuccessHandler.onReplySubmitted(submitSession.getSelectedWaveId());
+    }
+  }
+
+  private void handleReplyFailure(int generation, String error) {
+    if (generation != replyGeneration) {
+      return;
+    }
+    replySubmitting = false;
+    replyStatusText = "";
+    replyErrorText = error == null || error.isEmpty() ? "Reply failed." : error;
+    replyStaleBasis = false;
+    render();
+  }
+
+  private void render() {
+    if (!started) {
+      return;
+    }
+    view.render(
+        new J2clComposeSurfaceModel(
+            !signedOut,
+            createDraft,
+            createSubmitting,
+            createStatusText,
+            createErrorText,
+            !signedOut && writeSession != null,
+            writeSession == null ? "" : writeSession.getReplyTargetBlipId(),
+            replyDraft,
+            replySubmitting,
+            replyStaleBasis,
+            replyStatusText,
+            replyErrorText));
+  }
+
+  private boolean sessionChanged(J2clSidecarWriteSession nextWriteSession) {
+    if (writeSession == null || nextWriteSession == null) {
+      return writeSession != nextWriteSession;
+    }
+    return !safeEquals(writeSession.getSelectedWaveId(), nextWriteSession.getSelectedWaveId())
+        || !safeEquals(writeSession.getChannelId(), nextWriteSession.getChannelId())
+        || writeSession.getBaseVersion() != nextWriteSession.getBaseVersion()
+        || !safeEquals(writeSession.getHistoryHash(), nextWriteSession.getHistoryHash())
+        || !safeEquals(writeSession.getReplyTargetBlipId(), nextWriteSession.getReplyTargetBlipId());
+  }
+
+  private boolean selectedWaveChanged(J2clSidecarWriteSession nextWriteSession) {
+    String currentWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
+    String nextWaveId = nextWriteSession == null ? null : nextWriteSession.getSelectedWaveId();
+    return !safeEquals(currentWaveId, nextWaveId);
+  }
+
+  private static String normalizeDraft(String draft) {
+    return draft == null ? "" : draft;
+  }
+
+  private static String messageOrDefault(RuntimeException error, String fallback) {
+    String message = error.getMessage();
+    return message == null || message.isEmpty() ? fallback : message;
+  }
+
+  private static boolean safeEquals(String left, String right) {
+    if (left == null) {
+      return right == null;
+    }
+    return left.equals(right);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -190,7 +190,7 @@ public final class J2clComposeSurfaceController {
       }
     }
     writeSession = nextWriteSession;
-    if (writeSession == null && replyStatusText.isEmpty()) {
+    if (!hasSelectedWave(writeSession) && replyStatusText.isEmpty()) {
       replyStatusText = "Open a wave before replying.";
     }
     render();
@@ -357,6 +357,7 @@ public final class J2clComposeSurfaceController {
     if (!started) {
       return;
     }
+    boolean replyAvailable = !signedOut && hasSelectedWave(writeSession);
     view.render(
         new J2clComposeSurfaceModel(
             !signedOut,
@@ -364,8 +365,8 @@ public final class J2clComposeSurfaceController {
             createSubmitting,
             createStatusText,
             createErrorText,
-            !signedOut && writeSession != null,
-            writeSession == null ? "" : writeSession.getReplyTargetBlipId(),
+            replyAvailable,
+            replyAvailable ? writeSession.getReplyTargetBlipId() : "",
             replyDraft,
             replySubmitting,
             replyStaleBasis,
@@ -388,6 +389,10 @@ public final class J2clComposeSurfaceController {
     String currentWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
     String nextWaveId = nextWriteSession == null ? null : nextWriteSession.getSelectedWaveId();
     return !safeEquals(currentWaveId, nextWaveId);
+  }
+
+  private static boolean hasSelectedWave(J2clSidecarWriteSession session) {
+    return session != null && !isEmpty(session.getSelectedWaveId());
   }
 
   private static String normalizeDraft(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -114,6 +114,8 @@ public final class J2clComposeSurfaceController {
 
   public void onSignedOut() {
     signedOut = true;
+    createGeneration++;
+    replyGeneration++;
     createSubmitting = false;
     replySubmitting = false;
     writeSession = null;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -124,6 +124,7 @@ public final class J2clComposeSurfaceController {
     replyStaleBasis = false;
     replyStaleWaveId = null;
     replyErrorText = "";
+    createErrorText = "";
     createStatusText = "Sign in to create or reply in the J2CL root shell.";
     replyStatusText = createStatusText;
     render();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -162,7 +162,7 @@ public final class J2clComposeSurfaceController {
       }
       replySubmitting = false;
       replyStatusText = "";
-      if (selectedWaveChanged(nextWriteSession)) {
+      if (selectedWaveChanged(nextWriteSession) && !replyStaleBasis) {
         replyDraft = "";
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -62,6 +62,7 @@ public final class J2clComposeSurfaceController {
   private String replyDraft = "";
   private boolean replySubmitting;
   private boolean replyStaleBasis;
+  private String replyStaleWaveId;
   private String replyStatusText = "Open a wave before replying.";
   private String replyErrorText = "";
   private int createGeneration;
@@ -139,6 +140,7 @@ public final class J2clComposeSurfaceController {
     replyDraft = normalizeDraft(draft);
     replyErrorText = "";
     replyStaleBasis = false;
+    replyStaleWaveId = null;
     render();
   }
 
@@ -156,14 +158,23 @@ public final class J2clComposeSurfaceController {
       if (replySubmitting) {
         replyErrorText = STALE_REPLY_MESSAGE;
         replyStaleBasis = true;
+        replyStaleWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
       } else {
         replyErrorText = "";
-        replyStaleBasis = false;
       }
       replySubmitting = false;
       replyStatusText = "";
-      if (selectedWaveChanged(nextWriteSession) && !replyStaleBasis) {
-        replyDraft = "";
+      if (selectedWaveChanged(nextWriteSession)) {
+        String nextWaveId = nextWriteSession == null ? null : nextWriteSession.getSelectedWaveId();
+        // Preserve a stale draft through null (disconnected) and same-wave reconnect transitions.
+        // Only clear when navigating to a different non-null wave.
+        boolean clearDraft = !replyStaleBasis
+            || (nextWaveId != null && !safeEquals(replyStaleWaveId, nextWaveId));
+        if (clearDraft) {
+          replyDraft = "";
+          replyStaleBasis = false;
+          replyStaleWaveId = null;
+        }
       }
     }
     writeSession = nextWriteSession;
@@ -307,6 +318,7 @@ public final class J2clComposeSurfaceController {
     replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
     replyErrorText = "";
     replyStaleBasis = false;
+    replyStaleWaveId = null;
     render();
     if (replySuccessHandler != null
         && submitSession != null
@@ -324,6 +336,7 @@ public final class J2clComposeSurfaceController {
     replyStatusText = "";
     replyErrorText = error == null || error.isEmpty() ? "Reply failed." : error;
     replyStaleBasis = false;
+    replyStaleWaveId = null;
     render();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -46,8 +46,9 @@ public final class J2clComposeSurfaceController {
     void onReplySubmitted(String waveId);
   }
 
-  private static final String STALE_REPLY_MESSAGE =
-      "Selection changed before submit completed. Review the draft and retry.";
+  static final String STALE_REPLY_MESSAGE =
+      "The wave changed before your reply was sent. Review it, then retry if it still belongs"
+          + " here.";
 
   private final Gateway gateway;
   private final View view;
@@ -120,6 +121,9 @@ public final class J2clComposeSurfaceController {
     createSubmitting = false;
     replySubmitting = false;
     writeSession = null;
+    replyStaleBasis = false;
+    replyStaleWaveId = null;
+    replyErrorText = "";
     createStatusText = "Sign in to create or reply in the J2CL root shell.";
     replyStatusText = createStatusText;
     render();
@@ -154,12 +158,16 @@ public final class J2clComposeSurfaceController {
       return;
     }
     if (sessionChanged(nextWriteSession)) {
+      boolean wasReplySubmitting = replySubmitting;
       replyGeneration++;
-      if (replySubmitting) {
+      if (wasReplySubmitting) {
         replyErrorText = STALE_REPLY_MESSAGE;
         replyStaleBasis = true;
+        // submitReply() guarantees a non-empty selected wave id here, but stay defensive.
         replyStaleWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
-      } else {
+      } else if (!replyStaleBasis) {
+        // Stale explanations stay visible across benign reconnect/version refreshes until
+        // the user edits/retries or navigates to a different wave.
         replyErrorText = "";
       }
       replySubmitting = false;
@@ -167,11 +175,15 @@ public final class J2clComposeSurfaceController {
       if (selectedWaveChanged(nextWriteSession)) {
         String nextWaveId = nextWriteSession == null ? null : nextWriteSession.getSelectedWaveId();
         // Preserve a stale draft through null (disconnected) and same-wave reconnect transitions.
-        // Only clear when navigating to a different non-null wave.
+        // Also preserve the first transition that invalidates an in-flight submit so the user
+        // can review the unsent text instead of losing it.
         boolean clearDraft = !replyStaleBasis
-            || (nextWaveId != null && !safeEquals(replyStaleWaveId, nextWaveId));
+            || (!wasReplySubmitting
+                && nextWaveId != null
+                && !safeEquals(replyStaleWaveId, nextWaveId));
         if (clearDraft) {
           replyDraft = "";
+          replyErrorText = "";
           replyStaleBasis = false;
           replyStaleWaveId = null;
         }
@@ -260,7 +272,7 @@ public final class J2clComposeSurfaceController {
       render();
       return;
     }
-    if (writeSession == null) {
+    if (writeSession == null || isEmpty(writeSession.getSelectedWaveId())) {
       replyStatusText = "";
       replyErrorText = "Open a wave before sending a reply.";
       render();
@@ -274,6 +286,7 @@ public final class J2clComposeSurfaceController {
     }
     replySubmitting = true;
     replyStaleBasis = false;
+    replyStaleWaveId = null;
     replyStatusText = "Bootstrapping the root-shell submit session.";
     replyErrorText = "";
     final String submittedDraft = replyDraft;
@@ -391,5 +404,9 @@ public final class J2clComposeSurfaceController {
       return right == null;
     }
     return left.equals(right);
+  }
+
+  private static boolean isEmpty(String value) {
+    return value == null || value.isEmpty();
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java
@@ -1,0 +1,95 @@
+package org.waveprotocol.box.j2cl.compose;
+
+public final class J2clComposeSurfaceModel {
+  private final boolean createEnabled;
+  private final String createDraft;
+  private final boolean createSubmitting;
+  private final String createStatusText;
+  private final String createErrorText;
+  private final boolean replyAvailable;
+  private final String replyTargetLabel;
+  private final String replyDraft;
+  private final boolean replySubmitting;
+  private final boolean replyStaleBasis;
+  private final String replyStatusText;
+  private final String replyErrorText;
+
+  public J2clComposeSurfaceModel(
+      boolean createEnabled,
+      String createDraft,
+      boolean createSubmitting,
+      String createStatusText,
+      String createErrorText,
+      boolean replyAvailable,
+      String replyTargetLabel,
+      String replyDraft,
+      boolean replySubmitting,
+      boolean replyStaleBasis,
+      String replyStatusText,
+      String replyErrorText) {
+    this.createEnabled = createEnabled;
+    this.createDraft = nullToEmpty(createDraft);
+    this.createSubmitting = createSubmitting;
+    this.createStatusText = nullToEmpty(createStatusText);
+    this.createErrorText = nullToEmpty(createErrorText);
+    this.replyAvailable = replyAvailable;
+    this.replyTargetLabel = nullToEmpty(replyTargetLabel);
+    this.replyDraft = nullToEmpty(replyDraft);
+    this.replySubmitting = replySubmitting;
+    this.replyStaleBasis = replyStaleBasis;
+    this.replyStatusText = nullToEmpty(replyStatusText);
+    this.replyErrorText = nullToEmpty(replyErrorText);
+  }
+
+  public boolean isCreateEnabled() {
+    return createEnabled;
+  }
+
+  public String getCreateDraft() {
+    return createDraft;
+  }
+
+  public boolean isCreateSubmitting() {
+    return createSubmitting;
+  }
+
+  public String getCreateStatusText() {
+    return createStatusText;
+  }
+
+  public String getCreateErrorText() {
+    return createErrorText;
+  }
+
+  public boolean isReplyAvailable() {
+    return replyAvailable;
+  }
+
+  public String getReplyTargetLabel() {
+    return replyTargetLabel;
+  }
+
+  public String getReplyDraft() {
+    return replyDraft;
+  }
+
+  public boolean isReplySubmitting() {
+    return replySubmitting;
+  }
+
+  public boolean isReplyStaleBasis() {
+    return replyStaleBasis;
+  }
+
+  public String getReplyStatusText() {
+    return replyStatusText;
+  }
+
+  public String getReplyErrorText() {
+    return replyErrorText;
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -1,0 +1,110 @@
+package org.waveprotocol.box.j2cl.compose;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLFormElement;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLTextAreaElement;
+import jsinterop.base.Js;
+
+public final class J2clComposeSurfaceView implements J2clComposeSurfaceController.View {
+  private final HTMLTextAreaElement createInput;
+  private final HTMLElement createSubmit;
+  private final HTMLElement replyElement;
+  private J2clComposeSurfaceController.Listener listener;
+
+  public J2clComposeSurfaceView(HTMLElement createHost, HTMLElement replyHost) {
+    createHost.innerHTML = "";
+    replyHost.innerHTML = "";
+
+    HTMLElement shell = (HTMLElement) DomGlobal.document.createElement("composer-shell");
+    createHost.appendChild(shell);
+
+    HTMLFormElement createForm = (HTMLFormElement) DomGlobal.document.createElement("form");
+    createForm.setAttribute("slot", "create");
+    createForm.className = "j2cl-compose-create-form";
+    shell.appendChild(createForm);
+
+    createInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
+    createInput.setAttribute("aria-label", "New wave content");
+    createInput.setAttribute("placeholder", "Start a new wave");
+    createInput.rows = 4;
+    createInput.oninput =
+        event -> {
+          if (listener != null) {
+            listener.onCreateDraftChanged(createInput.value);
+          }
+          return null;
+        };
+    createForm.appendChild(createInput);
+
+    createSubmit = (HTMLElement) DomGlobal.document.createElement("composer-submit-affordance");
+    setProperty(createSubmit, "label", "Create wave");
+    createForm.appendChild(createSubmit);
+    createSubmit.addEventListener(
+        "submit-affordance",
+        event -> {
+          if (listener != null) {
+            listener.onCreateSubmitted(createInput.value);
+          }
+        });
+
+    replyElement = (HTMLElement) DomGlobal.document.createElement("composer-inline-reply");
+    replyHost.appendChild(replyElement);
+    replyElement.addEventListener(
+        "draft-change",
+        event -> {
+          if (listener != null) {
+            listener.onReplyDraftChanged(eventDetailValue(event));
+          }
+        });
+    replyElement.addEventListener(
+        "reply-submit",
+        event -> {
+          if (listener != null) {
+            listener.onReplySubmitted(propertyString(replyElement, "draft"));
+          }
+        });
+  }
+
+  @Override
+  public void bind(J2clComposeSurfaceController.Listener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void render(J2clComposeSurfaceModel model) {
+    createInput.value = model.getCreateDraft();
+    createInput.disabled = !model.isCreateEnabled() || model.isCreateSubmitting();
+    setProperty(createSubmit, "busy", model.isCreateSubmitting());
+    setProperty(createSubmit, "disabled", !model.isCreateEnabled() || model.isCreateSubmitting());
+    setProperty(createSubmit, "status", model.getCreateStatusText());
+    setProperty(createSubmit, "error", model.getCreateErrorText());
+
+    setProperty(replyElement, "available", model.isReplyAvailable());
+    setProperty(replyElement, "targetLabel", model.getReplyTargetLabel());
+    setProperty(replyElement, "draft", model.getReplyDraft());
+    setProperty(replyElement, "submitting", model.isReplySubmitting());
+    setProperty(replyElement, "staleBasis", model.isReplyStaleBasis());
+    setProperty(replyElement, "status", model.getReplyStatusText());
+    setProperty(replyElement, "error", model.getReplyErrorText());
+  }
+
+  private static void setProperty(HTMLElement element, String name, Object value) {
+    Js.asPropertyMap(element).set(name, value);
+  }
+
+  private static String propertyString(HTMLElement element, String name) {
+    Object value = Js.asPropertyMap(element).get(name);
+    return value == null ? "" : String.valueOf(value);
+  }
+
+  private static String eventDetailValue(Event event) {
+    Object detail = Js.asPropertyMap(event).get("detail");
+    if (detail == null) {
+      return "";
+    }
+    Object value = Js.asPropertyMap(detail).get("value");
+    return value == null ? "" : String.valueOf(value);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -1,29 +1,38 @@
 package org.waveprotocol.box.j2cl.root;
 
 import elemental2.dom.HTMLElement;
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceView;
 import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
-import org.waveprotocol.box.j2cl.search.J2clSidecarComposeController;
-import org.waveprotocol.box.j2cl.search.J2clSidecarComposeView;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveView;
+import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceController;
+import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceView;
 
 public final class J2clRootShellController {
   private final HTMLElement host;
+  private boolean started;
 
   public J2clRootShellController(HTMLElement host) {
     this.host = host;
   }
 
   public void start() {
+    if (started) {
+      return;
+    }
+    started = true;
     J2clRootShellView shellView = new J2clRootShellView(host);
     J2clSearchGateway gateway = new J2clSearchGateway();
     final J2clSidecarRouteController[] routeControllerRef = new J2clSidecarRouteController[1];
     final J2clSelectedWaveController[] selectedWaveControllerRef =
         new J2clSelectedWaveController[1];
+    final J2clToolbarSurfaceController[] toolbarControllerRef =
+        new J2clToolbarSurfaceController[1];
     // The route controller is wired below; the starter runs only after that assignment.
     J2clRootLiveSurfaceController liveSurfaceController =
         new J2clRootLiveSurfaceController(shellView, () -> routeControllerRef[0].start());
@@ -32,24 +41,39 @@ public final class J2clRootShellController {
             shellView.getWorkflowHost(), J2clSearchPanelView.ShellPresentation.ROOT_SHELL);
     J2clSelectedWaveView selectedWaveView =
         new J2clSelectedWaveView(searchView.getSelectedWaveHost());
-    J2clSidecarComposeController composeController =
-        new J2clSidecarComposeController(
+    HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
+    HTMLElement selectedToolbarHost =
+        createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
+    HTMLElement selectedReplyHost =
+        createChildHost(selectedWaveComposeHost, "j2cl-root-reply-host");
+    J2clComposeSurfaceController composeController =
+        new J2clComposeSurfaceController(
             gateway,
-            new J2clSidecarComposeView(
-                searchView.getComposeHost(),
-                selectedWaveView.getComposeHost(),
-                J2clSearchPanelView.ShellPresentation.ROOT_SHELL),
+            new J2clComposeSurfaceView(searchView.getComposeHost(), selectedReplyHost),
             new J2clPlainTextDeltaFactory(buildRootShellSessionSeed()),
             waveId -> routeControllerRef[0].selectWave(waveId),
             waveId -> {
               if (selectedWaveControllerRef[0] != null) {
                 selectedWaveControllerRef[0].refreshSelectedWave();
               }
-            },
-            J2clSearchPanelView.ShellPresentation.ROOT_SHELL);
+            });
+    J2clToolbarSurfaceController toolbarController =
+        new J2clToolbarSurfaceController(
+            new J2clToolbarSurfaceView(selectedToolbarHost),
+            action ->
+                toolbarControllerRef[0].onActionUnavailable(
+                    action, "This toolbar action is not wired in the J2CL root shell yet."));
+    toolbarControllerRef[0] = toolbarController;
     J2clSelectedWaveController selectedWaveController =
         new J2clSelectedWaveController(
-            gateway, selectedWaveView, composeController::onWriteSessionChanged);
+            gateway,
+            selectedWaveView,
+            writeSession -> {
+              composeController.onWriteSessionChanged(writeSession);
+              toolbarController.onWriteSessionChanged(writeSession);
+              toolbarController.onEditStateChanged(
+                  new J2clToolbarSurfaceController.EditState(writeSession != null));
+            });
     selectedWaveControllerRef[0] = selectedWaveController;
     J2clSearchPanelController controller =
         new J2clSearchPanelController(
@@ -63,13 +87,30 @@ public final class J2clRootShellController {
         new J2clSidecarRouteController(
             new J2clSidecarRouteController.BrowserHistoryAdapter(),
             controller,
-            liveSurfaceController.selectedWaveController(selectedWaveController),
+            liveSurfaceController.selectedWaveController(
+                (waveId, digestItem) -> {
+                  toolbarController.onSelectedWaveStateChanged(
+                      // TODO(#971): publish real archive/pin/mention state from the root-live or
+                      // selected-wave model before enabling folder-specific toolbar controls.
+                      new J2clToolbarSurfaceController.SelectedWaveState(
+                          waveId != null && !waveId.isEmpty(), false, false, true, false, false));
+                  selectedWaveController.onWaveSelected(waveId, digestItem);
+                }),
             "view=j2cl-root",
             liveSurfaceController::onRouteUrlChanged);
     routeControllerRef[0] = routeController;
     searchView.setSessionSummary("Mounted inside the J2CL root shell.");
     composeController.start();
+    toolbarController.start();
+    toolbarController.onEditStateChanged(new J2clToolbarSurfaceController.EditState(false));
     liveSurfaceController.start();
+  }
+
+  private static HTMLElement createChildHost(HTMLElement parent, String className) {
+    HTMLElement child = (HTMLElement) elemental2.dom.DomGlobal.document.createElement("div");
+    child.className = className;
+    parent.appendChild(child);
+    return child;
   }
 
   private static double resolveViewportWidth() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -6,6 +6,7 @@ import elemental2.dom.XMLHttpRequest;
 import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
@@ -21,7 +22,8 @@ public final class J2clSearchGateway
     implements
         J2clSearchPanelController.SearchGateway,
         J2clSelectedWaveController.Gateway,
-        J2clSidecarComposeController.Gateway {
+        J2clSidecarComposeController.Gateway,
+        J2clComposeSurfaceController.Gateway {
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
   private static final String CROSS_HOST_WEBSOCKET_ERROR =
       "The J2CL sidecar requires core.http_websocket_presented_address to use the current page host when HttpOnly session cookies are enabled.";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clDailyToolbarAction.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clDailyToolbarAction.java
@@ -1,0 +1,74 @@
+package org.waveprotocol.box.j2cl.toolbar;
+
+public enum J2clDailyToolbarAction {
+  RECENT("recent", "Recent", "View", false, false),
+  NEXT_UNREAD("next-unread", "Next unread", "View", false, false),
+  PREVIOUS("previous", "Previous", "View", false, false),
+  NEXT("next", "Next", "View", false, false),
+  LAST("last", "Last", "View", false, false),
+  PREVIOUS_MENTION("previous-mention", "Previous mention", "Mentions", false, false),
+  NEXT_MENTION("next-mention", "Next mention", "Mentions", false, false),
+  ARCHIVE("archive", "Archive", "Folders", false, false),
+  INBOX("inbox", "Inbox", "Folders", false, false),
+  PIN("pin", "Pin", "Folders", false, false),
+  UNPIN("unpin", "Unpin", "Folders", false, false),
+  HISTORY("history", "History", "Folders", false, false),
+  BOLD("bold", "Bold", "Edit", true, true),
+  ITALIC("italic", "Italic", "Edit", true, true),
+  UNDERLINE("underline", "Underline", "Edit", true, true),
+  STRIKETHROUGH("strikethrough", "Strikethrough", "Edit", true, true),
+  HEADING("heading", "Heading", "Edit", false, true),
+  UNORDERED_LIST("unordered-list", "Bulleted list", "Edit", true, true),
+  ORDERED_LIST("ordered-list", "Numbered list", "Edit", true, true),
+  ALIGN_LEFT("align-left", "Align left", "Edit", true, true),
+  ALIGN_CENTER("align-center", "Align center", "Edit", true, true),
+  ALIGN_RIGHT("align-right", "Align right", "Edit", true, true),
+  RTL("rtl", "Right-to-left", "Edit", true, true),
+  LINK("link", "Create link", "Edit", false, true),
+  UNLINK("unlink", "Remove link", "Edit", false, true),
+  CLEAR_FORMATTING("clear-formatting", "Clear formatting", "Edit", false, true);
+
+  private final String id;
+  private final String label;
+  private final String groupLabel;
+  private final boolean toggle;
+  private final boolean editAction;
+
+  J2clDailyToolbarAction(
+      String id, String label, String groupLabel, boolean toggle, boolean editAction) {
+    this.id = id;
+    this.label = label;
+    this.groupLabel = groupLabel;
+    this.toggle = toggle;
+    this.editAction = editAction;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  public String label() {
+    return label;
+  }
+
+  public String groupLabel() {
+    return groupLabel;
+  }
+
+  public boolean isToggle() {
+    return toggle;
+  }
+
+  public boolean isEditAction() {
+    return editAction;
+  }
+
+  public static J2clDailyToolbarAction fromId(String id) {
+    for (J2clDailyToolbarAction action : values()) {
+      if (action.id.equals(id)) {
+        return action;
+      }
+    }
+    return null;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
@@ -1,0 +1,223 @@
+package org.waveprotocol.box.j2cl.toolbar;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+
+public final class J2clToolbarSurfaceController {
+  public interface View {
+    void bind(Listener listener);
+
+    void render(J2clToolbarSurfaceModel model);
+  }
+
+  public interface Listener {
+    void onActionRequested(String actionId);
+  }
+
+  @FunctionalInterface
+  public interface ActionDispatcher {
+    void dispatch(J2clDailyToolbarAction action);
+  }
+
+  public static final class SelectedWaveState {
+    private final boolean selectedWavePresent;
+    private final boolean archived;
+    private final boolean pinned;
+    private final boolean historyVisible;
+    private final boolean mentionOrderAvailable;
+    private final boolean folderStateAvailable;
+
+    public SelectedWaveState(
+        boolean selectedWavePresent,
+        boolean archived,
+        boolean pinned,
+        boolean historyVisible,
+        boolean mentionOrderAvailable) {
+      this(selectedWavePresent, archived, pinned, historyVisible, mentionOrderAvailable, true);
+    }
+
+    public SelectedWaveState(
+        boolean selectedWavePresent,
+        boolean archived,
+        boolean pinned,
+        boolean historyVisible,
+        boolean mentionOrderAvailable,
+        boolean folderStateAvailable) {
+      this.selectedWavePresent = selectedWavePresent;
+      this.archived = archived;
+      this.pinned = pinned;
+      this.historyVisible = historyVisible;
+      this.mentionOrderAvailable = mentionOrderAvailable;
+      this.folderStateAvailable = folderStateAvailable;
+    }
+  }
+
+  public static final class EditState {
+    private final boolean editable;
+    private final Set<String> pressedActionIds = new HashSet<String>();
+
+    public EditState(boolean editable, String... pressedActionIds) {
+      this.editable = editable;
+      if (pressedActionIds != null) {
+        for (String actionId : pressedActionIds) {
+          this.pressedActionIds.add(actionId);
+        }
+      }
+    }
+  }
+
+  private final View view;
+  private final ActionDispatcher dispatcher;
+  private SelectedWaveState selectedWaveState =
+      new SelectedWaveState(false, false, false, false, false);
+  private EditState editState = new EditState(false);
+  private J2clSidecarWriteSession writeSession;
+  private J2clDailyToolbarAction errorAction;
+  private String errorText = "";
+  private boolean started;
+
+  public J2clToolbarSurfaceController(View view, ActionDispatcher dispatcher) {
+    this.view = view;
+    this.dispatcher = dispatcher;
+  }
+
+  public void start() {
+    if (started) {
+      return;
+    }
+    started = true;
+    view.bind(this::onActionRequested);
+    render();
+  }
+
+  public void onSelectedWaveStateChanged(SelectedWaveState state) {
+    selectedWaveState = state == null ? new SelectedWaveState(false, false, false, false, false) : state;
+    render();
+  }
+
+  public void onEditStateChanged(EditState state) {
+    editState = state == null ? new EditState(false) : state;
+    render();
+  }
+
+  public void onWriteSessionChanged(J2clSidecarWriteSession writeSession) {
+    this.writeSession = writeSession;
+    if (writeSession != null && errorAction != null && errorAction.isEditAction()) {
+      errorAction = null;
+      errorText = "";
+    }
+    render();
+  }
+
+  public void onActionRequested(String actionId) {
+    J2clDailyToolbarAction action = J2clDailyToolbarAction.fromId(actionId);
+    if (action == null) {
+      return;
+    }
+    errorAction = null;
+    errorText = "";
+    if (action.isEditAction() && writeSession == null) {
+      errorAction = action;
+      errorText = "Open a current wave before using edit toolbar actions.";
+      render();
+      return;
+    }
+    if (dispatcher != null) {
+      dispatcher.dispatch(action);
+    }
+    render();
+  }
+
+  public void onActionUnavailable(J2clDailyToolbarAction action, String message) {
+    if (action == null) {
+      return;
+    }
+    errorAction = action;
+    errorText = message == null || message.isEmpty() ? "Toolbar action is not available." : message;
+    render();
+  }
+
+  private void render() {
+    if (!started) {
+      return;
+    }
+    List<J2clToolbarSurfaceModel.ActionModel> actions =
+        new ArrayList<J2clToolbarSurfaceModel.ActionModel>();
+    addViewActions(actions);
+    addEditActions(actions);
+    view.render(new J2clToolbarSurfaceModel(actions));
+  }
+
+  private void addViewActions(List<J2clToolbarSurfaceModel.ActionModel> actions) {
+    add(actions, J2clDailyToolbarAction.RECENT, !selectedWaveState.selectedWavePresent, false);
+    add(actions, J2clDailyToolbarAction.NEXT_UNREAD, !selectedWaveState.selectedWavePresent, false);
+    add(actions, J2clDailyToolbarAction.PREVIOUS, !selectedWaveState.selectedWavePresent, false);
+    add(actions, J2clDailyToolbarAction.NEXT, !selectedWaveState.selectedWavePresent, false);
+    add(actions, J2clDailyToolbarAction.LAST, !selectedWaveState.selectedWavePresent, false);
+    add(
+        actions,
+        J2clDailyToolbarAction.PREVIOUS_MENTION,
+        !selectedWaveState.selectedWavePresent || !selectedWaveState.mentionOrderAvailable,
+        false);
+    add(
+        actions,
+        J2clDailyToolbarAction.NEXT_MENTION,
+        !selectedWaveState.selectedWavePresent || !selectedWaveState.mentionOrderAvailable,
+        false);
+    if (selectedWaveState.folderStateAvailable) {
+      add(
+          actions,
+          selectedWaveState.archived ? J2clDailyToolbarAction.INBOX : J2clDailyToolbarAction.ARCHIVE,
+          !selectedWaveState.selectedWavePresent,
+          false);
+      add(
+          actions,
+          selectedWaveState.pinned ? J2clDailyToolbarAction.UNPIN : J2clDailyToolbarAction.PIN,
+          !selectedWaveState.selectedWavePresent,
+          selectedWaveState.pinned);
+    }
+    add(
+        actions,
+        J2clDailyToolbarAction.HISTORY,
+        !selectedWaveState.selectedWavePresent || !selectedWaveState.historyVisible,
+        false);
+  }
+
+  private void addEditActions(List<J2clToolbarSurfaceModel.ActionModel> actions) {
+    addEdit(actions, J2clDailyToolbarAction.BOLD);
+    addEdit(actions, J2clDailyToolbarAction.ITALIC);
+    addEdit(actions, J2clDailyToolbarAction.UNDERLINE);
+    addEdit(actions, J2clDailyToolbarAction.STRIKETHROUGH);
+    addEdit(actions, J2clDailyToolbarAction.HEADING);
+    addEdit(actions, J2clDailyToolbarAction.UNORDERED_LIST);
+    addEdit(actions, J2clDailyToolbarAction.ORDERED_LIST);
+    addEdit(actions, J2clDailyToolbarAction.ALIGN_LEFT);
+    addEdit(actions, J2clDailyToolbarAction.ALIGN_CENTER);
+    addEdit(actions, J2clDailyToolbarAction.ALIGN_RIGHT);
+    addEdit(actions, J2clDailyToolbarAction.RTL);
+    addEdit(actions, J2clDailyToolbarAction.LINK);
+    addEdit(actions, J2clDailyToolbarAction.UNLINK);
+    addEdit(actions, J2clDailyToolbarAction.CLEAR_FORMATTING);
+  }
+
+  private void addEdit(
+      List<J2clToolbarSurfaceModel.ActionModel> actions, J2clDailyToolbarAction action) {
+    add(actions, action, !editState.editable, editState.pressedActionIds.contains(action.id()));
+  }
+
+  private void add(
+      List<J2clToolbarSurfaceModel.ActionModel> actions,
+      J2clDailyToolbarAction action,
+      boolean disabled,
+      boolean pressed) {
+    actions.add(
+        new J2clToolbarSurfaceModel.ActionModel(
+            action,
+            disabled,
+            pressed,
+            errorAction == action ? errorText : ""));
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
@@ -72,7 +72,7 @@ public final class J2clToolbarSurfaceController {
   private final View view;
   private final ActionDispatcher dispatcher;
   private SelectedWaveState selectedWaveState =
-      new SelectedWaveState(false, false, false, false, false);
+      new SelectedWaveState(false, false, false, false, false, false);
   private EditState editState = new EditState(false);
   private J2clSidecarWriteSession writeSession;
   private J2clDailyToolbarAction errorAction;
@@ -94,7 +94,8 @@ public final class J2clToolbarSurfaceController {
   }
 
   public void onSelectedWaveStateChanged(SelectedWaveState state) {
-    selectedWaveState = state == null ? new SelectedWaveState(false, false, false, false, false) : state;
+    selectedWaveState =
+        state == null ? new SelectedWaveState(false, false, false, false, false, false) : state;
     render();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceModel.java
@@ -1,0 +1,93 @@
+package org.waveprotocol.box.j2cl.toolbar;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clToolbarSurfaceModel {
+  public static final class ActionModel {
+    private final J2clDailyToolbarAction action;
+    private final boolean disabled;
+    private final boolean pressed;
+    private final String errorText;
+
+    public ActionModel(
+        J2clDailyToolbarAction action,
+        boolean disabled,
+        boolean pressed,
+        String errorText) {
+      this.action = action;
+      this.disabled = disabled;
+      this.pressed = pressed;
+      this.errorText = errorText == null ? "" : errorText;
+    }
+
+    public J2clDailyToolbarAction getAction() {
+      return action;
+    }
+
+    public String getActionId() {
+      return action.id();
+    }
+
+    public String getLabel() {
+      return action.label();
+    }
+
+    public String getGroupLabel() {
+      return action.groupLabel();
+    }
+
+    public boolean isDisabled() {
+      return disabled;
+    }
+
+    public boolean isPressed() {
+      return pressed;
+    }
+
+    public boolean isBusy() {
+      return false;
+    }
+
+    public boolean isToggle() {
+      return action.isToggle();
+    }
+
+    public String getErrorText() {
+      return errorText;
+    }
+  }
+
+  private final List<ActionModel> actions;
+
+  public J2clToolbarSurfaceModel(List<ActionModel> actions) {
+    this.actions = Collections.unmodifiableList(new ArrayList<ActionModel>(actions));
+  }
+
+  public List<ActionModel> getActions() {
+    return actions;
+  }
+
+  public boolean hasAction(J2clDailyToolbarAction action) {
+    return action(action) != null;
+  }
+
+  public boolean hasActionId(String actionId) {
+    for (ActionModel model : actions) {
+      if (model.getActionId().equals(actionId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public ActionModel action(J2clDailyToolbarAction action) {
+    for (ActionModel model : actions) {
+      if (model.getAction() == action) {
+        return model;
+      }
+    }
+    return null;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java
@@ -1,0 +1,139 @@
+package org.waveprotocol.box.j2cl.toolbar;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLElement;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import jsinterop.base.Js;
+
+public final class J2clToolbarSurfaceView implements J2clToolbarSurfaceController.View {
+  private final HTMLElement host;
+  private final Map<String, HTMLElement> groupsByLabel = new HashMap<String, HTMLElement>();
+  private final Map<String, HTMLElement> buttonsByAction = new HashMap<String, HTMLElement>();
+  private final Map<String, HTMLElement> errorsByAction = new HashMap<String, HTMLElement>();
+  private J2clToolbarSurfaceController.Listener listener;
+
+  public J2clToolbarSurfaceView(HTMLElement host) {
+    this.host = host;
+    host.addEventListener("toolbar-action", this::onToolbarAction);
+  }
+
+  @Override
+  public void bind(J2clToolbarSurfaceController.Listener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void render(J2clToolbarSurfaceModel model) {
+    Set<String> seenGroups = new HashSet<String>();
+    Set<String> seenActions = new HashSet<String>();
+    String currentGroup = "";
+    HTMLElement group = null;
+    for (J2clToolbarSurfaceModel.ActionModel action : model.getActions()) {
+      if (!action.getGroupLabel().equals(currentGroup)) {
+        currentGroup = action.getGroupLabel();
+        group = ensureGroup(currentGroup);
+        seenGroups.add(currentGroup);
+      }
+      HTMLElement button = ensureButton(action.getActionId());
+      setProperty(button, "action", action.getActionId());
+      setProperty(button, "label", action.getLabel());
+      setProperty(button, "toggle", action.isToggle());
+      setProperty(button, "pressed", action.isPressed());
+      setProperty(button, "disabled", action.isDisabled());
+      if (button.parentElement != group) {
+        group.appendChild(button);
+      }
+      seenActions.add(action.getActionId());
+      if (!action.getErrorText().isEmpty()) {
+        HTMLElement error = ensureError(action.getActionId());
+        error.textContent = action.getErrorText();
+        button.setAttribute("aria-describedby", error.id);
+        if (error.parentElement != group) {
+          group.appendChild(error);
+        }
+      } else {
+        button.removeAttribute("aria-describedby");
+        remove(errorsByAction.remove(action.getActionId()));
+      }
+    }
+    removeStaleActions(seenActions);
+    removeStaleGroups(seenGroups);
+  }
+
+  private void onToolbarAction(Event event) {
+    if (listener == null) {
+      return;
+    }
+    Object detail = Js.asPropertyMap(event).get("detail");
+    Object action = detail == null ? null : Js.asPropertyMap(detail).get("action");
+    if (action != null) {
+      listener.onActionRequested(String.valueOf(action));
+    }
+  }
+
+  private static void setProperty(HTMLElement element, String name, Object value) {
+    Js.asPropertyMap(element).set(name, value);
+  }
+
+  private HTMLElement ensureGroup(String groupLabel) {
+    HTMLElement group = groupsByLabel.get(groupLabel);
+    if (group == null) {
+      group = (HTMLElement) DomGlobal.document.createElement("toolbar-group");
+      group.setAttribute("label", groupLabel);
+      groupsByLabel.put(groupLabel, group);
+      host.appendChild(group);
+    }
+    return group;
+  }
+
+  private HTMLElement ensureButton(String actionId) {
+    HTMLElement button = buttonsByAction.get(actionId);
+    if (button == null) {
+      button = (HTMLElement) DomGlobal.document.createElement("toolbar-button");
+      buttonsByAction.put(actionId, button);
+    }
+    return button;
+  }
+
+  private HTMLElement ensureError(String actionId) {
+    HTMLElement error = errorsByAction.get(actionId);
+    if (error == null) {
+      error = (HTMLElement) DomGlobal.document.createElement("p");
+      error.id = "j2cl-toolbar-error-" + actionId;
+      error.className = "j2cl-toolbar-error";
+      error.setAttribute("role", "status");
+      error.setAttribute("aria-live", "polite");
+      errorsByAction.put(actionId, error);
+    }
+    return error;
+  }
+
+  private void removeStaleActions(Set<String> seenActions) {
+    Set<String> existing = new HashSet<String>(buttonsByAction.keySet());
+    for (String actionId : existing) {
+      if (!seenActions.contains(actionId)) {
+        remove(buttonsByAction.remove(actionId));
+        remove(errorsByAction.remove(actionId));
+      }
+    }
+  }
+
+  private void removeStaleGroups(Set<String> seenGroups) {
+    Set<String> existing = new HashSet<String>(groupsByLabel.keySet());
+    for (String groupLabel : existing) {
+      if (!seenGroups.contains(groupLabel)) {
+        remove(groupsByLabel.remove(groupLabel));
+      }
+    }
+  }
+
+  private static void remove(HTMLElement element) {
+    if (element != null && element.parentElement != null) {
+      element.parentElement.removeChild(element);
+    }
+  }
+}

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -6,7 +6,7 @@
   <title>SupaWave J2CL Sidecar Sandbox</title>
   <link rel="stylesheet" href="./assets/sidecar.css">
   <script type="module" src="./assets/shell.js"></script>
-  <script src="./sidecar/j2cl-sidecar.js"></script>
+  <script defer src="./sidecar/j2cl-sidecar.js"></script>
 </head>
 <body>
   <main class="sidecar-shell">

--- a/j2cl/src/main/webapp/index.html
+++ b/j2cl/src/main/webapp/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SupaWave J2CL Sidecar Sandbox</title>
   <link rel="stylesheet" href="./assets/sidecar.css">
+  <script type="module" src="./assets/shell.js"></script>
   <script src="./sidecar/j2cl-sidecar.js"></script>
 </head>
 <body>

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -120,6 +120,25 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void signedOutMidFlightCreateAbandonsPendingCallback() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    List<String> created = new ArrayList<String>();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), created, new ArrayList<String>());
+
+    controller.start();
+    controller.onCreateSubmitted("Hello");
+    controller.onSignedOut();
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals(0, gateway.submitCalls);
+    Assert.assertTrue(created.isEmpty());
+    Assert.assertFalse(view.model.isCreateEnabled());
+  }
+
+  @Test
   public void signedOutStateDisablesComposeWithoutFetchingBootstrap() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -1,0 +1,234 @@
+package org.waveprotocol.box.j2cl.compose;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+@J2clTestInput(J2clComposeSurfaceControllerTest.class)
+public class J2clComposeSurfaceControllerTest {
+  @Test
+  public void initialModelEnablesCreateAndKeepsReplyUnavailableUntilWriteSession() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(gateway, view, new FakeFactory(), waveId -> { }, waveId -> { });
+
+    controller.start();
+
+    Assert.assertTrue(view.model.isCreateEnabled());
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
+  }
+
+  @Test
+  public void writeSessionEnablesReplyAndPublishesTargetLabel() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+
+    Assert.assertTrue(view.model.isReplyAvailable());
+    Assert.assertEquals("b+root", view.model.getReplyTargetLabel());
+  }
+
+  @Test
+  public void sameWaveBasisRefreshPreservesDraftAndSurfacesStaleSubmitState() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    Assert.assertEquals(
+        "Selection changed before submit completed. Review the draft and retry.",
+        view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  @Test
+  public void differentWaveSelectionClearsReplyDraft() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplyDraftChanged("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+  }
+
+  @Test
+  public void bootstrapFailurePreservesDraftAndSurfacesRootSubmitError() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.bootstrapError = "bootstrap unavailable";
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertEquals("bootstrap unavailable", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void successfulReplyClearsDraftAndRefreshesThroughHandoff() {
+    FakeGateway gateway = new FakeGateway();
+    FakeFactory factory = new FakeFactory();
+    FakeView view = new FakeView();
+    List<String> refreshed = new ArrayList<String>();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, factory, new ArrayList<String>(), refreshed);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertEquals(Arrays.asList("example.com/w+1"), refreshed);
+    Assert.assertEquals("Reply", factory.lastReplyText);
+  }
+
+  @Test
+  public void signedOutStateDisablesComposeWithoutFetchingBootstrap() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onSignedOut();
+    controller.onCreateSubmitted("Hello");
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertFalse(view.model.isCreateEnabled());
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("Sign in to create or reply in the J2CL root shell.", view.model.getCreateStatusText());
+    Assert.assertEquals(0, gateway.fetchBootstrapCalls);
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  private static J2clComposeSurfaceController newController(
+      FakeGateway gateway,
+      FakeView view,
+      FakeFactory factory,
+      List<String> created,
+      List<String> refreshed) {
+    return new J2clComposeSurfaceController(
+        gateway, view, factory, created::add, refreshed::add);
+  }
+
+  private static final class FakeGateway implements J2clComposeSurfaceController.Gateway {
+    private int fetchBootstrapCalls;
+    private int submitCalls;
+    private boolean autoResolveBootstrap = true;
+    private String bootstrapError;
+    private SidecarSubmitResponse submitResponse = new SidecarSubmitResponse(1, "", 45L);
+    private J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> pendingBootstrapSuccess;
+    private J2clSearchPanelController.ErrorCallback pendingBootstrapError;
+
+    @Override
+    public void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      fetchBootstrapCalls++;
+      if (bootstrapError != null) {
+        onError.accept(bootstrapError);
+        return;
+      }
+      if (autoResolveBootstrap) {
+        onSuccess.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+        return;
+      }
+      pendingBootstrapSuccess = onSuccess;
+      pendingBootstrapError = onError;
+    }
+
+    @Override
+    public void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      submitCalls++;
+      onSuccess.accept(submitResponse);
+    }
+
+    private void resolveBootstrap() {
+      if (pendingBootstrapSuccess == null) {
+        throw new IllegalStateException("No pending bootstrap to resolve");
+      }
+      J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> success =
+          pendingBootstrapSuccess;
+      pendingBootstrapSuccess = null;
+      pendingBootstrapError = null;
+      success.accept(new SidecarSessionBootstrap("user@example.com", "socket.example.test"));
+    }
+  }
+
+  private static final class FakeView implements J2clComposeSurfaceController.View {
+    private J2clComposeSurfaceModel model;
+
+    @Override
+    public void bind(J2clComposeSurfaceController.Listener listener) {
+    }
+
+    @Override
+    public void render(J2clComposeSurfaceModel model) {
+      this.model = model;
+    }
+  }
+
+  private static final class FakeFactory extends J2clPlainTextDeltaFactory {
+    private String lastReplyText;
+
+    private FakeFactory() {
+      super("seed");
+    }
+
+    @Override
+    public CreateWaveRequest createWaveRequest(String address, String text) {
+      return new CreateWaveRequest(
+          "example.com/w+new",
+          new SidecarSubmitRequest("example.com/w+new/~/conv+root", "{\"create\":true}", null));
+    }
+
+    @Override
+    public SidecarSubmitRequest createReplyRequest(
+        String address, J2clSidecarWriteSession session, String text) {
+      lastReplyText = text;
+      return new SidecarSubmitRequest(
+          session.getSelectedWaveId() + "/~/conv+root", "{\"reply\":true}", session.getChannelId());
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -95,6 +95,9 @@ public class J2clComposeSurfaceControllerTest {
 
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("", view.model.getReplyTargetLabel());
+    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
     Assert.assertEquals(0, gateway.fetchBootstrapCalls);
   }
@@ -112,6 +115,9 @@ public class J2clComposeSurfaceControllerTest {
 
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("", view.model.getReplyTargetLabel());
+    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
     Assert.assertEquals(0, gateway.fetchBootstrapCalls);
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -91,13 +91,17 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(new J2clSidecarWriteSession(null, "chan-1", 44L, "ABCD", "b+root"));
+
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("", view.model.getReplyTargetLabel());
+    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
     controller.onReplySubmitted("Draft");
 
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertFalse(view.model.isReplySubmitting());
     Assert.assertFalse(view.model.isReplyAvailable());
     Assert.assertEquals("", view.model.getReplyTargetLabel());
-    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
+    Assert.assertEquals("", view.model.getReplyStatusText());
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
     Assert.assertEquals(0, gateway.fetchBootstrapCalls);
   }
@@ -111,13 +115,17 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(new J2clSidecarWriteSession("", "chan-1", 44L, "ABCD", "b+root"));
+
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertEquals("", view.model.getReplyTargetLabel());
+    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
     controller.onReplySubmitted("Draft");
 
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertFalse(view.model.isReplySubmitting());
     Assert.assertFalse(view.model.isReplyAvailable());
     Assert.assertEquals("", view.model.getReplyTargetLabel());
-    Assert.assertEquals("Open a wave before replying.", view.model.getReplyStatusText());
+    Assert.assertEquals("", view.model.getReplyStatusText());
     Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
     Assert.assertEquals(0, gateway.fetchBootstrapCalls);
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -62,8 +62,7 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertTrue(view.model.isReplyStaleBasis());
     Assert.assertEquals(
-        "Selection changed before submit completed. Review the draft and retry.",
-        view.model.getReplyErrorText());
+        J2clComposeSurfaceController.STALE_REPLY_MESSAGE, view.model.getReplyErrorText());
     Assert.assertEquals(0, gateway.submitCalls);
   }
 
@@ -84,6 +83,40 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void missingSelectedWaveRejectsReplyWithoutFetchingBootstrap() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(new J2clSidecarWriteSession(null, "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.fetchBootstrapCalls);
+  }
+
+  @Test
+  public void emptySelectedWaveRejectsReplyWithoutFetchingBootstrap() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(new J2clSidecarWriteSession("", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals("Open a wave before sending a reply.", view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.fetchBootstrapCalls);
+  }
+
+  @Test
   public void differentWaveSelectionDuringStaleSubmitPreservesDraft() {
     FakeGateway gateway = new FakeGateway();
     gateway.autoResolveBootstrap = false;
@@ -100,6 +133,297 @@ public class J2clComposeSurfaceControllerTest {
 
     Assert.assertEquals("Draft", view.model.getReplyDraft());
     Assert.assertTrue(view.model.isReplyStaleBasis());
+  }
+
+  @Test
+  public void laterDifferentWaveSelectionAfterStaleSubmitClearsDraft() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+3", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+  }
+
+  @Test
+  public void nullWriteSessionAfterStaleSubmitPreservesDraftUntilDifferentWaveReconnect() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(null);
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void nullWriteSessionAfterStaleSubmitPreservesDraftThroughSameWaveReconnect() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(null);
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.STALE_REPLY_MESSAGE, view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void sameWaveRefreshesAfterStaleSubmitKeepDraftAndErrorUntilRetry() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.STALE_REPLY_MESSAGE, view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void editingStaleDraftThenNavigatingToDifferentWaveClearsEditedDraft() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onReplyDraftChanged("Edited draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+3", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void returningToOriginalWaveAfterStaleDifferentWaveKeepsDraftForReview() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    Assert.assertEquals(J2clComposeSurfaceController.STALE_REPLY_MESSAGE, view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void staleDraftRetrySuccessClearsStaleState() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeFactory factory = new FakeFactory();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, factory, new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    gateway.autoResolveBootstrap = true;
+    controller.onReplyDraftChanged("Edited draft");
+    controller.onReplySubmitted("Edited draft");
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+    Assert.assertEquals("Edited draft", factory.lastReplyText);
+  }
+
+  @Test
+  public void retryInvalidatedByAnotherSessionChangeReparksStaleDraft() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onReplyDraftChanged("Retry draft");
+    controller.onReplySubmitted("Retry draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("Retry draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.STALE_REPLY_MESSAGE, view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  @Test
+  public void staleDraftRetryFailureClearsStaleStateAndKeepsDraftEditable() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    gateway.submitResponse = new SidecarSubmitResponse(1, "server rejected", 45L);
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    gateway.autoResolveBootstrap = true;
+    controller.onReplyDraftChanged("Edited draft");
+    controller.onReplySubmitted("Edited draft");
+
+    Assert.assertEquals("Edited draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("server rejected", view.model.getReplyErrorText());
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+  }
+
+  @Test
+  public void staleDraftRetryBootstrapFailureClearsStaleStateAndKeepsDraftEditable() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    gateway.bootstrapError = "bootstrap unavailable";
+    controller.onReplyDraftChanged("Edited draft");
+    controller.onReplySubmitted("Edited draft");
+
+    Assert.assertEquals("Edited draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("bootstrap unavailable", view.model.getReplyErrorText());
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  @Test
+  public void sameWaveRefreshAfterEditingStaleDraftKeepsDraftWithoutStaleBanner() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onReplyDraftChanged("Edited draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-3", 46L, "CDEF", "b+root"));
+
+    Assert.assertEquals("Edited draft", view.model.getReplyDraft());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void signOutWhileReplyStaleClearsStaleMarkersAndError() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+    controller.onSignedOut();
+
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+    Assert.assertEquals(
+        "Sign in to create or reply in the J2CL root shell.", view.model.getReplyStatusText());
   }
 
   @Test
@@ -155,6 +479,30 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals(0, gateway.submitCalls);
     Assert.assertTrue(created.isEmpty());
     Assert.assertFalse(view.model.isCreateEnabled());
+  }
+
+  @Test
+  public void signedOutMidFlightReplyAbandonsPendingCallbackAndClearsStaleState() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    List<String> refreshed = new ArrayList<String>();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), refreshed);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onSignedOut();
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals(0, gateway.submitCalls);
+    Assert.assertTrue(refreshed.isEmpty());
+    Assert.assertFalse(view.model.isReplyAvailable());
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertFalse(view.model.isReplyStaleBasis());
+    Assert.assertEquals("", view.model.getReplyErrorText());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -496,6 +496,26 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void signOutAfterCreateFailureClearsCreateError() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitResponse = new SidecarSubmitResponse(1, "server rejected", 45L);
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onCreateSubmitted("Hello");
+
+    Assert.assertEquals("server rejected", view.model.getCreateErrorText());
+    Assert.assertEquals("", view.model.getCreateStatusText());
+    controller.onSignedOut();
+
+    Assert.assertFalse(view.model.isCreateEnabled());
+    Assert.assertEquals("", view.model.getCreateErrorText());
+    Assert.assertEquals("Sign in to create or reply in the J2CL root shell.", view.model.getCreateStatusText());
+  }
+
+  @Test
   public void signedOutMidFlightReplyAbandonsPendingCallbackAndClearsStaleState() {
     FakeGateway gateway = new FakeGateway();
     gateway.autoResolveBootstrap = false;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -84,6 +84,25 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void differentWaveSelectionDuringStaleSubmitPreservesDraft() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Draft");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("Draft", view.model.getReplyDraft());
+    Assert.assertTrue(view.model.isReplyStaleBasis());
+  }
+
+  @Test
   public void bootstrapFailurePreservesDraftAndSurfacesRootSubmitError() {
     FakeGateway gateway = new FakeGateway();
     gateway.bootstrapError = "bootstrap unavailable";

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java
@@ -1,0 +1,176 @@
+package org.waveprotocol.box.j2cl.toolbar;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+
+@J2clTestInput(J2clToolbarSurfaceControllerTest.class)
+public class J2clToolbarSurfaceControllerTest {
+  @Test
+  public void viewToolbarIncludesDailyNavigationAndFolderActions() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, false, false, true, false));
+
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.RECENT));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.NEXT_UNREAD));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.PREVIOUS));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.NEXT));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.LAST));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ARCHIVE));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.PIN));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.HISTORY));
+  }
+
+  @Test
+  public void mentionNavigationIsDisabledUntilMentionOrderExists() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, false, false, false, false));
+
+    Assert.assertTrue(view.model.action(J2clDailyToolbarAction.PREVIOUS_MENTION).isDisabled());
+    Assert.assertTrue(view.model.action(J2clDailyToolbarAction.NEXT_MENTION).isDisabled());
+  }
+
+  @Test
+  public void actionDispatchUsesCommandInterfaceWithoutLeavingStuckBusyState() {
+    FakeView view = new FakeView();
+    List<J2clDailyToolbarAction> dispatched = new ArrayList<J2clDailyToolbarAction>();
+    J2clToolbarSurfaceController controller =
+        new J2clToolbarSurfaceController(view, dispatched::add);
+
+    controller.start();
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, false, false, true, false));
+    controller.onActionRequested(J2clDailyToolbarAction.ARCHIVE.id());
+
+    Assert.assertEquals(1, dispatched.size());
+    Assert.assertEquals(J2clDailyToolbarAction.ARCHIVE, dispatched.get(0));
+    Assert.assertFalse(view.model.action(J2clDailyToolbarAction.ARCHIVE).isBusy());
+  }
+
+  @Test
+  public void archivePinActionsReflectKnownFolderStateAndAreOmittedWhenUnknown() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, true, true, true, false));
+
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.INBOX));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.ARCHIVE));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.UNPIN));
+    Assert.assertTrue(view.model.action(J2clDailyToolbarAction.UNPIN).isPressed());
+
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, false, false, true, false, false));
+
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.ARCHIVE));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.PIN));
+  }
+
+  @Test
+  public void editToolbarIncludesDailyFormattingControlsOnly() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onEditStateChanged(new J2clToolbarSurfaceController.EditState(true, "bold", "rtl"));
+
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ITALIC));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.UNDERLINE));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.STRIKETHROUGH));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.HEADING));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.UNORDERED_LIST));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ORDERED_LIST));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ALIGN_LEFT));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ALIGN_CENTER));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.ALIGN_RIGHT));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.RTL));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.LINK));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.UNLINK));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.CLEAR_FORMATTING));
+    Assert.assertTrue(view.model.action(J2clDailyToolbarAction.BOLD).isPressed());
+    Assert.assertTrue(view.model.action(J2clDailyToolbarAction.RTL).isPressed());
+    Assert.assertFalse(view.model.hasActionId("attachment-upload"));
+    Assert.assertFalse(view.model.hasActionId("task-overlay"));
+    Assert.assertFalse(view.model.hasActionId("reaction-picker"));
+    Assert.assertFalse(view.model.hasActionId("mention-autocomplete"));
+  }
+
+  @Test
+  public void editActionWithoutWriteSessionSurfacesExplicitError() {
+    FakeView view = new FakeView();
+    List<J2clDailyToolbarAction> dispatched = new ArrayList<J2clDailyToolbarAction>();
+    J2clToolbarSurfaceController controller =
+        new J2clToolbarSurfaceController(view, dispatched::add);
+
+    controller.start();
+    controller.onEditStateChanged(new J2clToolbarSurfaceController.EditState(true));
+    controller.onActionRequested(J2clDailyToolbarAction.BOLD.id());
+
+    Assert.assertTrue(dispatched.isEmpty());
+    Assert.assertEquals(
+        "Open a current wave before using edit toolbar actions.",
+        view.model.action(J2clDailyToolbarAction.BOLD).getErrorText());
+
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan", 1L, "HASH", "b+root"));
+
+    Assert.assertEquals("", view.model.action(J2clDailyToolbarAction.BOLD).getErrorText());
+  }
+
+  @Test
+  public void editActionWithWriteBasisDispatchesWithoutLegacyGwtClasses() {
+    FakeView view = new FakeView();
+    List<J2clDailyToolbarAction> dispatched = new ArrayList<J2clDailyToolbarAction>();
+    J2clToolbarSurfaceController controller =
+        new J2clToolbarSurfaceController(view, dispatched::add);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan", 1L, "HASH", "b+root"));
+    controller.onEditStateChanged(new J2clToolbarSurfaceController.EditState(true));
+    controller.onActionRequested(J2clDailyToolbarAction.BOLD.id());
+
+    Assert.assertEquals(1, dispatched.size());
+    Assert.assertEquals(J2clDailyToolbarAction.BOLD, dispatched.get(0));
+  }
+
+  @Test
+  public void unavailableActionSurfacesExplicitErrorText() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onSelectedWaveStateChanged(
+        new J2clToolbarSurfaceController.SelectedWaveState(true, false, false, true, false));
+    controller.onActionUnavailable(J2clDailyToolbarAction.HISTORY, "Not wired yet.");
+
+    Assert.assertEquals("Not wired yet.", view.model.action(J2clDailyToolbarAction.HISTORY).getErrorText());
+  }
+
+  private static final class FakeView implements J2clToolbarSurfaceController.View {
+    private J2clToolbarSurfaceModel model;
+
+    @Override
+    public void bind(J2clToolbarSurfaceController.Listener listener) {
+    }
+
+    @Override
+    public void render(J2clToolbarSurfaceModel model) {
+      this.model = model;
+    }
+  }
+}

--- a/journal/local-verification/2026-04-24-issue-969-stage-three-compose.md
+++ b/journal/local-verification/2026-04-24-issue-969-stage-three-compose.md
@@ -1,0 +1,57 @@
+# Local Verification: Issue #969 StageThree Compose / Toolbar
+
+Worktree: `/Users/vega/devroot/worktrees/issue-969-stage-three-compose`
+Branch: `issue-969-stage-three-compose`
+Plan: `docs/superpowers/plans/2026-04-23-issue-969-stage-three-compose.md`
+
+## Phase 0 Revalidation
+
+- `gh repo view --json nameWithOwner` => `vega113/supawave`
+- `gh issue view 966 --repo vega113/supawave --json state,title,closedAt` => `CLOSED`, closed `2026-04-23T21:59:37Z`
+- `gh issue view 967 --repo vega113/supawave --json state,title,closedAt` => `CLOSED`, closed `2026-04-24T03:49:15Z`
+- `gh issue view 968 --repo vega113/supawave --json state,title,closedAt` => `CLOSED`, closed `2026-04-24T06:34:42Z`
+- `git fetch origin main && git merge-base --is-ancestor origin/main HEAD` => exit 0
+- Handoff drift found and documented in plan Section 4.1 plus issue comment: root-live owns route/status selected-wave-id publication, while `J2clSelectedWaveController` still owns bootstrap/reconnect/write-session publication.
+
+## Verification Commands
+
+Results below are filled in after implementation verification runs.
+
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => PASS; assembled 236 entries and validation passed.
+- `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` => PASS; 106 tests, 0 failures, 0 errors.
+- `cd j2cl/lit && npm test -- --runInBand` => PASS; 15 test files, 28 tests, 0 failures.
+- `sbt -batch j2clSearchBuild j2clSearchTest` => PASS; `j2clSearchBuild` completed in 14s and `j2clSearchTest` completed in 1s.
+- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave` => PASS; linked `_accounts`, `_attachments`, and `_deltas` into this worktree.
+- `PORT=9900 bash scripts/wave-smoke.sh start` => FAIL; initial staged config still bound Jetty to `127.0.0.1:9898`, so the script's `localhost:9900` readiness probe timed out.
+- `bash scripts/worktree-boot.sh --port 9900` => PASS; regenerated `journal/runtime-config/issue-969-stage-three-compose-port-9900.application.conf` and restaged assets. During this run the J2CL disk-cache background thread logged a `ClosedWatchServiceException` after the build had completed; the command exited 0.
+- `PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-969-stage-three-compose/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-969-stage-three-compose/wave/config/jaas.config' bash scripts/wave-smoke.sh start` => PARTIAL; script reported `PROBE_HTTP=200`, `READY`, and resolved PID on port 9900, but the server process exited before a subsequent `PORT=9900 bash scripts/wave-smoke.sh check` could connect.
+- Short-window HTTP sanity while the server was ready: `GET /` => 200 with `webclient/webclient.nocache.js`; `GET /?view=j2cl-root` => 200 with `data-j2cl-root-shell`. Full interactive browser assertions could not be completed because the local smoke server did not remain running after readiness.
+- `git diff --check` => PASS.
+- Post-format focused rerun: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest test` => PASS; 13 tests, 0 failures, 0 errors.
+
+## Post-Claude-Review Fix Verification
+
+- Claude Opus implementation review round 2 completed with blockers in `/tmp/issue-969-implementation-claude-round2.out`.
+- After fixes: `git diff --check` => PASS.
+- After fixes: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` => PASS; 107 tests, 0 failures, 0 errors.
+- After fixes: `cd j2cl/lit && npm test -- --runInBand` => PASS; 15 test files, 28 tests, 0 failures.
+- Claude Opus implementation review round 3 completed in `/tmp/issue-969-implementation-claude-round3.out`; previous blockers were resolved, with remaining UX concerns around edit enablement and silent no-op toolbar clicks.
+- Final UX fixes made edit enablement follow write-session availability and added explicit unbound-action error text for toolbar clicks.
+- Final verification: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` => PASS; 108 tests, 0 failures, 0 errors.
+- Final verification: `cd j2cl/lit && npm test -- --runInBand` => PASS; 15 test files, 28 tests, 0 failures.
+- Final verification: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => PASS; assembled 236 entries and validation passed.
+- Final verification: `sbt -batch j2clSearchBuild j2clSearchTest` => PASS; `j2clSearchBuild` completed in 17s and `j2clSearchTest` completed in 2s.
+- Claude Opus final focused review completed in `/tmp/issue-969-implementation-claude-round4.out`; no blockers reported.
+- Final cleanup removed dead toolbar busy state, avoided clearing the selected-wave compose host at startup, added a folder-state TODO, and associated toolbar error text with live status semantics.
+- Final-final verification: `git diff --check` => PASS.
+- Final-final verification: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` => PASS; 108 tests, 0 failures, 0 errors.
+- Final-final verification: `cd j2cl/lit && npm test -- --runInBand` => PASS; 15 test files, 28 tests, 0 failures.
+- Final-final verification: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => PASS; assembled 236 entries and validation passed.
+- Final-final verification: `sbt -batch j2clSearchBuild j2clSearchTest` => PASS; `j2clSearchBuild` completed in 10s and `j2clSearchTest` completed in 1s.
+- Claude Opus final diff sanity review completed in `/tmp/issue-969-implementation-claude-round5.out`; no blockers reported.
+- Post-round-5 tidy-up removed the remaining dead toolbar busy storage, added root-shell start idempotence, avoided duplicate reply live-region announcements, and removed the redundant create-form submit path.
+- Post-round-5 verification: `git diff --check` => PASS.
+- Post-round-5 verification: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest,org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceControllerTest,org.waveprotocol.box.j2cl.search.J2clSidecarComposeControllerTest,org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveControllerTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` => PASS; 108 tests, 0 failures, 0 errors.
+- Post-round-5 verification: `cd j2cl/lit && npm test -- --runInBand` => PASS; 15 test files, 28 tests, 0 failures.
+- Post-round-5 verification: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => PASS; assembled 236 entries and validation passed.
+- Post-round-5 verification: `sbt -batch j2clSearchBuild j2clSearchTest` => PASS; `j2clSearchBuild` completed in 8s and `j2clSearchTest` completed in 1s.

--- a/wave/config/changelog.d/2026-04-24-issue-969-stage-three-compose.json
+++ b/wave/config/changelog.d/2026-04-24-issue-969-stage-three-compose.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-24-issue-969-stage-three-compose",
+  "version": "Issue #969",
+  "date": "2026-04-24",
+  "title": "J2CL root shell gains practical compose and daily toolbar parity",
+  "summary": "The opt-in J2CL root shell now exposes Lit-backed compose/reply controls and daily view/edit toolbar actions on top of the current selected-wave write-session seam.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added Lit compose primitives that show create, reply, submit, disabled, error, and stale-basis states in the J2CL root shell",
+        "Added J2CL compose state management that consumes the selected-wave write-session listener without introducing a parallel bootstrap or reconnect lifecycle",
+        "Added daily view and edit toolbar primitives and controller command seams while leaving mention autocomplete, task overlays, reactions, and attachments to their follow-up issues"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Lit compose and toolbar primitives for the J2CL root shell.
- Adds J2CL compose and daily toolbar surface controllers/models/views.
- Wires the new surfaces through the root shell while preserving the existing sidecar compose path.

Closes #969.

## Verification
- `git diff --check` PASS.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` PASS.
- Focused J2CL Maven tests PASS: 108 tests.
- `cd j2cl/lit && npm test -- --runInBand` PASS: 28 tests.
- `sbt -batch j2clSearchBuild j2clSearchTest` PASS.
- Claude Opus implementation review loop reached no-blocker status in round 5.

## Browser Smoke Caveat
- `scripts/worktree-boot.sh --port 9900` reached readiness and short-window HTTP checks returned `GET /` 200 and `GET /?view=j2cl-root` 200 with `data-j2cl-root-shell`.
- Full interactive browser assertions were not completed because the local smoke server exited after readiness before the follow-up `wave-smoke.sh check` could connect.
- This limitation is recorded in `journal/local-verification/2026-04-24-issue-969-stage-three-compose.md` and issue #969.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lit-backed compose UI: create form, inline reply, submit affordance with status/error messaging, keyboard/ARIA accessibility, and a daily toolbar with grouped actions, overflow menu, toggles, and keyboard navigation.
  * Draft/stale-submit handling preserving drafts across reconnects and surfacing retry/error states; toolbar surfaces show explicit no-op/error text for unavailable edit actions.
* **Documentation**
  * Added implementation plan, verification journal, and changelog entry for compose/toolbar parity.
* **Tests**
  * New unit and component tests covering compose surfaces and toolbar behaviors.
* **Chores**
  * Updated client bootstrap to include the new shell entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->