### PR TITLE
Render selected-wave attachments in J2CL read surface

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -278,7 +278,7 @@ public final class J2clAttachmentRenderModel {
 
   private static String safeUrl(String value) {
     String normalized = normalize(value);
-    if (containsControlCharacter(normalized)) {
+    if (containsControlCharacterOrSpace(normalized)) {
       return "";
     }
     // Root-relative paths are same-origin attachment endpoints, not executable URL schemes.
@@ -292,7 +292,7 @@ public final class J2clAttachmentRenderModel {
     return "";
   }
 
-  private static boolean containsControlCharacter(String value) {
+  private static boolean containsControlCharacterOrSpace(String value) {
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
       if (c <= ' ' || c == 0x7F) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -1,0 +1,363 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import java.util.Locale;
+
+/** Read-surface rendering decision for one Wave attachment element. */
+public final class J2clAttachmentRenderModel {
+  private static final String DISPLAY_SMALL = "small";
+  private static final String DISPLAY_MEDIUM = "medium";
+  private static final String DISPLAY_LARGE = "large";
+  private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+  private static final String DEFAULT_DOWNLOAD_FILE_NAME = "attachment";
+
+  private final String attachmentId;
+  private final String caption;
+  private final String displaySize;
+  private final String fileName;
+  private final String mimeType;
+  private final String sourceUrl;
+  private final String openUrl;
+  private final String downloadUrl;
+  private final String downloadFileName;
+  private final String statusText;
+  private final boolean inlineImage;
+  private final boolean blocked;
+  private final boolean metadataFailure;
+  private final boolean metadataPending;
+
+  private J2clAttachmentRenderModel(
+      String attachmentId,
+      String caption,
+      String displaySize,
+      String fileName,
+      String mimeType,
+      String sourceUrl,
+      String openUrl,
+      String downloadUrl,
+      String statusText,
+      boolean inlineImage,
+      boolean blocked,
+      boolean metadataFailure,
+      boolean metadataPending) {
+    String safeSourceUrl = safeUrl(sourceUrl);
+    this.attachmentId = normalize(attachmentId);
+    this.caption = normalize(caption);
+    // Empty source URLs mean there is no safe preview, so render as a compact card.
+    this.displaySize =
+        safeSourceUrl.isEmpty() && !blocked && !metadataFailure && !metadataPending
+            ? DISPLAY_SMALL
+            : normalizeDisplaySize(displaySize);
+    this.fileName = normalize(fileName);
+    this.mimeType = normalize(mimeType);
+    this.sourceUrl = safeSourceUrl;
+    this.openUrl = safeUrl(openUrl);
+    this.downloadUrl = safeUrl(downloadUrl);
+    this.downloadFileName = safeDownloadFileName(this.fileName, this.attachmentId);
+    this.statusText = normalize(statusText);
+    this.inlineImage = inlineImage && !this.sourceUrl.isEmpty();
+    this.blocked = blocked;
+    this.metadataFailure = metadataFailure;
+    this.metadataPending = metadataPending;
+  }
+
+  public static J2clAttachmentRenderModel fromMetadata(
+      String attachmentId,
+      String caption,
+      String requestedDisplaySize,
+      J2clAttachmentMetadata metadata) {
+    if (metadata == null) {
+      return metadataFailure(
+          attachmentId, caption, requestedDisplaySize, "metadata unavailable");
+    }
+    String normalizedAttachmentId = firstNonEmpty(attachmentId, metadata.getAttachmentId());
+    String normalizedFileName =
+        firstNonEmpty(metadata.getFileName(), caption, normalizedAttachmentId);
+    String normalizedMimeType = firstNonEmpty(metadata.getMimeType(), DEFAULT_MIME_TYPE);
+    String normalizedCaption = firstNonEmpty(caption, normalizedFileName, normalizedAttachmentId);
+    String normalizedDisplaySize = normalizeDisplaySize(requestedDisplaySize);
+    if (metadata.isMalware()) {
+      return new J2clAttachmentRenderModel(
+          normalizedAttachmentId,
+          normalizedCaption,
+          normalizedDisplaySize,
+          normalizedFileName,
+          normalizedMimeType,
+          "",
+          "",
+          "",
+          "Attachment blocked by malware scan.",
+          false,
+          true,
+          false,
+          false);
+    }
+
+    boolean image = isImageMimeType(normalizedMimeType);
+    boolean hasImageDimensions = hasDimensions(metadata.getImageMetadata());
+    boolean inlineImage =
+        image
+            && hasImageDimensions
+            && (DISPLAY_MEDIUM.equals(normalizedDisplaySize)
+                || DISPLAY_LARGE.equals(normalizedDisplaySize));
+    String effectiveDisplaySize =
+        image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
+    String sourceUrl =
+        inlineImage
+            ? firstNonEmpty(metadata.getAttachmentUrl(), metadata.getThumbnailUrl())
+            : firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
+
+    return new J2clAttachmentRenderModel(
+        normalizedAttachmentId,
+        normalizedCaption,
+        effectiveDisplaySize,
+        normalizedFileName,
+        normalizedMimeType,
+        sourceUrl,
+        metadata.getAttachmentUrl(),
+        metadata.getAttachmentUrl(),
+        "",
+        inlineImage,
+        false,
+        false,
+        false);
+  }
+
+  public static J2clAttachmentRenderModel metadataFailure(
+      String attachmentId, String caption, String requestedDisplaySize, String reason) {
+    String normalizedAttachmentId = normalize(attachmentId);
+    String normalizedCaption = firstNonEmpty(caption, normalizedAttachmentId, "attachment");
+    String normalizedReason = firstNonEmpty(reason, "Attachment metadata unavailable.");
+    return new J2clAttachmentRenderModel(
+        normalizedAttachmentId,
+        normalizedCaption,
+        requestedDisplaySize,
+        normalizedCaption,
+        DEFAULT_MIME_TYPE,
+        "",
+        "",
+        "",
+        metadataFailureStatus(normalizedReason),
+        false,
+        false,
+        true,
+        false);
+  }
+
+  public static J2clAttachmentRenderModel metadataPending(
+      String attachmentId, String caption, String requestedDisplaySize) {
+    String normalizedAttachmentId = normalize(attachmentId);
+    String normalizedCaption = firstNonEmpty(caption, normalizedAttachmentId, "attachment");
+    return new J2clAttachmentRenderModel(
+        normalizedAttachmentId,
+        normalizedCaption,
+        requestedDisplaySize,
+        normalizedCaption,
+        DEFAULT_MIME_TYPE,
+        "",
+        "",
+        "",
+        "Attachment metadata loading...",
+        false,
+        false,
+        false,
+        true);
+  }
+
+  public String getAttachmentId() {
+    return attachmentId;
+  }
+
+  public String getCaption() {
+    return caption;
+  }
+
+  public String getDisplaySize() {
+    return displaySize;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public String getSourceUrl() {
+    return sourceUrl;
+  }
+
+  public String getOpenUrl() {
+    return openUrl;
+  }
+
+  public String getDownloadUrl() {
+    return downloadUrl;
+  }
+
+  public String getDownloadFileName() {
+    return downloadFileName;
+  }
+
+  public String getStatusText() {
+    return statusText;
+  }
+
+  public boolean isInlineImage() {
+    return inlineImage;
+  }
+
+  public boolean isBlocked() {
+    return blocked;
+  }
+
+  public boolean isMetadataFailure() {
+    return metadataFailure;
+  }
+
+  public boolean isMetadataPending() {
+    return metadataPending;
+  }
+
+  public boolean canOpen() {
+    return !blocked && !metadataFailure && !metadataPending && !openUrl.isEmpty();
+  }
+
+  public boolean canDownload() {
+    return !blocked && !metadataFailure && !metadataPending && !downloadUrl.isEmpty();
+  }
+
+  public String getOpenLabel() {
+    return "Open attachment " + fileName + " (" + mimeType + ")";
+  }
+
+  public String getDownloadLabel() {
+    return "Download attachment " + fileName + " (" + mimeType + ")";
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof J2clAttachmentRenderModel)) {
+      return false;
+    }
+    J2clAttachmentRenderModel that = (J2clAttachmentRenderModel) other;
+    return attachmentId.equals(that.attachmentId)
+        && caption.equals(that.caption)
+        && displaySize.equals(that.displaySize)
+        && fileName.equals(that.fileName)
+        && mimeType.equals(that.mimeType)
+        && sourceUrl.equals(that.sourceUrl)
+        && openUrl.equals(that.openUrl)
+        && downloadUrl.equals(that.downloadUrl)
+        && downloadFileName.equals(that.downloadFileName)
+        && statusText.equals(that.statusText)
+        && inlineImage == that.inlineImage
+        && blocked == that.blocked
+        && metadataFailure == that.metadataFailure
+        && metadataPending == that.metadataPending;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = attachmentId.hashCode();
+    result = 31 * result + caption.hashCode();
+    result = 31 * result + displaySize.hashCode();
+    result = 31 * result + fileName.hashCode();
+    result = 31 * result + mimeType.hashCode();
+    result = 31 * result + sourceUrl.hashCode();
+    result = 31 * result + openUrl.hashCode();
+    result = 31 * result + downloadUrl.hashCode();
+    result = 31 * result + downloadFileName.hashCode();
+    result = 31 * result + statusText.hashCode();
+    result = 31 * result + (inlineImage ? 1 : 0);
+    result = 31 * result + (blocked ? 1 : 0);
+    result = 31 * result + (metadataFailure ? 1 : 0);
+    result = 31 * result + (metadataPending ? 1 : 0);
+    return result;
+  }
+
+  private static String safeUrl(String value) {
+    String normalized = normalize(value);
+    if (containsControlCharacter(normalized)) {
+      return "";
+    }
+    // Root-relative paths are same-origin attachment endpoints, not executable URL schemes.
+    if (normalized.startsWith("/") && !normalized.startsWith("//")) {
+      return normalized;
+    }
+    String lower = normalized.toLowerCase(Locale.ROOT);
+    if (lower.startsWith("https://")) {
+      return normalized;
+    }
+    return "";
+  }
+
+  private static boolean containsControlCharacter(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c <= ' ' || c == 0x7F) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String safeDownloadFileName(String fileName, String fallback) {
+    String candidate =
+        firstNonEmpty(fileName, fallback, DEFAULT_DOWNLOAD_FILE_NAME).replace('\\', '/');
+    int slash = candidate.lastIndexOf('/');
+    if (slash >= 0) {
+      candidate = candidate.substring(slash + 1);
+    }
+    StringBuilder safe = new StringBuilder(candidate.length());
+    for (int i = 0; i < candidate.length(); i++) {
+      char c = candidate.charAt(i);
+      safe.append(c <= ' ' || c == 0x7F || c == '/' || c == '\\' ? '_' : c);
+    }
+    String normalized = safe.toString().trim();
+    if (normalized.isEmpty() || ".".equals(normalized) || "..".equals(normalized)) {
+      return DEFAULT_DOWNLOAD_FILE_NAME;
+    }
+    return normalized;
+  }
+
+  private static boolean isImageMimeType(String mimeType) {
+    return mimeType != null && mimeType.toLowerCase(Locale.ROOT).startsWith("image/");
+  }
+
+  private static boolean hasDimensions(J2clAttachmentMetadata.ImageMetadata imageMetadata) {
+    return imageMetadata != null && imageMetadata.getWidth() > 0 && imageMetadata.getHeight() > 0;
+  }
+
+  private static String metadataFailureStatus(String reason) {
+    if (reason.toLowerCase(Locale.ROOT).startsWith("attachment metadata unavailable")) {
+      return reason;
+    }
+    return "Attachment metadata unavailable: " + reason;
+  }
+
+  private static String normalizeDisplaySize(String displaySize) {
+    String normalized = normalize(displaySize).toLowerCase(Locale.ROOT);
+    if (DISPLAY_MEDIUM.equals(normalized) || DISPLAY_LARGE.equals(normalized)) {
+      return normalized;
+    }
+    return DISPLAY_SMALL;
+  }
+
+  private static String firstNonEmpty(String first, String second) {
+    return firstNonEmpty(first, second, "");
+  }
+
+  private static String firstNonEmpty(String first, String second, String fallback) {
+    String normalizedFirst = normalize(first);
+    if (!normalizedFirst.isEmpty()) {
+      return normalizedFirst;
+    }
+    String normalizedSecond = normalize(second);
+    return normalizedSecond.isEmpty() ? normalize(fallback) : normalizedSecond;
+  }
+
+  private static String normalize(String value) {
+    return value == null ? "" : value.trim();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -1,12 +1,27 @@
 package org.waveprotocol.box.j2cl.read;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+
 public final class J2clReadBlip {
   private final String blipId;
   private final String text;
+  private final List<J2clAttachmentRenderModel> attachments;
 
   public J2clReadBlip(String blipId, String text) {
+    this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
+  }
+
+  public J2clReadBlip(
+      String blipId, String text, List<J2clAttachmentRenderModel> attachments) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
+    this.attachments =
+        attachments == null
+            ? Collections.<J2clAttachmentRenderModel>emptyList()
+            : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
   }
 
   public String getBlipId() {
@@ -15,5 +30,9 @@ public final class J2clReadBlip {
 
   public String getText() {
     return text;
+  }
+
+  public List<J2clAttachmentRenderModel> getAttachments() {
+    return attachments;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -69,8 +69,9 @@ public final class J2clReadBlipContent {
   }
 
   private static String attributeValue(String tag, String name) {
-    int cursor = tag.indexOf(' ');
-    if (cursor < 0) {
+    // Start after the tag name; indexOf(' ') would miss tabs or newlines as the first separator.
+    int cursor = "<image".length();
+    if (cursor >= tag.length()) {
       return "";
     }
     while (cursor < tag.length()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.read;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 
 /** Parsed text and attachment placeholders extracted from a selected-wave blip snapshot. */
@@ -147,12 +148,9 @@ public final class J2clReadBlipContent {
         tagBuf.setLength(0);
       } else if (c == '>') {
         insideTag = false;
-        // <line/> and <line> are DocOp structural separators; insert a space so adjacent segments
-        // aren't concatenated (e.g. <line/>Hello<line/>World → "Hello World", not "HelloWorld").
-        if (isLineTag(tagBuf.toString())
-            && stripped.length() > 0
-            && stripped.charAt(stripped.length() - 1) != ' ') {
-          stripped.append(' ');
+        // <line/> and <line> are DocOp structural separators: Hello<line/>World -> Hello\nWorld.
+        if (isLineTag(tagBuf.toString())) {
+          appendLineSeparator(stripped);
         }
         tagBuf.setLength(0);
       } else if (insideTag) {
@@ -166,10 +164,23 @@ public final class J2clReadBlipContent {
 
   private static boolean isLineTag(String tagContent) {
     // Matches <line/>, <line>, <line attrs...> but not e.g. <linefeed>.
-    return tagContent.startsWith("line")
-        && (tagContent.length() == 4
-            || tagContent.charAt(4) == '/'
-            || tagContent.charAt(4) == ' ');
+    String normalized = tagContent.trim().toLowerCase(Locale.ROOT);
+    return normalized.startsWith("line")
+        && (normalized.length() == 4
+            || normalized.charAt(4) == '/'
+            || Character.isWhitespace(normalized.charAt(4)));
+  }
+
+  private static void appendLineSeparator(StringBuilder stripped) {
+    // Normalize horizontal whitespace at paragraph boundaries before emitting one line break.
+    while (stripped.length() > 0
+        && Character.isWhitespace(stripped.charAt(stripped.length() - 1))
+        && stripped.charAt(stripped.length() - 1) != '\n') {
+      stripped.deleteCharAt(stripped.length() - 1);
+    }
+    if (stripped.length() > 0 && stripped.charAt(stripped.length() - 1) != '\n') {
+      stripped.append('\n');
+    }
   }
 
   private static String decodeEntities(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -146,7 +146,7 @@ public final class J2clReadBlipContent {
       if (c == '<') {
         insideTag = true;
         tagBuf.setLength(0);
-      } else if (c == '>') {
+      } else if (c == '>' && insideTag) {
         insideTag = false;
         // <line/> and <line> are DocOp structural separators: Hello<line/>World -> Hello\nWorld.
         if (isLineTag(tagBuf.toString())) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -1,0 +1,166 @@
+package org.waveprotocol.box.j2cl.read;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+
+/** Parsed text and attachment placeholders extracted from a selected-wave blip snapshot. */
+public final class J2clReadBlipContent {
+  private final String text;
+  private final List<J2clAttachmentRenderModel> attachments;
+
+  private J2clReadBlipContent(String text, List<J2clAttachmentRenderModel> attachments) {
+    this.text = text == null ? "" : text;
+    this.attachments =
+        attachments == null
+            ? Collections.<J2clAttachmentRenderModel>emptyList()
+            : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
+  }
+
+  public static J2clReadBlipContent parseRawSnapshot(String rawSnapshot) {
+    // Sidecar fragments currently provide DocOp debug XML, not a browser XML document. Keep this
+    // parser narrow to the Wave image doodad shape and treat malformed input as visible text.
+    String raw = rawSnapshot == null ? "" : rawSnapshot;
+    List<J2clAttachmentRenderModel> attachments =
+        new ArrayList<J2clAttachmentRenderModel>();
+    StringBuilder visibleText = new StringBuilder(raw.length());
+    int cursor = 0;
+    while (cursor < raw.length()) {
+      int imageStart = raw.indexOf("<image", cursor);
+      if (imageStart < 0) {
+        visibleText.append(raw.substring(cursor));
+        break;
+      }
+      int imageTagEnd = raw.indexOf('>', imageStart);
+      if (imageTagEnd < 0) {
+        visibleText.append(raw.substring(cursor));
+        break;
+      }
+      String startTag = raw.substring(imageStart, imageTagEnd + 1);
+      String attachmentId = attributeValue(startTag, "attachment");
+      if (attachmentId.isEmpty()) {
+        visibleText.append(raw.substring(cursor, imageTagEnd + 1));
+        cursor = imageTagEnd + 1;
+        continue;
+      }
+      visibleText.append(raw.substring(cursor, imageStart));
+      int imageClose = raw.indexOf("</image>", imageTagEnd + 1);
+      String inner = imageClose < 0 ? "" : raw.substring(imageTagEnd + 1, imageClose);
+      String displaySize = attributeValue(startTag, "display-size");
+      String caption = firstNonEmpty(captionText(inner), attachmentId);
+      attachments.add(
+          J2clAttachmentRenderModel.metadataPending(
+              decodeEntities(attachmentId),
+              decodeEntities(caption),
+              decodeEntities(displaySize)));
+      cursor = imageClose < 0 ? imageTagEnd + 1 : imageClose + "</image>".length();
+    }
+    return new J2clReadBlipContent(
+        decodeEntities(stripTags(visibleText.toString())), attachments);
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public List<J2clAttachmentRenderModel> getAttachments() {
+    return attachments;
+  }
+
+  private static String attributeValue(String tag, String name) {
+    int cursor = tag.indexOf(' ');
+    if (cursor < 0) {
+      return "";
+    }
+    while (cursor < tag.length()) {
+      cursor = skipWhitespace(tag, cursor);
+      if (cursor >= tag.length() || tag.charAt(cursor) == '>' || tag.charAt(cursor) == '/') {
+        return "";
+      }
+      int nameStart = cursor;
+      while (cursor < tag.length()
+          && !Character.isWhitespace(tag.charAt(cursor))
+          && tag.charAt(cursor) != '='
+          && tag.charAt(cursor) != '>'
+          && tag.charAt(cursor) != '/') {
+        cursor++;
+      }
+      String attributeName = tag.substring(nameStart, cursor);
+      cursor = skipWhitespace(tag, cursor);
+      if (cursor >= tag.length() || tag.charAt(cursor) != '=') {
+        continue;
+      }
+      int valueStart = skipWhitespace(tag, cursor + 1);
+      if (valueStart >= tag.length()) {
+        return "";
+      }
+      char quote = tag.charAt(valueStart);
+      if (quote != '"' && quote != '\'') {
+        // Unquoted attributes are outside the debug-XML shape; advance to avoid rescanning.
+        cursor = valueStart + 1;
+        continue;
+      }
+      int valueEnd = tag.indexOf(quote, valueStart + 1);
+      if (valueEnd < 0) {
+        return "";
+      }
+      if (name.equalsIgnoreCase(attributeName)) {
+        return tag.substring(valueStart + 1, valueEnd);
+      }
+      cursor = valueEnd + 1;
+    }
+    return "";
+  }
+
+  private static int skipWhitespace(String tag, int cursor) {
+    while (cursor < tag.length() && Character.isWhitespace(tag.charAt(cursor))) {
+      cursor++;
+    }
+    return cursor;
+  }
+
+  private static String captionText(String innerXml) {
+    int start = innerXml.indexOf("<caption>");
+    if (start < 0) {
+      return "";
+    }
+    start += "<caption>".length();
+    int end = innerXml.indexOf("</caption>", start);
+    if (end < 0) {
+      return "";
+    }
+    return stripTags(innerXml.substring(start, end));
+  }
+
+  private static String stripTags(String value) {
+    // This is intentionally not an XML parser; it handles the narrow debug-XML snapshots emitted
+    // for selected-wave text and leaves malformed tags as best-effort visible text.
+    StringBuilder stripped = new StringBuilder(value.length());
+    boolean insideTag = false;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '<') {
+        insideTag = true;
+      } else if (c == '>') {
+        insideTag = false;
+      } else if (!insideTag) {
+        stripped.append(c);
+      }
+    }
+    return stripped.toString();
+  }
+
+  private static String decodeEntities(String value) {
+    return value.replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&");
+  }
+
+  private static String firstNonEmpty(String first, String fallback) {
+    String normalized = first == null ? "" : first.trim();
+    return normalized.isEmpty() ? fallback : normalized;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -138,18 +138,38 @@ public final class J2clReadBlipContent {
     // This is intentionally not an XML parser; it handles the narrow debug-XML snapshots emitted
     // for selected-wave text and leaves malformed tags as best-effort visible text.
     StringBuilder stripped = new StringBuilder(value.length());
+    StringBuilder tagBuf = new StringBuilder();
     boolean insideTag = false;
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
       if (c == '<') {
         insideTag = true;
+        tagBuf.setLength(0);
       } else if (c == '>') {
         insideTag = false;
-      } else if (!insideTag) {
+        // <line/> and <line> are DocOp structural separators; insert a space so adjacent segments
+        // aren't concatenated (e.g. <line/>Hello<line/>World → "Hello World", not "HelloWorld").
+        if (isLineTag(tagBuf.toString())
+            && stripped.length() > 0
+            && stripped.charAt(stripped.length() - 1) != ' ') {
+          stripped.append(' ');
+        }
+        tagBuf.setLength(0);
+      } else if (insideTag) {
+        tagBuf.append(c);
+      } else {
         stripped.append(c);
       }
     }
     return stripped.toString();
+  }
+
+  private static boolean isLineTag(String tagContent) {
+    // Matches <line/>, <line>, <line attrs...> but not e.g. <linefeed>.
+    return tagContent.startsWith("line")
+        && (tagContent.length() == 4
+            || tagContent.charAt(4) == '/'
+            || tagContent.charAt(4) == ' ');
   }
 
   private static String decodeEntities(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -294,6 +294,7 @@ public final class J2clReadSurfaceDomRenderer {
         preview.setAttribute("src", model.getSourceUrl());
         preview.setAttribute("alt", model.getCaption());
         preview.setAttribute("loading", "lazy");
+        preview.setAttribute("referrerpolicy", "no-referrer");
       } else {
         preview.setAttribute("aria-hidden", "true");
         preview.textContent = "Attachment";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -79,7 +79,6 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     clearViewportScrollMemory();
-    // Preserve scroll-growth direction across window rebuilds; placeholders may still need it.
     host.innerHTML = "";
     renderedBlips.clear();
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
@@ -359,6 +358,7 @@ public final class J2clReadSurfaceDomRenderer {
     link.setAttribute("aria-label", ariaLabel);
     link.setAttribute("tabindex", "0");
     link.setAttribute(dataAttribute, "true");
+    link.setAttribute("title", fileName);
     if (download) {
       link.setAttribute("download", fileName);
       if (isExternalHttpsUrl(href)) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -286,18 +286,16 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     if (!model.getSourceUrl().isEmpty()) {
-      HTMLElement preview =
-          (HTMLElement)
-              DomGlobal.document.createElement(model.isInlineImage() ? "img" : "span");
+      HTMLElement preview = (HTMLElement) DomGlobal.document.createElement("img");
       preview.className = "j2cl-read-attachment-preview";
+      preview.setAttribute("src", model.getSourceUrl());
+      preview.setAttribute("referrerpolicy", "no-referrer");
       if (model.isInlineImage()) {
-        preview.setAttribute("src", model.getSourceUrl());
         preview.setAttribute("alt", model.getCaption());
         preview.setAttribute("loading", "lazy");
-        preview.setAttribute("referrerpolicy", "no-referrer");
       } else {
+        preview.setAttribute("alt", "");
         preview.setAttribute("aria-hidden", "true");
-        preview.textContent = "Attachment";
       }
       attachment.appendChild(preview);
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -10,6 +10,8 @@ import elemental2.dom.NodeList;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clReadSurfaceDomRenderer {
@@ -23,6 +25,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   private final HTMLDivElement host;
   private final List<HTMLElement> renderedBlips = new ArrayList<HTMLElement>();
+  private List<J2clReadBlip> renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
   private List<J2clReadWindowEntry> renderedWindowEntries =
       Collections.<J2clReadWindowEntry>emptyList();
   private HTMLElement renderedSurface;
@@ -61,6 +64,7 @@ public final class J2clReadSurfaceDomRenderer {
       clearViewportScrollMemory();
       host.innerHTML = "";
       renderedBlips.clear();
+      renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
       renderedSurface = null;
       focusedBlip = null;
@@ -75,8 +79,10 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     clearViewportScrollMemory();
+    // Preserve scroll-growth direction across window rebuilds; placeholders may still need it.
     host.innerHTML = "";
     renderedBlips.clear();
+    renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
     renderedSurface = null;
     focusedBlip = null;
@@ -97,6 +103,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
 
     host.appendChild(surface);
+    renderedLiveBlips = immutableBlipCopy(effectiveBlips);
     renderedSurface = surface;
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
@@ -109,6 +116,7 @@ public final class J2clReadSurfaceDomRenderer {
       clearViewportScrollMemory();
       host.innerHTML = "";
       renderedBlips.clear();
+      renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
       renderedSurface = null;
       focusedBlip = null;
@@ -126,6 +134,8 @@ public final class J2clReadSurfaceDomRenderer {
 
     host.innerHTML = "";
     renderedBlips.clear();
+    renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
+    renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
     renderedSurface = null;
     focusedBlip = null;
 
@@ -146,7 +156,10 @@ public final class J2clReadSurfaceDomRenderer {
       J2clReadWindowEntry entry = entries.get(i);
       if (entry.isLoaded()) {
         rootThread.appendChild(
-            renderBlip(new J2clReadBlip(entry.getBlipId(), entry.getText()), blipIndex++));
+            renderBlip(
+                new J2clReadBlip(
+                    entry.getBlipId(), entry.getText(), entry.getAttachments()),
+                blipIndex++));
       } else {
         hasPlaceholder = true;
         rootThread.appendChild(renderPlaceholder(entry));
@@ -160,6 +173,7 @@ public final class J2clReadSurfaceDomRenderer {
     host.appendChild(surface);
     renderedWindowEntries =
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
+    renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedSurface = surface;
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
@@ -209,12 +223,14 @@ public final class J2clReadSurfaceDomRenderer {
     if (surface == null) {
       renderedSurface = null;
       renderedBlips.clear();
+      renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
       focusedBlip = null;
       return false;
     }
     HTMLElement previousFocusedBlip = focusedBlip;
     renderedBlips.clear();
+    renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
     renderedSurface = surface;
     focusedBlip = null;
@@ -243,7 +259,137 @@ public final class J2clReadSurfaceDomRenderer {
     content.className = "blip-content j2cl-read-blip-content";
     content.textContent = blip.getText();
     article.appendChild(content);
+    if (!blip.getAttachments().isEmpty()) {
+      HTMLElement attachments = (HTMLElement) DomGlobal.document.createElement("div");
+      attachments.className = "j2cl-read-attachments";
+      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
+        attachments.appendChild(renderAttachment(attachment));
+      }
+      article.appendChild(attachments);
+    }
     return article;
+  }
+
+  private HTMLElement renderAttachment(J2clAttachmentRenderModel model) {
+    HTMLElement attachment = (HTMLElement) DomGlobal.document.createElement("div");
+    attachment.className =
+        model.isInlineImage()
+            ? "j2cl-read-attachment j2cl-read-attachment-inline-image"
+            : "j2cl-read-attachment j2cl-read-attachment-card";
+    attachment.setAttribute("data-j2cl-read-attachment", "true");
+    attachment.setAttribute("role", "group");
+    attachment.setAttribute("aria-label", model.getCaption());
+    attachment.setAttribute("data-attachment-id", model.getAttachmentId());
+    attachment.setAttribute("data-display-size", model.getDisplaySize());
+    attachment.setAttribute("data-attachment-state", attachmentState(model));
+    if (model.isMetadataPending()) {
+      attachment.setAttribute("aria-busy", "true");
+    }
+
+    if (!model.getSourceUrl().isEmpty()) {
+      HTMLElement preview =
+          (HTMLElement)
+              DomGlobal.document.createElement(model.isInlineImage() ? "img" : "span");
+      preview.className = "j2cl-read-attachment-preview";
+      if (model.isInlineImage()) {
+        preview.setAttribute("src", model.getSourceUrl());
+        preview.setAttribute("alt", model.getCaption());
+        preview.setAttribute("loading", "lazy");
+      } else {
+        preview.setAttribute("aria-hidden", "true");
+        preview.textContent = "Attachment";
+      }
+      attachment.appendChild(preview);
+    }
+
+    HTMLElement label = (HTMLElement) DomGlobal.document.createElement("div");
+    label.className = "j2cl-read-attachment-label";
+    label.setAttribute("aria-hidden", "true");
+    label.textContent = model.getCaption();
+    attachment.appendChild(label);
+
+    if (!model.getStatusText().isEmpty()) {
+      HTMLElement status = (HTMLElement) DomGlobal.document.createElement("div");
+      status.className = "j2cl-read-attachment-status";
+      status.setAttribute(
+          "role", model.isBlocked() || model.isMetadataFailure() ? "alert" : "status");
+      status.textContent = model.getStatusText();
+      attachment.appendChild(status);
+    }
+
+    if (model.canOpen() || model.canDownload()) {
+      HTMLElement actions = (HTMLElement) DomGlobal.document.createElement("div");
+      actions.className = "j2cl-read-attachment-actions";
+      if (model.canOpen()) {
+        actions.appendChild(
+            renderAttachmentLink(
+                "Open",
+                model.getOpenUrl(),
+                model.getOpenLabel(),
+                "data-j2cl-attachment-open",
+                false,
+                model.getFileName()));
+      }
+      if (model.canDownload()) {
+        actions.appendChild(
+            renderAttachmentLink(
+                "Download",
+                model.getDownloadUrl(),
+                model.getDownloadLabel(),
+                "data-j2cl-attachment-download",
+                true,
+                model.getDownloadFileName()));
+      }
+      attachment.appendChild(actions);
+    }
+    return attachment;
+  }
+
+  private HTMLElement renderAttachmentLink(
+      String text,
+      String href,
+      String ariaLabel,
+      String dataAttribute,
+      boolean download,
+      String fileName) {
+    HTMLElement link = (HTMLElement) DomGlobal.document.createElement("a");
+    link.className = "j2cl-read-attachment-link";
+    link.textContent = text;
+    link.setAttribute("href", href);
+    link.setAttribute("aria-label", ariaLabel);
+    link.setAttribute("tabindex", "0");
+    link.setAttribute(dataAttribute, "true");
+    if (download) {
+      link.setAttribute("download", fileName);
+      if (isExternalHttpsUrl(href)) {
+        link.setAttribute("rel", "noopener noreferrer");
+        link.setAttribute("referrerpolicy", "no-referrer");
+        link.setAttribute("target", "_blank");
+      }
+    } else {
+      // Opening an attachment should never replace the selected-wave SPA.
+      link.setAttribute("rel", "noopener noreferrer");
+      link.setAttribute("referrerpolicy", "no-referrer");
+      link.setAttribute("target", "_blank");
+    }
+    return link;
+  }
+
+  private static boolean isExternalHttpsUrl(String href) {
+    return href != null && href.toLowerCase(Locale.ROOT).startsWith("https://");
+  }
+
+  private static String attachmentState(J2clAttachmentRenderModel model) {
+    if (model.isBlocked()) {
+      return "blocked";
+    }
+    if (model.isMetadataFailure()) {
+      return "metadata-failure";
+    }
+    if (model.isMetadataPending()) {
+      return "pending";
+    }
+    return "ready";
   }
 
   private HTMLElement renderPlaceholder(J2clReadWindowEntry entry) {
@@ -631,12 +777,16 @@ public final class J2clReadSurfaceDomRenderer {
     if (host.querySelector("[data-j2cl-viewport-placeholder='true']") != null) {
       return false;
     }
-    if (renderedBlips.size() != blips.size()) {
+    if (renderedBlips.size() != blips.size() || renderedLiveBlips.size() != blips.size()) {
       return false;
     }
     for (int i = 0; i < blips.size(); i++) {
       J2clReadBlip expected = blips.get(i);
+      J2clReadBlip previous = renderedLiveBlips.get(i);
       HTMLElement actual = renderedBlips.get(i);
+      if (!sameReadBlip(previous, expected)) {
+        return false;
+      }
       if (!expected.getBlipId().equals(actual.getAttribute("data-blip-id"))) {
         return false;
       }
@@ -645,6 +795,12 @@ public final class J2clReadSurfaceDomRenderer {
       }
     }
     return true;
+  }
+
+  private static boolean sameReadBlip(J2clReadBlip left, J2clReadBlip right) {
+    return left.getBlipId().equals(right.getBlipId())
+        && left.getText().equals(right.getText())
+        && left.getAttachments().equals(right.getAttachments());
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
@@ -669,7 +825,8 @@ public final class J2clReadSurfaceDomRenderer {
         && left.getToVersion() == right.getToVersion()
         && left.getSegment().equals(right.getSegment())
         && left.getBlipId().equals(right.getBlipId())
-        && left.getText().equals(right.getText());
+        && left.getText().equals(right.getText())
+        && left.getAttachments().equals(right.getAttachments());
   }
 
   private HTMLElement renderedBlipById(String blipId) {
@@ -827,5 +984,9 @@ public final class J2clReadSurfaceDomRenderer {
       fallbackBlips.add(new J2clReadBlip("entry-" + (i + 1), fallbackEntries.get(i)));
     }
     return fallbackBlips;
+  }
+
+  private static List<J2clReadBlip> immutableBlipCopy(List<J2clReadBlip> blips) {
+    return Collections.unmodifiableList(new ArrayList<J2clReadBlip>(blips));
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -1,11 +1,17 @@
 package org.waveprotocol.box.j2cl.read;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+
 public final class J2clReadWindowEntry {
   private final String segment;
   private final long fromVersion;
   private final long toVersion;
   private final String blipId;
   private final String text;
+  private final List<J2clAttachmentRenderModel> attachments;
   private final boolean loaded;
 
   private J2clReadWindowEntry(
@@ -14,23 +20,52 @@ public final class J2clReadWindowEntry {
       long toVersion,
       String blipId,
       String text,
+      List<J2clAttachmentRenderModel> attachments,
       boolean loaded) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
+    this.attachments =
+        attachments == null
+            ? Collections.<J2clAttachmentRenderModel>emptyList()
+            : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
     this.loaded = loaded;
   }
 
   public static J2clReadWindowEntry loaded(
       String segment, long fromVersion, long toVersion, String blipId, String text) {
-    return new J2clReadWindowEntry(segment, fromVersion, toVersion, blipId, text, true);
+    return loaded(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        Collections.<J2clAttachmentRenderModel>emptyList());
+  }
+
+  public static J2clReadWindowEntry loaded(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments) {
+    return new J2clReadWindowEntry(
+        segment, fromVersion, toVersion, blipId, text, attachments, true);
   }
 
   public static J2clReadWindowEntry placeholder(
       String segment, long fromVersion, long toVersion, String blipId) {
-    return new J2clReadWindowEntry(segment, fromVersion, toVersion, blipId, "", false);
+    return new J2clReadWindowEntry(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        "",
+        Collections.<J2clAttachmentRenderModel>emptyList(),
+        false);
   }
 
   public String getSegment() {
@@ -51,6 +86,10 @@ public final class J2clReadWindowEntry {
 
   public String getText() {
     return text;
+  }
+
+  public List<J2clAttachmentRenderModel> getAttachments() {
+    return attachments;
   }
 
   public boolean isLoaded() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -3,9 +3,11 @@ package org.waveprotocol.box.j2cl.search;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.WebSocket;
 import elemental2.dom.XMLHttpRequest;
+import java.util.List;
 import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
@@ -165,6 +167,14 @@ public final class J2clSearchGateway
           }
         },
         onError);
+  }
+
+  @Override
+  public void fetchAttachmentMetadata(
+      List<String> attachmentIds,
+      J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
+          onComplete) {
+    new J2clAttachmentMetadataClient().fetchMetadata(attachmentIds, result -> onComplete.accept(result));
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1,8 +1,16 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
@@ -59,6 +67,19 @@ public final class J2clSelectedWaveController
         long endVersion,
         J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> onSuccess,
         J2clSearchPanelController.ErrorCallback onError);
+
+    /**
+     * Fetches attachment metadata for the given attachment IDs and delivers the
+     * result to {@code onComplete}. Implementations that do not support metadata
+     * hydration may leave the callback un-invoked; attachments will remain in the
+     * {@code metadataPending} state for those implementations (e.g. test doubles).
+     */
+    default void fetchAttachmentMetadata(
+        List<String> attachmentIds,
+        J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
+            onComplete) {
+      // Default no-op: leaves pending attachments in their pending state.
+    }
   }
 
   public interface View {
@@ -241,6 +262,7 @@ public final class J2clSelectedWaveController
                 readStateStale);
         view.render(currentModel);
         publishWriteSession();
+        hydrateAttachmentsIfNeeded(currentModel);
       }
       return;
     }
@@ -342,6 +364,7 @@ public final class J2clSelectedWaveController
                       readStateStale);
               view.render(currentModel);
               publishWriteSession();
+              hydrateAttachmentsIfNeeded(currentModel);
               activeReconnectCount[0] = 0;
               this.reconnectCount = projectedReconnectCount;
               scheduleReadStateFetch(generation);
@@ -442,6 +465,7 @@ public final class J2clSelectedWaveController
           }
           view.render(currentModel);
           publishWriteSession();
+          hydrateAttachmentsIfNeeded(currentModel);
           fragmentFetchesInFlight.remove(edgeKey);
         },
         error -> {
@@ -632,6 +656,7 @@ public final class J2clSelectedWaveController
             currentModel, selectedDigestItem, currentReadState, readStateStale);
     view.render(currentModel);
     publishWriteSession();
+    hydrateAttachmentsIfNeeded(currentModel);
   }
 
   private void resetReadStateFetchTracking() {
@@ -667,5 +692,111 @@ public final class J2clSelectedWaveController
                 onVisible.run();
               }
             });
+  }
+
+  // --- Attachment metadata hydration -----------------------------------------
+
+  /**
+   * After a render cycle, collects all {@code metadataPending} attachments from
+   * the current read blips and triggers a single metadata fetch through the
+   * gateway. On success, re-renders with {@code fromMetadata}-hydrated models;
+   * on failure (or for IDs missing from the response), falls back to
+   * {@code metadataFailure} display. Only one hydration pass is performed per
+   * render — if the selected wave changes while the fetch is in-flight the
+   * result is discarded.
+   */
+  private void hydrateAttachmentsIfNeeded(J2clSelectedWaveModel model) {
+    List<J2clReadBlip> readBlips = model.getReadBlips();
+    if (readBlips.isEmpty()) {
+      return;
+    }
+    // Collect all pending attachment IDs across all blips.
+    List<String> pendingIds = new ArrayList<String>();
+    for (J2clReadBlip blip : readBlips) {
+      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
+        if (attachment.isMetadataPending()) {
+          pendingIds.add(attachment.getAttachmentId());
+        }
+      }
+    }
+    if (pendingIds.isEmpty()) {
+      return;
+    }
+    final int hydrationGeneration = requestGeneration;
+    final String hydrationWaveId = selectedWaveId;
+    gateway.fetchAttachmentMetadata(
+        pendingIds,
+        result -> {
+          // Discard if the wave selection has changed since the fetch started.
+          if (hydrationGeneration != requestGeneration
+              || !equalsNullSafe(hydrationWaveId, selectedWaveId)) {
+            return;
+          }
+          // Build a lookup map from attachmentId -> metadata for successful results.
+          Map<String, J2clAttachmentMetadata> metadataById =
+              new HashMap<String, J2clAttachmentMetadata>();
+          if (result.isSuccess()) {
+            for (J2clAttachmentMetadata metadata : result.getAttachments()) {
+              metadataById.put(metadata.getAttachmentId(), metadata);
+            }
+          }
+          // Re-build each blip's attachment list, hydrating pending entries.
+          List<J2clReadBlip> hydratedBlips = new ArrayList<J2clReadBlip>(currentModel.getReadBlips().size());
+          for (J2clReadBlip blip : currentModel.getReadBlips()) {
+            boolean hasAnyPending = false;
+            for (J2clAttachmentRenderModel a : blip.getAttachments()) {
+              if (a.isMetadataPending()) {
+                hasAnyPending = true;
+                break;
+              }
+            }
+            if (!hasAnyPending) {
+              hydratedBlips.add(blip);
+              continue;
+            }
+            List<J2clAttachmentRenderModel> hydratedAttachments =
+                new ArrayList<J2clAttachmentRenderModel>(blip.getAttachments().size());
+            for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
+              if (!attachment.isMetadataPending()) {
+                hydratedAttachments.add(attachment);
+                continue;
+              }
+              String attachmentId = attachment.getAttachmentId();
+              J2clAttachmentMetadata metadata = metadataById.get(attachmentId);
+              if (!result.isSuccess()) {
+                // Whole-fetch failure: surface the error message from the result.
+                hydratedAttachments.add(
+                    J2clAttachmentRenderModel.metadataFailure(
+                        attachmentId,
+                        attachment.getCaption(),
+                        attachment.getDisplaySize(),
+                        result.getMessage()));
+              } else if (metadata != null) {
+                hydratedAttachments.add(
+                    J2clAttachmentRenderModel.fromMetadata(
+                        attachmentId,
+                        attachment.getCaption(),
+                        attachment.getDisplaySize(),
+                        metadata));
+              } else {
+                // ID was not returned by the server.
+                hydratedAttachments.add(
+                    J2clAttachmentRenderModel.metadataFailure(
+                        attachmentId,
+                        attachment.getCaption(),
+                        attachment.getDisplaySize(),
+                        "attachment not found"));
+              }
+            }
+            hydratedBlips.add(new J2clReadBlip(blip.getBlipId(), blip.getText(), hydratedAttachments));
+          }
+          currentModel = currentModel.withReadBlips(hydratedBlips);
+          view.render(currentModel);
+          publishWriteSession();
+        });
+  }
+
+  private static boolean equalsNullSafe(String a, String b) {
+    return a == null ? b == null : a.equals(b);
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -431,6 +431,30 @@ public final class J2clSelectedWaveModel {
         readStateStale);
   }
 
+  J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
+    return new J2clSelectedWaveModel(
+        hasSelection,
+        loading,
+        error,
+        selectedWaveId,
+        titleText,
+        snippetText,
+        unreadText,
+        statusText,
+        detailText,
+        reconnectCount,
+        participantIds,
+        contentEntries,
+        newReadBlips,
+        viewportState,
+        interactionBlips,
+        writeSession,
+        unreadCount,
+        read,
+        readStateKnown,
+        readStateStale);
+  }
+
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
     // Soft status updates keep the selected-wave card interactive and avoid the blocking error
     // presentation used for bootstrap/stream failures.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -150,7 +150,8 @@ public final class J2clSelectedWaveViewportState {
                   Math.max(existing.getToVersion(), fragmentEntry.getToVersion()),
                   existing.getRawSnapshot(),
                   existing.getAdjustOperationCount(),
-                  existing.getDiffOperationCount()));
+                  existing.getDiffOperationCount(),
+                  existing.shouldParseAttachmentElements()));
         } else {
           merged.set(existingIndex, fragmentEntry);
         }
@@ -286,9 +287,16 @@ public final class J2clSelectedWaveViewportState {
       if (!entry.isLoaded() || !entry.isBlip()) {
         continue;
       }
-      J2clReadBlipContent content = J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
-      readBlips.add(
-          new J2clReadBlip(entry.getBlipId(), content.getText(), content.getAttachments()));
+      // parseAttachmentElements is true only for fragment entries (fromFragments); document
+      // entries (fromDocuments) leave it false, so plain text like "2 < 3" is never mangled.
+      if (entry.shouldParseAttachmentElements()) {
+        J2clReadBlipContent content =
+            J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
+        readBlips.add(
+            new J2clReadBlip(entry.getBlipId(), content.getText(), content.getAttachments()));
+      } else {
+        readBlips.add(new J2clReadBlip(entry.getBlipId(), entry.getRawSnapshot()));
+      }
     }
     return readBlips;
   }
@@ -300,16 +308,26 @@ public final class J2clSelectedWaveViewportState {
         continue;
       }
       if (entry.isLoaded()) {
-        J2clReadBlipContent content =
-            J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
-        windowEntries.add(
-            J2clReadWindowEntry.loaded(
-                entry.getSegment(),
-                entry.getFromVersion(),
-                entry.getToVersion(),
-                entry.getBlipId(),
-                content.getText(),
-                content.getAttachments()));
+        if (entry.shouldParseAttachmentElements()) {
+          J2clReadBlipContent content =
+              J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
+          windowEntries.add(
+              J2clReadWindowEntry.loaded(
+                  entry.getSegment(),
+                  entry.getFromVersion(),
+                  entry.getToVersion(),
+                  entry.getBlipId(),
+                  content.getText(),
+                  content.getAttachments()));
+        } else {
+          windowEntries.add(
+              J2clReadWindowEntry.loaded(
+                  entry.getSegment(),
+                  entry.getFromVersion(),
+                  entry.getToVersion(),
+                  entry.getBlipId(),
+                  entry.getRawSnapshot()));
+        }
       } else {
         windowEntries.add(
             J2clReadWindowEntry.placeholder(
@@ -378,6 +396,7 @@ public final class J2clSelectedWaveViewportState {
     private final int adjustOperationCount;
     private final int diffOperationCount;
     private final boolean loaded;
+    private final boolean parseAttachmentElements;
 
     private Entry(
         String segment,
@@ -386,7 +405,8 @@ public final class J2clSelectedWaveViewportState {
         String rawSnapshot,
         int adjustOperationCount,
         int diffOperationCount,
-        boolean loaded) {
+        boolean loaded,
+        boolean parseAttachmentElements) {
       this.segment = segment == null ? "" : segment;
       this.fromVersion = fromVersion;
       this.toVersion = toVersion;
@@ -394,6 +414,7 @@ public final class J2clSelectedWaveViewportState {
       this.adjustOperationCount = adjustOperationCount;
       this.diffOperationCount = diffOperationCount;
       this.loaded = loaded;
+      this.parseAttachmentElements = parseAttachmentElements;
     }
 
     static Entry fromRange(
@@ -408,6 +429,7 @@ public final class J2clSelectedWaveViewportState {
           fragment.getRawSnapshot(),
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
+          true,
           true);
     }
 
@@ -422,6 +444,7 @@ public final class J2clSelectedWaveViewportState {
           fragment.getRawSnapshot(),
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
+          true,
           true);
     }
 
@@ -432,6 +455,24 @@ public final class J2clSelectedWaveViewportState {
         String rawSnapshot,
         int adjustOperationCount,
         int diffOperationCount) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          false);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        boolean parseAttachmentElements) {
       return new Entry(
           segment,
           fromVersion,
@@ -439,11 +480,12 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
-          true);
+          true,
+          parseAttachmentElements);
     }
 
     static Entry placeholder(String segment, long fromVersion, long toVersion) {
-      return new Entry(segment, fromVersion, toVersion, "", 0, 0, false);
+      return new Entry(segment, fromVersion, toVersion, "", 0, 0, false, false);
     }
 
     public String getSegment() {
@@ -472,6 +514,10 @@ public final class J2clSelectedWaveViewportState {
 
     public boolean isLoaded() {
       return loaded;
+    }
+
+    public boolean shouldParseAttachmentElements() {
+      return parseAttachmentElements;
     }
 
     public boolean isBlip() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -455,6 +455,7 @@ public final class J2clSelectedWaveViewportState {
         String rawSnapshot,
         int adjustOperationCount,
         int diffOperationCount) {
+      // Default loaded entries are document text snapshots; fragment debug XML opts in below.
       return loaded(
           segment,
           fromVersion,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
@@ -285,7 +286,9 @@ public final class J2clSelectedWaveViewportState {
       if (!entry.isLoaded() || !entry.isBlip()) {
         continue;
       }
-      readBlips.add(new J2clReadBlip(entry.getBlipId(), entry.getRawSnapshot()));
+      J2clReadBlipContent content = J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
+      readBlips.add(
+          new J2clReadBlip(entry.getBlipId(), content.getText(), content.getAttachments()));
     }
     return readBlips;
   }
@@ -297,13 +300,16 @@ public final class J2clSelectedWaveViewportState {
         continue;
       }
       if (entry.isLoaded()) {
+        J2clReadBlipContent content =
+            J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
         windowEntries.add(
             J2clReadWindowEntry.loaded(
                 entry.getSegment(),
                 entry.getFromVersion(),
                 entry.getToVersion(),
                 entry.getBlipId(),
-                entry.getRawSnapshot()));
+                content.getText(),
+                content.getAttachments()));
       } else {
         windowEntries.add(
             J2clReadWindowEntry.placeholder(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -1,0 +1,364 @@
+package org.waveprotocol.box.j2cl.attachment;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clAttachmentRenderModelTest.class)
+public class J2clAttachmentRenderModelTest {
+  @Test
+  public void mediumImageUsesOriginalAttachmentUrl() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            metadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(model.isInlineImage());
+    Assert.assertEquals("medium", model.getDisplaySize());
+    Assert.assertEquals("/attachment/example.com/att+hero", model.getSourceUrl());
+    Assert.assertEquals("/attachment/example.com/att+hero", model.getOpenUrl());
+    Assert.assertEquals("hero.png", model.getDownloadFileName());
+    Assert.assertEquals("Open attachment hero.png (image/png)", model.getOpenLabel());
+    Assert.assertEquals("Download attachment hero.png (image/png)", model.getDownloadLabel());
+  }
+
+  @Test
+  public void nonImageStaysCardBasedAndUsesThumbnailSource() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+pdf",
+            "Spec",
+            "large",
+            metadata(
+                "example.com/att+pdf",
+                "spec.pdf",
+                "application/pdf",
+                "/attachment/example.com/att+pdf",
+                "/thumbnail/example.com/att+pdf",
+                null,
+                false));
+
+    Assert.assertFalse(model.isInlineImage());
+    Assert.assertEquals("large", model.getDisplaySize());
+    Assert.assertEquals("/thumbnail/example.com/att+pdf", model.getSourceUrl());
+    Assert.assertEquals("/attachment/example.com/att+pdf", model.getOpenUrl());
+  }
+
+  @Test
+  public void imageMissingDimensionsFallsBackToSmallTile() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+pending",
+            "Pending image",
+            "large",
+            metadata(
+                "example.com/att+pending",
+                "pending.png",
+                "image/png",
+                "/attachment/example.com/att+pending",
+                "/thumbnail/example.com/att+pending",
+                null,
+                false));
+
+    Assert.assertFalse(model.isInlineImage());
+    Assert.assertEquals("small", model.getDisplaySize());
+    Assert.assertEquals("/thumbnail/example.com/att+pending", model.getSourceUrl());
+  }
+
+  @Test
+  public void smallImageWithDimensionsUsesThumbnailTile() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+small",
+            "Small image",
+            "small",
+            metadata(
+                "example.com/att+small",
+                "small.png",
+                "image/png",
+                "/attachment/example.com/att+small",
+                "/thumbnail/example.com/att+small",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+
+    Assert.assertFalse(model.isInlineImage());
+    Assert.assertEquals("small", model.getDisplaySize());
+    Assert.assertEquals("/thumbnail/example.com/att+small", model.getSourceUrl());
+  }
+
+  @Test
+  public void nonImageWithoutThumbnailFallsBackToAttachmentUrl() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+pdf",
+            "Spec",
+            "small",
+            metadata(
+                "example.com/att+pdf",
+                "spec.pdf",
+                "application/pdf",
+                "/attachment/example.com/att+pdf",
+                "",
+                null,
+                false));
+
+    Assert.assertFalse(model.isInlineImage());
+    Assert.assertEquals("/attachment/example.com/att+pdf", model.getSourceUrl());
+  }
+
+  @Test
+  public void unsafeAttachmentUrlsDisablePreviewOpenAndDownload() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+unsafe",
+            "Unsafe",
+            "medium",
+            metadata(
+                "example.com/att+unsafe",
+                "unsafe.png",
+                "image/png",
+                "javascript:alert(1)",
+                "data:image/png;base64,AAAA",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+
+    Assert.assertEquals("", model.getSourceUrl());
+    Assert.assertEquals("", model.getOpenUrl());
+    Assert.assertFalse(model.canOpen());
+    Assert.assertFalse(model.canDownload());
+  }
+
+  @Test
+  public void protocolRelativeAndHttpUrlsAreRejected() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+unsafe",
+            "Unsafe",
+            "medium",
+            metadata(
+                "example.com/att+unsafe",
+                "unsafe.png",
+                "image/png",
+                "http://cdn.example.test/unsafe.png",
+                "//cdn.example.test/unsafe-thumbnail.png",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+
+    Assert.assertEquals("", model.getSourceUrl());
+    Assert.assertEquals("", model.getOpenUrl());
+    Assert.assertEquals("small", model.getDisplaySize());
+    Assert.assertFalse(model.isInlineImage());
+  }
+
+  @Test
+  public void httpsUrlsAreAcceptedAndControlCharactersAreRejected() {
+    J2clAttachmentRenderModel accepted =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+https",
+            "Https",
+            "medium",
+            metadata(
+                "example.com/att+https",
+                "https.png",
+                "image/png",
+                "https://cdn.example.test/https.png",
+                "https://cdn.example.test/https-thumb.png",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+    J2clAttachmentRenderModel rejected =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+control",
+            "Control",
+            "medium",
+            metadata(
+                "example.com/att+control",
+                "control.png",
+                "image/png",
+                "https://cdn.example.test/control\tbad.png",
+                "/thumbnail/example.com/control\r\nbad.png",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+
+    Assert.assertEquals("https://cdn.example.test/https.png", accepted.getSourceUrl());
+    Assert.assertTrue(accepted.isInlineImage());
+    Assert.assertEquals("", rejected.getOpenUrl());
+    Assert.assertFalse(rejected.canOpen());
+  }
+
+  @Test
+  public void malwareMetadataBlocksOpenAndDownloadControls() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+blocked",
+            "Blocked",
+            "small",
+            metadata(
+                "example.com/att+blocked",
+                "blocked.exe",
+                "application/octet-stream",
+                "/attachment/example.com/att+blocked",
+                "",
+                null,
+                true));
+
+    Assert.assertTrue(model.isBlocked());
+    Assert.assertFalse(model.canOpen());
+    Assert.assertFalse(model.canDownload());
+    Assert.assertTrue(model.getStatusText().contains("blocked"));
+  }
+
+  @Test
+  public void metadataFailureSurfacesErrorState() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.metadataFailure(
+            "example.com/att+missing", "Missing", "medium", "metadata endpoint failed");
+
+    Assert.assertTrue(model.isMetadataFailure());
+    Assert.assertFalse(model.canOpen());
+    Assert.assertFalse(model.canDownload());
+    Assert.assertEquals("medium", model.getDisplaySize());
+    Assert.assertTrue(model.getStatusText().contains("metadata endpoint failed"));
+  }
+
+  @Test
+  public void metadataPendingIsDistinctFromFailure() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.metadataPending(
+            "example.com/att+pending", "Pending", "medium");
+
+    Assert.assertTrue(model.isMetadataPending());
+    Assert.assertFalse(model.isMetadataFailure());
+    Assert.assertFalse(model.canOpen());
+    Assert.assertFalse(model.canDownload());
+    Assert.assertEquals("Attachment metadata loading...", model.getStatusText());
+  }
+
+  @Test
+  public void nullMetadataUsesFailureWithoutDuplicatingStatusPrefix() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+missing", "Missing", "small", null);
+
+    Assert.assertTrue(model.isMetadataFailure());
+    Assert.assertEquals(
+        "Attachment metadata unavailable: metadata unavailable", model.getStatusText());
+  }
+
+  @Test
+  public void downloadFileNameFallsBackToSafeLastPathSegment() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "",
+            "small",
+            metadata(
+                "example.com/att+hero",
+                "",
+                "application/octet-stream",
+                "/attachment/example.com/att+hero",
+                "",
+                null,
+                false));
+
+    Assert.assertEquals("att+hero", model.getDownloadFileName());
+  }
+
+  @Test
+  public void downloadFileNameRejectsEmptyDotAndDotDotNames() {
+    J2clAttachmentRenderModel whitespace =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+blank",
+            "",
+            "small",
+            metadata(
+                "example.com/att+blank",
+                " ",
+                "application/octet-stream",
+                "/attachment/example.com/att+blank",
+                "",
+                null,
+                false));
+    J2clAttachmentRenderModel dot =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+dot",
+            "",
+            "small",
+            metadata(
+                "example.com/att+dot",
+                ".",
+                "application/octet-stream",
+                "/attachment/example.com/att+dot",
+                "",
+                null,
+                false));
+    J2clAttachmentRenderModel dotDot =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+dotdot",
+            "",
+            "small",
+            metadata(
+                "example.com/att+dotdot",
+                "..",
+                "application/octet-stream",
+                "/attachment/example.com/att+dotdot",
+                "",
+                null,
+                false));
+
+    Assert.assertEquals("att+blank", whitespace.getDownloadFileName());
+    Assert.assertEquals("attachment", dot.getDownloadFileName());
+    Assert.assertEquals("attachment", dotDot.getDownloadFileName());
+  }
+
+  @Test
+  public void emptySourceUrlsForceSmallDisplaySize() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+missing",
+            "Missing",
+            "large",
+            metadata(
+                "example.com/att+missing",
+                "missing.png",
+                "image/png",
+                "",
+                "",
+                new J2clAttachmentMetadata.ImageMetadata(320, 200),
+                false));
+
+    Assert.assertEquals("small", model.getDisplaySize());
+    Assert.assertEquals("", model.getSourceUrl());
+    Assert.assertFalse(model.isInlineImage());
+  }
+
+  private static J2clAttachmentMetadata metadata(
+      String attachmentId,
+      String fileName,
+      String mimeType,
+      String attachmentUrl,
+      String thumbnailUrl,
+      J2clAttachmentMetadata.ImageMetadata imageMetadata,
+      boolean malware) {
+    return new J2clAttachmentMetadata(
+        attachmentId,
+        "example.com/w+1/~/conv+root",
+        fileName,
+        mimeType,
+        1234L,
+        "user@example.com",
+        attachmentUrl,
+        thumbnailUrl,
+        imageMetadata,
+        null,
+        malware);
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -186,4 +186,18 @@ public class J2clReadBlipContentTest {
     Assert.assertEquals("example.com/att+self", attachment.getAttachmentId());
     Assert.assertEquals("medium", attachment.getDisplaySize());
   }
+
+  @Test
+  public void literalGreaterThanInPlainTextIsPreserved() {
+    J2clReadBlipContent parsed = J2clReadBlipContent.parseRawSnapshot("a > b");
+    Assert.assertEquals("a > b", parsed.getText());
+    Assert.assertEquals(0, parsed.getAttachments().size());
+  }
+
+  @Test
+  public void literalGreaterThanOutsideTagIsNotTreatedAsTagClose() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body>x > y</body>");
+    Assert.assertEquals("x > y", parsed.getText());
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -91,8 +91,87 @@ public class J2clReadBlipContentTest {
         J2clReadBlipContent.parseRawSnapshot(
             "<body><line/>Hello<line/>World</body>");
 
-    Assert.assertEquals("Hello World", parsed.getText());
+    Assert.assertEquals("Hello\nWorld", parsed.getText());
     Assert.assertTrue(parsed.getAttachments().isEmpty());
+  }
+
+  @Test
+  public void leadingLineTagDoesNotAddLeadingSeparator() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body><line/>Hello</body>");
+
+    Assert.assertEquals("Hello", parsed.getText());
+  }
+
+  @Test
+  public void trailingLineTagDocumentsTrailingSeparatorBehavior() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body>Hello<line/></body>");
+
+    Assert.assertEquals("Hello\n", parsed.getText());
+  }
+
+  @Test
+  public void consecutiveLineTagsDoNotDuplicateLeadingSeparator() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body><line/><line/>Hello</body>");
+
+    Assert.assertEquals("Hello", parsed.getText());
+  }
+
+  @Test
+  public void consecutiveLineTagsInsideTextCollapseToSingleSeparator() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body>Hello<line/><line/>World</body>");
+
+    Assert.assertEquals("Hello\nWorld", parsed.getText());
+  }
+
+  @Test
+  public void trailingHorizontalWhitespaceIsNormalizedAtLineBoundary() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body>Hello   <line/>World</body>");
+
+    Assert.assertEquals("Hello\nWorld", parsed.getText());
+  }
+
+  @Test
+  public void lineTagsMatchCaseAndWhitespaceVariants() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body>A<LINE t=\"1\"/>B<line\n/>C<line \t t=\"2\"></line>D</body>");
+
+    Assert.assertEquals("A\nB\nC\nD", parsed.getText());
+  }
+
+  @Test
+  public void linefeedTagDoesNotCountAsLineSeparator() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot("<body>A<linefeed/>B</body>");
+
+    Assert.assertEquals("AB", parsed.getText());
+  }
+
+  @Test
+  public void lineSeparatorAndImageExtractionCompose() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><line/>X<image attachment=\"example.com/att+1\"/>"
+                + "<line/>Y</body>");
+
+    Assert.assertEquals("X\nY", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    Assert.assertEquals("example.com/att+1", parsed.getAttachments().get(0).getAttachmentId());
+  }
+
+  @Test
+  public void leadingLineBeforeImageDoesNotAddSeparator() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><line/><image attachment=\"example.com/att+1\"/><line/>Y</body>");
+
+    Assert.assertEquals("Y", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -1,0 +1,100 @@
+package org.waveprotocol.box.j2cl.read;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+
+@J2clTestInput(J2clReadBlipContentTest.class)
+public class J2clReadBlipContentTest {
+  @Test
+  public void parsesSingleAndDoubleQuotedImageAttributesWithEntities() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image attachment='ex&amp;ample.com/att+1' display-size=\"large\">"
+                + "<caption>AT&amp;T &lt;diagram&gt;</caption></image> after");
+
+    Assert.assertEquals("Before  after", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    J2clAttachmentRenderModel attachment = parsed.getAttachments().get(0);
+    Assert.assertEquals("ex&ample.com/att+1", attachment.getAttachmentId());
+    Assert.assertEquals("AT&T <diagram>", attachment.getCaption());
+    Assert.assertEquals("large", attachment.getDisplaySize());
+    Assert.assertTrue(attachment.isMetadataPending());
+  }
+
+  @Test
+  public void ignoresAttributeNameSubstrings() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image data-attachment=\"wrong\" data-note=\"x attachment=oops\" "
+                + "attachment=\"right\" "
+                + "data-display-size=\"large\" display-size=\"medium\">"
+                + "<caption>Caption</caption></image> after");
+
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    J2clAttachmentRenderModel attachment = parsed.getAttachments().get(0);
+    Assert.assertEquals("right", attachment.getAttachmentId());
+    Assert.assertEquals("medium", attachment.getDisplaySize());
+  }
+
+  @Test
+  public void normalizesUppercaseDisplaySizeAttributeValues() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<image ATTACHMENT=\"example.com/att+1\" DISPLAY-SIZE=\"MEDIUM\">"
+                + "<caption>Caption</caption></image>");
+
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    Assert.assertEquals("medium", parsed.getAttachments().get(0).getDisplaySize());
+  }
+
+  @Test
+  public void malformedImageWithoutAttachmentRemainsVisibleText() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image display-size=\"large\"><caption>Visible</caption></image> after");
+
+    Assert.assertEquals("Before Visible after", parsed.getText());
+    Assert.assertTrue(parsed.getAttachments().isEmpty());
+  }
+
+  @Test
+  public void malformedImageWithoutAttachmentAdvancesToNextImage() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image display-size=\"large\"><caption>Visible</caption></image>"
+                + "<image attachment=\"example.com/att+2\"><caption>Second</caption></image>");
+
+    Assert.assertEquals("Before Visible", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    Assert.assertEquals("example.com/att+2", parsed.getAttachments().get(0).getAttachmentId());
+  }
+
+  @Test
+  public void unclosedImageCreatesPendingAttachmentAndKeepsFollowingTextOutOfCaption() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image attachment=\"example.com/att+1\" display-size=\"medium\"> after");
+
+    Assert.assertEquals("Before  after", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    J2clAttachmentRenderModel attachment = parsed.getAttachments().get(0);
+    Assert.assertEquals("example.com/att+1", attachment.getAttachmentId());
+    Assert.assertEquals("example.com/att+1", attachment.getCaption());
+    Assert.assertEquals("medium", attachment.getDisplaySize());
+  }
+
+  @Test
+  public void selfClosingImageCreatesPendingAttachment() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image attachment=\"example.com/att+self\" display-size=\"medium\" /> after");
+
+    Assert.assertEquals("Before  after", parsed.getText());
+    Assert.assertEquals(1, parsed.getAttachments().size());
+    J2clAttachmentRenderModel attachment = parsed.getAttachments().get(0);
+    Assert.assertEquals("example.com/att+self", attachment.getAttachmentId());
+    Assert.assertEquals("medium", attachment.getDisplaySize());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -86,6 +86,16 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void lineTagsSeparateAdjacentTextSegments() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><line/>Hello<line/>World</body>");
+
+    Assert.assertEquals("Hello World", parsed.getText());
+    Assert.assertTrue(parsed.getAttachments().isEmpty());
+  }
+
+  @Test
   public void selfClosingImageCreatesPendingAttachment() {
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -546,6 +546,46 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void cardStyleAttachmentWithThumbnailRendersImgPreview() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    // Small display size with an image mime type → card style (not inline), but sourceUrl is set
+    // to the thumbnail so the preview img must be rendered with src pointing to it.
+    J2clAttachmentRenderModel card =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+pdf",
+            "Report",
+            "small",
+            attachmentMetadata(
+                "example.com/att+pdf",
+                "report.pdf",
+                "application/pdf",
+                "/attachment/example.com/att+pdf",
+                "/thumbnail/example.com/att+pdf",
+                null,
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip("b+root", "Root text", Arrays.asList(card))),
+                Collections.<String>emptyList()));
+
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+pdf']");
+    Assert.assertNotNull(tile);
+    Assert.assertEquals("j2cl-read-attachment j2cl-read-attachment-card", tile.className);
+    HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
+    Assert.assertNotNull(preview);
+    Assert.assertEquals("IMG", preview.tagName);
+    Assert.assertEquals("/thumbnail/example.com/att+pdf", preview.getAttribute("src"));
+    Assert.assertEquals("no-referrer", preview.getAttribute("referrerpolicy"));
+    Assert.assertEquals("true", preview.getAttribute("aria-hidden"));
+    Assert.assertEquals("", preview.getAttribute("alt"));
+  }
+
+  @Test
   public void focusedBlipReceivesCurrentMarker() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -16,6 +16,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 @J2clTestInput(J2clReadSurfaceDomRendererTest.class)
