### PR TITLE
Fix Android IME ghost text after Done teardown

### DIFF
--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
@@ -8,6 +8,7 @@
 
 **Files:**
 - `wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java`
 - `wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java`
 - `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java`
 - `wave/config/changelog.d/2026-04-24-android-ime-done-sibling-disappear.json`

--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
@@ -25,6 +25,6 @@
 
 - `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
 - `sbt "wave/testOnly org.waveprotocol.wave.client.editor.integration.MobileImeFlushGwtTest"`
-- `bash scripts/worktree-boot.sh --port 9931`
-- `PORT=9931 bash scripts/wave-smoke.sh check`
-- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9931`: register/login, create wave, type `new blip`, tap Done, reload, assert body contains `new blip` and not an `ew`-only collapse.
+- `bash scripts/worktree-boot.sh --port 9932`
+- `PORT=9932 bash scripts/wave-smoke.sh check`
+- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9932`: register/login, create wave, type `new blip`, tap Done, reload, assert body contains `new blip` and not an `ew`-only collapse.

--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
@@ -1,0 +1,29 @@
+# Issue #828 Android IME Done Sibling Disappearance Follow-Up Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:systematic-debugging` and focused regression tests before changing editor behavior.
+
+**Goal:** Fix the remaining Android Chrome IME failure where typing `new blip` in a blip can display or persist as `ewlip`/`ew` after the keyboard Done action removes the temporary sibling text that carried the missing leading characters.
+
+**Root Cause:** The previous Android IME recovery path kept captured ghost text only when the final adjacent DOM sibling still existed and had returned to the content-model baseline. The phone repro shows a harsher teardown path: Android Chrome can remove the adjacent sibling entirely before `flushPendingInput()` commits the composition. In that state the captured `n` / ` b` was no longer trusted, so only the scratch text (`ew` or `lip`) was committed.
+
+**Files:**
+- `wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java`
+- `wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java`
+- `wave/config/changelog.d/2026-04-24-android-ime-done-sibling-disappear.json`
+
+## Acceptance Criteria
+
+- Captured previous-sibling ghost text survives when the final sibling text node is absent.
+- Captured second-word ghost text (`" b"` over model baseline `"new"`) survives the same Done teardown.
+- Symmetric next-sibling ghost text remains covered.
+- The editor's reported IME composition state uses the same effective recovered text that the flush path commits.
+- Local mobile Chrome simulation against the staged app can type `new blip`, tap Done, reload, and still find `new blip` rather than `ew`.
+
+## Verification
+
+- `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
+- `sbt "wave/testOnly org.waveprotocol.wave.client.editor.integration.MobileImeFlushGwtTest"`
+- `bash scripts/worktree-boot.sh --port 9930`
+- `PORT=9930 bash scripts/wave-smoke.sh check`
+- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9930`: register/login, create wave, type `new blip`, tap Done, reload, assert body contains `new blip` and not an `ew`-only collapse.

--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md
@@ -4,7 +4,7 @@
 
 **Goal:** Fix the remaining Android Chrome IME failure where typing `new blip` in a blip can display or persist as `ewlip`/`ew` after the keyboard Done action removes the temporary sibling text that carried the missing leading characters.
 
-**Root Cause:** The previous Android IME recovery path kept captured ghost text only when the final adjacent DOM sibling still existed and had returned to the content-model baseline. The phone repro shows a harsher teardown path: Android Chrome can remove the adjacent sibling entirely before `flushPendingInput()` commits the composition. In that state the captured `n` / ` b` was no longer trusted, so only the scratch text (`ew` or `lip`) was committed.
+**Root Cause:** The previous Android IME recovery path kept captured ghost text only when the final adjacent DOM sibling still existed and had returned to the content-model baseline. The phone repro shows a harsher teardown path: Android Chrome can remove the adjacent sibling entirely before `flushPendingInput()` commits the composition. In that state the captured `"n"` / `" b"` was no longer trusted, so only the scratch text (`ew` or `lip`) was committed.
 
 **Files:**
 - `wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java`
