### PR TITLE
Add J2CL attachment composer controller

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -216,6 +216,7 @@ public final class J2clAttachmentComposerController {
   // explicit clear; this keeps status/error reporting available to the Lit wiring task.
   private final List<QueueItem> queue = new ArrayList<QueueItem>();
   private boolean uploadInProgress;
+  private boolean drainingQueue;
   // Cursor avoids rescanning terminal items retained for status/error display.
   private int nextQueueIndex;
   private int resetGeneration;
@@ -281,13 +282,24 @@ public final class J2clAttachmentComposerController {
   }
 
   private void startNextUpload() {
-    if (uploadInProgress) {
+    if (uploadInProgress || drainingQueue) {
       return;
     }
-    QueueItem item = firstQueuedItem();
-    if (item == null) {
-      return;
+    drainingQueue = true;
+    try {
+      while (!uploadInProgress) {
+        QueueItem item = firstQueuedItem();
+        if (item == null) {
+          return;
+        }
+        startUpload(item);
+      }
+    } finally {
+      drainingQueue = false;
     }
+  }
+
+  private void startUpload(QueueItem item) {
     uploadInProgress = true;
     item.status = UploadStatus.UPLOADING;
     int generation = resetGeneration;
@@ -367,8 +379,10 @@ public final class J2clAttachmentComposerController {
       }
     } finally {
       item.payload = null;
-      // onInsert can enqueue or cancel; startNextUpload is idempotent for those re-entrant paths.
-      startNextUpload();
+      // Synchronous upload completions are drained by the active loop to avoid recursive dispatch.
+      if (!drainingQueue) {
+        startNextUpload();
+      }
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -7,7 +7,7 @@ import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
 
 /** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
 public final class J2clAttachmentComposerController {
-  /** Error code used when upload succeeds but composer document insertion fails. */
+  /** Error code value used when upload succeeds but composer document insertion fails. */
   public static final String INSERT_FAILED_ERROR_CODE = "INSERT_FAILED";
 
   public interface DocumentInsertionCallback {
@@ -132,9 +132,9 @@ public final class J2clAttachmentComposerController {
 
     private UploadItem(QueueItem item) {
       this.attachmentId = item.attachmentId;
-      this.fileName = item.selection.fileName;
+      this.fileName = item.fileName;
       this.caption = item.caption();
-      this.displaySize = item.selection.displaySize;
+      this.displaySize = item.displaySize;
       this.status = item.status;
       this.progressPercent = item.progressPercent;
       this.errorCode = item.errorCode;
@@ -181,7 +181,11 @@ public final class J2clAttachmentComposerController {
 
   private static final class QueueItem {
     private final String attachmentId;
-    private final AttachmentSelection selection;
+    private final String fileName;
+    private final String caption;
+    private final DisplaySize displaySize;
+    private final boolean pastedImage;
+    private Object payload;
     private UploadStatus status = UploadStatus.QUEUED;
     private int progressPercent;
     private String errorCode = "";
@@ -189,12 +193,16 @@ public final class J2clAttachmentComposerController {
 
     private QueueItem(String attachmentId, AttachmentSelection selection) {
       this.attachmentId = attachmentId;
-      this.selection = selection;
+      this.fileName = selection.fileName;
+      this.caption = selection.caption;
+      this.displaySize = selection.displaySize;
+      this.pastedImage = selection.pastedImage;
+      this.payload = selection.payload;
     }
 
     private String caption() {
-      String trimmed = selection.caption.trim();
-      return trimmed.isEmpty() ? selection.fileName : trimmed;
+      String trimmed = caption.trim();
+      return trimmed.isEmpty() ? fileName : trimmed;
     }
   }
 
@@ -224,6 +232,8 @@ public final class J2clAttachmentComposerController {
     if (selections == null) {
       throw new IllegalArgumentException("Attachment selections are required.");
     }
+    // Field validity is enforced by AttachmentSelection factories; this pass keeps batch enqueue
+    // atomic by rejecting null entries before consuming any attachment ids.
     List<AttachmentSelection> validatedSelections =
         new ArrayList<AttachmentSelection>(selections.size());
     for (AttachmentSelection selection : selections) {
@@ -287,15 +297,15 @@ public final class J2clAttachmentComposerController {
         };
     J2clAttachmentUploadClient.UploadCallback uploadCallback =
         result -> handleUploadComplete(generation, item, result);
-    if (item.selection.pastedImage) {
+    if (item.pastedImage) {
       uploadClient.uploadPastedImage(
-          item.attachmentId, waveRef, item.selection.payload, progressCallback, uploadCallback);
+          item.attachmentId, waveRef, item.payload, progressCallback, uploadCallback);
     } else {
       uploadClient.uploadFile(
           item.attachmentId,
           waveRef,
-          item.selection.payload,
-          item.selection.fileName,
+          item.payload,
+          item.fileName,
           progressCallback,
           uploadCallback);
     }
@@ -313,8 +323,10 @@ public final class J2clAttachmentComposerController {
   private void handleUploadComplete(
       int generation, QueueItem item, J2clAttachmentUploadClient.UploadResult result) {
     if (generation != resetGeneration) {
+      item.payload = null;
       return;
     }
+    // This must be false before insertAttachment so re-entrant selectFiles/pasteImage can start.
     uploadInProgress = false;
     try {
       if (result != null && result.isSuccess()) {
@@ -339,6 +351,7 @@ public final class J2clAttachmentComposerController {
             result == null ? "Attachment upload failed without a result." : result.getMessage();
       }
     } finally {
+      item.payload = null;
       // onInsert can enqueue or cancel; startNextUpload is idempotent for those re-entrant paths.
       startNextUpload();
     }
@@ -346,7 +359,7 @@ public final class J2clAttachmentComposerController {
 
   private void insertAttachment(QueueItem item) {
     AttachmentInsertion insertion =
-        new AttachmentInsertion(item.attachmentId, item.caption(), item.selection.displaySize);
+        new AttachmentInsertion(item.attachmentId, item.caption(), item.displaySize);
     J2clComposerDocument document =
         J2clComposerDocument.builder()
             .imageAttachment(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -216,7 +216,8 @@ public final class J2clAttachmentComposerController {
   // explicit clear; this keeps status/error reporting available to the Lit wiring task.
   private final List<QueueItem> queue = new ArrayList<QueueItem>();
   private boolean uploadInProgress;
-  // True while startNextUpload is iterating; suppresses re-entrant recursive dispatch.
+  // True while startNextUpload is iterating; re-entrant startNextUpload callers become no-ops so
+  // synchronous upload callbacks cannot recursively dispatch the next item.
   private boolean drainingQueue;
   // Cursor avoids rescanning terminal items retained for status/error display.
   private int nextQueueIndex;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -1,0 +1,311 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
+
+/** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
+public final class J2clAttachmentComposerController {
+  private static final String PASTED_IMAGE_FILENAME = "pasted-image.png";
+
+  public interface DocumentInsertionCallback {
+    void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
+  }
+
+  public enum DisplaySize {
+    SMALL("small"),
+    MEDIUM("medium"),
+    LARGE("large");
+
+    private final String documentValue;
+
+    DisplaySize(String documentValue) {
+      this.documentValue = documentValue;
+    }
+
+    public String getDocumentValue() {
+      return documentValue;
+    }
+  }
+
+  public enum UploadStatus {
+    QUEUED,
+    UPLOADING,
+    COMPLETE,
+    FAILED
+  }
+
+  public static final class AttachmentSelection {
+    private final Object payload;
+    private final String fileName;
+    private final String caption;
+    private final DisplaySize displaySize;
+    private final boolean pastedImage;
+
+    private AttachmentSelection(
+        Object payload,
+        String fileName,
+        String caption,
+        DisplaySize displaySize,
+        boolean pastedImage) {
+      this.payload = payload;
+      this.fileName = requireNonEmpty(fileName, "Attachment file name is required.");
+      this.caption = caption == null ? "" : caption;
+      this.displaySize = requirePresent(displaySize, "Attachment display size is required.");
+      this.pastedImage = pastedImage;
+      if (payload == null) {
+        throw new IllegalArgumentException("Attachment payload is required.");
+      }
+    }
+
+    public static AttachmentSelection file(
+        Object payload, String fileName, String caption, DisplaySize displaySize) {
+      return new AttachmentSelection(payload, fileName, caption, displaySize, false);
+    }
+  }
+
+  public static final class AttachmentInsertion {
+    private final String attachmentId;
+    private final String caption;
+    private final DisplaySize displaySize;
+
+    private AttachmentInsertion(String attachmentId, String caption, DisplaySize displaySize) {
+      this.attachmentId = attachmentId;
+      this.caption = caption;
+      this.displaySize = displaySize;
+    }
+
+    public String getAttachmentId() {
+      return attachmentId;
+    }
+
+    public String getCaption() {
+      return caption;
+    }
+
+    public DisplaySize getDisplaySize() {
+      return displaySize;
+    }
+  }
+
+  public static final class UploadItem {
+    private final String attachmentId;
+    private final String fileName;
+    private final String caption;
+    private final DisplaySize displaySize;
+    private final UploadStatus status;
+    private final int progressPercent;
+    private final String errorCode;
+    private final String errorMessage;
+
+    private UploadItem(QueueItem item) {
+      this.attachmentId = item.attachmentId;
+      this.fileName = item.selection.fileName;
+      this.caption = item.caption();
+      this.displaySize = item.selection.displaySize;
+      this.status = item.status;
+      this.progressPercent = item.progressPercent;
+      this.errorCode = item.errorCode;
+      this.errorMessage = item.errorMessage;
+    }
+
+    public String getAttachmentId() {
+      return attachmentId;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public String getCaption() {
+      return caption;
+    }
+
+    public DisplaySize getDisplaySize() {
+      return displaySize;
+    }
+
+    public UploadStatus getStatus() {
+      return status;
+    }
+
+    public int getProgressPercent() {
+      return progressPercent;
+    }
+
+    public String getErrorCode() {
+      return errorCode;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
+    }
+  }
+
+  private static final class QueueItem {
+    private final String attachmentId;
+    private final AttachmentSelection selection;
+    private UploadStatus status = UploadStatus.QUEUED;
+    private int progressPercent;
+    private String errorCode = "";
+    private String errorMessage = "";
+
+    private QueueItem(String attachmentId, AttachmentSelection selection) {
+      this.attachmentId = attachmentId;
+      this.selection = selection;
+    }
+
+    private String caption() {
+      String trimmed = selection.caption.trim();
+      return trimmed.isEmpty() ? selection.fileName : trimmed;
+    }
+  }
+
+  private final String waveRef;
+  private final J2clAttachmentUploadClient uploadClient;
+  private final J2clAttachmentIdGenerator idGenerator;
+  private final DocumentInsertionCallback insertionCallback;
+  private final List<QueueItem> queue = new ArrayList<QueueItem>();
+  private boolean uploadInProgress;
+  private int resetGeneration;
+
+  public J2clAttachmentComposerController(
+      String waveRef,
+      J2clAttachmentUploadClient uploadClient,
+      J2clAttachmentIdGenerator idGenerator,
+      DocumentInsertionCallback insertionCallback) {
+    this.waveRef = requireNonEmpty(waveRef, "Wave ref is required.");
+    this.uploadClient = requirePresent(uploadClient, "Attachment upload client is required.");
+    this.idGenerator = requirePresent(idGenerator, "Attachment id generator is required.");
+    this.insertionCallback =
+        requirePresent(insertionCallback, "Attachment insertion callback is required.");
+  }
+
+  public void selectFiles(List<AttachmentSelection> selections) {
+    if (selections == null) {
+      throw new IllegalArgumentException("Attachment selections are required.");
+    }
+    for (AttachmentSelection selection : selections) {
+      queue.add(
+          new QueueItem(
+              idGenerator.nextAttachmentId(),
+              requirePresent(selection, "Attachment selection is required.")));
+    }
+    startNextUpload();
+  }
+
+  public void pasteImage(Object imagePayload, String caption, DisplaySize displaySize) {
+    queue.add(
+        new QueueItem(
+            idGenerator.nextAttachmentId(),
+            new AttachmentSelection(
+                imagePayload, PASTED_IMAGE_FILENAME, caption, displaySize, true)));
+    startNextUpload();
+  }
+
+  public List<UploadItem> getQueueSnapshot() {
+    List<UploadItem> snapshot = new ArrayList<UploadItem>();
+    for (QueueItem item : queue) {
+      snapshot.add(new UploadItem(item));
+    }
+    return Collections.unmodifiableList(snapshot);
+  }
+
+  public void cancelAndReset() {
+    resetGeneration++;
+    uploadInProgress = false;
+    queue.clear();
+  }
+
+  private void startNextUpload() {
+    if (uploadInProgress) {
+      return;
+    }
+    QueueItem item = firstQueuedItem();
+    if (item == null) {
+      return;
+    }
+    uploadInProgress = true;
+    item.status = UploadStatus.UPLOADING;
+    int generation = resetGeneration;
+    J2clAttachmentUploadClient.UploadProgressCallback progressCallback =
+        percent -> {
+          if (generation == resetGeneration && item.status == UploadStatus.UPLOADING) {
+            item.progressPercent = percent;
+          }
+        };
+    J2clAttachmentUploadClient.UploadCallback uploadCallback =
+        result -> handleUploadComplete(generation, item, result);
+    if (item.selection.pastedImage) {
+      uploadClient.uploadPastedImage(
+          item.attachmentId, waveRef, item.selection.payload, progressCallback, uploadCallback);
+    } else {
+      uploadClient.uploadFile(
+          item.attachmentId,
+          waveRef,
+          item.selection.payload,
+          item.selection.fileName,
+          progressCallback,
+          uploadCallback);
+    }
+  }
+
+  private QueueItem firstQueuedItem() {
+    for (QueueItem item : queue) {
+      if (item.status == UploadStatus.QUEUED) {
+        return item;
+      }
+    }
+    return null;
+  }
+
+  private void handleUploadComplete(
+      int generation, QueueItem item, J2clAttachmentUploadClient.UploadResult result) {
+    if (generation != resetGeneration || !queue.contains(item)) {
+      return;
+    }
+    uploadInProgress = false;
+    if (result != null && result.isSuccess()) {
+      item.status = UploadStatus.COMPLETE;
+      item.progressPercent = 100;
+      insertAttachment(item);
+    } else {
+      item.status = UploadStatus.FAILED;
+      J2clAttachmentUploadClient.ErrorType errorType =
+          result == null ? J2clAttachmentUploadClient.ErrorType.NETWORK : result.getErrorType();
+      item.errorCode = errorType == null ? "" : errorType.name();
+      item.errorMessage =
+          result == null ? "Attachment upload failed without a result." : result.getMessage();
+    }
+    startNextUpload();
+  }
+
+  private void insertAttachment(QueueItem item) {
+    AttachmentInsertion insertion =
+        new AttachmentInsertion(item.attachmentId, item.caption(), item.selection.displaySize);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .imageAttachment(
+                insertion.getAttachmentId(),
+                insertion.getCaption(),
+                insertion.getDisplaySize().getDocumentValue())
+            .build();
+    insertionCallback.onInsert(document, insertion);
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return trimmed;
+  }
+
+  private static <T> T requirePresent(T value, String message) {
+    if (value == null) {
+      throw new IllegalArgumentException(message);
+    }
+    return value;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -7,7 +7,11 @@ import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
 
 /** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
 public final class J2clAttachmentComposerController {
+  /** Error code used when upload succeeds but composer document insertion fails. */
+  public static final String INSERT_FAILED_ERROR_CODE = "INSERTION";
+
   public interface DocumentInsertionCallback {
+    /** Runtime exceptions are contained as {@link UploadStatus#INSERT_FAILED}; VM errors are not. */
     void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
   }
 
@@ -48,14 +52,11 @@ public final class J2clAttachmentComposerController {
         String caption,
         DisplaySize displaySize,
         boolean pastedImage) {
-      this.payload = payload;
+      this.payload = requirePresent(payload, "Attachment payload is required.");
       this.fileName = requireNonEmpty(fileName, "Attachment file name is required.");
       this.caption = caption == null ? "" : caption;
       this.displaySize = requirePresent(displaySize, "Attachment display size is required.");
       this.pastedImage = pastedImage;
-      if (payload == null) {
-        throw new IllegalArgumentException("Attachment payload is required.");
-      }
     }
 
     public static AttachmentSelection file(
@@ -159,10 +160,15 @@ public final class J2clAttachmentComposerController {
       return progressPercent;
     }
 
+    /**
+     * Returns an empty string when there is no error, an upload {@code ErrorType.name()}, or
+     * {@link #INSERT_FAILED_ERROR_CODE} when document insertion fails after upload success.
+     */
     public String getErrorCode() {
       return errorCode;
     }
 
+    /** Returns an empty string when there is no error. */
     public String getErrorMessage() {
       return errorMessage;
     }
@@ -246,6 +252,8 @@ public final class J2clAttachmentComposerController {
    *
    * <p>This does not abort the underlying browser transport request; the current upload may
    * continue on the network, but its eventual progress or completion callback will be ignored.
+   * The attachment id generator is intentionally not reset so later selections keep globally
+   * unique ids.
    */
   public void cancelAndReset() {
     resetGeneration++;
@@ -309,7 +317,7 @@ public final class J2clAttachmentComposerController {
           insertAttachment(item);
         } catch (RuntimeException e) {
           item.status = UploadStatus.INSERT_FAILED;
-          item.errorCode = "INSERTION";
+          item.errorCode = INSERT_FAILED_ERROR_CODE;
           item.errorMessage =
               e.getMessage() == null ? "Attachment insertion failed." : e.getMessage();
         }
@@ -322,6 +330,7 @@ public final class J2clAttachmentComposerController {
             result == null ? "Attachment upload failed without a result." : result.getMessage();
       }
     } finally {
+      // onInsert can enqueue or cancel; startNextUpload is idempotent for those re-entrant paths.
       startNextUpload();
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -214,6 +214,8 @@ public final class J2clAttachmentComposerController {
   // explicit clear; this keeps status/error reporting available to the Lit wiring task.
   private final List<QueueItem> queue = new ArrayList<QueueItem>();
   private boolean uploadInProgress;
+  // Cursor avoids rescanning terminal items retained for status/error display.
+  private int nextQueueIndex;
   private int resetGeneration;
 
   public J2clAttachmentComposerController(
@@ -232,14 +234,11 @@ public final class J2clAttachmentComposerController {
     if (selections == null) {
       throw new IllegalArgumentException("Attachment selections are required.");
     }
-    // Field validity is enforced by AttachmentSelection factories; this pass keeps batch enqueue
-    // atomic by rejecting null entries before consuming any attachment ids.
-    List<AttachmentSelection> validatedSelections =
-        new ArrayList<AttachmentSelection>(selections.size());
+    // Factories enforce field validity; this preflight only rejects null entries before id use.
     for (AttachmentSelection selection : selections) {
-      validatedSelections.add(requirePresent(selection, "Attachment selection is required."));
+      requirePresent(selection, "Attachment selection is required.");
     }
-    for (AttachmentSelection selection : validatedSelections) {
+    for (AttachmentSelection selection : selections) {
       enqueue(selection);
     }
     startNextUpload();
@@ -275,6 +274,7 @@ public final class J2clAttachmentComposerController {
   public void cancelAndReset() {
     resetGeneration++;
     uploadInProgress = false;
+    nextQueueIndex = 0;
     queue.clear();
   }
 
@@ -312,7 +312,8 @@ public final class J2clAttachmentComposerController {
   }
 
   private QueueItem firstQueuedItem() {
-    for (QueueItem item : queue) {
+    while (nextQueueIndex < queue.size()) {
+      QueueItem item = queue.get(nextQueueIndex++);
       if (item.status == UploadStatus.QUEUED) {
         return item;
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -63,6 +63,32 @@ public final class J2clAttachmentComposerController {
         Object payload, String fileName, String caption, DisplaySize displaySize) {
       return new AttachmentSelection(payload, fileName, caption, displaySize, false);
     }
+
+    public static AttachmentSelection pastedImage(
+        Object payload, String caption, DisplaySize displaySize) {
+      return new AttachmentSelection(
+          payload, PASTED_IMAGE_FILENAME, caption, displaySize, true);
+    }
+
+    public Object getPayload() {
+      return payload;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public String getCaption() {
+      return caption;
+    }
+
+    public DisplaySize getDisplaySize() {
+      return displaySize;
+    }
+
+    public boolean isPastedImage() {
+      return pastedImage;
+    }
   }
 
   public static final class AttachmentInsertion {
@@ -198,11 +224,10 @@ public final class J2clAttachmentComposerController {
   }
 
   public void pasteImage(Object imagePayload, String caption, DisplaySize displaySize) {
+    AttachmentSelection selection =
+        AttachmentSelection.pastedImage(imagePayload, caption, displaySize);
     queue.add(
-        new QueueItem(
-            idGenerator.nextAttachmentId(),
-            new AttachmentSelection(
-                imagePayload, PASTED_IMAGE_FILENAME, caption, displaySize, true)));
+        new QueueItem(idGenerator.nextAttachmentId(), selection));
     startNextUpload();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -14,7 +14,8 @@ public final class J2clAttachmentComposerController {
     /**
      * Runtime exceptions escaping the callback, including from re-entrant controller calls, are
      * contained as {@link UploadStatus#INSERT_FAILED}. VM errors are not contained; completion
-     * cleanup still runs, so a queued upload can start before the error reaches the caller.
+     * cleanup still runs, so a queued upload can start before the error reaches the caller. If
+     * the callback resets the controller before throwing, stale item mutations are dropped.
      */
     void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
   }
@@ -201,6 +202,8 @@ public final class J2clAttachmentComposerController {
   private final J2clAttachmentUploadClient uploadClient;
   private final J2clAttachmentIdGenerator idGenerator;
   private final DocumentInsertionCallback insertionCallback;
+  // Terminal items stay visible until the composer lifecycle calls cancelAndReset or a future
+  // explicit clear; this keeps status/error reporting available to the Lit wiring task.
   private final List<QueueItem> queue = new ArrayList<QueueItem>();
   private boolean uploadInProgress;
   private int resetGeneration;
@@ -320,10 +323,12 @@ public final class J2clAttachmentComposerController {
         try {
           insertAttachment(item);
         } catch (RuntimeException e) {
-          item.status = UploadStatus.INSERT_FAILED;
-          item.errorCode = INSERT_FAILED_ERROR_CODE;
-          item.errorMessage =
-              e.getMessage() == null ? "Attachment insertion failed." : e.getMessage();
+          if (generation == resetGeneration) {
+            item.status = UploadStatus.INSERT_FAILED;
+            item.errorCode = INSERT_FAILED_ERROR_CODE;
+            item.errorMessage =
+                e.getMessage() == null ? "Attachment insertion failed." : e.getMessage();
+          }
         }
       } else {
         item.status = UploadStatus.FAILED;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -7,8 +7,6 @@ import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
 
 /** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
 public final class J2clAttachmentComposerController {
-  private static final String PASTED_IMAGE_FILENAME = "pasted-image.png";
-
   public interface DocumentInsertionCallback {
     void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
   }
@@ -67,7 +65,7 @@ public final class J2clAttachmentComposerController {
     public static AttachmentSelection pastedImage(
         Object payload, String caption, DisplaySize displaySize) {
       return new AttachmentSelection(
-          payload, PASTED_IMAGE_FILENAME, caption, displaySize, true);
+          payload, J2clAttachmentUploadClient.PASTED_IMAGE_FILENAME, caption, displaySize, true);
     }
 
     public Object getPayload() {
@@ -239,6 +237,12 @@ public final class J2clAttachmentComposerController {
     return Collections.unmodifiableList(snapshot);
   }
 
+  /**
+   * Clears controller queue state and ignores late callbacks from the active upload generation.
+   *
+   * <p>This does not abort the underlying browser transport request; the current upload may
+   * continue on the network, but its eventual progress or completion callback will be ignored.
+   */
   public void cancelAndReset() {
     resetGeneration++;
     uploadInProgress = false;
@@ -293,19 +297,22 @@ public final class J2clAttachmentComposerController {
       return;
     }
     uploadInProgress = false;
-    if (result != null && result.isSuccess()) {
-      item.status = UploadStatus.COMPLETE;
-      item.progressPercent = 100;
-      insertAttachment(item);
-    } else {
-      item.status = UploadStatus.FAILED;
-      J2clAttachmentUploadClient.ErrorType errorType =
-          result == null ? J2clAttachmentUploadClient.ErrorType.NETWORK : result.getErrorType();
-      item.errorCode = errorType == null ? "" : errorType.name();
-      item.errorMessage =
-          result == null ? "Attachment upload failed without a result." : result.getMessage();
+    try {
+      if (result != null && result.isSuccess()) {
+        item.status = UploadStatus.COMPLETE;
+        item.progressPercent = 100;
+        insertAttachment(item);
+      } else {
+        item.status = UploadStatus.FAILED;
+        J2clAttachmentUploadClient.ErrorType errorType =
+            result == null ? J2clAttachmentUploadClient.ErrorType.NETWORK : result.getErrorType();
+        item.errorCode = errorType == null ? "" : errorType.name();
+        item.errorMessage =
+            result == null ? "Attachment upload failed without a result." : result.getMessage();
+      }
+    } finally {
+      startNextUpload();
     }
-    startNextUpload();
   }
 
   private void insertAttachment(QueueItem item) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -216,6 +216,7 @@ public final class J2clAttachmentComposerController {
   // explicit clear; this keeps status/error reporting available to the Lit wiring task.
   private final List<QueueItem> queue = new ArrayList<QueueItem>();
   private boolean uploadInProgress;
+  // True while startNextUpload is iterating; suppresses re-entrant recursive dispatch.
   private boolean drainingQueue;
   // Cursor avoids rescanning terminal items retained for status/error display.
   private int nextQueueIndex;
@@ -290,7 +291,7 @@ public final class J2clAttachmentComposerController {
       while (!uploadInProgress) {
         QueueItem item = firstQueuedItem();
         if (item == null) {
-          return;
+          break;
         }
         startUpload(item);
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -31,7 +31,8 @@ public final class J2clAttachmentComposerController {
     QUEUED,
     UPLOADING,
     COMPLETE,
-    FAILED
+    FAILED,
+    INSERT_FAILED
   }
 
   public static final class AttachmentSelection {
@@ -222,6 +223,7 @@ public final class J2clAttachmentComposerController {
   }
 
   public void pasteImage(Object imagePayload, String caption, DisplaySize displaySize) {
+    // Keep the browser payload opaque here; Task 5's Lit wiring owns the File/Blob boundary.
     AttachmentSelection selection =
         AttachmentSelection.pastedImage(imagePayload, caption, displaySize);
     queue.add(
@@ -293,15 +295,24 @@ public final class J2clAttachmentComposerController {
 
   private void handleUploadComplete(
       int generation, QueueItem item, J2clAttachmentUploadClient.UploadResult result) {
-    if (generation != resetGeneration || !queue.contains(item)) {
+    if (generation != resetGeneration) {
       return;
     }
     uploadInProgress = false;
     try {
       if (result != null && result.isSuccess()) {
-        item.status = UploadStatus.COMPLETE;
-        item.progressPercent = 100;
-        insertAttachment(item);
+        try {
+          insertAttachment(item);
+          item.status = UploadStatus.COMPLETE;
+          item.progressPercent = 100;
+        } catch (RuntimeException e) {
+          item.status = UploadStatus.INSERT_FAILED;
+          item.progressPercent = 100;
+          item.errorCode = "INSERTION";
+          item.errorMessage =
+              e.getMessage() == null ? "Attachment insertion failed." : e.getMessage();
+          throw e;
+        }
       } else {
         item.status = UploadStatus.FAILED;
         J2clAttachmentUploadClient.ErrorType errorType =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -8,14 +8,16 @@ import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
 /** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
 public final class J2clAttachmentComposerController {
   /** Error code value used when upload succeeds but composer document insertion fails. */
-  public static final String INSERT_FAILED_ERROR_CODE = "INSERT_FAILED";
+  public static final String INSERT_FAILED_ERROR_CODE = UploadStatus.INSERT_FAILED.name();
 
   public interface DocumentInsertionCallback {
     /**
      * Runtime exceptions escaping the callback, including from re-entrant controller calls, are
      * contained as {@link UploadStatus#INSERT_FAILED}. VM errors are not contained; completion
      * cleanup still runs, so a queued upload can start before the error reaches the caller. If
-     * the callback resets the controller before throwing, stale item mutations are dropped.
+     * the callback resets the controller before throwing, stale item mutations are dropped. The
+     * item is already marked {@link UploadStatus#COMPLETE} while this callback runs because the
+     * upload itself finished before document insertion starts.
      */
     void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
   }
@@ -313,6 +315,7 @@ public final class J2clAttachmentComposerController {
 
   private QueueItem firstQueuedItem() {
     while (nextQueueIndex < queue.size()) {
+      // Items at or after nextQueueIndex are expected to be QUEUED; keep the guard defensive.
       QueueItem item = queue.get(nextQueueIndex++);
       if (item.status == UploadStatus.QUEUED) {
         return item;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -263,7 +263,7 @@ public final class J2clAttachmentComposerController {
     J2clAttachmentUploadClient.UploadProgressCallback progressCallback =
         percent -> {
           if (generation == resetGeneration && item.status == UploadStatus.UPLOADING) {
-            item.progressPercent = percent;
+            item.progressPercent = clampPercent(percent);
           }
         };
     J2clAttachmentUploadClient.UploadCallback uploadCallback =
@@ -334,6 +334,16 @@ public final class J2clAttachmentComposerController {
       throw new IllegalArgumentException(message);
     }
     return trimmed;
+  }
+
+  private static int clampPercent(int percent) {
+    if (percent < 0) {
+      return 0;
+    }
+    if (percent > 100) {
+      return 100;
+    }
+    return percent;
   }
 
   private static <T> T requirePresent(T value, String message) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -8,10 +8,14 @@ import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
 /** Controller-domain layer for composer attachment selection, upload, and insertion callbacks. */
 public final class J2clAttachmentComposerController {
   /** Error code used when upload succeeds but composer document insertion fails. */
-  public static final String INSERT_FAILED_ERROR_CODE = "INSERTION";
+  public static final String INSERT_FAILED_ERROR_CODE = "INSERT_FAILED";
 
   public interface DocumentInsertionCallback {
-    /** Runtime exceptions are contained as {@link UploadStatus#INSERT_FAILED}; VM errors are not. */
+    /**
+     * Runtime exceptions escaping the callback, including from re-entrant controller calls, are
+     * contained as {@link UploadStatus#INSERT_FAILED}. VM errors are not contained; completion
+     * cleanup still runs, so a queued upload can start before the error reaches the caller.
+     */
     void onInsert(J2clComposerDocument document, AttachmentInsertion insertion);
   }
 
@@ -162,7 +166,7 @@ public final class J2clAttachmentComposerController {
 
     /**
      * Returns an empty string when there is no error, an upload {@code ErrorType.name()}, or
-     * {@link #INSERT_FAILED_ERROR_CODE} when document insertion fails after upload success.
+     * {@code "INSERT_FAILED"} when document insertion fails after upload success.
      */
     public String getErrorCode() {
       return errorCode;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -217,18 +217,20 @@ public final class J2clAttachmentComposerController {
       validatedSelections.add(requirePresent(selection, "Attachment selection is required."));
     }
     for (AttachmentSelection selection : validatedSelections) {
-      queue.add(new QueueItem(idGenerator.nextAttachmentId(), selection));
+      enqueue(selection);
     }
     startNextUpload();
   }
 
   public void pasteImage(Object imagePayload, String caption, DisplaySize displaySize) {
-    // Keep the browser payload opaque here; Task 5's Lit wiring owns the File/Blob boundary.
     AttachmentSelection selection =
         AttachmentSelection.pastedImage(imagePayload, caption, displaySize);
-    queue.add(
-        new QueueItem(idGenerator.nextAttachmentId(), selection));
+    enqueue(selection);
     startNextUpload();
+  }
+
+  private void enqueue(AttachmentSelection selection) {
+    queue.add(new QueueItem(idGenerator.nextAttachmentId(), selection));
   }
 
   public List<UploadItem> getQueueSnapshot() {
@@ -301,17 +303,15 @@ public final class J2clAttachmentComposerController {
     uploadInProgress = false;
     try {
       if (result != null && result.isSuccess()) {
+        item.status = UploadStatus.COMPLETE;
+        item.progressPercent = 100;
         try {
           insertAttachment(item);
-          item.status = UploadStatus.COMPLETE;
-          item.progressPercent = 100;
         } catch (RuntimeException e) {
           item.status = UploadStatus.INSERT_FAILED;
-          item.progressPercent = 100;
           item.errorCode = "INSERTION";
           item.errorMessage =
               e.getMessage() == null ? "Attachment insertion failed." : e.getMessage();
-          throw e;
         }
       } else {
         item.status = UploadStatus.FAILED;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -299,17 +299,28 @@ public final class J2clAttachmentComposerController {
         };
     J2clAttachmentUploadClient.UploadCallback uploadCallback =
         result -> handleUploadComplete(generation, item, result);
-    if (item.pastedImage) {
-      uploadClient.uploadPastedImage(
-          item.attachmentId, waveRef, item.payload, progressCallback, uploadCallback);
-    } else {
-      uploadClient.uploadFile(
-          item.attachmentId,
-          waveRef,
-          item.payload,
-          item.fileName,
-          progressCallback,
-          uploadCallback);
+    try {
+      if (item.pastedImage) {
+        uploadClient.uploadPastedImage(
+            item.attachmentId, waveRef, item.payload, progressCallback, uploadCallback);
+      } else {
+        uploadClient.uploadFile(
+            item.attachmentId,
+            waveRef,
+            item.payload,
+            item.fileName,
+            progressCallback,
+            uploadCallback);
+      }
+    } catch (RuntimeException e) {
+      handleUploadComplete(
+          generation,
+          item,
+          J2clAttachmentUploadClient.UploadResult.failure(
+              J2clAttachmentUploadClient.ErrorType.NETWORK,
+              e.getMessage() == null
+                  ? "Attachment upload failed before the request was sent."
+                  : e.getMessage()));
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerController.java
@@ -186,11 +186,13 @@ public final class J2clAttachmentComposerController {
     if (selections == null) {
       throw new IllegalArgumentException("Attachment selections are required.");
     }
+    List<AttachmentSelection> validatedSelections =
+        new ArrayList<AttachmentSelection>(selections.size());
     for (AttachmentSelection selection : selections) {
-      queue.add(
-          new QueueItem(
-              idGenerator.nextAttachmentId(),
-              requirePresent(selection, "Attachment selection is required.")));
+      validatedSelections.add(requirePresent(selection, "Attachment selection is required."));
+    }
+    for (AttachmentSelection selection : validatedSelections) {
+      queue.add(new QueueItem(idGenerator.nextAttachmentId(), selection));
     }
     startNextUpload();
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -4,7 +4,8 @@ package org.waveprotocol.box.j2cl.attachment;
  * Deterministic attachment id generator for J2CL composer uploads.
  *
  * <p>Callers should pass the same unpredictable per-session seed used by the legacy
- * {@code IdGeneratorImpl} path.
+ * {@code IdGeneratorImpl} path. The domain is expected to be the server-provided normalized wave
+ * domain; this generator rejects the attachment path separator to preserve legacy id shape.
  */
 public final class J2clAttachmentIdGenerator {
   private static final String DEFAULT_SEED = "j2cl";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -2,6 +2,7 @@ package org.waveprotocol.box.j2cl.attachment;
 
 /** Deterministic attachment id generator for J2CL composer uploads. */
 public final class J2clAttachmentIdGenerator {
+  private static final String DEFAULT_SEED = "j2cl";
   private static final char[] WEB64_ALPHABET =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
 
@@ -15,7 +16,7 @@ public final class J2clAttachmentIdGenerator {
   }
 
   public String nextAttachmentId() {
-    return domain + "/attachment+" + seed + base64Encode(counter++);
+    return domain + "/" + seed + base64Encode(counter++);
   }
 
   private static String requireNonEmpty(String value, String message) {
@@ -28,7 +29,7 @@ public final class J2clAttachmentIdGenerator {
 
   private static String sanitizeSeed(String rawSeed) {
     if (rawSeed == null || rawSeed.isEmpty()) {
-      return "j2cl";
+      return DEFAULT_SEED;
     }
     StringBuilder sanitized = new StringBuilder(rawSeed.length());
     for (int i = 0; i < rawSeed.length(); i++) {
@@ -41,10 +42,11 @@ public final class J2clAttachmentIdGenerator {
         sanitized.append(c);
       }
     }
-    return sanitized.length() == 0 ? "j2cl" : sanitized.toString();
+    return sanitized.length() == 0 ? DEFAULT_SEED : sanitized.toString();
   }
 
   private static String base64Encode(int intValue) {
+    assert intValue >= 0;
     if (intValue == 0) {
       return "A";
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -1,0 +1,74 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+/** Deterministic attachment id generator for J2CL composer uploads. */
+public final class J2clAttachmentIdGenerator {
+  private static final char[] WEB64_ALPHABET =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+
+  private final String domain;
+  private final String seed;
+  private int counter;
+
+  public J2clAttachmentIdGenerator(String domain, String seed) {
+    this.domain = requireNonEmpty(domain, "Attachment id domain is required.");
+    this.seed = sanitizeSeed(seed);
+  }
+
+  public String nextAttachmentId() {
+    return domain + "/attachment+" + seed + base64Encode(counter++);
+  }
+
+  private static String requireNonEmpty(String value, String message) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.isEmpty()) {
+      throw new IllegalArgumentException(message);
+    }
+    return trimmed;
+  }
+
+  private static String sanitizeSeed(String rawSeed) {
+    if (rawSeed == null || rawSeed.isEmpty()) {
+      return "j2cl";
+    }
+    StringBuilder sanitized = new StringBuilder(rawSeed.length());
+    for (int i = 0; i < rawSeed.length(); i++) {
+      char c = rawSeed.charAt(i);
+      if ((c >= 'A' && c <= 'Z')
+          || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_') {
+        sanitized.append(c);
+      }
+    }
+    return sanitized.length() == 0 ? "j2cl" : sanitized.toString();
+  }
+
+  private static String base64Encode(int intValue) {
+    if (intValue == 0) {
+      return "A";
+    }
+    int numEncodedBytes = (int) Math.ceil((32 - Integer.numberOfLeadingZeros(intValue)) / 6.0);
+    StringBuilder encoded = new StringBuilder(numEncodedBytes);
+    switch (numEncodedBytes) {
+      case 6:
+        encoded.append(WEB64_ALPHABET[(intValue >> 30) & 0x3F]);
+        // fall through
+      case 5:
+        encoded.append(WEB64_ALPHABET[(intValue >> 24) & 0x3F]);
+        // fall through
+      case 4:
+        encoded.append(WEB64_ALPHABET[(intValue >> 18) & 0x3F]);
+        // fall through
+      case 3:
+        encoded.append(WEB64_ALPHABET[(intValue >> 12) & 0x3F]);
+        // fall through
+      case 2:
+        encoded.append(WEB64_ALPHABET[(intValue >> 6) & 0x3F]);
+        // fall through
+      default:
+        encoded.append(WEB64_ALPHABET[intValue & 0x3F]);
+    }
+    return encoded.toString();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -16,8 +16,13 @@ public final class J2clAttachmentIdGenerator {
   private int counter;
 
   public J2clAttachmentIdGenerator(String domain, String seed) {
+    this(domain, seed, 0);
+  }
+
+  J2clAttachmentIdGenerator(String domain, String seed, int initialCounter) {
     this.domain = requireDomain(domain);
     this.seed = sanitizeSeed(seed);
+    this.counter = initialCounter;
   }
 
   public String nextAttachmentId() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -1,6 +1,11 @@
 package org.waveprotocol.box.j2cl.attachment;
 
-/** Deterministic attachment id generator for J2CL composer uploads. */
+/**
+ * Deterministic attachment id generator for J2CL composer uploads.
+ *
+ * <p>Callers should pass the same unpredictable per-session seed used by the legacy
+ * {@code IdGeneratorImpl} path.
+ */
 public final class J2clAttachmentIdGenerator {
   private static final String DEFAULT_SEED = "j2cl";
   private static final char[] WEB64_ALPHABET =
@@ -16,6 +21,9 @@ public final class J2clAttachmentIdGenerator {
   }
 
   public String nextAttachmentId() {
+    if (counter < 0) {
+      throw new IllegalStateException("Attachment id counter overflow.");
+    }
     return domain + "/" + seed + base64Encode(counter++);
   }
 
@@ -55,7 +63,9 @@ public final class J2clAttachmentIdGenerator {
   }
 
   private static String base64Encode(int intValue) {
-    assert intValue >= 0;
+    if (intValue < 0) {
+      throw new IllegalArgumentException("Attachment id counter must be non-negative.");
+    }
     if (intValue == 0) {
       return "A";
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGenerator.java
@@ -11,7 +11,7 @@ public final class J2clAttachmentIdGenerator {
   private int counter;
 
   public J2clAttachmentIdGenerator(String domain, String seed) {
-    this.domain = requireNonEmpty(domain, "Attachment id domain is required.");
+    this.domain = requireDomain(domain);
     this.seed = sanitizeSeed(seed);
   }
 
@@ -25,6 +25,15 @@ public final class J2clAttachmentIdGenerator {
       throw new IllegalArgumentException(message);
     }
     return trimmed;
+  }
+
+  private static String requireDomain(String value) {
+    String normalized = requireNonEmpty(value, "Attachment id domain is required.");
+    if (normalized.indexOf('/') >= 0) {
+      throw new IllegalArgumentException(
+          "Attachment id domain cannot contain '/': " + normalized);
+    }
+    return normalized;
   }
 
   private static String sanitizeSeed(String rawSeed) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentUploadClient.java
@@ -8,8 +8,9 @@ import java.util.List;
 import jsinterop.base.Js;
 
 public final class J2clAttachmentUploadClient {
+  public static final String PASTED_IMAGE_FILENAME = "pasted-image.png";
+
   private static final String ATTACHMENT_URL_PREFIX = "/attachment/";
-  private static final String PASTED_IMAGE_FILENAME = "pasted-image.png";
   private static final int NO_TIMEOUT_MILLIS = 0;
   private static final int PASTED_IMAGE_TIMEOUT_MILLIS = 60000;
   private static final UploadProgressCallback NO_UPLOAD_PROGRESS_CALLBACK =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -483,6 +483,40 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void laterSynchronousUploadStartFailureDoesNotRecurseOrStopDrainCleanup() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    transport.failPostNumber(2, new IllegalStateException("second unavailable"));
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals(
+        "second unavailable", controller.getQueueSnapshot().get(1).getErrorMessage());
+    Assert.assertEquals(1, transport.maxPostDepth);
+  }
+
+  @Test
   public void failedUploadStartsNextQueuedItem() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -720,6 +754,38 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.COMPLETE,
         controller.getQueueSnapshot().get(1).getStatus());
+  }
+
+  @Test
+  public void insertionCallbackFailureDuringSynchronousDrainMarksItemAndContinues() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    OneShotThrowingInsertionCallback insertionCallback =
+        new OneShotThrowingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals(1, transport.maxPostDepth);
   }
 
   @Test
@@ -1388,8 +1454,11 @@ public class J2clAttachmentComposerControllerTest {
     private final List<J2clAttachmentUploadClient.ResponseHandler> handlers =
         new ArrayList<J2clAttachmentUploadClient.ResponseHandler>();
     // When set, post() completes uploads before returning to simulate browser/client fakes.
-    private J2clAttachmentUploadClient.HttpResponse inlineResponse;
+    private J2clAttachmentUploadClient.HttpResponse inlinePostResponse;
     private RuntimeException nextPostFailure;
+    private RuntimeException numberedPostFailure;
+    private int failingPostNumber;
+    private int postCount;
     private int postDepth;
     private int maxPostDepth;
 
@@ -1399,16 +1468,23 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentUploadClient.ResponseHandler handler) {
       postDepth++;
       maxPostDepth = Math.max(maxPostDepth, postDepth);
+      postCount++;
       try {
         if (nextPostFailure != null) {
           RuntimeException failure = nextPostFailure;
           nextPostFailure = null;
           throw failure;
         }
+        if (numberedPostFailure != null && postCount == failingPostNumber) {
+          RuntimeException failure = numberedPostFailure;
+          numberedPostFailure = null;
+          failingPostNumber = 0;
+          throw failure;
+        }
         requests.add(request);
         handlers.add(handler);
-        if (inlineResponse != null) {
-          handler.onResponse(inlineResponse);
+        if (inlinePostResponse != null) {
+          handler.onResponse(inlinePostResponse);
         }
       } finally {
         postDepth--;
@@ -1419,8 +1495,13 @@ public class J2clAttachmentComposerControllerTest {
       nextPostFailure = failure;
     }
 
+    void failPostNumber(int postNumber, RuntimeException failure) {
+      failingPostNumber = postNumber;
+      numberedPostFailure = failure;
+    }
+
     void completePostsInline(J2clAttachmentUploadClient.HttpResponse response) {
-      inlineResponse = response;
+      inlinePostResponse = response;
     }
 
     void complete(int index, J2clAttachmentUploadClient.HttpResponse response) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -1,0 +1,271 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.richtext.J2clComposerDocument;
+import org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactory;
+
+@J2clTestInput(J2clAttachmentComposerControllerTest.class)
+public class J2clAttachmentComposerControllerTest {
+  private static final String WAVE_REF = "example.com/w+wave/~/conv+root";
+
+  @Test
+  public void selectingFilesStartsUploadQueueInOrderAndGeneratesPerFileIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    Object firstPayload = new Object();
+    Object secondPayload = new Object();
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                firstPayload,
+                "first.png",
+                "First caption",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                secondPayload,
+                "second.png",
+                "Second caption",
+                J2clAttachmentComposerController.DisplaySize.LARGE)));
+
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertEquals(
+        "/attachment/example.com/attachment+seedA", transport.requests.get(0).getUrl());
+    Assert.assertSame(firstPayload, transport.requests.get(0).getPart(2).getPayload());
+    Assert.assertEquals("first.png", transport.requests.get(0).getPart(2).getFileName());
+    Assert.assertEquals(2, controller.getQueueSnapshot().size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.QUEUED,
+        controller.getQueueSnapshot().get(1).getStatus());
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        "/attachment/example.com/attachment+seedB", transport.requests.get(1).getUrl());
+    Assert.assertSame(secondPayload, transport.requests.get(1).getPart(2).getPayload());
+    Assert.assertEquals("second.png", transport.requests.get(1).getPart(2).getFileName());
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+  }
+
+  @Test
+  public void progressUpdatesActiveItemState() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "progress.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    transport.requests.get(0).getProgressCallback().onProgress(47);
+
+    J2clAttachmentComposerController.UploadItem item = controller.getQueueSnapshot().get(0);
+    Assert.assertEquals(J2clAttachmentComposerController.UploadStatus.UPLOADING, item.getStatus());
+    Assert.assertEquals(47, item.getProgressPercent());
+  }
+
+  @Test
+  public void uploadFailureMarksItemFailedAndDoesNotInsertDocument() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "broken.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(500, "OK", null));
+
+    J2clAttachmentComposerController.UploadItem item = controller.getQueueSnapshot().get(0);
+    Assert.assertEquals(J2clAttachmentComposerController.UploadStatus.FAILED, item.getStatus());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.HTTP_STATUS.name(), item.getErrorCode());
+    Assert.assertTrue(item.getErrorMessage().contains("HTTP 500"));
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+  }
+
+  @Test
+  public void cancelResetClearsQueueAndIgnoresLateUploadCompletion() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "cancel.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "queued.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    controller.cancelAndReset();
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(1, transport.requests.size());
+  }
+
+  @Test
+  public void successfulFileUploadInvokesInsertionWithCaptionFallbackAndDisplaySize() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "fallback.png",
+                "   ",
+                J2clAttachmentComposerController.DisplaySize.LARGE)));
+
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    J2clAttachmentComposerController.AttachmentInsertion insertion =
+        insertionCallback.insertions.get(0);
+    Assert.assertEquals("example.com/attachment+seedA", insertion.getAttachmentId());
+    Assert.assertEquals("fallback.png", insertion.getCaption());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.DisplaySize.LARGE, insertion.getDisplaySize());
+    assertDocumentContainsAttachment(
+        insertionCallback.documents.get(0),
+        "example.com/attachment+seedA",
+        "fallback.png",
+        "large");
+  }
+
+  @Test
+  public void pastedImageUploadCapturesIntentAndMutatesOnlyAfterSuccess() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    Object imagePayload = new Object();
+
+    controller.pasteImage(
+        imagePayload,
+        "paste caption",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertSame(imagePayload, transport.requests.get(0).getPart(2).getPayload());
+    Assert.assertEquals("pasted-image.png", transport.requests.get(0).getPart(2).getFileName());
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals("paste caption", insertionCallback.insertions.get(0).getCaption());
+    assertDocumentContainsAttachment(
+        insertionCallback.documents.get(0),
+        "example.com/attachment+seedA",
+        "paste caption",
+        "medium");
+  }
+
+  @Test
+  public void pastedImageFailureDoesNotMutateDocument() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.pasteImage(
+        new Object(),
+        "paste caption",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(202, "accepted", null));
+
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+  }
+
+  private static J2clAttachmentComposerController newController(
+      FakeUploadTransport transport, RecordingInsertionCallback insertionCallback) {
+    return new J2clAttachmentComposerController(
+        WAVE_REF,
+        new J2clAttachmentUploadClient(transport),
+        new J2clAttachmentIdGenerator("example.com", "seed"),
+        insertionCallback);
+  }
+
+  private static void assertDocumentContainsAttachment(
+      J2clComposerDocument document, String attachmentId, String caption, String displaySize) {
+    String deltaJson =
+        new J2clRichContentDeltaFactory("verify")
+            .createWaveRequest("user@example.com", document)
+            .getSubmitRequest()
+            .getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"1\":\"attachment\",\"2\":\"" + attachmentId + "\"}",
+        "{\"1\":\"display-size\",\"2\":\"" + displaySize + "\"}",
+        "\"2\":\"" + caption + "\"");
+  }
+
+  private static void assertContains(String value, String... expectedSubstrings) {
+    for (String expectedSubstring : expectedSubstrings) {
+      Assert.assertTrue(
+          "Expected to find <" + expectedSubstring + "> in <" + value + ">",
+          value.contains(expectedSubstring));
+    }
+  }
+
+  private static final class FakeUploadTransport
+      implements J2clAttachmentUploadClient.UploadTransport {
+    private final List<J2clAttachmentUploadClient.MultipartUploadRequest> requests =
+        new ArrayList<J2clAttachmentUploadClient.MultipartUploadRequest>();
+    private final List<J2clAttachmentUploadClient.ResponseHandler> handlers =
+        new ArrayList<J2clAttachmentUploadClient.ResponseHandler>();
+
+    @Override
+    public void post(
+        J2clAttachmentUploadClient.MultipartUploadRequest request,
+        J2clAttachmentUploadClient.ResponseHandler handler) {
+      requests.add(request);
+      handlers.add(handler);
+    }
+
+    void complete(int index, J2clAttachmentUploadClient.HttpResponse response) {
+      handlers.get(index).onResponse(response);
+    }
+  }
+
+  private static final class RecordingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private final List<J2clAttachmentComposerController.AttachmentInsertion> insertions =
+        new ArrayList<J2clAttachmentComposerController.AttachmentInsertion>();
+    private final List<J2clComposerDocument> documents = new ArrayList<J2clComposerDocument>();
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      documents.add(document);
+      insertions.add(insertion);
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -204,6 +204,48 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void constructorRejectsNullUploadClient() {
+    try {
+      new J2clAttachmentComposerController(
+          WAVE_REF,
+          null,
+          new J2clAttachmentIdGenerator("example.com", "seed"),
+          new RecordingInsertionCallback());
+      Assert.fail("Expected null upload client to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("upload client"));
+    }
+  }
+
+  @Test
+  public void constructorRejectsNullIdGenerator() {
+    try {
+      new J2clAttachmentComposerController(
+          WAVE_REF,
+          new J2clAttachmentUploadClient(new FakeUploadTransport()),
+          null,
+          new RecordingInsertionCallback());
+      Assert.fail("Expected null id generator to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("id generator"));
+    }
+  }
+
+  @Test
+  public void constructorRejectsNullInsertionCallback() {
+    try {
+      new J2clAttachmentComposerController(
+          WAVE_REF,
+          new J2clAttachmentUploadClient(new FakeUploadTransport()),
+          new J2clAttachmentIdGenerator("example.com", "seed"),
+          null);
+      Assert.fail("Expected null insertion callback to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("insertion callback"));
+    }
+  }
+
+  @Test
   public void progressUpdatesActiveItemState() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -403,7 +445,7 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
-  public void cancelResetAllowsReuseWithNextId() {
+  public void cancelAndResetDoesNotResetIdGenerator() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
         newController(transport, new RecordingInsertionCallback());
@@ -660,6 +702,33 @@ public class J2clAttachmentComposerControllerTest {
         controller.getQueueSnapshot().get(1).getStatus());
 
     transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, insertionCallback.insertions.size());
+    Assert.assertEquals(2, transport.requests.size());
+  }
+
+  @Test
+  public void reentrantPasteFromInsertionCallbackStartsSingleNextUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ReentrantPastingInsertionCallback insertionCallback = new ReentrantPastingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.pasteImage(
+        new Object(),
+        "first",
+        J2clAttachmentComposerController.DisplaySize.SMALL);
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertEquals("pasted-image.png", transport.requests.get(1).getPart(2).getFileName());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
 
     Assert.assertEquals(2, insertionCallback.insertions.size());
     Assert.assertEquals(2, transport.requests.size());
@@ -1159,6 +1228,32 @@ public class J2clAttachmentComposerControllerTest {
                     "reentrant.png",
                     "",
                     J2clAttachmentComposerController.DisplaySize.SMALL)));
+      }
+    }
+  }
+
+  private static final class ReentrantPastingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private final List<J2clAttachmentComposerController.AttachmentInsertion> insertions =
+        new ArrayList<J2clAttachmentComposerController.AttachmentInsertion>();
+    private J2clAttachmentComposerController controller;
+    private boolean pastedReentrantImage;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      insertions.add(insertion);
+      if (!pastedReentrantImage) {
+        pastedReentrantImage = true;
+        controller.pasteImage(
+            new Object(),
+            "reentrant paste",
+            J2clAttachmentComposerController.DisplaySize.SMALL);
       }
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -105,6 +105,33 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void nullSelectionListDoesNotQueueStartUploadOrConsumeIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    try {
+      controller.selectFiles(null);
+      Assert.fail("Expected null selection list to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("selections"));
+    }
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "next.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+  }
+
+  @Test
   public void invalidFileSelectionFactoryDoesNotQueueStartUploadOrConsumeIds() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -160,6 +187,20 @@ public class J2clAttachmentComposerControllerTest {
 
     Assert.assertEquals(WAVE_REF, transport.requests.get(0).getPart(1).getStringValue());
     Assert.assertEquals("spaced.png", transport.requests.get(0).getPart(2).getFileName());
+  }
+
+  @Test
+  public void blankWaveRefIsRejected() {
+    try {
+      new J2clAttachmentComposerController(
+          "   ",
+          new J2clAttachmentUploadClient(new FakeUploadTransport()),
+          new J2clAttachmentIdGenerator("example.com", "seed"),
+          new RecordingInsertionCallback());
+      Assert.fail("Expected blank wave ref to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("Wave ref"));
+    }
   }
 
   @Test
@@ -278,6 +319,30 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentComposerController.UploadStatus.FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
     Assert.assertEquals(0, controller.getQueueSnapshot().get(0).getProgressPercent());
+  }
+
+  @Test
+  public void fileUploadUnexpectedResponseMarksItemFailedAndDoesNotInsertDocument() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "unexpected.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "stored", null));
+
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.UNEXPECTED_RESPONSE.name(),
+        controller.getQueueSnapshot().get(0).getErrorCode());
   }
 
   @Test
@@ -407,6 +472,41 @@ public class J2clAttachmentComposerControllerTest {
         controller.getQueueSnapshot().get(0).getStatus());
 
     transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals("example.com/seedB", insertionCallback.insertions.get(0).getAttachmentId());
+  }
+
+  @Test
+  public void cancelResetAllowsImmediatePasteReuseAndIgnoresLateFileCompletion() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "stale.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    controller.cancelAndReset();
+    Object pastedPayload = new Object();
+    controller.pasteImage(
+        pastedPayload,
+        "paste caption",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(1, controller.getQueueSnapshot().size());
+    Assert.assertSame(pastedPayload, transport.requests.get(1).getPart(2).getPayload());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(0).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
 
     Assert.assertEquals(1, insertionCallback.insertions.size());
     Assert.assertEquals("example.com/seedB", insertionCallback.insertions.get(0).getAttachmentId());
@@ -591,6 +691,60 @@ public class J2clAttachmentComposerControllerTest {
         controller.getQueueSnapshot().get(0).getErrorCode());
     Assert.assertTrue(
         controller.getQueueSnapshot().get(0).getErrorMessage().contains("selections"));
+    Assert.assertEquals(1, transport.requests.size());
+  }
+
+  @Test
+  public void reentrantSelectionThenThrowMarksCurrentItemAndKeepsNextUploadRunning() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ReentrantSelectingThenThrowingInsertionCallback insertionCallback =
+        new ReentrantSelectingThenThrowingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+  }
+
+  @Test
+  public void resetThenRuntimeFailureFromInsertionCallbackDropsStaleItemMutation() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ResettingThrowingInsertionCallback insertionCallback =
+        new ResettingThrowingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
     Assert.assertEquals(1, transport.requests.size());
   }
 
@@ -1022,6 +1176,46 @@ public class J2clAttachmentComposerControllerTest {
         J2clComposerDocument document,
         J2clAttachmentComposerController.AttachmentInsertion insertion) {
       controller.selectFiles(null);
+    }
+  }
+
+  private static final class ReentrantSelectingThenThrowingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private J2clAttachmentComposerController controller;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      controller.selectFiles(
+          Arrays.asList(
+              J2clAttachmentComposerController.AttachmentSelection.file(
+                  new Object(),
+                  "reentrant.png",
+                  "",
+                  J2clAttachmentComposerController.DisplaySize.SMALL)));
+      throw new IllegalStateException("boom");
+    }
+  }
+
+  private static final class ResettingThrowingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private J2clAttachmentComposerController controller;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      controller.cancelAndReset();
+      throw new IllegalStateException("boom");
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -651,6 +651,39 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void consecutiveInsertionFailuresRemainIndependent() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new AlwaysThrowingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.INSERT_FAILED_ERROR_CODE,
+        controller.getQueueSnapshot().get(1).getErrorCode());
+  }
+
+  @Test
   public void cancelResetFromInsertionCallbackClearsQueueAndDoesNotStartNextUpload() {
     FakeUploadTransport transport = new FakeUploadTransport();
     CancelingInsertionCallback insertionCallback = new CancelingInsertionCallback();
@@ -815,6 +848,32 @@ public class J2clAttachmentComposerControllerTest {
 
     Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
     Assert.assertEquals(1, transport.requests.size());
+  }
+
+  @Test
+  public void resetThenReentrantSelectionFromInsertionCallbackStartsFreshGeneration() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ResettingSelectingInsertionCallback insertionCallback =
+        new ResettingSelectingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(1, controller.getQueueSnapshot().size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(0).getStatus());
   }
 
   @Test
@@ -1311,6 +1370,33 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentComposerController.AttachmentInsertion insertion) {
       controller.cancelAndReset();
       throw new IllegalStateException("boom");
+    }
+  }
+
+  private static final class ResettingSelectingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private J2clAttachmentComposerController controller;
+    private boolean resetAndSelected;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      if (!resetAndSelected) {
+        resetAndSelected = true;
+        controller.cancelAndReset();
+        controller.selectFiles(
+            Arrays.asList(
+                J2clAttachmentComposerController.AttachmentSelection.file(
+                    new Object(),
+                    "fresh.png",
+                    "",
+                    J2clAttachmentComposerController.DisplaySize.SMALL)));
+      }
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -105,6 +105,42 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void invalidFileSelectionFactoryDoesNotQueueStartUploadOrConsumeIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    assertInvalidFileSelection(
+        null,
+        "file.png",
+        J2clAttachmentComposerController.DisplaySize.SMALL,
+        "payload");
+    assertInvalidFileSelection(
+        new Object(),
+        "   ",
+        J2clAttachmentComposerController.DisplaySize.SMALL,
+        "file name");
+    assertInvalidFileSelection(
+        new Object(),
+        "file.png",
+        null,
+        "display size");
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "valid.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+  }
+
+  @Test
   public void progressUpdatesActiveItemState() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -147,6 +183,29 @@ public class J2clAttachmentComposerControllerTest {
 
     transport.requests.get(0).getProgressCallback().onProgress(200);
 
+    Assert.assertEquals(100, controller.getQueueSnapshot().get(0).getProgressPercent());
+  }
+
+  @Test
+  public void progressAfterTerminalStatusIsIgnored() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "progress.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    transport.requests.get(0).getProgressCallback().onProgress(12);
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(0).getStatus());
     Assert.assertEquals(100, controller.getQueueSnapshot().get(0).getProgressPercent());
   }
 
@@ -369,7 +428,9 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
-    Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.INSERT_FAILED_ERROR_CODE,
+        controller.getQueueSnapshot().get(0).getErrorCode());
     Assert.assertEquals("boom", controller.getQueueSnapshot().get(0).getErrorMessage());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
@@ -381,6 +442,63 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.COMPLETE,
         controller.getQueueSnapshot().get(1).getStatus());
+  }
+
+  @Test
+  public void cancelResetFromInsertionCallbackClearsQueueAndDoesNotStartNextUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    CancelingInsertionCallback insertionCallback = new CancelingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(1, insertionCallback.insertCalls);
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertEquals(1, transport.requests.size());
+  }
+
+  @Test
+  public void reentrantSelectionFromInsertionCallbackStartsSingleNextUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ReentrantSelectingInsertionCallback insertionCallback =
+        new ReentrantSelectingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, insertionCallback.insertions.size());
+    Assert.assertEquals(2, transport.requests.size());
   }
 
   @Test
@@ -522,7 +640,9 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
-    Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.INSERT_FAILED_ERROR_CODE,
+        controller.getQueueSnapshot().get(0).getErrorCode());
     Assert.assertEquals("boom", controller.getQueueSnapshot().get(0).getErrorMessage());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
@@ -625,6 +745,26 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.UNEXPECTED_RESPONSE.name(),
+        controller.getQueueSnapshot().get(0).getErrorCode());
+  }
+
+  private static void assertInvalidFileSelection(
+      Object payload,
+      String fileName,
+      J2clAttachmentComposerController.DisplaySize displaySize,
+      String expectedMessage) {
+    try {
+      J2clAttachmentComposerController.AttachmentSelection.file(
+          payload,
+          fileName,
+          "",
+          displaySize);
+      Assert.fail("Expected invalid file selection to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains(expectedMessage));
+    }
   }
 
   private static J2clAttachmentComposerController newController(
@@ -691,6 +831,53 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentComposerController.AttachmentInsertion insertion) {
       documents.add(document);
       insertions.add(insertion);
+    }
+  }
+
+  private static final class CancelingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private J2clAttachmentComposerController controller;
+    private int insertCalls;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      insertCalls++;
+      controller.cancelAndReset();
+    }
+  }
+
+  private static final class ReentrantSelectingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private final List<J2clAttachmentComposerController.AttachmentInsertion> insertions =
+        new ArrayList<J2clAttachmentComposerController.AttachmentInsertion>();
+    private J2clAttachmentComposerController controller;
+    private boolean selectedReentrantFile;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      insertions.add(insertion);
+      if (!selectedReentrantFile) {
+        selectedReentrantFile = true;
+        controller.selectFiles(
+            Arrays.asList(
+                J2clAttachmentComposerController.AttachmentSelection.file(
+                    new Object(),
+                    "reentrant.png",
+                    "",
+                    J2clAttachmentComposerController.DisplaySize.SMALL)));
+      }
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -36,7 +36,7 @@ public class J2clAttachmentComposerControllerTest {
 
     Assert.assertEquals(1, transport.requests.size());
     Assert.assertEquals(
-        "/attachment/example.com/attachment+seedA", transport.requests.get(0).getUrl());
+        "/attachment/example.com/seedA", transport.requests.get(0).getUrl());
     Assert.assertSame(firstPayload, transport.requests.get(0).getPart(2).getPayload());
     Assert.assertEquals("first.png", transport.requests.get(0).getPart(2).getFileName());
     Assert.assertEquals(2, controller.getQueueSnapshot().size());
@@ -51,7 +51,7 @@ public class J2clAttachmentComposerControllerTest {
 
     Assert.assertEquals(2, transport.requests.size());
     Assert.assertEquals(
-        "/attachment/example.com/attachment+seedB", transport.requests.get(1).getUrl());
+        "/attachment/example.com/seedB", transport.requests.get(1).getUrl());
     Assert.assertSame(secondPayload, transport.requests.get(1).getPart(2).getPayload());
     Assert.assertEquals("second.png", transport.requests.get(1).getPart(2).getFileName());
     Assert.assertEquals(1, insertionCallback.insertions.size());
@@ -89,7 +89,7 @@ public class J2clAttachmentComposerControllerTest {
                 J2clAttachmentComposerController.DisplaySize.SMALL)));
 
     Assert.assertEquals(
-        "/attachment/example.com/attachment+seedA", transport.requests.get(0).getUrl());
+        "/attachment/example.com/seedA", transport.requests.get(0).getUrl());
   }
 
   @Test
@@ -136,6 +136,37 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void failedUploadStartsNextQueuedItem() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "broken.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "next.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(500, "nope", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+  }
+
+  @Test
   public void cancelResetClearsQueueAndIgnoresLateUploadCompletion() {
     FakeUploadTransport transport = new FakeUploadTransport();
     RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
@@ -162,6 +193,33 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void cancelResetAllowsReuseWithNextId() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "cancel.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    controller.cancelAndReset();
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "next.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertEquals(1, controller.getQueueSnapshot().size());
+  }
+
+  @Test
   public void successfulFileUploadInvokesInsertionWithCaptionFallbackAndDisplaySize() {
     FakeUploadTransport transport = new FakeUploadTransport();
     RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
@@ -181,15 +239,66 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(1, insertionCallback.insertions.size());
     J2clAttachmentComposerController.AttachmentInsertion insertion =
         insertionCallback.insertions.get(0);
-    Assert.assertEquals("example.com/attachment+seedA", insertion.getAttachmentId());
+    Assert.assertEquals("example.com/seedA", insertion.getAttachmentId());
     Assert.assertEquals("fallback.png", insertion.getCaption());
     Assert.assertEquals(
         J2clAttachmentComposerController.DisplaySize.LARGE, insertion.getDisplaySize());
     assertDocumentContainsAttachment(
         insertionCallback.documents.get(0),
-        "example.com/attachment+seedA",
+        "example.com/seedA",
         "fallback.png",
         "large");
+  }
+
+  @Test
+  public void additionalSelectionsWaitBehindActiveUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+
+    Assert.assertEquals(1, transport.requests.size());
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+  }
+
+  @Test
+  public void queueSnapshotIsReadOnly() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "snapshot.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    try {
+      controller.getQueueSnapshot().add(null);
+      Assert.fail("Expected snapshot to be immutable.");
+    } catch (UnsupportedOperationException expected) {
+      // Expected.
+    }
   }
 
   @Test
@@ -215,9 +324,65 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals("paste caption", insertionCallback.insertions.get(0).getCaption());
     assertDocumentContainsAttachment(
         insertionCallback.documents.get(0),
-        "example.com/attachment+seedA",
+        "example.com/seedA",
         "paste caption",
         "medium");
+  }
+
+  @Test
+  public void invalidPastedImageDoesNotQueueStartUploadOrConsumeIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    try {
+      controller.pasteImage(
+          null,
+          "paste caption",
+          J2clAttachmentComposerController.DisplaySize.MEDIUM);
+      Assert.fail("Expected invalid pasted image to fail.");
+    } catch (IllegalArgumentException expected) {
+      // Expected.
+    }
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
+
+    controller.pasteImage(
+        new Object(),
+        "valid paste",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+
+    Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+  }
+
+  @Test
+  public void pastedImageWaitsBehindActiveFileUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    Object pastedPayload = new Object();
+    controller.pasteImage(
+        pastedPayload,
+        "paste caption",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+
+    Assert.assertEquals(1, transport.requests.size());
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertSame(pastedPayload, transport.requests.get(1).getPart(2).getPayload());
+    Assert.assertEquals("pasted-image.png", transport.requests.get(1).getPart(2).getFileName());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -424,6 +424,33 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void synchronousUploadCompletionsDrainQueueWithoutNestedDispatch() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    List<J2clAttachmentComposerController.AttachmentSelection> selections =
+        new ArrayList<J2clAttachmentComposerController.AttachmentSelection>();
+    for (int i = 0; i < 50; i++) {
+      selections.add(
+          J2clAttachmentComposerController.AttachmentSelection.file(
+              new Object(),
+              "inline-" + i + ".png",
+              "",
+              J2clAttachmentComposerController.DisplaySize.SMALL));
+    }
+
+    controller.selectFiles(selections);
+
+    Assert.assertEquals(50, transport.requests.size());
+    Assert.assertEquals(50, insertionCallback.insertions.size());
+    Assert.assertEquals(1, transport.maxPostDepth);
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(49).getStatus());
+  }
+
+  @Test
   public void failedUploadStartsNextQueuedItem() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -1276,23 +1303,39 @@ public class J2clAttachmentComposerControllerTest {
         new ArrayList<J2clAttachmentUploadClient.MultipartUploadRequest>();
     private final List<J2clAttachmentUploadClient.ResponseHandler> handlers =
         new ArrayList<J2clAttachmentUploadClient.ResponseHandler>();
+    private J2clAttachmentUploadClient.HttpResponse inlineResponse;
     private RuntimeException nextPostFailure;
+    private int postDepth;
+    private int maxPostDepth;
 
     @Override
     public void post(
         J2clAttachmentUploadClient.MultipartUploadRequest request,
         J2clAttachmentUploadClient.ResponseHandler handler) {
-      if (nextPostFailure != null) {
-        RuntimeException failure = nextPostFailure;
-        nextPostFailure = null;
-        throw failure;
+      postDepth++;
+      maxPostDepth = Math.max(maxPostDepth, postDepth);
+      try {
+        if (nextPostFailure != null) {
+          RuntimeException failure = nextPostFailure;
+          nextPostFailure = null;
+          throw failure;
+        }
+        requests.add(request);
+        handlers.add(handler);
+        if (inlineResponse != null) {
+          handler.onResponse(inlineResponse);
+        }
+      } finally {
+        postDepth--;
       }
-      requests.add(request);
-      handlers.add(handler);
     }
 
     void failNextPost(RuntimeException failure) {
       nextPostFailure = failure;
+    }
+
+    void completePostsInline(J2clAttachmentUploadClient.HttpResponse response) {
+      inlineResponse = response;
     }
 
     void complete(int index, J2clAttachmentUploadClient.HttpResponse response) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -93,6 +93,18 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void emptySelectionListDoesNothing() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(Arrays.asList());
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
+  }
+
+  @Test
   public void progressUpdatesActiveItemState() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -110,6 +122,25 @@ public class J2clAttachmentComposerControllerTest {
     J2clAttachmentComposerController.UploadItem item = controller.getQueueSnapshot().get(0);
     Assert.assertEquals(J2clAttachmentComposerController.UploadStatus.UPLOADING, item.getStatus());
     Assert.assertEquals(47, item.getProgressPercent());
+  }
+
+  @Test
+  public void progressAfterCancelResetIsIgnored() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "progress.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    controller.cancelAndReset();
+    transport.requests.get(0).getProgressCallback().onProgress(88);
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
   }
 
   @Test
@@ -220,6 +251,42 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void staleCompletionAfterResetDoesNotAffectNewQueue() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "stale.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    controller.cancelAndReset();
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "fresh.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(1, controller.getQueueSnapshot().size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(0).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals("example.com/seedB", insertionCallback.insertions.get(0).getAttachmentId());
+  }
+
+  @Test
   public void successfulFileUploadInvokesInsertionWithCaptionFallbackAndDisplaySize() {
     FakeUploadTransport transport = new FakeUploadTransport();
     RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
@@ -248,6 +315,39 @@ public class J2clAttachmentComposerControllerTest {
         "example.com/seedA",
         "fallback.png",
         "large");
+  }
+
+  @Test
+  public void insertionCallbackFailureStillStartsNextUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ThrowingThenRecordingInsertionCallback insertionCallback =
+        new ThrowingThenRecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    try {
+      transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+      Assert.fail("Expected insertion callback failure.");
+    } catch (IllegalStateException expected) {
+      // Expected.
+    }
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
   }
 
   @Test
@@ -330,6 +430,23 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void pastedImageBlankCaptionFallsBackToPastedImageFilename() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.pasteImage(new Object(), "   ", J2clAttachmentComposerController.DisplaySize.SMALL);
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
+
+    Assert.assertEquals("pasted-image.png", insertionCallback.insertions.get(0).getCaption());
+    assertDocumentContainsAttachment(
+        insertionCallback.documents.get(0),
+        "example.com/seedA",
+        "pasted-image.png",
+        "small");
+  }
+
+  @Test
   public void invalidPastedImageDoesNotQueueStartUploadOrConsumeIds() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -404,7 +521,8 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   private static J2clAttachmentComposerController newController(
-      FakeUploadTransport transport, RecordingInsertionCallback insertionCallback) {
+      FakeUploadTransport transport,
+      J2clAttachmentComposerController.DocumentInsertionCallback insertionCallback) {
     return new J2clAttachmentComposerController(
         WAVE_REF,
         new J2clAttachmentUploadClient(transport),
@@ -466,6 +584,21 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentComposerController.AttachmentInsertion insertion) {
       documents.add(document);
       insertions.add(insertion);
+    }
+  }
+
+  private static final class ThrowingThenRecordingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private boolean shouldThrow = true;
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new IllegalStateException("boom");
+      }
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -451,6 +451,38 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void synchronousUploadStartFailureContinuesInlineDrain() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.failNextPost(new IllegalStateException("transport unavailable"));
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals(1, transport.maxPostDepth);
+  }
+
+  @Test
   public void failedUploadStartsNextQueuedItem() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -804,6 +836,31 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void reentrantSelectionDuringSynchronousDrainStartsAfterCurrentPostReturns() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    ReentrantSelectingInsertionCallback insertionCallback =
+        new ReentrantSelectingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(2, insertionCallback.insertions.size());
+    Assert.assertEquals(1, transport.maxPostDepth);
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(1).getStatus());
+  }
+
+  @Test
   public void reentrantPasteFromInsertionCallbackStartsSingleNextUpload() {
     FakeUploadTransport transport = new FakeUploadTransport();
     ReentrantPastingInsertionCallback insertionCallback = new ReentrantPastingInsertionCallback();
@@ -937,6 +994,33 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
         controller.getQueueSnapshot().get(0).getStatus());
+  }
+
+  @Test
+  public void cancelResetDuringSynchronousDrainClearsQueueAndStopsDrain() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.completePostsInline(new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    CancelingInsertionCallback insertionCallback = new CancelingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(1, insertionCallback.insertCalls);
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertEquals(1, transport.maxPostDepth);
   }
 
   @Test
@@ -1303,6 +1387,7 @@ public class J2clAttachmentComposerControllerTest {
         new ArrayList<J2clAttachmentUploadClient.MultipartUploadRequest>();
     private final List<J2clAttachmentUploadClient.ResponseHandler> handlers =
         new ArrayList<J2clAttachmentUploadClient.ResponseHandler>();
+    // When set, post() completes uploads before returning to simulate browser/client fakes.
     private J2clAttachmentUploadClient.HttpResponse inlineResponse;
     private RuntimeException nextPostFailure;
     private int postDepth;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -388,6 +388,42 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void synchronousFileUploadStartFailureMarksFailedAndStartsNextQueuedItem() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.failNextPost(new IllegalStateException("transport unavailable"));
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(1, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.NETWORK.name(),
+        controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals(
+        "transport unavailable",
+        controller.getQueueSnapshot().get(0).getErrorMessage());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(0).getUrl());
+  }
+
+  @Test
   public void failedUploadStartsNextQueuedItem() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -1160,6 +1196,31 @@ public class J2clAttachmentComposerControllerTest {
         controller.getQueueSnapshot().get(0).getErrorCode());
   }
 
+  @Test
+  public void synchronousPastedImageUploadStartFailureMarksFailed() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    transport.failNextPost(new IllegalStateException("transport unavailable"));
+    RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.pasteImage(
+        new Object(),
+        "paste caption",
+        J2clAttachmentComposerController.DisplaySize.MEDIUM);
+
+    Assert.assertTrue(transport.requests.isEmpty());
+    Assert.assertTrue(insertionCallback.insertions.isEmpty());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentUploadClient.ErrorType.NETWORK.name(),
+        controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals(
+        "transport unavailable",
+        controller.getQueueSnapshot().get(0).getErrorMessage());
+  }
+
   private static void assertInvalidFileSelection(
       Object payload,
       String fileName,
@@ -1215,13 +1276,23 @@ public class J2clAttachmentComposerControllerTest {
         new ArrayList<J2clAttachmentUploadClient.MultipartUploadRequest>();
     private final List<J2clAttachmentUploadClient.ResponseHandler> handlers =
         new ArrayList<J2clAttachmentUploadClient.ResponseHandler>();
+    private RuntimeException nextPostFailure;
 
     @Override
     public void post(
         J2clAttachmentUploadClient.MultipartUploadRequest request,
         J2clAttachmentUploadClient.ResponseHandler handler) {
+      if (nextPostFailure != null) {
+        RuntimeException failure = nextPostFailure;
+        nextPostFailure = null;
+        throw failure;
+      }
       requests.add(request);
       handlers.add(handler);
+    }
+
+    void failNextPost(RuntimeException failure) {
+      nextPostFailure = failure;
     }
 
     void complete(int index, J2clAttachmentUploadClient.HttpResponse response) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -141,6 +141,28 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void fileSelectionAndWaveRefWhitespaceIsTrimmedBeforeUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        new J2clAttachmentComposerController(
+            "  " + WAVE_REF + "  ",
+            new J2clAttachmentUploadClient(transport),
+            new J2clAttachmentIdGenerator("example.com", "seed"),
+            new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "  spaced.png  ",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(WAVE_REF, transport.requests.get(0).getPart(1).getStringValue());
+    Assert.assertEquals("spaced.png", transport.requests.get(0).getPart(2).getFileName());
+  }
+
+  @Test
   public void progressUpdatesActiveItemState() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -249,6 +271,13 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentUploadClient.ErrorType.HTTP_STATUS.name(), item.getErrorCode());
     Assert.assertTrue(item.getErrorMessage().contains("HTTP 500"));
     Assert.assertTrue(insertionCallback.insertions.isEmpty());
+
+    transport.requests.get(0).getProgressCallback().onProgress(88);
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(0, controller.getQueueSnapshot().get(0).getProgressPercent());
   }
 
   @Test
@@ -333,6 +362,18 @@ public class J2clAttachmentComposerControllerTest {
     Assert.assertEquals(2, transport.requests.size());
     Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
     Assert.assertEquals(1, controller.getQueueSnapshot().size());
+  }
+
+  @Test
+  public void cancelResetWhileIdleIsNoOp() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.cancelAndReset();
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
   }
 
   @Test
@@ -445,6 +486,29 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void progressAfterInsertFailedStatusIsIgnored() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new AlwaysThrowingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+    transport.requests.get(0).getProgressCallback().onProgress(12);
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(100, controller.getQueueSnapshot().get(0).getProgressPercent());
+  }
+
+  @Test
   public void cancelResetFromInsertionCallbackClearsQueueAndDoesNotStartNextUpload() {
     FakeUploadTransport transport = new FakeUploadTransport();
     CancelingInsertionCallback insertionCallback = new CancelingInsertionCallback();
@@ -499,6 +563,70 @@ public class J2clAttachmentComposerControllerTest {
 
     Assert.assertEquals(2, insertionCallback.insertions.size());
     Assert.assertEquals(2, transport.requests.size());
+  }
+
+  @Test
+  public void invalidReentrantSelectionFromInsertionCallbackMarksCurrentItemInsertFailed() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    InvalidReentrantSelectingInsertionCallback insertionCallback =
+        new InvalidReentrantSelectingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+    insertionCallback.setController(controller);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.INSERT_FAILED_ERROR_CODE,
+        controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertTrue(
+        controller.getQueueSnapshot().get(0).getErrorMessage().contains("selections"));
+    Assert.assertEquals(1, transport.requests.size());
+  }
+
+  @Test
+  public void insertionCallbackErrorPropagatesAfterStartingNextQueuedUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ErrorThrowingInsertionCallback insertionCallback = new ErrorThrowingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL),
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    try {
+      transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+      Assert.fail("Expected insertion callback error to propagate.");
+    } catch (AssertionError expected) {
+      Assert.assertEquals("fatal", expected.getMessage());
+    }
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
   }
 
   @Test
@@ -878,6 +1006,42 @@ public class J2clAttachmentComposerControllerTest {
                     "",
                     J2clAttachmentComposerController.DisplaySize.SMALL)));
       }