@@ -289,6 +291,258 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("0", firstBlip(host).getAttribute("tabindex"));
     Assert.assertEquals(
         "ArrowUp ArrowDown Home End", firstBlip(host).getAttribute("aria-keyshortcuts"));
+  }
+
+  @Test
+  public void renderWindowEntriesIncludeKeyboardReachableAttachmentControls() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.loaded(
+                        "blip:b+root",
+                        0L,
+                        9L,
+                        "b+root",
+                        "Root text",
+                        Arrays.asList(attachment)))));
+
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+    Assert.assertNotNull(tile);
+    Assert.assertEquals("example.com/att+hero", tile.getAttribute("data-attachment-id"));
+    Assert.assertEquals("medium", tile.getAttribute("data-display-size"));
+    Assert.assertNotNull(tile.querySelector("img"));
+
+    HTMLElement open =
+        (HTMLElement) tile.querySelector("[data-j2cl-attachment-open='true']");
+    HTMLElement download =
+        (HTMLElement) tile.querySelector("[data-j2cl-attachment-download='true']");
+    Assert.assertNotNull(open);
+    Assert.assertNotNull(download);
+    Assert.assertEquals("/attachment/example.com/att+hero", open.getAttribute("href"));
+    Assert.assertEquals("0", open.getAttribute("tabindex"));
+    Assert.assertEquals("noopener noreferrer", open.getAttribute("rel"));
+    Assert.assertEquals("no-referrer", open.getAttribute("referrerpolicy"));
+    Assert.assertNull(download.getAttribute("rel"));
+    Assert.assertNull(download.getAttribute("referrerpolicy"));
+    Assert.assertNull(download.getAttribute("target"));
+    Assert.assertEquals("hero.png", download.getAttribute("download"));
+    Assert.assertEquals("group", tile.getAttribute("role"));
+    Assert.assertEquals(
+        "true", tile.querySelector(".j2cl-read-attachment-label").getAttribute("aria-hidden"));
+    Assert.assertEquals("lazy", tile.querySelector("img").getAttribute("loading"));
+    Assert.assertEquals("Open attachment hero.png (image/png)", open.getAttribute("aria-label"));
+    Assert.assertEquals(
+        "Download attachment hero.png (image/png)", download.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void crossOriginDownloadLinksOpenSafelyWhenDownloadAttributeIsIgnored() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+cdn",
+            "CDN image",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+cdn",
+                "cdn.png",
+                "image/png",
+                "https://cdn.example.test/attachment/cdn.png",
+                "https://cdn.example.test/thumbnail/cdn.png",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip(
+                        "b+root", "Root text", Arrays.asList(attachment))),
+                Collections.<String>emptyList()));
+
+    HTMLElement download =
+        (HTMLElement) host.querySelector("[data-j2cl-attachment-download='true']");
+    Assert.assertEquals("cdn.png", download.getAttribute("download"));
+    Assert.assertEquals("_blank", download.getAttribute("target"));
+    Assert.assertEquals("noopener noreferrer", download.getAttribute("rel"));
+    Assert.assertEquals("no-referrer", download.getAttribute("referrerpolicy"));
+  }
+
+  @Test
+  public void rerenderingSameAttachmentBlipsPreservesRenderedNodes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+    List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+root", "Root text", Arrays.asList(attachment)));
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+
+    Assert.assertTrue(renderer.render(blips, Collections.<String>emptyList()));
+
+    Assert.assertSame(tile, host.querySelector("[data-j2cl-read-attachment='true']"));
+  }
+
+  @Test
+  public void rerenderingChangedAttachmentBlipsReplacesRenderedNodes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel firstAttachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+first",
+            "First",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+first",
+                "first.png",
+                "image/png",
+                "/attachment/example.com/att+first",
+                "/thumbnail/example.com/att+first",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+    J2clAttachmentRenderModel secondAttachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+second",
+            "Second",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+second",
+                "second.png",
+                "image/png",
+                "/attachment/example.com/att+second",
+                "/thumbnail/example.com/att+second",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root text", Arrays.asList(firstAttachment))),
+            Collections.<String>emptyList()));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root text", Arrays.asList(secondAttachment))),
+            Collections.<String>emptyList()));
+
+    Assert.assertNotSame(tile, host.querySelector("[data-j2cl-read-attachment='true']"));
+    Assert.assertNotNull(host.querySelector("[data-attachment-id='example.com/att+second']"));
+  }
+
+  @Test
+  public void renderLiveBlipsSurfacesBlockedAttachmentStateWithoutControls() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+blocked",
+            "Blocked",
+            "small",
+            attachmentMetadata(
+                "example.com/att+blocked",
+                "blocked.exe",
+                "application/octet-stream",
+                "/attachment/example.com/att+blocked",
+                "",
+                null,
+                true));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip(
+                        "b+root", "Root text", Arrays.asList(attachment))),
+                Collections.<String>emptyList()));
+
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+    Assert.assertNotNull(tile);
+    Assert.assertEquals("blocked", tile.getAttribute("data-attachment-state"));
+    Assert.assertNull(tile.querySelector("[data-j2cl-attachment-open='true']"));
+    Assert.assertTrue(
+        ((HTMLElement) tile.querySelector(".j2cl-read-attachment-status"))
+            .textContent
+            .contains("blocked"));
+    Assert.assertEquals(
+        "alert",
+        ((HTMLElement) tile.querySelector(".j2cl-read-attachment-status")).getAttribute("role"));
+  }
+
+  @Test
+  public void renderLiveBlipsSurfacesPendingAndFailureAttachmentStatesWithoutControls() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel pending =
+        J2clAttachmentRenderModel.metadataPending(
+            "example.com/att+pending", "Pending", "medium");
+    J2clAttachmentRenderModel failure =
+        J2clAttachmentRenderModel.metadataFailure(
+            "example.com/att+failure", "Failure", "medium", "metadata endpoint failed");
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip(
+                        "b+root", "Root text", Arrays.asList(pending, failure))),
+                Collections.<String>emptyList()));
+
+    HTMLElement pendingTile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+pending']");
+    HTMLElement failureTile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+failure']");
+    Assert.assertEquals("pending", pendingTile.getAttribute("data-attachment-state"));
+    Assert.assertEquals("true", pendingTile.getAttribute("aria-busy"));
+    Assert.assertEquals(
+        "Attachment metadata loading...",
+        ((HTMLElement) pendingTile.querySelector(".j2cl-read-attachment-status")).textContent);
+    Assert.assertNull(pendingTile.querySelector("[data-j2cl-attachment-open='true']"));
+    Assert.assertNull(pendingTile.querySelector(".j2cl-read-attachment-preview"));
+    Assert.assertEquals("metadata-failure", failureTile.getAttribute("data-attachment-state"));
+    Assert.assertEquals(
+        "alert",
+        ((HTMLElement) failureTile.querySelector(".j2cl-read-attachment-status"))
+            .getAttribute("role"));
+    Assert.assertNull(failureTile.querySelector("[data-j2cl-attachment-open='true']"));
   }
 
   @Test
