### PR TITLE
Add J2CL rich-content delta builder

### DIFF
--- a/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
@@ -1,0 +1,291 @@
+# Issue #971 Rich-Edit And Attachment Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the daily attachment and remaining rich-edit parity gap that blocks practical Lit/J2CL root cutover.
+
+**Architecture:** Build on the #969 compose/toolbar surface instead of extending the current textarea-only J2CL write pilot. Keep the existing server attachment endpoints and attachment-id document model, add J2CL-side upload/metadata/rendering clients, and add only the daily rich-edit commands left unclaimed by #969; any non-daily legacy editor behavior is documented in the parity matrix addendum or a follow-up issue before #971 closes.
+
+**Tech Stack:** J2CL Java, Elemental2 DOM, Lit shell primitives, existing `/attachment`, `/thumbnail`, and `/attachmentsInfo` servlets, current Wave `image@attachment` document model, Maven J2CL tests, Lit web-test-runner tests, `sbt` server/client verification, and worktree smoke/browser verification.
+
+---
+
+## Dependency Gates
+
+- Do not implement #971 until #969 has landed or this branch is rebased onto the final #969 implementation branch. #971 depends on the compose/toolbar surface and must not create a parallel composer shell.
+- Before implementation, compare the final #969 packet and PR diff against this plan. Remove any #971 rich-edit item already claimed and implemented by #969; keep #971 focused on `R-5.6` and only the `R-5.7` daily affordances that remain.
+- Task 1 is not complete until the final #971-owned `R-5.7` command list is written either into this plan or into a linked #971 issue comment. Do not start Task 2 while the command list is still a candidate set.
+- Before touching any compose toolbar, overlay host, focus-management, or shortcut files, inspect #970 status. If #970 modifies the same files, sequence #971 after #970 or split ownership with an issue comment that names the exact files and command IDs.
+- Keep `/` serving legacy GWT by default. Verify #971 only through the explicit J2CL/Lit route or rollout flag seam inherited from #969.
+- If #969 has not introduced a J2CL rich editor command model, Task 1 below must add that adapter as a narrow extension; do not reimplement GWT `StageThree`.
+- GitHub commands in this plan use `--repo vega113/supawave`; this is verified against `origin=https://github.com/vega113/supawave.git`.
+
+## Slice Parity Packet - Issue #971
+
+**Title:** Port attachment and remaining rich-edit parity required for daily Wave use in Lit/J2CL
+
+**Stage:** compose
+
+**Dependencies:** #969, plus coordination with #970 where command palettes, popovers, overlay host, shortcuts, or focus restoration overlap.
+
+### Parity Matrix Rows Claimed
+
+- `R-5.6` - Attachment upload/download/open paths preserve daily behavior, errors are user-visible, and attachment content round-trips through the model.
+- `R-5.7` - Only daily remaining rich-edit affordances not closed by #969. Initial candidate set: pasted image upload, attachment caption/display-size insertion, attachment tile rendering, attachment keyboard open/download, clear formatting, indent/outdent, block quote if still missing, and any daily inline-link gap not covered by #969.
+
+### GWT Seams De-Risked
+
+- `wave/src/main/java/org/waveprotocol/wave/client/StageThree.java:187-194` creates the edit toolbar and `:226-274` installs editing, toolbar switching, overlays, reactions, draft mode, and diff upgrade.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:301-309` creates the attachment ID generator and paste uploader, `:319-362` enumerates daily toolbar groups, `:524-603` uploads and inserts attachment XML, and `:647-737` covers link, heading, indent/outdent, and list commands.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/AttachmentPopupWidget.java:94-160` owns selected-file state and upload URL constants, `:560-662` queues per-file uploads and inserts uploaded attachments, `:881-953` POSTs multipart uploads through XHR, and `:1000-1066` resets popup state and wave-ref binding.
+- `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/attachment/ClipboardImageUploader.java:77-113` detects pasted images and starts upload, `:119-154` inserts attachment XML only after upload success, and `:267-320` POSTs the pasted image to `/attachment/{id}`.
+- `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/ImageThumbnail.java:55-92` defines `image@attachment`, `style`, and `display-size`; `:155-162` builds the captioned attachment XML used by uploads.
+- `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/AttachmentManagerImpl.java:58-66` builds `/attachmentsInfo` requests and `:143-188` parses metadata responses.
+- `wave/src/main/java/org/waveprotocol/wave/client/doodad/attachment/render/ImageThumbnailWidget.java:551-627` chooses thumbnail vs original attachment URL and applies display-size classes.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AttachmentServlet.java:60-62` defines `/attachment` and `/thumbnail`, `:102-168` authorizes and serves attachment bytes, and `:180-227` accepts authorized multipart uploads.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AttachmentInfoServlet.java:47-99` serves authorized attachment metadata JSON for `/attachmentsInfo`.
+- `wave/src/main/java/org/waveprotocol/box/server/attachment/AttachmentService.java:85-135` stores uploads and metadata, attachment URLs, thumbnail URLs, image dimensions, and fallback thumbnail metadata.
+
+### Current J2CL Gap
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeView.java:53-84` and `:103-134` expose create/reply as plain textareas plus submit buttons.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java:180-220` and `:253-301` submit only normalized text drafts.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java:34-71` emits only text DocOp JSON for create and reply.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:174-210` preserves the write-session basis but has no attachment/rich-content document operation builder.
+
+## Acceptance Criteria
+
+- A J2CL/Lit daily attachment flow can select one or more files, upload to `/attachment/{id}`, insert `<image attachment="..."><caption>...</caption></image>` with `display-size` where applicable, fetch metadata from `/attachmentsInfo`, render the attachment tile/inline image, and open/download through the authorized `/attachment/{id}` URL.
+- Pasted image upload in the J2CL/Lit composer uploads first and mutates the document only after upload success, preserving the GWT failure-safety behavior.
+- Attachment upload failures, metadata failures, and unauthorized download/open failures produce user-visible and accessible error state rather than silent no-op.
+- Remaining daily rich-edit commands not already delivered by #969 are reachable from the #969 toolbar/composer, preserve selection/caret where the GWT command did, and emit structured document operations rather than flattening to plain text.
+- Keyboard/focus coverage includes toolbar reachability, escape/cancel for the attachment picker, focus restoration to the composer after picker close, and keyboard open/download for rendered attachments.
+- Accessibility coverage includes `role=status` or an equivalent polite live region for upload progress, `role=alert` or assertive announcement for upload/download errors, reachable labels for file picker controls, and non-color-only failure indication.
+- Security coverage confirms the J2CL clients preserve the existing session-cookie authorization path, do not add a client-side CSRF bypass, honor server-side size/mime rejection, and render malware-flagged or unauthorized attachments as blocked/error states instead of openable links.
+- Verification evidence includes Maven/JVM tests for operation builders and transport parsing, Lit tests for UI state, worktree smoke, a narrow browser flow on the J2CL route, and a local attachment upload/open/download round trip.
+- Drag-and-drop and client-side image compression are not required for the first daily parity claim unless #969/#971 acceptance is amended; if deferred, record them under `docs/j2cl-gwt-parity-matrix.md` Section 10 or a linked follow-up.
+- Any discovered non-daily editor behavior left out of #971 is documented either as a `docs/j2cl-gwt-parity-matrix.md` Section 10 ("Deferred Edge Cases") addendum in the same #971 PR or as a linked follow-up issue before claiming the issue complete.
+
+## File Ownership And Proposed Files
+
+- Modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeModel.java` only if #969 leaves the model in `search`; otherwise modify the #969 final compose model file.
+- Modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java` only as an adapter to the #969 composer; do not add another independent compose surface.
+- Replace or wrap `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java` with a structured builder such as `J2clRichContentDeltaFactory`. Keep the plain-text factory tests passing until #969 intentionally retires it.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java` for deterministic testable attachment IDs using the existing sidecar seed/counter pattern.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java` for multipart XHR upload to `/attachment/{id}`.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java` for `/attachmentsInfo?attachmentIds=...` requests and parser ownership.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadata.java` as the J2CL-safe DTO for id, filename, mime type, size, creator, attachment URL, thumbnail URL, image dimensions, thumbnail dimensions, and malware flag.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java` for file selection, paste handling, upload queue, progress, cancel, and model insertion callbacks.
+- Create `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java` for rendered tile/inline-image decisions.
+- Add Lit elements under `j2cl/lit/src/elements/` only for visual presentation inherited from #969: suggested names `compose-attachment-picker.js`, `compose-attachment-card.js`, and `compose-rich-toolbar-extra.js`. If #969 already created equivalent elements, extend those instead.
+- Add tests under `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/` and `j2cl/lit/test/`. Keep test fixtures independent of live server credentials.
+- Add `wave/config/changelog.d/2026-04-23-issue-971-rich-edit-attachments.json` during implementation because this is user-facing behavior.
+- Add local verification evidence under `journal/local-verification/2026-04-23-issue-971-rich-edit-attachments.md` during implementation.
+
+## Phased Implementation Slices
+
+### Task 1: Rebase And Freeze Ownership
+
+- [ ] Fetch `origin/main`, #969, and #970 branch heads or PR heads.
+- [ ] Rebase the implementation branch onto the final #969 baseline.
+- [ ] Diff #969 for compose/toolbar file names and update the file ownership list in this plan if the final files differ.
+- [ ] Diff #970 for shared overlay/toolbar/focus files. If any file overlaps, comment on #971 with `#970 overlap: <file list>` and do not edit those files until the owner sequence is clear.
+- [ ] Write the final #971-owned `R-5.7` command list into this plan or a linked #971 issue comment. The list must explicitly say which candidate commands were absorbed by #969 and which remain for #971.
+- [ ] Confirm no product code is changed before the implementation gate.
+
+Expected command examples:
+
+```bash
+gh issue view 969 --repo vega113/supawave --json state,comments,url
+gh issue view 970 --repo vega113/supawave --json state,comments,url
+git fetch origin
+git status --short --branch
+```
+
+### Task 2: Add Structured Rich-Content Operation Builder
+
+- [ ] Write failing tests for a builder that emits create/reply DocOp JSON containing text, annotation boundaries for daily inline styles, and `<image attachment="..."><caption>...</caption></image>` element components.
+- [ ] Preserve the atomic basis contract from the existing write session: reply operations must use `J2clSidecarWriteSession.getBaseVersion()`, `getHistoryHash()`, and `getChannelId()`.
+- [ ] Implement the builder with a typed command input rather than string concatenation at call sites. Suggested minimum API:
+
+```java
+J2clRichContentDeltaFactory.CreateWaveRequest createWaveRequest(
+    String address, J2clComposerDocument document);
+
+SidecarSubmitRequest createReplyRequest(
+    String address, J2clSidecarWriteSession session, J2clComposerDocument document);
+```
+
+- [ ] Keep plain-text create/reply behavior as a compatibility path by representing plain text as one `J2clComposerTextSegment`.
+- [ ] Commit after tests pass.
+
+Target tests:
+
+```bash
+cd j2cl && ./mvnw -Dtest=J2clRichContentDeltaFactoryTest test
+```
+
+### Task 3: Add Attachment Upload And Metadata Clients
+
+- [ ] Write failing tests for request construction and metadata parsing. Include encoded attachment IDs with `+`, `/`, `=`, and `:` because prior attachment ID work made encoding a real seam.
+- [ ] Implement `J2clAttachmentUploadClient` with multipart fields matching GWT: `attachmentId`, `waveRef`, and `uploadFormElement`.
+- [ ] Treat file-picker uploads as successful only for HTTP 200-299 responses whose body contains `OK`, matching `AttachmentPopupWidget`. Treat pasted-image uploads as successful for HTTP 200 or 201, matching `ClipboardImageUploader`. Add one test per success rule.
+- [ ] Implement `J2clAttachmentMetadataClient` parser for the numeric proto/Gson field names currently served by `AttachmentInfoServlet` through `ProtoSerializer`. Hand-author fixtures from the current generated field map and include at least one image, one non-image, one malware-flagged, and one missing-metadata fixture.
+- [ ] Surface metadata failures as typed error results, not exceptions swallowed by UI.
+- [ ] Commit after tests pass.
+
+Target tests:
+
+```bash
+cd j2cl && ./mvnw -Dtest='J2clAttachmentUploadClientTest,J2clAttachmentMetadataClientTest' test
+```
+
+### Task 4: Add Attachment Composer Controller
+
+- [ ] Write controller tests for selecting files, upload queue order, per-file ID generation, progress state, failure state, cancel/reset, and successful insertion callback.
+- [ ] Add paste handling that mirrors GWT's success-before-mutation behavior: capture the insertion intent, upload, then call the rich-content builder insertion only after success.
+- [ ] Keep image compression optional. If compression is not practical in the first J2CL slice, document it as non-daily unless the #971 issue explicitly requires mobile large-image compression before parity.
+- [ ] Require display size choices `small`, `medium`, `large` and caption fallback to filename.
+- [ ] Commit after tests pass.
+
+Target tests:
+
+```bash
+cd j2cl && ./mvnw -Dtest=J2clAttachmentComposerControllerTest test
+```
+
+### Task 5: Wire Into The #969 Composer And Toolbar
+
+- [ ] Extend the final #969 composer model/view instead of reusing the old `J2clSidecarComposeView` textareas directly.
+- [ ] Add toolbar affordances only for #971-owned commands: attachment picker, pasted image, and remaining rich-edit commands not implemented by #969.
+- [ ] Preserve focus restoration: opening a picker or link/block-format popover must return focus to the composer trigger or prior caret after close.
+- [ ] Emit accessible labels and live-region status for upload progress and errors.
+- [ ] Do not implement mentions, tasks, reactions, autocomplete listboxes, or comparable overlays here; those belong to #970.
+- [ ] Commit after J2CL tests pass.
+
+Target tests:
+
+```bash
+cd j2cl && ./mvnw -Dtest='J2clSidecarComposeControllerTest,J2clAttachmentComposerControllerTest,J2clRichContentDeltaFactoryTest' test
+```
+
+### Task 6: Add Attachment Rendering In The J2CL Selected-Wave Surface
+
+- [ ] Add projector tests for selected-wave content containing `image@attachment` and `display-size`.
+- [ ] Add `J2clAttachmentRenderModel` to select thumbnail vs original attachment source using the same user-visible rules as `ImageThumbnailWidget`: medium/large image attachments use original attachment URL when metadata says the file is an image; non-images stay tile/card based; missing dimensions use the existing small/tile fallback rather than stretching to zero.
+- [ ] Render keyboard-reachable open/download controls with labels derived from filename/mime type.
+- [ ] Surface malware or metadata-failure state if present in metadata.
+- [ ] Commit after tests pass.
+
+Target tests:
+
+```bash
+cd j2cl && ./mvnw -Dtest='J2clSelectedWaveProjectorTest,J2clAttachmentRenderModelTest' test
+```
+
+### Task 7: Add Lit Presentation Tests
+
+- [ ] If #969 has Lit composer elements, extend them; otherwise add the three #971 elements listed in file ownership.
+- [ ] Add web-test-runner tests for picker open/close, keyboard traversal, caption input, display-size selection, upload progress/error/success rendering, and rendered attachment open/download controls.
+- [ ] Verify reduced-motion and focus-visible behavior through DOM assertions rather than screenshots.
+- [ ] Commit after Lit tests pass.
+
+Target tests:
+
+```bash
+cd j2cl/lit && npm test
+cd j2cl/lit && npm run build
+```
+
+### Task 8: Add Changelog And Local Verification Record
+
+- [ ] Add a changelog fragment under `wave/config/changelog.d/`.
+- [ ] Run changelog assembly and validation:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py
+```
+
+- [ ] Create `journal/local-verification/2026-04-23-issue-971-rich-edit-attachments.md` with exact commands and observed results.
+- [ ] Commit docs/config after validation.
+
+### Task 9: End-To-End Verification
+
+- [ ] Run targeted J2CL/JVM tests:
+
+```bash
+cd j2cl && ./mvnw test
+```
+
+- [ ] Run Lit tests and build:
+
+```bash
+cd j2cl/lit && npm test && npm run build
+```
+
+- [ ] Run server/client compile verification:
+
+```bash
+sbt wave/compile
+sbt compileGwt
+```
+
+- [ ] Run worktree smoke from the implementation worktree:
+
+```bash
+bash scripts/worktree-boot.sh --port 9900
+PORT=9900 JAVA_OPTS='<printed by worktree-boot.sh>' bash scripts/wave-smoke.sh start
+PORT=9900 bash scripts/wave-smoke.sh check
+```
+
+- [ ] Browser verification required by `docs/runbooks/change-type-verification-matrix.md` because #971 changes J2CL/Lit UI and editor behavior. Exercise only this path: register/sign in a fresh local user, open `http://localhost:9900/?view=j2cl-root`, create/open a wave, attach an image and a non-image file, verify progress/success/error states, verify rendered attachment open/download, paste an image, apply each #971-owned rich-edit command, reload, and confirm the content persists.
+- [ ] Stop smoke server:
+
+```bash
+PORT=9900 bash scripts/wave-smoke.sh stop
+```
+
+## Telemetry And Observability
+
+- Add counters or structured client log events for `attachment.upload.started`, `attachment.upload.succeeded`, `attachment.upload.failed`, `attachment.metadata.failed`, `attachment.open.clicked`, and `richEdit.command.applied`.
+- Include result reason fields for upload failure: `network`, `forbidden`, `server`, `unsupported-file`, `cancelled`, and `metadata`.
+- If the existing J2CL stats/log channel from #969/#968 is not ready, implement local structured console logs behind the same rollout flag and document the gap in the issue comment. Also create or link a follow-up to migrate those console logs to the shared channel; do not leave console logging as the silent long-term telemetry plan.
+
+## Rollback Plan
+
+- The legacy GWT root remains the default `/` route.
+- #971 behavior must sit behind the J2CL/Lit root route and any #969 rollout flag. Disable by turning off the J2CL compose/rich-edit flag or routing users back to legacy GWT.
+- Server endpoints are existing shared endpoints. Do not introduce incompatible attachment schema or endpoint changes.
+- Keep old plain-text J2CL create/reply path available until the rich-content builder has passed browser verification by routing empty-format documents through the existing plain-text adapter or by guarding rich-content submit behind the #969/#971 rollout flag.
+
+## Non-Goals
+
+- No default-root cutover.
+- No legacy GWT root retirement.
+- No rewrite of `StageThree`, GWT editor internals, or attachment servlets unless verification proves a shared endpoint bug.
+- No mention/autocomplete, task metadata overlays, reactions, or overlay infrastructure owned by #970.
+- No exhaustive historical editor parity. Rare formatting commands, old browser-specific keyboard paths, drag-and-drop, client-side compression, mobile/touch-specific toolbar gestures beyond file-picker and paste, and GWT-only harness assumptions are deferred through the parity matrix addendum or follow-up issue unless the final #971 command list names them as daily requirements.
+
+## Risks
+
+- #969 may land a different composer architecture than the current sidecar classes. Mitigation: freeze file ownership after rebasing onto #969 before implementation.
+- #970 may touch overlay host and focus restoration. Mitigation: sequence overlapping files and keep #971's picker non-modal unless the #969/#970 host defines a shared modal contract.
+- Low-level DocOp JSON is currently built manually in J2CL. Mitigation: typed builder tests must cover every emitted component and preserve version/hash/channel basis.
+- `/attachmentsInfo` currently serves proto/Gson numeric fields. Mitigation: isolate parsing in `J2clAttachmentMetadataClient` and test against fixture JSON generated from current server shape.
+- Browser file input, paste, drag/drop, and compression APIs differ across desktop/mobile. Mitigation: daily parity requires file-picker and paste first; drag/drop and client compression can be deferred only with explicit addendum/follow-up evidence.
+
+## Deferred Edge-Case Criteria
+
+Document a behavior in `docs/j2cl-gwt-parity-matrix.md` Section 10 ("Deferred Edge Cases") or a linked follow-up issue when all are true:
+
+- It is not needed for daily create/reply/edit/attachment use by the parity matrix.
+- It is not part of #969's accepted compose/toolbar row or #970's overlay rows.
+- It would require old-browser-specific editor internals, broad GWT harness resurrection, or a separate design/architecture decision.
+- The #971 browser path still passes without it.
+
+Do not defer a behavior when it is required for one-file upload, pasted image upload, attachment rendering/open/download, caption/display-size preservation, or a daily rich-edit command explicitly left to #971 after #969.
+
+## Implementation Readiness Verdict
+
+Plan-ready, implementation-blocked. This plan is concrete enough for a worker after #969 lands, but code work must not begin until the #969 dependency gate is satisfied and #970 overlap is checked against the final file list.

