### PR TITLE
Add J2CL attachment upload and metadata clients

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadata.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadata.java
@@ -1,0 +1,102 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+public final class J2clAttachmentMetadata {
+  private final String attachmentId;
+  private final String waveRef;
+  private final String fileName;
+  private final String mimeType;
+  private final long size;
+  private final String creator;
+  private final String attachmentUrl;
+  private final String thumbnailUrl;
+  private final ImageMetadata imageMetadata;
+  private final ImageMetadata thumbnailMetadata;
+  private final boolean malware;
+
+  public J2clAttachmentMetadata(
+      String attachmentId,
+      String waveRef,
+      String fileName,
+      String mimeType,
+      long size,
+      String creator,
+      String attachmentUrl,
+      String thumbnailUrl,
+      ImageMetadata imageMetadata,
+      ImageMetadata thumbnailMetadata,
+      boolean malware) {
+    this.attachmentId = attachmentId;
+    this.waveRef = waveRef;
+    this.fileName = fileName;
+    this.mimeType = mimeType;
+    this.size = size;
+    this.creator = creator;
+    this.attachmentUrl = attachmentUrl;
+    this.thumbnailUrl = thumbnailUrl;
+    this.imageMetadata = imageMetadata;
+    this.thumbnailMetadata = thumbnailMetadata;
+    this.malware = malware;
+  }
+
+  public String getAttachmentId() {
+    return attachmentId;
+  }
+
+  public String getWaveRef() {
+    return waveRef;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public String getCreator() {
+    return creator;
+  }
+
+  public String getAttachmentUrl() {
+    return attachmentUrl;
+  }
+
+  public String getThumbnailUrl() {
+    return thumbnailUrl;
+  }
+
+  public ImageMetadata getImageMetadata() {
+    return imageMetadata;
+  }
+
+  public ImageMetadata getThumbnailMetadata() {
+    return thumbnailMetadata;
+  }
+
+  public boolean isMalware() {
+    return malware;
+  }
+
+  public static final class ImageMetadata {
+    private final int width;
+    private final int height;
+
+    public ImageMetadata(int width, int height) {
+      this.width = width;
+      this.height = height;
+    }
+
+    public int getWidth() {
+      return width;
+    }
+
+    public int getHeight() {
+      return height;
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -39,6 +39,16 @@ public final class J2clAttachmentMetadataClient {
     this(new BrowserMetadataTransport(), DEFAULT_ATTACHMENTS_INFO_URL);
   }
 
+  /**
+   * Creates the browser-backed metadata client.
+   *
+   * @param metadataTimeoutMillis metadata XHR timeout in milliseconds; use {@code 0} to disable
+   *     the per-request timeout and leave browser defaults in effect.
+   */
+  public J2clAttachmentMetadataClient(int metadataTimeoutMillis) {
+    this(new BrowserMetadataTransport(metadataTimeoutMillis), DEFAULT_ATTACHMENTS_INFO_URL);
+  }
+
   public J2clAttachmentMetadataClient(MetadataTransport transport) {
     this(transport, DEFAULT_ATTACHMENTS_INFO_URL);
   }
@@ -424,10 +434,27 @@ public final class J2clAttachmentMetadataClient {
   }
 
   private static final class BrowserMetadataTransport implements MetadataTransport {
+    private static final int DEFAULT_TIMEOUT_MILLIS = 60000;
+    private final int timeoutMillis;
+
+    private BrowserMetadataTransport() {
+      this(DEFAULT_TIMEOUT_MILLIS);
+    }
+
+    private BrowserMetadataTransport(int timeoutMillis) {
+      if (timeoutMillis < 0) {
+        throw new IllegalArgumentException("Metadata timeout must not be negative.");
+      }
+      this.timeoutMillis = timeoutMillis;
+    }
+
     @Override
     public void get(String url, ResponseHandler handler) {
       XMLHttpRequest xhr = new XMLHttpRequest();
       xhr.open("GET", url, true);
+      if (timeoutMillis > 0) {
+        xhr.timeout = timeoutMillis;
+      }
       xhr.onload =
           event ->
               handler.onResponse(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -91,8 +91,7 @@ public final class J2clAttachmentMetadataClient {
           ErrorType.HTTP_STATUS,
           "HTTP " + response.getStatusCode() + " while fetching attachment metadata.");
     }
-    if (response.getContentType() == null
-        || !response.getContentType().toLowerCase(Locale.ROOT).startsWith("application/json")) {
+    if (!isJsonContentType(response.getContentType())) {
       return MetadataResult.failure(
           ErrorType.UNEXPECTED_CONTENT_TYPE,
           "Attachment metadata endpoint did not return JSON.");
@@ -106,6 +105,14 @@ public final class J2clAttachmentMetadataClient {
               ? "Unable to parse attachment metadata."
               : e.getMessage());
     }
+  }
+
+  private static boolean isJsonContentType(String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    String mediaType = contentType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+    return "application/json".equals(mediaType);
   }
 
   private static MetadataResult parseMetadataResult(List<String> requestedIds, String json) {
@@ -222,6 +229,10 @@ public final class J2clAttachmentMetadataClient {
       return requireIntegralLong((Number) value, key);
     }
     List<Object> words = asList(value);
+    if (words.size() != 2) {
+      throw new IllegalArgumentException(
+          "Expected two-word attachment metadata field " + key + ".");
+    }
     int lowWord = getIntValue(words.get(0), key + "[0]");
     int highWord = getIntValue(words.get(1), key + "[1]");
     return (((long) highWord) << 32) | (lowWord & 0xffffffffL);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -168,10 +168,11 @@ public final class J2clAttachmentMetadataClient {
   }
 
   private static String requireNonEmpty(String value, String message) {
-    if (value == null || value.trim().isEmpty()) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.isEmpty()) {
       throw new IllegalArgumentException(message);
     }
-    return value.trim();
+    return trimmed;
   }
 
   private static String requireString(Map<String, Object> object, String key, String name) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -1,0 +1,448 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import elemental2.dom.XMLHttpRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+
+public final class J2clAttachmentMetadataClient {
+  private static final String DEFAULT_ATTACHMENTS_INFO_URL = "/attachmentsInfo";
+  private final MetadataTransport transport;
+  private final String baseUrl;
+
+  public interface MetadataTransport {
+    void get(String url, ResponseHandler handler);
+  }
+
+  public interface ResponseHandler {
+    void onResponse(HttpResponse response);
+  }
+
+  public interface MetadataCallback {
+    void onComplete(MetadataResult result);
+  }
+
+  public enum ErrorType {
+    INVALID_REQUEST,
+    NETWORK,
+    HTTP_STATUS,
+    UNEXPECTED_CONTENT_TYPE,
+    PARSE_ERROR
+  }
+
+  public J2clAttachmentMetadataClient() {
+    this(new BrowserMetadataTransport(), DEFAULT_ATTACHMENTS_INFO_URL);
+  }
+
+  public J2clAttachmentMetadataClient(MetadataTransport transport) {
+    this(transport, DEFAULT_ATTACHMENTS_INFO_URL);
+  }
+
+  public J2clAttachmentMetadataClient(MetadataTransport transport, String baseUrl) {
+    if (transport == null) {
+      throw new IllegalArgumentException("Metadata transport is required.");
+    }
+    this.transport = transport;
+    this.baseUrl = requireNonEmpty(baseUrl, "Attachments info base URL is required.");
+  }
+
+  public void fetchMetadata(List<String> attachmentIds, MetadataCallback callback) {
+    if (callback == null) {
+      throw new IllegalArgumentException("Metadata callback is required.");
+    }
+    List<String> requestedIds;
+    String requestUrl;
+    try {
+      requestedIds = normalizeIds(attachmentIds);
+      requestUrl = buildRequestUrl(baseUrl, requestedIds);
+    } catch (IllegalArgumentException e) {
+      callback.onComplete(MetadataResult.failure(ErrorType.INVALID_REQUEST, e.getMessage()));
+      return;
+    }
+    transport.get(
+        requestUrl,
+        response -> callback.onComplete(decodeResponse(requestedIds, response)));
+  }
+
+  private static MetadataResult decodeResponse(List<String> requestedIds, HttpResponse response) {
+    if (response == null) {
+      return MetadataResult.failure(ErrorType.NETWORK, "Attachment metadata request failed without a response.");
+    }
+    if (response.getNetworkError() != null && !response.getNetworkError().isEmpty()) {
+      return MetadataResult.failure(ErrorType.NETWORK, response.getNetworkError());
+    }
+    if (response.getStatusCode() != 200) {
+      return MetadataResult.failure(
+          ErrorType.HTTP_STATUS,
+          "HTTP " + response.getStatusCode() + " while fetching attachment metadata.");
+    }
+    if (response.getContentType() == null
+        || !response.getContentType().toLowerCase(Locale.ROOT).startsWith("application/json")) {
+      return MetadataResult.failure(
+          ErrorType.UNEXPECTED_CONTENT_TYPE,
+          "Attachment metadata endpoint did not return JSON.");
+    }
+    try {
+      return parseMetadataResult(requestedIds, response.getResponseText());
+    } catch (RuntimeException e) {
+      return MetadataResult.failure(
+          ErrorType.PARSE_ERROR,
+          e.getMessage() == null || e.getMessage().isEmpty()
+              ? "Unable to parse attachment metadata."
+              : e.getMessage());
+    }
+  }
+
+  private static MetadataResult parseMetadataResult(List<String> requestedIds, String json) {
+    Map<String, Object> root = SidecarTransportCodec.parseJsonObject(json);
+    Object rawAttachments = root.get("1");
+    List<J2clAttachmentMetadata> attachments = new ArrayList<J2clAttachmentMetadata>();
+    Set<String> returnedIds = new LinkedHashSet<String>();
+    if (rawAttachments != null) {
+      for (Object rawAttachment : asList(rawAttachments)) {
+        J2clAttachmentMetadata attachment = parseAttachment(asObject(rawAttachment));
+        attachments.add(attachment);
+        returnedIds.add(attachment.getAttachmentId());
+      }
+    }
+    List<String> missingIds = new ArrayList<String>();
+    for (String requestedId : requestedIds) {
+      if (!returnedIds.contains(requestedId)) {
+        missingIds.add(requestedId);
+      }
+    }
+    return MetadataResult.success(attachments, missingIds);
+  }
+
+  private static J2clAttachmentMetadata parseAttachment(Map<String, Object> object) {
+    String attachmentId = requireString(object, "1", "attachmentId");
+    return new J2clAttachmentMetadata(
+        attachmentId,
+        requireString(object, "2", "waveRef"),
+        requireString(object, "3", "fileName"),
+        requireString(object, "4", "mimeType"),
+        getLong(object, "5"),
+        requireString(object, "6", "creator"),
+        requireString(object, "7", "attachmentUrl"),
+        requireString(object, "8", "thumbnailUrl"),
+        parseImageMetadata(object.get("9")),
+        parseImageMetadata(object.get("10")),
+        getBoolean(object, "11"));
+  }
+
+  private static J2clAttachmentMetadata.ImageMetadata parseImageMetadata(Object value) {
+    if (value == null) {
+      return null;
+    }
+    Map<String, Object> image = asObject(value);
+    return new J2clAttachmentMetadata.ImageMetadata(getInt(image, "1"), getInt(image, "2"));
+  }
+
+  private static List<String> normalizeIds(List<String> attachmentIds) {
+    if (attachmentIds == null || attachmentIds.isEmpty()) {
+      throw new IllegalArgumentException("At least one attachment id is required.");
+    }
+    List<String> normalized = new ArrayList<String>();
+    for (String attachmentId : attachmentIds) {
+      normalized.add(requireNonEmpty(attachmentId, "Attachment id is required."));
+    }
+    return Collections.unmodifiableList(normalized);
+  }
+
+  static String buildRequestUrl(String baseUrl, List<String> attachmentIds) {
+    // Keep this tiny builder local: the J2CL module intentionally does not depend on GWT media classes.
+    char separator = baseUrl.indexOf('?') >= 0 ? '&' : '?';
+    StringBuilder request = new StringBuilder(baseUrl).append(separator).append("attachmentIds=");
+    for (int i = 0; i < attachmentIds.size(); i++) {
+      if (i > 0) {
+        request.append(',');
+      }
+      request.append(encodeUriComponentFallback(attachmentIds.get(i)));
+    }
+    return request.toString();
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
+  }
+
+  private static String requireString(Map<String, Object> object, String key, String name) {
+    String value = getString(object, key);
+    if (value == null) {
+      throw new IllegalArgumentException("Missing attachment metadata field " + name + ".");
+    }
+    return value;
+  }
+
+  private static String getString(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof String)) {
+      throw new IllegalArgumentException("Expected string attachment metadata field " + key + ".");
+    }
+    return (String) value;
+  }
+
+  private static int getInt(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (!(value instanceof Number)) {
+      throw new IllegalArgumentException("Expected numeric attachment metadata field " + key + ".");
+    }
+    long integral = requireIntegralLong((Number) value, key);
+    if (integral < Integer.MIN_VALUE || integral > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Expected int-range attachment metadata field " + key + ".");
+    }
+    return (int) integral;
+  }
+
+  private static long getLong(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (value instanceof Number) {
+      return requireIntegralLong((Number) value, key);
+    }
+    List<Object> words = asList(value);
+    int lowWord = getIntValue(words.get(0), key + "[0]");
+    int highWord = getIntValue(words.get(1), key + "[1]");
+    return (((long) highWord) << 32) | (lowWord & 0xffffffffL);
+  }
+
+  private static int getIntValue(Object value, String key) {
+    if (!(value instanceof Number)) {
+      throw new IllegalArgumentException("Expected numeric attachment metadata field " + key + ".");
+    }
+    long integral = requireIntegralLong((Number) value, key);
+    if (integral < Integer.MIN_VALUE || integral > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("Expected int-range attachment metadata field " + key + ".");
+    }
+    return (int) integral;
+  }
+
+  private static long requireIntegralLong(Number value, String key) {
+    if (value instanceof Byte
+        || value instanceof Short
+        || value instanceof Integer
+        || value instanceof Long) {
+      return value.longValue();
+    }
+    // Large int64 proto fields are expected as [low, high] words; scalar doubles must be exact.
+    double candidate = value.doubleValue();
+    if (!Double.isFinite(candidate)) {
+      throw new IllegalArgumentException("Expected finite attachment metadata field " + key + ".");
+    }
+    long integral = (long) candidate;
+    if ((double) integral != candidate) {
+      throw new IllegalArgumentException("Expected integral attachment metadata field " + key + ".");
+    }
+    return integral;
+  }
+
+  private static boolean getBoolean(Map<String, Object> object, String key) {
+    Object value = object.get(key);
+    if (value == null) {
+      return false;
+    }
+    if (!(value instanceof Boolean)) {
+      throw new IllegalArgumentException("Expected boolean attachment metadata field " + key + ".");
+    }
+    return ((Boolean) value).booleanValue();
+  }
+
+  private static Map<String, Object> asObject(Object value) {
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException("Expected attachment metadata object.");
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> object = (Map<String, Object>) value;
+    return object;
+  }
+
+  private static List<Object> asList(Object value) {
+    if (!(value instanceof List)) {
+      throw new IllegalArgumentException("Expected attachment metadata array.");
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) value;
+    return list;
+  }
+
+  private static String encodeUriComponentFallback(String value) {
+    StringBuilder encoded = new StringBuilder(value.length());
+    for (int index = 0; index < value.length(); ) {
+      int codePoint = value.codePointAt(index);
+      if (codePoint <= 0xFFFF && Character.isSurrogate((char) codePoint)) {
+        throw new IllegalArgumentException("Attachment id contains an invalid Unicode surrogate.");
+      }
+      if (isUnreserved(codePoint)) {
+        encoded.append((char) codePoint);
+      } else {
+        appendUtf8EncodedCodePoint(encoded, codePoint);
+      }
+      index += Character.charCount(codePoint);
+    }
+    return encoded.toString();
+  }
+
+  private static boolean isUnreserved(int value) {
+    return (value >= 'A' && value <= 'Z')
+        || (value >= 'a' && value <= 'z')
+        || (value >= '0' && value <= '9')
+        || value == '-'
+        || value == '_'
+        || value == '.'
+        || value == '~';
+  }
+
+  private static void appendUtf8EncodedCodePoint(StringBuilder target, int codePoint) {
+    if (codePoint <= 0x7F) {
+      appendEncodedByte(target, codePoint);
+    } else if (codePoint <= 0x7FF) {
+      appendEncodedByte(target, 0xC0 | (codePoint >> 6));
+      appendEncodedByte(target, 0x80 | (codePoint & 0x3F));
+    } else if (codePoint <= 0xFFFF) {
+      appendEncodedByte(target, 0xE0 | (codePoint >> 12));
+      appendEncodedByte(target, 0x80 | ((codePoint >> 6) & 0x3F));
+      appendEncodedByte(target, 0x80 | (codePoint & 0x3F));
+    } else {
+      appendEncodedByte(target, 0xF0 | (codePoint >> 18));
+      appendEncodedByte(target, 0x80 | ((codePoint >> 12) & 0x3F));
+      appendEncodedByte(target, 0x80 | ((codePoint >> 6) & 0x3F));
+      appendEncodedByte(target, 0x80 | (codePoint & 0x3F));
+    }
+  }
+
+  private static void appendEncodedByte(StringBuilder target, int value) {
+    target.append('%');
+    appendHex(target, value >> 4);
+    appendHex(target, value);
+  }
+
+  private static void appendHex(StringBuilder target, int value) {
+    int nibble = value & 0x0F;
+    target.append((char) (nibble < 10 ? '0' + nibble : 'A' + (nibble - 10)));
+  }
+
+  public static final class HttpResponse {
+    private final int statusCode;
+    private final String contentType;
+    private final String responseText;
+    private final String networkError;
+
+    public HttpResponse(int statusCode, String contentType, String responseText, String networkError) {
+      this.statusCode = statusCode;
+      this.contentType = contentType;
+      this.responseText = responseText == null ? "" : responseText;
+      this.networkError = networkError;
+    }
+
+    /** Use only for transport-level failures; HTTP responses should keep their status code. */
+    public static HttpResponse networkError(String message) {
+      return new HttpResponse(0, "", "", message == null || message.isEmpty() ? "Network failure." : message);
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+
+    public String getContentType() {
+      return contentType;
+    }
+
+    public String getResponseText() {
+      return responseText;
+    }
+
+    public String getNetworkError() {
+      return networkError;
+    }
+  }
+
+  public static final class MetadataResult {
+    private final boolean success;
+    private final List<J2clAttachmentMetadata> attachments;
+    private final List<String> missingAttachmentIds;
+    private final ErrorType errorType;
+    private final String message;
+
+    private MetadataResult(
+        boolean success,
+        List<J2clAttachmentMetadata> attachments,
+        List<String> missingAttachmentIds,
+        ErrorType errorType,
+        String message) {
+      this.success = success;
+      this.attachments = Collections.unmodifiableList(new ArrayList<J2clAttachmentMetadata>(attachments));
+      this.missingAttachmentIds = Collections.unmodifiableList(new ArrayList<String>(missingAttachmentIds));
+      this.errorType = errorType;
+      this.message = message == null ? "" : message;
+    }
+
+    static MetadataResult success(
+        List<J2clAttachmentMetadata> attachments,
+        List<String> missingAttachmentIds) {
+      return new MetadataResult(true, attachments, missingAttachmentIds, null, "");
+    }
+
+    static MetadataResult failure(ErrorType errorType, String message) {
+      return new MetadataResult(
+          false,
+          Collections.<J2clAttachmentMetadata>emptyList(),
+          Collections.<String>emptyList(),
+          errorType,
+          message);
+    }
+
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public List<J2clAttachmentMetadata> getAttachments() {
+      return attachments;
+    }
+
+    public List<String> getMissingAttachmentIds() {
+      return missingAttachmentIds;
+    }
+
+    public ErrorType getErrorType() {
+      return errorType;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+
+  private static final class BrowserMetadataTransport implements MetadataTransport {
+    @Override
+    public void get(String url, ResponseHandler handler) {
+      XMLHttpRequest xhr = new XMLHttpRequest();
+      xhr.open("GET", url, true);
+      xhr.onload =
+          event ->
+              handler.onResponse(
+                  new HttpResponse(
+                      xhr.status,
+                      xhr.getResponseHeader("Content-Type"),
+                      xhr.responseText,
+                      null));
+      xhr.onerror =
+          event -> {
+            handler.onResponse(HttpResponse.networkError("Network failure while fetching attachment metadata."));
+            return null;
+          };
+      xhr.ontimeout =
+          event -> handler.onResponse(HttpResponse.networkError("Attachment metadata request timed out."));
+      xhr.send();
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -171,7 +171,7 @@ public final class J2clAttachmentMetadataClient {
     if (value == null || value.trim().isEmpty()) {
       throw new IllegalArgumentException(message);
     }
-    return value;
+    return value.trim();
   }
 
   private static String requireString(Map<String, Object> object, String key, String name) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
@@ -147,8 +147,7 @@ public final class J2clAttachmentUploadClient {
     }
     if (source == UploadSource.FILE_PICKER) {
       // Preserve the legacy GWT file-picker contract: any 2xx response containing "OK" succeeds.
-      if (statusCode >= 200
-          && response.getResponseText() != null
+      if (response.getResponseText() != null
           && response.getResponseText().contains("OK")) {
         return UploadResult.success();
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
@@ -1,0 +1,360 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import elemental2.dom.FormData;
+import elemental2.dom.XMLHttpRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import jsinterop.base.Js;
+
+public final class J2clAttachmentUploadClient {
+  private static final String ATTACHMENT_URL_PREFIX = "/attachment/";
+  private static final String PASTED_IMAGE_FILENAME = "pasted-image.png";
+  private static final int NO_TIMEOUT_MILLIS = 0;
+  private static final int PASTED_IMAGE_TIMEOUT_MILLIS = 60000;
+  private static final UploadProgressCallback NO_UPLOAD_PROGRESS_CALLBACK =
+      percent -> {};
+
+  public interface UploadTransport {
+    void post(MultipartUploadRequest request, ResponseHandler handler);
+  }
+
+  public interface ResponseHandler {
+    void onResponse(HttpResponse response);
+  }
+
+  public interface UploadCallback {
+    void onComplete(UploadResult result);
+  }
+
+  public interface UploadProgressCallback {
+    void onProgress(int percent);
+  }
+
+  public enum ErrorType {
+    INVALID_REQUEST,
+    NETWORK,
+    HTTP_STATUS,
+    UNEXPECTED_RESPONSE
+  }
+
+  private enum UploadSource {
+    FILE_PICKER,
+    PASTED_IMAGE
+  }
+
+  private final UploadTransport transport;
+
+  public J2clAttachmentUploadClient() {
+    this(new BrowserUploadTransport());
+  }
+
+  public J2clAttachmentUploadClient(UploadTransport transport) {
+    if (transport == null) {
+      throw new IllegalArgumentException("Upload transport is required.");
+    }
+    this.transport = transport;
+  }
+
+  public void uploadFile(
+      String attachmentId,
+      String waveRef,
+      Object filePayload,
+      String fileName,
+      UploadCallback callback) {
+    uploadFile(attachmentId, waveRef, filePayload, fileName, null, callback);
+  }
+
+  public void uploadFile(
+      String attachmentId,
+      String waveRef,
+      Object filePayload,
+      String fileName,
+      UploadProgressCallback progressCallback,
+      UploadCallback callback) {
+    upload(
+        attachmentId,
+        waveRef,
+        filePayload,
+        fileName,
+        UploadSource.FILE_PICKER,
+        progressCallback,
+        callback);
+  }
+
+  public void uploadPastedImage(
+      String attachmentId,
+      String waveRef,
+      Object imagePayload,
+      UploadCallback callback) {
+    uploadPastedImage(attachmentId, waveRef, imagePayload, null, callback);
+  }
+
+  public void uploadPastedImage(
+      String attachmentId,
+      String waveRef,
+      Object imagePayload,
+      UploadProgressCallback progressCallback,
+      UploadCallback callback) {
+    upload(
+        attachmentId,
+        waveRef,
+        imagePayload,
+        PASTED_IMAGE_FILENAME,
+        UploadSource.PASTED_IMAGE,
+        progressCallback,
+        callback);
+  }
+
+  private void upload(
+      String attachmentId,
+      String waveRef,
+      Object payload,
+      String fileName,
+      UploadSource source,
+      UploadProgressCallback progressCallback,
+      UploadCallback callback) {
+    requireCallback(callback);
+    String normalizedAttachmentId = requireNonEmpty(attachmentId, "Attachment id is required.");
+    String normalizedWaveRef = requireNonEmpty(waveRef, "Wave ref is required.");
+    String normalizedFileName = requireNonEmpty(fileName, "File name is required.");
+    if (payload == null) {
+      callback.onComplete(UploadResult.failure(ErrorType.INVALID_REQUEST, "Upload payload is required."));
+      return;
+    }
+
+    MultipartUploadRequest request =
+        new MultipartUploadRequest(
+            ATTACHMENT_URL_PREFIX + normalizedAttachmentId,
+            source == UploadSource.PASTED_IMAGE ? PASTED_IMAGE_TIMEOUT_MILLIS : NO_TIMEOUT_MILLIS,
+            progressCallback == null ? NO_UPLOAD_PROGRESS_CALLBACK : progressCallback,
+            MultipartPart.stringPart("attachmentId", normalizedAttachmentId),
+            MultipartPart.stringPart("waveRef", normalizedWaveRef),
+            MultipartPart.filePart("uploadFormElement", payload, normalizedFileName));
+    transport.post(request, response -> callback.onComplete(classifyResponse(source, response)));
+  }
+
+  private static UploadResult classifyResponse(UploadSource source, HttpResponse response) {
+    if (response == null) {
+      return UploadResult.failure(ErrorType.NETWORK, "Attachment upload failed without a response.");
+    }
+    if (response.getNetworkError() != null && !response.getNetworkError().isEmpty()) {
+      return UploadResult.failure(ErrorType.NETWORK, response.getNetworkError());
+    }
+    int statusCode = response.getStatusCode();
+    if (statusCode < 200 || statusCode >= 300) {
+      return UploadResult.failure(ErrorType.HTTP_STATUS, "HTTP " + statusCode + " while uploading attachment.");
+    }
+    if (source == UploadSource.FILE_PICKER) {
+      // Preserve the legacy GWT file-picker contract: any 2xx response containing "OK" succeeds.
+      if (statusCode >= 200
+          && response.getResponseText() != null
+          && response.getResponseText().contains("OK")) {
+        return UploadResult.success();
+      }
+      return UploadResult.failure(
+          ErrorType.UNEXPECTED_RESPONSE,
+          "Attachment upload did not return the expected OK sentinel.");
+    }
+    if (statusCode == 200 || statusCode == 201) {
+      return UploadResult.success();
+    }
+    return UploadResult.failure(
+        ErrorType.UNEXPECTED_RESPONSE,
+        "Pasted image upload returned an unexpected HTTP " + statusCode + " response.");
+  }
+
+  private static void requireCallback(UploadCallback callback) {
+    if (callback == null) {
+      throw new IllegalArgumentException("Upload callback is required.");
+    }
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
+  }
+
+  public static final class MultipartUploadRequest {
+    private final String url;
+    private final int timeoutMillis;
+    private final UploadProgressCallback progressCallback;
+    private final List<MultipartPart> parts;
+
+    MultipartUploadRequest(
+        String url,
+        int timeoutMillis,
+        UploadProgressCallback progressCallback,
+        MultipartPart... parts) {
+      this.url = url;
+      this.timeoutMillis = timeoutMillis;
+      this.progressCallback = progressCallback;
+      List<MultipartPart> copied = new ArrayList<MultipartPart>();
+      Collections.addAll(copied, parts);
+      this.parts = Collections.unmodifiableList(copied);
+    }
+
+    public String getUrl() {
+      return url;
+    }
+
+    public int getTimeoutMillis() {
+      return timeoutMillis;
+    }
+
+    public UploadProgressCallback getProgressCallback() {
+      return progressCallback;
+    }
+
+    public List<MultipartPart> getParts() {
+      return parts;
+    }
+
+    public MultipartPart getPart(int index) {
+      return parts.get(index);
+    }
+  }
+
+  public static final class MultipartPart {
+    private final String name;
+    private final String stringValue;
+    private final Object payload;
+    private final String fileName;
+
+    private MultipartPart(String name, String stringValue, Object payload, String fileName) {
+      this.name = name;
+      this.stringValue = stringValue;
+      this.payload = payload;
+      this.fileName = fileName;
+    }
+
+    static MultipartPart stringPart(String name, String value) {
+      return new MultipartPart(name, value, null, null);
+    }
+
+    static MultipartPart filePart(String name, Object payload, String fileName) {
+      return new MultipartPart(name, null, payload, fileName);
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getStringValue() {
+      return stringValue;
+    }
+
+    public Object getPayload() {
+      return payload;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    boolean isFile() {
+      return payload != null;
+    }
+  }
+
+  public static final class HttpResponse {
+    private final int statusCode;
+    private final String responseText;
+    private final String networkError;
+
+    public HttpResponse(int statusCode, String responseText, String networkError) {
+      this.statusCode = statusCode;
+      this.responseText = responseText == null ? "" : responseText;
+      this.networkError = networkError;
+    }
+
+    public static HttpResponse networkError(String message) {
+      return new HttpResponse(0, "", message == null || message.isEmpty() ? "Network failure." : message);
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+
+    public String getResponseText() {
+      return responseText;
+    }
+
+    public String getNetworkError() {
+      return networkError;
+    }
+  }
+
+  public static final class UploadResult {
+    private final boolean success;
+    private final ErrorType errorType;
+    private final String message;
+
+    private UploadResult(boolean success, ErrorType errorType, String message) {
+      this.success = success;
+      this.errorType = errorType;
+      this.message = message == null ? "" : message;
+    }
+
+    static UploadResult success() {
+      return new UploadResult(true, null, "");
+    }
+
+    static UploadResult failure(ErrorType errorType, String message) {
+      return new UploadResult(false, errorType, message);
+    }
+
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public ErrorType getErrorType() {
+      return errorType;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+
+  private static final class BrowserUploadTransport implements UploadTransport {
+    @Override
+    public void post(MultipartUploadRequest request, ResponseHandler handler) {
+      FormData formData = new FormData();
+      for (MultipartPart part : request.getParts()) {
+        if (part.isFile()) {
+          FormData.AppendValueUnionType value = Js.uncheckedCast(part.getPayload());
+          formData.append(part.getName(), value, part.getFileName());
+        } else {
+          formData.append(part.getName(), part.getStringValue());
+        }
+      }
+
+      XMLHttpRequest xhr = new XMLHttpRequest();
+      xhr.open("POST", request.getUrl(), true);
+      if (request.getTimeoutMillis() > 0) {
+        xhr.timeout = request.getTimeoutMillis();
+      }
+      xhr.upload.onprogress =
+          event -> {
+            if (event.lengthComputable && event.total > 0) {
+              request
+                  .getProgressCallback()
+                  .onProgress((int) Math.round((event.loaded / event.total) * 100));
+            }
+          };
+      xhr.onload =
+          event -> handler.onResponse(new HttpResponse(xhr.status, xhr.responseText, null));
+      xhr.ontimeout =
+          event -> handler.onResponse(HttpResponse.networkError("Attachment upload timed out."));
+      xhr.onerror =
+          event -> {
+            handler.onResponse(HttpResponse.networkError("Network failure while uploading attachment."));
+            return null;
+          };
+      xhr.send(formData);
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
@@ -174,7 +174,7 @@ public final class J2clAttachmentUploadClient {
     if (value == null || value.trim().isEmpty()) {
       throw new IllegalArgumentException(message);
     }
-    return value;
+    return value.trim();
   }
 
   public static final class MultipartUploadRequest {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
@@ -171,10 +171,11 @@ public final class J2clAttachmentUploadClient {
   }
 
   private static String requireNonEmpty(String value, String message) {
-    if (value == null || value.trim().isEmpty()) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.isEmpty()) {
       throw new IllegalArgumentException(message);
     }
-    return value.trim();
+    return trimmed;
   }
 
   public static final class MultipartUploadRequest {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -65,15 +65,24 @@ public final class J2clRichContentDeltaFactory {
     requirePresent(document, "Missing composer document.");
     String normalizedAddress = normalizeAddress(address);
     extractDomain(normalizedAddress);
+    String selectedWaveId =
+        requireNonEmpty(session.getSelectedWaveId(), "Missing selected wave id.");
+    String historyHash =
+        requireNonEmpty(session.getHistoryHash(), "Missing write-session history hash.");
+    String channelId = requireNonEmpty(session.getChannelId(), "Missing write-session channel id.");
+    long baseVersion = session.getBaseVersion();
+    if (baseVersion < 0) {
+      throw new IllegalArgumentException("Invalid write-session base version.");
+    }
     String replyBlipId = nextToken("b+");
     String deltaJson =
         buildDeltaJson(
-            session.getBaseVersion(),
-            session.getHistoryHash(),
+            baseVersion,
+            historyHash,
             normalizedAddress,
             buildDocumentOperation(replyBlipId, document));
     return new SidecarSubmitRequest(
-        buildWaveletName(session.getSelectedWaveId()), deltaJson, session.getChannelId());
+        buildWaveletName(selectedWaveId), deltaJson, channelId);
   }
 
   private String buildDocumentOperation(String documentId, J2clComposerDocument document) {
@@ -189,6 +198,13 @@ public final class J2clRichContentDeltaFactory {
       throw new IllegalArgumentException(message);
     }
     return value;
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return value.trim();
   }
 
   private static String normalizeAddress(String address) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -207,6 +207,21 @@ public class J2clAttachmentMetadataClientTest {
   }
 
   @Test
+  public void negativeBrowserMetadataTimeoutIsRejected() {
+    try {
+      new J2clAttachmentMetadataClient(-1);
+      Assert.fail("Expected negative metadata timeout to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("Metadata timeout must not be negative.", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void zeroBrowserMetadataTimeoutIsAcceptedAsDisabled() {
+    new J2clAttachmentMetadataClient(0);
+  }
+
+  @Test
   public void httpFailureReturnsTypedErrorWithoutThrowing() {
     FakeMetadataTransport transport = new FakeMetadataTransport();
     J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -61,6 +61,21 @@ public class J2clAttachmentMetadataClientTest {
   }
 
   @Test
+  public void missingMetadataReportsTrimmedAttachmentId() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("  miss+1  "), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200, "application/json", "{\"1\":[]}", null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertEquals(Arrays.asList("miss+1"), callback.result.getMissingAttachmentIds());
+  }
+
+  @Test
   public void parsesImageNonImageMalwareAndMissingMetadataFromNumericProtoJson() {
     FakeMetadataTransport transport = new FakeMetadataTransport();
     J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -39,6 +39,28 @@ public class J2clAttachmentMetadataClientTest {
   }
 
   @Test
+  public void trimsAttachmentIdsBeforeRequestAndMissingCalculation() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("  a+1  "), callback);
+    Assert.assertEquals("/attachmentsInfo?attachmentIds=a%2B1", transport.url);
+
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"a+1\",\"2\":\"wave/ref\",\"3\":\"doc.txt\","
+                + "\"4\":\"text/plain\",\"5\":1,\"6\":\"alice@example.com\","
+                + "\"7\":\"/attachment/a+1\",\"8\":\"/thumbnail/a+1\"}]}",
+            null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertTrue(callback.result.getMissingAttachmentIds().isEmpty());
+  }
+
+  @Test
   public void parsesImageNonImageMalwareAndMissingMetadataFromNumericProtoJson() {
     FakeMetadataTransport transport = new FakeMetadataTransport();
     J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -271,6 +271,23 @@ public class J2clAttachmentMetadataClientTest {
   }
 
   @Test
+  public void nearJsonContentTypeReturnsTypedErrorWithoutParsing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200, "application/jsonp", "{\"1\":[]}", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.UNEXPECTED_CONTENT_TYPE,
+        callback.result.getErrorType());
+  }
+
+  @Test
   public void malformedJsonReturnsTypedParseErrorWithoutThrowing() {
     FakeMetadataTransport transport = new FakeMetadataTransport();
     J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
@@ -336,6 +353,27 @@ public class J2clAttachmentMetadataClientTest {
             "application/json",
             "{\"1\":[{\"1\":\"a+1\",\"2\":\"wave/ref\",\"3\":\"doc.txt\","
                 + "\"4\":\"text/plain\",\"5\":[1],\"6\":\"alice@example.com\","
+                + "\"7\":\"/attachment/a+1\",\"8\":\"/thumbnail/a+1\"}]}",
+            null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.PARSE_ERROR, callback.result.getErrorType());
+  }
+
+  @Test
+  public void extraLongWordsReturnTypedParseError() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"a+1\",\"2\":\"wave/ref\",\"3\":\"doc.txt\","
+                + "\"4\":\"text/plain\",\"5\":[1,2,3],\"6\":\"alice@example.com\","
                 + "\"7\":\"/attachment/a+1\",\"8\":\"/thumbnail/a+1\"}]}",
             null));
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -1,0 +1,320 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clAttachmentMetadataClientTest.class)
+public class J2clAttachmentMetadataClientTest {
+  @Test
+  public void buildsEncodedMetadataRequestForAttachmentIds() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+
+    client.fetchMetadata(
+        Arrays.asList(
+            "example.com/att+id=42:raw",
+            "plain:id",
+            "emoji-\uD83D\uDE00",
+            "bold-\uD835\uDC00"),
+        result -> {});
+
+    Assert.assertEquals(
+        "/attachmentsInfo?attachmentIds="
+            + "example.com%2Fatt%2Bid%3D42%3Araw,plain%3Aid,"
+            + "emoji-%F0%9F%98%80,bold-%F0%9D%90%80",
+        transport.url);
+  }
+
+  @Test
+  public void appendsAttachmentIdsWithAmpersandWhenBaseUrlAlreadyHasQuery() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client =
+        new J2clAttachmentMetadataClient(transport, "/attachmentsInfo?cacheBust=1");
+
+    client.fetchMetadata(Arrays.asList("a+b"), result -> {});
+
+    Assert.assertEquals("/attachmentsInfo?cacheBust=1&attachmentIds=a%2Bb", transport.url);
+  }
+
+  @Test
+  public void parsesImageNonImageMalwareAndMissingMetadataFromNumericProtoJson() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(
+        Arrays.asList("img+1", "pdf+1", "bad+1", "missing+1"),
+        callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json; charset=utf8",
+            "{\"1\":["
+                + "{\"1\":\"img+1\",\"2\":\"wave/ref\",\"3\":\"cat.png\",\"4\":\"image/png\","
+                + "\"5\":[123,0],\"6\":\"alice@example.com\",\"7\":\"/attachment/img+1\","
+                + "\"8\":\"/thumbnail/img+1\",\"9\":{\"1\":640,\"2\":480},"
+                + "\"10\":{\"1\":160,\"2\":120}},"
+                + "{\"1\":\"pdf+1\",\"2\":\"wave/ref\",\"3\":\"doc.pdf\",\"4\":\"application/pdf\","
+                + "\"5\":456,\"6\":\"bob@example.com\",\"7\":\"/attachment/pdf+1\","
+                + "\"8\":\"/thumbnail/pdf+1\"},"
+                + "{\"1\":\"bad+1\",\"2\":\"wave/ref\",\"3\":\"bad.exe\",\"4\":\"application/octet-stream\","
+                + "\"5\":789,\"6\":\"eve@example.com\",\"7\":\"/attachment/bad+1\","
+                + "\"8\":\"/thumbnail/bad+1\",\"11\":true}"
+                + "]}",
+            null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertEquals(3, callback.result.getAttachments().size());
+    Assert.assertEquals(Arrays.asList("missing+1"), callback.result.getMissingAttachmentIds());
+
+    J2clAttachmentMetadata image = callback.result.getAttachments().get(0);
+    Assert.assertEquals("cat.png", image.getFileName());
+    Assert.assertEquals(123L, image.getSize());
+    Assert.assertNotNull(image.getImageMetadata());
+    Assert.assertEquals(640, image.getImageMetadata().getWidth());
+    Assert.assertEquals(120, image.getThumbnailMetadata().getHeight());
+
+    J2clAttachmentMetadata document = callback.result.getAttachments().get(1);
+    Assert.assertEquals("application/pdf", document.getMimeType());
+    Assert.assertNull(document.getImageMetadata());
+    Assert.assertFalse(document.isMalware());
+
+    J2clAttachmentMetadata malware = callback.result.getAttachments().get(2);
+    Assert.assertTrue(malware.isMalware());
+  }
+
+  @Test
+  public void parsesLargeLongMetadataAndNoMissingAttachmentIds() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("large+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"large+1\",\"2\":\"wave/ref\",\"3\":\"large.bin\","
+                + "\"4\":\"application/octet-stream\",\"5\":[0,1],"
+                + "\"6\":\"alice@example.com\",\"7\":\"/attachment/large+1\","
+                + "\"8\":\"/thumbnail/large+1\"}]}",
+            null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertEquals(1, callback.result.getAttachments().size());
+    Assert.assertEquals(4294967296L, callback.result.getAttachments().get(0).getSize());
+    Assert.assertTrue(callback.result.getMissingAttachmentIds().isEmpty());
+  }
+
+  @Test
+  public void duplicateRequestedIdsUseReturnedIdSetForMissingCalculation() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("dup+1", "dup+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"dup+1\",\"2\":\"wave/ref\",\"3\":\"dup.txt\","
+                + "\"4\":\"text/plain\",\"5\":1,\"6\":\"alice@example.com\","
+                + "\"7\":\"/attachment/dup+1\",\"8\":\"/thumbnail/dup+1\"}]}",
+            null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertTrue(callback.result.getMissingAttachmentIds().isEmpty());
+  }
+
+  @Test
+  public void invalidAttachmentIdRequestReturnsTypedErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("valid+1", " "), callback);
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.INVALID_REQUEST, callback.result.getErrorType());
+    Assert.assertNull(transport.handler);
+  }
+
+  @Test
+  public void unpairedSurrogateAttachmentIdReturnsTypedErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("bad-\uD800x"), callback);
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.INVALID_REQUEST, callback.result.getErrorType());
+    Assert.assertNull(transport.handler);
+  }
+
+  @Test
+  public void nullMetadataCallbackThrowsIllegalArgumentException() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+
+    try {
+      client.fetchMetadata(Arrays.asList("a+1"), null);
+      Assert.fail("Expected null metadata callback to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("Metadata callback is required.", expected.getMessage());
+    }
+  }
+
+  @Test
+  public void httpFailureReturnsTypedErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            403, "application/json", "{\"error\":\"denied\"}", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.HTTP_STATUS, callback.result.getErrorType());
+  }
+
+  @Test
+  public void httpFailureDoesNotAttemptToParseBody() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            500, "application/json", "{not-json", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.HTTP_STATUS, callback.result.getErrorType());
+  }
+
+  @Test
+  public void nonJsonContentTypeReturnsTypedErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200, "text/plain", "not-json", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.UNEXPECTED_CONTENT_TYPE,
+        callback.result.getErrorType());
+  }
+
+  @Test
+  public void malformedJsonReturnsTypedParseErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200, "application/json", "{not-json", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.PARSE_ERROR, callback.result.getErrorType());
+  }
+
+  @Test
+  public void emptyJsonBodyReturnsTypedParseErrorWithoutThrowing() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200, "application/json", "", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.PARSE_ERROR, callback.result.getErrorType());
+  }
+
+  @Test
+  public void unexpectedMetadataFieldTypeReturnsTypedParseError() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"a+1\",\"2\":\"wave/ref\",\"3\":\"doc.txt\","
+                + "\"4\":\"text/plain\",\"5\":1,\"6\":\"alice@example.com\","
+                + "\"7\":\"/attachment/a+1\",\"8\":\"/thumbnail/a+1\",\"11\":\"true\"}]}",
+            null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.PARSE_ERROR, callback.result.getErrorType());
+  }
+
+  @Test
+  public void incompleteLongWordsReturnTypedParseError() {
+    FakeMetadataTransport transport = new FakeMetadataTransport();
+    J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);
+    RecordingMetadataCallback callback = new RecordingMetadataCallback();
+
+    client.fetchMetadata(Arrays.asList("a+1"), callback);
+    transport.complete(
+        new J2clAttachmentMetadataClient.HttpResponse(
+            200,
+            "application/json",
+            "{\"1\":[{\"1\":\"a+1\",\"2\":\"wave/ref\",\"3\":\"doc.txt\","
+                + "\"4\":\"text/plain\",\"5\":[1],\"6\":\"alice@example.com\","
+                + "\"7\":\"/attachment/a+1\",\"8\":\"/thumbnail/a+1\"}]}",
+            null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentMetadataClient.ErrorType.PARSE_ERROR, callback.result.getErrorType());
+  }
+
+  private static final class FakeMetadataTransport
+      implements J2clAttachmentMetadataClient.MetadataTransport {
+    private String url;
+    private J2clAttachmentMetadataClient.ResponseHandler handler;
+
+    @Override
+    public void get(String url, J2clAttachmentMetadataClient.ResponseHandler handler) {
+      this.url = url;
+      this.handler = handler;
+    }
+
+    void complete(J2clAttachmentMetadataClient.HttpResponse response) {
+      handler.onResponse(response);
+    }
+  }
+
+  private static final class RecordingMetadataCallback
+      implements J2clAttachmentMetadataClient.MetadataCallback {
+    private J2clAttachmentMetadataClient.MetadataResult result;
+
+    @Override
+    public void onComplete(J2clAttachmentMetadataClient.MetadataResult result) {
+      this.result = result;
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
@@ -83,6 +83,25 @@ public class J2clAttachmentUploadClientTest {
   }
 
   @Test
+  public void filePickerUploadRejectsHttpStatusBoundaryResponses() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+
+    client.uploadFile("a+1", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(199, "OK", null));
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.HTTP_STATUS, callback.result.getErrorType());
+
+    client.uploadFile("a+2", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(300, "OK", null));
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.HTTP_STATUS, callback.result.getErrorType());
+  }
+
+  @Test
   public void pastedImageUploadAcceptsOnlyHttpOkOrCreatedWithoutOkSentinel() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