@@ -576,6 +830,187 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals(root, DomGlobal.document.activeElement);
     Assert.assertEquals("0", root.getAttribute("tabindex"));
     Assert.assertEquals("true", root.getAttribute("aria-current"));
+  }
+
+  @Test
+  public void renderWindowPlaceholderUpgradeToLoadedAttachmentReplacesRenderedNodes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder("blip:b+reply", 36L, 40L, "b+reply"))));
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+reply",
+                    36L,
+                    40L,
+                    "b+reply",
+                    "Reply text",
+                    Arrays.asList(attachment)))));
+
+    Assert.assertNotSame(root, blip(host, "b+root"));
+    Assert.assertNotNull(host.querySelector("[data-attachment-id='example.com/att+hero']"));
+    Assert.assertEquals(blip(host, "b+root"), DomGlobal.document.activeElement);
+  }
+
+  @Test
+  public void renderWindowMixedPlaceholderAndAttachmentMarksSurfaceLiveAndBusy() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.loaded(
+                        "blip:b+root",
+                        30L,
+                        36L,
+                        "b+root",
+                        "Root text",
+                        Arrays.asList(attachment)),
+                    J2clReadWindowEntry.placeholder(
+                        "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals(
+        "polite", host.querySelector("[data-j2cl-read-surface]").getAttribute("aria-live"));
+    Assert.assertEquals(
+        "true", host.querySelector("[data-thread-id='root']").getAttribute("aria-busy"));
+    Assert.assertNotNull(host.querySelector("[data-attachment-id='example.com/att+hero']"));
+    Assert.assertNotNull(host.querySelector("[data-j2cl-viewport-placeholder='true']"));
+  }
+
+  @Test
+  public void rerenderingSameWindowEntryAttachmentsPreservesRenderedNodes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+    List<J2clReadWindowEntry> entries =
+        Arrays.asList(
+            J2clReadWindowEntry.loaded(
+                "blip:b+root",
+                30L,
+                36L,
+                "b+root",
+                "Root text",
+                Arrays.asList(attachment)));
+
+    Assert.assertTrue(renderer.renderWindow(entries));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+
+    Assert.assertTrue(renderer.renderWindow(entries));
+
+    Assert.assertSame(tile, host.querySelector("[data-j2cl-read-attachment='true']"));
+  }
+
+  @Test
+  public void rerenderingChangedWindowEntryAttachmentsReplacesRenderedNodes() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel firstAttachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+first",
+            "First",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+first",
+                "first.png",
+                "image/png",
+                "/attachment/example.com/att+first",
+                "/thumbnail/example.com/att+first",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+    J2clAttachmentRenderModel secondAttachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+second",
+            "Second",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+second",
+                "second.png",
+                "image/png",
+                "/attachment/example.com/att+second",
+                "/thumbnail/example.com/att+second",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root",
+                    30L,
+                    36L,
+                    "b+root",
+                    "Root text",
+                    Arrays.asList(firstAttachment)))));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-j2cl-read-attachment='true']");
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root",
+                    30L,
+                    36L,
+                    "b+root",
+                    "Root text",
+                    Arrays.asList(secondAttachment)))));
+
+    Assert.assertNotSame(tile, host.querySelector("[data-j2cl-read-attachment='true']"));
+    Assert.assertNotNull(host.querySelector("[data-attachment-id='example.com/att+second']"));
   }
 
   @Test
