### PR TITLE
Fix signed-out Android GWT startup

### DIFF
--- a/wave/config/changelog.d/2026-04-25-android-gwt-topbarless-startup.json
+++ b/wave/config/changelog.d/2026-04-25-android-gwt-topbarless-startup.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-android-gwt-topbarless-startup",
+  "version": "Issue #1019",
+  "date": "2026-04-25",
+  "title": "Fix Android wave loading when the topbar is absent",
+  "summary": "The legacy GWT wave client now finishes booting when server-rendered topbar controls such as the language selector are not present.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Opening SupaWave on Android no longer gets stuck on the wave-list skeleton because the GWT client skips optional topbar wiring when those controls are absent."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -212,11 +212,13 @@ public class WaveClientServlet extends HttpServlet {
     response.setCharacterEncoding("UTF-8");
     response.setStatus(HttpServletResponse.SC_OK);
     try (var w = response.getWriter()) {
-      String topBarHtml = "";
+      String username = null;
+      String userDomain = null;
+      String userRole = null;
       if (id != null) {
-        String username = id.getAddress().split("@")[0];
-        String userDomain = id.getDomain();
-        String userRole = HumanAccountData.ROLE_USER;
+        username = id.getAddress().split("@")[0];
+        userDomain = id.getDomain();
+        userRole = HumanAccountData.ROLE_USER;
         try {
           AccountData acctData = accountStore.getAccount(id);
           if (acctData != null && acctData.isHuman()) {
@@ -225,8 +227,9 @@ public class WaveClientServlet extends HttpServlet {
         } catch (Exception e) {
           LOG.warning("Failed to look up role for " + id.getAddress(), e);
         }
-        topBarHtml = HtmlRenderer.renderTopBar(username, userDomain, userRole);
       }
+      // renderTopBar accepts a null username and emits the signed-out auth shell.
+      String topBarHtml = HtmlRenderer.renderTopBar(username, userDomain, userRole);
 
       // Keep the legacy rollback path on the existing skeleton load until the
       // server-side pre-rendered fragment has an explicit sanitization boundary.

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
@@ -450,7 +450,8 @@ public class WebClient implements EntryPoint {
     currentWebSocket = websocket;
     websocket.connect();
 
-    if (Session.get().isLoggedIn()) {
+    boolean loggedIn = Session.get().isLoggedIn();
+    if (loggedIn) {
       loggedInUser = new ParticipantId(Session.get().getAddress());
       idGenerator = ClientIdGenerator.create();
       loginToServer();
@@ -462,8 +463,10 @@ public class WebClient implements EntryPoint {
     setupUi();
     setupStatistics();
 
-    restoreLastWaveFromStorage();
-    History.fireCurrentHistoryState();
+    if (loggedIn) {
+      restoreLastWaveFromStorage();
+      History.fireCurrentHistoryState();
+    }
     LOG.info("SimpleWebClient.onModuleLoad() done");
 
     // Export JSNI function for creating direct waves from profile card popup
@@ -611,7 +614,10 @@ public class WebClient implements EntryPoint {
     // Hide the frame until waves start getting opened.
     UIObject.setVisible(waveFrame.getElement(), false);
 
-    Document.get().getElementById("signout").setInnerText(messages.signout());
+    Element signout = Document.get().getElementById("signout");
+    if (signout != null) {
+      signout.setInnerText(messages.signout());
+    }
 
     // Handles opening waves.
     ClientEvents.get().addWaveSelectionEventHandler(new WaveSelectionEventHandler() {
@@ -624,6 +630,9 @@ public class WebClient implements EntryPoint {
 
   private void setupLocaleSelect() {
     final SelectElement select = (SelectElement) Document.get().getElementById("lang");
+    if (select == null) {
+      return;
+    }
     final com.google.gwt.dom.client.Element langCodeBadge =
         Document.get().getElementById("langCode");
     String currentLocale = LocaleInfo.getCurrentLocale().getLocaleName();
@@ -835,6 +844,10 @@ public class WebClient implements EntryPoint {
    */
   private void openWave(WaveRef waveRef, boolean isNewWave, boolean isDirectMessage,
       Set<ParticipantId> participants) {
+    if (channel == null || idGenerator == null) {
+      LOG.info("Ignoring wave open request before login is complete");
+      return;
+    }
     final org.waveprotocol.box.stat.Timer timer = Timing.startRequest("Open Wave");
     LOG.info("WebClient.openWave()");
     String selectedToken = GwtWaverefEncoder.encodeToUriPathSegment(waveRef);

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -115,6 +115,28 @@ public final class WaveClientServletJ2clBootstrapTest {
   }
 
   @Test
+  public void signedOutLegacyRootStillRendersTopbarShell() throws Exception {
+    WaveClientServlet servlet = createServlet(null, false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getContextPath()).thenReturn("");
+    when(request.getSession(false)).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("<div class=\"topbar\">"));
+    assertTrue(html.contains("id=\"banner\""));
+    assertTrue(html.contains("href=\"/auth/register\""));
+    assertTrue(html.contains("href=\"/auth/signin?r=/\""));
+    assertFalse(html.contains("id=\"lang\""));
+    assertFalse(html.contains("id=\"signout\""));
+  }
+
+  @Test
   public void signedOutPlainRootBootsIntoJ2clShellWhenBootstrapFlagIsOn() throws Exception {
     WaveClientServlet servlet = createServlet(null, true);
     HttpServletRequest request = mock(HttpServletRequest.class);

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -265,6 +265,31 @@ public final class ToolbarLayoutContractTest extends TestCase {
         "<path d=\\\"M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7z\\\"></path>"));
   }
 
+  public void testWebClientLocaleSelectorDoesNotBlockTopbarlessStartup() throws Exception {
+    String javaSource = read(
+        "wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java");
+
+    assertTrue(javaSource.contains("boolean loggedIn = Session.get().isLoggedIn();"));
+    assertTrue(javaSource.contains("if (loggedIn) {"));
+    assertTrue(javaSource.indexOf("if (loggedIn) {", javaSource.indexOf("setupStatistics();"))
+        < javaSource.indexOf("restoreLastWaveFromStorage();"));
+    assertTrue(javaSource.indexOf("restoreLastWaveFromStorage();")
+        < javaSource.indexOf("History.fireCurrentHistoryState();"));
+    assertTrue(javaSource.contains("if (channel == null || idGenerator == null) {"));
+    assertTrue(javaSource.contains("LOG.info(\"Ignoring wave open request before login is complete\")"));
+    assertTrue(javaSource.indexOf("if (channel == null || idGenerator == null) {")
+        < javaSource.indexOf("Timing.startRequest(\"Open Wave\")"));
+    assertTrue(javaSource.contains("final SelectElement select = (SelectElement)"));
+    assertTrue(javaSource.contains("if (select == null) {"));
+    assertTrue(javaSource.contains("return;"));
+    assertTrue(javaSource.indexOf("if (select == null) {")
+        < javaSource.indexOf("select.add(option, null);"));
+    assertTrue(javaSource.contains("Element signout = Document.get().getElementById(\"signout\");"));
+    assertTrue(javaSource.contains("if (signout != null) {"));
+    assertTrue(javaSource.indexOf("if (signout != null) {")
+        < javaSource.indexOf("signout.setInnerText(messages.signout());"));
+  }
+
   private static String read(String relativePath) throws IOException {
     return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/ToolbarLayoutContractTest.java
@@ -280,10 +280,14 @@ public final class ToolbarLayoutContractTest extends TestCase {
     assertTrue(javaSource.indexOf("if (channel == null || idGenerator == null) {")
         < javaSource.indexOf("Timing.startRequest(\"Open Wave\")"));
     assertTrue(javaSource.contains("final SelectElement select = (SelectElement)"));
-    assertTrue(javaSource.contains("if (select == null) {"));
-    assertTrue(javaSource.contains("return;"));
-    assertTrue(javaSource.indexOf("if (select == null) {")
-        < javaSource.indexOf("select.add(option, null);"));
+    int selectNullGuardIndex = javaSource.indexOf("if (select == null) {");
+    int selectNullReturnIndex = javaSource.indexOf("return;", selectNullGuardIndex);
+    int selectAddIndex = javaSource.indexOf("select.add(option, null);");
+    assertTrue(selectNullGuardIndex != -1);
+    assertTrue(selectNullReturnIndex != -1);
+    assertTrue(selectAddIndex != -1);
+    assertTrue(selectNullGuardIndex < selectNullReturnIndex);
+    assertTrue(selectNullReturnIndex < selectAddIndex);
     assertTrue(javaSource.contains("Element signout = Document.get().getElementById(\"signout\");"));
     assertTrue(javaSource.contains("if (signout != null) {"));
     assertTrue(javaSource.indexOf("if (signout != null) {")


### PR DESCRIPTION
Fixes #1019

## Summary
- Render the signed-out topbar/banner/auth shell for the legacy GWT root instead of leaving the page topbarless.
- Treat legacy topbar controls as optional in GWT startup so missing `#lang` / `#signout` does not abort module load.
- Skip selected-wave history replay while signed out and guard `openWave` before channel/id-generator initialization.
- Add a changelog fragment for the Android skeleton-load fix.

## Verification
- `sbt -batch "testOnly org.waveprotocol.box.server.rpc.WaveClientServletJ2clBootstrapTest org.waveprotocol.box.server.util.ToolbarLayoutContractTest"` -> PASS, 29 tests.
- `python3 scripts/validate-changelog.py && git diff --check` -> PASS.
- `sbt -batch compileGwt` -> PASS.
- Mobile browser sanity using production Android HTML shape plus local compiled `/webclient` assets -> PASS: no pageerror, skeleton removed, no error banner.

## Review
- Claude Code Opus review round 1 found no blockers and requested hardening later signed-out hash opens.
- Follow-up added the `openWave` guard and tightened servlet assertions.
- Claude Code Opus review round 2: no blockers, LGTM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android wave loading stalling at skeleton state for legacy GWT client when server-rendered topbar controls are unavailable
  * Enhanced initialization flow to gracefully handle missing optional UI elements like language selector and signout controls

* **Tests**
  * Added test coverage for signed-out initialization scenarios
  * Introduced contract tests validating initialization sequencing and proper handling of optional UI components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->