### PR TITLE
Fix Android IME live composition preview

### DIFF
--- a/docs/superpowers/plans/2026-04-25-issue-828-android-ime-live-preview.md
+++ b/docs/superpowers/plans/2026-04-25-issue-828-android-ime-live-preview.md
@@ -1,0 +1,35 @@
+# Issue 828 Android IME Live Preview Follow-Up
+
+## Goal
+
+Fix the remaining real Android Chrome IME symptom after PR #1009: typing `new blip`
+now commits correctly after Done, but the active composition still visibly shows
+Chrome's raw scratch text such as `ew lip` while the user is typing.
+
+## Root Cause
+
+The Android `compositionupdate.data` stream contains enough information to
+recover `new` and `blip`, and `ImeExtractor.getEffectiveContent()` uses that
+stream at composition flush time. During active typing, however, Android fires
+`compositionupdate` before its `input` event rewrites the IME scratch span, so
+the DOM visible to the user remains the browser's shortened raw scratch until
+composition end.
+
+## Plan
+
+- Add a separate live-preview path to `ImeCompositionTextTracker`.
+- Keep `effectiveText()` conservative for final commit semantics.
+- Render the Android live preview as a visual overlay on the IME scratch span
+  instead of mutating the IME's real text node.
+- Clear the overlay when the raw scratch catches up, the extractor deactivates,
+  or the scratch resets.
+
+## Acceptance
+
+- The tracker preview returns `ne` for the stream `n -> e` with raw scratch `e`.
+- Final effective text still returns raw scratch for an unconfirmed pending
+  replacement.
+- Focused tracker and ghost text tests pass.
+- GWT client compilation passes.
+- Local mobile browser verification still types, commits, and reloads `new blip`
+  without regressing the PR #1009 persistence path.

--- a/wave/config/changelog.d/2026-04-25-android-ime-live-preview.json
+++ b/wave/config/changelog.d/2026-04-25-android-ime-live-preview.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-android-ime-live-preview",
+  "version": "Issue #828",
+  "date": "2026-04-25",
+  "title": "Show recovered Android IME text while composing",
+  "summary": "Android Chrome composition now displays the recovered text while typing, so a blip no longer visibly shows the raw shortened IME scratch such as \"ew lip\" before the keyboard Done action commits it as \"new blip\".",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Typing text such as \"new blip\" on Android Chrome now previews the recovered composition text during active typing, not only after pressing Done."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -19,11 +19,13 @@
 
 package org.waveprotocol.wave.client.editor.extract;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Display;
+import com.google.gwt.dom.client.StyleInjector;
 import com.google.gwt.dom.client.Text;
 
 import org.waveprotocol.wave.client.common.util.DomHelper;