@@ -1109,6 +1544,28 @@ public class J2clReadSurfaceDomRendererTest {
   private static String renderedText(HTMLElement blip) {
     HTMLElement content = (HTMLElement) blip.querySelector(".j2cl-read-blip-content");
     return content == null ? "" : content.textContent;
+  }
+
+  private static J2clAttachmentMetadata attachmentMetadata(
+      String attachmentId,
+      String fileName,
+      String mimeType,
+      String attachmentUrl,
+      String thumbnailUrl,
+      J2clAttachmentMetadata.ImageMetadata imageMetadata,
+      boolean malware) {
+    return new J2clAttachmentMetadata(
+        attachmentId,
+        "example.com/w+1/~/conv+root",
+        fileName,
+        mimeType,
+        1234L,
+        "user@example.com",
+        attachmentUrl,
+        thumbnailUrl,
+        imageMetadata,
+        null,
+        malware);
   }
 
   private static void setLastScrollDirection(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -10,6 +10,9 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
@@ -881,6 +884,126 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
   }
 
+  @Test
+  public void pendingAttachmentsInReadBlipsTriggerMetadataFetch() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    // Deliver a fragment update whose raw snapshot contains an image element — this causes
+    // J2clReadBlipContent.parseRawSnapshot to produce a metadataPending attachment model.
+    harness.deliverRawUpdate(0, updateWithImageAttachment("img-001", "My photo", "medium", "Body text"));
+
+    // The controller must have triggered a metadata fetch for the pending attachment.
+    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
+    Assert.assertEquals(Arrays.asList("img-001"), harness.attachmentMetadataFetchAttempts.get(0).attachmentIds);
+  }
+
+  @Test
+  public void successfulMetadataFetchReRendersWithHydratedAttachments() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithImageAttachment("img-002", "A picture", "small", "Hello"));
+
+    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
+
+    // Capture the render count before the hydration re-render.
+    int rendersBefore = harness.renderCount;
+
+    // Supply metadata for img-002: minimal well-formed JSON for the attachment info endpoint.
+    harness.resolveAttachmentMetadataFetch(0, buildSingleAttachmentResultJson("img-002",
+        "photo.jpg", "image/jpeg", "/attachments/img-002", "/thumbnails/img-002", false));
+
+    // The controller must have called view.render a second time.
+    Assert.assertEquals(rendersBefore + 1, harness.renderCount);
+
+    // The re-rendered blips must have a non-pending attachment for img-002.
+    @SuppressWarnings("unchecked")
+    List<J2clReadBlip> readBlips = (List<J2clReadBlip>) harness.modelValue("getReadBlips");
+    Assert.assertFalse(readBlips.isEmpty());
+    boolean foundHydrated = false;
+    for (J2clReadBlip blip : readBlips) {
+      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
+        if ("img-002".equals(attachment.getAttachmentId())) {
+          Assert.assertFalse(
+              "Expected attachment to be hydrated (not metadataPending)",
+              attachment.isMetadataPending());
+          Assert.assertFalse(
+              "Expected attachment to not be metadataFailure after successful fetch",
+              attachment.isMetadataFailure());
+          foundHydrated = true;
+        }
+      }
+    }
+    Assert.assertTrue("No hydrated attachment for img-002 found in rendered model", foundHydrated);
+  }
+
+  @Test
+  public void failedMetadataFetchReRendersWithMetadataFailureAttachments() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithImageAttachment("img-003", "Broken", "small", ""));
+
+    int rendersBefore = harness.renderCount;
+    harness.rejectAttachmentMetadataFetch(0, "network error");
+
+    Assert.assertEquals(rendersBefore + 1, harness.renderCount);
+
+    @SuppressWarnings("unchecked")
+    List<J2clReadBlip> readBlips = (List<J2clReadBlip>) harness.modelValue("getReadBlips");
+    boolean foundFailure = false;
+    for (J2clReadBlip blip : readBlips) {
+      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
+        if ("img-003".equals(attachment.getAttachmentId())) {
+          Assert.assertFalse("Expected not pending after failed fetch", attachment.isMetadataPending());
+          Assert.assertTrue("Expected metadataFailure after failed fetch", attachment.isMetadataFailure());
+          foundFailure = true;
+        }
+      }
+    }
+    Assert.assertTrue("No failure attachment for img-003 found", foundFailure);
+  }
+
+  @Test
+  public void staleAttachmentFetchIsDiscardedAfterWaveReselection() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithImageAttachment("img-004", "Wave 1 photo", "small", ""));
+    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
+
+    // Switch to a different wave before the attachment fetch completes.
+    harness.selectWave(controller, "example.com/w+2", null);
+
+    int renderCountAfterSwitch = harness.renderCount;
+    harness.resolveAttachmentMetadataFetch(0, buildSingleAttachmentResultJson("img-004",
+        "photo.jpg", "image/jpeg", "/attachments/img-004", "/thumbnails/img-004", false));
+
+    // The stale result must be discarded — no extra re-render for wave 2.
+    Assert.assertEquals(renderCountAfterSwitch, harness.renderCount);
+  }
+
+  @Test
+  public void blipsWithNoAttachmentsDoNotTriggerMetadataFetch() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Just plain text, no attachments");
+
+    Assert.assertEquals(0, harness.attachmentMetadataFetchAttempts.size());
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
@@ -889,6 +1012,7 @@ public class J2clSelectedWaveControllerTest {
   private static final class Harness {
     private int openCount;
     private int closedCount;
+    private int renderCount;
     private final List<Integer> scheduledDelays = new ArrayList<Integer>();
     private final List<Runnable> scheduledRetries = new ArrayList<Runnable>();
     private final List<BootstrapAttempt> bootstrapAttempts = new ArrayList<BootstrapAttempt>();
@@ -896,6 +1020,8 @@ public class J2clSelectedWaveControllerTest {
     private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
     private final List<FragmentFetchAttempt> fragmentFetchAttempts =
         new ArrayList<FragmentFetchAttempt>();
+    private final List<AttachmentMetadataFetchAttempt> attachmentMetadataFetchAttempts =
+        new ArrayList<AttachmentMetadataFetchAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
     private SidecarViewportHints initialViewportHints;
@@ -992,6 +1118,19 @@ public class J2clSelectedWaveControllerTest {
                           error));
                   return null;
                 }
+                if ("fetchAttachmentMetadata".equals(method.getName())) {
+                  @SuppressWarnings("unchecked")
+                  List<String> ids = (List<String>) args[0];
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
+                      callback =
+                          (J2clSearchPanelController.SuccessCallback<
+                                  J2clAttachmentMetadataClient.MetadataResult>)
+                              args[1];
+                  attachmentMetadataFetchAttempts.add(
+                      new AttachmentMetadataFetchAttempt(ids, callback));
+                  return null;
+                }
                 return null;
               });
 