@@ -24,6 +24,6 @@
 
 - `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
 - `sbt "wave/testOnly org.waveprotocol.wave.client.editor.integration.MobileImeFlushGwtTest"`
-- `bash scripts/worktree-boot.sh --port 9930`
-- `PORT=9930 bash scripts/wave-smoke.sh check`
-- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9930`: register/login, create wave, type `new blip`, tap Done, reload, assert body contains `new blip` and not an `ew`-only collapse.
+- `bash scripts/worktree-boot.sh --port 9931`
+- `PORT=9931 bash scripts/wave-smoke.sh check`
+- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9931`: register/login, create wave, type `new blip`, tap Done, reload, assert body contains `new blip` and not an `ew`-only collapse.

--- a/wave/config/changelog.d/2026-04-24-android-ime-done-sibling-disappear.json
+++ b/wave/config/changelog.d/2026-04-24-android-ime-done-sibling-disappear.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-24-android-ime-done-sibling-disappear",
+  "version": "Unreleased",
+  "date": "2026-04-24",
+  "title": "Recover Android IME text when Done removes temporary siblings",
+  "summary": "Android Chrome can remove the adjacent DOM text node that temporarily carries leading IME characters before the editor flushes the composition. The editor now keeps the captured ghost text across that teardown and reports the same recovered composition state that it commits.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Typing text such as \"new blip\" into a blip from Android Chrome now preserves the leading characters when the keyboard Done action removes the browser's temporary sibling text before commit."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
@@ -2746,7 +2746,7 @@ public class EditorImpl extends LogicalPanel.Impl implements
   ////// Editor context methods
   @Override
   public String getImeCompositionState() {
-    return imeExtractor.getContent();
+    return imeExtractor.getEffectiveContent();
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -153,8 +153,8 @@ public class ImeExtractor {
     if (scratchContent == null) {
       scratchContent = "";
     }
-    String currentPrev = readText(ghostPreviousSibling);
-    String currentNext = readText(ghostNextSibling);
+    String currentPrev = readCurrentPreviousText();
+    String currentNext = readCurrentNextText();
     String result = GhostTextReconciler.combineWithCapturedGhosts(scratchContent,
         ghostPreviousSiblingModelBaseline, ghostPreviousSiblingCapturedText, currentPrev,
         ghostNextSiblingModelBaseline, ghostNextSiblingCapturedText, currentNext);
@@ -262,11 +262,13 @@ public class ImeExtractor {
       ImeDebugTracer.start("ImeExtractor.deactivate")
           .add("scratch", imeContainer.getInnerText())
           .add("prevSibling", ImeDebugTracer.describe(ghostPreviousSibling))
-          .add("prevCurrent", ImeDebugTracer.readText(ghostPreviousSibling))
+          .add("prevCurrent", readCurrentPreviousText())
+          .add("prevCapturedNodeCurrent", ImeDebugTracer.readText(ghostPreviousSibling))
           .add("prevModelBaseline", ghostPreviousSiblingModelBaseline)
           .add("prevCaptured", ghostPreviousSiblingCapturedText)
           .add("nextSibling", ImeDebugTracer.describe(ghostNextSibling))
-          .add("nextCurrent", ImeDebugTracer.readText(ghostNextSibling))
+          .add("nextCurrent", readCurrentNextText())
+          .add("nextCapturedNodeCurrent", ImeDebugTracer.readText(ghostNextSibling))
           .add("nextModelBaseline", ghostNextSiblingModelBaseline)
           .add("nextCaptured", ghostNextSiblingCapturedText)
           .emit();
@@ -285,14 +287,38 @@ public class ImeExtractor {
   }
 
   private void restoreGhostBaseline() {
-    restorePreviousTextNode(ghostPreviousSibling, ghostPreviousSiblingModelBaseline);
-    restoreNextTextNode(ghostNextSibling, ghostNextSiblingModelBaseline);
+    Node currentPreviousSibling = currentAdjacentSibling(true);
+    Node currentNextSibling = currentAdjacentSibling(false);
+    restorePreviousTextNode(currentPreviousSibling, ghostPreviousSiblingModelBaseline);
+    restoreNextTextNode(currentNextSibling, ghostNextSiblingModelBaseline);
+    if (currentPreviousSibling != ghostPreviousSibling) {
+      restorePreviousTextNode(ghostPreviousSibling, ghostPreviousSiblingModelBaseline);
+    }
+    if (currentNextSibling != ghostNextSibling) {
+      restoreNextTextNode(ghostNextSibling, ghostNextSiblingModelBaseline);
+    }
     ghostPreviousSibling = null;
     ghostPreviousSiblingModelBaseline = null;
     ghostPreviousSiblingCapturedText = null;
     ghostNextSibling = null;
     ghostNextSiblingModelBaseline = null;
     ghostNextSiblingCapturedText = null;
+  }
+
+  private String readCurrentPreviousText() {
+    return readText(currentAdjacentSibling(true));
+  }
+
+  private String readCurrentNextText() {
+    return readText(currentAdjacentSibling(false));
+  }
+
+  private Node currentAdjacentSibling(boolean previous) {
+    Element scratchDomAnchor = imeContainer.getParentElement();
+    if (scratchDomAnchor == null) {
+      return null;
+    }
+    return previous ? scratchDomAnchor.getPreviousSibling() : scratchDomAnchor.getNextSibling();
   }
 
   private static void restorePreviousTextNode(Node node, String baseline) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -95,8 +95,9 @@ public final class GhostTextReconciler {
    * then compares that captured ghost with the final DOM state. If the final
    * DOM still has a model-relative ghost, the final DOM wins because it may
    * contain IME rewrites made after activation. If the final DOM has returned
-   * exactly to the model baseline, the captured ghost is kept so Android's
-   * Done path cannot drop the first character by deleting the temporary
+   * exactly to the model baseline, or if Android removed the sibling text node
+   * entirely while tearing down the composition, the captured ghost is kept so
+   * the Done path cannot drop the first character by deleting the temporary
    * sibling text. If the final DOM no longer matches the model baseline, the
    * captured ghost is not trusted.
    */
@@ -130,11 +131,21 @@ public final class GhostTextReconciler {
     if (!currentGhost.isEmpty()) {
       return currentGhost;
     }
-    return isAtModelBaseline(modelBaseline, currentText) ? capturedGhost : "";
+    if (capturedGhost.isEmpty()) {
+      return "";
+    }
+    return isAtModelBaseline(modelBaseline, currentText)
+        || didSiblingDisappearAfterCapturingGhost(modelBaseline, currentText)
+        ? capturedGhost : "";
   }
 
   private static boolean isAtModelBaseline(String modelBaseline, String currentText) {
     return modelBaseline != null && modelBaseline.equals(currentText);
+  }
+
+  private static boolean didSiblingDisappearAfterCapturingGhost(String modelBaseline,
+      String currentText) {
+    return modelBaseline != null && currentText == null;
   }
 
   private static String withoutSuffixAlreadyAtScratchStart(String ghost, String scratchContent) {

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -147,6 +147,11 @@ public class GhostTextReconcilerTest extends TestCase {
         "ew", "", "n", "", null, null, null));
   }
 
+  public void testCapturedPreviousGhostSurvivesDoneWhenSiblingDisappears() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "ew", "", "n", null, null, null, null));
+  }
+
   public void testCapturedPreviousGhostDoesNotDuplicateWhenMovedIntoScratch() {
     assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
         "new", "", "n", "", null, null, null));
@@ -182,6 +187,11 @@ public class GhostTextReconcilerTest extends TestCase {
         "lip", "new", "new b", "new", null, null, null));
   }
 
+  public void testCapturedSecondWordGhostSurvivesDoneWhenSiblingDisappears() {
+    assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
+        "lip", "new", "new b", null, null, null, null));
+  }
+
   public void testCapturedGhostKeepsPostCaptureGrowthSupport() {
     assertEquals(" blip", GhostTextReconciler.combineWithCapturedGhosts(
         "lip", "new", "new", "new b", null, null, null));
@@ -190,6 +200,11 @@ public class GhostTextReconcilerTest extends TestCase {
   public void testCapturedNextGhostSurvivesDoneWhenDomNoLongerHasIt() {
     assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
         "ne", null, null, null, "world", "wworld", "world"));
+  }
+
+  public void testCapturedNextGhostSurvivesDoneWhenSiblingDisappears() {
+    assertEquals("new", GhostTextReconciler.combineWithCapturedGhosts(
+        "ne", null, null, null, "world", "wworld", null));
   }
 
   public void testCapturedNextGhostDoesNotDuplicateWhenMovedIntoScratch() {


### PR DESCRIPTION
Closes #828

## Summary
- Keep activation-time Android IME ghost text when the final adjacent sibling disappears during keyboard Done teardown.
- Report the editor's effective recovered IME composition state instead of the raw scratch text.
- Add disappearing-sibling regression coverage, an issue plan, and a changelog fragment.

## Verification
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt "wave/testOnly org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
- `sbt "wave/testOnly org.waveprotocol.wave.client.editor.integration.MobileImeFlushGwtTest"` (standard JVM test configuration reported no runnable target and exited successfully)
- `bash scripts/worktree-boot.sh --port 9931`
- `PORT=9931 bash scripts/wave-smoke.sh check`
- Playwright Chromium mobile simulation with `devices['Galaxy S9+']` against `http://127.0.0.1:9931`: login, create wave, type `new blip`, tap Done, reload, and verify the body still contains `new blip` with no `ew`-only collapse.

## Local Evidence
- Worktree: `/Users/vega/devroot/worktrees/codex-android-ime-mobile-local-20260424`
- Plan: `docs/superpowers/plans/2026-04-24-issue-828-android-ime-done-sibling-disappear.md`
- Local verification journal: `journal/local-verification/2026-04-24-branch-codex-android-ime-mobile-local-20260424.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android Chrome IME: preserved and recovered typed text when pressing the keyboard "Done" so leading characters are no longer lost during commit, even if temporary DOM elements are removed.
* **Tests**
  * Added unit and integration tests to verify recovery across sibling disappearance and end-to-end IME flush scenarios.
* **Documentation**
  * Added a follow-up plan and changelog entry describing verification steps and acceptance criteria for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->