@@ -1,0 +1,179 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clAttachmentUploadClientTest.class)
+public class J2clAttachmentUploadClientTest {
+  @Test
+  public void filePickerUploadBuildsGwtCompatibleMultipartRequest() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    Object file = new Object();
+
+    client.uploadFile(
+        "example.com/attachment+ABC",
+        "example.com/wave+1/~/conv+root",
+        file,
+        "wave.png",
+        result -> {});
+
+    Assert.assertEquals("/attachment/example.com/attachment+ABC", transport.request.getUrl());
+    Assert.assertEquals("attachmentId", transport.request.getPart(0).getName());
+    Assert.assertEquals("example.com/attachment+ABC", transport.request.getPart(0).getStringValue());
+    Assert.assertEquals("waveRef", transport.request.getPart(1).getName());
+    Assert.assertEquals("example.com/wave+1/~/conv+root", transport.request.getPart(1).getStringValue());
+    Assert.assertEquals("uploadFormElement", transport.request.getPart(2).getName());
+    Assert.assertSame(file, transport.request.getPart(2).getPayload());
+    Assert.assertEquals("wave.png", transport.request.getPart(2).getFileName());
+    Assert.assertEquals(0, transport.request.getTimeoutMillis());
+    transport.request.getProgressCallback().onProgress(12);
+  }
+
+  @Test
+  public void filePickerUploadRequiresOkSentinelInTwoHundredResponse() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+
+    client.uploadFile("a+1", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(201, "Created", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.UNEXPECTED_RESPONSE, callback.result.getErrorType());
+
+    client.uploadFile("a+2", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(204, "OK", null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+  }
+
+  @Test
+  public void filePickerUploadReturnsHttpStatusBeforeParsingUnexpectedBody() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+
+    client.uploadFile("a+1", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(500, "OK", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.HTTP_STATUS, callback.result.getErrorType());
+  }
+
+  @Test
+  public void pastedImageUploadAcceptsOnlyHttpOkOrCreatedWithoutOkSentinel() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+    Object imageBlob = new Object();
+
+    client.uploadPastedImage("paste+1", "wave/ref", imageBlob, callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(201, "image stored", null));
+
+    Assert.assertTrue(callback.result.isSuccess());
+    Assert.assertEquals("pasted-image.png", transport.request.getPart(2).getFileName());
+    Assert.assertSame(imageBlob, transport.request.getPart(2).getPayload());
+
+    client.uploadPastedImage("paste+2", "wave/ref", imageBlob, callback);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(202, "accepted", null));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.UNEXPECTED_RESPONSE, callback.result.getErrorType());
+  }
+
+  @Test
+  public void uploadProgressCallbackIsExposedOnRequest() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+    final int[] progress = {-1};
+
+    client.uploadFile(
+        "a+1",
+        "wave/ref",
+        new Object(),
+        "doc.txt",
+        percent -> progress[0] = percent,
+        callback);
+    transport.request.getProgressCallback().onProgress(73);
+    transport.complete(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(73, progress[0]);
+    Assert.assertTrue(callback.result.isSuccess());
+  }
+
+  @Test
+  public void networkFailureReturnsTypedError() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+
+    client.uploadFile("a+1", "wave/ref", new Object(), "doc.txt", callback);
+    transport.complete(J2clAttachmentUploadClient.HttpResponse.networkError("socket boom"));
+
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(J2clAttachmentUploadClient.ErrorType.NETWORK, callback.result.getErrorType());
+    Assert.assertEquals("socket boom", callback.result.getMessage());
+  }
+
+  @Test
+  public void pastedImageUsesTimeoutAndReturnsTypedNetworkErrors() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+    RecordingUploadCallback callback = new RecordingUploadCallback();
+
+    client.uploadPastedImage("paste+1", "wave/ref", new Object(), callback);
+    transport.complete(J2clAttachmentUploadClient.HttpResponse.networkError("timeout"));
+
+    Assert.assertEquals(60000, transport.request.getTimeoutMillis());
+    Assert.assertFalse(callback.result.isSuccess());
+    Assert.assertEquals(J2clAttachmentUploadClient.ErrorType.NETWORK, callback.result.getErrorType());
+    Assert.assertEquals("timeout", callback.result.getMessage());
+  }
+
+  @Test
+  public void nullUploadCallbackThrowsIllegalArgumentException() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+
+    try {
+      client.uploadFile("a+1", "wave/ref", new Object(), "doc.txt", null);
+      Assert.fail("Expected null upload callback to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("Upload callback is required.", expected.getMessage());
+    }
+  }
+
+  private static final class FakeUploadTransport
+      implements J2clAttachmentUploadClient.UploadTransport {
+    private J2clAttachmentUploadClient.MultipartUploadRequest request;
+    private J2clAttachmentUploadClient.ResponseHandler handler;
+
+    @Override
+    public void post(
+        J2clAttachmentUploadClient.MultipartUploadRequest request,
+        J2clAttachmentUploadClient.ResponseHandler handler) {
+      this.request = request;
+      this.handler = handler;
+    }
+
+    void complete(J2clAttachmentUploadClient.HttpResponse response) {
+      handler.onResponse(response);
+    }
+  }
+
+  private static final class RecordingUploadCallback
+      implements J2clAttachmentUploadClient.UploadCallback {
+    private J2clAttachmentUploadClient.UploadResult result;
+
+    @Override
+    public void onComplete(J2clAttachmentUploadClient.UploadResult result) {
+      this.result = result;
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClientTest.java
@@ -32,6 +32,24 @@ public class J2clAttachmentUploadClientTest {
   }
 
   @Test
+  public void filePickerUploadTrimsRequestIdentifiersBeforeSending() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);
+
+    client.uploadFile(
+        "  example.com/attachment+ABC  ",
+        "  example.com/wave+1/~/conv+root  ",
+        new Object(),
+        "  wave.png  ",
+        result -> {});
+
+    Assert.assertEquals("/attachment/example.com/attachment+ABC", transport.request.getUrl());
+    Assert.assertEquals("example.com/attachment+ABC", transport.request.getPart(0).getStringValue());
+    Assert.assertEquals("example.com/wave+1/~/conv+root", transport.request.getPart(1).getStringValue());
+    Assert.assertEquals("wave.png", transport.request.getPart(2).getFileName());
+  }
+
+  @Test
   public void filePickerUploadRequiresOkSentinelInTwoHundredResponse() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentUploadClient client = new J2clAttachmentUploadClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -74,6 +74,18 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void replyRequestAllowsVersionZeroWriteSession() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 0L, "ZERO", "b+root");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("First reply").build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+
