### PR TITLE
Fix Android IME composition history recovery

### DIFF
--- a/docs/superpowers/plans/2026-04-24-issue-828-android-ime-composition-history.md
+++ b/docs/superpowers/plans/2026-04-24-issue-828-android-ime-composition-history.md
@@ -1,0 +1,37 @@
+# Issue #828 Android IME Composition History Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:systematic-debugging` and focused regression tests before changing editor behavior.
+
+**Goal:** Fix the real Galaxy/Chrome failure where typing `new blip` in a blip displays blank after Done and reloads as only `ew`.
+
+**Root Cause:** The supplied device trace shows Android Chrome replacing the active composition scratch text with shortened values before commit. The first word reports `n -> e -> e -> ew`, so reading the final scratch span commits only `ew`. The second word reports `b -> l -> l -> li -> lip`, so reading the final scratch span commits only `lip`. The trace also shows the space after the first word arriving as a standalone Android `textInput` after composition has ended, without a normal soft-key `keydown` to activate `TypingExtractor`.
+
+**Files:**
+- `wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandler.java`
+- `wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEvent.java`
+- `wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java`
+- `wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java`
+- `wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java`
+- `wave/config/changelog.d/2026-04-24-android-ime-composition-history.json`
+
+## Acceptance Criteria
+
+- Reconstruct Android replacement streams like `n, e, e, ew` as `new`.
+- Reconstruct replacement streams like `b, l, l, li, lip` as `blip`.
+- Preserve standalone Android `textInput` separators such as the space between words.
+- Do not restore an unrelated empty-baseline previous sibling to empty after the event-history tracker has already recovered the current word.
+- GWT dev compile succeeds.
+- Local mobile Chrome simulation can type `new blip`, tap Done, reload, and still find `new blip`.
+
+## Verification
+
+- `sbt "Test/runMain org.junit.runner.JUnitCore org.waveprotocol.wave.model.util.ImeCompositionTextTrackerTest org.waveprotocol.wave.model.util.GhostTextReconcilerTest"`
+- `sbt compileGwtDev`
+- `python3 scripts/assemble-changelog.py`
+- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+- `bash scripts/worktree-boot.sh --port 9933`
+- `PORT=9933 bash scripts/wave-smoke.sh check`
+- Playwright Chromium with `devices['Galaxy S9+']` against `http://127.0.0.1:9933`: register/login, create wave, type `new blip`, tap Done, reload, assert the page still contains `new blip`.

