### PR TITLE
Fix mobile IME debug overlay controls

### DIFF
--- a/docs/superpowers/plans/2026-04-24-ime-debug-panel-mobile.md
+++ b/docs/superpowers/plans/2026-04-24-ime-debug-panel-mobile.md
@@ -53,6 +53,8 @@ content and destroys any icon markup that could make the controls compact.
   a hidden log body by default, and buttons for show/hide, copy, and clear.
   Native buttons handle keyboard focus and activation; no custom focus trap is
   needed.
+- Reserve bottom space on the document body and Wave thread scroll containers so
+  absolutely positioned mobile wave content can scroll above the minimized panel.
 - Update `ImeDebugTracer.appendToOverlayJsni()` to append rows into the log body,
   not the overlay chrome.
 - Update `HtmlRenderer` mobile chrome controls to keep SVG icons in the button

--- a/docs/superpowers/plans/2026-04-24-ime-debug-panel-mobile.md
+++ b/docs/superpowers/plans/2026-04-24-ime-debug-panel-mobile.md
@@ -1,0 +1,73 @@
+# IME Debug Panel Mobile Usability Plan
+
+Issue: https://github.com/vega113/supawave/issues/1005
+Branch: `codex/ime-debug-panel-mobile-1005`
+Worktree: `$WORKTREE/codex-ime-debug-panel-mobile-1005`
+
+## Root Cause
+
+`ImeDebugTracer.ensureOverlayJsni()` creates a single fixed bottom overlay as soon as
+the tracer is enabled. It starts fully expanded with `max-height:45%`, captures
+pointer events, and appends log rows directly into the overlay. The only built-in
+local control is hidden double-tap/Escape clearing, so on mobile the panel covers
+the lower blips and offers no obvious minimize or copy-log action.
+
+The server-rendered mobile chrome controls also render as visible text pills
+(`Tags`, `Tag Pin`, `Pin`) and the state-sync script rewrites the full button
+text on every update. That makes the tag controls look bolted on over the wave
+content and destroys any icon markup that could make the controls compact.
+
+## Acceptance Criteria
+
+- The IME debug panel starts minimized when enabled.
+- The minimized state is compact and touch-friendly on mobile: the collapsed
+  strip is no taller than the standard 44px touch target and leaves the log body
+  hidden. Only that collapsed strip should capture pointer events while minimized,
+  and the page should reserve the same bottom space so bottom-most editor content
+  can scroll above it, including any mobile safe-area inset.
+- The user can expand and minimize the log from the panel.
+- The user can copy the current debug log from the panel, with a fallback for
+  clipboard API failures. The fallback will use a temporary textarea plus
+  `document.execCommand('copy')`.
+- Copying an empty log should not fail; it should show inline feedback that
+  there are no log lines yet. Successful copy should also show inline feedback.
+- Existing remote logging and console logging continue unchanged.
+- Overlay log row pruning still limits retained rows.
+- Persisting expanded/minimized state across reloads is out of scope; every new
+  tracer session starts minimized.
+- The previous hidden Escape-to-clear and double-tap-to-clear gestures are
+  replaced by explicit Clear and Escape-to-minimize behavior.
+- Mobile wave and tag chrome controls render as compact 44px icon buttons with
+  hidden accessible text labels; state sync must preserve the icon markup.
+
+## Implementation
+
+- Add a focused source-contract regression test for the JSNI overlay contract at
+  `wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java`.
+  This lives in the server util test package because normal JVM tests exclude
+  most `org/waveprotocol/wave/client` test sources.
+- Add a source-contract regression test for server-rendered mobile wave/tag
+  controls at
+  `wave/src/test/java/org/waveprotocol/box/server/util/MobileChromeControlsContractTest.java`.
+- Update `ImeDebugTracer.ensureOverlayJsni()` so the overlay has a compact header,
+  a hidden log body by default, and buttons for show/hide, copy, and clear.
+  Native buttons handle keyboard focus and activation; no custom focus trap is
+  needed.
+- Update `ImeDebugTracer.appendToOverlayJsni()` to append rows into the log body,
+  not the overlay chrome.
+- Update `HtmlRenderer` mobile chrome controls to keep SVG icons in the button
+  body while state sync updates `aria-label`, `title`, and hidden label text.
+- Add `wave/config/changelog.d/2026-04-24-ime-debug-panel-mobile.json` because the
+  diagnostic UI behavior changes.
+
+## Verification
+
+- `sbt --batch "testOnly org.waveprotocol.box.server.util.ImeDebugOverlayContractTest"`
+- `sbt --batch "testOnly org.waveprotocol.box.server.util.MobileChromeControlsContractTest"`
+- `python3 scripts/assemble-changelog.py`
+- `python3 scripts/validate-changelog.py`
+- Local server sanity before PR: boot the app from this worktree and verify the
+  generated client response is served.
+- Browser verification before PR: inspect the overlay behavior with
+  `?ime_debug=on` in a mobile viewport and confirm it starts minimized, expands,
+  minimizes again, and exposes copy/clear controls.