@@ -1002,6 +1141,7 @@ public class J2clSelectedWaveControllerTest {
               (proxy, method, args) -> {
                 if ("render".equals(method.getName())) {
                   lastModel = args[0];
+                  renderCount++;
                   Runnable callback = onNextRender;
                   onNextRender = null;
                   if (callback != null) {
@@ -1155,6 +1295,35 @@ public class J2clSelectedWaveControllerTest {
       fragmentFetchAttempts.get(index).error.accept(message);
     }
 
+    /**
+     * Resolves the attachment metadata fetch at {@code index} by running a real
+     * {@link J2clAttachmentMetadataClient} with a synchronous fake transport that
+     * returns the given JSON string as a successful 200 application/json response.
+     */
+    private void resolveAttachmentMetadataFetch(int index, String json) {
+      AttachmentMetadataFetchAttempt attempt = attachmentMetadataFetchAttempts.get(index);
+      J2clAttachmentMetadataClient client =
+          new J2clAttachmentMetadataClient(
+              (url, handler) ->
+                  handler.onResponse(
+                      new J2clAttachmentMetadataClient.HttpResponse(
+                          200, "application/json", json, null)));
+      client.fetchMetadata(attempt.attachmentIds, result -> attempt.callback.accept(result));
+    }
+
+    /**
+     * Rejects the attachment metadata fetch at {@code index} by invoking the
+     * callback with a network-failure result.
+     */
+    private void rejectAttachmentMetadataFetch(int index, String errorMessage) {
+      AttachmentMetadataFetchAttempt attempt = attachmentMetadataFetchAttempts.get(index);
+      J2clAttachmentMetadataClient client =
+          new J2clAttachmentMetadataClient(
+              (url, handler) ->
+                  handler.onResponse(J2clAttachmentMetadataClient.HttpResponse.networkError(errorMessage)));
+      client.fetchMetadata(attempt.attachmentIds, result -> attempt.callback.accept(result));
+    }
+
     private void deliverUpdate(int index, String rawSnapshot) {
       deliverRawUpdate(index, update("example.com!w+1/example.com!conv+root", rawSnapshot));
     }
@@ -1294,6 +1463,69 @@ public class J2clSelectedWaveControllerTest {
         json.toString());
   }
 
+  /**
+   * Creates a selected-wave update whose root blip raw snapshot contains an {@code <image>}
+   * element so that {@link J2clReadBlipContent#parseRawSnapshot} produces a
+   * {@code metadataPending} attachment model.
+   */
+  private static SidecarSelectedWaveUpdate updateWithImageAttachment(
+      String attachmentId, String caption, String displaySize, String bodyText) {
+    String rawSnapshot =
+        bodyText
+            + "<image attachment=\""
+            + attachmentId
+            + "\" display-size=\""
+            + displaySize
+            + "\"><caption>"
+            + caption
+            + "</caption></image>";
+    return new SidecarSelectedWaveUpdate(
+        1,
+        "example.com!w+1/example.com!conv+root",
+        true,
+        "chan-1",
+        44L,
+        "ABCD",
+        Arrays.asList("user@example.com"),
+        Arrays.asList(
+            new SidecarSelectedWaveDocument(
+                "b+root", "user@example.com", 40L, 44L, rawSnapshot)),
+        new SidecarSelectedWaveFragments(
+            44L,
+            40L,
+            44L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
+                new SidecarSelectedWaveFragmentRange("blip:b+root", 40L, 44L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
+                new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
+  }
+
+  /**
+   * Builds a JSON string in the format expected by
+   * {@link J2clAttachmentMetadataClient} for a single attachment.
+   */
+  private static String buildSingleAttachmentResultJson(
+      String attachmentId,
+      String fileName,
+      String mimeType,
+      String attachmentUrl,
+      String thumbnailUrl,
+      boolean malware) {
+    return "{\"1\":[{"
+        + "\"1\":\"" + attachmentId + "\","
+        + "\"2\":\"example.com/w+1\","
+        + "\"3\":\"" + fileName + "\","
+        + "\"4\":\"" + mimeType + "\","
+        + "\"5\":1024,"
+        + "\"6\":\"user@example.com\","
+        + "\"7\":\"" + attachmentUrl + "\","
+        + "\"8\":\"" + thumbnailUrl + "\","
+        + "\"11\":" + malware
+        + "}]}";
+  }
+
   private static SidecarSelectedWaveUpdate snapshotOnlyUpdate(String textContent) {
     return new SidecarSelectedWaveUpdate(
         1,
@@ -1362,6 +1594,20 @@ public class J2clSelectedWaveControllerTest {
       this.endVersion = endVersion;
       this.success = success;
       this.error = error;
+    }
+  }
+
+  private static final class AttachmentMetadataFetchAttempt {
+    private final List<String> attachmentIds;
+    private final J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
+        callback;
+
+    private AttachmentMetadataFetchAttempt(
+        List<String> attachmentIds,
+        J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
+            callback) {
+      this.attachmentIds = attachmentIds;
+      this.callback = callback;
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -284,6 +284,97 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void viewportDocumentMergeOverFragmentSwitchesBackToLiteralText() {
+    J2clSelectedWaveViewportState state =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                9L,
+                0L,
+                9L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "<image attachment=\"example.com/att+hero\">"
+                            + "<caption>Hero</caption></image>",
+                        0,
+                        0))));
+    String literalText = "Literal 2 < 3 and <image attachment=\"example.com/att+literal\">";
+
+    state =
+        state.mergeDocuments(
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 7L, 10L, literalText)));
+
+    Assert.assertEquals(literalText, state.getLoadedReadBlips().get(0).getText());
+    Assert.assertTrue(state.getLoadedReadBlips().get(0).getAttachments().isEmpty());
+    Assert.assertEquals(literalText, state.getReadWindowEntries().get(0).getText());
+    Assert.assertTrue(state.getReadWindowEntries().get(0).getAttachments().isEmpty());
+  }
+
+  @Test
+  public void viewportFragmentMergeOverDocumentRestoresAttachmentParsing() {
+    J2clSelectedWaveViewportState state =
+        J2clSelectedWaveViewportState.fromDocuments(
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 7L, 8L, "Literal <image> text")));
+
+    state =
+        state.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                10L,
+                0L,
+                10L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 10L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "Intro <image attachment=\"example.com/att+hero\">"
+                            + "<caption>Hero</caption></image> outro",
+                        0,
+                        0))),
+            J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertEquals("Intro  outro", state.getLoadedReadBlips().get(0).getText());
+    Assert.assertEquals(1, state.getLoadedReadBlips().get(0).getAttachments().size());
+    Assert.assertEquals(1, state.getReadWindowEntries().get(0).getAttachments().size());
+  }
+
+  @Test
+  public void viewportPlaceholderMergePreservesFragmentAttachmentParsing() {
+    J2clSelectedWaveViewportState state =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                9L,
+                0L,
+                9L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "Intro <image attachment=\"example.com/att+hero\">"
+                            + "<caption>Hero</caption></image> outro",
+                        0,
+                        0))));
+
+    state =
+        state.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                10L,
+                0L,
+                10L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 10L)),
+                Collections.<SidecarSelectedWaveFragment>emptyList()),
+            J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertEquals("Intro  outro", state.getLoadedReadBlips().get(0).getText());
+    Assert.assertEquals(1, state.getLoadedReadBlips().get(0).getAttachments().size());
+    Assert.assertEquals(1, state.getReadWindowEntries().get(0).getAttachments().size());
+  }
+
+  @Test
   public void projectBuildsInteractionBlipMetadataFromDocumentAnnotationsAndReactionDocs() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -251,6 +251,39 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectDocumentFallbackPreservesLiteralMarkupAndComparisons() {
+    String literalText =
+        "Literal 2 < 3 and <image attachment=\"example.com/att+literal\"> stays text";
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root", "user@example.com", 7L, 8L, literalText)),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals(literalText, blip.getText());
+    Assert.assertTrue(blip.getAttachments().isEmpty());
+    Assert.assertEquals(
+        literalText, projected.getViewportState().getReadWindowEntries().get(0).getText());
+    Assert.assertTrue(
+        projected.getViewportState().getReadWindowEntries().get(0).getAttachments().isEmpty());
+  }
+
+  @Test
   public void projectBuildsInteractionBlipMetadataFromDocumentAnnotationsAndReactionDocs() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
