### PR TITLE
Add J2CL Lit interaction overlay primitives

### DIFF
--- a/j2cl/lit/src/elements/interaction-overlay-layer.js
+++ b/j2cl/lit/src/elements/interaction-overlay-layer.js
@@ -1,0 +1,143 @@
+import { LitElement, css, html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+export class InteractionOverlayLayer extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    modal: { type: Boolean, reflect: true },
+    label: { type: String },
+    focusTargetId: { type: String, attribute: "focus-target-id" }
+  };
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+
+    [part="surface"] {
+      position: relative;
+      z-index: var(--shell-z-overlay-menu, 20);
+      box-sizing: border-box;
+      max-width: min(92vw, 420px);
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 16px;
+      padding: 12px;
+      background: var(--shell-color-surface-overlay, #fff);
+      box-shadow: var(--shell-shadow-overlay, 0 16px 44px rgb(10 38 64 / 18%));
+      color: var(--shell-color-text-primary, #181c1d);
+    }
+
+    :host([modal]) [part="surface"] {
+      z-index: var(--shell-z-overlay-modal, 40);
+      box-shadow: var(--shell-shadow-modal, 0 22px 70px rgb(10 38 64 / 24%));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.modal = false;
+    this.label = "";
+    this.focusTargetId = "";
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  updated(changed) {
+    if (changed.has("open") && this.open && this.modal) {
+      queueMicrotask(() => this.renderRoot.querySelector("[part='surface']")?.focus());
+    }
+  }
+
+  render() {
+    if (!this.open) {
+      return "";
+    }
+    return html`
+      <div
+        part="surface"
+        role=${this.modal ? "dialog" : "group"}
+        tabindex="-1"
+        aria-modal=${ifDefined(this.modal ? "true" : undefined)}
+        aria-label=${this.label || "Interaction overlay"}
+      >
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close("escape");
+      return;
+    }
+    if (this.modal && event.key === "Tab") {
+      this.trapFocus(event);
+    }
+  };
+
+  close(reason) {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("overlay-close", {
+        detail: { reason, focusTargetId: this.focusTargetId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  trapFocus(event) {
+    const controls = this.focusableControls();
+    if (controls.length === 0) {
+      return;
+    }
+    const active = this.renderRoot.activeElement || this.getRootNode().activeElement;
+    const currentIndex = controls.indexOf(active);
+    if (currentIndex === -1) {
+      event.preventDefault();
+      controls[event.shiftKey ? controls.length - 1 : 0].focus();
+      return;
+    }
+    if (event.shiftKey && currentIndex === 0) {
+      event.preventDefault();
+      controls[controls.length - 1].focus();
+      return;
+    }
+    if (!event.shiftKey && currentIndex === controls.length - 1) {
+      event.preventDefault();
+      controls[0].focus();
+    }
+  }
+
+  focusableControls() {
+    const slot = this.renderRoot.querySelector("slot");
+    const assigned = slot?.assignedElements({ flatten: true }) || [];
+    const controls = [];
+    for (const element of assigned) {
+      if (this.isFocusable(element)) {
+        controls.push(element);
+      }
+      controls.push(...Array.from(element.querySelectorAll(this.focusableSelector())));
+    }
+    const contentControls = controls.filter(Boolean).filter(element => !element.disabled);
+    return contentControls.length > 0
+      ? contentControls
+      : [this.renderRoot.querySelector("[part='surface']")].filter(Boolean);
+  }
+
+  isFocusable(element) {
+    return element.matches?.(this.focusableSelector());
+  }
+
+  focusableSelector() {
+    return "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])";
+  }
+}
+
+if (!customElements.get("interaction-overlay-layer")) {
+  customElements.define("interaction-overlay-layer", InteractionOverlayLayer);
+}

--- a/j2cl/lit/src/elements/interaction-overlay-layer.js
+++ b/j2cl/lit/src/elements/interaction-overlay-layer.js
@@ -95,7 +95,10 @@ export class InteractionOverlayLayer extends LitElement {
     if (controls.length === 0) {
       return;
     }
-    const active = this.renderRoot.activeElement || this.getRootNode().activeElement;
+    const active =
+      event.composedPath?.()[0] ||
+      this.renderRoot.activeElement ||
+      this.getRootNode().activeElement;
     const currentIndex = controls.indexOf(active);
     if (currentIndex === -1) {
       event.preventDefault();
@@ -118,15 +121,32 @@ export class InteractionOverlayLayer extends LitElement {
     const assigned = slot?.assignedElements({ flatten: true }) || [];
     const controls = [];
     for (const element of assigned) {
-      if (this.isFocusable(element)) {
-        controls.push(element);
-      }
-      controls.push(...Array.from(element.querySelectorAll(this.focusableSelector())));
+      this.collectFocusableControls(element, controls);
     }
     const contentControls = controls.filter(Boolean).filter(element => !element.disabled);
     return contentControls.length > 0
       ? contentControls
       : [this.renderRoot.querySelector("[part='surface']")].filter(Boolean);
+  }
+
+  collectFocusableControls(root, controls) {
+    if (!root) {
+      return;
+    }
+    if (this.isFocusable(root)) {
+      controls.push(root);
+    }
+    for (const element of Array.from(root.querySelectorAll?.("*") || [])) {
+      if (this.isFocusable(element)) {
+        controls.push(element);
+      }
+      if (element.shadowRoot) {
+        this.collectFocusableControls(element.shadowRoot, controls);
+      }
+    }
+    if (root.shadowRoot) {
+      this.collectFocusableControls(root.shadowRoot, controls);
+    }
   }
 
   isFocusable(element) {

--- a/j2cl/lit/src/elements/interaction-overlay-layer.js
+++ b/j2cl/lit/src/elements/interaction-overlay-layer.js
@@ -70,6 +70,9 @@ export class InteractionOverlayLayer extends LitElement {
       return;
     }
     if (event.key === "Escape") {
+      if (event.defaultPrevented) {
+        return;
+      }
       event.preventDefault();
       this.close("escape");
       return;

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -123,7 +123,7 @@ export class MentionSuggestionPopover extends LitElement {
       this.activeIndex = this.clampedIndex(this.activeIndex + offset);
       return;
     }
-    if (event.key === "Enter") {
+    if (event.key === "Enter" && this.safeCandidates().length > 0) {
       event.preventDefault();
       this.selectCandidate(this.clampedIndex(this.activeIndex));
       return;

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -176,7 +176,12 @@ export class MentionSuggestionPopover extends LitElement {
   }
 
   safeCandidates() {
-    return Array.isArray(this.candidates) ? this.candidates : [];
+    if (!Array.isArray(this.candidates)) {
+      return [];
+    }
+    return this.candidates.filter(
+      candidate => candidate && typeof candidate === "object" && !Array.isArray(candidate)
+    );
   }
 
   liveText(count) {

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -1,0 +1,185 @@
+import { LitElement, css, html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+let mentionPopoverCounter = 0;
+
+export class MentionSuggestionPopover extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    candidates: { type: Array },
+    activeIndex: { type: Number, attribute: "active-index" },
+    focusTargetId: { type: String, attribute: "focus-target-id" }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .popover {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 14px;
+      padding: 8px;
+      background: var(--shell-color-surface-overlay, #fff);
+      box-shadow: var(--shell-shadow-overlay, 0 16px 44px rgb(10 38 64 / 18%));
+    }
+
+    [role="option"] {
+      display: block;
+      width: 100%;
+      border: 0;
+      border-radius: 10px;
+      padding: 8px 10px;
+      background: transparent;
+      text-align: left;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    [aria-selected="true"] {
+      background: var(--shell-color-accent-selection, #e4f1fb);
+      box-shadow: inset 3px 0 0 var(--shell-color-accent-focus, #206ea6);
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.candidates = [];
+    this.activeIndex = 0;
+    this.focusTargetId = "";
+    this.optionIdPrefix = `mention-option-${++mentionPopoverCounter}`;
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  render() {
+    if (!this.open) {
+      return "";
+    }
+    const candidates = this.safeCandidates();
+    const activeIndex = this.clampedIndex(this.activeIndex, candidates);
+    const activeId = candidates.length > 0 ? this.optionId(activeIndex) : "";
+    return html`
+      <div class="popover">
+        <div
+          role="listbox"
+          aria-label="Mention suggestions"
+          aria-activedescendant=${ifDefined(activeId || undefined)}
+        >
+          ${candidates.length === 0
+            ? html`<p>No mention matches</p>`
+            : candidates.map((candidate, index) =>
+                this.renderCandidate(candidate, index, activeIndex)
+              )}
+        </div>
+        <span class="sr-only" aria-live="polite">${this.liveText(candidates.length)}</span>
+      </div>
+    `;
+  }
+
+  renderCandidate(candidate, index, activeIndex) {
+    const active = index === activeIndex;
+    return html`
+      <div
+        id=${this.optionId(index)}
+        role="option"
+        tabindex="-1"
+        aria-selected=${active ? "true" : "false"}
+        data-address=${candidate.address || ""}
+        @click=${() => this.selectCandidate(index)}
+      >
+        ${candidate.displayName || candidate.address}
+      </div>
+    `;
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close("escape");
+      return;
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const offset = event.key === "ArrowDown" ? 1 : -1;
+      this.activeIndex = this.clampedIndex(this.activeIndex + offset);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      this.selectCandidate(this.clampedIndex(this.activeIndex));
+      return;
+    }
+    if (event.key === "Tab" && this.safeCandidates().length > 0) {
+      event.preventDefault();
+      this.selectCandidate(this.clampedIndex(this.activeIndex));
+    }
+  };
+
+  selectCandidate(index) {
+    const candidates = this.safeCandidates();
+    const candidate = candidates[this.clampedIndex(index, candidates)];
+    if (!candidate) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("mention-select", {
+        detail: {
+          address: candidate.address || "",
+          displayName: candidate.displayName || candidate.address || ""
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  close(reason) {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("overlay-close", {
+        detail: { reason, focusTargetId: this.focusTargetId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  clampedIndex(index, candidates = this.safeCandidates()) {
+    const count = candidates.length;
+    if (count === 0) {
+      return 0;
+    }
+    return (index + count) % count;
+  }
+
+  optionId(index) {
+    return `${this.optionIdPrefix}-${index}`;
+  }
+
+  safeCandidates() {
+    return Array.isArray(this.candidates) ? this.candidates : [];
+  }
+
+  liveText(count) {
+    if (count === 0) {
+      return "No mention suggestions.";
+    }
+    return `${count} mention ${count === 1 ? "suggestion" : "suggestions"}.`;
+  }
+}
+
+if (!customElements.get("mention-suggestion-popover")) {
+  customElements.define("mention-suggestion-popover", MentionSuggestionPopover);
+}

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -168,7 +168,9 @@ export class MentionSuggestionPopover extends LitElement {
     if (count === 0) {
       return 0;
     }
-    return ((index % count) + count) % count;
+    const numericIndex = Number(index);
+    const finiteIndex = Number.isFinite(numericIndex) ? numericIndex : 0;
+    return ((finiteIndex % count) + count) % count;
   }
 
   optionId(index) {

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -181,9 +181,19 @@ export class MentionSuggestionPopover extends LitElement {
     if (!Array.isArray(this.candidates)) {
       return [];
     }
-    return this.candidates.filter(
-      candidate => candidate && typeof candidate === "object" && !Array.isArray(candidate)
-    );
+    return this.candidates
+      .filter(
+        candidate =>
+          candidate &&
+          typeof candidate === "object" &&
+          !Array.isArray(candidate) &&
+          typeof candidate.address === "string" &&
+          candidate.address.trim() !== ""
+      )
+      .map(candidate => ({
+        ...candidate,
+        address: candidate.address.trim()
+      }));
   }
 
   liveText(count) {

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -168,7 +168,7 @@ export class MentionSuggestionPopover extends LitElement {
     if (count === 0) {
       return 0;
     }
-    return (index + count) % count;
+    return ((index % count) + count) % count;
   }
 
   optionId(index) {

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -60,6 +60,12 @@ export class MentionSuggestionPopover extends LitElement {
     this.addEventListener("keydown", this.onKeyDown);
   }
 
+  updated(changed) {
+    if (changed.has("open") && this.open) {
+      queueMicrotask(() => this.renderRoot.querySelector("[role='listbox']")?.focus());
+    }
+  }
+
   render() {
     if (!this.open) {
       return "";
@@ -71,6 +77,7 @@ export class MentionSuggestionPopover extends LitElement {
       <div class="popover">
         <div
           role="listbox"
+          tabindex="-1"
           aria-label="Mention suggestions"
           aria-activedescendant=${ifDefined(activeId || undefined)}
         >

--- a/j2cl/lit/src/elements/reaction-authors-popover.js
+++ b/j2cl/lit/src/elements/reaction-authors-popover.js
@@ -40,7 +40,7 @@ export class ReactionAuthorsPopover extends LitElement {
       return "";
     }
     const authors = this.safeAuthors();
-    const label = this.reactionLabel || this.emoji;
+    const label = this.reactionLabel || this.emoji || "this reaction";
     return html`
       <section
         class="popover"

--- a/j2cl/lit/src/elements/reaction-authors-popover.js
+++ b/j2cl/lit/src/elements/reaction-authors-popover.js
@@ -1,0 +1,88 @@
+import { LitElement, css, html } from "lit";
+
+export class ReactionAuthorsPopover extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    emoji: { type: String },
+    reactionLabel: { type: String, attribute: "reaction-label" },
+    authors: { type: Array },
+    focusTargetId: { type: String, attribute: "focus-target-id" }
+  };
+
+  static styles = css`
+    .popover {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 14px;
+      padding: 10px 12px;
+      background: var(--shell-color-surface-overlay, #fff);
+      box-shadow: var(--shell-shadow-overlay, 0 16px 44px rgb(10 38 64 / 18%));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.emoji = "";
+    this.reactionLabel = "";
+    this.authors = [];
+    this.focusTargetId = "";
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  updated(changed) {
+    if (changed.has("open") && this.open) {
+      queueMicrotask(() => this.renderRoot.querySelector(".popover")?.focus());
+    }
+  }
+
+  render() {
+    if (!this.open) {
+      return "";
+    }
+    const authors = this.safeAuthors();
+    const label = this.reactionLabel || this.emoji;
+    return html`
+      <section
+        class="popover"
+        role="region"
+        tabindex="-1"
+        aria-label=${`Authors for ${label}`}
+      >
+        ${authors.length === 0
+          ? html`<p>No reactions yet</p>`
+          : html`
+              <ul>
+                ${authors.map(author => html`<li>${author}</li>`)}
+              </ul>
+            `}
+      </section>
+    `;
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open || event.key !== "Escape") {
+      return;
+    }
+    event.preventDefault();
+    this.close("escape");
+  };
+
+  close(reason) {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("overlay-close", {
+        detail: { reason, focusTargetId: this.focusTargetId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  safeAuthors() {
+    return Array.isArray(this.authors) ? this.authors : [];
+  }
+}
+
+if (!customElements.get("reaction-authors-popover")) {
+  customElements.define("reaction-authors-popover", ReactionAuthorsPopover);
+}

--- a/j2cl/lit/src/elements/reaction-picker-popover.js
+++ b/j2cl/lit/src/elements/reaction-picker-popover.js
@@ -1,0 +1,175 @@
+import { LitElement, css, html } from "lit";
+
+let activePicker = null;
+
+export class ReactionPickerPopover extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    blipId: { type: String, attribute: "blip-id" },
+    emojis: { type: Array },
+    focusTargetId: { type: String, attribute: "focus-target-id" }
+  };
+
+  static styles = css`
+    .picker {
+      display: flex;
+      gap: 6px;
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 14px;
+      padding: 8px;
+      background: var(--shell-color-surface-overlay, #fff);
+      box-shadow: var(--shell-shadow-overlay, 0 16px 44px rgb(10 38 64 / 18%));
+    }
+
+    button {
+      border: 0;
+      border-radius: 10px;
+      padding: 8px;
+      background: transparent;
+      font: inherit;
+    }
+
+    button:focus {
+      outline: 2px solid var(--shell-color-accent-focus, #206ea6);
+      outline-offset: 2px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.blipId = "";
+    this.emojis = [];
+    this.focusTargetId = "";
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  disconnectedCallback() {
+    if (activePicker === this) {
+      activePicker = null;
+    }
+    super.disconnectedCallback();
+  }
+
+  updated(changed) {
+    if (changed.has("open") && this.open) {
+      if (activePicker && activePicker !== this) {
+        activePicker.close("superseded");
+      }
+      activePicker = this;
+      queueMicrotask(() => this.renderRoot.querySelector("button")?.focus());
+    }
+  }
+
+  render() {
+    if (!this.open) {
+      return "";
+    }
+    return html`
+      <div
+        class="picker"
+        role="menu"
+        aria-label="Choose reaction"
+        aria-orientation="horizontal"
+      >
+        ${this.safeEmojis().map(
+          emoji => html`
+            <button
+              type="button"
+              role="menuitem"
+              data-emoji=${emoji}
+              @click=${() => this.pick(emoji)}
+            >
+              ${emoji}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close("escape");
+      return;
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      this.focusByOffset(1);
+      return;
+    }
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      this.focusByOffset(-1);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      this.focusButton(0);
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      this.focusButton(this.buttons().length - 1);
+    }
+  };
+
+  pick(emoji) {
+    this.dispatchEvent(
+      new CustomEvent("reaction-pick", {
+        detail: { blipId: this.blipId, emoji },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  close(reason) {
+    this.open = false;
+    if (activePicker === this) {
+      activePicker = null;
+    }
+    this.dispatchEvent(
+      new CustomEvent("overlay-close", {
+        detail: { reason, focusTargetId: this.focusTargetId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  safeEmojis() {
+    return Array.isArray(this.emojis) ? this.emojis : [];
+  }
+
+  focusByOffset(offset) {
+    const buttons = this.buttons();
+    if (buttons.length === 0) {
+      return;
+    }
+    const currentIndex = buttons.indexOf(this.renderRoot.activeElement);
+    const nextIndex =
+      currentIndex < 0 ? 0 : (currentIndex + offset + buttons.length) % buttons.length;
+    this.focusButton(nextIndex);
+  }
+
+  focusButton(index) {
+    const buttons = this.buttons();
+    if (buttons.length === 0) {
+      return;
+    }
+    buttons[(index + buttons.length) % buttons.length].focus();
+  }
+
+  buttons() {
+    return Array.from(this.renderRoot.querySelectorAll("button"));
+  }
+}
+
+if (!customElements.get("reaction-picker-popover")) {
+  customElements.define("reaction-picker-popover", ReactionPickerPopover);
+}

--- a/j2cl/lit/src/elements/reaction-picker-popover.js
+++ b/j2cl/lit/src/elements/reaction-picker-popover.js
@@ -52,12 +52,19 @@ export class ReactionPickerPopover extends LitElement {
   }
 
   updated(changed) {
-    if (changed.has("open") && this.open) {
+    if (!changed.has("open")) {
+      return;
+    }
+    if (this.open) {
       if (activePicker && activePicker !== this) {
         activePicker.close("superseded");
       }
       activePicker = this;
       queueMicrotask(() => this.renderRoot.querySelector("button")?.focus());
+      return;
+    }
+    if (activePicker === this) {
+      activePicker = null;
     }
   }
 

--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -129,7 +129,12 @@ export class ReactionRow extends LitElement {
   }
 
   safeReactions() {
-    return Array.isArray(this.reactions) ? this.reactions : [];
+    if (!Array.isArray(this.reactions)) {
+      return [];
+    }
+    return this.reactions.filter(
+      reaction => reaction && typeof reaction === "object" && !Array.isArray(reaction)
+    );
   }
 
   humanizeName(value) {

--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -1,0 +1,142 @@
+import { LitElement, css, html } from "lit";
+
+export class ReactionRow extends LitElement {
+  static properties = {
+    blipId: { type: String, attribute: "blip-id" },
+    reactions: { type: Array }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 999px;
+      padding: 5px 9px;
+      background: #fff;
+      font: inherit;
+    }
+
+    [aria-pressed="true"] {
+      background: var(--shell-color-accent-selection, #e4f1fb);
+      border-color: var(--shell-color-accent-focus, #206ea6);
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+    }
+  `;
+
+  constructor() {
+    super();
+    this.blipId = "";
+    this.reactions = [];
+  }
+
+  render() {
+    return html`
+      <div class="row" role="group" aria-label="Reactions">
+        ${this.safeReactions().map(reaction => this.renderReaction(reaction))}
+        <button
+          type="button"
+          data-reaction-add
+          aria-label="Add reaction"
+          @click=${this.onAdd}
+        >
+          +
+        </button>
+      </div>
+      <span class="sr-only" aria-live="polite">${this.liveText()}</span>
+    `;
+  }
+
+  renderReaction(reaction) {
+    const emoji = reaction.emoji || "";
+    const glyph = reaction.glyph || emoji;
+    const name = reaction.accessibleName || reaction.label || this.humanizeName(emoji);
+    const count = this.safeCount(reaction.count);
+    return html`
+      <span role="group" aria-label=${`${name} reaction`}>
+        <button
+          type="button"
+          data-reaction-chip
+          data-emoji=${emoji}
+          aria-pressed=${reaction.active ? "true" : "false"}
+          aria-label=${`Toggle ${name} reaction, ${count} ${
+            count === 1 ? "person" : "people"
+          }`}
+          @click=${() => this.emit("reaction-toggle", emoji)}
+        >
+          ${glyph} ${count}
+        </button>
+        <button
+          type="button"
+          data-reaction-inspect
+          data-emoji=${emoji}
+          aria-label=${reaction.inspectLabel || `Inspect ${name} reactions`}
+          @click=${() => this.emit("reaction-inspect", emoji)}
+        >
+          authors
+        </button>
+      </span>
+    `;
+  }
+
+  onAdd = () => {
+    this.dispatchEvent(
+      new CustomEvent("reaction-add", {
+        detail: { blipId: this.blipId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  };
+
+  emit(type, emoji) {
+    this.dispatchEvent(
+      new CustomEvent(type, {
+        detail: { blipId: this.blipId, emoji },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  liveText() {
+    const count = this.safeReactions().reduce(
+      (sum, reaction) => sum + this.safeCount(reaction.count),
+      0
+    );
+    return `${count} ${count === 1 ? "reaction" : "reactions"}.`;
+  }
+
+  safeCount(value) {
+    const count = Number(value || 0);
+    return Number.isFinite(count) ? Math.max(0, count) : 0;
+  }
+
+  safeReactions() {
+    return Array.isArray(this.reactions) ? this.reactions : [];
+  }
+
+  humanizeName(value) {
+    return String(value || "").replaceAll("_", " ");
+  }
+}
+
+if (!customElements.get("reaction-row")) {
+  customElements.define("reaction-row", ReactionRow);
+}

--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -133,7 +133,7 @@ export class ReactionRow extends LitElement {
   }
 
   humanizeName(value) {
-    return String(value || "").replaceAll("_", " ");
+    return String(value || "").split("_").join(" ");
   }
 }
 

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -73,6 +73,12 @@ export class TaskMetadataPopover extends LitElement {
     this.addEventListener("keydown", this.onKeyDown);
   }
 
+  willUpdate(changed) {
+    if (changed.has("open") && !this.open) {
+      this.error = "";
+    }
+  }
+
   updated(changed) {
     if (changed.has("open") && this.open) {
       queueMicrotask(() => this.renderRoot.querySelector("select")?.focus());

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -91,6 +91,8 @@ export class TaskMetadataPopover extends LitElement {
     }
     const titleId = `${this.instanceId}-title`;
     const errorId = `${this.instanceId}-due-date-error`;
+    const assigneeOptions = this.assigneeOptions();
+    const currentAssigneeKey = this.currentAssigneeKey();
     return html`
       <form
         class="dialog"
@@ -104,12 +106,11 @@ export class TaskMetadataPopover extends LitElement {
           Assignee
           <select name="assignee">
             <option value="">Unassigned</option>
-            ${this.assigneeFallbackOption()}
-            ${this.safeParticipants().map(
+            ${assigneeOptions.map(
               participant => html`
                 <option
                   value=${participant.address || ""}
-                  ?selected=${(participant.address || "") === this.assigneeAddress}
+                  ?selected=${this.normalizedAddress(participant.address) === currentAssigneeKey}
                 >
                   ${participant.displayName || participant.address}
                 </option>
@@ -242,17 +243,6 @@ export class TaskMetadataPopover extends LitElement {
     );
   }
 
-  assigneeFallbackOption() {
-    if (!this.assigneeAddress) {
-      return "";
-    }
-    const inList = this.safeParticipants().some(p => p.address === this.assigneeAddress);
-    if (inList) {
-      return "";
-    }
-    return html`<option value=${this.assigneeAddress} selected>${this.assigneeAddress}</option>`;
-  }
-
   safeParticipants() {
     if (!Array.isArray(this.participants)) {
       return [];
@@ -265,6 +255,36 @@ export class TaskMetadataPopover extends LitElement {
         typeof participant.address === "string" &&
         participant.address.trim() !== ""
     );
+  }
+
+  assigneeOptions() {
+    const participants = this.safeParticipants();
+    const assigneeAddress =
+      typeof this.assigneeAddress === "string" ? this.assigneeAddress.trim() : "";
+    const assigneeKey = this.normalizedAddress(assigneeAddress);
+    if (
+      assigneeAddress === "" ||
+      participants.some(
+        participant => this.normalizedAddress(participant.address) === assigneeKey
+      )
+    ) {
+      return participants;
+    }
+    return [
+      {
+        address: assigneeAddress,
+        displayName: assigneeAddress
+      },
+      ...participants
+    ];
+  }
+
+  currentAssigneeKey() {
+    return this.normalizedAddress(this.assigneeAddress);
+  }
+
+  normalizedAddress(address) {
+    return typeof address === "string" ? address.trim().toLowerCase() : "";
   }
 }
 

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -186,7 +186,7 @@ export class TaskMetadataPopover extends LitElement {
 
   submit = (event) => {
     event?.preventDefault();
-    const dueDate = this.renderRoot.querySelector("input[name='dueDate']")?.value || "";
+    const dueDate = (this.renderRoot.querySelector("input[name='dueDate']")?.value || "").trim();
     if (dueDate && !this.isValidDueDate(dueDate)) {
       this.error = "Use YYYY-MM-DD for the due date.";
       return;

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -1,0 +1,242 @@
+import { LitElement, css, html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
+
+export class TaskMetadataPopover extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    taskId: { type: String, attribute: "task-id" },
+    assigneeAddress: { type: String, attribute: "assignee-address" },
+    dueDate: { type: String, attribute: "due-date" },
+    participants: { type: Array },
+    error: { type: String },
+    focusTargetId: { type: String, attribute: "focus-target-id" }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .dialog {
+      display: grid;
+      gap: 10px;
+      width: min(92vw, 360px);
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 16px;
+      padding: 14px;
+      background: var(--shell-color-surface-overlay, #fff);
+      box-shadow: var(--shell-shadow-modal, 0 22px 70px rgb(10 38 64 / 24%));
+    }
+
+    label {
+      display: grid;
+      gap: 4px;
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.9rem;
+    }
+
+    select,
+    input,
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 10px;
+      padding: 8px 10px;
+      font: inherit;
+    }
+
+    select:focus,
+    input:focus,
+    button:focus {
+      outline: 2px solid var(--shell-color-accent-focus, #206ea6);
+      outline-offset: 2px;
+    }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.taskId = "";
+    this.assigneeAddress = "";
+    this.dueDate = "";
+    this.participants = [];
+    this.error = "";
+    this.focusTargetId = "";
+    this.addEventListener("keydown", this.onKeyDown);
+  }
+
+  updated(changed) {
+    if (changed.has("open") && this.open) {
+      queueMicrotask(() => this.renderRoot.querySelector("select")?.focus());
+    }
+  }
+
+  render() {
+    if (!this.open) {
+      return "";
+    }
+    const titleId = "task-metadata-title";
+    const errorId = "task-due-date-error";
+    return html`
+      <form
+        class="dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby=${titleId}
+        @submit=${this.submit}
+      >
+        <h2 id=${titleId}>Task details</h2>
+        <label>
+          Assignee
+          <select name="assignee">
+            <option value="">Unassigned</option>
+            ${this.safeParticipants().map(
+              participant => html`
+                <option
+                  value=${participant.address || ""}
+                  ?selected=${(participant.address || "") === this.assigneeAddress}
+                >
+                  ${participant.displayName || participant.address}
+                </option>
+              `
+            )}
+          </select>
+        </label>
+        <label>
+          Due date
+          <input
+            name="dueDate"
+            inputmode="numeric"
+            placeholder="YYYY-MM-DD"
+            aria-invalid=${this.error ? "true" : "false"}
+            aria-describedby=${ifDefined(this.error ? errorId : undefined)}
+            .value=${this.dueDate}
+          />
+        </label>
+        ${this.error ? html`<p id=${errorId} role="alert">${this.error}</p>` : ""}
+        <div class="actions">
+          <button type="button" @click=${() => this.close("cancel")}>Cancel</button>
+          <button type="submit">Save</button>
+        </div>
+      </form>
+    `;
+  }
+
+  onKeyDown = (event) => {
+    if (!this.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      this.close("escape");
+      return;
+    }
+    if (event.key === "Tab") {
+      this.trapFocus(event);
+      return;
+    }
+    if (event.key === "Enter") {
+      if (this.isFormControl(event)) {
+        return;
+      }
+      event.preventDefault();
+      this.submit();
+    }
+  };
+
+  trapFocus(event) {
+    const controls = this.focusableControls();
+    if (controls.length === 0) {
+      return;
+    }
+    const currentIndex = controls.indexOf(this.renderRoot.activeElement);
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    if (currentIndex === -1) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+    if (event.shiftKey && (currentIndex <= 0 || this.renderRoot.activeElement === first)) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+    if (!event.shiftKey && this.renderRoot.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  submit = (event) => {
+    event?.preventDefault();
+    const dueDate = this.renderRoot.querySelector("input[name='dueDate']")?.value || "";
+    if (dueDate && !this.isValidDueDate(dueDate)) {
+      this.error = "Use YYYY-MM-DD for the due date.";
+      return;
+    }
+    this.error = "";
+    this.dispatchEvent(
+      new CustomEvent("task-metadata-submit", {
+        detail: {
+          taskId: this.taskId,
+          assigneeAddress: this.renderRoot.querySelector("select[name='assignee']")?.value || "",
+          dueDate
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+  };
+
+  isFormControl(event) {
+    const target = event.composedPath?.()[0] || event.target;
+    return Boolean(target?.closest?.("input, select, textarea, button"));
+  }
+
+  focusableControls() {
+    return Array.from(this.renderRoot.querySelectorAll("select, input, button")).filter(
+      element => !element.disabled
+    );
+  }
+
+  isValidDueDate(value) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) {
+      return false;
+    }
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() === month - 1 &&
+      date.getUTCDate() === day
+    );
+  }
+
+  close(reason) {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("overlay-close", {
+        detail: { reason, focusTargetId: this.focusTargetId },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  safeParticipants() {
+    return Array.isArray(this.participants) ? this.participants : [];
+  }
+}
+
+if (!customElements.get("task-metadata-popover")) {
+  customElements.define("task-metadata-popover", TaskMetadataPopover);
+}

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -246,7 +246,12 @@ export class TaskMetadataPopover extends LitElement {
       return [];
     }
     return this.participants.filter(
-      participant => participant && typeof participant === "object" && !Array.isArray(participant)
+      participant =>
+        participant &&
+        typeof participant === "object" &&
+        !Array.isArray(participant) &&
+        typeof participant.address === "string" &&
+        participant.address.trim() !== ""
     );
   }
 }

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -104,6 +104,7 @@ export class TaskMetadataPopover extends LitElement {
           Assignee
           <select name="assignee">
             <option value="">Unassigned</option>
+            ${this.assigneeFallbackOption()}
             ${this.safeParticipants().map(
               participant => html`
                 <option
@@ -239,6 +240,17 @@ export class TaskMetadataPopover extends LitElement {
         composed: true
       })
     );
+  }
+
+  assigneeFallbackOption() {
+    if (!this.assigneeAddress) {
+      return "";
+    }
+    const inList = this.safeParticipants().some(p => p.address === this.assigneeAddress);
+    if (inList) {
+      return "";
+    }
+    return html`<option value=${this.assigneeAddress} selected>${this.assigneeAddress}</option>`;
   }
 
   safeParticipants() {

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -1,6 +1,8 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 
+let taskMetadataPopoverCounter = 0;
+
 export class TaskMetadataPopover extends LitElement {
   static properties = {
     open: { type: Boolean, reflect: true },
@@ -67,6 +69,7 @@ export class TaskMetadataPopover extends LitElement {
     this.participants = [];
     this.error = "";
     this.focusTargetId = "";
+    this.instanceId = `task-metadata-${++taskMetadataPopoverCounter}`;
     this.addEventListener("keydown", this.onKeyDown);
   }
 
@@ -80,8 +83,8 @@ export class TaskMetadataPopover extends LitElement {
     if (!this.open) {
       return "";
     }
-    const titleId = "task-metadata-title";
-    const errorId = "task-due-date-error";
+    const titleId = `${this.instanceId}-title`;
+    const errorId = `${this.instanceId}-due-date-error`;
     return html`
       <form
         class="dialog"

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -242,7 +242,12 @@ export class TaskMetadataPopover extends LitElement {
   }
 
   safeParticipants() {
-    return Array.isArray(this.participants) ? this.participants : [];
+    if (!Array.isArray(this.participants)) {
+      return [];
+    }
+    return this.participants.filter(
+      participant => participant && typeof participant === "object" && !Array.isArray(participant)
+    );
   }
 }
 

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -247,14 +247,19 @@ export class TaskMetadataPopover extends LitElement {
     if (!Array.isArray(this.participants)) {
       return [];
     }
-    return this.participants.filter(
-      participant =>
-        participant &&
-        typeof participant === "object" &&
-        !Array.isArray(participant) &&
-        typeof participant.address === "string" &&
-        participant.address.trim() !== ""
-    );
+    return this.participants
+      .filter(
+        participant =>
+          participant &&
+          typeof participant === "object" &&
+          !Array.isArray(participant) &&
+          typeof participant.address === "string" &&
+          participant.address.trim() !== ""
+      )
+      .map(participant => ({
+        ...participant,
+        address: participant.address.trim()
+      }));
   }
 
   assigneeOptions() {

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -150,7 +150,7 @@ export class TaskMetadataPopover extends LitElement {
       return;
     }
     if (event.key === "Enter") {
-      if (this.isFormControl(event)) {
+      if (this.usesNativeEnterBehavior(event)) {
         return;
       }
       event.preventDefault();
@@ -203,9 +203,9 @@ export class TaskMetadataPopover extends LitElement {
     );
   };
 
-  isFormControl(event) {
+  usesNativeEnterBehavior(event) {
     const target = event.composedPath?.()[0] || event.target;
-    return Boolean(target?.closest?.("input, select, textarea, button"));
+    return Boolean(target?.closest?.("select, textarea, button"));
   }
 
   focusableControls() {

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -14,6 +14,12 @@ import "./elements/composer-shell.js";
 import "./elements/toolbar-button.js";
 import "./elements/toolbar-group.js";
 import "./elements/toolbar-overflow-menu.js";
+import "./elements/interaction-overlay-layer.js";
+import "./elements/mention-suggestion-popover.js";
+import "./elements/task-metadata-popover.js";
+import "./elements/reaction-row.js";
+import "./elements/reaction-picker-popover.js";
+import "./elements/reaction-authors-popover.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/interaction-overlay-layer.test.js
+++ b/j2cl/lit/test/interaction-overlay-layer.test.js
@@ -1,0 +1,71 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/interaction-overlay-layer.js";
+
+describe("<interaction-overlay-layer>", () => {
+  it("wraps non-modal overlay content and dispatches close with focus target", async () => {
+    const el = await fixture(html`
+      <interaction-overlay-layer open focus-target-id="trigger-1">
+        <button>Overlay action</button>
+      </interaction-overlay-layer>
+    `);
+
+    expect(el.renderRoot.querySelector("[part='surface']").getAttribute("role")).to.equal(
+      "group"
+    );
+    expect(el.renderRoot.querySelector("[part='surface']").hasAttribute("aria-modal")).to.equal(
+      false
+    );
+    expect(getComputedStyle(el.renderRoot.querySelector("[part='surface']")).position).to.equal(
+      "relative"
+    );
+
+    const eventPromise = oneEvent(el, "overlay-close");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect((await eventPromise).detail).to.deep.equal({
+      reason: "escape",
+      focusTargetId: "trigger-1"
+    });
+  });
+
+  it("supports modal role and hidden closed state", async () => {
+    const el = await fixture(html`
+      <interaction-overlay-layer modal label="Task details">
+        <button id="first">First</button>
+        <button id="last">Last</button>
+      </interaction-overlay-layer>
+    `);
+
+    expect(el.renderRoot.querySelector("[part='surface']")).to.equal(null);
+
+    el.open = true;
+    await el.updateComplete;
+
+    const surface = el.renderRoot.querySelector("[part='surface']");
+    expect(surface.getAttribute("role")).to.equal("dialog");
+    expect(surface.getAttribute("aria-modal")).to.equal("true");
+    expect(surface.getAttribute("aria-label")).to.equal("Task details");
+    expect(surface).to.equal(el.shadowRoot.activeElement);
+
+    el.querySelector("#last").focus();
+    el.querySelector("#last").dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      })
+    );
+    expect(document.activeElement).to.equal(el.querySelector("#first"));
+
+    el.querySelector("#first").dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      })
+    );
+    expect(document.activeElement).to.equal(el.querySelector("#last"));
+  });
+});

--- a/j2cl/lit/test/interaction-overlay-layer.test.js
+++ b/j2cl/lit/test/interaction-overlay-layer.test.js
@@ -83,6 +83,34 @@ describe("<interaction-overlay-layer>", () => {
     expect(document.activeElement).to.equal(el.querySelector("#last"));
   });
 
+  it("does not close when slotted content already handled Escape", async () => {
+    const el = await fixture(html`
+      <interaction-overlay-layer open modal label="Nested overlay">
+        <button id="nested">Nested close</button>
+      </interaction-overlay-layer>
+    `);
+    let closeCount = 0;
+    const nested = el.querySelector("#nested");
+    el.addEventListener("overlay-close", () => {
+      closeCount += 1;
+    });
+    nested.addEventListener("keydown", event => {
+      event.preventDefault();
+    });
+
+    nested.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      })
+    );
+
+    expect(closeCount).to.equal(0);
+    expect(el.open).to.equal(true);
+  });
+
   it("traps modal focus through slotted custom element shadow controls", async () => {
     const el = await fixture(html`
       <interaction-overlay-layer open modal label="Shadow task details">

--- a/j2cl/lit/test/interaction-overlay-layer.test.js
+++ b/j2cl/lit/test/interaction-overlay-layer.test.js
@@ -1,6 +1,20 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
 import "../src/elements/interaction-overlay-layer.js";
 
+class ShadowOverlayControls extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" }).innerHTML = `
+      <button id="first">First</button>
+      <button id="last">Last</button>
+    `;
+  }
+}
+
+if (!customElements.get("shadow-overlay-controls")) {
+  customElements.define("shadow-overlay-controls", ShadowOverlayControls);
+}
+
 describe("<interaction-overlay-layer>", () => {
   it("wraps non-modal overlay content and dispatches close with focus target", async () => {
     const el = await fixture(html`
@@ -67,5 +81,38 @@ describe("<interaction-overlay-layer>", () => {
       })
     );
     expect(document.activeElement).to.equal(el.querySelector("#last"));
+  });
+
+  it("traps modal focus through slotted custom element shadow controls", async () => {
+    const el = await fixture(html`
+      <interaction-overlay-layer open modal label="Shadow task details">
+        <shadow-overlay-controls></shadow-overlay-controls>
+      </interaction-overlay-layer>
+    `);
+    const controls = el.querySelector("shadow-overlay-controls");
+    const first = controls.shadowRoot.querySelector("#first");
+    const last = controls.shadowRoot.querySelector("#last");
+
+    first.focus();
+    first.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      })
+    );
+    expect(controls.shadowRoot.activeElement).to.equal(last);
+
+    last.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      })
+    );
+    expect(controls.shadowRoot.activeElement).to.equal(first);
   });
 });

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -112,6 +112,36 @@ describe("<mention-suggestion-popover>", () => {
     expect(event.defaultPrevented).to.equal(false);
   });
 
+  it("does not trap Enter when no candidates are selectable", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${[]} open></mention-suggestion-popover>
+    `);
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true
+    });
+
+    el.dispatchEvent(event);
+
+    expect(event.defaultPrevented).to.equal(false);
+  });
+
+  it("traps Enter when a candidate is selectable", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true
+    });
+
+    el.dispatchEvent(event);
+
+    expect(event.defaultPrevented).to.equal(true);
+  });
+
   it("keeps option ids unique across popover instances", async () => {
     const first = await fixture(html`
       <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -157,4 +157,15 @@ describe("<mention-suggestion-popover>", () => {
     expect(options.length).to.equal(1);
     expect(options[0].dataset.address).to.equal("valid@example.com");
   });
+
+  it("does not consume Enter when there are no candidates", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${[]} open></mention-suggestion-popover>
+    `);
+
+    const enterEvent = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    el.dispatchEvent(enterEvent);
+
+    expect(enterEvent.defaultPrevented).to.equal(false);
+  });
 });

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -144,4 +144,17 @@ describe("<mention-suggestion-popover>", () => {
 
     expect((await eventPromise).detail.address).to.equal("solo@example.com");
   });
+
+  it("filters malformed candidate entries before rendering", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${[null, "bad", { address: "valid@example.com" }]}
+        open
+      ></mention-suggestion-popover>
+    `);
+
+    const options = el.renderRoot.querySelectorAll("[role='option']");
+    expect(options.length).to.equal(1);
+    expect(options[0].dataset.address).to.equal("valid@example.com");
+  });
 });

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -1,0 +1,145 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/mention-suggestion-popover.js";
+
+describe("<mention-suggestion-popover>", () => {
+  const candidates = [
+    { address: "alice@example.com", displayName: "Alice Adams" },
+    { address: "bob@example.com", displayName: "Bob Brown" }
+  ];
+
+  it("renders listbox options and announces candidate count", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+
+    const listbox = el.renderRoot.querySelector("[role='listbox']");
+    const options = el.renderRoot.querySelectorAll("[role='option']");
+    expect(listbox.getAttribute("aria-activedescendant")).to.equal(options[0].id);
+    expect(options[0].getAttribute("aria-selected")).to.equal("true");
+    expect(options[1].dataset.address).to.equal("bob@example.com");
+    expect(el.renderRoot.querySelector("[aria-live='polite']").textContent).to.include(
+      "2 mention suggestions"
+    );
+  });
+
+  it("moves active option with arrows and selects with Enter", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+    const eventPromise = oneEvent(el, "mention-select");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[role='listbox']").getAttribute("aria-activedescendant")).to.equal(
+      el.renderRoot.querySelectorAll("[role='option']")[1].id
+    );
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect((await eventPromise).detail.address).to.equal("bob@example.com");
+  });
+
+  it("selects candidates from pointer activation", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+    const eventPromise = oneEvent(el, "mention-select");
+
+    el.renderRoot.querySelectorAll("[role='option']")[1].click();
+
+    expect((await eventPromise).detail).to.deep.equal({
+      address: "bob@example.com",
+      displayName: "Bob Brown"
+    });
+  });
+
+  it("wraps with ArrowUp and selects with Tab", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+    const eventPromise = oneEvent(el, "mention-select");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    await el.updateComplete;
+    expect(
+      el.renderRoot.querySelectorAll("[role='option']")[1].getAttribute("aria-selected")
+    ).to.equal("true");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+
+    expect((await eventPromise).detail.address).to.equal("bob@example.com");
+  });
+
+  it("emits overlay-close on Escape and handles empty candidates", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${[]}
+        focus-target-id="composer-caret"
+        open
+      ></mention-suggestion-popover>
+    `);
+    const eventPromise = oneEvent(el, "overlay-close");
+
+    expect(el.renderRoot.textContent).to.include("No mention matches");
+    expect(el.renderRoot.querySelector("[role='listbox']").hasAttribute("aria-activedescendant")).to.equal(
+      false
+    );
+    expect(el.renderRoot.querySelector("[aria-live='polite']").textContent).to.include(
+      "No mention suggestions"
+    );
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect((await eventPromise).detail).to.deep.equal({
+      reason: "escape",
+      focusTargetId: "composer-caret"
+    });
+  });
+
+  it("does not trap Tab when no candidates are selectable", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover .candidates=${[]} open></mention-suggestion-popover>
+    `);
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true
+    });
+
+    el.dispatchEvent(event);
+
+    expect(event.defaultPrevented).to.equal(false);
+  });
+
+  it("keeps option ids unique across popover instances", async () => {
+    const first = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+    const second = await fixture(html`
+      <mention-suggestion-popover .candidates=${candidates} open></mention-suggestion-popover>
+    `);
+
+    expect(first.renderRoot.querySelector("[role='option']").id).to.not.equal(
+      second.renderRoot.querySelector("[role='option']").id
+    );
+  });
+
+  it("clamps active selection when candidates shrink", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${candidates}
+        active-index="5"
+        open
+      ></mention-suggestion-popover>
+    `);
+    const eventPromise = oneEvent(el, "mention-select");
+
+    el.candidates = [{ address: "solo@example.com", displayName: "Solo" }];
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[role='listbox']").getAttribute("aria-activedescendant")).to.equal(
+      el.renderRoot.querySelector("[role='option']").id
+    );
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect((await eventPromise).detail.address).to.equal("solo@example.com");
+  });
+});

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -190,6 +190,21 @@ describe("<mention-suggestion-popover>", () => {
     );
   });
 
+  it("falls back to the first option for non-finite active indexes", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${candidates}
+        .activeIndex=${Number.NaN}
+        open
+      ></mention-suggestion-popover>
+    `);
+    const options = el.renderRoot.querySelectorAll("[role='option']");
+
+    expect(el.renderRoot.querySelector("[role='listbox']").getAttribute("aria-activedescendant")).to.equal(
+      options[0].id
+    );
+  });
+
   it("filters malformed candidate entries before rendering", async () => {
     const el = await fixture(html`
       <mention-suggestion-popover

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -218,6 +218,23 @@ describe("<mention-suggestion-popover>", () => {
     expect(options[0].dataset.address).to.equal("valid@example.com");
   });
 
+  it("filters candidate entries without usable addresses before rendering", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${[
+          { displayName: "Missing" },
+          { address: "   ", displayName: "Blank" },
+          { address: " valid@example.com ", displayName: "Valid" }
+        ]}
+        open
+      ></mention-suggestion-popover>
+    `);
+
+    const options = el.renderRoot.querySelectorAll("[role='option']");
+    expect(options.length).to.equal(1);
+    expect(options[0].dataset.address).to.equal("valid@example.com");
+  });
+
   it("does not consume Enter when there are no candidates", async () => {
     const el = await fixture(html`
       <mention-suggestion-popover .candidates=${[]} open></mention-suggestion-popover>

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -14,6 +14,8 @@ describe("<mention-suggestion-popover>", () => {
 
     const listbox = el.renderRoot.querySelector("[role='listbox']");
     const options = el.renderRoot.querySelectorAll("[role='option']");
+    expect(listbox).to.equal(el.shadowRoot.activeElement);
+    expect(listbox.getAttribute("tabindex")).to.equal("-1");
     expect(listbox.getAttribute("aria-activedescendant")).to.equal(options[0].id);
     expect(options[0].getAttribute("aria-selected")).to.equal("true");
     expect(options[1].dataset.address).to.equal("bob@example.com");

--- a/j2cl/lit/test/mention-suggestion-popover.test.js
+++ b/j2cl/lit/test/mention-suggestion-popover.test.js
@@ -175,6 +175,21 @@ describe("<mention-suggestion-popover>", () => {
     expect((await eventPromise).detail.address).to.equal("solo@example.com");
   });
 
+  it("wraps active selection for negative active indexes below the candidate count", async () => {
+    const el = await fixture(html`
+      <mention-suggestion-popover
+        .candidates=${candidates}
+        active-index="-3"
+        open
+      ></mention-suggestion-popover>
+    `);
+    const options = el.renderRoot.querySelectorAll("[role='option']");
+
+    expect(el.renderRoot.querySelector("[role='listbox']").getAttribute("aria-activedescendant")).to.equal(
+      options[1].id
+    );
+  });
+
   it("filters malformed candidate entries before rendering", async () => {
     const el = await fixture(html`
       <mention-suggestion-popover

--- a/j2cl/lit/test/reaction-authors-popover.test.js
+++ b/j2cl/lit/test/reaction-authors-popover.test.js
@@ -1,0 +1,57 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/reaction-authors-popover.js";
+
+describe("<reaction-authors-popover>", () => {
+  it("renders author list semantics and empty state", async () => {
+    const el = await fixture(html`
+      <reaction-authors-popover
+        emoji="tada"
+        reaction-label="party popper"
+        .authors=${["alice@example.com", "bob@example.com"]}
+        open
+      ></reaction-authors-popover>
+    `);
+
+    expect(el.renderRoot.querySelector("[role='region']").getAttribute("aria-label")).to.equal(
+      "Authors for party popper"
+    );
+    expect(el.renderRoot.querySelector(".popover")).to.equal(el.shadowRoot.activeElement);
+    expect(el.renderRoot.querySelectorAll("li").length).to.equal(2);
+
+    el.authors = [];
+    await el.updateComplete;
+    expect(el.renderRoot.textContent).to.include("No reactions yet");
+  });
+
+  it("closes from Escape and emits focus restoration target", async () => {
+    const el = await fixture(html`
+      <reaction-authors-popover
+        emoji="tada"
+        focus-target-id="reaction-tada"
+        .authors=${["alice@example.com"]}
+        open
+      ></reaction-authors-popover>
+    `);
+    const eventPromise = oneEvent(el, "overlay-close");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect((await eventPromise).detail).to.deep.equal({
+      reason: "escape",
+      focusTargetId: "reaction-tada"
+    });
+  });
+
+  it("focuses the popover surface again after reopening", async () => {
+    const el = await fixture(html`
+      <reaction-authors-popover emoji="tada" .authors=${[]} open></reaction-authors-popover>
+    `);
+
+    el.close("test");
+    await el.updateComplete;
+    el.open = true;
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector(".popover")).to.equal(el.shadowRoot.activeElement);
+  });
+});

--- a/j2cl/lit/test/reaction-authors-popover.test.js
+++ b/j2cl/lit/test/reaction-authors-popover.test.js
@@ -54,4 +54,14 @@ describe("<reaction-authors-popover>", () => {
 
     expect(el.renderRoot.querySelector(".popover")).to.equal(el.shadowRoot.activeElement);
   });
+
+  it("uses a non-empty accessible label when reaction metadata is missing", async () => {
+    const el = await fixture(html`
+      <reaction-authors-popover .authors=${[]} open></reaction-authors-popover>
+    `);
+
+    expect(el.renderRoot.querySelector("[role='region']").getAttribute("aria-label")).to.equal(
+      "Authors for this reaction"
+    );
+  });
 });

