### PR TITLE
Add IME debug log export controls

### DIFF
--- a/wave/config/changelog.d/2026-04-25-ime-debug-panel-share-download.json
+++ b/wave/config/changelog.d/2026-04-25-ime-debug-panel-share-download.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-ime-debug-panel-share-download",
+  "version": "Unreleased",
+  "date": "2026-04-25",
+  "title": "IME debug logs are easier to export on Android",
+  "summary": "The IME debug overlay now offers direct download and Android share-sheet actions for the current log.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "IME debug tracing now includes Download and Share controls so Android users can save the log as a text file or send it through apps such as Telegram from the system share sheet."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -843,7 +843,13 @@ public final class ImeDebugTracer {
           return;
         }
         if (!shareLog(text, filename)) {
-          setStatus(triggerDownload(text, filename) ? "IME log downloaded" : "Share unavailable");
+          if (triggerDownload(text, filename)) {
+            setStatus("IME log downloaded");
+          } else {
+            fallbackCopy(text, function (copied) {
+              setStatus(copied ? "IME log copied" : "Share unavailable; download and copy failed");
+            });
+          }
         }
         ev.stopPropagation();
       }, false);

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/debug/ImeDebugTracer.java
@@ -513,10 +513,13 @@ public final class ImeDebugTracer {
       toolbar.style.gap = "6px";
       toolbar.style.padding = "0 6px";
       toolbar.style.boxSizing = "border-box";
+      toolbar.style.overflowX = "auto";
+      toolbar.style.overflowY = "hidden";
+      toolbar.style.webkitOverflowScrolling = "touch";
 
       var title = d.createElement("span");
       title.textContent = "IME";
-      title.style.flex = "1 1 auto";
+      title.style.flex = "0 0 auto";
       title.style.fontWeight = "700";
       title.style.minWidth = "0";
 
@@ -530,30 +533,49 @@ public final class ImeDebugTracer {
         button.style.font = "12px/1 sans-serif";
         button.style.padding = "0 10px";
         button.style.cursor = "pointer";
+        button.style.flex = "0 0 auto";
+        button.style.whiteSpace = "nowrap";
       }
 
       var toggle = d.createElement("button");
       toggle.type = "button";
-      toggle.textContent = "Show IME log";
+      toggle.textContent = "Show";
+      toggle.setAttribute("title", "Show IME log");
       styleButton(toggle);
 
       var copy = d.createElement("button");
       copy.type = "button";
       copy.textContent = "Copy";
       copy.setAttribute("aria-label", "Copy IME debug log");
+      copy.setAttribute("title", "Copy IME debug log");
       styleButton(copy);
+
+      var download = d.createElement("button");
+      download.type = "button";
+      download.textContent = "Download";
+      download.setAttribute("aria-label", "Download IME debug log");
+      download.setAttribute("title", "Download IME debug log");
+      styleButton(download);
+
+      var share = d.createElement("button");
+      share.type = "button";
+      share.textContent = "Share";
+      share.setAttribute("aria-label", "Share IME debug log");
+      share.setAttribute("title", "Share IME debug log");
+      styleButton(share);
 
       var clear = d.createElement("button");
       clear.type = "button";
       clear.textContent = "Clear";
       clear.setAttribute("aria-label", "Clear IME debug log");
+      clear.setAttribute("title", "Clear IME debug log");
       styleButton(clear);
 
       var status = d.createElement("span");
       status.setAttribute("aria-live", "polite");
-      status.style.flex = "0 1 auto";
+      status.style.flex = "1 1 56px";
       status.style.minWidth = "0";
-      status.style.maxWidth = "28vw";
+      status.style.maxWidth = "34vw";
       status.style.overflow = "hidden";
       status.style.textOverflow = "ellipsis";
       status.style.whiteSpace = "nowrap";
@@ -592,8 +614,9 @@ public final class ImeDebugTracer {
             ? "ime-debug-overlay ime-debug-overlay-expanded"
             : "ime-debug-overlay ime-debug-overlay-minimized";
         ov.setAttribute("aria-expanded", expanded ? "true" : "false");
-        toggle.textContent = expanded ? "Hide IME log" : "Show IME log";
+        toggle.textContent = expanded ? "Hide" : "Show";
         toggle.setAttribute("aria-label", expanded ? "Hide IME debug log" : "Show IME debug log");
+        toggle.setAttribute("title", expanded ? "Hide IME log" : "Show IME log");
         log.style.display = expanded ? "block" : "none";
         if (expanded) {
           ov.style.height = "auto";
@@ -611,6 +634,119 @@ public final class ImeDebugTracer {
           rows.push(log.children[i].textContent || "");
         }
         return rows.join("\n");
+      }
+
+      function logFilename() {
+        var stamp;
+        try {
+          stamp = new Date().toISOString().replace(/[:.]/g, "-");
+        } catch (e) {
+          stamp = String(new Date().getTime());
+        }
+        return "ime-debug-log-" + stamp + ".txt";
+      }
+
+      function createLogBlob(text) {
+        if (!w.Blob) {
+          return null;
+        }
+        try {
+          return new w.Blob([text], {type: "text/plain;charset=utf-8"});
+        } catch (e) {
+          return null;
+        }
+      }
+
+      function triggerDownload(text, filename) {
+        var anchor = d.createElement("a");
+        var blob = createLogBlob(text);
+        var url = null;
+        if (blob && w.URL && w.URL.createObjectURL) {
+          url = w.URL.createObjectURL(blob);
+          anchor.href = url;
+        } else {
+          anchor.href = "data:text/plain;charset=utf-8," + encodeURIComponent(text);
+        }
+        anchor.download = filename;
+        anchor.setAttribute("aria-hidden", "true");
+        anchor.style.display = "none";
+        d.body.appendChild(anchor);
+        try {
+          anchor.click();
+          return true;
+        } catch (e) {
+          return false;
+        } finally {
+          d.body.removeChild(anchor);
+          if (url && w.URL && w.URL.revokeObjectURL) {
+            w.setTimeout(function () {
+              w.URL.revokeObjectURL(url);
+            }, 1000);
+          }
+        }
+      }
+
+      function createShareFile(text, filename) {
+        if (!w.File) {
+          return null;
+        }
+        try {
+          return new w.File([text], filename, {type: "text/plain;charset=utf-8"});
+        } catch (e) {
+          return null;
+        }
+      }
+
+      function shareLog(text, filename) {
+        var navigator = w.navigator;
+        if (!navigator || !navigator.share) {
+          return false;
+        }
+        var file = createShareFile(text, filename);
+        var payload = {
+          title: "SupaWave IME debug log",
+          text: text
+        };
+        try {
+          if (file && navigator.canShare && navigator.canShare({files: [file]})) {
+            payload = {
+              title: "SupaWave IME debug log",
+              text: "SupaWave IME debug log attached.",
+              files: [file]
+            };
+          }
+        } catch (e) {
+          payload = {
+            title: "SupaWave IME debug log",
+            text: text
+          };
+        }
+        try {
+          navigator.share(payload).then(function () {
+            setStatus("IME log shared");
+          }, function (err) {
+            if (err && err.name === "AbortError") {
+              setStatus("Share canceled");
+              return;
+            }
+            if (triggerDownload(text, filename)) {
+              setStatus("Share failed; IME log downloaded");
+            } else {
+              fallbackCopy(text, function (copied) {
+                setStatus(copied ? "Share failed; IME log copied" : "Share failed");
+              });
+            }
+          });
+        } catch (e) {
+          if (triggerDownload(text, filename)) {
+            setStatus("Share failed; IME log downloaded");
+          } else {
+            fallbackCopy(text, function (copied) {
+              setStatus(copied ? "Share failed; IME log copied" : "Share failed");
+            });
+          }
+        }
+        return true;
       }
 
       function reserveBottomSpace(element, amount) {
@@ -688,6 +824,29 @@ public final class ImeDebugTracer {
         }
         ev.stopPropagation();
       }, false);
+      download.addEventListener('click', function (ev) {
+        var text = copyLogText(log);
+        if (!text) {
+          setStatus("No IME log lines yet");
+          ev.stopPropagation();
+          return;
+        }
+        setStatus(triggerDownload(text, logFilename()) ? "IME log downloaded" : "Download failed");
+        ev.stopPropagation();
+      }, false);
+      share.addEventListener('click', function (ev) {
+        var text = copyLogText(log);
+        var filename = logFilename();
+        if (!text) {
+          setStatus("No IME log lines yet");
+          ev.stopPropagation();
+          return;
+        }
+        if (!shareLog(text, filename)) {
+          setStatus(triggerDownload(text, filename) ? "IME log downloaded" : "Share unavailable");
+        }
+        ev.stopPropagation();
+      }, false);
       clear.addEventListener('click', function (ev) {
         log.textContent = "";
         setStatus("IME log cleared");
@@ -710,6 +869,8 @@ public final class ImeDebugTracer {
       toolbar.appendChild(title);
       toolbar.appendChild(toggle);
       toolbar.appendChild(copy);
+      toolbar.appendChild(download);
+      toolbar.appendChild(share);
       toolbar.appendChild(clear);
       toolbar.appendChild(status);
       ov.appendChild(toolbar);
@@ -726,10 +887,9 @@ public final class ImeDebugTracer {
         }, true);
       }
     } catch (e) {
-      // swallow
+      // Diagnostic overlay must never break editor initialization.
     }
   }-*/;