--- a/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
@@ -143,9 +143,9 @@ git diff --stat origin/main..HEAD
 
 ### Task 2: Add Structured Rich-Content Operation Builder
 
-- [ ] Write failing tests for a builder that emits create/reply DocOp JSON containing text, annotation boundaries for daily inline styles, and `<image attachment="..."><caption>...</caption></image>` element components.
-- [ ] Preserve the atomic basis contract from the existing write session: reply operations must use `J2clSidecarWriteSession.getBaseVersion()`, `getHistoryHash()`, and `getChannelId()`.
-- [ ] Implement the builder with a typed command input rather than string concatenation at call sites. Suggested minimum API:
+- [x] Write failing tests for a builder that emits create/reply DocOp JSON containing text, annotation boundaries for daily inline styles, and `<image attachment="..."><caption>...</caption></image>` element components.
+- [x] Preserve the atomic basis contract from the existing write session: reply operations must use `J2clSidecarWriteSession.getBaseVersion()`, `getHistoryHash()`, and `getChannelId()`.
+- [x] Implement the builder with a typed command input rather than string concatenation at call sites. Suggested minimum API:
 
 ```java
 J2clRichContentDeltaFactory.CreateWaveRequest createWaveRequest(
@@ -155,8 +155,8 @@ SidecarSubmitRequest createReplyRequest(
     String address, J2clSidecarWriteSession session, J2clComposerDocument document);
 ```
 