--- a/j2cl/lit/test/reaction-picker-popover.test.js
+++ b/j2cl/lit/test/reaction-picker-popover.test.js
@@ -1,0 +1,93 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/reaction-picker-popover.js";
+
+describe("<reaction-picker-popover>", () => {
+  it("focuses the first emoji when opened and emits selected emoji", async () => {
+    const el = await fixture(html`
+      <reaction-picker-popover
+        blip-id="b+1"
+        .emojis=${["tada", "thumbs_up"]}
+        open
+      ></reaction-picker-popover>
+    `);
+    const first = el.renderRoot.querySelector("[data-emoji='tada']");
+    expect(el.renderRoot.querySelector("[role='menu']").getAttribute("aria-orientation")).to.equal(
+      "horizontal"
+    );
+    expect(first).to.equal(el.shadowRoot.activeElement);
+
+    const eventPromise = oneEvent(el, "reaction-pick");
+    first.click();
+    expect((await eventPromise).detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
+  });
+
+  it("keeps a single active picker and closes on Escape", async () => {
+    const first = await fixture(html`
+      <reaction-picker-popover blip-id="b+1" .emojis=${["tada"]} open></reaction-picker-popover>
+    `);
+    const supersededPromise = oneEvent(first, "overlay-close");
+    const second = await fixture(html`
+      <reaction-picker-popover blip-id="b+2" .emojis=${["wave"]} open></reaction-picker-popover>
+    `);
+
+    expect((await supersededPromise).detail).to.deep.equal({
+      reason: "superseded",
+      focusTargetId: ""
+    });
+    expect(first.open).to.equal(false);
+    expect(second.open).to.equal(true);
+
+    const closePromise = oneEvent(second, "overlay-close");
+    second.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect((await closePromise).detail).to.deep.equal({ reason: "escape", focusTargetId: "" });
+  });
+
+  it("moves focus through the reaction menu with arrow, Home, and End keys", async () => {
+    const el = await fixture(html`
+      <reaction-picker-popover
+        blip-id="b+1"
+        .emojis=${["tada", "wave", "heart"]}
+        open
+      ></reaction-picker-popover>
+    `);
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.shadowRoot.activeElement.dataset.emoji).to.equal("wave");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(el.shadowRoot.activeElement.dataset.emoji).to.equal("wave");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    expect(el.shadowRoot.activeElement.dataset.emoji).to.equal("tada");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    expect(el.shadowRoot.activeElement.dataset.emoji).to.equal("heart");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    expect(el.shadowRoot.activeElement.dataset.emoji).to.equal("tada");
+  });
+
+  it("ignores navigation keys when the picker has no buttons", async () => {
+    const el = await fixture(html`
+      <reaction-picker-popover blip-id="b+empty" open></reaction-picker-popover>
+    `);
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+
+    expect(el.renderRoot.querySelectorAll("button").length).to.equal(0);
+  });
+
+  it("clears the active picker reference when disconnected", async () => {
+    const first = await fixture(html`
+      <reaction-picker-popover blip-id="b+1" .emojis=${["tada"]} open></reaction-picker-popover>
+    `);
+    first.remove();
+
+    const second = await fixture(html`
+      <reaction-picker-popover blip-id="b+2" .emojis=${["wave"]} open></reaction-picker-popover>
+    `);
+
+    expect(second.open).to.equal(true);
+  });
+});