+    assertContains(request.getDeltaJson(), "\"1\":{\"1\":0,\"2\":\"ZERO\"}", "\"1\":\"b+seedA\"");
+  }
+
+  @Test
   public void replyRequestSerializesAttachmentElements() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =
@@ -158,6 +170,30 @@ public class J2clRichContentDeltaFactoryTest {
     assertThrows(() -> factory.createReplyRequest("user@example.com", session, null));
     assertThrows(
         () ->
+            factory.createReplyRequest(
+                "user@example.com",
+                new J2clSidecarWriteSession(null, "chan-7", 44L, "ABCD", "b+root"),
+                document));
+    assertThrows(
+        () ->
+            factory.createReplyRequest(
+                "user@example.com",
+                new J2clSidecarWriteSession("example.com/w+reply", "", 44L, "ABCD", "b+root"),
+                document));
+    assertThrows(
+        () ->
+            factory.createReplyRequest(
+                "user@example.com",
+                new J2clSidecarWriteSession("example.com/w+reply", "chan-7", -1L, "ABCD", "b+root"),
+                document));
+    assertThrows(
+        () ->
+            factory.createReplyRequest(
+                "user@example.com",
+                new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, null, "b+root"),
+                document));
+    assertThrows(
+        () ->
             factory.createWaveRequest(
                 "missing-domain", document));
     assertThrows(() -> factory.createReplyRequest("missing-domain", session, document));
