### PR TITLE
feat(j2cl): refine interaction overlay models

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-970-interaction-overlays.md
+++ b/docs/superpowers/plans/2026-04-23-issue-970-interaction-overlays.md
@@ -450,15 +450,27 @@ Exit criteria:
 
 ### Slice 2 - Add Overlay Models And Projection
 
-- [ ] Create the pure overlay model classes under `j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/`.
-- [ ] Add `interactionBlips()` to `J2clSelectedWaveModel`.
-- [ ] Project mention ranges, task items, and reaction summaries in `J2clSelectedWaveProjector`.
-- [ ] Keep `contentEntries()` behavior intact for current read UI compatibility.
-- [ ] Add null/empty-state tests for waves without overlays.
+- [x] Create the pure overlay model classes under `j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/`.
+- [x] Add `interactionBlips()` to `J2clSelectedWaveModel`.
+- [x] Project mention ranges, task items, and reaction summaries in `J2clSelectedWaveProjector`.
+- [x] Keep `contentEntries()` behavior intact for current read UI compatibility.
+- [x] Add null/empty-state tests for waves without overlays.
 
 Exit criteria:
 
 - Selected-wave model can represent a blip with text, mentions, task metadata, and reaction summaries without requiring Lit.
+
+Implementation evidence (2026-04-24):
+
+- RED: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test`
+  failed first with missing overlay model classes and accessors.
+- GREEN: targeted overlay/projector verification passed after implementation:
+  `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.overlay.J2clOverlayModelTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test`
+  passed with 51 tests, 0 failures, 0 errors, 0 skipped.
+- Formatting gate: `git diff --check` exited 0.
+- Scope note: task `checked` remains `false` until a later slice safely exposes
+  checkbox element state; current decoded metadata covers id, assignee, and due
+  timestamp only.
 
 ### Slice 3 - Add Lit Overlay Primitives
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -62,7 +62,7 @@ public final class J2clInteractionBlipModel {
             ? Collections.<SidecarReactionEntry>emptyList()
             : Collections.unmodifiableList(new ArrayList<SidecarReactionEntry>(reactionEntries));
     this.mentionRanges = refineMentionRanges(this.text, this.annotationRanges);
-    this.taskItems = refineTaskItems(this.blipId, this.annotationRanges);
+    this.taskItems = refineTaskItems(this.blipId, this.annotationRanges, this.editable);
     this.reactionSummaries = refineReactionSummaries(this.reactionEntries);
   }
 
@@ -131,7 +131,7 @@ public final class J2clInteractionBlipModel {
   }
 
   private static List<J2clTaskItemModel> refineTaskItems(
-      String blipId, List<SidecarAnnotationRange> annotationRanges) {
+      String blipId, List<SidecarAnnotationRange> annotationRanges, boolean editable) {
     if (annotationRanges == null || annotationRanges.isEmpty()) {
       return Collections.emptyList();
     }
@@ -152,7 +152,7 @@ public final class J2clInteractionBlipModel {
               findTaskValue(annotationRanges, "task/assignee", taskIdRange),
               parseLong(findTaskValue(annotationRanges, "task/dueTs", taskIdRange)),
               false,
-              true));
+              editable));
     }
     return Collections.unmodifiableList(tasks);
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -8,17 +8,51 @@ import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 
 public final class J2clInteractionBlipModel {
   private final String blipId;
+  private final String documentId;
+  private final String author;
   private final String text;
+  private final List<String> participantContext;
+  private final boolean editable;
   private final List<SidecarAnnotationRange> annotationRanges;
   private final List<SidecarReactionEntry> reactionEntries;
+  private final List<J2clMentionRange> mentionRanges;
+  private final List<J2clTaskItemModel> taskItems;
+  private final List<J2clReactionSummary> reactionSummaries;
 
   public J2clInteractionBlipModel(
       String blipId,
       String text,
       List<SidecarAnnotationRange> annotationRanges,
       List<SidecarReactionEntry> reactionEntries) {
+    this(
+        blipId,
+        blipId,
+        "",
+        text,
+        Collections.<String>emptyList(),
+        false,
+        annotationRanges,
+        reactionEntries);
+  }
+
+  public J2clInteractionBlipModel(
+      String blipId,
+      String documentId,
+      String author,
+      String text,
+      List<String> participantContext,
+      boolean editable,
+      List<SidecarAnnotationRange> annotationRanges,
+      List<SidecarReactionEntry> reactionEntries) {
     this.blipId = blipId == null ? "" : blipId;
+    this.documentId = documentId == null ? this.blipId : documentId;
+    this.author = author == null ? "" : author;
     this.text = text == null ? "" : text;
+    this.participantContext =
+        participantContext == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(participantContext));
+    this.editable = editable;
     this.annotationRanges =
         annotationRanges == null
             ? Collections.<SidecarAnnotationRange>emptyList()
@@ -27,14 +61,33 @@ public final class J2clInteractionBlipModel {
         reactionEntries == null
             ? Collections.<SidecarReactionEntry>emptyList()
             : Collections.unmodifiableList(new ArrayList<SidecarReactionEntry>(reactionEntries));
+    this.mentionRanges = refineMentionRanges(this.text, this.annotationRanges);
+    this.taskItems = refineTaskItems(this.blipId, this.annotationRanges);
+    this.reactionSummaries = refineReactionSummaries(this.reactionEntries);
   }
 
   public String getBlipId() {
     return blipId;
   }
 
+  public String getDocumentId() {
+    return documentId;
+  }
+
+  public String getAuthor() {
+    return author;
+  }
+
   public String getText() {
     return text;
+  }
+
+  public List<String> getParticipantContext() {
+    return participantContext;
+  }
+
+  public boolean isEditable() {
+    return editable;
   }
 
   public List<SidecarAnnotationRange> getAnnotationRanges() {
@@ -43,5 +96,121 @@ public final class J2clInteractionBlipModel {
 
   public List<SidecarReactionEntry> getReactionEntries() {
     return reactionEntries;
+  }
+
+  public List<J2clMentionRange> getMentionRanges() {
+    return mentionRanges;
+  }
+
+  public List<J2clTaskItemModel> getTaskItems() {
+    return taskItems;
+  }
+
+  public List<J2clReactionSummary> getReactionSummaries() {
+    return reactionSummaries;
+  }
+
+  private static List<J2clMentionRange> refineMentionRanges(
+      String text, List<SidecarAnnotationRange> annotationRanges) {
+    if (annotationRanges == null || annotationRanges.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clMentionRange> mentions = new ArrayList<J2clMentionRange>();
+    for (SidecarAnnotationRange range : annotationRanges) {
+      if (range == null || !range.isMention()) {
+        continue;
+      }
+      mentions.add(
+          new J2clMentionRange(
+              range.getStartOffset(),
+              range.getEndOffset(),
+              range.getValue(),
+              sliceText(text, range.getStartOffset(), range.getEndOffset())));
+    }
+    return Collections.unmodifiableList(mentions);
+  }
+
+  private static List<J2clTaskItemModel> refineTaskItems(
+      String blipId, List<SidecarAnnotationRange> annotationRanges) {
+    if (annotationRanges == null || annotationRanges.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clTaskItemModel> tasks = new ArrayList<J2clTaskItemModel>();
+    for (SidecarAnnotationRange taskIdRange : annotationRanges) {
+      if (taskIdRange == null || !"task/id".equals(taskIdRange.getKey())) {
+        continue;
+      }
+      String taskId = safe(taskIdRange.getValue());
+      if (taskId.isEmpty()) {
+        continue;
+      }
+      tasks.add(
+          new J2clTaskItemModel(
+              taskId,
+              taskIdRange.getStartOffset(),
+              "task-" + safe(blipId) + "-" + safe(taskId),
+              findTaskValue(annotationRanges, "task/assignee", taskIdRange),
+              parseLong(findTaskValue(annotationRanges, "task/dueTs", taskIdRange)),
+              false,
+              true));
+    }
+    return Collections.unmodifiableList(tasks);
+  }
+
+  private static List<J2clReactionSummary> refineReactionSummaries(
+      List<SidecarReactionEntry> reactionEntries) {
+    if (reactionEntries == null || reactionEntries.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clReactionSummary> summaries = new ArrayList<J2clReactionSummary>();
+    for (SidecarReactionEntry entry : reactionEntries) {
+      String emoji = entry == null ? "" : safe(entry.getEmoji());
+      if (emoji.isEmpty()) {
+        continue;
+      }
+      // Slice 2 has no signed-in-user context; controllers will fill this later.
+      summaries.add(
+          new J2clReactionSummary(emoji, entry.getAddresses(), false, ""));
+    }
+    return Collections.unmodifiableList(summaries);
+  }
+
+  private static String findTaskValue(
+      List<SidecarAnnotationRange> annotationRanges, String key, SidecarAnnotationRange taskIdRange) {
+    // GWT task metadata annotations share the same range as task/id; keep that contract explicit.
+    // Empty string signals that no matching sibling metadata annotation exists.
+    for (SidecarAnnotationRange range : annotationRanges) {
+      if (range == null || !key.equals(range.getKey())) {
+        continue;
+      }
+      if (range.getStartOffset() == taskIdRange.getStartOffset()
+          && range.getEndOffset() == taskIdRange.getEndOffset()) {
+        return safe(range.getValue());
+      }
+    }
+    return "";
+  }
+
+  private static String sliceText(String text, int startOffset, int endOffset) {
+    String value = text == null ? "" : text;
+    int start = Math.max(0, Math.min(startOffset, value.length()));
+    int end = Math.max(start, Math.min(endOffset, value.length()));
+    return value.substring(start, end);
+  }
+
+  private static long parseLong(String value) {
+    // Missing or non-numeric task/dueTs values intentionally stay unknown.
+    if (value == null || value.isEmpty()) {
+      return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    }
+  }
+
+  private static String safe(String value) {
+    return value == null ? "" : value;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clMentionCandidate.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clMentionCandidate.java
@@ -1,0 +1,42 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+public final class J2clMentionCandidate {
+  private final String address;
+  private final String displayName;
+  private final String avatarToken;
+  private final String sortKey;
+  private final boolean currentUser;
+
+  public J2clMentionCandidate(
+      String address,
+      String displayName,
+      String avatarToken,
+      String sortKey,
+      boolean currentUser) {
+    this.address = address == null ? "" : address;
+    this.displayName = displayName == null || displayName.isEmpty() ? this.address : displayName;
+    this.avatarToken = avatarToken == null ? "" : avatarToken;
+    this.sortKey = sortKey == null || sortKey.isEmpty() ? this.displayName : sortKey;
+    this.currentUser = currentUser;
+  }
+
+  public String getAddress() {
+    return address;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public String getAvatarToken() {
+    return avatarToken;
+  }
+
+  public String getSortKey() {
+    return sortKey;
+  }
+
+  public boolean isCurrentUser() {
+    return currentUser;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clMentionRange.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clMentionRange.java
@@ -1,0 +1,32 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+public final class J2clMentionRange {
+  private final int startOffset;
+  private final int endOffset;
+  private final String userAddress;
+  private final String displayText;
+
+  public J2clMentionRange(
+      int startOffset, int endOffset, String userAddress, String displayText) {
+    this.startOffset = Math.max(0, startOffset);
+    this.endOffset = Math.max(this.startOffset, endOffset);
+    this.userAddress = userAddress == null ? "" : userAddress;
+    this.displayText = displayText == null ? "" : displayText;
+  }
+
+  public int getStartOffset() {
+    return startOffset;
+  }
+
+  public int getEndOffset() {
+    return endOffset;
+  }
+
+  public String getUserAddress() {
+    return userAddress;
+  }
+
+  public String getDisplayText() {
+    return displayText;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayFocusTarget.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayFocusTarget.java
@@ -1,0 +1,13 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+public final class J2clOverlayFocusTarget {
+  private final String targetId;
+
+  public J2clOverlayFocusTarget(String targetId) {
+    this.targetId = targetId == null ? "" : targetId;
+  }
+
+  public String getTargetId() {
+    return targetId;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clReactionSummary.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clReactionSummary.java
@@ -1,0 +1,53 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class J2clReactionSummary {
+  private final String emoji;
+  private final List<String> participantAddresses;
+  private final boolean activeForCurrentUser;
+  private final String inspectLabel;
+
+  public J2clReactionSummary(
+      String emoji,
+      List<String> participantAddresses,
+      boolean activeForCurrentUser,
+      String inspectLabel) {
+    this.emoji = emoji == null ? "" : emoji;
+    this.participantAddresses =
+        participantAddresses == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(participantAddresses));
+    this.activeForCurrentUser = activeForCurrentUser;
+    this.inspectLabel =
+        inspectLabel == null || inspectLabel.isEmpty()
+            ? buildInspectLabel(this.emoji, this.participantAddresses.size())
+            : inspectLabel;
+  }
+
+  public String getEmoji() {
+    return emoji;
+  }
+
+  public List<String> getParticipantAddresses() {
+    return participantAddresses;
+  }
+
+  public boolean isActiveForCurrentUser() {
+    return activeForCurrentUser;
+  }
+
+  public int getCount() {
+    return participantAddresses.size();
+  }
+
+  public String getInspectLabel() {
+    return inspectLabel;
+  }
+
+  private static String buildInspectLabel(String emoji, int count) {
+    return count + (count == 1 ? " reaction" : " reactions") + " for " + emoji + ".";
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clTaskItemModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clTaskItemModel.java
@@ -1,0 +1,58 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+public final class J2clTaskItemModel {
+  public static final long UNKNOWN_DUE_TIMESTAMP = -1L;
+
+  private final String taskId;
+  private final int textOffset;
+  private final String elementAnchorId;
+  private final String assigneeAddress;
+  private final long dueTimestamp;
+  private final boolean checked;
+  private final boolean editable;
+
+  public J2clTaskItemModel(
+      String taskId,
+      int textOffset,
+      String elementAnchorId,
+      String assigneeAddress,
+      long dueTimestamp,
+      boolean checked,
+      boolean editable) {
+    this.taskId = taskId == null ? "" : taskId;
+    this.textOffset = Math.max(0, textOffset);
+    this.elementAnchorId = elementAnchorId == null ? "" : elementAnchorId;
+    this.assigneeAddress = assigneeAddress == null ? "" : assigneeAddress;
+    this.dueTimestamp = dueTimestamp;
+    this.checked = checked;
+    this.editable = editable;
+  }
+
+  public String getTaskId() {
+    return taskId;
+  }
+
+  public int getTextOffset() {
+    return textOffset;
+  }
+
+  public String getElementAnchorId() {
+    return elementAnchorId;
+  }
+
+  public String getAssigneeAddress() {
+    return assigneeAddress;
+  }
+
+  public long getDueTimestamp() {
+    return dueTimestamp;
+  }
+
+  public boolean isChecked() {
+    return checked;
+  }
+
+  public boolean isEditable() {
+    return editable;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -79,12 +79,18 @@ public final class J2clSelectedWaveProjector {
         && !previous.getReadBlips().isEmpty()) {
       readBlips = previous.getReadBlips();
     }
+    J2clSidecarWriteSession writeSession = buildWriteSession(selectedWaveId, update, previous);
+    boolean interactionEditable = writeSession != null;
     List<J2clInteractionBlipModel> interactionBlips =
-        extractInteractionBlips(update.getDocuments(), participantIds);
+        extractInteractionBlips(update.getDocuments(), participantIds, interactionEditable);
     if (previousMatchesWave && previous != null && !previous.getInteractionBlips().isEmpty()) {
       interactionBlips =
           mergePreviousInteractionBlips(
-              interactionBlips, update.getDocuments(), previous.getInteractionBlips());
+              interactionBlips,
+              update.getDocuments(),
+              previous.getInteractionBlips(),
+              participantIds,
+              interactionEditable);
     }
 
     String detailText = buildDetailText(update);
@@ -134,7 +140,7 @@ public final class J2clSelectedWaveProjector {
         readBlips,
         viewportState,
         interactionBlips,
-        buildWriteSession(selectedWaveId, update, previous),
+        writeSession,
         unreadCount,
         read,
         readStateKnown,
@@ -356,7 +362,9 @@ public final class J2clSelectedWaveProjector {
   }
 
   private static List<J2clInteractionBlipModel> extractInteractionBlips(
-      List<SidecarSelectedWaveDocument> documents, List<String> participantIds) {
+      List<SidecarSelectedWaveDocument> documents,
+      List<String> participantIds,
+      boolean editable) {
     if (documents == null || documents.isEmpty()) {
       return Collections.emptyList();
     }
@@ -379,7 +387,7 @@ public final class J2clSelectedWaveProjector {
               document.getAuthor(),
               document.getTextContent(),
               participantIds,
-              true,
+              editable,
               document.getAnnotationRanges(),
               reactions == null ? Collections.<SidecarReactionEntry>emptyList() : reactions));
     }
@@ -389,7 +397,9 @@ public final class J2clSelectedWaveProjector {
   private static List<J2clInteractionBlipModel> mergePreviousInteractionBlips(
       List<J2clInteractionBlipModel> projectedBlips,
       List<SidecarSelectedWaveDocument> documents,
-      List<J2clInteractionBlipModel> previousBlips) {
+      List<J2clInteractionBlipModel> previousBlips,
+      List<String> participantIds,
+      boolean editable) {
     Map<String, List<SidecarReactionEntry>> reactionsByBlip = extractReactionsByBlip(documents);
     Map<String, J2clInteractionBlipModel> previousByBlip = indexInteractionBlips(previousBlips);
     List<J2clInteractionBlipModel> merged = new ArrayList<J2clInteractionBlipModel>();
@@ -408,8 +418,8 @@ public final class J2clSelectedWaveProjector {
               projected.getDocumentId(),
               projected.getAuthor(),
               projected.getText(),
-              projected.getParticipantContext(),
-              projected.isEditable(),
+              participantIds,
+              editable,
               projected.getAnnotationRanges(),
               reactions));
       seenBlipIds.add(projected.getBlipId());
@@ -428,8 +438,8 @@ public final class J2clSelectedWaveProjector {
               previous.getDocumentId(),
               previous.getAuthor(),
               previous.getText(),
-              previous.getParticipantContext(),
-              previous.isEditable(),
+              participantIds,
+              editable,
               previous.getAnnotationRanges(),
               reactions));
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -400,6 +400,8 @@ public final class J2clSelectedWaveProjector {
       List<J2clInteractionBlipModel> previousBlips,
       List<String> participantIds,
       boolean editable) {
+    // Rebuild carried-forward blips so read-only state and participant context follow the
+    // current selected-wave snapshot instead of stale per-blip state.
     Map<String, List<SidecarReactionEntry>> reactionsByBlip = extractReactionsByBlip(documents);
     Map<String, J2clInteractionBlipModel> previousByBlip = indexInteractionBlips(previousBlips);
     List<J2clInteractionBlipModel> merged = new ArrayList<J2clInteractionBlipModel>();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -80,7 +80,7 @@ public final class J2clSelectedWaveProjector {
       readBlips = previous.getReadBlips();
     }
     List<J2clInteractionBlipModel> interactionBlips =
-        extractInteractionBlips(update.getDocuments());
+        extractInteractionBlips(update.getDocuments(), participantIds);
     if (previousMatchesWave && previous != null && !previous.getInteractionBlips().isEmpty()) {
       interactionBlips =
           mergePreviousInteractionBlips(
@@ -356,7 +356,7 @@ public final class J2clSelectedWaveProjector {
   }
 
   private static List<J2clInteractionBlipModel> extractInteractionBlips(
-      List<SidecarSelectedWaveDocument> documents) {
+      List<SidecarSelectedWaveDocument> documents, List<String> participantIds) {
     if (documents == null || documents.isEmpty()) {
       return Collections.emptyList();
     }
@@ -375,7 +375,11 @@ public final class J2clSelectedWaveProjector {
       blips.add(
           new J2clInteractionBlipModel(
               documentId,
+              documentId,
+              document.getAuthor(),
               document.getTextContent(),
+              participantIds,
+              true,
               document.getAnnotationRanges(),
               reactions == null ? Collections.<SidecarReactionEntry>emptyList() : reactions));
     }
@@ -401,7 +405,11 @@ public final class J2clSelectedWaveProjector {
       merged.add(
           new J2clInteractionBlipModel(
               projected.getBlipId(),
+              projected.getDocumentId(),
+              projected.getAuthor(),
               projected.getText(),
+              projected.getParticipantContext(),
+              projected.isEditable(),
               projected.getAnnotationRanges(),
               reactions));
       seenBlipIds.add(projected.getBlipId());
@@ -417,7 +425,11 @@ public final class J2clSelectedWaveProjector {
       merged.add(
           new J2clInteractionBlipModel(
               previous.getBlipId(),
+              previous.getDocumentId(),
+              previous.getAuthor(),
               previous.getText(),
+              previous.getParticipantContext(),
+              previous.isEditable(),
               previous.getAnnotationRanges(),
               reactions));
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -415,15 +415,7 @@ public final class J2clSelectedWaveProjector {
         reactions = previous.getReactionEntries();
       }
       merged.add(
-          new J2clInteractionBlipModel(
-              projected.getBlipId(),
-              projected.getDocumentId(),
-              projected.getAuthor(),
-              projected.getText(),
-              participantIds,
-              editable,
-              projected.getAnnotationRanges(),
-              reactions));
+          rebuildInteractionBlip(projected, participantIds, editable, reactions));
       seenBlipIds.add(projected.getBlipId());
     }
     for (J2clInteractionBlipModel previous : previousBlips) {
@@ -435,17 +427,25 @@ public final class J2clSelectedWaveProjector {
               ? reactionsByBlip.get(previous.getBlipId())
               : previous.getReactionEntries();
       merged.add(
-          new J2clInteractionBlipModel(
-              previous.getBlipId(),
-              previous.getDocumentId(),
-              previous.getAuthor(),
-              previous.getText(),
-              participantIds,
-              editable,
-              previous.getAnnotationRanges(),
-              reactions));
+          rebuildInteractionBlip(previous, participantIds, editable, reactions));
     }
     return merged;
+  }
+
+  private static J2clInteractionBlipModel rebuildInteractionBlip(
+      J2clInteractionBlipModel source,
+      List<String> participantIds,
+      boolean editable,
+      List<SidecarReactionEntry> reactions) {
+    return new J2clInteractionBlipModel(
+        source.getBlipId(),
+        source.getDocumentId(),
+        source.getAuthor(),
+        source.getText(),
+        participantIds,
+        editable,
+        source.getAnnotationRanges(),
+        reactions);
   }
 
   private static Map<String, List<SidecarReactionEntry>> extractReactionsByBlip(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -133,6 +133,23 @@ public class J2clOverlayModelTest {
   }
 
   @Test
+  public void interactionBlipTaskItemsFollowBlipEditability() {
+    J2clInteractionBlipModel blip =
+        new J2clInteractionBlipModel(
+            "b+root",
+            "b+root",
+            "author@example.com",
+            "Review spec",
+            Arrays.asList("author@example.com"),
+            false,
+            Arrays.asList(new SidecarAnnotationRange("task/id", "task-123", 0, 11)),
+            Collections.<SidecarReactionEntry>emptyList());
+
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    Assert.assertFalse(blip.getTaskItems().get(0).isEditable());
+  }
+
+  @Test
   public void interactionBlipRefinedListsAreImmutable() {
     ArrayList<String> participantContext =
         new ArrayList<String>(Arrays.asList("alice@example.com"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -102,6 +102,15 @@ public class J2clOverlayModelTest {
   }
 
   @Test
+  public void reactionSummaryHandlesNullParticipants() {
+    J2clReactionSummary summary = new J2clReactionSummary("thumbs_up", null, false, null);
+
+    Assert.assertEquals(0, summary.getCount());
+    Assert.assertEquals(Collections.<String>emptyList(), summary.getParticipantAddresses());
+    Assert.assertEquals("0 reactions for thumbs_up.", summary.getInspectLabel());
+  }
+
+  @Test
   public void interactionBlipClampsMentionTextAndSkipsEmptyReactionEmoji() {
     J2clInteractionBlipModel blip =
         new J2clInteractionBlipModel(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -1,0 +1,193 @@
+package org.waveprotocol.box.j2cl.overlay;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
+import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
+
+@J2clTestInput(J2clOverlayModelTest.class)
+public class J2clOverlayModelTest {
+  @Test
+  public void mentionCandidateUsesAddressFallbacks() {
+    J2clMentionCandidate candidate =
+        new J2clMentionCandidate("alice@example.com", "", null, "", true);
+
+    Assert.assertEquals("alice@example.com", candidate.getAddress());
+    Assert.assertEquals("alice@example.com", candidate.getDisplayName());
+    Assert.assertEquals("", candidate.getAvatarToken());
+    Assert.assertEquals("alice@example.com", candidate.getSortKey());
+    Assert.assertTrue(candidate.isCurrentUser());
+  }
+
+  @Test
+  public void mentionCandidateNormalizesNullValues() {
+    J2clMentionCandidate candidate =
+        new J2clMentionCandidate(null, null, null, null, false);
+
+    Assert.assertEquals("", candidate.getAddress());
+    Assert.assertEquals("", candidate.getDisplayName());
+    Assert.assertEquals("", candidate.getAvatarToken());
+    Assert.assertEquals("", candidate.getSortKey());
+    Assert.assertFalse(candidate.isCurrentUser());
+  }
+
+  @Test
+  public void reactionSummaryDefensivelyCopiesParticipantAddresses() {
+    ArrayList<String> addresses =
+        new ArrayList<String>(Arrays.asList("alice@example.com", "bob@example.com"));
+
+    J2clReactionSummary summary = new J2clReactionSummary("tada", addresses, true, "");
+    addresses.add("carol@example.com");
+
+    Assert.assertEquals("tada", summary.getEmoji());
+    Assert.assertEquals(2, summary.getCount());
+    Assert.assertEquals(
+        Arrays.asList("alice@example.com", "bob@example.com"),
+        summary.getParticipantAddresses());
+    Assert.assertTrue(summary.isActiveForCurrentUser());
+    Assert.assertEquals("2 reactions for tada.", summary.getInspectLabel());
+    try {
+      summary.getParticipantAddresses().add("mallory@example.com");
+      Assert.fail("reaction participant addresses should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+  }
+
+  @Test
+  public void taskItemAndFocusTargetNormalizeNullValues() {
+    J2clTaskItemModel task =
+        new J2clTaskItemModel(null, -4, null, null, 123L, true, false);
+    J2clOverlayFocusTarget target = new J2clOverlayFocusTarget(null);
+
+    Assert.assertEquals("", task.getTaskId());
+    Assert.assertEquals(0, task.getTextOffset());
+    Assert.assertEquals("", task.getElementAnchorId());
+    Assert.assertEquals("", task.getAssigneeAddress());
+    Assert.assertEquals(123L, task.getDueTimestamp());
+    Assert.assertTrue(task.isChecked());
+    Assert.assertFalse(task.isEditable());
+    Assert.assertEquals("", target.getTargetId());
+  }
+
+  @Test
+  public void mentionRangeNormalizesOffsetsAndNullText() {
+    J2clMentionRange mention = new J2clMentionRange(-1, -2, null, null);
+
+    Assert.assertEquals(0, mention.getStartOffset());
+    Assert.assertEquals(0, mention.getEndOffset());
+    Assert.assertEquals("", mention.getUserAddress());
+    Assert.assertEquals("", mention.getDisplayText());
+  }
+
+  @Test
+  public void mentionRangeClampsEndOffsetToStartOffset() {
+    J2clMentionRange mention = new J2clMentionRange(7, 2, "alice@example.com", "@Alice");
+
+    Assert.assertEquals(7, mention.getStartOffset());
+    Assert.assertEquals(7, mention.getEndOffset());
+  }
+
+  @Test
+  public void reactionSummaryHandlesEmptyParticipants() {
+    J2clReactionSummary summary =
+        new J2clReactionSummary("thumbs_up", Collections.<String>emptyList(), false, null);
+
+    Assert.assertEquals(0, summary.getCount());
+    Assert.assertEquals("0 reactions for thumbs_up.", summary.getInspectLabel());
+  }
+
+  @Test
+  public void interactionBlipClampsMentionTextAndSkipsEmptyReactionEmoji() {
+    J2clInteractionBlipModel blip =
+        new J2clInteractionBlipModel(
+            "b+root",
+            "b+root",
+            "author@example.com",
+            "Hi @Al",
+            Arrays.asList("author@example.com"),
+            true,
+            Arrays.asList(
+                new SidecarAnnotationRange("mention/user", "alice@example.com", 3, 99),
+                new SidecarAnnotationRange("task/id", "task-123", 0, 2),
+                null),
+            Arrays.asList(
+                new SidecarReactionEntry("tada", Arrays.asList("alice@example.com")),
+                new SidecarReactionEntry("", Arrays.asList("bob@example.com")),
+                new SidecarReactionEntry(null, Arrays.asList("carol@example.com"))));
+
+    Assert.assertEquals("b+root", blip.getDocumentId());
+    Assert.assertEquals(1, blip.getMentionRanges().size());
+    Assert.assertEquals("@Al", blip.getMentionRanges().get(0).getDisplayText());
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    Assert.assertEquals("", blip.getTaskItems().get(0).getAssigneeAddress());
+    Assert.assertEquals(
+        J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+        blip.getTaskItems().get(0).getDueTimestamp());
+    Assert.assertEquals(1, blip.getReactionSummaries().size());
+    Assert.assertEquals("tada", blip.getReactionSummaries().get(0).getEmoji());
+  }
+
+  @Test
+  public void interactionBlipRefinedListsAreImmutable() {
+    ArrayList<String> participantContext =
+        new ArrayList<String>(Arrays.asList("alice@example.com"));
+    J2clInteractionBlipModel blip =
+        new J2clInteractionBlipModel(
+            "b+root",
+            "b+root",
+            "author@example.com",
+            "Root",
+            participantContext,
+            true,
+            Arrays.asList(new SidecarAnnotationRange("mention/user", "alice@example.com", 0, 4)),
+            Arrays.asList(new SidecarReactionEntry("tada", Arrays.asList("alice@example.com"))));
+    participantContext.add("mallory@example.com");
+
+    Assert.assertEquals(Arrays.asList("alice@example.com"), blip.getParticipantContext());
+    try {
+      blip.getParticipantContext().add("mallory@example.com");
+      Assert.fail("participant context should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+    try {
+      blip.getAnnotationRanges().add(
+          new SidecarAnnotationRange("mention/user", "mallory@example.com", 0, 1));
+      Assert.fail("raw annotation ranges should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+    try {
+      blip.getReactionEntries().add(
+          new SidecarReactionEntry("heart", Arrays.asList("mallory@example.com")));
+      Assert.fail("raw reaction entries should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+    try {
+      blip.getMentionRanges().add(new J2clMentionRange(0, 1, "x", "x"));
+      Assert.fail("mention ranges should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+    try {
+      blip.getTaskItems().add(
+          new J2clTaskItemModel("task-1", 0, "task-1", "", -1L, false, false));
+      Assert.fail("task items should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+    try {
+      blip.getReactionSummaries().add(
+          new J2clReactionSummary("heart", Arrays.asList("alice@example.com"), false, ""));
+      Assert.fail("reaction summaries should be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // Expected immutable-list contract.
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -339,6 +339,41 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectMarksInteractionBlipsReadOnlyWithoutWriteSession() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                "",
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Review spec",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "task-123", 0, 11)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    Assert.assertNull(projected.getWriteSession());
+    J2clInteractionBlipModel blip = projected.getInteractionBlips().get(0);
+    Assert.assertFalse(blip.isEditable());
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    Assert.assertFalse(blip.getTaskItems().get(0).isEditable());
+  }
+
+  @Test
   public void projectSkipsTaskItemsWithoutTaskId() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(
@@ -1727,6 +1762,67 @@ public class J2clSelectedWaveProjectorTest {
     SidecarSelectedWaveUpdate noHash = updateWithVersionAndHash(5L, null);
     Assert.assertNull(
         J2clSelectedWaveProjector.project(WAVE_ID, null, noHash, null, 0).getWriteSession());
+  }
+
+  @Test
+  public void projectRefreshesParticipantContextWhenCarryingForwardPreviousInteractionBlips() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("alice@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "author@example.com",
+                        7L,
+                        8L,
+                        "Root text")),
+                null),
+            null,
+            0);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                10L,
+                "HASH-2",
+                Arrays.asList("alice@example.com", "bob@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "react+b+root",
+                        "author@example.com",
+                        7L,
+                        8L,
+                        "",
+                        Collections.<SidecarAnnotationRange>emptyList(),
+                        Arrays.asList(
+                            new SidecarReactionEntry(
+                                "tada", Arrays.asList("alice@example.com"))))),
+                null),
+            first,
+            0);
+
+    Assert.assertEquals(1, second.getInteractionBlips().size());
+    J2clInteractionBlipModel blip = second.getInteractionBlips().get(0);
+    Assert.assertEquals(
+        Arrays.asList("alice@example.com", "bob@example.com"),
+        blip.getParticipantContext());
+    Assert.assertEquals(1, blip.getReactionEntries().size());
+    Assert.assertEquals("tada", blip.getReactionEntries().get(0).getEmoji());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -1784,7 +1784,10 @@ public class J2clSelectedWaveProjectorTest {
                         "author@example.com",
                         7L,
                         8L,
-                        "Root text")),
+                        "Root text",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "task-123", 0, 4)),
+                        Collections.<SidecarReactionEntry>emptyList())),
                 null),
             null,
             0);
@@ -1821,6 +1824,9 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals(
         Arrays.asList("alice@example.com", "bob@example.com"),
         blip.getParticipantContext());
+    Assert.assertTrue(blip.isEditable());
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    Assert.assertTrue(blip.getTaskItems().get(0).isEditable());
     Assert.assertEquals(1, blip.getReactionEntries().size());
     Assert.assertEquals("tada", blip.getReactionEntries().get(0).getEmoji());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -7,6 +7,9 @@ import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
+import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
+import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
@@ -252,6 +255,259 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("task/id", blip.getAnnotationRanges().get(1).getKey());
     Assert.assertEquals(1, blip.getReactionEntries().size());
     Assert.assertEquals("thumbs_up", blip.getReactionEntries().get(0).getEmoji());
+  }
+
+  @Test
+  public void projectRefinesMentionRangesFromMentionAnnotations() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Hi @Teammate",
+                        Arrays.asList(
+                            new SidecarAnnotationRange(
+                                "mention/user", "teammate@example.com", 3, 12)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    J2clInteractionBlipModel blip = projected.getInteractionBlips().get(0);
+    Assert.assertEquals(1, blip.getMentionRanges().size());
+    J2clMentionRange mention = blip.getMentionRanges().get(0);
+    Assert.assertEquals(3, mention.getStartOffset());
+    Assert.assertEquals(12, mention.getEndOffset());
+    Assert.assertEquals("teammate@example.com", mention.getUserAddress());
+    Assert.assertEquals("@Teammate", mention.getDisplayText());
+  }
+
+  @Test
+  public void projectRefinesTaskItemsFromTaskAnnotationsWithSharedRange() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Review spec",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "task-123", 0, 11),
+                            new SidecarAnnotationRange(
+                                "task/assignee", "alice@example.com", 0, 11),
+                            new SidecarAnnotationRange("task/dueTs", "1714000000000", 0, 11)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    J2clInteractionBlipModel blip = projected.getInteractionBlips().get(0);
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    J2clTaskItemModel task = blip.getTaskItems().get(0);
+    Assert.assertEquals("task-123", task.getTaskId());
+    Assert.assertEquals(0, task.getTextOffset());
+    Assert.assertEquals("task-b+root-task-123", task.getElementAnchorId());
+    Assert.assertEquals("alice@example.com", task.getAssigneeAddress());
+    Assert.assertEquals(1714000000000L, task.getDueTimestamp());
+    Assert.assertFalse(task.isChecked());
+    Assert.assertTrue(task.isEditable());
+  }
+
+  @Test
+  public void projectSkipsTaskItemsWithoutTaskId() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Review spec",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "", 0, 11),
+                            new SidecarAnnotationRange(
+                                "task/assignee", "alice@example.com", 0, 11)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    Assert.assertTrue(projected.getInteractionBlips().get(0).getTaskItems().isEmpty());
+  }
+
+  @Test
+  public void projectRequiresTaskMetadataAnnotationsToShareTaskIdRange() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Review spec",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "task-123", 0, 11),
+                            new SidecarAnnotationRange(
+                                "task/assignee", "alice@example.com", 0, 6)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    J2clTaskItemModel task = projected.getInteractionBlips().get(0).getTaskItems().get(0);
+    Assert.assertEquals("", task.getAssigneeAddress());
+  }
+
+  @Test
+  public void projectUsesUnknownDueTimestampForInvalidTaskDueAnnotation() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "Review spec",
+                        Arrays.asList(
+                            new SidecarAnnotationRange("task/id", "task-123", 0, 11),
+                            new SidecarAnnotationRange("task/dueTs", "tomorrow", 0, 11)),
+                        Collections.<SidecarReactionEntry>emptyList())),
+                null),
+            null,
+            0);
+
+    J2clTaskItemModel task = projected.getInteractionBlips().get(0).getTaskItems().get(0);
+    Assert.assertEquals(J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP, task.getDueTimestamp());
+  }
+
+  @Test
+  public void projectRefinesReactionSummariesFromReactionDataDocuments() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, "Root text"),
+                    new SidecarSelectedWaveDocument(
+                        "react+b+root",
+                        "user@example.com",
+                        7L,
+                        8L,
+                        "",
+                        Collections.<SidecarAnnotationRange>emptyList(),
+                        Arrays.asList(
+                            new SidecarReactionEntry(
+                                "tada",
+                                Arrays.asList("alice@example.com", "bob@example.com"))))),
+                null),
+            null,
+            0);
+
+    J2clInteractionBlipModel blip = projected.getInteractionBlips().get(0);
+    Assert.assertEquals(1, blip.getReactionSummaries().size());
+    J2clReactionSummary reaction = blip.getReactionSummaries().get(0);
+    Assert.assertEquals("tada", reaction.getEmoji());
+    Assert.assertEquals(2, reaction.getCount());
+    Assert.assertEquals("alice@example.com", reaction.getParticipantAddresses().get(0));
+    Assert.assertEquals("bob@example.com", reaction.getParticipantAddresses().get(1));
+    Assert.assertFalse(reaction.isActiveForCurrentUser());
+    Assert.assertEquals("2 reactions for tada.", reaction.getInspectLabel());
+  }
+
+  @Test
+  public void projectKeepsEmptyOverlayListsAndContentEntriesForPlainBlips() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, "Plain text")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getContentEntries().size());
+    Assert.assertEquals("Plain text", projected.getContentEntries().get(0));
+    J2clInteractionBlipModel blip = projected.getInteractionBlips().get(0);
+    Assert.assertTrue(blip.getMentionRanges().isEmpty());
+    Assert.assertTrue(blip.getTaskItems().isEmpty());
+    Assert.assertTrue(blip.getReactionSummaries().isEmpty());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-04-24-issue-970-overlay-models.json
+++ b/wave/config/changelog.d/2026-04-24-issue-970-overlay-models.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-issue-970-overlay-models",
+  "version": "Issue #970",
+  "date": "2026-04-24",
+  "title": "Refine J2CL interaction overlay models",
+  "summary": "The opt-in J2CL selected-wave pipeline now exposes pure mention, task, reaction, and focus-target models so the next Lit overlay slices can render parity features without depending on raw transport metadata.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added pure J2CL models for mention ranges, mention candidates, task metadata, reaction summaries, and overlay focus targets",
+        "Projected selected-wave interaction blips into refined mention, task, and reaction views while preserving the existing read surface data"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements issue #970 Slice 2 on top of the merged #1003 transport metadata work.

- Adds pure J2CL overlay DTOs for mention ranges, mention candidates, task items, reaction summaries, and focus targets.
- Refines `J2clInteractionBlipModel` so selected-wave interaction blips expose mention/task/reaction views while preserving the raw Slice 1 annotation/reaction accessors.
- Threads participant context, document id, author, and editability through `J2clSelectedWaveProjector` without changing `contentEntries()` or `readBlips()` behavior.
- Updates the #970 implementation plan and adds a changelog fragment.

## Verification

- `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest,org.waveprotocol.box.j2cl.overlay.J2clOverlayModelTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest test` passed: 91 tests, 0 failures, 0 errors, 0 skipped.
- `git diff --check origin/main..HEAD` passed.
- `sbt -batch j2clSearchBuild j2clSearchTest` passed.
- `python3 scripts/assemble-changelog.py` and `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` passed.

## Review

- Self-review addressed DTO coverage, null task id handling, and immutable-list coverage.
- Claude Opus review loop ran through round 5; final result: no blockers or required follow-ups.

Closes part of #970 under parent #904/#960. This does not close #970 because later Lit/controller/integration slices remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refined interaction overlays: mentions, task items, reaction summaries, and overlay focus targets with normalized/defensive data and editability awareness.
  * Mention candidates include display/sort fallbacks; mention ranges normalize offsets and text.
  * Task items surface assignee and due-date metadata with UNKNOWN due handling; editability depends on write-session presence.
  * Reaction summaries expose participant lists, counts, inspect labels, and active-for-current-user flags; lists are immutable.

* **Tests**
  * Comprehensive tests for model normalization, immutability, projection rules, and editability.

* **Documentation**
  * Added changelog entry for the overlay models release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->