--- a/wave/config/changelog.d/2026-04-24-ime-debug-panel-mobile.json
+++ b/wave/config/changelog.d/2026-04-24-ime-debug-panel-mobile.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-24-ime-debug-panel-mobile",
+  "version": "Unreleased",
+  "date": "2026-04-24",
+  "title": "IME debug log no longer covers mobile editing",
+  "summary": "The IME debug overlay now starts compact on mobile, reserves space for editing, and provides explicit log controls.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "IME debug tracing now starts in a compact bottom control with show, copy, and clear actions instead of covering editable mobile blips by default",
+        "The hidden Escape and double-tap clear gestures were replaced with an explicit Clear action; Escape now minimizes the debug log",
+        "Mobile wave and tags controls now render as compact icon buttons with accessible labels instead of visible text pills"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -2787,22 +2787,46 @@ public final class HtmlRenderer {
     sb.append("    position: fixed;\n");
     sb.append("    bottom: 56px;\n");
     sb.append("    z-index: 130;\n");
-    sb.append("    border: 0;\n");
-    sb.append("    border-radius: 999px;\n");
-    sb.append("    background: rgba(0, 119, 182, 0.92);\n");
+    sb.append("    width: 44px;\n");
+    sb.append("    height: 44px;\n");
+    sb.append("    min-width: 44px;\n");
+    sb.append("    min-height: 44px;\n");
+    sb.append("    padding: 0;\n");
+    sb.append("    border: 1px solid rgba(255,255,255,0.22);\n");
+    sb.append("    border-radius: 12px;\n");
+    sb.append("    background: rgba(2, 62, 107, 0.92);\n");
     sb.append("    color: #fff;\n");
-    sb.append("    min-height: 40px;\n");
-    sb.append("    padding: 0 14px;\n");
     sb.append("    box-shadow: 0 8px 18px rgba(0,0,0,0.18);\n");
     sb.append("    display: none;\n");
     sb.append("    align-items: center;\n");
     sb.append("    justify-content: center;\n");
+    sb.append("    backdrop-filter: blur(8px);\n");
+    sb.append("  }\n");
+    sb.append("  .mobile-wave-chrome-control[aria-pressed='true'] {\n");
+    sb.append("    background: rgba(0, 119, 182, 0.96);\n");
+    sb.append("    box-shadow: 0 10px 22px rgba(0,0,0,0.22);\n");
+    sb.append("  }\n");
+    sb.append("  .mobile-wave-chrome-control .mobile-control-svg {\n");
+    sb.append("    display: block;\n");
+    sb.append("    width: 20px;\n");
+    sb.append("    height: 20px;\n");
+    sb.append("  }\n");
+    sb.append("  .mobile-wave-chrome-control .mobile-control-label {\n");
+    sb.append("    position: absolute;\n");
+    sb.append("    width: 1px;\n");
+    sb.append("    height: 1px;\n");
+    sb.append("    padding: 0;\n");
+    sb.append("    margin: -1px;\n");
+    sb.append("    overflow: hidden;\n");
+    sb.append("    clip: rect(0, 0, 0, 0);\n");
+    sb.append("    white-space: nowrap;\n");
+    sb.append("    border: 0;\n");
     sb.append("  }\n");
     sb.append("  body.mobile-wave-open .mobile-wave-chrome-control { display: inline-flex; }\n");
     sb.append("  body.mobile-wave-open #mobileWaveChromeReveal { display: none; }\n");
     sb.append("  #mobileWaveChromeReveal { left: 12px; }\n");
-    sb.append("  #mobileWaveChromePin { left: 66px; }\n");
-    sb.append("  #mobileTagsToggle { right: 66px; }\n");
+    sb.append("  #mobileWaveChromePin { left: 64px; }\n");
+    sb.append("  #mobileTagsToggle { right: 64px; }\n");
     sb.append("  #mobileTagsPin { right: 12px; }\n");
     sb.append("  body.mobile-wave-open.mobile-wave-chrome-hidden #mobileWaveChromeReveal { display: inline-flex; }\n");
     sb.append("}\n");
@@ -3012,10 +3036,14 @@ public final class HtmlRenderer {
     sb.append("</div>\n");
     // Mobile backdrop overlay (for closing slide panel)
     sb.append("<div class=\"mobile-backdrop\" id=\"mobileBackdrop\" role=\"button\" tabindex=\"0\" aria-label=\"Close navigation\"></div>\n");
-    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileWaveChromeReveal\" aria-label=\"Show wave controls\" aria-pressed=\"false\">Show</button>\n");
-    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileWaveChromePin\" aria-label=\"Pin wave controls\" aria-pressed=\"false\">Pin</button>\n");
-    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileTagsToggle\" aria-label=\"Show tags tray\" aria-pressed=\"false\">Tags</button>\n");
-    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileTagsPin\" aria-label=\"Pin tags tray\" aria-pressed=\"false\">Tag Pin</button>\n");
+    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileWaveChromeReveal\" aria-label=\"Show wave controls\" title=\"Show wave controls\" aria-pressed=\"false\">");
+    sb.append(ICON_SLIDERS).append("<span class=\"mobile-control-label\">Show wave controls</span></button>\n");
+    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileWaveChromePin\" aria-label=\"Pin wave controls\" title=\"Pin wave controls\" aria-pressed=\"false\">");
+    sb.append(ICON_PIN).append("<span class=\"mobile-control-label\">Pin wave controls</span></button>\n");
+    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileTagsToggle\" aria-label=\"Show tags tray\" title=\"Show tags tray\" aria-pressed=\"false\">");
+    sb.append(ICON_TAG).append("<span class=\"mobile-control-label\">Show tags tray</span></button>\n");
+    sb.append("<button type=\"button\" class=\"mobile-wave-chrome-control\" id=\"mobileTagsPin\" aria-label=\"Pin tags tray\" title=\"Pin tags tray\" aria-pressed=\"false\">");
+    sb.append(ICON_PIN).append("<span class=\"mobile-control-label\">Pin tags tray</span></button>\n");
     sb.append("<noscript>\n");
     sb.append("<div style=\"width:22em;position:absolute;left:50%;margin-left:-11em;");
     sb.append("color:red;background-color:white;border:1px solid red;padding:4px;font-family:sans-serif\">\n");