-- [ ] Keep plain-text create/reply behavior as a compatibility path by representing plain text as one `J2clComposerTextSegment`.
-- [ ] Commit after tests pass.
+- [x] Keep plain-text create/reply behavior as a compatibility path by representing plain text as one `J2clComposerTextSegment`.
+- [x] Commit after tests pass.
 
 Target tests:
 

--- a/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
@@ -28,24 +28,24 @@ Task 1 has been revalidated after the dependency chain landed:
 - #970 merged as PR #1006 at `d3f13547084a4aaac15749187b0eabf0c63b8c15` and introduced the Lit interaction overlay primitives for mentions, task metadata, reactions, and generic overlay focus/lifecycle.
 - This #971 branch was rebased onto `origin/main` at `d3f13547084a4aaac15749187b0eabf0c63b8c15`, which is the #970 merge commit and the current `origin/main` HEAD for this gate; product-code implementation can now start from this branch.
 
-#969 absorbed the following ownership:
+Issue #969 absorbed the following ownership:
 
 - J2CL root composer/toolbar host creation in `J2clRootShellController`.
 - Plain-text create/reply submit flow through `J2clComposeSurfaceController` and `J2clPlainTextDeltaFactory`.
 - Lit shell primitives: `composer-shell`, `composer-inline-reply`, `composer-submit-affordance`, `toolbar-button`, `toolbar-group`, and `toolbar-overflow-menu`.
 - Daily toolbar action identifiers and disabled/error presentation for `bold`, `italic`, `underline`, `strikethrough`, `heading`, `unordered-list`, `ordered-list`, `align-left`, `align-center`, `align-right`, `rtl`, `link`, `unlink`, and `clear-formatting`.
 
-#969 did not wire those edit toolbar actions to a rich editor or structured DocOp command model. #971 owns that command execution layer where it is needed for daily parity.
+Issue #969 did not wire those edit toolbar actions to a rich editor or structured DocOp command model. #971 owns that command execution layer where it is needed for daily parity.
 
-#970 absorbed the following ownership:
+Issue #970 absorbed the following ownership:
 
 - Generic Lit overlay/focus primitive: `interaction-overlay-layer`.
 - Mention, task metadata, reaction picker/authors/row Lit primitives.
 - Tests for those overlay primitives under `j2cl/lit/test/`.
 