--- a/j2cl/lit/test/reaction-picker-popover.test.js
+++ b/j2cl/lit/test/reaction-picker-popover.test.js
@@ -90,4 +90,22 @@ describe("<reaction-picker-popover>", () => {
 
     expect(second.open).to.equal(true);
   });
+
+  it("clears the active picker reference when closed by property update", async () => {
+    const first = await fixture(html`
+      <reaction-picker-popover blip-id="b+1" .emojis=${["tada"]} open></reaction-picker-popover>
+    `);
+    let firstCloseCount = 0;
+    first.addEventListener("overlay-close", () => {
+      firstCloseCount += 1;
+    });
+
+    first.open = false;
+    await first.updateComplete;
+    await fixture(html`
+      <reaction-picker-popover blip-id="b+2" .emojis=${["wave"]} open></reaction-picker-popover>
+    `);
+
+    expect(firstCloseCount).to.equal(0);
+  });
 });

--- a/j2cl/lit/test/reaction-row.test.js
+++ b/j2cl/lit/test/reaction-row.test.js
@@ -1,0 +1,99 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/reaction-row.js";
+
+describe("<reaction-row>", () => {
+  const reactions = [
+    { emoji: "tada", count: 2, active: true, inspectLabel: "2 reactions for tada." },
+    { emoji: "thumbs_up", count: 1, active: false, inspectLabel: "1 reaction for thumbs up." }
+  ];
+
+  it("renders stable reaction chips and live reaction count text", async () => {
+    const el = await fixture(html`<reaction-row blip-id="b+1" .reactions=${reactions}></reaction-row>`);
+
+    const chips = el.renderRoot.querySelectorAll("[data-reaction-chip]");
+    expect(chips.length).to.equal(2);
+    expect(chips[0].dataset.emoji).to.equal("tada");
+    expect(chips[0].getAttribute("aria-pressed")).to.equal("true");
+    expect(chips[0].getAttribute("aria-label")).to.include("2 people");
+    expect(el.renderRoot.querySelector("[aria-live='polite']").textContent).to.include(
+      "3 reactions"
+    );
+  });
+
+  it("emits add, toggle, and inspect events with stable ids", async () => {
+    const el = await fixture(html`<reaction-row blip-id="b+1" .reactions=${reactions}></reaction-row>`);
+
+    const addPromise = oneEvent(el, "reaction-add");
+    el.renderRoot.querySelector("[data-reaction-add]").click();
+    expect((await addPromise).detail.blipId).to.equal("b+1");
+
+    const togglePromise = oneEvent(el, "reaction-toggle");
+    el.renderRoot.querySelector("[data-reaction-chip]").click();
+    expect((await togglePromise).detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
+
+    const inspectPromise = oneEvent(el, "reaction-inspect");
+    el.renderRoot.querySelector("[data-reaction-inspect]").click();
+    expect((await inspectPromise).detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
+  });
+
+  it("renders an empty add-only state without mutation decisions", async () => {
+    const el = await fixture(html`<reaction-row blip-id="b+empty" .reactions=${[]}></reaction-row>`);
+
+    expect(el.renderRoot.querySelectorAll("[data-reaction-chip]").length).to.equal(0);
+    expect(el.renderRoot.querySelector("[data-reaction-add]").getAttribute("aria-label")).to.equal(
+      "Add reaction"
+    );
+  });
+
+  it("normalizes malformed reaction counts for visible and live text", async () => {
+    const el = await fixture(html`
+      <reaction-row
+        blip-id="b+bad-count"
+        .reactions=${[{ emoji: "wave", count: "abc" }]}
+      ></reaction-row>
+    `);
+
+    expect(el.renderRoot.querySelector("[data-reaction-chip]").textContent).to.include("wave 0");
+    expect(el.renderRoot.querySelector("[aria-live='polite']").textContent).to.equal(
+      "0 reactions."
+    );
+  });
+
+  it("accepts pre-resolved reaction glyphs without changing event ids", async () => {
+    const el = await fixture(html`
+      <reaction-row
+        blip-id="b+glyph"
+        .reactions=${[
+          { emoji: "thumbs_up", glyph: "👍", accessibleName: "thumbs up", count: 1 }
+        ]}
+      ></reaction-row>
+    `);
+    const togglePromise = oneEvent(el, "reaction-toggle");
+
+    expect(el.renderRoot.querySelector("[data-reaction-chip]").textContent).to.include("👍 1");
+    el.renderRoot.querySelector("[data-reaction-chip]").click();
+    expect((await togglePromise).detail).to.deep.equal({
+      blipId: "b+glyph",
+      emoji: "thumbs_up"
+    });
+  });
+
+  it("clamps negative and infinite reaction counts", async () => {
+    const el = await fixture(html`
+      <reaction-row
+        blip-id="b+safe-count"
+        .reactions=${[
+          { emoji: "sad", count: -3 },
+          { emoji: "fire", count: Infinity }
+        ]}
+      ></reaction-row>
+    `);
+
+    const chips = el.renderRoot.querySelectorAll("[data-reaction-chip]");
+    expect(chips[0].textContent).to.include("sad 0");
+    expect(chips[1].textContent).to.include("fire 0");
+    expect(el.renderRoot.querySelector("[aria-live='polite']").textContent).to.equal(
+      "0 reactions."
+    );
+  });
+});

--- a/j2cl/lit/test/reaction-row.test.js
+++ b/j2cl/lit/test/reaction-row.test.js
@@ -96,4 +96,17 @@ describe("<reaction-row>", () => {
       "0 reactions."
     );
   });
+
+  it("filters malformed reaction entries before rendering", async () => {
+    const el = await fixture(html`
+      <reaction-row
+        blip-id="b+bad-reactions"
+        .reactions=${[null, "bad", { emoji: "wave", count: 1 }]}
+      ></reaction-row>
+    `);
+
+    const chips = el.renderRoot.querySelectorAll("[data-reaction-chip]");
+    expect(chips.length).to.equal(1);
+    expect(chips[0].dataset.emoji).to.equal("wave");
+  });
 });