@@ -3064,19 +3092,21 @@ public final class HtmlRenderer {
     sb.append("  var tagsPinned = false;\n");
     sb.append("  var lastWaveScrollTop = 0;\n");
     sb.append("  var waveThread = null;\n");
-    sb.append("  function setToggleState(button, pressed, label, text) {\n");
+    sb.append("  function setToggleState(button, pressed, label) {\n");
     sb.append("    if (!button) return;\n");
     sb.append("    button.setAttribute('aria-pressed', pressed ? 'true' : 'false');\n");
     sb.append("    button.setAttribute('aria-label', label);\n");
-    sb.append("    button.textContent = text;\n");
+    sb.append("    button.setAttribute('title', label);\n");
+    sb.append("    var hiddenLabel = button.querySelector('.mobile-control-label');\n");
+    sb.append("    if (hiddenLabel) hiddenLabel.textContent = label;\n");
     sb.append("  }\n");
     sb.append("  function syncMobileChromeButtons() {\n");
     sb.append("    var chromeHidden = body.classList.contains('mobile-wave-chrome-hidden');\n");
     sb.append("    var tagsOpen = body.classList.contains('mobile-tags-open');\n");
-    sb.append("    setToggleState(mobileWaveChromeReveal, chromeHidden, chromeHidden ? 'Show wave controls' : 'Hide wave controls', chromeHidden ? 'Show' : 'Hide');\n");
-    sb.append("    setToggleState(mobileWaveChromePin, chromePinned, chromePinned ? 'Unpin wave controls' : 'Pin wave controls', chromePinned ? 'Unpin' : 'Pin');\n");
-    sb.append("    setToggleState(mobileTagsToggle, tagsOpen, tagsOpen ? 'Hide tags tray' : 'Show tags tray', tagsOpen ? 'Close Tags' : 'Tags');\n");
-    sb.append("    setToggleState(mobileTagsPin, tagsPinned, tagsPinned ? 'Unpin tags tray' : 'Pin tags tray', tagsPinned ? 'Unpin Tags' : 'Tag Pin');\n");
+    sb.append("    setToggleState(mobileWaveChromeReveal, chromeHidden, chromeHidden ? 'Show wave controls' : 'Hide wave controls');\n");
+    sb.append("    setToggleState(mobileWaveChromePin, chromePinned, chromePinned ? 'Unpin wave controls' : 'Pin wave controls');\n");
+    sb.append("    setToggleState(mobileTagsToggle, tagsOpen, tagsOpen ? 'Hide tags tray' : 'Show tags tray');\n");
+    sb.append("    setToggleState(mobileTagsPin, tagsPinned, tagsPinned ? 'Unpin tags tray' : 'Pin tags tray');\n");
     sb.append("  }\n");
     sb.append("  function openPanel() {\n");
     sb.append("    body.classList.add('mobile-panel-open');\n");
@@ -4746,6 +4776,31 @@ public final class HtmlRenderer {
       "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
       + "<path d=\"M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z\"/>"
       + "<polyline points=\"22,6 12,13 2,6\"/>"
+      + "</svg>";
+
+  /** Sliders icon for mobile wave controls. */
+  private static final String ICON_SLIDERS =
+      "<svg class=\"mobile-control-svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
+      + "<line x1=\"4\" y1=\"6\" x2=\"20\" y2=\"6\"/>"
+      + "<line x1=\"4\" y1=\"12\" x2=\"20\" y2=\"12\"/>"
+      + "<line x1=\"4\" y1=\"18\" x2=\"20\" y2=\"18\"/>"
+      + "<circle cx=\"9\" cy=\"6\" r=\"2\"/>"
+      + "<circle cx=\"15\" cy=\"12\" r=\"2\"/>"
+      + "<circle cx=\"11\" cy=\"18\" r=\"2\"/>"
+      + "</svg>";
+
+  /** Pin icon for mobile control pinning. */
+  private static final String ICON_PIN =
+      "<svg class=\"mobile-control-svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
+      + "<path d=\"M15 4l5 5-4 1-4 7-2-2 7-4 1-4-5-5z\"/>"
+      + "<path d=\"M9 15l-5 5\"/>"
+      + "</svg>";
+
+  /** Tag icon for the mobile tags tray. */
+  private static final String ICON_TAG =
+      "<svg class=\"mobile-control-svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
+      + "<path d=\"M20.5 13.5L13.5 20.5a2 2 0 0 1-2.8 0L3 12.8V3h9.8l7.7 7.7a2 2 0 0 1 0 2.8z\"/>"
+      + "<circle cx=\"8\" cy=\"8\" r=\"1.5\"/>"
       + "</svg>";
 
   // =========================================================================

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -565,7 +565,7 @@ public final class ImeDebugTracer {
       log.setAttribute("role", "log");
       log.setAttribute("aria-live", "polite");
       log.style.display = "none";
-      log.style.maxHeight = "calc(45vh - " + collapsedHeight + " - " + safeAreaInset + ")";
+      log.style.maxHeight = "calc(45vh - " + collapsedHeight + " - 1px - " + safeAreaInset + ")";
       log.style.overflowY = "auto";
       log.style.padding = "0 6px 6px";
       log.style.boxSizing = "border-box";
@@ -613,16 +613,34 @@ public final class ImeDebugTracer {
         return rows.join("\n");
       }
 
-      function reserveBodyBottomSpace(d) {
-        if (!d.body || d.body.getAttribute("data-ime-debug-body-padding-reserved") === "true") {
+      function reserveBottomSpace(element, amount) {
+        if (!element || element.getAttribute("data-ime-debug-bottom-space-reserved") === "true") {
           return;
         }
-        var previous = d.body.style.paddingBottom || "";
-        d.body.setAttribute("data-ime-debug-body-padding-reserved", "true");
-        d.body.setAttribute("data-ime-debug-body-padding-previous", previous);
-        d.body.style.paddingBottom = previous
-            ? "calc(" + previous + " + " + collapsedHeight + " + " + safeAreaInset + ")"
-            : reservedHeight;
+        var previousPadding = element.style.paddingBottom || "";
+        var previousScrollPadding = element.style.scrollPaddingBottom || "";
+        element.setAttribute("data-ime-debug-bottom-space-reserved", "true");
+        element.setAttribute("data-ime-debug-padding-bottom-previous", previousPadding);
+        element.setAttribute("data-ime-debug-scroll-padding-bottom-previous", previousScrollPadding);
+        element.style.paddingBottom = previousPadding
+            ? "calc(" + previousPadding + " + " + amount + ")"
+            : amount;
+        element.style.scrollPaddingBottom = previousScrollPadding
+            ? "calc(" + previousScrollPadding + " + " + amount + ")"
+            : amount;
+      }
+
+      function reserveBottomEditingSpace(d) {
+        if (d.body) {
+          reserveBottomSpace(d.body, reservedHeight);
+        }
+        if (!d.querySelectorAll) {
+          return;
+        }
+        var scrollers = d.querySelectorAll("[data-mobile-role='wave-thread']");
+        for (var i = 0; i < scrollers.length; i++) {
+          reserveBottomSpace(scrollers[i], reservedHeight);
+        }
       }
 
       function fallbackCopy(text, done) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -484,45 +484,229 @@ public final class ImeDebugTracer {
   private static native void ensureOverlayJsni() /*-{
     try {
       var d = $doc;
+      var w = $wnd;
       var id = "ime-debug-overlay";
       if (d.getElementById(id)) return;
       var ov = d.createElement("div");
       ov.id = id;
+      ov.className = "ime-debug-overlay ime-debug-overlay-minimized";
       ov.tabIndex = 0;
-      ov.setAttribute("role", "log");
-      ov.setAttribute("aria-label",
-          "IME debug overlay. Double-tap or press Escape while focused to clear.");
+      ov.setAttribute("role", "region");
+      ov.setAttribute("aria-label", "IME debug overlay");
+      ov.setAttribute("aria-expanded", "false");
+      var collapsedHeight = "44px";
+      var safeAreaInset = "env(safe-area-inset-bottom, 0px)";
+      var reservedHeight = "calc(" + collapsedHeight + " + " + safeAreaInset + ")";
       ov.style.cssText =
-          "position:fixed;left:0;right:0;bottom:0;max-height:45%;overflow-y:auto;"
-          + "background:rgba(0,0,0,0.85);color:#b2ff59;font:10px/1.25 monospace;"
-          + "padding:4px 6px;z-index:2147483646;white-space:pre-wrap;"
-          + "word-break:break-all;pointer-events:auto;border-top:2px solid #555;";
-      if (d.body) {
-        d.body.appendChild(ov);
-      } else {
-        d.addEventListener('DOMContentLoaded', function () { d.body.appendChild(ov); }, true);
+          "position:fixed;left:0;right:0;bottom:0;z-index:2147483646;"
+          + "height:" + reservedHeight + ";max-height:" + reservedHeight + ";overflow:hidden;"
+          + "background:rgba(8,18,27,0.94);color:#c8ff6a;font:11px/1.25 monospace;"
+          + "border-top:1px solid rgba(178,255,89,0.45);"
+          + "box-shadow:0 -6px 18px rgba(0,0,0,0.25);pointer-events:auto;"
+          + "box-sizing:border-box;padding-bottom:" + safeAreaInset + ";";
+
+      var toolbar = d.createElement("div");
+      toolbar.style.height = collapsedHeight;
+      toolbar.style.minHeight = collapsedHeight;
+      toolbar.style.display = "flex";
+      toolbar.style.alignItems = "center";
+      toolbar.style.gap = "6px";
+      toolbar.style.padding = "0 6px";
+      toolbar.style.boxSizing = "border-box";
+
+      var title = d.createElement("span");
+      title.textContent = "IME";
+      title.style.flex = "1 1 auto";
+      title.style.fontWeight = "700";
+      title.style.minWidth = "0";
+
+      function styleButton(button) {
+        button.style.minHeight = collapsedHeight;
+        button.style.minWidth = collapsedHeight;
+        button.style.border = "1px solid rgba(178,255,89,0.35)";
+        button.style.borderRadius = "6px";
+        button.style.background = "rgba(255,255,255,0.08)";
+        button.style.color = "#e1ff9c";
+        button.style.font = "12px/1 sans-serif";
+        button.style.padding = "0 10px";
+        button.style.cursor = "pointer";
       }
-      // Double-tap the overlay to clear it.
-      var lastTap = 0;
-      ov.addEventListener('click', function (ev) {
-        var now = Date.now();
-        if (now - lastTap < 400) {
-          ov.innerHTML = "";
+
+      var toggle = d.createElement("button");
+      toggle.type = "button";
+      toggle.textContent = "Show IME log";
+      styleButton(toggle);
+
+      var copy = d.createElement("button");
+      copy.type = "button";
+      copy.textContent = "Copy";
+      copy.setAttribute("aria-label", "Copy IME debug log");
+      styleButton(copy);
+
+      var clear = d.createElement("button");
+      clear.type = "button";
+      clear.textContent = "Clear";
+      clear.setAttribute("aria-label", "Clear IME debug log");
+      styleButton(clear);
+
+      var status = d.createElement("span");
+      status.setAttribute("aria-live", "polite");
+      status.style.flex = "0 1 auto";
+      status.style.minWidth = "0";
+      status.style.maxWidth = "28vw";
+      status.style.overflow = "hidden";
+      status.style.textOverflow = "ellipsis";
+      status.style.whiteSpace = "nowrap";
+      status.style.color = "#e1ff9c";
+      status.style.font = "11px/1 sans-serif";
+
+      var log = d.createElement("div");
+      log.id = "ime-debug-log";
+      log.setAttribute("role", "log");
+      log.setAttribute("aria-live", "polite");
+      log.style.display = "none";
+      log.style.maxHeight = "calc(45vh - " + collapsedHeight + " - " + safeAreaInset + ")";
+      log.style.overflowY = "auto";
+      log.style.padding = "0 6px 6px";
+      log.style.boxSizing = "border-box";
+      log.style.whiteSpace = "pre-wrap";
+      log.style.wordBreak = "break-all";
+
+      var statusTimer = null;
+      function setStatus(message) {
+        status.textContent = message || "";
+        if (statusTimer) {
+          w.clearTimeout(statusTimer);
+          statusTimer = null;
         }
-        lastTap = now;
+        if (message) {
+          statusTimer = w.setTimeout(function () {
+            status.textContent = "";
+            statusTimer = null;
+          }, 1600);
+        }
+      }
+
+      function setExpanded(expanded) {
+        ov.className = expanded
+            ? "ime-debug-overlay ime-debug-overlay-expanded"
+            : "ime-debug-overlay ime-debug-overlay-minimized";
+        ov.setAttribute("aria-expanded", expanded ? "true" : "false");
+        toggle.textContent = expanded ? "Hide IME log" : "Show IME log";
+        toggle.setAttribute("aria-label", expanded ? "Hide IME debug log" : "Show IME debug log");
+        log.style.display = expanded ? "block" : "none";
+        if (expanded) {
+          ov.style.height = "auto";
+          ov.style.maxHeight = "45vh";
+          log.scrollTop = log.scrollHeight;
+        } else {
+          ov.style.height = reservedHeight;
+          ov.style.maxHeight = reservedHeight;
+        }
+      }
+
+      function copyLogText(log) {
+        var rows = [];
+        for (var i = 0; i < log.children.length; i++) {
+          rows.push(log.children[i].textContent || "");
+        }
+        return rows.join("\n");
+      }
+
+      function reserveBodyBottomSpace(d) {
+        if (!d.body || d.body.getAttribute("data-ime-debug-body-padding-reserved") === "true") {
+          return;
+        }
+        var previous = d.body.style.paddingBottom || "";
+        d.body.setAttribute("data-ime-debug-body-padding-reserved", "true");
+        d.body.setAttribute("data-ime-debug-body-padding-previous", previous);
+        d.body.style.paddingBottom = previous
+            ? "calc(" + previous + " + " + collapsedHeight + " + " + safeAreaInset + ")"
+            : reservedHeight;
+      }
+
+      function fallbackCopy(text, done) {
+        var textarea = d.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "readonly");
+        textarea.style.position = "fixed";
+        textarea.style.top = "-1000px";
+        textarea.style.left = "-1000px";
+        d.body.appendChild(textarea);
+        textarea.select();
+        var copied = false;
+        try {
+          copied = d.execCommand('copy');
+        } catch (e) {
+          copied = false;
+        }
+        d.body.removeChild(textarea);
+        done(copied);
+      }
+
+      toggle.addEventListener('click', function (ev) {
+        setExpanded(log.style.display === "none");
+        ev.stopPropagation();
       }, false);
-      // Keyboard-accessible clear: focus the overlay (Tab until the log
-      // element is reached) and press Escape. Also Ctrl+Shift+C on the
-      // overlay clears without relying on focus order.
+      copy.addEventListener('click', function (ev) {
+        var text = copyLogText(log);
+        if (!text) {
+          setStatus("No IME log lines yet");
+          ev.stopPropagation();
+          return;
+        }
+        if (w.navigator && w.navigator.clipboard && w.navigator.clipboard.writeText) {
+          w.navigator.clipboard.writeText(text).then(function () {
+            setStatus("IME log copied");
+          }, function () {
+            fallbackCopy(text, function (copied) {
+              setStatus(copied ? "IME log copied" : "Copy failed");
+            });
+          });
+        } else {
+          fallbackCopy(text, function (copied) {
+            setStatus(copied ? "IME log copied" : "Copy failed");
+          });
+        }
+        ev.stopPropagation();
+      }, false);
+      clear.addEventListener('click', function (ev) {
+        log.textContent = "";
+        setStatus("IME log cleared");
+        ev.stopPropagation();
+      }, false);
       ov.addEventListener('keydown', function (ev) {
-        if (ev.key === 'Escape'
-            || (ev.key === 'c' && ev.ctrlKey && ev.shiftKey)
+        if (ev.key === 'Escape') {
+          setExpanded(false);
+          ev.stopPropagation();
+          ev.preventDefault();
+        } else if ((ev.key === 'c' && ev.ctrlKey && ev.shiftKey)
             || (ev.key === 'C' && ev.ctrlKey && ev.shiftKey)) {
-          ov.innerHTML = "";
+          log.textContent = "";
+          setStatus("IME log cleared");
           ev.stopPropagation();
           ev.preventDefault();
         }
       }, false);
+
+      toolbar.appendChild(title);
+      toolbar.appendChild(toggle);
+      toolbar.appendChild(copy);
+      toolbar.appendChild(clear);
+      toolbar.appendChild(status);
+      ov.appendChild(toolbar);
+      ov.appendChild(log);
+      setExpanded(false);
+
+      if (d.body) {
+        reserveBodyBottomSpace(d);
+        d.body.appendChild(ov);
+      } else {
+        d.addEventListener('DOMContentLoaded', function () {
+          reserveBodyBottomSpace(d);
+          d.body.appendChild(ov);
+        }, true);
+      }
     } catch (e) {
       // swallow
     }
@@ -531,15 +715,18 @@ public final class ImeDebugTracer {
   private static native void appendToOverlayJsni(String line) /*-{
     try {
       var d = $doc;
-      var ov = d.getElementById("ime-debug-overlay");
-      if (!ov) { return; }
+      function getLogBody(d) {
+        return d.getElementById("ime-debug-log");
+      }
+      var log = getLogBody(d);
+      if (!log) { return; }
       var row = d.createElement("div");
       row.textContent = line;
-      ov.appendChild(row);
-      while (ov.children.length > @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::MAX_OVERLAY_LINES) {
-        ov.removeChild(ov.firstChild);
+      log.appendChild(row);
+      while (log.children.length > @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::MAX_OVERLAY_LINES) {
+        log.removeChild(log.firstChild);
       }
-      ov.scrollTop = ov.scrollHeight;
+      log.scrollTop = log.scrollHeight;
     } catch (e) {
       // swallow
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -717,11 +717,11 @@ public final class ImeDebugTracer {
       setExpanded(false);
 
       if (d.body) {
-        reserveBodyBottomSpace(d);
+        reserveBottomEditingSpace(d);
         d.body.appendChild(ov);
       } else {
         d.addEventListener('DOMContentLoaded', function () {
-          reserveBodyBottomSpace(d);
+          reserveBottomEditingSpace(d);
           d.body.appendChild(ov);
         }, true);
       }

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -496,7 +496,7 @@ public final class ImeDebugTracer {
       ov.setAttribute("aria-expanded", "false");
       var collapsedHeight = "44px";
       var safeAreaInset = "env(safe-area-inset-bottom, 0px)";
-      var reservedHeight = "calc(" + collapsedHeight + " + " + safeAreaInset + ")";
+      var reservedHeight = "calc(" + collapsedHeight + " + 1px + " + safeAreaInset + ")";
       ov.style.cssText =
           "position:fixed;left:0;right:0;bottom:0;z-index:2147483646;"
           + "height:" + reservedHeight + ";max-height:" + reservedHeight + ";overflow:hidden;"

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
@@ -75,14 +75,15 @@ public final class ImeDebugOverlayContractTest extends TestCase {
   public void testMinimizedOverlayReservesBottomEditingSpace() throws Exception {
     String source = readTracerSource();
 
-    assertContains(source, "reserveBodyBottomSpace");
-    assertContains(source, "data-ime-debug-body-padding-reserved");
+    assertContains(source, "reserveBottomEditingSpace");
+    assertContains(source, "reserveBottomSpace");
+    assertContains(source, "data-ime-debug-bottom-space-reserved");
+    assertContains(source, "querySelectorAll(\"[data-mobile-role='wave-thread']\")");
     assertContains(source, "safeAreaInset = \"env(safe-area-inset-bottom, 0px)\"");
     assertContains(source, "\" + 1px + \" + safeAreaInset");
     assertContains(source, "style.paddingBottom");
-    assertContains(source, " + collapsedHeight + ");
-    assertContains(source, " + 1px + ");
-    assertContains(source, " + safeAreaInset");
+    assertContains(source, "style.scrollPaddingBottom");
+    assertContains(source, "reservedHeight = \"calc(\" + collapsedHeight + \" + 1px + \" + safeAreaInset + \")\"");
   }
 
   public void testConsoleAndRemoteLoggingCallsRemainPresent() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Source-level JSNI contract test. The normal JVM test source set excludes most
+ * client test packages, so this verifies client overlay invariants from here.
+ */
+public final class ImeDebugOverlayContractTest extends TestCase {
+
+  public void testOverlayStartsMinimizedWithTouchFriendlyControls() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "ime-debug-overlay-minimized");
+    assertContains(source, "setExpanded(false)");
+    assertContains(source, "Show IME log");
+    assertContains(source, "Hide IME log");
+    assertContains(source, "style.display = \"none\"");
+    assertContains(source, "collapsedHeight = \"44px\"");
+    assertContains(source, "toolbar.style.height = collapsedHeight");
+    assertContains(source, "toolbar.style.padding = \"0 6px\"");
+    assertFalse("Overlay must not start with the previous expanded 45% height",
+        source.contains("max-height:45%"));
+  }
+
+  public void testOverlayProvidesCopyAndClearButtons() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "Copy IME debug log");
+    assertContains(source, "Clear IME debug log");
+    assertContains(source, "navigator.clipboard.writeText");
+    assertContains(source, "execCommand('copy')");
+    assertContains(source, "createElement(\"textarea\")");
+    assertContains(source, "removeChild(textarea)");
+    assertContains(source, "copyLogText");
+    assertContains(source, "No IME log lines yet");
+    assertContains(source, "IME log copied");
+  }
+
+  public void testLogRowsAppendInsideScrollableLogBody() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "var log = getLogBody(d)");
+    assertContains(source, "log.appendChild(row)");
+    assertContains(source, "log.children.length > @org.waveprotocol.wave.client.editor.debug.ImeDebugTracer::MAX_OVERLAY_LINES");
+    assertContains(source, "log.removeChild(log.firstChild)");
+    assertContains(source, "log.scrollTop = log.scrollHeight");
+    assertFalse("Rows should no longer append directly to the overlay chrome",
+        source.contains("ov.appendChild(row)"));
+  }
+
+  public void testMinimizedOverlayReservesBottomEditingSpace() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "reserveBodyBottomSpace");
+    assertContains(source, "data-ime-debug-body-padding-reserved");
+    assertContains(source, "safeAreaInset = \"env(safe-area-inset-bottom, 0px)\"");
+    assertContains(source, "style.paddingBottom");
+    assertContains(source, " + collapsedHeight + ");
+    assertContains(source, " + safeAreaInset");
+  }
+
+  public void testConsoleAndRemoteLoggingCallsRemainPresent() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "consoleLogJsni(");
+    assertContains(source, "queueRemoteLogJsni(");
+    assertContains(source, "queueRemoteLogJsniBridge");
+  }
+
+  private static String readTracerSource() throws Exception {
+    Path root = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (root != null && !Files.exists(root.resolve("wave/src/main/java"))) {
+      root = root.getParent();
+    }
+    if (root == null) {
+      fail("Could not locate repository root from " + System.getProperty("user.dir"));
+    }
+    byte[] bytes = Files.readAllBytes(root.resolve(
+        "wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java"));
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  private static void assertContains(String source, String expected) {
+    assertTrue("Expected source to contain: " + expected, source.contains(expected));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
@@ -78,8 +78,10 @@ public final class ImeDebugOverlayContractTest extends TestCase {
     assertContains(source, "reserveBodyBottomSpace");
     assertContains(source, "data-ime-debug-body-padding-reserved");
     assertContains(source, "safeAreaInset = \"env(safe-area-inset-bottom, 0px)\"");
+    assertContains(source, "\" + 1px + \" + safeAreaInset");
     assertContains(source, "style.paddingBottom");
     assertContains(source, " + collapsedHeight + ");
+    assertContains(source, " + 1px + ");
     assertContains(source, " + safeAreaInset");
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/util/MobileChromeControlsContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/MobileChromeControlsContractTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Source-level contract for the server-rendered mobile wave/tag controls. */
+public final class MobileChromeControlsContractTest extends TestCase {
+
+  public void testMobileControlsUseIconButtonsWithAccessibleLabels() throws Exception {
+    String source = readHtmlRendererSource();
+
+    assertContains(source, "mobile-control-svg");
+    assertContains(source, "mobile-control-label");
+    assertContains(source, "width: 44px");
+    assertContains(source, "height: 44px");
+    assertContains(source, "border-radius: 12px");
+    assertContains(source, "title=\\\"Show tags tray\\\"");
+    assertContains(source, "title=\\\"Pin tags tray\\\"");
+  }
+
+  public void testMobileControlStateSyncPreservesIconMarkup() throws Exception {
+    String source = readHtmlRendererSource();
+
+    assertContains(source, "function setToggleState(button, pressed, label)");
+    assertContains(source, "button.setAttribute('title', label)");
+    assertContains(source, "hiddenLabel.textContent = label");
+    assertFalse("State sync must not replace icon markup with visible text",
+        source.contains("button.textContent = text"));
+    assertFalse("Tags tray control should not render as a visible text pill",
+        source.contains("aria-pressed=\\\"false\\\">Tags</button>"));
+    assertFalse("Tag pin control should not render as a visible text pill",
+        source.contains("aria-pressed=\\\"false\\\">Tag Pin</button>"));
+  }
+
+  private static String readHtmlRendererSource() throws Exception {
+    Path root = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+    while (root != null && !Files.exists(root.resolve("wave/src/jakarta-overrides/java"))) {
+      root = root.getParent();
+    }
+    if (root == null) {
+      fail("Could not locate repository root from " + System.getProperty("user.dir"));
+    }
+    byte[] bytes = Files.readAllBytes(root.resolve(
+        "wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java"));
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  private static void assertContains(String source, String expected) {
+    assertTrue("Expected source to contain: " + expected, source.contains(expected));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelMobileChromeContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelMobileChromeContractTest.java
@@ -63,8 +63,12 @@ public final class WavePanelMobileChromeContractTest extends TestCase {
             "body.mobile-wave-open.mobile-wave-chrome-hidden #mobileWaveChromeReveal { display: inline-flex; }"));
     assertTrue(html.contains("aria-pressed=\\\"false\\\""));
     assertTrue(html.contains("function syncMobileChromeButtons()"));
-    assertTrue(html.contains("function setToggleState(button, pressed, label, text)"));
+    assertTrue(html.contains("function setToggleState(button, pressed, label)"));
     assertTrue(html.contains("button.setAttribute('aria-pressed', pressed ? 'true' : 'false');"));
+    assertTrue(html.contains("button.setAttribute('title', label);"));
+    assertTrue(html.contains("hiddenLabel.textContent = label"));
+    assertTrue(html.contains("mobile-control-svg"));
+    assertTrue(html.contains("mobile-control-label"));
     assertTrue(html.contains("setToggleState(mobileWaveChromePin, chromePinned"));
     assertTrue(html.contains("setToggleState(mobileTagsToggle, tagsOpen"));
     assertTrue(html.contains("setToggleState(mobileTagsPin, tagsPinned"));


### PR DESCRIPTION
## Summary
- Make the IME debug overlay start as a compact 44px mobile-safe control instead of an expanded bottom log.
- Add explicit Show/Hide, Copy, and Clear controls while keeping log rows in a hidden scrollable body until expanded.
- Replace mobile wave/tag text pills with compact SVG icon buttons that preserve accessible labels during state sync.

Fixes #1005.

## Verification
- `sbt --batch "testOnly org.waveprotocol.box.server.util.ImeDebugOverlayContractTest org.waveprotocol.box.server.util.MobileChromeControlsContractTest"` passed: 7 tests, 0 failures.
- `python3 scripts/assemble-changelog.py` assembled 241 entries.
- `python3 scripts/validate-changelog.py` passed.
- `sbt --batch Universal/stage` passed; GWT production compile succeeded.
- `PORT=9905 bash scripts/wave-smoke.sh check` passed for root, health, landing, J2CL root/index, sidecar, and webclient asset.
- Pixel 5 Chromium viewport (`393x727`) against `http://localhost:9905/?ime_debug=on#local.net/w+mobile-test` passed: mobile wave/tag controls stayed 44x44 SVG icon buttons after state sync; compiled IME overlay started minimized at 44px, expanded to 87px under the 45vh cap, and minimized back to 44px.

## Notes
- Local browser verification used a long-lived foreground staged server because the smoke start helper's background child exits when the shell session ends in this worktree environment.
- The dev file store has no local accounts, so the Pixel check exercised the compiled GWT overlay functions from the generated `war/webclient` bundle on the local server page instead of creating a local test account.