-#971 must not modify the #970 overlay primitive element files unless a later review explicitly requires a shared bug fix. If #971 needs overlay behavior, compose it from those elements rather than reimplementing focus/lifecycle handling.
+Issue #971 must not modify the #970 overlay primitive element files unless a later review explicitly requires a shared bug fix. If #971 needs overlay behavior, compose it from those elements rather than reimplementing focus/lifecycle handling.
 
-#970 overlap scan result: no blocking overlap. #970 shipped new Lit overlay primitive files plus `j2cl/lit/src/index.js`; #971 may extend `j2cl/lit/src/index.js` only to register its own attachment/rich-edit elements, and must consume #970 overlay primitives by composition instead of editing them.
+Issue #970 overlap scan result: no blocking overlap. #970 shipped new Lit overlay primitive files plus `j2cl/lit/src/index.js`; #971 may extend `j2cl/lit/src/index.js` only to register its own attachment/rich-edit elements, and must consume #970 overlay primitives by composition instead of editing them.
 
 Final #971-owned `R-5.7` command list:
 

--- a/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
+++ b/docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md
@@ -20,6 +20,43 @@
 - If #969 has not introduced a J2CL rich editor command model, Task 1 below must add that adapter as a narrow extension; do not reimplement GWT `StageThree`.
 - GitHub commands in this plan use `--repo vega113/supawave`; this is verified against `origin=https://github.com/vega113/supawave.git`.
 
+### Task 1 Ownership Freeze - 2026-04-24
+
+Task 1 has been revalidated after the dependency chain landed:
+
+- #969 merged as PR #1002 at `d7ea91813a22aaf3c48d50817857765733c1ec53` and introduced the J2CL root compose/toolbar hosts plus Lit composer and toolbar primitives.
+- #970 merged as PR #1006 at `d3f13547084a4aaac15749187b0eabf0c63b8c15` and introduced the Lit interaction overlay primitives for mentions, task metadata, reactions, and generic overlay focus/lifecycle.
+- This #971 branch was rebased onto `origin/main` at `d3f13547084a4aaac15749187b0eabf0c63b8c15`, which is the #970 merge commit and the current `origin/main` HEAD for this gate; product-code implementation can now start from this branch.
+
+#969 absorbed the following ownership:
+
+- J2CL root composer/toolbar host creation in `J2clRootShellController`.
+- Plain-text create/reply submit flow through `J2clComposeSurfaceController` and `J2clPlainTextDeltaFactory`.
+- Lit shell primitives: `composer-shell`, `composer-inline-reply`, `composer-submit-affordance`, `toolbar-button`, `toolbar-group`, and `toolbar-overflow-menu`.
+- Daily toolbar action identifiers and disabled/error presentation for `bold`, `italic`, `underline`, `strikethrough`, `heading`, `unordered-list`, `ordered-list`, `align-left`, `align-center`, `align-right`, `rtl`, `link`, `unlink`, and `clear-formatting`.
+
+#969 did not wire those edit toolbar actions to a rich editor or structured DocOp command model. #971 owns that command execution layer where it is needed for daily parity.
+
+#970 absorbed the following ownership:
+
+- Generic Lit overlay/focus primitive: `interaction-overlay-layer`.
+- Mention, task metadata, reaction picker/authors/row Lit primitives.
+- Tests for those overlay primitives under `j2cl/lit/test/`.
+
+#971 must not modify the #970 overlay primitive element files unless a later review explicitly requires a shared bug fix. If #971 needs overlay behavior, compose it from those elements rather than reimplementing focus/lifecycle handling.
+
+#970 overlap scan result: no blocking overlap. #970 shipped new Lit overlay primitive files plus `j2cl/lit/src/index.js`; #971 may extend `j2cl/lit/src/index.js` only to register its own attachment/rich-edit elements, and must consume #970 overlay primitives by composition instead of editing them.
+
+Final #971-owned `R-5.7` command list:
+
+- Attachment command surface and execution with stable command/state IDs: `attachment-insert`, `attachment-upload-queue`, `attachment-cancel`, `attachment-paste-image`, `attachment-caption`, `attachment-size-small`, `attachment-size-medium`, `attachment-size-large`, `attachment-open`, `attachment-download`, and `attachment-error-state`. `attachment-error-state` is a stable controller/UI state identifier for tests and accessibility assertions, not a toolbar command.
+- Rich-content document model and structured builder for plain text, inline annotation segments, link annotation, paragraph/list/alignment/direction metadata, and attachment XML insertion.
+- Command execution for the #969-exposed daily edit actions: `bold`, `italic`, `underline`, `strikethrough`, `heading-default`, `heading-h1`, `heading-h2`, `heading-h3`, `heading-h4`, `unordered-list`, `ordered-list`, `align-left`, `align-center`, `align-right`, `rtl`, `link`, `unlink`, and `clear-formatting`. `heading-default` maps to the GWT "Default" heading menu entry, meaning paragraph/no heading.
+- Additional daily toolbar actions not exposed by #969 but present in the GWT daily edit toolbar and required by the original #971 candidate list: `indent` and `outdent`.
+- Pasted image upload must mutate the document only after upload success, matching GWT failure safety.
+
+Deferred non-daily GWT toolbar affordances to document before closing #971, not to implement in this first daily slice unless the parity tracker is amended: `superscript`, `subscript`, font size, font family, font color, and highlight color / `backColor`. `block quote` is not present in the inspected GWT `EditToolbar.java` action set and is not #971-owned unless a separate parity row identifies it.
+
 ## Slice Parity Packet - Issue #971
 
 **Title:** Port attachment and remaining rich-edit parity required for daily Wave use in Lit/J2CL
@@ -31,7 +68,7 @@
 ### Parity Matrix Rows Claimed
 
 - `R-5.6` - Attachment upload/download/open paths preserve daily behavior, errors are user-visible, and attachment content round-trips through the model.
-- `R-5.7` - Only daily remaining rich-edit affordances not closed by #969. Initial candidate set: pasted image upload, attachment caption/display-size insertion, attachment tile rendering, attachment keyboard open/download, clear formatting, indent/outdent, block quote if still missing, and any daily inline-link gap not covered by #969.
+- `R-5.7` - Only daily remaining rich-edit affordances not closed by #969. Initial candidate set resolved by the 2026-04-24 Ownership Freeze above: pasted image upload, attachment caption/display-size insertion, attachment tile rendering, attachment keyboard open/download, clear formatting, indent/outdent, and any daily inline-link gap not covered by #969. Block quote was checked against GWT `EditToolbar.java` during the freeze and is not #971-owned because that toolbar does not expose it.
 
 ### GWT Seams De-Risked
 
@@ -86,12 +123,13 @@
 
 ### Task 1: Rebase And Freeze Ownership
 
-- [ ] Fetch `origin/main`, #969, and #970 branch heads or PR heads.
-- [ ] Rebase the implementation branch onto the final #969 baseline.
-- [ ] Diff #969 for compose/toolbar file names and update the file ownership list in this plan if the final files differ.
-- [ ] Diff #970 for shared overlay/toolbar/focus files. If any file overlaps, comment on #971 with `#970 overlap: <file list>` and do not edit those files until the owner sequence is clear.
-- [ ] Write the final #971-owned `R-5.7` command list into this plan or a linked #971 issue comment. The list must explicitly say which candidate commands were absorbed by #969 and which remain for #971.
-- [ ] Confirm no product code is changed before the implementation gate.
+- [x] Fetch `origin/main`, #969, and #970 branch heads or PR heads.
+- [x] Rebase the implementation branch onto the final #969 baseline.
+- [x] Diff #969 for compose/toolbar file names and update the file ownership list in this plan if the final files differ.
+- [x] Diff #970 for shared overlay/toolbar/focus files. If any file overlaps, comment on #971 with `#970 overlap: <file list>` and do not edit those files until the owner sequence is clear.
+- [x] Write the final #971-owned `R-5.7` command list into this plan or a linked #971 issue comment. The list must explicitly say which candidate commands were absorbed by #969 and which remain for #971.
+- [x] Confirm no product code is changed before the implementation gate.
+- [x] Run `git diff --stat origin/main..HEAD` and confirm only the #971 plan file is included before opening the implementation gate.
 
 Expected command examples:
 
