### PR TITLE
Add Lit attachment presentation primitives

### DIFF
--- a/j2cl/lit/src/elements/attachment-display-sizes.js
+++ b/j2cl/lit/src/elements/attachment-display-sizes.js
@@ -1,0 +1,1 @@
+export const DISPLAY_SIZES = ["small", "medium", "large"];

--- a/j2cl/lit/src/elements/compose-attachment-card.js
+++ b/j2cl/lit/src/elements/compose-attachment-card.js
@@ -1,0 +1,205 @@
+import { LitElement, css, html } from "lit";
+
+export class ComposeAttachmentCard extends LitElement {
+  static properties = {
+    attachmentId: { type: String, attribute: "attachment-id" },
+    filename: { type: String },
+    mimeType: { type: String, attribute: "mime-type" },
+    sizeLabel: { type: String, attribute: "size-label" },
+    displaySize: { type: String, attribute: "display-size" },
+    openUrl: { type: String, attribute: "open-url" },
+    downloadUrl: { type: String, attribute: "download-url" },
+    thumbnailUrl: { type: String, attribute: "thumbnail-url" },
+    status: { type: String },
+    error: { type: String },
+    malwareBlocked: { type: Boolean, attribute: "malware-blocked", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    article {
+      display: grid;
+      gap: 10px;
+      max-width: 360px;
+      padding: 12px;
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 14px;
+      background: var(--shell-color-surface-shell, #fff);
+    }
+
+    .size-small {
+      max-width: 240px;
+    }
+
+    .size-large {
+      max-width: 520px;
+    }
+
+    .preview {
+      display: grid;
+      min-height: 72px;
+      place-items: center;
+      overflow: hidden;
+      border-radius: 10px;
+      background: var(--shell-color-surface-muted, #eef4f8);
+      color: var(--shell-color-text-muted, #5b6b80);
+    }
+
+    img {
+      display: block;
+      width: 100%;
+      max-height: 260px;
+      object-fit: contain;
+    }
+
+    .meta {
+      display: grid;
+      gap: 2px;
+    }
+
+    .name {
+      font-weight: 650;
+    }
+
+    .details {
+      color: var(--shell-color-text-muted, #5b6b80);
+      font-size: 0.9rem;
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 10px;
+      padding: 7px 10px;
+      background: #fff;
+      color: var(--shell-color-text-primary, #181c1d);
+      font: inherit;
+      cursor: pointer;
+    }
+
+    button:focus-visible {
+      outline: 3px solid var(--shell-color-focus-ring, #1e88e5);
+      outline-offset: 2px;
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    [role="alert"] {
+      color: var(--shell-color-danger, #a12a16);
+    }
+  `;
+
+  constructor() {
+    super();
+    this.attachmentId = "";
+    this.filename = "Attachment";
+    this.mimeType = "";
+    this.sizeLabel = "";
+    this.displaySize = "medium";
+    this.openUrl = "";
+    this.downloadUrl = "";
+    this.thumbnailUrl = "";
+    this.status = "";
+    this.error = "";
+    this.malwareBlocked = false;
+  }
+
+  render() {
+    const blocked = this.malwareBlocked || Boolean(this.error);
+    const openDisabled = blocked || !this.openUrl;
+    const downloadDisabled = blocked || !(this.downloadUrl || this.openUrl);
+    const displaySize = ["small", "medium", "large"].includes(this.displaySize)
+      ? this.displaySize
+      : "medium";
+    return html`
+      <article class=${`size-${displaySize}`} aria-label=${`Attachment ${this.filename}`}>
+        <div class="preview">
+          ${this.thumbnailUrl
+            ? html`<img src=${this.thumbnailUrl} alt=${this.filename} />`
+            : html`<span aria-hidden="true">${this.previewLabel()}</span>`}
+        </div>
+        <div class="meta">
+          <span class="name">${this.filename}</span>
+          <span class="details">${this.detailsLabel()}</span>
+        </div>
+        ${this.status && !blocked
+          ? html`<p role="status" aria-live="polite">${this.status}</p>`
+          : ""}
+        ${blocked
+          ? html`<p role="alert" aria-live="assertive">${this.error || "Attachment blocked."}</p>`
+          : ""}
+        <div class="actions">
+          <button
+            type="button"
+            data-action="attachment-open"
+            aria-label=${`Open attachment ${this.filename}`}
+            ?disabled=${openDisabled}
+            @click=${this.onOpen}
+          >
+            Open
+          </button>
+          <button
+            type="button"
+            data-action="attachment-download"
+            aria-label=${`Download attachment ${this.filename}`}
+            ?disabled=${downloadDisabled}
+            @click=${this.onDownload}
+          >
+            Download
+          </button>
+        </div>
+      </article>
+    `;
+  }
+
+  previewLabel() {
+    if (this.mimeType?.startsWith("image/")) {
+      return "Image attachment";
+    }
+    return "File attachment";
+  }
+
+  detailsLabel() {
+    return [this.mimeType, this.sizeLabel].filter(Boolean).join(" - ") || "Attachment file";
+  }
+
+  onOpen() {
+    this.emitAttachmentAction("attachment-open", this.openUrl);
+  }
+
+  onDownload() {
+    this.emitAttachmentAction("attachment-download", this.downloadUrl || this.openUrl);
+  }
+
+  emitAttachmentAction(type, url) {
+    if (this.malwareBlocked || this.error || !url) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent(type, {
+        detail: {
+          attachmentId: this.attachmentId,
+          filename: this.filename,
+          url: url || ""
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+}
+
+if (!customElements.get("compose-attachment-card")) {
+  customElements.define("compose-attachment-card", ComposeAttachmentCard);
+}

--- a/j2cl/lit/src/elements/compose-attachment-card.js
+++ b/j2cl/lit/src/elements/compose-attachment-card.js
@@ -192,7 +192,7 @@ export class ComposeAttachmentCard extends LitElement {
         detail: {
           attachmentId: this.attachmentId,
           filename: this.filename,
-          url: url || ""
+          url
         },
         bubbles: true,
         composed: true

--- a/j2cl/lit/src/elements/compose-attachment-card.js
+++ b/j2cl/lit/src/elements/compose-attachment-card.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { DISPLAY_SIZES } from "./attachment-display-sizes.js";
 
 export class ComposeAttachmentCard extends LitElement {
   static properties = {
@@ -119,7 +120,7 @@ export class ComposeAttachmentCard extends LitElement {
     const blocked = this.malwareBlocked || Boolean(this.error);
     const openDisabled = blocked || !this.openUrl;
     const downloadDisabled = blocked || !(this.downloadUrl || this.openUrl);
-    const displaySize = ["small", "medium", "large"].includes(this.displaySize)
+    const displaySize = DISPLAY_SIZES.includes(this.displaySize)
       ? this.displaySize
       : "medium";
     return html`

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -209,12 +209,6 @@ export class ComposeAttachmentPicker extends LitElement {
     `;
   }
 
-  updated(changedProperties) {
-    if (changedProperties.has("open") && this.open) {
-      this.renderRoot.querySelector("input[type='file']")?.focus();
-    }
-  }
-
   openPicker() {
     if (this.open) {
       return;
@@ -247,7 +241,7 @@ export class ComposeAttachmentPicker extends LitElement {
         composed: true
       })
     );
-    // interaction-overlay-layer reports focusTargetId; this host owns restoration.
+    // interaction-overlay-layer only reports focusTargetId; this host performs restoration.
     this.updateComplete.then(() => {
       this.renderRoot.querySelector("#attachment-picker-trigger")?.focus();
     });

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -297,6 +297,9 @@ export class ComposeAttachmentPicker extends LitElement {
 
   onFilesSelected(event) {
     const files = Array.from(event.target.files || []);
+    if (files.length === 0) {
+      return;
+    }
     this.dispatchEvent(
       new CustomEvent("attachment-files-selected", {
         detail: {

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -1,0 +1,323 @@
+import { LitElement, css, html } from "lit";
+import "./interaction-overlay-layer.js";
+
+const DISPLAY_SIZES = ["small", "medium", "large"];
+
+export class ComposeAttachmentPicker extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true },
+    caption: { type: String },
+    displaySize: { type: String, attribute: "display-size" },
+    uploadState: { type: String, attribute: "upload-state" },
+    uploadProgress: { type: Number, attribute: "upload-progress" },
+    uploadMessage: { type: String, attribute: "upload-message" },
+    uploadError: { type: String, attribute: "upload-error" }
+  };
+
+  static styles = css`
+    :host {
+      display: inline-block;
+    }
+
+    button,
+    input,
+    textarea {
+      font: inherit;
+    }
+
+    button {
+      border: 1px solid var(--shell-color-divider-subtle, #d8e3ee);
+      border-radius: 10px;
+      padding: 7px 10px;
+      background: #fff;
+      color: var(--shell-color-text-primary, #181c1d);
+      cursor: pointer;
+    }
+
+    button:focus-visible,
+    input:focus-visible,
+    textarea:focus-visible {
+      outline: 3px solid var(--shell-color-focus-ring, #1e88e5);
+      outline-offset: 2px;
+    }
+
+    .panel {
+      display: grid;
+      gap: 12px;
+      min-width: min(84vw, 340px);
+    }
+
+    label,
+    fieldset {
+      display: grid;
+      gap: 6px;
+      margin: 0;
+      padding: 0;
+      border: 0;
+    }
+
+    legend {
+      margin-block-end: 6px;
+      font-weight: 650;
+    }
+
+    textarea {
+      min-height: 72px;
+      resize: vertical;
+    }
+
+    .sizes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .sizes label {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+
+    progress {
+      width: 100%;
+    }
+
+    [role="alert"] {
+      color: var(--shell-color-danger, #a12a16);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      interaction-overlay-layer::part(surface) {
+        scroll-behavior: auto;
+      }
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this.caption = "";
+    this.displaySize = "medium";
+    this.uploadState = "";
+    this.uploadProgress = 0;
+    this.uploadMessage = "";
+    this.uploadError = "";
+  }
+
+  render() {
+    return html`
+      <button
+        id="attachment-picker-trigger"
+        type="button"
+        data-action="attachment-insert"
+        aria-haspopup="dialog"
+        aria-expanded=${this.open ? "true" : "false"}
+        aria-controls="attachment-picker-overlay"
+        @click=${this.openPicker}
+      >
+        Attach file
+      </button>
+      <interaction-overlay-layer
+        id="attachment-picker-overlay"
+        ?open=${this.open}
+        modal
+        label="Attach a file"
+        focus-target-id="attachment-picker-trigger"
+        @overlay-close=${this.onOverlayClose}
+      >
+        <div class="panel">
+          <label>
+            File
+            <input
+              type="file"
+              multiple
+              @change=${this.onFilesSelected}
+            />
+          </label>
+          <label>
+            Caption
+            <textarea
+              name="attachment-caption"
+              aria-label="Attachment caption"
+              .value=${this.caption}
+              @input=${this.onCaptionInput}
+            ></textarea>
+          </label>
+          <fieldset @keydown=${this.onSizeKeyDown}>
+            <legend>Display size</legend>
+            <div class="sizes">
+              ${DISPLAY_SIZES.map(size => html`
+                <label>
+                  <input
+                    type="radio"
+                    name="attachment-display-size"
+                    value=${size}
+                    .checked=${this.displaySize === size}
+                    @click=${() => this.selectDisplaySize(size)}
+                  />
+                  ${size}
+                </label>
+              `)}
+            </div>
+          </fieldset>
+          ${this.renderUploadState()}
+          <div class="actions">
+            <button type="button" data-action="attachment-cancel" @click=${this.cancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      </interaction-overlay-layer>
+    `;
+  }
+
+  renderUploadState() {
+    if (this.uploadState === "error") {
+      return html`
+        <p
+          role="alert"
+          aria-live="assertive"
+          data-state="attachment-error-state"
+        >${this.uploadError || "Attachment upload failed."}</p>
+      `;
+    }
+    if (!this.uploadState) {
+      return "";
+    }
+    return html`
+      <div role="status" aria-live="polite">
+        ${this.uploadMessage || this.uploadState}
+        ${this.uploadState === "uploading"
+          ? html`
+              <progress
+                role="progressbar"
+                aria-label="Attachment upload progress"
+                max="100"
+                value=${this.normalizedProgress()}
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow=${String(this.normalizedProgress())}
+              ></progress>
+            `
+          : ""}
+      </div>
+    `;
+  }
+
+  openPicker() {
+    if (this.open) {
+      return;
+    }
+    this.open = true;
+    this.dispatchEvent(
+      new CustomEvent("attachment-picker-open", {
+        detail: { action: "attachment-insert" },
+        bubbles: true,
+        composed: true
+      })
+    );
+    this.updateComplete.then(() => {
+      this.renderRoot.querySelector("input[type='file']")?.focus();
+    });
+  }
+
+  cancel() {
+    this.closePicker("cancel");
+  }
+
+  onOverlayClose(event) {
+    event.stopPropagation();
+    this.closePicker(event.detail?.reason || "overlay");
+  }
+
+  closePicker(reason) {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("attachment-picker-close", {
+        detail: { reason },
+        bubbles: true,
+        composed: true
+      })
+    );
+    // interaction-overlay-layer reports focusTargetId; this host owns restoration.
+    this.updateComplete.then(() => {
+      this.renderRoot.querySelector("#attachment-picker-trigger")?.focus();
+    });
+  }
+
+  onCaptionInput(event) {
+    this.caption = event.target.value;
+    this.dispatchEvent(
+      new CustomEvent("attachment-caption", {
+        detail: { action: "attachment-caption", caption: this.caption },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  selectDisplaySize(size) {
+    if (!DISPLAY_SIZES.includes(size)) {
+      return;
+    }
+    if (size === this.displaySize) {
+      return;
+    }
+    this.displaySize = size;
+    this.dispatchEvent(
+      new CustomEvent("attachment-size-selected", {
+        detail: { action: `attachment-size-${size}`, displaySize: size },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  onSizeKeyDown(event) {
+    if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].includes(event.key)) {
+      return;
+    }
+    const currentIndex = DISPLAY_SIZES.indexOf(this.displaySize);
+    const offset = event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
+    const nextIndex = (currentIndex + offset + DISPLAY_SIZES.length) % DISPLAY_SIZES.length;
+    event.preventDefault();
+    this.selectDisplaySize(DISPLAY_SIZES[nextIndex]);
+    this.updateComplete.then(() => {
+      this.renderRoot.querySelector(`input[value='${this.displaySize}']`)?.focus();
+    });
+  }
+
+  onFilesSelected(event) {
+    const files = Array.from(event.target.files || []);
+    this.dispatchEvent(
+      new CustomEvent("attachment-files-selected", {
+        detail: {
+          action: "attachment-upload-queue",
+          files,
+          caption: this.caption,
+          displaySize: this.displaySize
+        },
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  normalizedProgress() {
+    const progress = Number(this.uploadProgress);
+    if (!Number.isFinite(progress)) {
+      return 0;
+    }
+    return Math.min(100, Math.max(0, Math.round(progress)));
+  }
+}
+
+if (!customElements.get("compose-attachment-picker")) {
+  customElements.define("compose-attachment-picker", ComposeAttachmentPicker);
+}

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -1,7 +1,6 @@
 import { LitElement, css, html } from "lit";
 import "./interaction-overlay-layer.js";
-
-const DISPLAY_SIZES = ["small", "medium", "large"];
+import { DISPLAY_SIZES } from "./attachment-display-sizes.js";
 
 export class ComposeAttachmentPicker extends LitElement {
   static properties = {
@@ -210,6 +209,12 @@ export class ComposeAttachmentPicker extends LitElement {
     `;
   }
 
+  updated(changedProperties) {
+    if (changedProperties.has("open") && this.open) {
+      this.renderRoot.querySelector("input[type='file']")?.focus();
+    }
+  }
+
   openPicker() {
     if (this.open) {
       return;
@@ -222,9 +227,6 @@ export class ComposeAttachmentPicker extends LitElement {
         composed: true
       })
     );
-    this.updateComplete.then(() => {
-      this.renderRoot.querySelector("input[type='file']")?.focus();
-    });
   }
 
   cancel() {
@@ -283,7 +285,7 @@ export class ComposeAttachmentPicker extends LitElement {
     if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].includes(event.key)) {
       return;
     }
-    const currentIndex = DISPLAY_SIZES.indexOf(this.displaySize);
+    const currentIndex = Math.max(0, DISPLAY_SIZES.indexOf(this.displaySize));
     const offset = event.key === "ArrowRight" || event.key === "ArrowDown" ? 1 : -1;
     const nextIndex = (currentIndex + offset + DISPLAY_SIZES.length) % DISPLAY_SIZES.length;
     event.preventDefault();
@@ -307,6 +309,8 @@ export class ComposeAttachmentPicker extends LitElement {
         composed: true
       })
     );
+    // Reset so selecting the same file(s) again fires another change event.
+    event.target.value = "";
   }
 
   normalizedProgress() {

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -297,6 +297,7 @@ export class ComposeAttachmentPicker extends LitElement {
 
   onFilesSelected(event) {
     const files = Array.from(event.target.files || []);
+    event.target.value = "";
     if (files.length === 0) {
       return;
     }
@@ -312,8 +313,6 @@ export class ComposeAttachmentPicker extends LitElement {
         composed: true
       })
     );
-    // Reset so selecting the same file(s) again fires another change event.
-    event.target.value = "";
   }
 
   normalizedProgress() {

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -14,6 +14,8 @@ import "./elements/composer-shell.js";
 import "./elements/toolbar-button.js";
 import "./elements/toolbar-group.js";
 import "./elements/toolbar-overflow-menu.js";
+import "./elements/compose-attachment-picker.js";
+import "./elements/compose-attachment-card.js";
 import "./elements/interaction-overlay-layer.js";
 import "./elements/mention-suggestion-popover.js";
 import "./elements/task-metadata-popover.js";

--- a/j2cl/lit/test/compose-attachment-card.test.js
+++ b/j2cl/lit/test/compose-attachment-card.test.js
@@ -1,0 +1,94 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/index.js";
+
+describe("<compose-attachment-card>", () => {
+  it("is registered by the Lit shell bundle", () => {
+    expect(customElements.get("compose-attachment-card")).to.be.a("function");
+  });
+
+  it("renders keyboard-reachable open and download controls", async () => {
+    const el = await fixture(html`
+      <compose-attachment-card
+        attachment-id="att-1"
+        filename="diagram.png"
+        mime-type="image/png"
+        size-label="42 KB"
+        display-size="large"
+        open-url="/attachment/att-1"
+        download-url="/attachment/att-1?download=1"
+      ></compose-attachment-card>
+    `);
+
+    const article = el.renderRoot.querySelector("article");
+    const open = el.renderRoot.querySelector("[data-action='attachment-open']");
+    const download = el.renderRoot.querySelector("[data-action='attachment-download']");
+
+    expect(article.classList.contains("size-large")).to.equal(true);
+    expect(open.getAttribute("aria-label")).to.equal("Open attachment diagram.png");
+    expect(download.getAttribute("aria-label")).to.equal("Download attachment diagram.png");
+    expect(open.tabIndex).to.equal(0);
+    expect(download.tabIndex).to.equal(0);
+    open.focus();
+    expect(open).to.equal(el.shadowRoot.activeElement);
+
+    const openEvent = oneEvent(el, "attachment-open");
+    open.click();
+    expect((await openEvent).detail).to.deep.equal({
+      attachmentId: "att-1",
+      filename: "diagram.png",
+      url: "/attachment/att-1"
+    });
+
+    const downloadEvent = oneEvent(el, "attachment-download");
+    download.click();
+    expect((await downloadEvent).detail).to.deep.equal({
+      attachmentId: "att-1",
+      filename: "diagram.png",
+      url: "/attachment/att-1?download=1"
+    });
+  });
+
+  it("renders blocked and error states as alerts without openable controls", async () => {
+    const el = await fixture(html`
+      <compose-attachment-card
+        attachment-id="att-2"
+        filename="blocked.exe"
+        mime-type="application/octet-stream"
+        malware-blocked
+        error="This attachment is blocked by server policy."
+      ></compose-attachment-card>
+    `);
+
+    const alert = el.renderRoot.querySelector("[role='alert']");
+    const open = el.renderRoot.querySelector("[data-action='attachment-open']");
+    const download = el.renderRoot.querySelector("[data-action='attachment-download']");
+
+    expect(alert.textContent).to.include("blocked by server policy");
+    expect(open.disabled).to.equal(true);
+    expect(download.disabled).to.equal(true);
+  });
+
+  it("does not emit open or download events when controls are disabled", async () => {
+    const el = await fixture(html`
+      <compose-attachment-card
+        attachment-id="att-3"
+        filename="missing-metadata.bin"
+        mime-type="application/octet-stream"
+      ></compose-attachment-card>
+    `);
+    let openEvents = 0;
+    let downloadEvents = 0;
+    el.addEventListener("attachment-open", () => {
+      openEvents += 1;
+    });
+    el.addEventListener("attachment-download", () => {
+      downloadEvents += 1;
+    });
+
+    el.renderRoot.querySelector("[data-action='attachment-open']").click();
+    el.renderRoot.querySelector("[data-action='attachment-download']").click();
+
+    expect(openEvents).to.equal(0);
+    expect(downloadEvents).to.equal(0);
+  });
+});

--- a/j2cl/lit/test/compose-attachment-card.test.js
+++ b/j2cl/lit/test/compose-attachment-card.test.js
@@ -1,8 +1,8 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
-import "../src/index.js";
+import "../src/elements/compose-attachment-card.js";
 
 describe("<compose-attachment-card>", () => {
-  it("is registered by the Lit shell bundle", () => {
+  it("is registered as a custom element", () => {
     expect(customElements.get("compose-attachment-card")).to.be.a("function");
   });
 

--- a/j2cl/lit/test/compose-attachment-picker.test.js
+++ b/j2cl/lit/test/compose-attachment-picker.test.js
@@ -1,0 +1,166 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/index.js";
+
+describe("<compose-attachment-picker>", () => {
+  it("is registered by the Lit shell bundle", () => {
+    expect(customElements.get("compose-attachment-picker")).to.be.a("function");
+  });
+
+  it("opens and closes as a modal picker while restoring focus to the trigger", async () => {
+    const el = await fixture(html`<compose-attachment-picker></compose-attachment-picker>`);
+    const trigger = el.renderRoot.querySelector("[data-action='attachment-insert']");
+
+    const openEvent = oneEvent(el, "attachment-picker-open");
+    trigger.click();
+    expect((await openEvent).detail.action).to.equal("attachment-insert");
+    await el.updateComplete;
+
+    const overlay = el.renderRoot.querySelector("interaction-overlay-layer");
+    expect(trigger.getAttribute("aria-expanded")).to.equal("true");
+    expect(overlay.open).to.equal(true);
+    expect(overlay.modal).to.equal(true);
+
+    const closeEvent = oneEvent(el, "attachment-picker-close");
+    overlay.dispatchEvent(new CustomEvent("overlay-close", {
+      detail: { reason: "escape", focusTargetId: "attachment-picker-trigger" },
+      bubbles: true,
+      composed: true
+    }));
+    expect((await closeEvent).detail.reason).to.equal("escape");
+    await el.updateComplete;
+
+    expect(el.open).to.equal(false);
+    expect(trigger).to.equal(el.shadowRoot.activeElement);
+  });
+
+  it("does not re-emit open when the picker is already open", async () => {
+    const el = await fixture(html`<compose-attachment-picker></compose-attachment-picker>`);
+    const trigger = el.renderRoot.querySelector("[data-action='attachment-insert']");
+    let openEvents = 0;
+    el.addEventListener("attachment-picker-open", () => {
+      openEvents += 1;
+    });
+
+    trigger.click();
+    trigger.click();
+
+    expect(openEvents).to.equal(1);
+  });
+
+  it("closes from Cancel with a stable cancel reason", async () => {
+    const el = await fixture(html`<compose-attachment-picker open></compose-attachment-picker>`);
+    const cancel = el.renderRoot.querySelector("[data-action='attachment-cancel']");
+
+    const closeEvent = oneEvent(el, "attachment-picker-close");
+    cancel.click();
+    expect((await closeEvent).detail.reason).to.equal("cancel");
+    await el.updateComplete;
+
+    expect(el.open).to.equal(false);
+    expect(el.renderRoot.querySelector("[data-action='attachment-insert']")).to.equal(
+      el.shadowRoot.activeElement
+    );
+  });
+
+  it("emits selected files with caption and display size", async () => {
+    const el = await fixture(html`<compose-attachment-picker open></compose-attachment-picker>`);
+    const caption = el.renderRoot.querySelector("[name='attachment-caption']");
+    const large = el.renderRoot.querySelector("[value='large']");
+    const fileInput = el.renderRoot.querySelector("input[type='file']");
+    const image = new File(["png"], "diagram.png", { type: "image/png" });
+
+    caption.value = "Architecture diagram";
+    caption.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+
+    const captionEvent = oneEvent(el, "attachment-caption");
+    caption.value = "Updated caption";
+    caption.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    expect((await captionEvent).detail).to.deep.equal({
+      action: "attachment-caption",
+      caption: "Updated caption"
+    });
+
+    const sizeEvent = oneEvent(el, "attachment-size-selected");
+    large.click();
+    expect((await sizeEvent).detail).to.deep.equal({
+      action: "attachment-size-large",
+      displaySize: "large"
+    });
+
+    const selectEvent = oneEvent(el, "attachment-files-selected");
+    Object.defineProperty(fileInput, "files", {
+      value: [image],
+      configurable: true
+    });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+
+    expect((await selectEvent).detail).to.deep.equal({
+      action: "attachment-upload-queue",
+      files: [image],
+      caption: "Updated caption",
+      displaySize: "large"
+    });
+  });
+
+  it("does not re-emit display size when clicking the selected size", async () => {
+    const el = await fixture(html`<compose-attachment-picker open></compose-attachment-picker>`);
+    const medium = el.renderRoot.querySelector("[value='medium']");
+    let sizeEvents = 0;
+    el.addEventListener("attachment-size-selected", () => {
+      sizeEvents += 1;
+    });
+
+    medium.click();
+
+    expect(sizeEvents).to.equal(0);
+  });
+
+  it("renders upload progress, success, and error as accessible live regions", async () => {
+    const el = await fixture(html`
+      <compose-attachment-picker
+        open
+        upload-state="uploading"
+        upload-progress="45"
+        upload-message="Uploading diagram.png"
+      ></compose-attachment-picker>
+    `);
+
+    const status = el.renderRoot.querySelector("[role='status']");
+    const progress = el.renderRoot.querySelector("[role='progressbar']");
+    expect(status.getAttribute("aria-live")).to.equal("polite");
+    expect(status.textContent).to.include("Uploading diagram.png");
+    expect(progress.getAttribute("aria-valuenow")).to.equal("45");
+
+    el.uploadState = "success";
+    el.uploadMessage = "diagram.png attached";
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[role='status']").textContent).to.include("attached");
+
+    el.uploadState = "error";
+    el.uploadError = "Upload failed. Try again.";
+    await el.updateComplete;
+    const alert = el.renderRoot.querySelector("[role='alert']");
+    expect(alert.getAttribute("aria-live")).to.equal("assertive");
+    expect(alert.textContent).to.include("Upload failed");
+  });
+
+  it("keeps keyboard traversal and reduced-motion/focus-visible hooks testable", async () => {
+    const el = await fixture(html`<compose-attachment-picker open></compose-attachment-picker>`);
+    const medium = el.renderRoot.querySelector("[value='medium']");
+    const large = el.renderRoot.querySelector("[value='large']");
+
+    medium.focus();
+    medium.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    }));
+    await el.updateComplete;
+
+    expect(el.displaySize).to.equal("large");
+    expect(large).to.equal(el.shadowRoot.activeElement);
+    expect(String(el.constructor.styles.cssText)).to.include("prefers-reduced-motion");
+    expect(String(el.constructor.styles.cssText)).to.include(":focus-visible");
+  });
+});

--- a/j2cl/lit/test/compose-attachment-picker.test.js
+++ b/j2cl/lit/test/compose-attachment-picker.test.js
@@ -19,6 +19,11 @@ describe("<compose-attachment-picker>", () => {
     expect(trigger.getAttribute("aria-expanded")).to.equal("true");
     expect(overlay.open).to.equal(true);
     expect(overlay.modal).to.equal(true);
+    await overlay.updateComplete;
+    await Promise.resolve();
+    expect(overlay.renderRoot.querySelector("[part='surface']")).to.equal(
+      overlay.shadowRoot.activeElement
+    );
 
     const closeEvent = oneEvent(el, "attachment-picker-close");
     overlay.dispatchEvent(new CustomEvent("overlay-close", {

--- a/j2cl/lit/test/compose-attachment-picker.test.js
+++ b/j2cl/lit/test/compose-attachment-picker.test.js
@@ -100,6 +100,25 @@ describe("<compose-attachment-picker>", () => {
       caption: "Updated caption",
       displaySize: "large"
     });
+    expect(fileInput.value).to.equal("");
+  });
+
+  it("does not emit selected files when the file input is empty", async () => {
+    const el = await fixture(html`<compose-attachment-picker open></compose-attachment-picker>`);
+    const fileInput = el.renderRoot.querySelector("input[type='file']");
+    let selectedEvents = 0;
+    el.addEventListener("attachment-files-selected", () => {
+      selectedEvents += 1;
+    });
+
+    Object.defineProperty(fileInput, "files", {
+      value: [],
+      configurable: true
+    });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+
+    expect(selectedEvents).to.equal(0);
+    expect(fileInput.value).to.equal("");
   });
 
   it("does not re-emit display size when clicking the selected size", async () => {

--- a/j2cl/lit/test/compose-attachment-picker.test.js
+++ b/j2cl/lit/test/compose-attachment-picker.test.js
@@ -1,8 +1,8 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
-import "../src/index.js";
+import "../src/elements/compose-attachment-picker.js";
 
 describe("<compose-attachment-picker>", () => {
-  it("is registered by the Lit shell bundle", () => {
+  it("is registered as a custom element", () => {
     expect(customElements.get("compose-attachment-picker")).to.be.a("function");
   });
 

--- a/wave/config/changelog.d/2026-04-25-issue-971-lit-attachment-presentation.json
+++ b/wave/config/changelog.d/2026-04-25-issue-971-lit-attachment-presentation.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-issue-971-lit-attachment-presentation",
+  "version": "PR #1023",
+  "date": "2026-04-25",
+  "title": "Prepare Lit attachment picker and card presentation",
+  "summary": "The J2CL Lit shell now includes attachment picker and attachment card primitives for the attachment parity flow.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added Lit attachment presentation primitives for picker open and close, caption and display-size selection, upload live regions, blocked attachment alerts, and open or download controls."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `compose-attachment-picker` for Lit attachment picker presentation states: modal open/close, cancel, caption input, display-size selection, upload progress/success/error, and focus hooks.
- Add `compose-attachment-card` for rendered attachment open/download controls and blocked/error state presentation.
- Register both elements in the Lit shell bundle and add web-test-runner coverage for Task 7 parity scenarios.
- Add a changelog fragment for the new Lit attachment presentation primitives.

Refs #971. Refs #904.

## Verification
- `cd j2cl/lit && npm test && npm run build` - pass, 109 tests, 0 failures; build completed.
- `git diff --cached --check` - pass before both commits.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` - pass; assembled 253 entries and validation passed.

## Review
- Claude Opus review round 1: no blockers; important comments for size event idempotency, Cancel path coverage, disabled controls coverage. Addressed.
- Claude Opus review round 2: no blockers; important comment for idempotent open. Addressed.
- Claude Opus review round 3: no blockers and no important actionable comments; only minor nits/optional coverage refinements.

## Notes
- Scope is Lit presentation plus changelog only; no Java read-surface files and no #970 overlay primitive files were modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment display card with thumbnail/label preview, open/download controls, status and blocked alerts, and accessible keyboard behavior.
  * File picker modal for attaching files with caption input, display-size selection (small/medium/large), multi-file selection, upload progress, and live-region announcements.
  * Exported display-size options now available and components registered for app-wide use.

* **Tests**
  * Comprehensive test suites validating UI, accessibility, events, and keyboard interactions for both components.

* **Chores**
  * Added changelog entry for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->