@@ -178,6 +214,30 @@ public class J2clRichContentDeltaFactoryTest {
 
     assertContains(first.getDeltaJson(), "\"1\":\"b+seedA\"");
     assertContains(second.getDeltaJson(), "\"1\":\"b+seedB\"");
+  }
+
+  @Test
+  public void invalidReplySessionDoesNotAdvanceReplyBlipCounter() {
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession(null, "chan-7", 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("", "chan-7", 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("   ", "chan-7", 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", null, 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "", 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "   ", 44L, "ABCD", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, null, "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "   ", "b+root"));
+    assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+        new J2clSidecarWriteSession("example.com/w+reply", "chan-7", -1L, "ABCD", "b+root"));
   }
 
   @Test
@@ -288,6 +348,21 @@ public class J2clRichContentDeltaFactoryTest {
       Assert.assertTrue(
           "Missing fragment: " + fragment + "\nJSON: " + value, value.contains(fragment));
     }
+  }
+
+  private static void assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
+      J2clSidecarWriteSession invalidSession) {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Reply").build();
+    assertThrows(() -> factory.createReplyRequest("user@example.com", invalidSession, document));
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest(
+            "user@example.com",
+            new J2clSidecarWriteSession("example.com/w+reply", "chan-7", 44L, "ABCD", "b+root"),
+            document);
+
+    assertContains(request.getDeltaJson(), "\"1\":\"b+seedA\"");
   }
 
   private static void assertThrows(ThrowingRunnable runnable) {

--- a/wave/config/changelog.d/2026-04-24-issue-971-attachment-clients.json
+++ b/wave/config/changelog.d/2026-04-24-issue-971-attachment-clients.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-24-issue-971-attachment-clients",
+  "version": "Issue #971",
+  "date": "2026-04-24",
+  "title": "Prepare J2CL attachment upload and metadata clients",
+  "summary": "The opt-in J2CL shell now has tested attachment upload and metadata client primitives that mirror the GWT multipart and attachment-info contracts, preparing later Lit/J2CL composer wiring without changing the legacy GWT default route.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a J2CL attachment upload client that builds GWT-compatible multipart requests for file-picker and pasted-image flows",
+        "Added a J2CL attachment metadata client that reads numeric proto JSON, preserves missing-attachment reporting, and returns typed network, HTTP, content-type, and parse failures"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #971 and #904. This is the focused #971 Task 3 slice for J2CL attachment upload and metadata client primitives.

- Adds `J2clAttachmentUploadClient` with GWT-compatible multipart fields (`attachmentId`, `waveRef`, `uploadFormElement`), file-picker OK-sentinel success semantics, pasted-image 200/201 semantics, pasted-image timeout parity, and optional upload progress callbacks.
- Adds `J2clAttachmentMetadataClient` and `J2clAttachmentMetadata` for `/attachmentsInfo` requests, numeric proto JSON parsing, strict typed failures, supplementary Unicode query encoding, missing attachment reporting, image/non-image/malware metadata, and transport-injected JVM tests.
- Carries forward `dd41f6406` from the late #1010 review fix because #1010 merged before that validation commit reached `main`.
- Keeps legacy GWT as the default route; this only prepares opt-in J2CL parity primitives.

## Verification

- `cd j2cl && ./mvnw -Dtest=J2clAttachmentUploadClientTest,J2clAttachmentMetadataClientTest,J2clRichContentDeltaFactoryTest,J2clPlainTextDeltaFactoryTest test` passed: 40 tests, 0 failures.
- `cd j2cl && ./mvnw test` passed: 393 tests, 0 failures, 61 skipped.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` passed.
- `git diff --check` and `git diff --cached --check` passed.

## Review

Claude Opus review loop completed through round 4:
- Round 1: no blockers, requested timeout/progress/parser/coverage hardening.
- Round 2: found supplementary-code-point surrogate blocker.
- Round 3: found typed invalid-request consistency gap for unpaired surrogates.
- Round 4: approved with no blockers, no important concerns, and no required follow-ups.

Final review output: `/tmp/issue-971-task3-attachment-clients-claude-round4.out`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment upload (file picker and pasted images) with progress callbacks and typed error reporting.
  * Attachment metadata retrieval that preserves order, reports missing items, and returns structured image/preview info.

* **Improvements**
  * Stronger validation and normalization of session fields for rich-text reply operations.

* **Tests**
  * New test suites covering upload flows, metadata parsing and error modes, and reply-session validation.

* **Documentation**
  * Added changelog entry describing the new attachment clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->