@@ -100,6 +138,7 @@ gh issue view 969 --repo vega113/supawave --json state,comments,url
 gh issue view 970 --repo vega113/supawave --json state,comments,url
 git fetch origin
 git status --short --branch
+git diff --stat origin/main..HEAD
 ```
 
 ### Task 2: Add Structured Rich-Content Operation Builder
@@ -158,6 +197,7 @@ cd j2cl && ./mvnw -Dtest=J2clAttachmentComposerControllerTest test
 
 - [ ] Extend the final #969 composer model/view instead of reusing the old `J2clSidecarComposeView` textareas directly.
 - [ ] Add toolbar affordances only for #971-owned commands: attachment picker, pasted image, and remaining rich-edit commands not implemented by #969.
+- [ ] Add parameterized or explicit test coverage for every stable command/state ID named in the 2026-04-24 Ownership Freeze: all attachment IDs, `heading-default`, `heading-h1` through `heading-h4`, `indent`, `outdent`, and the #969-exposed edit action IDs.
 - [ ] Preserve focus restoration: opening a picker or link/block-format popover must return focus to the composer trigger or prior caret after close.
 - [ ] Emit accessible labels and live-region status for upload progress and errors.
 - [ ] Do not implement mentions, tasks, reactions, autocomplete listboxes, or comparable overlays here; those belong to #970.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -41,7 +41,7 @@ public final class J2clComposerDocument {
   public static final class Builder {
     private final List<Component> components = new ArrayList<Component>();
 
-    /** Appends literal text when non-empty; null or empty loop inputs are treated as no-ops. */
+    /** Appends literal text when non-empty; null or empty inputs are treated as no-ops. */
     public Builder text(String text) {
       if (text != null && !text.isEmpty()) {
         components.add(new Component(ComponentType.TEXT, text, "", "", "", ""));
@@ -53,10 +53,13 @@ public final class J2clComposerDocument {
     public Builder annotatedText(String annotationKey, String annotationValue, String text) {
       String key = requireNonEmpty(annotationKey, "Missing annotation key.");
       String value = requireNonEmpty(annotationValue, "Missing annotation value.");
+      if (text == null || text.trim().isEmpty()) {
+        throw new IllegalArgumentException("Missing annotated text.");
+      }
       components.add(
           new Component(
               ComponentType.ANNOTATED_TEXT,
-              requireNonEmpty(text, "Missing annotated text."),
+              text,
               key,
               value,
               "",

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -1,0 +1,122 @@
+package org.waveprotocol.box.j2cl.richtext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/** Immutable structured composer document used to build J2CL rich-content sidecar deltas. */
+public final class J2clComposerDocument {
+  enum ComponentType {
+    TEXT,
+    ANNOTATED_TEXT,
+    IMAGE_ATTACHMENT
+  }
+
+  /** Package-private value object intentionally kept internal to the delta builder package. */
+  static final class Component {
+    final ComponentType type;
+    final String text;
+    final String annotationKey;
+    final String annotationValue;
+    final String attachmentId;
+    final String displaySize;
+
+    private Component(
+        ComponentType type,
+        String text,
+        String annotationKey,
+        String annotationValue,
+        String attachmentId,
+        String displaySize) {
+      this.type = type;
+      this.text = nullToEmpty(text);
+      this.annotationKey = nullToEmpty(annotationKey);
+      this.annotationValue = nullToEmpty(annotationValue);
+      this.attachmentId = nullToEmpty(attachmentId);
+      this.displaySize = nullToEmpty(displaySize);
+    }
+  }
+
+  public static final class Builder {
+    private final List<Component> components = new ArrayList<Component>();
+
+    /** Appends literal text when non-empty; null or empty loop inputs are treated as no-ops. */
+    public Builder text(String text) {
+      if (text != null && !text.isEmpty()) {
+        components.add(new Component(ComponentType.TEXT, text, "", "", "", ""));
+      }
+      return this;
+    }
+
+    /** Appends non-empty text bracketed by one annotation start and end boundary. */
+    public Builder annotatedText(String annotationKey, String annotationValue, String text) {
+      String key = requireNonEmpty(annotationKey, "Missing annotation key.");
+      String value = requireNonEmpty(annotationValue, "Missing annotation value.");
+      components.add(
+          new Component(
+              ComponentType.ANNOTATED_TEXT,
+              requireNonEmpty(text, "Missing annotated text."),
+              key,
+              value,
+              "",
+              ""));
+      return this;
+    }
+
+    /** Appends an image attachment element; caption text is preserved exactly when present. */
+    public Builder imageAttachment(String attachmentId, String caption, String displaySize) {
+      components.add(
+          new Component(
+              ComponentType.IMAGE_ATTACHMENT,
+              caption,
+              "",
+              "",
+              requireNonEmpty(attachmentId, "Missing attachment id."),
+              normalizeDisplaySize(displaySize)));
+      return this;
+    }
+
+    public J2clComposerDocument build() {
+      return new J2clComposerDocument(components);
+    }
+  }
+
+  private final List<Component> components;
+
+  private J2clComposerDocument(List<Component> components) {
+    this.components =
+        Collections.unmodifiableList(new ArrayList<Component>(components));
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  List<Component> getComponents() {
+    return components;
+  }
+
+  private static String normalizeDisplaySize(String displaySize) {
+    String normalized = displaySize == null ? "" : displaySize.trim().toLowerCase(Locale.ROOT);
+    if (normalized.isEmpty()) {
+      return "medium";
+    }
+    if ("small".equals(normalized) || "medium".equals(normalized) || "large".equals(normalized)) {
+      return normalized;
+    }
+    throw new IllegalArgumentException("Invalid attachment display size: " + displaySize);
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    String normalized = value == null ? "" : value.trim();
+    if (normalized.isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return normalized;
+  }
+
+  private static String nullToEmpty(String value) {
+    return value == null ? "" : value;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -157,7 +157,7 @@ public final class J2clRichContentDeltaFactory {
   }
 
   private static void appendElementEnd(StringBuilder builder) {
-    builder.append("{\"4\":{}}");
+    builder.append("{\"4\":true}");
   }
 
   private String buildDeltaJson(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -1,0 +1,317 @@
+package org.waveprotocol.box.j2cl.richtext;
+
+import java.util.Locale;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+
+/**
+ * Builds sidecar submit deltas from structured composer content without wiring UI call sites.
+ *
+ * <p>The token counter is shared across create-wave and reply requests for one browser session. A
+ * create delta prepends the required AddParticipant op before the root blip document operation.
+ */
+public final class J2clRichContentDeltaFactory {
+  public static final class CreateWaveRequest {
+    private final String createdWaveId;
+    private final SidecarSubmitRequest submitRequest;
+
+    public CreateWaveRequest(String createdWaveId, SidecarSubmitRequest submitRequest) {
+      this.createdWaveId = createdWaveId;
+      this.submitRequest = submitRequest;
+    }
+
+    public String getCreatedWaveId() {
+      return createdWaveId;
+    }
+
+    public SidecarSubmitRequest getSubmitRequest() {
+      return submitRequest;
+    }
+  }
+
+  private static final char[] WEB64_ALPHABET =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+
+  private final String sessionSeed;
+  private int counter;
+
+  public J2clRichContentDeltaFactory(String sessionSeed) {
+    this.sessionSeed = sanitizeSeed(sessionSeed);
+  }
+
+  public CreateWaveRequest createWaveRequest(String address, J2clComposerDocument document) {
+    String normalizedAddress = normalizeAddress(address);
+    String domain = extractDomain(normalizedAddress);
+    String waveToken = nextToken("w+");
+    String createdWaveId = domain + "/" + waveToken;
+    String versionZeroHistoryHash = buildVersionZeroHistoryHash(domain, waveToken);
+    String deltaJson =
+        buildDeltaJson(
+            0L,
+            versionZeroHistoryHash,
+            normalizedAddress,
+            buildAddParticipantOperation(normalizedAddress)
+                + ","
+                + buildDocumentOperation("b+root", document));
+    return new CreateWaveRequest(
+        createdWaveId,
+        new SidecarSubmitRequest(buildWaveletName(createdWaveId), deltaJson, null));
+  }
+
+  public SidecarSubmitRequest createReplyRequest(
+      String address, J2clSidecarWriteSession session, J2clComposerDocument document) {
+    String normalizedAddress = normalizeAddress(address);
+    String replyBlipId = nextToken("b+");
+    String deltaJson =
+        buildDeltaJson(
+            session.getBaseVersion(),
+            session.getHistoryHash(),
+            normalizedAddress,
+            buildDocumentOperation(replyBlipId, document));
+    return new SidecarSubmitRequest(
+        buildWaveletName(session.getSelectedWaveId()), deltaJson, session.getChannelId());
+  }
+
+  private String buildDocumentOperation(String documentId, J2clComposerDocument document) {
+    StringBuilder components = new StringBuilder();
+    for (J2clComposerDocument.Component component : document.getComponents()) {
+      switch (component.type) {
+        case TEXT:
+          appendComponentSeparator(components);
+          appendCharacters(components, component.text);
+          break;
+        case ANNOTATED_TEXT:
+          appendComponentSeparator(components);
+          appendAnnotationStart(components, component.annotationKey, component.annotationValue);
+          appendComponentSeparator(components);
+          appendCharacters(components, component.text);
+          appendComponentSeparator(components);
+          appendAnnotationEnd(components, component.annotationKey);
+          break;
+        case IMAGE_ATTACHMENT:
+          appendComponentSeparator(components);
+          appendImageAttachment(components, component);
+          break;
+      }
+    }
+    StringBuilder operation = new StringBuilder(components.length() + documentId.length() + 32);
+    operation
+        .append("{\"3\":{\"1\":\"")
+        .append(escapeJson(documentId))
+        .append("\",\"2\":{\"1\":[")
+        .append(components)
+        .append("]}}}");
+    return operation.toString();
+  }
+
+  private void appendImageAttachment(
+      StringBuilder components, J2clComposerDocument.Component component) {
+    components
+        .append("{\"3\":{\"1\":\"image\",\"2\":[{\"1\":\"attachment\",\"2\":\"")
+        .append(escapeJson(component.attachmentId))
+        .append("\"},{\"1\":\"display-size\",\"2\":\"")
+        .append(escapeJson(component.displaySize))
+        .append("\"}]}}");
+    appendComponentSeparator(components);
+    components
+        .append("{\"3\":{\"1\":\"caption\"}}");
+    if (!component.text.isEmpty()) {
+      appendComponentSeparator(components);
+      appendCharacters(components, component.text);
+    }
+    appendComponentSeparator(components);
+    appendElementEnd(components);
+    appendComponentSeparator(components);
+    appendElementEnd(components);
+  }
+
+  private static String buildAddParticipantOperation(String address) {
+    return "{\"1\":\"" + escapeJson(address) + "\"}";
+  }
+
+  private static void appendComponentSeparator(StringBuilder builder) {
+    if (builder.length() > 0) {
+      builder.append(",");
+    }
+  }
+
+  private static void appendCharacters(StringBuilder builder, String text) {
+    builder.append("{\"2\":\"").append(escapeJson(text)).append("\"}");
+  }
+
+  private static void appendAnnotationStart(StringBuilder builder, String key, String value) {
+    builder
+        .append("{\"1\":{\"3\":[{\"1\":\"")
+        .append(escapeJson(key))
+        .append("\",\"3\":\"")
+        .append(escapeJson(value))
+        .append("\"}]}}");
+  }
+
+  private static void appendAnnotationEnd(StringBuilder builder, String key) {
+    builder.append("{\"1\":{\"2\":[\"").append(escapeJson(key)).append("\"]}}");
+  }
+
+  private static void appendElementEnd(StringBuilder builder) {
+    builder.append("{\"4\":{}}");
+  }
+
+  private String buildDeltaJson(
+      long baseVersion, String historyHash, String address, String operationsJson) {
+    return "{\"1\":{\"1\":"
+        + baseVersion
+        + ",\"2\":\""
+        + escapeJson(historyHash)
+        + "\"},\"2\":\""
+        + escapeJson(address)
+        + "\",\"3\":["
+        + operationsJson
+        + "]}";
+  }
+
+  private String buildWaveletName(String waveId) {
+    int separator = waveId.indexOf('/');
+    if (separator <= 0 || separator >= waveId.length() - 1) {
+      throw new IllegalArgumentException("Invalid wave id: " + waveId);
+    }
+    return waveId.substring(0, separator)
+        + "/"
+        + waveId.substring(separator + 1)
+        + "/~/conv+root";
+  }
+
+  private static String normalizeAddress(String address) {
+    if (address == null) {
+      throw new IllegalArgumentException("Missing session address for sidecar submit.");
+    }
+    String trimmed = address.trim().toLowerCase(Locale.ROOT);
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException("Missing session address for sidecar submit.");
+    }
+    return trimmed;
+  }
+
+  private static String extractDomain(String address) {
+    int at = address.indexOf('@');
+    if (at < 1 || at == address.length() - 1 || address.indexOf('@', at + 1) >= 0) {
+      throw new IllegalArgumentException("Invalid participant address: " + address);
+    }
+    String domain = address.substring(at + 1);
+    if (domain.indexOf('/') >= 0) {
+      throw new IllegalArgumentException("Invalid participant address: " + address);
+    }
+    return domain;
+  }
+
+  private static String buildVersionZeroHistoryHash(String domain, String waveToken) {
+    return encodeHex("wave://" + domain + "/" + waveToken + "/conv+root");
+  }
+
+  private static String encodeHex(String value) {
+    // Version-zero wave URIs are ASCII-only; this mirrors the existing plain-text factory.
+    StringBuilder encoded = new StringBuilder(value.length() * 2);
+    for (int i = 0; i < value.length(); i++) {
+      int ch = value.charAt(i);
+      encoded.append(toHexDigit((ch >> 4) & 0xF));
+      encoded.append(toHexDigit(ch & 0xF));
+    }
+    return encoded.toString();
+  }
+
+  private static char toHexDigit(int value) {
+    return (char) (value < 10 ? ('0' + value) : ('A' + (value - 10)));
+  }
+
+  private String nextToken(String prefix) {
+    return prefix + sessionSeed + base64Encode(counter++);
+  }
+
+  private static String sanitizeSeed(String rawSeed) {
+    if (rawSeed == null || rawSeed.isEmpty()) {
+      return "j2cl";
+    }
+    StringBuilder sanitized = new StringBuilder(rawSeed.length());
+    for (int i = 0; i < rawSeed.length(); i++) {
+      char c = rawSeed.charAt(i);
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_') {
+        sanitized.append(c);
+      }
+    }
+    return sanitized.length() == 0 ? "j2cl" : sanitized.toString();
+  }
+
+  private static String base64Encode(int intValue) {
+    if (intValue == 0) {
+      return "A";
+    }
+    int numEncodedBytes = (int) Math.ceil((32 - Integer.numberOfLeadingZeros(intValue)) / 6.0);
+    StringBuilder encoded = new StringBuilder(numEncodedBytes);
+    // Encode the highest non-zero 6-bit group first, then fall through for lower groups.
+    switch (numEncodedBytes) {
+      case 6:
+        encoded.append(WEB64_ALPHABET[(intValue >> 30) & 0x3F]);
+        // fall through
+      case 5:
+        encoded.append(WEB64_ALPHABET[(intValue >> 24) & 0x3F]);
+        // fall through
+      case 4:
+        encoded.append(WEB64_ALPHABET[(intValue >> 18) & 0x3F]);
+        // fall through
+      case 3:
+        encoded.append(WEB64_ALPHABET[(intValue >> 12) & 0x3F]);
+        // fall through
+      case 2:
+        encoded.append(WEB64_ALPHABET[(intValue >> 6) & 0x3F]);
+        // fall through
+      default:
+        encoded.append(WEB64_ALPHABET[intValue & 0x3F]);
+    }
+    return encoded.toString();
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder escaped = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"':
+          escaped.append("\\\"");
+          break;
+        case '\\':
+          escaped.append("\\\\");
+          break;
+        case '\b':
+          escaped.append("\\b");
+          break;
+        case '\f':
+          escaped.append("\\f");
+          break;
+        case '\n':
+          escaped.append("\\n");
+          break;
+        case '\r':
+          escaped.append("\\r");
+          break;
+        case '\t':
+          escaped.append("\\t");
+          break;
+        default:
+          if (c < 0x20) {
+            escaped.append("\\u00");
+            String hex = Integer.toHexString(c);
+            if (hex.length() == 1) {
+              escaped.append('0');
+            }
+            escaped.append(hex);
+          } else {
+            escaped.append(c);
+          }
+      }
+    }
+    return escaped.toString();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -40,6 +40,7 @@ public final class J2clRichContentDeltaFactory {
   }
 
   public CreateWaveRequest createWaveRequest(String address, J2clComposerDocument document) {
+    requirePresent(document, "Missing composer document.");
     String normalizedAddress = normalizeAddress(address);
     String domain = extractDomain(normalizedAddress);
     String waveToken = nextToken("w+");
@@ -60,7 +61,10 @@ public final class J2clRichContentDeltaFactory {
 
   public SidecarSubmitRequest createReplyRequest(
       String address, J2clSidecarWriteSession session, J2clComposerDocument document) {
+    requirePresent(session, "Missing write session.");
+    requirePresent(document, "Missing composer document.");
     String normalizedAddress = normalizeAddress(address);
+    extractDomain(normalizedAddress);
     String replyBlipId = nextToken("b+");
     String deltaJson =
         buildDeltaJson(
@@ -178,6 +182,13 @@ public final class J2clRichContentDeltaFactory {
         + "/"
         + waveId.substring(separator + 1)
         + "/~/conv+root";
+  }
+
+  private static <T> T requirePresent(T value, String message) {
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
   }
 
   private static String normalizeAddress(String address) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -1,0 +1,315 @@
+package org.waveprotocol.box.j2cl.richtext;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+
+@J2clTestInput(J2clRichContentDeltaFactoryTest.class)
+public class J2clRichContentDeltaFactoryTest {
+  @Test
+  public void createWaveRequestEmitsTextAnnotationsAndAttachmentElements() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .text("Hello ")
+            .annotatedText("fontWeight", "bold", "bold text")
+            .text(" before ")
+            .imageAttachment("att+hero/1=", "diagram.png", "medium")
+            .build();
+
+    J2clRichContentDeltaFactory.CreateWaveRequest request =
+        factory.createWaveRequest("User@Example.COM ", document);
+
+    Assert.assertEquals("example.com/w+seedA", request.getCreatedWaveId());
+    SidecarSubmitRequest submitRequest = request.getSubmitRequest();
+    Assert.assertEquals("example.com/w+seedA/~/conv+root", submitRequest.getWaveletName());
+    Assert.assertNull(submitRequest.getChannelId());
+    String deltaJson = submitRequest.getDeltaJson();
+    assertContains(
+        deltaJson,
+        "\"1\":{\"1\":0,\"2\":\"" + encodeHex("wave://example.com/w+seedA/conv+root") + "\"}",
+        "\"2\":\"user@example.com\"",
+        "{\"1\":\"user@example.com\"}",
+        "\"1\":\"b+root\"",
+        "\"2\":\"Hello \"",
+        "{\"1\":{\"3\":[{\"1\":\"fontWeight\",\"3\":\"bold\"}]}}",
+        "\"2\":\"bold text\"",
+        "{\"1\":{\"2\":[\"fontWeight\"]}}",
+        "\"3\":{\"1\":\"image\"",
+        "{\"1\":\"attachment\",\"2\":\"att+hero/1=\"}",
+        "{\"1\":\"display-size\",\"2\":\"medium\"}",
+        "\"3\":{\"1\":\"caption\"",
+        "\"2\":\"diagram.png\"");
+    Assert.assertTrue(
+        deltaJson.indexOf("{\"1\":\"user@example.com\"}")
+            < deltaJson.indexOf("\"1\":\"b+root\""));
+  }
+
+  @Test
+  public void replyRequestPreservesWriteSessionBasisAndChannel() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .text("Plain ")
+            .annotatedText("link/manual", "https://example.com", "link")
+            .build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+
+    Assert.assertEquals("example.com/w+reply/~/conv+root", request.getWaveletName());
+    Assert.assertEquals("chan-7", request.getChannelId());
+    assertContains(
+        request.getDeltaJson(),
+        "\"1\":{\"1\":44,\"2\":\"ABCD\"}",
+        "\"2\":\"user@example.com\"",
+        "\"1\":\"b+seedA\"",
+        "\"2\":\"Plain \"",
+        "{\"1\":{\"3\":[{\"1\":\"link/manual\",\"3\":\"https://example.com\"}]}}",
+        "\"2\":\"link\"",
+        "{\"1\":{\"2\":[\"link/manual\"]}}");
+  }
+
+  @Test
+  public void replyRequestSerializesAttachmentElements() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .text("See ")
+            .imageAttachment("att+reply/1=", "reply.png", "large")
+            .build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+
+    assertContains(
+        request.getDeltaJson(),
+        "\"1\":\"b+seedA\"",
+        "\"2\":\"See \"",
+        "\"3\":{\"1\":\"image\"",
+        "{\"1\":\"attachment\",\"2\":\"att+reply/1=\"}",
+        "{\"1\":\"display-size\",\"2\":\"large\"}",
+        "\"3\":{\"1\":\"caption\"",
+        "\"2\":\"reply.png\"");
+  }
+
+  @Test
+  public void emptyCaptionImageClosesCaptionAndImageElementsCleanly() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().imageAttachment("att+empty", "", "small").build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+
+    assertContains(
+        request.getDeltaJson(),
+        "\"3\":{\"1\":\"caption\"}},{\"4\":{}},{\"4\":{}}",
+        "{\"1\":\"display-size\",\"2\":\"small\"}");
+  }
+
+  @Test
+  public void escapesJsonInTextAnnotationValuesAndAttachmentAttributes() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .text("Quote \" slash \\ newline\n control" + (char) 1)
+            .annotatedText("link/manual", "https://example.com/a?x=\"y\"", "link")
+            .imageAttachment("att+quote\"slash\\", "caption \" slash \\", "medium")
+            .build();
+
+    String deltaJson =
+        factory.createWaveRequest("user@example.com", document).getSubmitRequest().getDeltaJson();
+
+    assertContains(
+        deltaJson,
+        "Quote \\\" slash \\\\ newline\\n",
+        "control\\u0001",
+        "https://example.com/a?x=\\\"y\\\"",
+        "att+quote\\\"slash\\\\",
+        "caption \\\" slash \\\\");
+  }
+
+  @Test
+  public void validatesStructuredDocumentInputs() {
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("", "bold", "text"));
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("   ", "bold", "text"));
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("fontWeight", "", "text"));
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("fontWeight", "   ", "text"));
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("fontWeight", "bold", ""));
+    assertThrows(() -> J2clComposerDocument.builder().annotatedText("fontWeight", "bold", "   "));
+    assertThrows(() -> J2clComposerDocument.builder().imageAttachment("", "caption", "small"));
+    assertThrows(() -> J2clComposerDocument.builder().imageAttachment("att+1", "caption", "huge"));
+
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("x").build();
+    assertThrows(() -> factory.createWaveRequest(null, document));
+    assertThrows(() -> factory.createReplyRequest(" ", session, document));
+    assertThrows(() -> factory.createReplyRequest(null, session, document));
+    assertThrows(
+        () ->
+            factory.createWaveRequest(
+                "missing-domain", document));
+    assertThrows(() -> factory.createWaveRequest("user@evil/path", document));
+    assertThrows(() -> factory.createWaveRequest("user@example.com@evil.com", document));
+  }
+
+  @Test
+  public void replyBlipIdsAdvanceAcrossRequests() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Reply").build();
+
+    SidecarSubmitRequest first = factory.createReplyRequest("user@example.com", session, document);
+    SidecarSubmitRequest second = factory.createReplyRequest("user@example.com", session, document);
+
+    assertContains(first.getDeltaJson(), "\"1\":\"b+seedA\"");
+    assertContains(second.getDeltaJson(), "\"1\":\"b+seedB\"");
+  }
+
+  @Test
+  public void createAndReplyRequestsShareOneTokenCounter() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Body").build();
+
+    J2clRichContentDeltaFactory.CreateWaveRequest create =
+        factory.createWaveRequest("user@example.com", document);
+    SidecarSubmitRequest reply = factory.createReplyRequest("user@example.com", session, document);
+
+    Assert.assertEquals("example.com/w+seedA", create.getCreatedWaveId());
+    assertContains(reply.getDeltaJson(), "\"1\":\"b+seedB\"");
+  }
+
+  @Test
+  public void tokenCounterUsesMultiCharacterWeb64TokensAfterSixtyFourValues() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Reply").build();
+
+    for (int i = 0; i < 64; i++) {
+      factory.createReplyRequest("user@example.com", session, document);
+    }
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+
+    assertContains(request.getDeltaJson(), "\"1\":\"b+seedBA\"");
+  }
+
+  @Test
+  public void createWaveIdsAdvanceAcrossRequests() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Wave").build();
+
+    J2clRichContentDeltaFactory.CreateWaveRequest first =
+        factory.createWaveRequest("user@example.com", document);
+    J2clRichContentDeltaFactory.CreateWaveRequest second =
+        factory.createWaveRequest("user@example.com", document);
+
+    Assert.assertEquals("example.com/w+seedA", first.getCreatedWaveId());
+    Assert.assertEquals("example.com/w+seedB", second.getCreatedWaveId());
+  }
+
+  @Test
+  public void consecutiveAnnotatedTextClosesEachAnnotationIndependently() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .annotatedText("fontWeight", "bold", "bold")
+            .annotatedText("fontStyle", "italic", "italic")
+            .build();
+
+    String deltaJson =
+        factory.createWaveRequest("user@example.com", document).getSubmitRequest().getDeltaJson();
+
+    assertContains(
+        deltaJson,
+        "{\"1\":{\"3\":[{\"1\":\"fontWeight\",\"3\":\"bold\"}]}}",
+        "{\"2\":\"bold\"}",
+        "{\"1\":{\"2\":[\"fontWeight\"]}}",
+        "{\"1\":{\"3\":[{\"1\":\"fontStyle\",\"3\":\"italic\"}]}}",
+        "{\"2\":\"italic\"}",
+        "{\"1\":{\"2\":[\"fontStyle\"]}}");
+  }
+
+  @Test
+  public void preservesUnicodeTextAndCaption() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    String text = "\u05e9\u05dc\u05d5\u05dd";
+    String caption = "\u05ea\u05de\u05d5\u05e0\u05d4";
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .text(text)
+            .imageAttachment("att+unicode", caption, "small")
+            .build();
+
+    String deltaJson =
+        factory.createWaveRequest("user@example.com", document).getSubmitRequest().getDeltaJson();
+
+    assertContains(deltaJson, "\"2\":\"" + text + "\"", "\"2\":\"" + caption + "\"");
+  }
+
+  @Test
+  public void normalizesDisplaySizeCaseDeterministically() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .imageAttachment("att+small", "small", "Small")
+            .imageAttachment("att+medium", "medium", "MEDIUM")
+            .imageAttachment("att+large", "large", "LaRgE")
+            .build();
+
+    String deltaJson =
+        factory.createWaveRequest("user@example.com", document).getSubmitRequest().getDeltaJson();
+
+    assertContains(
+        deltaJson,
+        "{\"1\":\"display-size\",\"2\":\"small\"}",
+        "{\"1\":\"display-size\",\"2\":\"medium\"}",
+        "{\"1\":\"display-size\",\"2\":\"large\"}");
+  }
+
+  private static void assertContains(String value, String... fragments) {
+    for (String fragment : fragments) {
+      Assert.assertTrue(
+          "Missing fragment: " + fragment + "\nJSON: " + value, value.contains(fragment));
+    }
+  }
+
+  private static void assertThrows(ThrowingRunnable runnable) {
+    try {
+      runnable.run();
+      Assert.fail("Expected IllegalArgumentException.");
+    } catch (IllegalArgumentException expected) {
+      // Expected.
+    }
+  }
+
+  private interface ThrowingRunnable {
+    void run();
+  }
+
+  // ASCII-only: mirrors the submit factory's version-zero URI hash encoding.
+  private static String encodeHex(String value) {
+    StringBuilder encoded = new StringBuilder(value.length() * 2);
+    for (int i = 0; i < value.length(); i++) {
+      int ch = value.charAt(i);
+      encoded.append(toHexDigit((ch >> 4) & 0xF));
+      encoded.append(toHexDigit(ch & 0xF));
+    }
+    return encoded.toString();
+  }
+
+  private static char toHexDigit(int value) {
+    return (char) (value < 10 ? ('0' + value) : ('A' + (value - 10)));
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -151,14 +151,19 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root");
     J2clComposerDocument document = J2clComposerDocument.builder().text("x").build();
     assertThrows(() -> factory.createWaveRequest(null, document));
+    assertThrows(() -> factory.createWaveRequest("user@example.com", null));
     assertThrows(() -> factory.createReplyRequest(" ", session, document));
     assertThrows(() -> factory.createReplyRequest(null, session, document));
+    assertThrows(() -> factory.createReplyRequest("user@example.com", null, document));
+    assertThrows(() -> factory.createReplyRequest("user@example.com", session, null));
     assertThrows(
         () ->
             factory.createWaveRequest(
                 "missing-domain", document));
+    assertThrows(() -> factory.createReplyRequest("missing-domain", session, document));
     assertThrows(() -> factory.createWaveRequest("user@evil/path", document));
     assertThrows(() -> factory.createWaveRequest("user@example.com@evil.com", document));
+    assertThrows(() -> factory.createReplyRequest("user@example.com@evil.com", session, document));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -109,7 +109,7 @@ public class J2clRichContentDeltaFactoryTest {
 
     assertContains(
         request.getDeltaJson(),
-        "\"3\":{\"1\":\"caption\"}},{\"4\":{}},{\"4\":{}}",
+        "\"3\":{\"1\":\"caption\"}},{\"4\":true},{\"4\":true}",
         "{\"1\":\"display-size\",\"2\":\"small\"}");
   }
 

--- a/wave/config/changelog.d/2026-04-24-issue-971-rich-content-delta.json
+++ b/wave/config/changelog.d/2026-04-24-issue-971-rich-content-delta.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-issue-971-rich-content-delta",
+  "version": "Issue #971",
+  "date": "2026-04-24",
+  "title": "Prepare J2CL rich-content submit deltas",
+  "summary": "The opt-in J2CL shell now has a tested structured delta builder for rich text and attachment document operations, enabling later attachment and rich-edit controller slices without changing the legacy GWT default route.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a structured J2CL composer document model for text, annotation boundaries, and image attachment caption elements",
+        "Added rich-content create and reply submit delta construction with participant-add ordering, write-session basis preservation, validation, escaping, and token-progression coverage"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Freeze #971 ownership after #969/#970 landed and record the final daily rich-edit/attachment command list.
- Add an additive structured J2CL composer document model and rich-content delta factory for create/reply submit requests.
- Cover text, annotation boundaries, image attachment/caption elements, AddParticipant ordering, basis/channel preservation, escaping, validation, and token progression.

## Verification
- `cd j2cl && ./mvnw -Dtest=J2clRichContentDeltaFactoryTest test`
- `cd j2cl && ./mvnw -Dtest=J2clRichContentDeltaFactoryTest,J2clPlainTextDeltaFactoryTest test`
- `cd j2cl && ./mvnw test`
- `git diff --check`
- Claude Opus 4.7 review loop passed on round 5 with no blockers, important concerns, or required follow-ups.

Closes no issue; this is Task 1/2 slice work toward #971.

Refs #971
Refs #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * J2CL path now supports structured rich-content composition: annotated text, image attachments with captions and normalized display sizes, and create/reply submit flows.

* **Tests**
  * Added comprehensive tests for rich-content serialization, identifier progression, validation/error cases, JSON escaping, and create/reply request behaviors.

* **Documentation**
  * Added an implementation plan and changelog entry describing acceptance criteria, rollout gating, testing slices, and telemetry requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->