--- a/j2cl/lit/test/reaction-row.test.js
+++ b/j2cl/lit/test/reaction-row.test.js
@@ -25,15 +25,24 @@ describe("<reaction-row>", () => {
 
     const addPromise = oneEvent(el, "reaction-add");
     el.renderRoot.querySelector("[data-reaction-add]").click();
-    expect((await addPromise).detail.blipId).to.equal("b+1");
+    const addEvent = await addPromise;
+    expect(addEvent.bubbles).to.equal(true);
+    expect(addEvent.composed).to.equal(true);
+    expect(addEvent.detail.blipId).to.equal("b+1");
 
     const togglePromise = oneEvent(el, "reaction-toggle");
     el.renderRoot.querySelector("[data-reaction-chip]").click();
-    expect((await togglePromise).detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
+    const toggleEvent = await togglePromise;
+    expect(toggleEvent.bubbles).to.equal(true);
+    expect(toggleEvent.composed).to.equal(true);
+    expect(toggleEvent.detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
 
     const inspectPromise = oneEvent(el, "reaction-inspect");
     el.renderRoot.querySelector("[data-reaction-inspect]").click();
-    expect((await inspectPromise).detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
+    const inspectEvent = await inspectPromise;
+    expect(inspectEvent.bubbles).to.equal(true);
+    expect(inspectEvent.composed).to.equal(true);
+    expect(inspectEvent.detail).to.deep.equal({ blipId: "b+1", emoji: "tada" });
   });
 
   it("renders an empty add-only state without mutation decisions", async () => {

--- a/j2cl/lit/test/reaction-row.test.js
+++ b/j2cl/lit/test/reaction-row.test.js
@@ -109,4 +109,9 @@ describe("<reaction-row>", () => {
     expect(chips.length).to.equal(1);
     expect(chips[0].dataset.emoji).to.equal("wave");
   });
+
+  it("falls back to empty when reactions is not an array", async () => {
+    const el = await fixture(html`<reaction-row blip-id="b+non-array" .reactions=${"not-an-array"}></reaction-row>`);
+    expect(el.renderRoot.querySelectorAll("[data-reaction-chip]").length).to.equal(0);
+  });
 });

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -51,6 +51,60 @@ describe("<task-metadata-popover>", () => {
     expect(options[1].value).to.equal("valid@example.com");
   });
 
+  it("preserves a current assignee that is no longer in the participant list", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        assignee-address=" carol@example.com "
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+    const options = Array.from(
+      el.renderRoot.querySelectorAll("select[name='assignee'] option")
+    );
+    const eventPromise = oneEvent(el, "task-metadata-submit");
+
+    expect(options.map(option => option.value)).to.include("carol@example.com");
+    expect(el.renderRoot.querySelector("select[name='assignee']").value).to.equal(
+      "carol@example.com"
+    );
+
+    el.renderRoot.querySelector("input[name='dueDate']").value = "2026-05-02";
+    el.renderRoot.querySelector("button[type='submit']").click();
+
+    expect((await eventPromise).detail).to.deep.equal({
+      taskId: "task-1",
+      assigneeAddress: "carol@example.com",
+      dueDate: "2026-05-02"
+    });
+  });
+
+  it("does not duplicate a current assignee that only differs by whitespace or case", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        assignee-address=" ALICE@example.com "
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+    const options = Array.from(
+      el.renderRoot.querySelectorAll("select[name='assignee'] option")
+    );
+
+    expect(options.length).to.equal(3);
+    expect(options.filter(option => option.value === "alice@example.com").length).to.equal(1);
+    expect(el.renderRoot.querySelector("select[name='assignee']").value).to.equal(
+      "alice@example.com"
+    );
+
+    const eventPromise = oneEvent(el, "task-metadata-submit");
+    el.renderRoot.querySelector("button[type='submit']").click();
+
+    expect((await eventPromise).detail.assigneeAddress).to.equal("alice@example.com");
+  });
+
   it("submits semantic task metadata on Enter", async () => {
     const el = await fixture(html`
       <task-metadata-popover

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -1,0 +1,167 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/task-metadata-popover.js";
+
+describe("<task-metadata-popover>", () => {
+  const participants = [
+    { address: "alice@example.com", displayName: "Alice" },
+    { address: "bob@example.com", displayName: "Bob" }
+  ];
+
+  it("renders a modal task dialog and focuses the assignee field when opened", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        assignee-address="alice@example.com"
+        due-date="2026-04-30"
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+
+    const dialog = el.renderRoot.querySelector("[role='dialog']");
+    const assignee = el.renderRoot.querySelector("select[name='assignee']");
+    expect(dialog.getAttribute("aria-modal")).to.equal("true");
+    expect(dialog.getAttribute("aria-labelledby")).to.not.equal("");
+    expect(assignee.value).to.equal("alice@example.com");
+    expect(assignee).to.equal(el.shadowRoot.activeElement);
+  });
+
+  it("submits semantic task metadata on Enter", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+    el.renderRoot.querySelector("select[name='assignee']").value = "bob@example.com";
+    el.renderRoot.querySelector("input[name='dueDate']").value = "2026-05-01";
+    const eventPromise = oneEvent(el, "task-metadata-submit");
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    expect((await eventPromise).detail).to.deep.equal({
+      taskId: "task-1",
+      assigneeAddress: "bob@example.com",
+      dueDate: "2026-05-01"
+    });
+  });
+
+  it("does not submit when Enter belongs to the assignee select", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+    let submitCount = 0;
+    el.addEventListener("task-metadata-submit", () => {
+      submitCount += 1;
+    });
+
+    el.renderRoot
+      .querySelector("select[name='assignee']")
+      .dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+      );
+    await el.updateComplete;
+
+    expect(submitCount).to.equal(0);
+  });
+
+  it("traps Tab inside the modal task dialog", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover open task-id="task-1"></task-metadata-popover>
+    `);
+    const controls = el.renderRoot.querySelectorAll("select, input, button");
+    controls[controls.length - 1].focus();
+
+    controls[controls.length - 1].dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      })
+    );
+
+    expect(controls[0]).to.equal(el.shadowRoot.activeElement);
+
+    controls[0].dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+        composed: true
+      })
+    );
+
+    expect(controls[controls.length - 1]).to.equal(el.shadowRoot.activeElement);
+  });
+
+  it("emits cancel close events with focus restoration target", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        focus-target-id="task-trigger-1"
+      ></task-metadata-popover>
+    `);
+    const closePromise = oneEvent(el, "overlay-close");
+
+    el.renderRoot.querySelector("button[type='button']").click();
+
+    expect((await closePromise).detail).to.deep.equal({
+      reason: "cancel",
+      focusTargetId: "task-trigger-1"
+    });
+  });
+
+  it("keeps invalid due date visible and closes on Escape", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        focus-target-id="task-trigger-1"
+      ></task-metadata-popover>
+    `);
+    const dueDate = el.renderRoot.querySelector("input[name='dueDate']");
+    dueDate.value = "tomorrow";
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    expect(dueDate.value).to.equal("tomorrow");
+    expect(el.renderRoot.querySelector("[role='alert']").textContent).to.include(
+      "Use YYYY-MM-DD"
+    );
+
+    const closePromise = oneEvent(el, "overlay-close");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect((await closePromise).detail).to.deep.equal({
+      reason: "escape",
+      focusTargetId: "task-trigger-1"
+    });
+  });
+
+  it("rejects impossible calendar dates", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover open task-id="task-1"></task-metadata-popover>
+    `);
+    el.renderRoot.querySelector("input[name='dueDate']").value = "2026-99-99";
+
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector("[role='alert']").textContent).to.include(
+      "Use YYYY-MM-DD"
+    );
+    expect(el.renderRoot.querySelector("input[name='dueDate']").getAttribute("aria-invalid")).to.equal(
+      "true"
+    );
+    expect(
+      el.renderRoot.querySelector("input[name='dueDate']").getAttribute("aria-describedby")
+    ).to.equal(el.renderRoot.querySelector("[role='alert']").id);
+  });
+});

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -149,6 +149,27 @@ describe("<task-metadata-popover>", () => {
     });
   });
 
+  it("trims due date input before validation and submit", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover open task-id="task-1"></task-metadata-popover>
+    `);
+    let detail;
+    el.addEventListener("task-metadata-submit", event => {
+      detail = event.detail;
+    });
+
+    el.renderRoot.querySelector("input[name='dueDate']").value = " 2026-05-01 ";
+    el.renderRoot.querySelector("button[type='submit']").click();
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector("[role='alert']")).to.equal(null);
+    expect(detail).to.deep.equal({
+      taskId: "task-1",
+      assigneeAddress: "",
+      dueDate: "2026-05-01"
+    });
+  });
+
   it("does not submit when Enter belongs to the assignee select", async () => {
     const el = await fixture(html`
       <task-metadata-popover

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -60,10 +60,11 @@ describe("<task-metadata-popover>", () => {
       ></task-metadata-popover>
     `);
     el.renderRoot.querySelector("select[name='assignee']").value = "bob@example.com";
-    el.renderRoot.querySelector("input[name='dueDate']").value = "2026-05-01";
+    const dueDateInput = el.renderRoot.querySelector("input[name='dueDate']");
+    dueDateInput.value = "2026-05-01";
     const eventPromise = oneEvent(el, "task-metadata-submit");
 
-    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    dueDateInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
 
     expect((await eventPromise).detail).to.deep.equal({
       taskId: "task-1",

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -176,4 +176,23 @@ describe("<task-metadata-popover>", () => {
       el.renderRoot.querySelector("input[name='dueDate']").getAttribute("aria-describedby")
     ).to.equal(el.renderRoot.querySelector("[role='alert']").id);
   });
+
+  it("clears stale validation errors across close and reopen", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover open task-id="task-1"></task-metadata-popover>
+    `);
+    el.renderRoot.querySelector("input[name='dueDate']").value = "tomorrow";
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await el.updateComplete;
+
+    el.open = false;
+    await el.updateComplete;
+    el.open = true;
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector("[role='alert']")).to.equal(null);
+    expect(el.renderRoot.querySelector("input[name='dueDate']").getAttribute("aria-invalid")).to.equal(
+      "false"
+    );
+  });
 });

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -38,6 +38,19 @@ describe("<task-metadata-popover>", () => {
     );
   });
 
+  it("filters malformed participant entries before rendering options", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        .participants=${[null, "bad", { address: "valid@example.com", displayName: "Valid" }]}
+      ></task-metadata-popover>
+    `);
+
+    const options = el.renderRoot.querySelectorAll("select[name='assignee'] option");
+    expect(options.length).to.equal(2);
+    expect(options[1].value).to.equal("valid@example.com");
+  });
+
   it("submits semantic task metadata on Enter", async () => {
     const el = await fixture(html`
       <task-metadata-popover

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -137,7 +137,10 @@ describe("<task-metadata-popover>", () => {
 
     el.renderRoot.querySelector("button[type='button']").click();
 
-    expect((await closePromise).detail).to.deep.equal({
+    const event = await closePromise;
+    expect(event.bubbles).to.equal(true);
+    expect(event.composed).to.equal(true);
+    expect(event.detail).to.deep.equal({
       reason: "cancel",
       focusTargetId: "task-trigger-1"
     });
@@ -164,7 +167,10 @@ describe("<task-metadata-popover>", () => {
 
     const closePromise = oneEvent(el, "overlay-close");
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    expect((await closePromise).detail).to.deep.equal({
+    const escapeEvent = await closePromise;
+    expect(escapeEvent.bubbles).to.equal(true);
+    expect(escapeEvent.composed).to.equal(true);
+    expect(escapeEvent.detail).to.deep.equal({
       reason: "escape",
       focusTargetId: "task-trigger-1"
     });

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -51,6 +51,26 @@ describe("<task-metadata-popover>", () => {
     expect(options[1].value).to.equal("valid@example.com");
   });
 
+  it("trims participant addresses before rendering and submitting options", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        assignee-address=" padded@example.com "
+        .participants=${[{ address: " padded@example.com ", displayName: "Padded" }]}
+      ></task-metadata-popover>
+    `);
+    const eventPromise = oneEvent(el, "task-metadata-submit");
+
+    expect(el.renderRoot.querySelector("select[name='assignee']").value).to.equal(
+      "padded@example.com"
+    );
+
+    el.renderRoot.querySelector("button[type='submit']").click();
+
+    expect((await eventPromise).detail.assigneeAddress).to.equal("padded@example.com");
+  });
+
   it("preserves a current assignee that is no longer in the participant list", async () => {
     const el = await fixture(html`
       <task-metadata-popover

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -199,6 +199,25 @@ describe("<task-metadata-popover>", () => {
     ).to.equal(el.renderRoot.querySelector("[role='alert']").id);
   });
 
+  it("preserves the current assignee when they are absent from participants", async () => {
+    const el = await fixture(html`
+      <task-metadata-popover
+        open
+        task-id="task-1"
+        assignee-address="carol@example.com"
+        .participants=${participants}
+      ></task-metadata-popover>
+    `);
+
+    const select = el.renderRoot.querySelector("select[name='assignee']");
+    expect(select.value).to.equal("carol@example.com");
+
+    const eventPromise = oneEvent(el, "task-metadata-submit");
+    el.renderRoot.querySelector("button[type='submit']").click();
+    const { detail } = await eventPromise;
+    expect(detail.assigneeAddress).to.equal("carol@example.com");
+  });
+
   it("clears stale validation errors across close and reopen", async () => {
     const el = await fixture(html`
       <task-metadata-popover open task-id="task-1"></task-metadata-popover>

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -26,6 +26,18 @@ describe("<task-metadata-popover>", () => {
     expect(assignee).to.equal(el.shadowRoot.activeElement);
   });
 
+  it("generates unique heading ids for multiple task dialogs", async () => {
+    const first = await fixture(html`<task-metadata-popover open></task-metadata-popover>`);
+    const second = await fixture(html`<task-metadata-popover open></task-metadata-popover>`);
+
+    expect(first.renderRoot.querySelector("h2").id).to.not.equal(
+      second.renderRoot.querySelector("h2").id
+    );
+    expect(first.renderRoot.querySelector("[role='dialog']").getAttribute("aria-labelledby")).to.equal(
+      first.renderRoot.querySelector("h2").id
+    );
+  });
+
   it("submits semantic task metadata on Enter", async () => {
     const el = await fixture(html`
       <task-metadata-popover

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -64,7 +64,9 @@ describe("<task-metadata-popover>", () => {
     dueDateInput.value = "2026-05-01";
     const eventPromise = oneEvent(el, "task-metadata-submit");
 
-    dueDateInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    dueDateInput.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, composed: true })
+    );
 
     expect((await eventPromise).detail).to.deep.equal({
       taskId: "task-1",

--- a/wave/config/changelog.d/2026-04-24-issue-970-lit-overlays.json
+++ b/wave/config/changelog.d/2026-04-24-issue-970-lit-overlays.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-issue-970-lit-overlays",
+  "version": "Issue #970",
+  "date": "2026-04-24",
+  "title": "Add J2CL Lit interaction overlay primitives",
+  "summary": "The opt-in J2CL shell now includes reusable Lit primitives for mention suggestions, task metadata, reaction rows, reaction picking, reaction authors, and overlay focus handling so later controller slices can wire parity interactions without adding legacy GWT dependencies.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Registered Lit primitives for mention, task, reaction, and overlay-layer interaction surfaces",
+        "Added Web Test Runner coverage for keyboard close/select flows, live-region labels, focus behavior, and semantic overlay events"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds J2CL Lit primitives for interaction overlay parity: mention suggestions, task metadata, reaction row, reaction picker, reaction authors, and overlay layering.
- Registers the primitives in the Lit shell entrypoint while keeping all mutation/data decisions delegated to parent J2CL models/controllers.
- Adds keyboard, focus, ARIA, close-event, malformed-data, and edge-case Web Test Runner coverage plus a changelog fragment.

Refs #970

## Verification
- `cd j2cl/lit && npm test` — pass, 21 test files / 64 tests.
- `cd j2cl/lit && npm run build` — pass.
- `git diff --check` — pass.
- `python3 scripts/assemble-changelog.py` — pass, assembled 241 entries.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` — pass.

## Review
- Self-review completed.
- Claude Opus review loop completed through Round 5; final review marked the slice ship-ready with no blockers.
- Follow-up notes from review are controller-wiring concerns for later slices: downstream controllers should pass accessible reaction labels and provide outer page inert/backdrop behavior where needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added several accessible overlay UI components: overlay layer, mention suggestions, task details popover, reaction row/picker/authors with keyboard navigation, focus management, and selection events.

* **Bug Fixes / Improvements**
  * Improved focus trapping/restoration, ARIA labeling/live announcements, single-active picker behavior, and due-date validation UX.

* **Tests**
  * Added comprehensive tests covering keyboard flows, selection/close events, live-region updates, focus behavior, and accessibility.

* **Documentation**
  * Added changelog entry summarizing the new Lit overlay primitives and test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->