-
   private static native void appendToOverlayJsni(String line) /*-{
     try {
       var d = $doc;

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
@@ -76,7 +76,7 @@ public final class ImeDebugOverlayContractTest extends TestCase {
     assertContains(source, "IME log downloaded");
     assertContains(source, "IME log shared");
     assertContains(source, "Share failed; IME log downloaded");
-    assertContains(source, "Share unavailable");
+    assertContains(source, "Share unavailable; download and copy failed");
   }
 
   public void testLogRowsAppendInsideScrollableLogBody() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ImeDebugOverlayContractTest.java
@@ -42,6 +42,8 @@ public final class ImeDebugOverlayContractTest extends TestCase {
     assertContains(source, "collapsedHeight = \"44px\"");
     assertContains(source, "toolbar.style.height = collapsedHeight");
     assertContains(source, "toolbar.style.padding = \"0 6px\"");
+    assertContains(source, "toolbar.style.overflowX = \"auto\"");
+    assertContains(source, "button.style.flex = \"0 0 auto\"");
     assertFalse("Overlay must not start with the previous expanded 45% height",
         source.contains("max-height:45%"));
   }
@@ -58,6 +60,23 @@ public final class ImeDebugOverlayContractTest extends TestCase {
     assertContains(source, "copyLogText");
     assertContains(source, "No IME log lines yet");
     assertContains(source, "IME log copied");
+  }
+
+  public void testOverlayProvidesDownloadAndShareButtons() throws Exception {
+    String source = readTracerSource();
+
+    assertContains(source, "Download IME debug log");
+    assertContains(source, "Share IME debug log");
+    assertContains(source, "ime-debug-log-");
+    assertContains(source, "text/plain;charset=utf-8");
+    assertContains(source, "createElement(\"a\")");
+    assertContains(source, "URL.createObjectURL");
+    assertContains(source, "navigator.canShare");
+    assertContains(source, "navigator.share");
+    assertContains(source, "IME log downloaded");
+    assertContains(source, "IME log shared");
+    assertContains(source, "Share failed; IME log downloaded");
+    assertContains(source, "Share unavailable");
   }
 
   public void testLogRowsAppendInsideScrollableLogBody() throws Exception {


### PR DESCRIPTION
Fixes #1011

## Summary
- add Download and Share controls to the IME debug overlay toolbar
- export logs as `ime-debug-log-<timestamp>.txt` with Blob/object-URL download and data-URI fallback
- use the Web Share API when available, preferring file sharing when Android supports it, with download/copy fallback on failures
- keep the minimized toolbar horizontally scrollable so the added controls remain usable on narrow Android screens

## Verification
- `sbt --batch "testOnly org.waveprotocol.box.server.util.ImeDebugOverlayContractTest"`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `git diff --check`
- `bash scripts/worktree-boot.sh --port 9911`
- `PORT=9911 bash scripts/wave-smoke.sh check`
- `curl -fsS http://localhost:9911/webclient/246CB6D4B8B3E5C3DF14F2F1D6DB8066.cache.js | rg -n "Download IME debug log|Share IME debug log|navigator_0\\.share|navigator_0\\.canShare|ime-debug-log-|IME log downloaded|Share failed; IME log downloaded"`

Notes: mobile-width browser verification loaded the SupaWave shell at `http://localhost:9911/?ime_debug=on`; the unauthenticated root did not activate the editor-driven overlay, so the browser evidence is the served compiled GWT bundle check above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * IME debug overlay now supports downloading logs as text files
  * IME debug overlay now supports sharing logs via the system share sheet
  * Enhanced toolbar design for improved visibility and usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->