--- a/wave/config/changelog.d/2026-04-24-android-ime-composition-history.json
+++ b/wave/config/changelog.d/2026-04-24-android-ime-composition-history.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-24-android-ime-composition-history",
+  "version": "Unreleased",
+  "date": "2026-04-24",
+  "title": "Recover Android IME text from composition history",
+  "summary": "Android Chrome can replace the active IME scratch span with shortened composition text, dropping the first character before commit. The editor now reconstructs the composed word from composition event data and commits standalone Android textInput separators directly.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Typing text such as \"new blip\" into a blip from Android Chrome now preserves leading letters and spaces when the keyboard rewrites the composition scratch text."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/common/util/FakeSignalEvent.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/common/util/FakeSignalEvent.java
@@ -41,6 +41,7 @@ public class FakeSignalEvent extends SignalEventImpl {
     private final boolean altKey, ctrlKey, metaKey, shiftKey;
     private final String type;
     private final String key;
+    private final String data;
     private final int mouseButton;
 
     boolean defaultPrevented = false;
@@ -53,8 +54,14 @@ public class FakeSignalEvent extends SignalEventImpl {
 
     public FakeNativeEvent(String type, String key,
         int mouseButton, EnumSet<KeyModifier> modifiers) {
+      this(type, key, null, mouseButton, modifiers);
+    }
+
+    public FakeNativeEvent(String type, String key, String data,
+        int mouseButton, EnumSet<KeyModifier> modifiers) {
       this.type = type;
       this.key = key;
+      this.data = data;
       this.mouseButton = mouseButton;
       this.altKey = modifiers != null && modifiers.contains(KeyModifier.ALT);
       this.ctrlKey = modifiers != null && modifiers.contains(KeyModifier.CTRL);
@@ -98,6 +105,11 @@ public class FakeSignalEvent extends SignalEventImpl {
     }
 
     @Override
+    public String getData() {
+      return data == null ? "" : data;
+    }
+
+    @Override
     public void preventDefault() {
       defaultPrevented = true;
     }
@@ -127,6 +139,11 @@ public class FakeSignalEvent extends SignalEventImpl {
   public static <T extends FakeSignalEvent> T createEvent(
       SignalEventFactory<T> factory, String type, String key) {
     return createInner(factory.create(), new FakeNativeEvent(type, key, 0, null), null);
+  }
+
+  public static <T extends FakeSignalEvent> T createEventWithData(
+      SignalEventFactory<T> factory, String type, String data) {
+    return createInner(factory.create(), new FakeNativeEvent(type, null, data, 0, null), null);
   }
 
   public static <T extends FakeSignalEvent> T createKeyPress(SignalEventFactory<T> factory,

--- a/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEvent.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEvent.java
@@ -176,6 +176,11 @@ public interface SignalEvent {
   String getKey();
 
   /**
+   * @return The text payload reported by text/composition input events, if any.
+   */
+  String getData();
+
+  /**
    * @return The target element of the event
    */
   Element getTarget();

--- a/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEvent.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEvent.java
@@ -176,7 +176,8 @@ public interface SignalEvent {
   String getKey();
 
   /**
-   * @return The text payload reported by text/composition input events, if any.
+   * @return The text payload reported by text/composition input events; never null -
+   *         implementations return {@code ""} when there is no text payload.
    */
   String getData();
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEventImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/common/util/SignalEventImpl.java
@@ -75,6 +75,7 @@ public class SignalEventImpl implements SignalEvent {
   interface NativeEvent {
     String getType();
     String getKey();
+    String getData();
     int getButton();
     boolean getCtrlKey();
     boolean getMetaKey();
@@ -202,6 +203,10 @@ public class SignalEventImpl implements SignalEvent {
 
     public final native String getKey() /*-{
       return this.key || '';
+    }-*/;
+
+    public final native String getData() /*-{
+      return this.data || '';
     }-*/;
   }
 
@@ -347,6 +352,11 @@ public class SignalEventImpl implements SignalEvent {
   @Override
   public final String getKey() {
     return nativeEvent.getKey();
+  }
+
+  @Override
+  public final String getData() {
+    return nativeEvent.getData();
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/EditorImpl.java
@@ -1249,9 +1249,8 @@ public class EditorImpl extends LogicalPanel.Impl implements
     }
 
     @Override
-    public void compositionUpdate() {
-      // TODO(danilatos): Some event or other, so e.g. we can show other users
-      // the composition state.
+    public void compositionUpdate(String compositionText) {
+      imeExtractor.compositionUpdate(compositionText);
     }
 
     @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandler.java
@@ -38,7 +38,7 @@ public class CompositionEventHandler<V> {
 
   public interface CompositionListener<V> {
     void compositionStart(V event);
-    void compositionUpdate();
+    void compositionUpdate(V event);
     void compositionEnd();
   }
 
@@ -126,7 +126,7 @@ public class CompositionEventHandler<V> {
     } else if (
         BrowserEvents.TEXT.equals(typeName) ||
         BrowserEvents.COMPOSITIONUPDATE.equals(typeName)) {
-      compositionUpdate();
+      compositionUpdate(event);
     } else if (BrowserEvents.COMPOSITIONEND.equals(typeName)){
       compositionEnd();
     } else if (BrowserEvents.TEXTINPUT.equals(typeName)) {
@@ -194,11 +194,11 @@ public class CompositionEventHandler<V> {
     listener.compositionStart(event);
   }
 
-  private void compositionUpdate() {
+  private void compositionUpdate(V event) {
     checkAppComposing();
 
     assert appComposing == true;
-    listener.compositionUpdate();
+    listener.compositionUpdate(event);
   }
 
   private void compositionEnd() {

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -97,8 +97,8 @@ public final class EditorEventHandler {
         }
 
         @Override
-        public void compositionUpdate() {
-          EditorEventHandler.this.compositionUpdate();
+        public void compositionUpdate(EditorEvent event) {
+          EditorEventHandler.this.compositionUpdate(event);
         }
 
         @Override
@@ -290,6 +290,9 @@ public final class EditorEventHandler {
       return handleKeyEvent(event);
     } else if (event.isCompositionEvent()) {
       if (useCompositionEvents) {
+        if (shouldHandleStandaloneAndroidTextInput(event)) {
+          return handleStandaloneAndroidTextInput(event);
+        }
         return handleCompositionEvent(event);
       } else {
         return false;
@@ -534,11 +537,52 @@ public final class EditorEventHandler {
   }
 
 
-  private void compositionUpdate() {
+  private void compositionUpdate(EditorEvent event) {
     if (ImeDebugTracer.isEnabled()) {
-      ImeDebugTracer.trace("EEH.compositionUpdate");
+      ImeDebugTracer.start("EEH.compositionUpdate")
+          .add("data", event.getData())
+          .emit();
     }
-    editorInteractor.compositionUpdate();
+    editorInteractor.compositionUpdate(event.getData());
+  }
+
+  private boolean shouldHandleStandaloneAndroidTextInput(EditorEvent event) {
+    return state == State.NORMAL
+        && UserAgent.isAndroid()
+        && BrowserEvents.TEXTINPUT.equals(event.getType())
+        && event.getData() != null
+        && !event.getData().isEmpty();
+  }
+
+  private boolean handleStandaloneAndroidTextInput(EditorEvent event)
+      throws SelectionLostException {
+    if (cachedSelection == null) {
+      refreshEditorWithCaret(event);
+    }
+    if (cachedSelection == null) {
+      return false;
+    }
+
+    Point<ContentNode> caret;
+    boolean isReplace = false;
+    if (cachedSelection.isCollapsed()) {
+      caret = cachedSelection.getFocus();
+    } else {
+      caret = deleteCachedSelectionRangeAndInvalidate(true);
+      isReplace = true;
+    }
+
+    caret = editorInteractor.insertText(caret, event.getData(), isReplace);
+    caret = editorInteractor.normalizePoint(caret);
+    setCaret(caret);
+    editorInteractor.rebiasSelection(CursorDirection.FROM_LEFT);
+    event.preventDefault();
+    if (ImeDebugTracer.isEnabled()) {
+      ImeDebugTracer.start("EEH.androidTextInput.insert")
+          .add("data", event.getData())
+          .emit();
+    }
+    return true;
   }
 
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorEventHandler.java
@@ -139,6 +139,8 @@ public final class EditorEventHandler {
   private final DelayedCompositionMutationGuard delayedCompositionMutationGuard =
       new DelayedCompositionMutationGuard();
 
+  private boolean androidImeStandaloneTextInputExpected;
+
   /**
    * We keep track of whether selection affinity is up to date. When we receive
    * an event, we assume that the event will invalidate the selection affinity,
@@ -248,6 +250,7 @@ public final class EditorEventHandler {
 
     // TODO(danilatos): IE IME keycode thingy!!
     invalidateSelection();
+    updateAndroidImeStandaloneTextInputExpectation(event);
 
     // NOTE(patcoleman): special cases FTW!
     // 1) click can be while the editor isn't editing, so needs to avoid needing content selection.
@@ -292,6 +295,9 @@ public final class EditorEventHandler {
       if (useCompositionEvents) {
         if (shouldHandleStandaloneAndroidTextInput(event)) {
           return handleStandaloneAndroidTextInput(event);
+        }
+        if (BrowserEvents.TEXTINPUT.equals(event.getType())) {
+          androidImeStandaloneTextInputExpected = false;
         }
         return handleCompositionEvent(event);
       } else {
@@ -468,6 +474,7 @@ public final class EditorEventHandler {
   }
 
   private void compositionStart(EditorEvent event) {
+    androidImeStandaloneTextInputExpected = false;
     if (state == State.COMPOSITION) {
       logger.error().log("State was already IME during a compositionstart event!");
     }
@@ -486,7 +493,7 @@ public final class EditorEventHandler {
     // On mobile browsers (e.g. Android Chrome), keydown with keyCode 229 fires
     // before compositionstart. That keydown activates the typing extractor.
     // We must flush it here so that the typing extractor and the IME composition
-    // handler are not both active simultaneously — otherwise the typing
+    // handler are not both active simultaneously - otherwise the typing
     // extractor's stale DOM tracking causes characters to be lost.
     editorInteractor.forceFlush();
     cachedSelection = editorInteractor.getSelectionPoints();
@@ -549,13 +556,25 @@ public final class EditorEventHandler {
   private boolean shouldHandleStandaloneAndroidTextInput(EditorEvent event) {
     return state == State.NORMAL
         && UserAgent.isAndroid()
+        && androidImeStandaloneTextInputExpected
         && BrowserEvents.TEXTINPUT.equals(event.getType())
         && event.getData() != null
         && !event.getData().isEmpty();
   }
 
+  private void updateAndroidImeStandaloneTextInputExpectation(EditorEvent event) {
+    if (!androidImeStandaloneTextInputExpected) {
+      return;
+    }
+    if (BrowserEvents.TEXTINPUT.equals(event.getType()) || event.isImeKeyEvent()) {
+      return;
+    }
+    androidImeStandaloneTextInputExpected = false;
+  }
+
   private boolean handleStandaloneAndroidTextInput(EditorEvent event)
       throws SelectionLostException {
+    androidImeStandaloneTextInputExpected = false;
     if (cachedSelection == null) {
       refreshEditorWithCaret(event);
     }
@@ -596,6 +615,7 @@ public final class EditorEventHandler {
     // into compositionStart()
     cachedSelection = editorInteractor.compositionEnd();
     state = State.NORMAL;
+    androidImeStandaloneTextInputExpected = UserAgent.isAndroid();
     // Only suppress the trailing DOM mutation when compositionEnd() produced a
     // real editor selection. If compositionEnd() returns null, that same
     // mutation is the fallback path that can still materialize browser-only
@@ -755,7 +775,7 @@ public final class EditorEventHandler {
     // issues when deleting around annotation boundaries.
     //
     // When composition events are enabled and the key is IME (keyCode 229),
-    // let the composition handler manage the input — compositionstart will
+    // let the composition handler manage the input - compositionstart will
     // follow this keydown. Activating the typing extractor here would
     // conflict with the IME composition flow and cause character loss on
     // mobile browsers (Android Chrome) where every soft keyboard key

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorInteractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/event/EditorInteractor.java
@@ -173,7 +173,7 @@ public interface EditorInteractor {
   /**
    * Composition state updated
    */
-  void compositionUpdate();
+  void compositionUpdate(String compositionText);
 
   /**
    * IME composition completed

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -28,6 +28,7 @@ import com.google.gwt.dom.client.Text;
 
 import org.waveprotocol.wave.client.common.util.DomHelper;
 import org.waveprotocol.wave.client.common.util.QuirksConstants;
+import org.waveprotocol.wave.client.common.util.UserAgent;
 import org.waveprotocol.wave.client.editor.ElementHandlerRegistry;
 import org.waveprotocol.wave.client.editor.content.ContentElement;
 import org.waveprotocol.wave.client.editor.content.ContentNode;
@@ -43,6 +44,7 @@ import org.waveprotocol.wave.model.document.util.FilteredView.Skip;
 import org.waveprotocol.wave.model.document.util.LocalDocument;
 import org.waveprotocol.wave.model.document.util.Point;
 import org.waveprotocol.wave.model.util.GhostTextReconciler;
+import org.waveprotocol.wave.model.util.ImeCompositionTextTracker;
 
 import java.util.Collections;
 
@@ -80,6 +82,9 @@ public class ImeExtractor {
   private Node ghostNextSibling;
   private String ghostNextSiblingModelBaseline;
   private String ghostNextSiblingCapturedText;
+  private final ImeCompositionTextTracker compositionTextTracker =
+      new ImeCompositionTextTracker();
+  private boolean suppressPreviousGhostForCurrentComposition;
 
   private static final String WRAPPER_TAGNAME = "l:ime";
 
@@ -155,12 +160,23 @@ public class ImeExtractor {
     }
     String currentPrev = readCurrentPreviousText();
     String currentNext = readCurrentNextText();
-    String result = GhostTextReconciler.combineWithCapturedGhosts(scratchContent,
-        ghostPreviousSiblingModelBaseline, ghostPreviousSiblingCapturedText, currentPrev,
+    String effectiveScratchContent = UserAgent.isAndroid()
+        ? compositionTextTracker.effectiveText(scratchContent)
+        : scratchContent;
+    suppressPreviousGhostForCurrentComposition = UserAgent.isAndroid()
+        && GhostTextReconciler.shouldSuppressPreviousGhostForRecoveredScratch(
+            scratchContent, effectiveScratchContent, ghostPreviousSiblingModelBaseline,
+            ghostPreviousSiblingCapturedText, currentPrev);
+    String result = GhostTextReconciler.combineWithCapturedGhosts(effectiveScratchContent,
+        suppressPreviousGhostForCurrentComposition ? null : ghostPreviousSiblingModelBaseline,
+        suppressPreviousGhostForCurrentComposition ? null : ghostPreviousSiblingCapturedText,
+        suppressPreviousGhostForCurrentComposition ? null : currentPrev,
         ghostNextSiblingModelBaseline, ghostNextSiblingCapturedText, currentNext);
     if (ImeDebugTracer.isEnabled()) {
       ImeDebugTracer.start("ImeExtractor.getEffectiveContent")
           .add("scratch", scratchContent)
+          .add("effectiveScratch", effectiveScratchContent)
+          .add("suppressPrevGhost", suppressPreviousGhostForCurrentComposition)
           .add("prevModelBaseline", ghostPreviousSiblingModelBaseline)
           .add("prevCaptured", ghostPreviousSiblingCapturedText)
           .add("currentPrev", currentPrev)
@@ -210,6 +226,8 @@ public class ImeExtractor {
     wrapper.getContainerNodelet().appendChild(imeContainer);
     NativeSelectionUtil.setCaret(inContainer);
     captureGhostBaseline(previousModelBaseline, nextModelBaseline);
+    compositionTextTracker.reset();
+    suppressPreviousGhostForCurrentComposition = false;
     if (ImeDebugTracer.isEnabled()) {
       Element anchor = imeContainer.getParentElement();
       ImeDebugTracer.start("ImeExtractor.activate")
@@ -221,6 +239,20 @@ public class ImeExtractor {
           .add("nextCaptured", ghostNextSiblingCapturedText)
           .add("anchorParent", ImeDebugTracer.describe(anchor == null ? null : anchor.getParentElement()))
           .add("anchorInnerText", ImeDebugTracer.innerText(anchor == null ? null : anchor.getParentElement()))
+          .emit();
+    }
+  }
+
+  /** Records composition event text for browsers that rewrite the scratch span. */
+  public void compositionUpdate(String compositionText) {
+    if (!isActive()) {
+      return;
+    }
+    compositionTextTracker.observe(compositionText);
+    if (ImeDebugTracer.isEnabled()) {
+      ImeDebugTracer.start("ImeExtractor.compositionUpdate")
+          .add("data", compositionText)
+          .add("scratch", imeContainer.getInnerText())
           .emit();
     }
   }
@@ -289,9 +321,12 @@ public class ImeExtractor {
   private void restoreGhostBaseline() {
     Node currentPreviousSibling = currentAdjacentSibling(true);
     Node currentNextSibling = currentAdjacentSibling(false);
-    restorePreviousTextNode(currentPreviousSibling, ghostPreviousSiblingModelBaseline);
+    if (!suppressPreviousGhostForCurrentComposition) {
+      restorePreviousTextNode(currentPreviousSibling, ghostPreviousSiblingModelBaseline);
+    }
     restoreNextTextNode(currentNextSibling, ghostNextSiblingModelBaseline);
-    if (currentPreviousSibling != ghostPreviousSibling) {
+    if (!suppressPreviousGhostForCurrentComposition
+        && currentPreviousSibling != ghostPreviousSibling) {
       restorePreviousTextNode(ghostPreviousSibling, ghostPreviousSiblingModelBaseline);
     }
     if (currentNextSibling != ghostNextSibling) {
@@ -303,6 +338,8 @@ public class ImeExtractor {
     ghostNextSibling = null;
     ghostNextSiblingModelBaseline = null;
     ghostNextSiblingCapturedText = null;
+    suppressPreviousGhostForCurrentComposition = false;
+    compositionTextTracker.reset();
   }
 
   private String readCurrentPreviousText() {

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/testing/FakeEditorEvent.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/testing/FakeEditorEvent.java
@@ -45,6 +45,15 @@ public class FakeEditorEvent extends FakeSignalEvent implements EditorEvent {
     return FakeSignalEvent.createEvent(ED_FACTORY, type);
   }
 
+  /**
+   * @param type
+   * @param data text payload reported by the event.
+   * @return a fake event of the given type and data.
+   */
+  public static FakeEditorEvent createWithData(String type, String data) {
+    return FakeSignalEvent.createEventWithData(ED_FACTORY, type, data);
+  }
+
 
   /**
    * Construct from a KeySignalType and a key code

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/GhostTextReconciler.java
@@ -126,6 +126,40 @@ public final class GhostTextReconciler {
     return ghostBefore + scratchContent + ghostAfter;
   }
 
+  /**
+   * Returns true when Android's composition event history has already recovered
+   * the full current word and an empty-baseline previous sibling looks like old
+   * committed text, not a prefix for this word.
+   *
+   * <p>The real Galaxy/Chrome trace that motivated this shows the second word
+   * of "new blip" activating with {@code previousModelBaseline=""} and
+   * {@code currentPrevious="ew "}. Treating that whole previous sibling as
+   * ghost text makes the current composition look like {@code "ew blip"} and
+   * the restore step can blank the displayed text by restoring that sibling to
+   * the empty baseline. If the recovered scratch is already ahead of the raw
+   * scratch and the previous sibling has no suffix/prefix overlap with the
+   * recovered word, it belongs to earlier committed text and must be ignored by
+   * the ghost combiner/restorer.
+   */
+  public static boolean shouldSuppressPreviousGhostForRecoveredScratch(String rawScratchContent,
+      String recoveredScratchContent, String previousModelBaseline, String capturedPrevious,
+      String currentPrevious) {
+    if (rawScratchContent == null || recoveredScratchContent == null) {
+      return false;
+    }
+    if (rawScratchContent.equals(recoveredScratchContent)) {
+      return false;
+    }
+    if (previousModelBaseline == null || !previousModelBaseline.isEmpty()) {
+      return false;
+    }
+    String candidatePrevious = !isNullOrEmpty(currentPrevious) ? currentPrevious : capturedPrevious;
+    if (isNullOrEmpty(candidatePrevious)) {
+      return false;
+    }
+    return suffixPrefixOverlap(candidatePrevious, recoveredScratchContent) == 0;
+  }
+
   private static String currentOrCapturedFallback(String capturedGhost, String currentGhost,
       String modelBaseline, String currentText) {
     if (!currentGhost.isEmpty()) {
@@ -146,6 +180,10 @@ public final class GhostTextReconciler {
   private static boolean didSiblingDisappearAfterCapturingGhost(String modelBaseline,
       String currentText) {
     return modelBaseline != null && currentText == null;
+  }
+
+  private static boolean isNullOrEmpty(String value) {
+    return value == null || value.isEmpty();
   }
 
   private static String withoutSuffixAlreadyAtScratchStart(String ghost, String scratchContent) {

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.util;
+
+/**
+ * Tracks Android IME composition text when the browser replaces the scratch
+ * span with a shortened composition value.
+ *
+ * <p>The real Galaxy/Chrome log for typing "new" shows composition data and
+ * scratch text moving through {@code n -> e -> e -> ew}. The final DOM scratch
+ * is therefore {@code ew}, but the event stream still contains enough monotonic
+ * evidence to recover {@code new}. This helper keeps that evidence as pure
+ * string state so the browser-facing editor code can stay small.
+ */
+public final class ImeCompositionTextTracker {
+
+  private String reconstructed = "";
+  private String lastObserved = "";
+
+  public void reset() {
+    reconstructed = "";
+    lastObserved = "";
+  }
+
+  public void observe(String value) {
+    if (value == null || value.isEmpty()) {
+      return;
+    }
+    if (reconstructed.isEmpty()) {
+      reconstructed = value;
+      lastObserved = value;
+      return;
+    }
+    if (value.equals(lastObserved)) {
+      return;
+    }
+    if (!lastObserved.isEmpty() && value.startsWith(lastObserved)) {
+      reconstructed += value.substring(lastObserved.length());
+      lastObserved = value;
+      return;
+    }
+    if (isSingleCharacterReplacement(value)) {
+      reconstructed += value;
+      lastObserved = value;
+      return;
+    }
+    lastObserved = value;
+  }
+
+  public String effectiveText(String scratchText) {
+    String scratch = scratchText == null ? "" : scratchText;
+    if (reconstructed.isEmpty()) {
+      return scratch;
+    }
+    if (scratch.isEmpty()) {
+      return reconstructed;
+    }
+    if (scratch.endsWith(reconstructed)) {
+      return scratch;
+    }
+    if (reconstructed.endsWith(scratch)) {
+      return reconstructed;
+    }
+    return scratch;
+  }
+
+  private boolean isSingleCharacterReplacement(String value) {
+    return value.length() == 1
+        && lastObserved.length() == 1
+        && reconstructed.endsWith(lastObserved);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -80,12 +80,13 @@ public final class ImeCompositionTextTracker {
     if (!pendingReplacementValue.isEmpty()
         && value.length() == 1
         && isAsciiLetterOrDigit(value.charAt(0))) {
-      confirmPendingReplacement();
+      // Another single-char revision of the composing position — don't confirm the
+      // previous pending (it was never extended/duplicated) and keep the original base.
+      pendingReplacementValue = value;
+      lastObserved = value;
+      return;
     }
     if (isSingleCharacterReplacement(value)) {
-      if (!pendingReplacementValue.isEmpty()) {
-        confirmPendingReplacement();
-      }
       pendingReplacementBase = reconstructed;
       pendingReplacementValue = value;
       lastObserved = value;

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -33,14 +33,20 @@ public final class ImeCompositionTextTracker {
 
   private String reconstructed = "";
   private String lastObserved = "";
+  private boolean hasRecoveredReplacement;
 
   public void reset() {
     reconstructed = "";
     lastObserved = "";
+    hasRecoveredReplacement = false;
   }
 
   public void observe(String value) {
-    if (value == null || value.isEmpty()) {
+    if (value == null) {
+      return;
+    }
+    if (value.isEmpty()) {
+      reset();
       return;
     }
     if (reconstructed.isEmpty()) {
@@ -59,9 +65,12 @@ public final class ImeCompositionTextTracker {
     if (isSingleCharacterReplacement(value)) {
       reconstructed += value;
       lastObserved = value;
+      hasRecoveredReplacement = true;
       return;
     }
+    reconstructed = value;
     lastObserved = value;
+    hasRecoveredReplacement = false;
   }
 
   public String effectiveText(String scratchText) {
@@ -70,12 +79,12 @@ public final class ImeCompositionTextTracker {
       return scratch;
     }
     if (scratch.isEmpty()) {
-      return reconstructed;
+      return scratch;
     }
     if (scratch.endsWith(reconstructed)) {
       return scratch;
     }
-    if (reconstructed.endsWith(scratch)) {
+    if (hasRecoveredReplacement && scratch.equals(lastObserved) && reconstructed.endsWith(scratch)) {
       return reconstructed;
     }
     return scratch;

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -33,11 +33,16 @@ public final class ImeCompositionTextTracker {
 
   private String reconstructed = "";
   private String lastObserved = "";
+  // A one-character replacement is ambiguous until a duplicate or extension follows.
+  private String pendingReplacementBase = "";
+  private String pendingReplacementValue = "";
   private boolean hasRecoveredReplacement;
 
   public void reset() {
     reconstructed = "";
     lastObserved = "";
+    pendingReplacementBase = "";
+    pendingReplacementValue = "";
     hasRecoveredReplacement = false;
   }
 
@@ -55,21 +60,41 @@ public final class ImeCompositionTextTracker {
       return;
     }
     if (value.equals(lastObserved)) {
+      if (value.equals(pendingReplacementValue)) {
+        confirmPendingReplacement();
+      }
       return;
     }
     if (!lastObserved.isEmpty() && value.startsWith(lastObserved)) {
-      reconstructed += value.substring(lastObserved.length());
+      if (lastObserved.equals(pendingReplacementValue)) {
+        reconstructed = pendingReplacementBase + value;
+        pendingReplacementBase = "";
+        pendingReplacementValue = "";
+        hasRecoveredReplacement = true;
+      } else {
+        reconstructed += value.substring(lastObserved.length());
+      }
       lastObserved = value;
       return;
     }
+    if (!pendingReplacementValue.isEmpty()
+        && value.length() == 1
+        && isAsciiLetterOrDigit(value.charAt(0))) {
+      confirmPendingReplacement();
+    }
     if (isSingleCharacterReplacement(value)) {
-      reconstructed += value;
+      if (!pendingReplacementValue.isEmpty()) {
+        confirmPendingReplacement();
+      }
+      pendingReplacementBase = reconstructed;
+      pendingReplacementValue = value;
       lastObserved = value;
-      hasRecoveredReplacement = true;
       return;
     }
     reconstructed = value;
     lastObserved = value;
+    pendingReplacementBase = "";
+    pendingReplacementValue = "";
     hasRecoveredReplacement = false;
   }
 
@@ -84,7 +109,9 @@ public final class ImeCompositionTextTracker {
     if (scratch.endsWith(reconstructed)) {
       return scratch;
     }
-    if (hasRecoveredReplacement && scratch.equals(lastObserved) && reconstructed.endsWith(scratch)) {
+    if (hasRecoveredReplacement
+        && scratch.equals(lastObserved)
+        && reconstructed.endsWith(scratch)) {
       return reconstructed;
     }
     return scratch;
@@ -93,6 +120,24 @@ public final class ImeCompositionTextTracker {
   private boolean isSingleCharacterReplacement(String value) {
     return value.length() == 1
         && lastObserved.length() == 1
+        && isAsciiLetterOrDigit(value.charAt(0))
+        && isAsciiLetterOrDigit(lastObserved.charAt(0))
         && reconstructed.endsWith(lastObserved);
+  }
+
+  private void confirmPendingReplacement() {
+    if (pendingReplacementValue.isEmpty()) {
+      return;
+    }
+    reconstructed = pendingReplacementBase + pendingReplacementValue;
+    pendingReplacementBase = "";
+    pendingReplacementValue = "";
+    hasRecoveredReplacement = true;
+  }
+
+  private boolean isAsciiLetterOrDigit(char c) {
+    return ('a' <= c && c <= 'z')
+        || ('A' <= c && c <= 'Z')
+        || ('0' <= c && c <= '9');
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
@@ -74,7 +74,7 @@ public class CompositionEventHandlerTest extends TestCase {
     nothingElseUpToNow();
   }
   private void verifyUpdate() {
-    verify(listener, times(1)).compositionUpdate();
+    verify(listener, times(1)).compositionUpdate(eventToken);
     nothingElseUpToNow();
   }
   private void verifyEnd() {

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/CompositionEventHandlerTest.java
@@ -73,8 +73,9 @@ public class CompositionEventHandlerTest extends TestCase {
     verify(listener, times(1)).compositionStart(token.length == 1 ? token[0] : eventToken);
     nothingElseUpToNow();
   }
-  private void verifyUpdate() {
-    verify(listener, times(1)).compositionUpdate(eventToken);
+  private void verifyUpdate(Object ... token) {
+    Preconditions.checkArgument(token.length <= 1);
+    verify(listener, times(1)).compositionUpdate(token.length == 1 ? token[0] : eventToken);
     nothingElseUpToNow();
   }
   private void verifyEnd() {

--- a/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/client/editor/event/EditorEventHandlerGwtTest.java
@@ -1286,8 +1286,8 @@ public class EditorEventHandlerGwtTest
     }
 
     @Override
-    public void compositionUpdate() {
-      methodCalledHelper(COMPOSITION_UPDATE);
+    public void compositionUpdate(String compositionText) {
+      methodCalledHelper(COMPOSITION_UPDATE, compositionText);
     }
 
     @Override

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/GhostTextReconcilerTest.java
@@ -242,6 +242,26 @@ public class GhostTextReconcilerTest extends TestCase {
         "lip", "new", "NEW b", "NEW b", null, null, null));
   }
 
+  public void testRecoveredScratchSuppressesUnrelatedEmptyBaselinePreviousGhost() {
+    assertTrue(GhostTextReconciler.shouldSuppressPreviousGhostForRecoveredScratch(
+        "lip", "blip", "", "ew ", "ew "));
+  }
+
+  public void testRecoveredScratchKeepsOverlappingPreviousGhost() {
+    assertFalse(GhostTextReconciler.shouldSuppressPreviousGhostForRecoveredScratch(
+        "ew", "new", "", "n", "n"));
+  }
+
+  public void testRecoveredScratchKeepsNonEmptyBaselinePreviousGhost() {
+    assertFalse(GhostTextReconciler.shouldSuppressPreviousGhostForRecoveredScratch(
+        "lip", "blip", "new", "new b", "new b"));
+  }
+
+  public void testUnrecoveredScratchKeepsPreviousGhost() {
+    assertFalse(GhostTextReconciler.shouldSuppressPreviousGhostForRecoveredScratch(
+        "lip", "lip", "", "ew ", "ew "));
+  }
+
   public void testNullScratchThrows() {
     try {
       GhostTextReconciler.combine(null, null, null, null, null);

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.util;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for Android Chrome composition streams where the browser replaces the
+ * whole scratch text with a shortened value while the user is still typing.
+ */
+public class ImeCompositionTextTrackerTest extends TestCase {
+
+  public void testAndroidSingleLetterReplacementSequenceRecoversNew() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("n");
+    tracker.observe("e");
+    tracker.observe("e");
+    tracker.observe("ew");
+    tracker.observe("ew");
+
+    assertEquals("new", tracker.effectiveText("ew"));
+  }
+
+  public void testAndroidSecondWordReplacementSequenceRecoversBlip() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("b");
+    tracker.observe("l");
+    tracker.observe("l");
+    tracker.observe("li");
+    tracker.observe("li");
+    tracker.observe("lip");
+
+    assertEquals("blip", tracker.effectiveText("lip"));
+  }
+
+  public void testRepeatedSingleCharacterDoesNotDuplicate() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("n");
+    tracker.observe("e");
+    tracker.observe("e");
+
+    assertEquals("ne", tracker.effectiveText("e"));
+  }
+
+  public void testBrowserCaughtUpScratchWins() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("n");
+    tracker.observe("e");
+
+    assertEquals("new", tracker.effectiveText("new"));
+  }
+
+  public void testUnrelatedMultiCharacterReplacementFallsBackToScratch() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("ab");
+    tracker.observe("c");
+
+    assertEquals("c", tracker.effectiveText("c"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -70,4 +70,17 @@ public class ImeCompositionTextTrackerTest extends TestCase {
   public void testSingleCharacterDiacriticReplacementKeepsScratch() {
     assertImeSequence("\u00e1", "\u00e1", "a", "\u00e1", "\u00e1");
   }
+
+  public void testNullObservedValueIsIgnored() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+    tracker.observe("n");
+    tracker.observe(null);
+    assertEquals("n", tracker.effectiveText("n"));
+  }
+
+  public void testNullScratchFallsBackToEmptyString() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+    tracker.observe("n");
+    assertEquals("", tracker.effectiveText(null));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -43,6 +43,10 @@ public class ImeCompositionTextTrackerTest extends TestCase {
     assertImeSequence("blip", "lip", "b", "l", "l", "li", "li", "lip");
   }
 
+  public void testAndroidReplacementCanRecoverWhenScratchExtendsPendingValue() {
+    assertImeSequence("new", "ew", "n", "e", "ew");
+  }
+
   public void testRepeatedSingleCharacterDoesNotDuplicate() {
     assertImeSequence("ne", "e", "n", "e", "e");
   }
@@ -61,5 +65,9 @@ public class ImeCompositionTextTrackerTest extends TestCase {
 
   public void testShrinkWithoutReplacementEvidenceKeepsScratch() {
     assertImeSequence("bc", "bc", "abc", "bc");
+  }
+
+  public void testSingleCharacterDiacriticReplacementKeepsScratch() {
+    assertImeSequence("\u00e1", "\u00e1", "a", "\u00e1", "\u00e1");
   }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -71,6 +71,12 @@ public class ImeCompositionTextTrackerTest extends TestCase {
     assertImeSequence("\u00e1", "\u00e1", "a", "\u00e1", "\u00e1");
   }
 
+  public void testConsecutiveSingleCharReplacementsAvoidStalePrefix() {
+    // 'b' was never confirmed (no duplicate/extension), so it must not appear in
+    // the reconstruction — only 'a' (key 1) and confirmed 'c' (key 2) are kept.
+    assertImeSequence("ac", "c", "a", "b", "c", "c");
+  }
+
   public void testNullObservedValueIsIgnored() {
     ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
     tracker.observe("n");

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -79,4 +79,22 @@ public class ImeCompositionTextTrackerTest extends TestCase {
 
     assertEquals("c", tracker.effectiveText("c"));
   }
+
+  public void testEmptyUpdateClearsRecoveredText() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("a");
+    tracker.observe("");
+
+    assertEquals("", tracker.effectiveText(""));
+  }
+
+  public void testShrinkWithoutReplacementEvidenceKeepsScratch() {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+
+    tracker.observe("abc");
+    tracker.observe("bc");
+
+    assertEquals("bc", tracker.effectiveText("bc"));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -27,74 +27,39 @@ import junit.framework.TestCase;
  */
 public class ImeCompositionTextTrackerTest extends TestCase {
 
-  public void testAndroidSingleLetterReplacementSequenceRecoversNew() {
+  private void assertImeSequence(String expectedText, String scratchText, String... observedValues) {
     ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+    for (String v : observedValues) {
+      tracker.observe(v);
+    }
+    assertEquals(expectedText, tracker.effectiveText(scratchText));
+  }
 
-    tracker.observe("n");
-    tracker.observe("e");
-    tracker.observe("e");
-    tracker.observe("ew");
-    tracker.observe("ew");
-
-    assertEquals("new", tracker.effectiveText("ew"));
+  public void testAndroidSingleLetterReplacementSequenceRecoversNew() {
+    assertImeSequence("new", "ew", "n", "e", "e", "ew", "ew");
   }
 
   public void testAndroidSecondWordReplacementSequenceRecoversBlip() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("b");
-    tracker.observe("l");
-    tracker.observe("l");
-    tracker.observe("li");
-    tracker.observe("li");
-    tracker.observe("lip");
-
-    assertEquals("blip", tracker.effectiveText("lip"));
+    assertImeSequence("blip", "lip", "b", "l", "l", "li", "li", "lip");
   }
 
   public void testRepeatedSingleCharacterDoesNotDuplicate() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("n");
-    tracker.observe("e");
-    tracker.observe("e");
-
-    assertEquals("ne", tracker.effectiveText("e"));
+    assertImeSequence("ne", "e", "n", "e", "e");
   }
 
   public void testBrowserCaughtUpScratchWins() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("n");
-    tracker.observe("e");
-
-    assertEquals("new", tracker.effectiveText("new"));
+    assertImeSequence("new", "new", "n", "e");
   }
 
   public void testUnrelatedMultiCharacterReplacementFallsBackToScratch() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("ab");
-    tracker.observe("c");
-
-    assertEquals("c", tracker.effectiveText("c"));
+    assertImeSequence("c", "c", "ab", "c");
   }
 
   public void testEmptyUpdateClearsRecoveredText() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("a");
-    tracker.observe("");
-
-    assertEquals("", tracker.effectiveText(""));
+    assertImeSequence("", "", "a", "");
   }
 
   public void testShrinkWithoutReplacementEvidenceKeepsScratch() {
-    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
-
-    tracker.observe("abc");
-    tracker.observe("bc");
-
-    assertEquals("bc", tracker.effectiveText("bc"));
+    assertImeSequence("bc", "bc", "abc", "bc");
   }
 }


### PR DESCRIPTION
Fixes #828.

## Summary
- Reconstruct Android IME replacement streams from `compositionupdate.data`, covering the observed `n -> e -> ew` and `b -> l -> li -> lip` sequences that dropped first letters in Chrome on Galaxy devices.
- Insert standalone Android `textInput` separators directly when they arrive outside an active composition, so spaces are not left as unmanaged DOM mutations.
- Suppress stale empty-baseline ghost restoration after the recovered composition text is flushed, avoiding the blank blip seen after tapping Done.

## Verification
- `sbt "Test/runMain org.junit.runner.JUnitCore org.waveprotocol.wave.model.util.ImeCompositionTextTrackerTest org.waveprotocol.wave.model.util.GhostTextReconcilerTest"` - PASS, OK (49 tests)
- `sbt compileGwtDev` - PASS, GWT one-permutation draft compile succeeded
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` - PASS, assembled 243 entries and validation passed
- `bash scripts/worktree-boot.sh --port 9933` - PASS, staged app/runtime built
- `PORT=9933 bash scripts/wave-smoke.sh check` - PASS, root/health/landing/J2CL/webclient endpoints returned expected 200 statuses
- Galaxy S9+ Chrome mobile simulation against local GWT server: typed `new blip`, tapped Done, reloaded, and verified `new blip` remained visible after each step
- `git diff --check` - PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android Chrome IME composition now reconstructs composed words, preserves leading letters/spaces, and commits standalone Android text separators so typed phrases (e.g., “new blip”) persist after Done and reload.

* **Tests**
  * Adds unit and integration tests covering composition recovery, suppression edge cases, and end-to-end persistence verification.

* **Documentation**
  * Adds a documentation plan and changelog entry describing the behavior and required verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->