@@ -85,8 +87,29 @@ public class ImeExtractor {
   private final ImeCompositionTextTracker compositionTextTracker =
       new ImeCompositionTextTracker();
   private boolean suppressPreviousGhostForCurrentComposition;
+  private boolean livePreviewSyncScheduled;
 
   private static final String WRAPPER_TAGNAME = "l:ime";
+  private static final String LIVE_PREVIEW_CLASS = "wave-ime-live-preview";
+  private static final String LIVE_PREVIEW_ATTR = "data-wave-ime-preview";
+  private static final String LIVE_PREVIEW_COLOR_PROPERTY = "--wave-ime-preview-color";
+  private static final String LIVE_PREVIEW_CSS =
+      "." + LIVE_PREVIEW_CLASS + " {"
+      + " color: transparent !important;"
+      + " caret-color: transparent;"
+      + " display: inline-block;"
+      + " position: relative;"
+      + "}"
+      + "." + LIVE_PREVIEW_CLASS + "::before {"
+      + " color: var(" + LIVE_PREVIEW_COLOR_PROPERTY + ", #111);"
+      + " content: attr(" + LIVE_PREVIEW_ATTR + ");"
+      + " left: 0;"
+      + " pointer-events: none;"
+      + " position: absolute;"
+      + " top: 0;"
+      + " white-space: pre;"
+      + "}";
+  private static boolean livePreviewCssInjected;
 
   public static void register(ElementHandlerRegistry registry) {
     registry.registerRenderer(WRAPPER_TAGNAME, new Renderer() {
@@ -99,6 +122,7 @@ public class ImeExtractor {
 
   /***/
   public ImeExtractor() {
+    ensureLivePreviewCssInjected();
     NodeManager.setTransparency(imeContainer, Skip.DEEP);
     NodeManager.setMayContainSelectionEvenWhenDeep(imeContainer, true);
     if (QuirksConstants.SUPPORTS_CARET_IN_EMPTY_SPAN) {
@@ -228,6 +252,8 @@ public class ImeExtractor {
     captureGhostBaseline(previousModelBaseline, nextModelBaseline);
     compositionTextTracker.reset();
     suppressPreviousGhostForCurrentComposition = false;
+    livePreviewSyncScheduled = false;
+    clearVisibleCompositionPreview();
     if (ImeDebugTracer.isEnabled()) {
       Element anchor = imeContainer.getParentElement();
       ImeDebugTracer.start("ImeExtractor.activate")
@@ -249,6 +275,7 @@ public class ImeExtractor {
       return;
     }
     compositionTextTracker.observe(compositionText);
+    scheduleVisibleCompositionPreviewSync();
     if (ImeDebugTracer.isEnabled()) {
       ImeDebugTracer.start("ImeExtractor.compositionUpdate")
           .add("data", compositionText)
@@ -340,6 +367,8 @@ public class ImeExtractor {
     ghostNextSiblingCapturedText = null;
     suppressPreviousGhostForCurrentComposition = false;
     compositionTextTracker.reset();
+    livePreviewSyncScheduled = false;
+    clearVisibleCompositionPreview();
   }
 
   private String readCurrentPreviousText() {
@@ -419,6 +448,86 @@ public class ImeExtractor {
     imeInput.setInnerText(text);
   }
 
+  private static void ensureLivePreviewCssInjected() {
+    if (livePreviewCssInjected) {
+      return;
+    }
+    StyleInjector.inject(LIVE_PREVIEW_CSS, true);
+    livePreviewCssInjected = true;
+  }
+
+  private void scheduleVisibleCompositionPreviewSync() {
+    if (!UserAgent.isAndroid() || livePreviewSyncScheduled) {
+      return;
+    }
+    livePreviewSyncScheduled = true;
+    Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+      @Override
+      public void execute() {
+        livePreviewSyncScheduled = false;
+        syncVisibleCompositionPreview();
+      }
+    });
+  }
+
+  private void syncVisibleCompositionPreview() {
+    if (!isActive() || !UserAgent.isAndroid()) {
+      clearVisibleCompositionPreview();
+      return;
+    }
+    String scratchContent = imeContainer.getInnerText();
+    if (scratchContent == null) {
+      scratchContent = "";
+    }
+    String previewContent = compositionTextTracker.previewText(scratchContent);
+    if (previewContent == null || previewContent.equals(scratchContent)) {
+      clearVisibleCompositionPreview();
+      return;
+    }
+    if (!imeContainer.hasClassName(LIVE_PREVIEW_CLASS)) {
+      String previewColor = readComputedColor(imeContainer);
+      if (previewColor != null && !previewColor.isEmpty()) {
+        setStyleProperty(imeContainer, LIVE_PREVIEW_COLOR_PROPERTY, previewColor);
+      }
+    }
+    imeContainer.setAttribute(LIVE_PREVIEW_ATTR, previewContent);
+    imeContainer.addClassName(LIVE_PREVIEW_CLASS);
+    imeContainer.getStyle().setProperty("minWidth", previewContent.length() + "ch");
+    if (ImeDebugTracer.isEnabled()) {
+      ImeDebugTracer.start("ImeExtractor.livePreview")
+          .add("scratch", scratchContent)
+          .add("preview", previewContent)
+          .emit();
+    }
+  }
+
+  private void clearVisibleCompositionPreview() {
+    imeContainer.removeClassName(LIVE_PREVIEW_CLASS);
+    imeContainer.removeAttribute(LIVE_PREVIEW_ATTR);
+    imeContainer.getStyle().clearProperty("minWidth");
+    clearStyleProperty(imeContainer, LIVE_PREVIEW_COLOR_PROPERTY);
+  }
+
+  private static native String readComputedColor(Element element) /*-{
+    if (!element || !$wnd.getComputedStyle) {
+      return "";
+    }
+    var style = $wnd.getComputedStyle(element);
+    return style && style.color ? style.color : "";
+  }-*/;
+
+  private static native void setStyleProperty(Element element, String name, String value) /*-{
+    if (element && element.style) {
+      element.style.setProperty(name, value);
+    }
+  }-*/;
+
+  private static native void clearStyleProperty(Element element, String name) /*-{
+    if (element && element.style) {
+      element.style.removeProperty(name);
+    }
+  }-*/;
+
   private void clearWrapper(LocalDocument<ContentNode, ContentElement, ContentTextNode> doc) {
     if (wrapper != null && wrapper.getParentElement() != null) {
       doc.transparentDeepRemove(wrapper);
@@ -428,6 +537,8 @@ public class ImeExtractor {
   }
 
   private void clearContainer() {
+    livePreviewSyncScheduled = false;
+    clearVisibleCompositionPreview();
     imeInput.setInnerHTML("");
     if (!QuirksConstants.SUPPORTS_CARET_IN_EMPTY_SPAN) {
       ParagraphHelper.INSTANCE.onEmpty(imeInput);

--- a/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/editor/extract/ImeExtractor.java
@@ -96,7 +96,7 @@ public class ImeExtractor {
   private static final String LIVE_PREVIEW_CSS =
       "." + LIVE_PREVIEW_CLASS + " {"
       + " color: transparent !important;"
-      + " caret-color: transparent;"
+      + " caret-color: var(" + LIVE_PREVIEW_COLOR_PROPERTY + ", #111);"
       + " display: inline-block;"
       + " position: relative;"
       + "}"

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -122,6 +122,11 @@ public final class ImeCompositionTextTracker {
    * Returns the text that should be shown while the Android composition is
    * still active.
    *
+   * <p>Callers must pass the current raw DOM scratch text from the active IME
+   * container, not reconstructed or model-derived text. The preview relies on
+   * DOM-synchronous composition state and can produce an incorrect result if
+   * {@code scratchText} is not the exact browser scratch value for this tick.
+   *
    * <p>The final effective text intentionally waits for duplicate or extension
    * evidence before committing a one-character replacement. For local live
    * display we can be more optimistic: if Android rewrites {@code n} to raw

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/ImeCompositionTextTracker.java
@@ -118,6 +118,29 @@ public final class ImeCompositionTextTracker {
     return scratch;
   }
 
+  /**
+   * Returns the text that should be shown while the Android composition is
+   * still active.
+   *
+   * <p>The final effective text intentionally waits for duplicate or extension
+   * evidence before committing a one-character replacement. For local live
+   * display we can be more optimistic: if Android rewrites {@code n} to raw
+   * scratch {@code e}, showing {@code ne} matches the user's key stream and can
+   * be corrected by the next update if the IME revises the composing character
+   * again. The committed text path still uses {@link #effectiveText(String)}.
+   */
+  public String previewText(String scratchText) {
+    String scratch = scratchText == null ? "" : scratchText;
+    if (scratch.isEmpty()) {
+      return scratch;
+    }
+    if (!pendingReplacementValue.isEmpty()
+        && scratch.equals(pendingReplacementValue)) {
+      return pendingReplacementBase + pendingReplacementValue;
+    }
+    return effectiveText(scratch);
+  }
+
   private boolean isSingleCharacterReplacement(String value) {
     return value.length() == 1
         && lastObserved.length() == 1

--- a/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/util/ImeCompositionTextTrackerTest.java
@@ -35,6 +35,15 @@ public class ImeCompositionTextTrackerTest extends TestCase {
     assertEquals(expectedText, tracker.effectiveText(scratchText));
   }
 
+  private void assertImePreviewSequence(String expectedText, String scratchText,
+      String... observedValues) {
+    ImeCompositionTextTracker tracker = new ImeCompositionTextTracker();
+    for (String v : observedValues) {
+      tracker.observe(v);
+    }
+    assertEquals(expectedText, tracker.previewText(scratchText));
+  }
+
   public void testAndroidSingleLetterReplacementSequenceRecoversNew() {
     assertImeSequence("new", "ew", "n", "e", "e", "ew", "ew");
   }
@@ -45,6 +54,17 @@ public class ImeCompositionTextTrackerTest extends TestCase {
 
   public void testAndroidReplacementCanRecoverWhenScratchExtendsPendingValue() {
     assertImeSequence("new", "ew", "n", "e", "ew");
+  }
+
+  public void testAndroidLivePreviewShowsPendingReplacementBeforeCommit() {
+    assertImePreviewSequence("ne", "e", "n", "e");
+    assertImePreviewSequence("new", "ew", "n", "e", "e", "ew");
+    assertImePreviewSequence("bl", "l", "b", "l");
+    assertImePreviewSequence("blip", "lip", "b", "l", "l", "li", "li", "lip");
+  }
+
+  public void testPendingReplacementDoesNotChangeFinalEffectiveText() {
+    assertImeSequence("e", "e", "n", "e");
   }
 
   public void testRepeatedSingleCharacterDoesNotDuplicate() {


### PR DESCRIPTION
## Summary

Fixes #828.

This follows up PR #1009. Final Android IME commit is now correct, but real Android Chrome still visibly showed the raw shortened composition scratch (`ew lip`) while typing. This PR adds an Android-only live preview overlay for active IME composition so the recovered stream is shown immediately without mutating the browser-owned scratch text node.

## Changes

- Add `ImeCompositionTextTracker.previewText()` for optimistic live display while keeping `effectiveText()` conservative for final commit.
- Render an Android-only CSS pseudo-element overlay on the active IME scratch container after the browser `input` event rewrites the scratch.
- Clear the overlay on scratch catch-up, extractor reset, and composition teardown.
- Add tracker regression tests for live preview of `new` and `blip` sequences.
- Add changelog fragment and issue plan.

## Verification

- `sbt "Test/runMain org.junit.runner.JUnitCore org.waveprotocol.wave.model.util.ImeCompositionTextTrackerTest org.waveprotocol.wave.model.util.GhostTextReconcilerTest"` -> `OK (58 tests)`
- `sbt compileGwtDev` -> GWT compilation and link succeeded
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> changelog validation passed
- `bash scripts/worktree-boot.sh --port 9934` -> staged local app
- `PORT=9934 bash scripts/wave-smoke.sh check` -> root GWT, health, landing, J2CL root, J2CL index, sidecar, and webclient checks passed
- Playwright Galaxy S9+ synthetic Android IME stream `n -> e -> e -> ew` -> raw scratch stayed `ew`, container preview became `data-wave-ime-preview="new"`, `::before` content was `"new"`, raw scratch color was transparent
- Playwright Galaxy S9+ normal edit/done/reload flow -> `new blip` visible during edit, after Done, and after reload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android Chrome IME Live Preview: When typing with an Input Method Editor on Android, composed text now displays as a live preview showing your actual input in real-time during active composition. This replaces the previous experience of seeing confusing raw scratch text during typing and only viewing the full text after the Done action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->