+    }
+  }
+
+  private static final class InvalidReentrantSelectingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private J2clAttachmentComposerController controller;
+
+    private void setController(J2clAttachmentComposerController controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      controller.selectFiles(null);
+    }
+  }
+
+  private static final class AlwaysThrowingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      throw new IllegalStateException("boom");
+    }
+  }
+
+  private static final class ErrorThrowingInsertionCallback
+      implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    @Override
+    public void onInsert(
+        J2clComposerDocument document,
+        J2clAttachmentComposerController.AttachmentInsertion insertion) {
+      throw new AssertionError("fatal");
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -125,6 +125,28 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void progressIsClampedToValidPercentRange() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "progress.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.MEDIUM)));
+    transport.requests.get(0).getProgressCallback().onProgress(-3);
+
+    Assert.assertEquals(0, controller.getQueueSnapshot().get(0).getProgressPercent());
+
+    transport.requests.get(0).getProgressCallback().onProgress(200);
+
+    Assert.assertEquals(100, controller.getQueueSnapshot().get(0).getProgressPercent());
+  }
+
+  @Test
   public void progressAfterCancelResetIsIgnored() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -402,6 +424,30 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void queueSnapshotItemsAreValueSnapshots() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "snapshot.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    List<J2clAttachmentComposerController.UploadItem> snapshot = controller.getQueueSnapshot();
