### PR TITLE
Fix J2CL attachment ID reuse across waves

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1,7 +1,9 @@
 package org.waveprotocol.box.j2cl.compose;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentComposerController;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentIdGenerator;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentUploadClient;
@@ -79,6 +81,10 @@ public final class J2clComposeSurfaceController {
         String domain,
         J2clAttachmentComposerController.DocumentInsertionCallback insertionCallback,
         J2clAttachmentComposerController.StateChangeCallback stateChangeCallback);
+  }
+
+  interface AttachmentUploadClientFactory {
+    J2clAttachmentUploadClient create();
   }
 
   public static final class AttachmentFileSelection {
@@ -743,13 +749,45 @@ public final class J2clComposeSurfaceController {
   }
 
   public static AttachmentControllerFactory attachmentControllerFactory(String sessionSeed) {
-    return (waveRef, domain, insertionCallback, stateChangeCallback) ->
-        new J2clAttachmentComposerController(
-            waveRef,
-            new J2clAttachmentUploadClient(),
-            new J2clAttachmentIdGenerator(domain, sessionSeed),
-            insertionCallback,
-            stateChangeCallback);
+    return attachmentControllerFactory(sessionSeed, () -> new J2clAttachmentUploadClient());
+  }
+
+  static AttachmentControllerFactory attachmentControllerFactory(
+      String sessionSeed, J2clAttachmentUploadClient uploadClient) {
+    // Test seam: reuse one injected client so tests can observe all generated upload requests.
+    J2clAttachmentUploadClient client =
+        requirePresent(uploadClient, "Attachment upload client is required.");
+    return attachmentControllerFactory(sessionSeed, () -> client);
+  }
+
+  static AttachmentControllerFactory attachmentControllerFactory(
+      String sessionSeed, AttachmentUploadClientFactory uploadClientFactory) {
+    AttachmentUploadClientFactory clientFactory =
+        requirePresent(uploadClientFactory, "Attachment upload client factory is required.");
+    Map<String, J2clAttachmentIdGenerator> idGeneratorsByDomain =
+        new HashMap<String, J2clAttachmentIdGenerator>();
+    return (waveRef, domain, insertionCallback, stateChangeCallback) -> {
+      J2clAttachmentIdGenerator idGenerator =
+          attachmentIdGeneratorForDomain(idGeneratorsByDomain, domain, sessionSeed);
+      J2clAttachmentUploadClient uploadClient =
+          requirePresent(clientFactory.create(), "Attachment upload client is required.");
+      return new J2clAttachmentComposerController(
+          waveRef, uploadClient, idGenerator, insertionCallback, stateChangeCallback);
+    };
+  }
+
+  private static J2clAttachmentIdGenerator attachmentIdGeneratorForDomain(
+      Map<String, J2clAttachmentIdGenerator> idGeneratorsByDomain,
+      String domain,
+      String sessionSeed) {
+    // Cache by the same trimmed domain that the generator uses for legacy id shape.
+    String normalizedDomain = domain == null ? "" : domain.trim();
+    J2clAttachmentIdGenerator idGenerator = idGeneratorsByDomain.get(normalizedDomain);
+    if (idGenerator == null) {
+      idGenerator = new J2clAttachmentIdGenerator(normalizedDomain, sessionSeed);
+      idGeneratorsByDomain.put(normalizedDomain, idGenerator);
+    }
+    return idGenerator;
   }
 
   public static DeltaFactory richContentDeltaFactory(J2clRichContentDeltaFactory factory) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.compose;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1305,6 +1306,203 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void attachmentControllerFactoryKeepsIdsMonotonicAcrossWaveChanges() {
+    FakeAttachmentTransport transport = new FakeAttachmentTransport();
+    J2clComposeSurfaceController.AttachmentControllerFactory factory =
+        J2clComposeSurfaceController.attachmentControllerFactory(
+            "seed", new J2clAttachmentUploadClient(transport));
+    J2clAttachmentComposerController firstController =
+        factory.create(
+            "example.com/w+1/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+    J2clAttachmentComposerController secondController =
+        factory.create(
+            "example.com/w+2/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+    J2clAttachmentComposerController otherDomainController =
+        factory.create(
+            "other.example/w+1/~/conv+root",
+            "other.example",
+            (document, insertion) -> { },
+            () -> { });
+
+    firstController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "first.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    firstController.cancelAndReset();
+    firstController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "after-cancel.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    otherDomainController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "other.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+    // Only selections consume ids: cancel clears queue state without rewinding the shared counter.
+    secondController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "second.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+    Assert.assertEquals("/attachment/other.example/seedA", transport.requests.get(2).getUrl());
+    Assert.assertEquals("/attachment/example.com/seedC", transport.requests.get(3).getUrl());
+
+    FakeAttachmentTransport secondTransport = new FakeAttachmentTransport();
+    J2clComposeSurfaceController.AttachmentControllerFactory secondFactory =
+        J2clComposeSurfaceController.attachmentControllerFactory(
+            "seed", new J2clAttachmentUploadClient(secondTransport));
+    J2clAttachmentComposerController secondFactoryController =
+        secondFactory.create(
+            "example.com/w+fresh/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+    secondFactoryController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "fresh.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals(
+        "/attachment/example.com/seedA", secondTransport.requests.get(0).getUrl());
+  }
+
+  @Test
+  public void attachmentControllerFactoryUsesGeneratorDomainValidationContract() {
+    FakeAttachmentTransport transport = new FakeAttachmentTransport();
+    J2clComposeSurfaceController.AttachmentControllerFactory factory =
+        J2clComposeSurfaceController.attachmentControllerFactory(
+            "seed", new J2clAttachmentUploadClient(transport));
+    J2clAttachmentComposerController controller =
+        factory.create(
+            "example.com/w+1/~/conv+root",
+            "  example.com  ",
+            (document, insertion) -> { },
+            () -> { });
+
+    controller.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "trimmed.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/example.com/seedA", transport.requests.get(0).getUrl());
+    J2clAttachmentComposerController normalizedController =
+        factory.create(
+            "example.com/w+2/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+    normalizedController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "normalized.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/example.com/seedB", transport.requests.get(1).getUrl());
+
+    assertFactoryRejectsDomain(factory, null);
+    assertFactoryRejectsDomain(factory, "");
+    assertFactoryRejectsDomain(factory, "   ");
+    assertFactoryRejectsDomain(factory, "example.com/bad");
+
+    J2clAttachmentComposerController freshController =
+        factory.create(
+            "fresh.example/w+1/~/conv+root",
+            "fresh.example",
+            (document, insertion) -> { },
+            () -> { });
+    freshController.selectFiles(
+        Arrays.asList(
+            J2clAttachmentComposerController.AttachmentSelection.file(
+                new Object(),
+                "fresh.png",
+                "",
+                J2clAttachmentComposerController.DisplaySize.SMALL)));
+
+    Assert.assertEquals("/attachment/fresh.example/seedA", transport.requests.get(2).getUrl());
+  }
+
+  @Test
+  public void attachmentControllerFactoryValidatesDomainBeforeCreatingUploadClient() {
+    CountingUploadClientFactory clientFactory = new CountingUploadClientFactory();
+    J2clComposeSurfaceController.AttachmentControllerFactory factory =
+        J2clComposeSurfaceController.attachmentControllerFactory("seed", clientFactory);
+
+    assertFactoryRejectsDomain(factory, null);
+    assertFactoryRejectsDomain(factory, "");
+    assertFactoryRejectsDomain(factory, "example.com/bad");
+
+    Assert.assertEquals(0, clientFactory.createCalls);
+  }
+
+  @Test
+  public void attachmentControllerFactoryCreatesUploadClientPerController() {
+    CountingUploadClientFactory clientFactory = new CountingUploadClientFactory();
+    J2clComposeSurfaceController.AttachmentControllerFactory factory =
+        J2clComposeSurfaceController.attachmentControllerFactory("seed", clientFactory);
+
+    factory.create(
+        "example.com/w+1/~/conv+root",
+        "example.com",
+        (document, insertion) -> { },
+        () -> { });
+    factory.create(
+        "example.com/w+2/~/conv+root",
+        "example.com",
+        (document, insertion) -> { },
+        () -> { });
+
+    Assert.assertEquals(2, clientFactory.createCalls);
+  }
+
+  @Test
+  public void publicAttachmentControllerFactoryCreatesFreshUploadClients() throws Exception {
+    J2clComposeSurfaceController.AttachmentControllerFactory factory =
+        J2clComposeSurfaceController.attachmentControllerFactory("seed");
+
+    J2clAttachmentComposerController first =
+        factory.create(
+            "example.com/w+1/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+    J2clAttachmentComposerController second =
+        factory.create(
+            "example.com/w+2/~/conv+root",
+            "example.com",
+            (document, insertion) -> { },
+            () -> { });
+
+    Assert.assertNotSame(uploadClient(first), uploadClient(second));
+  }
+
+  @Test
   public void sameWaveReconnectPreservesInFlightAttachmentUpload() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
@@ -2270,6 +2468,38 @@ public class J2clComposeSurfaceControllerTest {
             new J2clAttachmentIdGenerator(domain, "seed"),
             insertionCallback,
             stateChangeCallback);
+  }
+
+  private static void assertFactoryRejectsDomain(
+      J2clComposeSurfaceController.AttachmentControllerFactory factory, String domain) {
+    try {
+      factory.create(
+          "example.com/w+invalid/~/conv+root",
+          domain,
+          (document, insertion) -> { },
+          () -> { });
+      Assert.fail("Expected invalid domain to fail.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("domain"));
+    }
+  }
+
+  private static final class CountingUploadClientFactory
+      implements J2clComposeSurfaceController.AttachmentUploadClientFactory {
+    private int createCalls;
+
+    @Override
+    public J2clAttachmentUploadClient create() {
+      createCalls++;
+      return new J2clAttachmentUploadClient(new FakeAttachmentTransport());
+    }
+  }
+
+  private static J2clAttachmentUploadClient uploadClient(
+      J2clAttachmentComposerController controller) throws Exception {
+    Field field = J2clAttachmentComposerController.class.getDeclaredField("uploadClient");
+    field.setAccessible(true);
+    return (J2clAttachmentUploadClient) field.get(controller);
   }
 
   private static void assertContains(String value, String... expectedSubstrings) {

--- a/wave/config/changelog.d/2026-04-25-issue-971-attachment-id-monotonic.json
+++ b/wave/config/changelog.d/2026-04-25-issue-971-attachment-id-monotonic.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-issue-971-attachment-id-monotonic",
+  "version": "Unreleased",
+  "date": "2026-04-25",
+  "title": "J2CL attachment uploads keep unique IDs",
+  "summary": "The J2CL composer now keeps attachment IDs monotonic across wave changes in one browser session.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Attachment uploads from the J2CL composer no longer reuse the first generated ID after switching waves, preventing duplicate upload IDs in the same session."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Follow-up to #1017 for #971: keep J2CL composer attachment ID generation monotonic across wave/controller changes in one browser session.
- Cache `J2clAttachmentIdGenerator` per normalized domain inside the controller factory while preserving the public factory's fresh upload-client-per-controller behavior.
- Add regression coverage for cancel/no-rewind, cross-wave monotonicity, cross-domain isolation, fresh factory isolation, invalid-domain ordering, public fresh upload clients, and normalized-domain cache keys.
- Add changelog fragment `2026-04-25-issue-971-attachment-id-monotonic`.

## Verification
- `sbt -batch j2clSearchTest`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `git diff --check`
- Claude Opus review loop: final verdict “No actionable comments remain. Ready to merge.”

Fixes part of #971. Tracked under #904.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed an issue where attachment uploads would reuse the same ID after switching between waves in a single browser session, potentially causing duplicate upload errors. Attachment uploads now generate and maintain unique IDs throughout your session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->