@@ -175,6 +176,49 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("Root text", projected.getReadBlips().get(0).getText());
     Assert.assertEquals("b+reply", projected.getReadBlips().get(1).getBlipId());
     Assert.assertEquals("Reply text", projected.getReadBlips().get(1).getText());
+  }
+
+  @Test
+  public void projectExtractsAttachmentModelsFromImageElementsInFragments() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    9L,
+                    0L,
+                    9L,
+                    Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(
+                            "blip:b+root",
+                            "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+                                + "<caption>Hero diagram</caption></image> outro",
+                            0,
+                            0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("Intro  outro", blip.getText());
+    Assert.assertEquals(1, blip.getAttachments().size());
+    J2clAttachmentRenderModel attachment = blip.getAttachments().get(0);
+    Assert.assertEquals("example.com/att+hero", attachment.getAttachmentId());
+    Assert.assertEquals("medium", attachment.getDisplaySize());
+    Assert.assertEquals("Hero diagram", attachment.getCaption());
+    Assert.assertTrue(attachment.isMetadataPending());
+    Assert.assertEquals(
+        1, projected.getViewportState().getReadWindowEntries().get(0).getAttachments().size());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-04-25-issue-971-j2cl-attachment-rendering.json
+++ b/wave/config/changelog.d/2026-04-25-issue-971-j2cl-attachment-rendering.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-issue-971-j2cl-attachment-rendering",
+  "version": "Unreleased",
+  "date": "2026-04-25",
+  "title": "J2CL read surface can show attachments",
+  "summary": "The Lit/J2CL selected-wave read surface now carries attachment render metadata from image elements and exposes attachment controls in the read UI.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Selected-wave attachment elements in the J2CL read surface now render as attachment cards or inline images with keyboard-reachable open and download actions, plus blocked or metadata-unavailable states."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `J2clAttachmentRenderModel` and selected-wave raw snapshot parsing for image attachment placeholders.
- Plumb attachment models through J2CL read blips/window entries and render inline/card attachments with safe open/download controls.
- Cover metadata pending/failure/malware states, URL hardening, download filename sanitization, and live/window render-cache equality.
- Add changelog fragment for the J2CL read attachment rendering slice.

## Verification
- `sbt -batch j2clSearchTest` — passed after rebase onto `origin/main`.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — passed after rebase.
- `git diff --check` — passed after rebase.

## Review
- Self-review completed with staged diff, post-fix tests, and whitespace/changelog gates.
- Claude Opus 4.7 review loop ran through `/tmp/issue-971-task6-attachment-rendering-claude-final4.out`; final verdict: no blockers and no important actionable comments remain, ship-ready.

Part of #971. Tracked under #904.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parse attachments from embedded image markup and render them as cards or inline images with smarter sizing, preview selection, safe-URL enforcement, and filename sanitization.
  * Attachment models now propagate through blips, window entries, and the renderer; Open/Download controls are keyboard-reachable and respect blocked/pending/failed states and safe external-download behavior.

* **Tests**
  * Extensive tests for parsing, rendering, URL safety, filename handling, UI states, and rerender semantics.

* **Documentation**
  * Changelog entry added for attachment rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->