+
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING, snapshot.get(0).getStatus());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
+        controller.getQueueSnapshot().get(0).getStatus());
+  }
+
+  @Test
   public void pastedImageUploadCapturesIntentAndMutatesOnlyAfterSuccess() {
     FakeUploadTransport transport = new FakeUploadTransport();
     RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
@@ -447,6 +493,29 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void insertionCallbackFailureOnPasteStillStartsNextUpload() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    ThrowingThenRecordingInsertionCallback insertionCallback =
+        new ThrowingThenRecordingInsertionCallback();
+    J2clAttachmentComposerController controller = newController(transport, insertionCallback);
+
+    controller.pasteImage(new Object(), "first", J2clAttachmentComposerController.DisplaySize.SMALL);
+    controller.pasteImage(new Object(), "second", J2clAttachmentComposerController.DisplaySize.SMALL);
+
+    try {
+      transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
+      Assert.fail("Expected insertion callback failure.");
+    } catch (IllegalStateException expected) {
+      // Expected.
+    }
+
+    Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+  }
+
+  @Test
   public void invalidPastedImageDoesNotQueueStartUploadOrConsumeIds() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =
@@ -471,6 +540,23 @@ public class J2clAttachmentComposerControllerTest {
         J2clAttachmentComposerController.DisplaySize.MEDIUM);
 
     Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+  }
+
+  @Test
+  public void invalidPastedImageDisplaySizeDoesNotQueueStartUploadOrConsumeIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    try {
+      controller.pasteImage(new Object(), null, null);
+      Assert.fail("Expected invalid pasted image display size to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("display size"));
+    }
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -58,6 +58,41 @@ public class J2clAttachmentComposerControllerTest {
   }
 
   @Test
+  public void invalidSelectionBatchDoesNotPartiallyQueueOrConsumeIds() {
+    FakeUploadTransport transport = new FakeUploadTransport();
+    J2clAttachmentComposerController controller =
+        newController(transport, new RecordingInsertionCallback());
+
+    try {
+      controller.selectFiles(
+          Arrays.asList(
+              J2clAttachmentComposerController.AttachmentSelection.file(
+                  new Object(),
+                  "partial.png",
+                  "",
+                  J2clAttachmentComposerController.DisplaySize.SMALL),
+              null));
+      Assert.fail("Expected invalid selection batch to fail.");
+    } catch (IllegalArgumentException expected) {
+      // Expected.
+    }
+
+    Assert.assertTrue(controller.getQueueSnapshot().isEmpty());
+    Assert.assertTrue(transport.requests.isEmpty());
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "next.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(
+        "/attachment/example.com/attachment+seedA", transport.requests.get(0).getUrl());
+  }
+
+  @Test
   public void progressUpdatesActiveItemState() {
     FakeUploadTransport transport = new FakeUploadTransport();
     J2clAttachmentComposerController controller =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -122,6 +122,10 @@ public class J2clAttachmentComposerControllerTest {
     J2clAttachmentComposerController.UploadItem item = controller.getQueueSnapshot().get(0);
     Assert.assertEquals(J2clAttachmentComposerController.UploadStatus.UPLOADING, item.getStatus());
     Assert.assertEquals(47, item.getProgressPercent());
+
+    transport.requests.get(0).getProgressCallback().onProgress(68);
+
+    Assert.assertEquals(68, controller.getQueueSnapshot().get(0).getProgressPercent());
   }
 
   @Test
@@ -342,8 +346,8 @@ public class J2clAttachmentComposerControllerTest {
   @Test
   public void insertionCallbackFailureStillStartsNextUpload() {
     FakeUploadTransport transport = new FakeUploadTransport();
-    ThrowingThenRecordingInsertionCallback insertionCallback =
-        new ThrowingThenRecordingInsertionCallback();
+    OneShotThrowingInsertionCallback insertionCallback =
+        new OneShotThrowingInsertionCallback();
     J2clAttachmentComposerController controller = newController(transport, insertionCallback);
 
     controller.selectFiles(
@@ -367,6 +371,10 @@ public class J2clAttachmentComposerControllerTest {
     }
 
     Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
         controller.getQueueSnapshot().get(1).getStatus());
@@ -495,8 +503,8 @@ public class J2clAttachmentComposerControllerTest {
   @Test
   public void insertionCallbackFailureOnPasteStillStartsNextUpload() {
     FakeUploadTransport transport = new FakeUploadTransport();
-    ThrowingThenRecordingInsertionCallback insertionCallback =
-        new ThrowingThenRecordingInsertionCallback();
+    OneShotThrowingInsertionCallback insertionCallback =
+        new OneShotThrowingInsertionCallback();
     J2clAttachmentComposerController controller = newController(transport, insertionCallback);
 
     controller.pasteImage(new Object(), "first", J2clAttachmentComposerController.DisplaySize.SMALL);
@@ -510,6 +518,10 @@ public class J2clAttachmentComposerControllerTest {
     }
 
     Assert.assertEquals(2, transport.requests.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
+        controller.getQueueSnapshot().get(0).getStatus());
+    Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
         controller.getQueueSnapshot().get(1).getStatus());
@@ -673,7 +685,7 @@ public class J2clAttachmentComposerControllerTest {
     }
   }
 
-  private static final class ThrowingThenRecordingInsertionCallback
+  private static final class OneShotThrowingInsertionCallback
       implements J2clAttachmentComposerController.DocumentInsertionCallback {
     private boolean shouldThrow = true;
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentComposerControllerTest.java
@@ -363,20 +363,23 @@ public class J2clAttachmentComposerControllerTest {
                 "",
                 J2clAttachmentComposerController.DisplaySize.SMALL)));
 
-    try {
-      transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
-      Assert.fail("Expected insertion callback failure.");
-    } catch (IllegalStateException expected) {
-      // Expected.
-    }
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
 
     Assert.assertEquals(2, transport.requests.size());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
     Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals("boom", controller.getQueueSnapshot().get(0).getErrorMessage());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(200, "OK", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
         controller.getQueueSnapshot().get(1).getStatus());
   }
 
@@ -489,7 +492,10 @@ public class J2clAttachmentComposerControllerTest {
     RecordingInsertionCallback insertionCallback = new RecordingInsertionCallback();
     J2clAttachmentComposerController controller = newController(transport, insertionCallback);
 
-    controller.pasteImage(new Object(), "   ", J2clAttachmentComposerController.DisplaySize.SMALL);
+    controller.pasteImage(
+        new Object(),
+        "   ",
+        J2clAttachmentComposerController.DisplaySize.SMALL);
     transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
 
     Assert.assertEquals("pasted-image.png", insertionCallback.insertions.get(0).getCaption());
@@ -510,20 +516,23 @@ public class J2clAttachmentComposerControllerTest {
     controller.pasteImage(new Object(), "first", J2clAttachmentComposerController.DisplaySize.SMALL);
     controller.pasteImage(new Object(), "second", J2clAttachmentComposerController.DisplaySize.SMALL);
 
-    try {
-      transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
-      Assert.fail("Expected insertion callback failure.");
-    } catch (IllegalStateException expected) {
-      // Expected.
-    }
+    transport.complete(0, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
 
     Assert.assertEquals(2, transport.requests.size());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.INSERT_FAILED,
         controller.getQueueSnapshot().get(0).getStatus());
     Assert.assertEquals("INSERTION", controller.getQueueSnapshot().get(0).getErrorCode());
+    Assert.assertEquals("boom", controller.getQueueSnapshot().get(0).getErrorMessage());
     Assert.assertEquals(
         J2clAttachmentComposerController.UploadStatus.UPLOADING,
+        controller.getQueueSnapshot().get(1).getStatus());
+
+    transport.complete(1, new J2clAttachmentUploadClient.HttpResponse(201, "stored", null));
+
+    Assert.assertEquals(1, insertionCallback.insertions.size());
+    Assert.assertEquals(
+        J2clAttachmentComposerController.UploadStatus.COMPLETE,
         controller.getQueueSnapshot().get(1).getStatus());
   }
 
@@ -687,6 +696,8 @@ public class J2clAttachmentComposerControllerTest {
 
   private static final class OneShotThrowingInsertionCallback
       implements J2clAttachmentComposerController.DocumentInsertionCallback {
+    private final List<J2clAttachmentComposerController.AttachmentInsertion> insertions =
+        new ArrayList<J2clAttachmentComposerController.AttachmentInsertion>();
     private boolean shouldThrow = true;
 
     @Override
@@ -697,6 +708,7 @@ public class J2clAttachmentComposerControllerTest {
         shouldThrow = false;
         throw new IllegalStateException("boom");
       }
+      insertions.add(insertion);
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
@@ -1,0 +1,48 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clAttachmentIdGeneratorTest.class)
+public class J2clAttachmentIdGeneratorTest {
+  @Test
+  public void generatesLegacyCompatibleDomainAndSeedTokens() {
+    J2clAttachmentIdGenerator generator = new J2clAttachmentIdGenerator("example.com", "seed");
+
+    Assert.assertEquals("example.com/seedA", generator.nextAttachmentId());
+    Assert.assertEquals("example.com/seedB", generator.nextAttachmentId());
+  }
+
+  @Test
+  public void stripsUnsafeSeedCharacters() {
+    J2clAttachmentIdGenerator generator =
+        new J2clAttachmentIdGenerator("example.com", " se/ed:+ok_- ");
+
+    Assert.assertEquals("example.com/seedok_-A", generator.nextAttachmentId());
+  }
+
+  @Test
+  public void defaultsEmptySeedToJ2cl() {
+    J2clAttachmentIdGenerator generator = new J2clAttachmentIdGenerator("example.com", " /:+ ");
+
+    Assert.assertEquals("example.com/j2clA", generator.nextAttachmentId());
+  }
+
+  @Test
+  public void encodesBase64Boundaries() {
+    assertIdAtCounter(0, "example.com/seedA");
+    assertIdAtCounter(62, "example.com/seed-");
+    assertIdAtCounter(63, "example.com/seed_");
+    assertIdAtCounter(64, "example.com/seedBA");
+    assertIdAtCounter(4095, "example.com/seed__");
+  }
+
+  private static void assertIdAtCounter(int targetIndex, String expectedId) {
+    J2clAttachmentIdGenerator generator = new J2clAttachmentIdGenerator("example.com", "seed");
+    for (int i = 0; i < targetIndex; i++) {
+      generator.nextAttachmentId();
+    }
+    Assert.assertEquals(expectedId, generator.nextAttachmentId());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
@@ -30,6 +30,13 @@ public class J2clAttachmentIdGeneratorTest {
   }
 
   @Test
+  public void defaultsNullSeedToJ2cl() {
+    J2clAttachmentIdGenerator generator = new J2clAttachmentIdGenerator("example.com", null);
+
+    Assert.assertEquals("example.com/j2clA", generator.nextAttachmentId());
+  }
+
+  @Test
   public void rejectsDomainContainingAttachmentSeparator() {
     try {
       new J2clAttachmentIdGenerator("example.com/bad", "seed");
@@ -56,6 +63,21 @@ public class J2clAttachmentIdGeneratorTest {
     assertIdAtCounter(63, "example.com/seed_");
     assertIdAtCounter(64, "example.com/seedBA");
     assertIdAtCounter(4095, "example.com/seed__");
+  }
+
+  @Test
+  public void throwsOnCounterOverflow() {
+    J2clAttachmentIdGenerator generator =
+        new J2clAttachmentIdGenerator("example.com", "seed", Integer.MAX_VALUE);
+
+    Assert.assertEquals("example.com/seedB_____", generator.nextAttachmentId());
+
+    try {
+      generator.nextAttachmentId();
+      Assert.fail("Expected counter overflow to fail.");
+    } catch (IllegalStateException expected) {
+      Assert.assertTrue(expected.getMessage().contains("overflow"));
+    }
   }
 
   private static void assertIdAtCounter(int targetIndex, String expectedId) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
@@ -40,6 +40,16 @@ public class J2clAttachmentIdGeneratorTest {
   }
 
   @Test
+  public void rejectsNullDomain() {
+    try {
+      new J2clAttachmentIdGenerator(null, "seed");
+      Assert.fail("Expected null domain to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("domain"));
+    }
+  }
+
+  @Test
   public void encodesBase64Boundaries() {
     assertIdAtCounter(0, "example.com/seedA");
     assertIdAtCounter(62, "example.com/seed-");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentIdGeneratorTest.java
@@ -30,6 +30,16 @@ public class J2clAttachmentIdGeneratorTest {
   }
 
   @Test
+  public void rejectsDomainContainingAttachmentSeparator() {
+    try {
+      new J2clAttachmentIdGenerator("example.com/bad", "seed");
+      Assert.fail("Expected invalid domain to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("domain"));
+    }
+  }
+
+  @Test
   public void encodesBase64Boundaries() {
     assertIdAtCounter(0, "example.com/seedA");
     assertIdAtCounter(62, "example.com/seed-");


### PR DESCRIPTION
Part of #971. Implements Task 4 from `docs/superpowers/plans/2026-04-23-issue-971-rich-edit-attachments.md`.

Summary:
- Adds `J2clAttachmentComposerController` for file and pasted-image attachment selection, queueing, progress, cancellation/reset, and insertion callbacks.
- Adds `J2clAttachmentIdGenerator` with legacy-compatible `domain/seedToken` ids and validation.
- Keeps this slice UI-framework-neutral; Lit wiring remains a later task.
- Releases original file/blob payload references once an upload reaches a terminal or stale-completion path while preserving visible queue metadata.

Verification:
- `cd j2cl && ./mvnw -Dtest=J2clAttachmentComposerControllerTest,J2clAttachmentIdGeneratorTest,J2clAttachmentUploadClientTest,J2clAttachmentMetadataClientTest,J2clRichContentDeltaFactoryTest,J2clPlainTextDeltaFactoryTest test` — 100 tests, 0 failures.
- `cd j2cl && ./mvnw test` — 453 tests, 0 failures, 61 skipped.
- `git diff --check origin/main..HEAD` — passed.

Review:
- Self-review completed during the round-5 through round-12 fix loop.
- Claude review round 12 approved with no blockers.
- Final review output: `/tmp/issue-971-task4-attachment-composer-claude-round12.out`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment uploads in composer (file select + image paste) processed sequentially with automatic start, insertion into composer, and deterministic attachment IDs.
  * Captions default to trimmed filenames when blank; display-size options supported.

* **Bug Fixes**
  * Progress clamped to 0–100% and late callbacks ignored after cancel/reset.
  * Per-item error reporting: upload/insert failures marked and queue continues.

* **Tests**
  * Added comprehensive end-to-end tests covering enqueueing, progress, paste uploads, insertion, validation, cancel/reset, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->