### PR TITLE
Hydrate J2CL selected-wave attachment metadata

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -413,6 +413,9 @@ public final class J2clAttachmentMetadataClient {
     public static MetadataResult success(
         List<J2clAttachmentMetadata> attachments,
         List<String> missingAttachmentIds) {
+      if (attachments == null || missingAttachmentIds == null) {
+        throw new IllegalArgumentException("Metadata result lists are required.");
+      }
       return new MetadataResult(true, attachments, missingAttachmentIds, null, "");
     }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClient.java
@@ -408,13 +408,15 @@ public final class J2clAttachmentMetadataClient {
       this.message = message == null ? "" : message;
     }
 
-    static MetadataResult success(
+    // Public so controller tests outside this package can exercise metadata callback paths without
+    // routing through browser XHR transport.
+    public static MetadataResult success(
         List<J2clAttachmentMetadata> attachments,
         List<String> missingAttachmentIds) {
       return new MetadataResult(true, attachments, missingAttachmentIds, null, "");
     }
 
-    static MetadataResult failure(ErrorType errorType, String message) {
+    public static MetadataResult failure(ErrorType errorType, String message) {
       return new MetadataResult(
           false,
           Collections.<J2clAttachmentMetadata>emptyList(),

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -8,6 +8,7 @@ import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 
 /** Parsed text and attachment placeholders extracted from a selected-wave blip snapshot. */
 public final class J2clReadBlipContent {
+  private static final String IMAGE_CLOSE_TAG = "</image>";
   private final String text;
   private final List<J2clAttachmentRenderModel> attachments;
 
@@ -46,8 +47,9 @@ public final class J2clReadBlipContent {
         continue;
       }
       visibleText.append(raw.substring(cursor, imageStart));
-      int imageClose = raw.indexOf("</image>", imageTagEnd + 1);
-      String inner = imageClose < 0 ? "" : raw.substring(imageTagEnd + 1, imageClose);
+      boolean selfClosing = isSelfClosingTag(startTag);
+      int imageClose = selfClosing ? imageTagEnd : raw.indexOf(IMAGE_CLOSE_TAG, imageTagEnd + 1);
+      String inner = selfClosing || imageClose < 0 ? "" : raw.substring(imageTagEnd + 1, imageClose);
       String displaySize = attributeValue(startTag, "display-size");
       String caption = firstNonEmpty(captionText(inner), attachmentId);
       attachments.add(
@@ -55,7 +57,11 @@ public final class J2clReadBlipContent {
               decodeEntities(attachmentId),
               decodeEntities(caption),
               decodeEntities(displaySize)));
-      cursor = imageClose < 0 ? imageTagEnd + 1 : imageClose + "</image>".length();
+      if (selfClosing || imageClose < 0) {
+        cursor = imageTagEnd + 1;
+      } else {
+        cursor = imageClose + IMAGE_CLOSE_TAG.length();
+      }
     }
     return new J2clReadBlipContent(
         decodeEntities(stripTags(visibleText.toString())), attachments);
@@ -120,6 +126,17 @@ public final class J2clReadBlipContent {
       cursor++;
     }
     return cursor;
+  }
+
+  private static boolean isSelfClosingTag(String tag) {
+    if (tag.length() < 2) {
+      return false;
+    }
+    int cursor = tag.length() - 2; // Skip the closing '>'.
+    while (cursor >= 0 && Character.isWhitespace(tag.charAt(cursor))) {
+      cursor--;
+    }
+    return cursor >= 0 && tag.charAt(cursor) == '/';
   }
 
   private static String captionText(String innerXml) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -29,6 +29,18 @@ public final class J2clSearchGateway
   private static final String DEFAULT_WAVELET_PREFIX = "conv+root";
   private static final String CROSS_HOST_WEBSOCKET_ERROR =
       "The J2CL sidecar requires core.http_websocket_presented_address to use the current page host when HttpOnly session cookies are enabled.";
+  private final J2clAttachmentMetadataClient attachmentMetadataClient;
+
+  public J2clSearchGateway() {
+    this(new J2clAttachmentMetadataClient());
+  }
+
+  J2clSearchGateway(J2clAttachmentMetadataClient attachmentMetadataClient) {
+    this.attachmentMetadataClient =
+        attachmentMetadataClient == null
+            ? new J2clAttachmentMetadataClient()
+            : attachmentMetadataClient;
+  }
 
   @Override
   public void fetchRootSessionBootstrap(
@@ -172,9 +184,8 @@ public final class J2clSearchGateway
   @Override
   public void fetchAttachmentMetadata(
       List<String> attachmentIds,
-      J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
-          onComplete) {
-    new J2clAttachmentMetadataClient().fetchMetadata(attachmentIds, result -> onComplete.accept(result));
+      J2clAttachmentMetadataClient.MetadataCallback callback) {
+    attachmentMetadataClient.fetchMetadata(attachmentIds, callback);
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -2,15 +2,11 @@ package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
-import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
-import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
@@ -30,6 +26,8 @@ public final class J2clSelectedWaveController
       "Could not load more selected-wave content.";
   private static final String FRAGMENT_GROWTH_RECOVERED_STATUS =
       "More selected-wave content loaded.";
+  private static final String DEFAULT_METADATA_FAILURE_MESSAGE =
+      "Attachment metadata unavailable.";
   // Trailing-edge debounce for per-update read-state fetches. Short enough to
   // feel live, long enough to coalesce server-initiated flurries without
   // amplifying HTTP pressure.
@@ -68,18 +66,9 @@ public final class J2clSelectedWaveController
         J2clSearchPanelController.SuccessCallback<SidecarFragmentsResponse> onSuccess,
         J2clSearchPanelController.ErrorCallback onError);
 
-    /**
-     * Fetches attachment metadata for the given attachment IDs and delivers the
-     * result to {@code onComplete}. Implementations that do not support metadata
-     * hydration may leave the callback un-invoked; attachments will remain in the
-     * {@code metadataPending} state for those implementations (e.g. test doubles).
-     */
-    default void fetchAttachmentMetadata(
+    void fetchAttachmentMetadata(
         List<String> attachmentIds,
-        J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
-            onComplete) {
-      // Default no-op: leaves pending attachments in their pending state.
-    }
+        J2clAttachmentMetadataClient.MetadataCallback callback);
   }
 
   public interface View {
@@ -144,6 +133,7 @@ public final class J2clSelectedWaveController
   private int latestReadStateApplied;
   private int pendingDebounceToken;
   private final Set<String> fragmentFetchesInFlight = new HashSet<String>();
+  private final Set<String> attachmentMetadataFetchesInFlight = new HashSet<String>();
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
     this(
@@ -237,6 +227,7 @@ public final class J2clSelectedWaveController
     int generation = ++requestGeneration;
     closeSubscription();
     resetFragmentFetchTracking();
+    resetAttachmentMetadataFetchTracking();
     reconnectCount = 0;
     // A refresh happens after the reply already committed on the server, so transient bootstrap or
     // open failures should recover like a reconnect instead of strand the panel on stale content.
@@ -262,7 +253,7 @@ public final class J2clSelectedWaveController
                 readStateStale);
         view.render(currentModel);
         publishWriteSession();
-        hydrateAttachmentsIfNeeded(currentModel);
+        requestAttachmentMetadataForCurrentViewport(requestGeneration);
       }
       return;
     }
@@ -271,6 +262,7 @@ public final class J2clSelectedWaveController
     closeSubscription();
     resetReadStateFetchTracking();
     resetFragmentFetchTracking();
+    resetAttachmentMetadataFetchTracking();
 
     if (waveId == null || waveId.isEmpty()) {
       selectedWaveId = null;
@@ -364,7 +356,7 @@ public final class J2clSelectedWaveController
                       readStateStale);
               view.render(currentModel);
               publishWriteSession();
-              hydrateAttachmentsIfNeeded(currentModel);
+              requestAttachmentMetadataForCurrentViewport(generation);
               activeReconnectCount[0] = 0;
               this.reconnectCount = projectedReconnectCount;
               scheduleReadStateFetch(generation);
@@ -465,7 +457,7 @@ public final class J2clSelectedWaveController
           }
           view.render(currentModel);
           publishWriteSession();
-          hydrateAttachmentsIfNeeded(currentModel);
+          requestAttachmentMetadataForCurrentViewport(generation);
           fragmentFetchesInFlight.remove(edgeKey);
         },
         error -> {
@@ -577,6 +569,129 @@ public final class J2clSelectedWaveController
     fragmentFetchesInFlight.clear();
   }
 
+  private void resetAttachmentMetadataFetchTracking() {
+    attachmentMetadataFetchesInFlight.clear();
+  }
+
+  private void requestAttachmentMetadataForCurrentViewport(int generation) {
+    if (!isCurrentGeneration(generation)
+        || selectedWaveId == null
+        || selectedWaveId.isEmpty()
+        || currentModel == null) {
+      return;
+    }
+    J2clSelectedWaveViewportState viewportState = currentModel.getViewportState();
+    if (viewportState == null || viewportState.isEmpty()) {
+      return;
+    }
+    List<String> pendingIds = viewportState.getPendingAttachmentIds();
+    if (pendingIds.isEmpty()) {
+      return;
+    }
+    List<String> idsToFetch = new ArrayList<String>();
+    for (String attachmentId : pendingIds) {
+      if (attachmentId == null || attachmentId.isEmpty()) {
+        continue;
+      }
+      if (attachmentMetadataFetchesInFlight.add(attachmentId)) {
+        idsToFetch.add(attachmentId);
+      }
+    }
+    if (idsToFetch.isEmpty()) {
+      return;
+    }
+    String waveIdAtDispatch = selectedWaveId;
+    try {
+      gateway.fetchAttachmentMetadata(
+          idsToFetch,
+          result -> {
+            if (!isCurrentGeneration(generation) || !waveIdAtDispatch.equals(selectedWaveId)) {
+              // Selection changes reset the in-flight set, so stale callbacks must not clear IDs
+              // that may already belong to the newer generation's metadata request.
+              return;
+            }
+            clearAttachmentMetadataFetches(idsToFetch);
+            if (currentModel == null || currentModel.getViewportState().isEmpty()) {
+              return;
+            }
+            J2clSelectedWaveViewportState nextViewportState;
+            if (result != null && result.isSuccess()) {
+              nextViewportState =
+                  currentModel
+                      .getViewportState()
+                      .withAttachmentMetadata(
+                          result.getAttachments(),
+                          missingAttachmentIdsForRequest(idsToFetch, result));
+            } else {
+              nextViewportState =
+                  currentModel
+                      .getViewportState()
+                      .withAttachmentMetadataFailure(
+                          idsToFetch, metadataFailureMessage(result));
+            }
+            currentModel = currentModel.withViewportState(nextViewportState);
+            view.render(currentModel);
+            publishWriteSession();
+            requestAttachmentMetadataForCurrentViewport(generation);
+          });
+    } catch (RuntimeException e) {
+      clearAttachmentMetadataFetches(idsToFetch);
+      J2clSelectedWaveViewportState nextViewportState =
+          currentModel
+              .getViewportState()
+              .withAttachmentMetadataFailure(idsToFetch, metadataFailureMessage(e));
+      currentModel = currentModel.withViewportState(nextViewportState);
+      view.render(currentModel);
+      publishWriteSession();
+    }
+  }
+
+  private void clearAttachmentMetadataFetches(List<String> attachmentIds) {
+    for (String attachmentId : attachmentIds) {
+      attachmentMetadataFetchesInFlight.remove(attachmentId);
+    }
+  }
+
+  private static String metadataFailureMessage(
+      J2clAttachmentMetadataClient.MetadataResult result) {
+    if (result == null || result.getMessage() == null || result.getMessage().isEmpty()) {
+      return DEFAULT_METADATA_FAILURE_MESSAGE;
+    }
+    return result.getMessage();
+  }
+
+  private static String metadataFailureMessage(RuntimeException e) {
+    return e == null || e.getMessage() == null || e.getMessage().isEmpty()
+        ? DEFAULT_METADATA_FAILURE_MESSAGE
+        : e.getMessage();
+  }
+
+  private static List<String> missingAttachmentIdsForRequest(
+      List<String> requestedIds,
+      J2clAttachmentMetadataClient.MetadataResult result) {
+    List<String> missingIds = new ArrayList<String>();
+    Set<String> resolvedIds = new HashSet<String>();
+    if (result != null) {
+      for (J2clAttachmentMetadata metadata : result.getAttachments()) {
+        if (metadata != null && metadata.getAttachmentId() != null) {
+          resolvedIds.add(metadata.getAttachmentId());
+        }
+      }
+      for (String missingId : result.getMissingAttachmentIds()) {
+        if (missingId != null) {
+          missingIds.add(missingId);
+          resolvedIds.add(missingId);
+        }
+      }
+    }
+    for (String requestedId : requestedIds) {
+      if (requestedId != null && !requestedId.isEmpty() && !resolvedIds.contains(requestedId)) {
+        missingIds.add(requestedId);
+      }
+    }
+    return missingIds;
+  }
+
   // --- Read-state fetch orchestration ----------------------------------------
 
   private void scheduleReadStateFetch(int generation) {
@@ -656,7 +771,6 @@ public final class J2clSelectedWaveController
             currentModel, selectedDigestItem, currentReadState, readStateStale);
     view.render(currentModel);
     publishWriteSession();
-    hydrateAttachmentsIfNeeded(currentModel);
   }
 
   private void resetReadStateFetchTracking() {
@@ -692,111 +806,5 @@ public final class J2clSelectedWaveController
                 onVisible.run();
               }
             });
-  }
-
-  // --- Attachment metadata hydration -----------------------------------------
-
-  /**
-   * After a render cycle, collects all {@code metadataPending} attachments from
-   * the current read blips and triggers a single metadata fetch through the
-   * gateway. On success, re-renders with {@code fromMetadata}-hydrated models;
-   * on failure (or for IDs missing from the response), falls back to
-   * {@code metadataFailure} display. Only one hydration pass is performed per
-   * render — if the selected wave changes while the fetch is in-flight the
-   * result is discarded.
-   */
-  private void hydrateAttachmentsIfNeeded(J2clSelectedWaveModel model) {
-    List<J2clReadBlip> readBlips = model.getReadBlips();
-    if (readBlips.isEmpty()) {
-      return;
-    }
-    // Collect all pending attachment IDs across all blips.
-    List<String> pendingIds = new ArrayList<String>();
-    for (J2clReadBlip blip : readBlips) {
-      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
-        if (attachment.isMetadataPending()) {
-          pendingIds.add(attachment.getAttachmentId());
-        }
-      }
-    }
-    if (pendingIds.isEmpty()) {
-      return;
-    }
-    final int hydrationGeneration = requestGeneration;
-    final String hydrationWaveId = selectedWaveId;
-    gateway.fetchAttachmentMetadata(
-        pendingIds,
-        result -> {
-          // Discard if the wave selection has changed since the fetch started.
-          if (hydrationGeneration != requestGeneration
-              || !equalsNullSafe(hydrationWaveId, selectedWaveId)) {
-            return;
-          }
-          // Build a lookup map from attachmentId -> metadata for successful results.
-          Map<String, J2clAttachmentMetadata> metadataById =
-              new HashMap<String, J2clAttachmentMetadata>();
-          if (result.isSuccess()) {
-            for (J2clAttachmentMetadata metadata : result.getAttachments()) {
-              metadataById.put(metadata.getAttachmentId(), metadata);
-            }
-          }
-          // Re-build each blip's attachment list, hydrating pending entries.
-          List<J2clReadBlip> hydratedBlips = new ArrayList<J2clReadBlip>(currentModel.getReadBlips().size());
-          for (J2clReadBlip blip : currentModel.getReadBlips()) {
-            boolean hasAnyPending = false;
-            for (J2clAttachmentRenderModel a : blip.getAttachments()) {
-              if (a.isMetadataPending()) {
-                hasAnyPending = true;
-                break;
-              }
-            }
-            if (!hasAnyPending) {
-              hydratedBlips.add(blip);
-              continue;
-            }
-            List<J2clAttachmentRenderModel> hydratedAttachments =
-                new ArrayList<J2clAttachmentRenderModel>(blip.getAttachments().size());
-            for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
-              if (!attachment.isMetadataPending()) {
-                hydratedAttachments.add(attachment);
-                continue;
-              }
-              String attachmentId = attachment.getAttachmentId();
-              J2clAttachmentMetadata metadata = metadataById.get(attachmentId);
-              if (!result.isSuccess()) {
-                // Whole-fetch failure: surface the error message from the result.
-                hydratedAttachments.add(
-                    J2clAttachmentRenderModel.metadataFailure(
-                        attachmentId,
-                        attachment.getCaption(),
-                        attachment.getDisplaySize(),
-                        result.getMessage()));
-              } else if (metadata != null) {
-                hydratedAttachments.add(
-                    J2clAttachmentRenderModel.fromMetadata(
-                        attachmentId,
-                        attachment.getCaption(),
-                        attachment.getDisplaySize(),
-                        metadata));
-              } else {
-                // ID was not returned by the server.
-                hydratedAttachments.add(
-                    J2clAttachmentRenderModel.metadataFailure(
-                        attachmentId,
-                        attachment.getCaption(),
-                        attachment.getDisplaySize(),
-                        "attachment not found"));
-              }
-            }
-            hydratedBlips.add(new J2clReadBlip(blip.getBlipId(), blip.getText(), hydratedAttachments));
-          }
-          currentModel = currentModel.withReadBlips(hydratedBlips);
-          view.render(currentModel);
-          publishWriteSession();
-        });
-  }
-
-  private static boolean equalsNullSafe(String a, String b) {
-    return a == null ? b == null : a.equals(b);
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -2,9 +2,14 @@ package org.waveprotocol.box.j2cl.search;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
@@ -151,9 +156,11 @@ public final class J2clSelectedWaveViewportState {
                   existing.getRawSnapshot(),
                   existing.getAdjustOperationCount(),
                   existing.getDiffOperationCount(),
-                  existing.shouldParseAttachmentElements()));
+                  existing.shouldParseAttachmentElements(),
+                  existing.attachmentOverrides,
+                  existing.parsedContent));
         } else {
-          merged.set(existingIndex, fragmentEntry);
+          merged.set(existingIndex, fragmentEntry.withCachedParsedContentFrom(existing));
         }
       } else {
         missing.add(fragmentEntry);
@@ -281,6 +288,54 @@ public final class J2clSelectedWaveViewportState {
     return contentEntries.isEmpty() ? fallbackEntries : contentEntries;
   }
 
+  List<String> getPendingAttachmentIds() {
+    Set<String> pendingIds = new LinkedHashSet<String>();
+    for (Entry entry : entries) {
+      if (!entry.isLoaded() || !entry.shouldParseAttachmentElements()) {
+        continue;
+      }
+      J2clReadBlipContent content = entry.getParsedContent();
+      for (J2clAttachmentRenderModel attachment : resolveAttachments(entry, content)) {
+        if (attachment.isMetadataPending() && !attachment.getAttachmentId().isEmpty()) {
+          pendingIds.add(attachment.getAttachmentId());
+        }
+      }
+    }
+    return new ArrayList<String>(pendingIds);
+  }
+
+  J2clSelectedWaveViewportState withAttachmentMetadata(
+      List<J2clAttachmentMetadata> metadata,
+      List<String> missingAttachmentIds) {
+    Map<String, J2clAttachmentMetadata> metadataById =
+        new HashMap<String, J2clAttachmentMetadata>();
+    if (metadata != null) {
+      for (J2clAttachmentMetadata item : metadata) {
+        if (item != null && item.getAttachmentId() != null && !item.getAttachmentId().isEmpty()) {
+          metadataById.put(item.getAttachmentId(), item);
+        }
+      }
+    }
+    Set<String> missingIds = new HashSet<String>();
+    if (missingAttachmentIds != null) {
+      missingIds.addAll(missingAttachmentIds);
+    }
+    return withAttachmentResolution(metadataById, missingIds, Collections.<String>emptySet(), "");
+  }
+
+  J2clSelectedWaveViewportState withAttachmentMetadataFailure(
+      List<String> attachmentIds, String reason) {
+    Set<String> failedIds = new HashSet<String>();
+    if (attachmentIds != null) {
+      failedIds.addAll(attachmentIds);
+    }
+    return withAttachmentResolution(
+        Collections.<String, J2clAttachmentMetadata>emptyMap(),
+        Collections.<String>emptySet(),
+        failedIds,
+        reason);
+  }
+
   public List<J2clReadBlip> getLoadedReadBlips() {
     List<J2clReadBlip> readBlips = new ArrayList<J2clReadBlip>();
     for (Entry entry : entries) {
@@ -290,10 +345,12 @@ public final class J2clSelectedWaveViewportState {
       // parseAttachmentElements is true only for fragment entries (fromFragments); document
       // entries (fromDocuments) leave it false, so plain text like "2 < 3" is never mangled.
       if (entry.shouldParseAttachmentElements()) {
-        J2clReadBlipContent content =
-            J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
+        J2clReadBlipContent content = entry.getParsedContent();
         readBlips.add(
-            new J2clReadBlip(entry.getBlipId(), content.getText(), content.getAttachments()));
+            new J2clReadBlip(
+                entry.getBlipId(),
+                content.getText(),
+                resolveAttachments(entry, content)));
       } else {
         readBlips.add(new J2clReadBlip(entry.getBlipId(), entry.getRawSnapshot()));
       }
@@ -309,8 +366,7 @@ public final class J2clSelectedWaveViewportState {
       }
       if (entry.isLoaded()) {
         if (entry.shouldParseAttachmentElements()) {
-          J2clReadBlipContent content =
-              J2clReadBlipContent.parseRawSnapshot(entry.getRawSnapshot());
+          J2clReadBlipContent content = entry.getParsedContent();
           windowEntries.add(
               J2clReadWindowEntry.loaded(
                   entry.getSegment(),
@@ -318,7 +374,7 @@ public final class J2clSelectedWaveViewportState {
                   entry.getToVersion(),
                   entry.getBlipId(),
                   content.getText(),
-                  content.getAttachments()));
+                  resolveAttachments(entry, content)));
         } else {
           windowEntries.add(
               J2clReadWindowEntry.loaded(
@@ -338,6 +394,38 @@ public final class J2clSelectedWaveViewportState {
       }
     }
     return windowEntries;
+  }
+
+  private J2clSelectedWaveViewportState withAttachmentResolution(
+      Map<String, J2clAttachmentMetadata> metadataById,
+      Set<String> missingIds,
+      Set<String> failedIds,
+      String failureReason) {
+    if ((metadataById == null || metadataById.isEmpty())
+        && (missingIds == null || missingIds.isEmpty())
+        && (failedIds == null || failedIds.isEmpty())) {
+      return this;
+    }
+    List<Entry> resolved = new ArrayList<Entry>();
+    boolean changed = false;
+    for (Entry entry : entries) {
+      Entry next =
+          entry.withAttachmentResolution(metadataById, missingIds, failedIds, failureReason);
+      resolved.add(next);
+      changed = changed || next != entry;
+    }
+    if (!changed) {
+      return this;
+    }
+    return new J2clSelectedWaveViewportState(
+        snapshotVersion, startVersion, endVersion, resolved);
+  }
+
+  private static List<J2clAttachmentRenderModel> resolveAttachments(
+      Entry entry, J2clReadBlipContent content) {
+    return entry.getAttachmentOverrides().isEmpty()
+        ? content.getAttachments()
+        : entry.getAttachmentOverrides();
   }
 
   private static int indexOfSegment(List<Entry> entries, String segment) {
@@ -397,6 +485,11 @@ public final class J2clSelectedWaveViewportState {
     private final int diffOperationCount;
     private final boolean loaded;
     private final boolean parseAttachmentElements;
+    private final List<J2clAttachmentRenderModel> attachmentOverrides;
+    // Cache only: never include this mutable field in equality/hash semantics if Entry later gains
+    // value-style comparison. A loaded fragment can be projected into content, read blips, and
+    // attachment metadata overrides during the same viewport lifetime.
+    private J2clReadBlipContent parsedContent;
 
     private Entry(
         String segment,
@@ -406,7 +499,9 @@ public final class J2clSelectedWaveViewportState {
         int adjustOperationCount,
         int diffOperationCount,
         boolean loaded,
-        boolean parseAttachmentElements) {
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides,
+        J2clReadBlipContent parsedContent) {
       this.segment = segment == null ? "" : segment;
       this.fromVersion = fromVersion;
       this.toVersion = toVersion;
@@ -415,6 +510,12 @@ public final class J2clSelectedWaveViewportState {
       this.diffOperationCount = diffOperationCount;
       this.loaded = loaded;
       this.parseAttachmentElements = parseAttachmentElements;
+      this.attachmentOverrides =
+          attachmentOverrides == null
+              ? Collections.<J2clAttachmentRenderModel>emptyList()
+              : Collections.unmodifiableList(
+                  new ArrayList<J2clAttachmentRenderModel>(attachmentOverrides));
+      this.parsedContent = parsedContent;
     }
 
     static Entry fromRange(
@@ -430,7 +531,9 @@ public final class J2clSelectedWaveViewportState {
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
           true,
-          true);
+          true,
+          Collections.<J2clAttachmentRenderModel>emptyList(),
+          null);
     }
 
     static Entry fromFragment(SidecarSelectedWaveFragment fragment) {
@@ -445,7 +548,9 @@ public final class J2clSelectedWaveViewportState {
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
           true,
-          true);
+          true,
+          Collections.<J2clAttachmentRenderModel>emptyList(),
+          null);
     }
 
     static Entry loaded(
@@ -474,6 +579,48 @@ public final class J2clSelectedWaveViewportState {
         int adjustOperationCount,
         int diffOperationCount,
         boolean parseAttachmentElements) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          parseAttachmentElements,
+          Collections.<J2clAttachmentRenderModel>emptyList());
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          parseAttachmentElements,
+          attachmentOverrides,
+          null);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides,
+        J2clReadBlipContent parsedContent) {
       return new Entry(
           segment,
           fromVersion,
@@ -482,11 +629,111 @@ public final class J2clSelectedWaveViewportState {
           adjustOperationCount,
           diffOperationCount,
           true,
-          parseAttachmentElements);
+          parseAttachmentElements,
+          attachmentOverrides,
+          parsedContent);
     }
 
     static Entry placeholder(String segment, long fromVersion, long toVersion) {
-      return new Entry(segment, fromVersion, toVersion, "", 0, 0, false, false);
+      return new Entry(
+          segment,
+          fromVersion,
+          toVersion,
+          "",
+          0,
+          0,
+          false,
+          false,
+          Collections.<J2clAttachmentRenderModel>emptyList(),
+          null);
+    }
+
+    private Entry withAttachmentResolution(
+        Map<String, J2clAttachmentMetadata> metadataById,
+        Set<String> missingIds,
+        Set<String> failedIds,
+        String failureReason) {
+      if (!loaded || !parseAttachmentElements) {
+        return this;
+      }
+      J2clReadBlipContent content = getParsedContent();
+      if (content.getAttachments().isEmpty()) {
+        return attachmentOverrides.isEmpty()
+            ? this
+            : loaded(
+                segment,
+                fromVersion,
+                toVersion,
+                rawSnapshot,
+                adjustOperationCount,
+                diffOperationCount,
+                parseAttachmentElements,
+                Collections.<J2clAttachmentRenderModel>emptyList(),
+                content);
+      }
+      Map<String, J2clAttachmentRenderModel> currentById =
+          new HashMap<String, J2clAttachmentRenderModel>();
+      for (J2clAttachmentRenderModel current : attachmentOverrides) {
+        if (!current.getAttachmentId().isEmpty()) {
+          currentById.put(current.getAttachmentId(), current);
+        }
+      }
+      List<J2clAttachmentRenderModel> nextAttachments =
+          new ArrayList<J2clAttachmentRenderModel>();
+      for (J2clAttachmentRenderModel parsed : content.getAttachments()) {
+        String attachmentId = parsed.getAttachmentId();
+        J2clAttachmentMetadata metadata = metadataById.get(attachmentId);
+        if (metadata != null) {
+          nextAttachments.add(
+              J2clAttachmentRenderModel.fromMetadata(
+                  attachmentId, parsed.getCaption(), parsed.getDisplaySize(), metadata));
+        } else if (missingIds.contains(attachmentId)) {
+          nextAttachments.add(
+              J2clAttachmentRenderModel.metadataFailure(
+                  attachmentId,
+                  parsed.getCaption(),
+                  parsed.getDisplaySize(),
+                  "Attachment metadata unavailable."));
+        } else if (failedIds.contains(attachmentId)) {
+          nextAttachments.add(
+              J2clAttachmentRenderModel.metadataFailure(
+                  attachmentId, parsed.getCaption(), parsed.getDisplaySize(), failureReason));
+        } else {
+          J2clAttachmentRenderModel current = currentById.get(attachmentId);
+          nextAttachments.add(current == null ? parsed : current);
+        }
+      }
+      if (nextAttachments.equals(attachmentOverrides)) {
+        return this;
+      }
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          parseAttachmentElements,
+          nextAttachments,
+          content);
+    }
+
+    private Entry withCachedParsedContentFrom(Entry existing) {
+      if (existing == null || !rawSnapshot.equals(existing.rawSnapshot)) {
+        return this;
+      }
+      // J2clReadBlipContent is a pure parse of rawSnapshot, so exact raw equality is the only
+      // safe cache/override reuse key across fragment replacements.
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          parseAttachmentElements,
+          existing.attachmentOverrides,
+          existing.parsedContent);
     }
 
     public String getSegment() {
@@ -519,6 +766,17 @@ public final class J2clSelectedWaveViewportState {
 
     public boolean shouldParseAttachmentElements() {
       return parseAttachmentElements;
+    }
+
+    List<J2clAttachmentRenderModel> getAttachmentOverrides() {
+      return attachmentOverrides;
+    }
+
+    J2clReadBlipContent getParsedContent() {
+      if (parsedContent == null) {
+        parsedContent = J2clReadBlipContent.parseRawSnapshot(rawSnapshot);
+      }
+      return parsedContent;
     }
 
     public boolean isBlip() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -1,7 +1,9 @@
 package org.waveprotocol.box.j2cl.search;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -671,11 +673,16 @@ public final class J2clSelectedWaveViewportState {
                 Collections.<J2clAttachmentRenderModel>emptyList(),
                 content);
       }
-      Map<String, J2clAttachmentRenderModel> currentById =
-          new HashMap<String, J2clAttachmentRenderModel>();
+      Map<String, Deque<J2clAttachmentRenderModel>> currentQueuesById =
+          new HashMap<String, Deque<J2clAttachmentRenderModel>>();
       for (J2clAttachmentRenderModel current : attachmentOverrides) {
         if (!current.getAttachmentId().isEmpty()) {
-          currentById.put(current.getAttachmentId(), current);
+          Deque<J2clAttachmentRenderModel> queue = currentQueuesById.get(current.getAttachmentId());
+          if (queue == null) {
+            queue = new ArrayDeque<J2clAttachmentRenderModel>();
+            currentQueuesById.put(current.getAttachmentId(), queue);
+          }
+          queue.add(current);
         }
       }
       List<J2clAttachmentRenderModel> nextAttachments =
@@ -699,7 +706,8 @@ public final class J2clSelectedWaveViewportState {
               J2clAttachmentRenderModel.metadataFailure(
                   attachmentId, parsed.getCaption(), parsed.getDisplaySize(), failureReason));
         } else {
-          J2clAttachmentRenderModel current = currentById.get(attachmentId);
+          Deque<J2clAttachmentRenderModel> queue = currentQueuesById.get(attachmentId);
+          J2clAttachmentRenderModel current = queue != null ? queue.poll() : null;
           nextAttachments.add(current == null ? parsed : current);
         }
       }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentMetadataClientTest.java
@@ -222,6 +222,24 @@ public class J2clAttachmentMetadataClientTest {
   }
 
   @Test
+  public void publicSuccessFactoryRejectsNullLists() {
+    try {
+      J2clAttachmentMetadataClient.MetadataResult.success(null, Arrays.asList("missing+1"));
+      Assert.fail("Expected null attachment list to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("Metadata result lists are required.", expected.getMessage());
+    }
+
+    try {
+      J2clAttachmentMetadataClient.MetadataResult.success(
+          Arrays.<J2clAttachmentMetadata>asList(), null);
+      Assert.fail("Expected null missing-id list to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("Metadata result lists are required.", expected.getMessage());
+    }
+  }
+
+  @Test
   public void httpFailureReturnsTypedErrorWithoutThrowing() {
     FakeMetadataTransport transport = new FakeMetadataTransport();
     J2clAttachmentMetadataClient client = new J2clAttachmentMetadataClient(transport);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -188,6 +188,23 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void selfClosingImageDoesNotConsumeLaterClosedImage() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "Before <image attachment=\"example.com/att+self\" /> between "
+                + "<image attachment=\"example.com/att+closed\" display-size=\"large\">"
+                + "<caption>Closed caption</caption></image> after");
+
+    Assert.assertEquals("Before  between  after", parsed.getText());
+    Assert.assertEquals(2, parsed.getAttachments().size());
+    Assert.assertEquals("example.com/att+self", parsed.getAttachments().get(0).getAttachmentId());
+    Assert.assertEquals("example.com/att+self", parsed.getAttachments().get(0).getCaption());
+    Assert.assertEquals("example.com/att+closed", parsed.getAttachments().get(1).getAttachmentId());
+    Assert.assertEquals("Closed caption", parsed.getAttachments().get(1).getCaption());
+    Assert.assertEquals("large", parsed.getAttachments().get(1).getDisplaySize());
+  }
+
+  @Test
   public void literalGreaterThanInPlainTextIsPreserved() {
     J2clReadBlipContent parsed = J2clReadBlipContent.parseRawSnapshot("a > b");
     Assert.assertEquals("a > b", parsed.getText());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
@@ -885,123 +886,161 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
-  public void pendingAttachmentsInReadBlipsTriggerMetadataFetch() throws Exception {
+  public void selectedWaveHydratesPendingFragmentAttachments() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
-    // Deliver a fragment update whose raw snapshot contains an image element — this causes
-    // J2clReadBlipContent.parseRawSnapshot to produce a metadataPending attachment model.
-    harness.deliverRawUpdate(0, updateWithImageAttachment("img-001", "My photo", "medium", "Body text"));
+    harness.deliverUpdate(
+        0,
+        "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+            + "<caption>Hero diagram</caption></image> outro");
 
-    // The controller must have triggered a metadata fetch for the pending attachment.
-    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
-    Assert.assertEquals(Arrays.asList("img-001"), harness.attachmentMetadataFetchAttempts.get(0).attachmentIds);
+    Assert.assertEquals(1, harness.attachmentMetadataAttempts.size());
+    Assert.assertEquals(
+        Arrays.asList("example.com/att+hero"),
+        harness.attachmentMetadataAttempts.get(0).attachmentIds);
+    Assert.assertTrue(harness.firstReadAttachment().isMetadataPending());
+
+    harness.resolveAttachmentMetadata(
+        0,
+        Arrays.asList(
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachments/hero.png",
+                "/thumbnails/hero.png")),
+        Collections.<String>emptyList());
+
+    J2clAttachmentRenderModel attachment = harness.firstReadAttachment();
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.canOpen());
+    Assert.assertEquals("/attachments/hero.png", attachment.getOpenUrl());
+    Assert.assertEquals("Hero diagram", attachment.getCaption());
+    Assert.assertEquals(1, harness.attachmentMetadataAttempts.size());
   }
 
   @Test
-  public void successfulMetadataFetchReRendersWithHydratedAttachments() throws Exception {
+  public void selectedWaveMarksAttachmentMetadataFailure() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
-    harness.deliverRawUpdate(0, updateWithImageAttachment("img-002", "A picture", "small", "Hello"));
+    harness.deliverUpdate(
+        0,
+        "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+            + "<caption>Hero diagram</caption></image> outro");
 
-    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
+    harness.rejectAttachmentMetadata(0, "metadata network failure");
 
-    // Capture the render count before the hydration re-render.
-    int rendersBefore = harness.renderCount;
-
-    // Supply metadata for img-002: minimal well-formed JSON for the attachment info endpoint.
-    harness.resolveAttachmentMetadataFetch(0, buildSingleAttachmentResultJson("img-002",
-        "photo.jpg", "image/jpeg", "/attachments/img-002", "/thumbnails/img-002", false));
-
-    // The controller must have called view.render a second time.
-    Assert.assertEquals(rendersBefore + 1, harness.renderCount);
-
-    // The re-rendered blips must have a non-pending attachment for img-002.
-    @SuppressWarnings("unchecked")
-    List<J2clReadBlip> readBlips = (List<J2clReadBlip>) harness.modelValue("getReadBlips");
-    Assert.assertFalse(readBlips.isEmpty());
-    boolean foundHydrated = false;
-    for (J2clReadBlip blip : readBlips) {
-      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
-        if ("img-002".equals(attachment.getAttachmentId())) {
-          Assert.assertFalse(
-              "Expected attachment to be hydrated (not metadataPending)",
-              attachment.isMetadataPending());
-          Assert.assertFalse(
-              "Expected attachment to not be metadataFailure after successful fetch",
-              attachment.isMetadataFailure());
-          foundHydrated = true;
-        }
-      }
-    }
-    Assert.assertTrue("No hydrated attachment for img-002 found in rendered model", foundHydrated);
+    J2clAttachmentRenderModel attachment = harness.firstReadAttachment();
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.isMetadataFailure());
+    Assert.assertFalse(attachment.canOpen());
+    Assert.assertTrue(attachment.getStatusText().contains("metadata network failure"));
+    Assert.assertEquals(1, harness.attachmentMetadataAttempts.size());
   }
 
   @Test
-  public void failedMetadataFetchReRendersWithMetadataFailureAttachments() throws Exception {
+  public void selectedWaveMarksAttachmentMetadataDispatchThrowAsFailure() throws Exception {
     Harness harness = new Harness();
+    harness.attachmentMetadataDispatchError = "metadata dispatch failed";
     Object controller = harness.createController(false);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
-    harness.deliverRawUpdate(0, updateWithImageAttachment("img-003", "Broken", "small", ""));
+    harness.deliverUpdate(
+        0,
+        "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+            + "<caption>Hero diagram</caption></image> outro");
 
-    int rendersBefore = harness.renderCount;
-    harness.rejectAttachmentMetadataFetch(0, "network error");
-
-    Assert.assertEquals(rendersBefore + 1, harness.renderCount);
-
-    @SuppressWarnings("unchecked")
-    List<J2clReadBlip> readBlips = (List<J2clReadBlip>) harness.modelValue("getReadBlips");
-    boolean foundFailure = false;
-    for (J2clReadBlip blip : readBlips) {
-      for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
-        if ("img-003".equals(attachment.getAttachmentId())) {
-          Assert.assertFalse("Expected not pending after failed fetch", attachment.isMetadataPending());
-          Assert.assertTrue("Expected metadataFailure after failed fetch", attachment.isMetadataFailure());
-          foundFailure = true;
-        }
-      }
-    }
-    Assert.assertTrue("No failure attachment for img-003 found", foundFailure);
+    J2clAttachmentRenderModel attachment = harness.firstReadAttachment();
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.isMetadataFailure());
+    Assert.assertTrue(attachment.getStatusText().contains("metadata dispatch failed"));
+    Assert.assertEquals(0, harness.attachmentMetadataAttempts.size());
   }
 
   @Test
-  public void staleAttachmentFetchIsDiscardedAfterWaveReselection() throws Exception {
+  public void selectedWaveTreatsEmptyMetadataSuccessAsMissing() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
 
     harness.selectWave(controller, "example.com/w+1", null);
     harness.resolveBootstrap(0);
-    harness.deliverRawUpdate(0, updateWithImageAttachment("img-004", "Wave 1 photo", "small", ""));
-    Assert.assertEquals(1, harness.attachmentMetadataFetchAttempts.size());
+    harness.deliverUpdate(
+        0,
+        "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+            + "<caption>Hero diagram</caption></image> outro");
 
-    // Switch to a different wave before the attachment fetch completes.
-    harness.selectWave(controller, "example.com/w+2", null);
+    harness.resolveAttachmentMetadata(
+        0,
+        Collections.<J2clAttachmentMetadata>emptyList(),
+        Collections.<String>emptyList());
 
-    int renderCountAfterSwitch = harness.renderCount;
-    harness.resolveAttachmentMetadataFetch(0, buildSingleAttachmentResultJson("img-004",
-        "photo.jpg", "image/jpeg", "/attachments/img-004", "/thumbnails/img-004", false));
-
-    // The stale result must be discarded — no extra re-render for wave 2.
-    Assert.assertEquals(renderCountAfterSwitch, harness.renderCount);
+    J2clAttachmentRenderModel attachment = harness.firstReadAttachment();
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.isMetadataFailure());
+    Assert.assertFalse(attachment.canOpen());
+    Assert.assertEquals(1, harness.attachmentMetadataAttempts.size());
   }
 
   @Test
-  public void blipsWithNoAttachmentsDoNotTriggerMetadataFetch() throws Exception {
+  public void staleAttachmentMetadataCallbackDoesNotClearNewerInFlightFetch()
+      throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
 
-    harness.selectWave(controller, "example.com/w+1", null);
+    harness.selectWave(controller, "example.com/w+a", null);
     harness.resolveBootstrap(0);
-    harness.deliverUpdate(0, "Just plain text, no attachments");
+    harness.deliverUpdate(
+        0,
+        "Wave A <image attachment=\"example.com/att+old\" display-size=\"medium\">"
+            + "<caption>Old</caption></image>");
+    Assert.assertEquals(1, harness.attachmentMetadataAttempts.size());
 
-    Assert.assertEquals(0, harness.attachmentMetadataFetchAttempts.size());
+    harness.selectWave(controller, "example.com/w+b", null);
+    harness.resolveBootstrap(1);
+    harness.deliverUpdate(
+        1,
+        "Wave B <image attachment=\"example.com/att+new\" display-size=\"medium\">"
+            + "<caption>New</caption></image>");
+    Assert.assertEquals(2, harness.attachmentMetadataAttempts.size());
+
+    harness.resolveAttachmentMetadata(
+        0,
+        Arrays.asList(
+            attachmentMetadata(
+                "example.com/att+old",
+                "old.png",
+                "image/png",
+                "/attachments/old.png",
+                "/thumbnails/old.png")),
+        Collections.<String>emptyList());
+    Assert.assertEquals("example.com/att+new", harness.firstReadAttachment().getAttachmentId());
+    Assert.assertTrue(harness.firstReadAttachment().isMetadataPending());
+
+    harness.deliverUpdate(
+        1,
+        "Wave B <image attachment=\"example.com/att+new\" display-size=\"medium\">"
+            + "<caption>New</caption></image>");
+    Assert.assertEquals(2, harness.attachmentMetadataAttempts.size());
+
+    harness.resolveAttachmentMetadata(
+        1,
+        Arrays.asList(
+            attachmentMetadata(
+                "example.com/att+new",
+                "new.png",
+                "image/png",
+                "/attachments/new.png",
+                "/thumbnails/new.png")),
+        Collections.<String>emptyList());
+    Assert.assertFalse(harness.firstReadAttachment().isMetadataPending());
+    Assert.assertEquals("/attachments/new.png", harness.firstReadAttachment().getOpenUrl());
   }
 
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
@@ -1009,10 +1048,29 @@ public class J2clSelectedWaveControllerTest {
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);
   }
 
+  private static J2clAttachmentMetadata attachmentMetadata(
+      String attachmentId,
+      String fileName,
+      String mimeType,
+      String attachmentUrl,
+      String thumbnailUrl) {
+    return new J2clAttachmentMetadata(
+        attachmentId,
+        "example.com/w+1/~/conv+root",
+        fileName,
+        mimeType,
+        4096L,
+        "user@example.com",
+        attachmentUrl,
+        thumbnailUrl,
+        new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+        new J2clAttachmentMetadata.ImageMetadata(320, 200),
+        false);
+  }
+
   private static final class Harness {
     private int openCount;
     private int closedCount;
-    private int renderCount;
     private final List<Integer> scheduledDelays = new ArrayList<Integer>();
     private final List<Runnable> scheduledRetries = new ArrayList<Runnable>();
     private final List<BootstrapAttempt> bootstrapAttempts = new ArrayList<BootstrapAttempt>();
@@ -1020,8 +1078,8 @@ public class J2clSelectedWaveControllerTest {
     private final List<ReadStateFetchAttempt> readStateAttempts = new ArrayList<ReadStateFetchAttempt>();
     private final List<FragmentFetchAttempt> fragmentFetchAttempts =
         new ArrayList<FragmentFetchAttempt>();
-    private final List<AttachmentMetadataFetchAttempt> attachmentMetadataFetchAttempts =
-        new ArrayList<AttachmentMetadataFetchAttempt>();
+    private final List<AttachmentMetadataAttempt> attachmentMetadataAttempts =
+        new ArrayList<AttachmentMetadataAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
     private SidecarViewportHints initialViewportHints;
@@ -1029,6 +1087,7 @@ public class J2clSelectedWaveControllerTest {
     private Runnable onNextRender;
     private Method onWaveSelectedMethod;
     private Method onWaveSelectedWithDigestMethod;
+    private String attachmentMetadataDispatchError;
 
     private Object createControllerWithVisibility(boolean withScheduler) throws Exception {
       return createControllerInternal(withScheduler, /* injectVisibility= */ true);
@@ -1119,16 +1178,15 @@ public class J2clSelectedWaveControllerTest {
                   return null;
                 }
                 if ("fetchAttachmentMetadata".equals(method.getName())) {
+                  if (attachmentMetadataDispatchError != null) {
+                    throw new RuntimeException(attachmentMetadataDispatchError);
+                  }
                   @SuppressWarnings("unchecked")
-                  List<String> ids = (List<String>) args[0];
-                  @SuppressWarnings("unchecked")
-                  J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
-                      callback =
-                          (J2clSearchPanelController.SuccessCallback<
-                                  J2clAttachmentMetadataClient.MetadataResult>)
-                              args[1];
-                  attachmentMetadataFetchAttempts.add(
-                      new AttachmentMetadataFetchAttempt(ids, callback));
+                  List<String> attachmentIds = (List<String>) args[0];
+                  J2clAttachmentMetadataClient.MetadataCallback callback =
+                      (J2clAttachmentMetadataClient.MetadataCallback) args[1];
+                  attachmentMetadataAttempts.add(
+                      new AttachmentMetadataAttempt(attachmentIds, callback));
                   return null;
                 }
                 return null;
@@ -1141,7 +1199,6 @@ public class J2clSelectedWaveControllerTest {
               (proxy, method, args) -> {
                 if ("render".equals(method.getName())) {
                   lastModel = args[0];
-                  renderCount++;
                   Runnable callback = onNextRender;
                   onNextRender = null;
                   if (callback != null) {
@@ -1295,33 +1352,25 @@ public class J2clSelectedWaveControllerTest {
       fragmentFetchAttempts.get(index).error.accept(message);
     }
 
-    /**
-     * Resolves the attachment metadata fetch at {@code index} by running a real
-     * {@link J2clAttachmentMetadataClient} with a synchronous fake transport that
-     * returns the given JSON string as a successful 200 application/json response.
-     */
-    private void resolveAttachmentMetadataFetch(int index, String json) {
-      AttachmentMetadataFetchAttempt attempt = attachmentMetadataFetchAttempts.get(index);
-      J2clAttachmentMetadataClient client =
-          new J2clAttachmentMetadataClient(
-              (url, handler) ->
-                  handler.onResponse(
-                      new J2clAttachmentMetadataClient.HttpResponse(
-                          200, "application/json", json, null)));
-      client.fetchMetadata(attempt.attachmentIds, result -> attempt.callback.accept(result));
+    private void resolveAttachmentMetadata(
+        int index,
+        List<J2clAttachmentMetadata> attachments,
+        List<String> missingAttachmentIds) {
+      attachmentMetadataAttempts
+          .get(index)
+          .callback
+          .onComplete(
+              J2clAttachmentMetadataClient.MetadataResult.success(
+                  attachments, missingAttachmentIds));
     }
 
-    /**
-     * Rejects the attachment metadata fetch at {@code index} by invoking the
-     * callback with a network-failure result.
-     */
-    private void rejectAttachmentMetadataFetch(int index, String errorMessage) {
-      AttachmentMetadataFetchAttempt attempt = attachmentMetadataFetchAttempts.get(index);
-      J2clAttachmentMetadataClient client =
-          new J2clAttachmentMetadataClient(
-              (url, handler) ->
-                  handler.onResponse(J2clAttachmentMetadataClient.HttpResponse.networkError(errorMessage)));
-      client.fetchMetadata(attempt.attachmentIds, result -> attempt.callback.accept(result));
+    private void rejectAttachmentMetadata(int index, String message) {
+      attachmentMetadataAttempts
+          .get(index)
+          .callback
+          .onComplete(
+              J2clAttachmentMetadataClient.MetadataResult.failure(
+                  J2clAttachmentMetadataClient.ErrorType.NETWORK, message));
     }
 
     private void deliverUpdate(int index, String rawSnapshot) {
@@ -1339,6 +1388,12 @@ public class J2clSelectedWaveControllerTest {
     private Object modelValue(String methodName) throws Exception {
       Method method = lastModel.getClass().getMethod(methodName);
       return method.invoke(lastModel);
+    }
+
+    private J2clAttachmentRenderModel firstReadAttachment() throws Exception {
+      @SuppressWarnings("unchecked")
+      List<J2clReadBlip> readBlips = (List<J2clReadBlip>) modelValue("getReadBlips");
+      return readBlips.get(0).getAttachments().get(0);
     }
   }
 
@@ -1463,69 +1518,6 @@ public class J2clSelectedWaveControllerTest {
         json.toString());
   }
 
-  /**
-   * Creates a selected-wave update whose root blip raw snapshot contains an {@code <image>}
-   * element so that {@link J2clReadBlipContent#parseRawSnapshot} produces a
-   * {@code metadataPending} attachment model.
-   */
-  private static SidecarSelectedWaveUpdate updateWithImageAttachment(
-      String attachmentId, String caption, String displaySize, String bodyText) {
-    String rawSnapshot =
-        bodyText
-            + "<image attachment=\""
-            + attachmentId
-            + "\" display-size=\""
-            + displaySize
-            + "\"><caption>"
-            + caption
-            + "</caption></image>";
-    return new SidecarSelectedWaveUpdate(
-        1,
-        "example.com!w+1/example.com!conv+root",
-        true,
-        "chan-1",
-        44L,
-        "ABCD",
-        Arrays.asList("user@example.com"),
-        Arrays.asList(
-            new SidecarSelectedWaveDocument(
-                "b+root", "user@example.com", 40L, 44L, rawSnapshot)),
-        new SidecarSelectedWaveFragments(
-            44L,
-            40L,
-            44L,
-            Arrays.asList(
-                new SidecarSelectedWaveFragmentRange("manifest", 40L, 44L),
-                new SidecarSelectedWaveFragmentRange("blip:b+root", 40L, 44L)),
-            Arrays.asList(
-                new SidecarSelectedWaveFragment("manifest", "conversation: Inbox wave", 0, 0),
-                new SidecarSelectedWaveFragment("blip:b+root", rawSnapshot, 0, 0))));
-  }
-
-  /**
-   * Builds a JSON string in the format expected by
-   * {@link J2clAttachmentMetadataClient} for a single attachment.
-   */
-  private static String buildSingleAttachmentResultJson(
-      String attachmentId,
-      String fileName,
-      String mimeType,
-      String attachmentUrl,
-      String thumbnailUrl,
-      boolean malware) {
-    return "{\"1\":[{"
-        + "\"1\":\"" + attachmentId + "\","
-        + "\"2\":\"example.com/w+1\","
-        + "\"3\":\"" + fileName + "\","
-        + "\"4\":\"" + mimeType + "\","
-        + "\"5\":1024,"
-        + "\"6\":\"user@example.com\","
-        + "\"7\":\"" + attachmentUrl + "\","
-        + "\"8\":\"" + thumbnailUrl + "\","
-        + "\"11\":" + malware
-        + "}]}";
-  }
-
   private static SidecarSelectedWaveUpdate snapshotOnlyUpdate(String textContent) {
     return new SidecarSelectedWaveUpdate(
         1,
@@ -1597,16 +1589,14 @@ public class J2clSelectedWaveControllerTest {
     }
   }
 
-  private static final class AttachmentMetadataFetchAttempt {
+  private static final class AttachmentMetadataAttempt {
     private final List<String> attachmentIds;
-    private final J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
-        callback;
+    private final J2clAttachmentMetadataClient.MetadataCallback callback;
 
-    private AttachmentMetadataFetchAttempt(
+    private AttachmentMetadataAttempt(
         List<String> attachmentIds,
-        J2clSearchPanelController.SuccessCallback<J2clAttachmentMetadataClient.MetadataResult>
-            callback) {
-      this.attachmentIds = attachmentIds;
+        J2clAttachmentMetadataClient.MetadataCallback callback) {
+      this.attachmentIds = new ArrayList<String>(attachmentIds);
       this.callback = callback;
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -6,12 +6,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
+import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
@@ -30,6 +32,9 @@ public class J2clSelectedWaveProjectorTest {
   private static final String CHANNEL_ID = "chan-1";
   private static final String INDEX_SEGMENT = "index";
   private static final String MANIFEST_SEGMENT = "manifest";
+  private static final String ATTACHMENT_RAW_SNAPSHOT =
+      "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+          + "<caption>Hero diagram</caption></image> outro";
 
   // -- Read-state projection (issue #931) -------------------------------------
 
@@ -219,6 +224,203 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertTrue(attachment.isMetadataPending());
     Assert.assertEquals(
         1, projected.getViewportState().getReadWindowEntries().get(0).getAttachments().size());
+  }
+
+  @Test
+  public void viewportHydratesPendingFragmentAttachmentMetadata() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+
+    J2clAttachmentRenderModel attachment =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.canOpen());
+    Assert.assertTrue(attachment.canDownload());
+    Assert.assertEquals("/attachments/hero.png", attachment.getOpenUrl());
+    Assert.assertEquals("/attachments/hero.png", attachment.getSourceUrl());
+    Assert.assertEquals(
+        attachment, state.getReadWindowEntries().get(0).getAttachments().get(0));
+  }
+
+  @Test
+  public void viewportMarksMissingAttachmentMetadataAsFailure() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+
+    state =
+        state.withAttachmentMetadata(
+            Collections.<J2clAttachmentMetadata>emptyList(),
+            Arrays.asList("example.com/att+hero"));
+
+    J2clAttachmentRenderModel attachment =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+    Assert.assertFalse(attachment.isMetadataPending());
+    Assert.assertTrue(attachment.isMetadataFailure());
+    Assert.assertFalse(attachment.canOpen());
+    Assert.assertEquals("Hero diagram", attachment.getCaption());
+    Assert.assertEquals(
+        attachment, state.getReadWindowEntries().get(0).getAttachments().get(0));
+  }
+
+  @Test
+  public void viewportPreservesResolvedAttachmentWhenResolvingAnotherBatch() {
+    J2clSelectedWaveViewportState state = viewportWithTwoAttachments();
+
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+    J2clAttachmentRenderModel resolvedHero =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+
+    state =
+        state.withAttachmentMetadata(
+            Collections.<J2clAttachmentMetadata>emptyList(),
+            Arrays.asList("example.com/att+diagram"));
+
+    J2clAttachmentRenderModel hero =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+    J2clAttachmentRenderModel diagram =
+        state.getLoadedReadBlips().get(0).getAttachments().get(1);
+    Assert.assertEquals(resolvedHero, hero);
+    Assert.assertFalse(hero.isMetadataPending());
+    Assert.assertTrue(hero.canOpen());
+    Assert.assertTrue(diagram.isMetadataFailure());
+    Assert.assertFalse(diagram.isMetadataPending());
+  }
+
+  @Test
+  public void viewportReusesParsedContentAcrossAttachmentResolution() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+    J2clReadBlipContent parsed = state.getEntries().get(0).getParsedContent();
+
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+
+    Assert.assertSame(parsed, state.getEntries().get(0).getParsedContent());
+  }
+
+  @Test
+  public void viewportPreservesResolvedAttachmentAcrossSameRawFragmentMerge() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+    J2clReadBlipContent parsed = state.getEntries().get(0).getParsedContent();
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+    J2clAttachmentRenderModel resolved =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+
+    state =
+        state.mergeFragments(
+            attachmentFragments(10L, 0L, 10L),
+            J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertSame(parsed, state.getEntries().get(0).getParsedContent());
+    Assert.assertEquals(resolved, state.getLoadedReadBlips().get(0).getAttachments().get(0));
+    Assert.assertFalse(state.getPendingAttachmentIds().contains("example.com/att+hero"));
+  }
+
+  @Test
+  public void viewportPreservesResolvedAttachmentAcrossPlaceholderFragmentMerge() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+    J2clReadBlipContent parsed = state.getEntries().get(0).getParsedContent();
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+    J2clAttachmentRenderModel resolved =
+        state.getLoadedReadBlips().get(0).getAttachments().get(0);
+
+    state =
+        state.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                10L,
+                0L,
+                10L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 10L)),
+                Collections.<SidecarSelectedWaveFragment>emptyList()),
+            J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertSame(parsed, state.getEntries().get(0).getParsedContent());
+    Assert.assertEquals(resolved, state.getLoadedReadBlips().get(0).getAttachments().get(0));
+    Assert.assertFalse(state.getPendingAttachmentIds().contains("example.com/att+hero"));
+  }
+
+  @Test
+  public void viewportDropsParsedCacheAndOverridesWhenRawFragmentChanges() {
+    J2clSelectedWaveViewportState state = viewportWithAttachment();
+    J2clReadBlipContent parsed = state.getEntries().get(0).getParsedContent();
+    state =
+        state.withAttachmentMetadata(
+            Arrays.asList(
+                attachmentMetadata(
+                    "example.com/att+hero",
+                    "hero.png",
+                    "image/png",
+                    "/attachments/hero.png",
+                    "/thumbnails/hero.png",
+                    false)),
+            Collections.<String>emptyList());
+
+    state =
+        state.mergeFragments(
+            new SidecarSelectedWaveFragments(
+                10L,
+                0L,
+                10L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 10L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "Changed <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+                            + "<caption>Changed hero</caption></image>",
+                        0,
+                        0))),
+            J2clViewportGrowthDirection.FORWARD);
+
+    Assert.assertNotSame(parsed, state.getEntries().get(0).getParsedContent());
+    Assert.assertTrue(state.getLoadedReadBlips().get(0).getAttachments().get(0).isMetadataPending());
   }
 
   @Test
@@ -2068,6 +2270,61 @@ public class J2clSelectedWaveProjectorTest {
         Arrays.asList(
             new SidecarSelectedWaveFragment(INDEX_SEGMENT, "index", 0, 0),
             new SidecarSelectedWaveFragment(MANIFEST_SEGMENT, "metadata", 0, 0)));
+  }
+
+  private static J2clSelectedWaveViewportState viewportWithAttachment() {
+    return J2clSelectedWaveViewportState.fromFragments(attachmentFragments(9L, 0L, 9L));
+  }
+
+  private static SidecarSelectedWaveFragments attachmentFragments(
+      long snapshotVersion, long fromVersion, long toVersion) {
+    return new SidecarSelectedWaveFragments(
+        snapshotVersion,
+        fromVersion,
+        toVersion,
+        Arrays.asList(
+            new SidecarSelectedWaveFragmentRange("blip:b+root", fromVersion, toVersion)),
+        Arrays.asList(
+            new SidecarSelectedWaveFragment("blip:b+root", ATTACHMENT_RAW_SNAPSHOT, 0, 0)));
+  }
+
+  private static J2clSelectedWaveViewportState viewportWithTwoAttachments() {
+    return J2clSelectedWaveViewportState.fromFragments(
+        new SidecarSelectedWaveFragments(
+            9L,
+            0L,
+            9L,
+            Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment(
+                    "blip:b+root",
+                    "Intro <image attachment=\"example.com/att+hero\" display-size=\"medium\">"
+                        + "<caption>Hero diagram</caption></image>"
+                        + " and <image attachment=\"example.com/att+diagram\" "
+                        + "display-size=\"small\"><caption>Diagram</caption></image>",
+                    0,
+                    0))));
+  }
+
+  private static J2clAttachmentMetadata attachmentMetadata(
+      String attachmentId,
+      String fileName,
+      String mimeType,
+      String attachmentUrl,
+      String thumbnailUrl,
+      boolean malware) {
+    return new J2clAttachmentMetadata(
+        attachmentId,
+        "example.com/w+1/~/conv+root",
+        fileName,
+        mimeType,
+        4096L,
+        "user@example.com",
+        attachmentUrl,
+        thumbnailUrl,
+        new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+        new J2clAttachmentMetadata.ImageMetadata(320, 200),
+        malware);
   }
 
   private static J2clSelectedWaveViewportState.Entry entryBySegment(

--- a/wave/config/changelog.d/2026-04-25-issue-971-attachment-hydration-followup.json
+++ b/wave/config/changelog.d/2026-04-25-issue-971-attachment-hydration-followup.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-issue-971-attachment-hydration-followup",
+  "version": "Unreleased",
+  "date": "2026-04-25",
+  "title": "J2CL selected-wave attachments hydrate metadata",
+  "summary": "Selected-wave attachments in the J2CL read surface now hydrate server metadata after the initial render so read-only waves can expose real preview, open, and download actions.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2CL selected-wave attachment placeholders now resolve to hydrated attachment models, preserve resolved metadata across unchanged viewport fragment merges, and avoid losing later attachments when self-closing image tags appear before normal image tags."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- follow up PR #1022 by hydrating selected-wave attachment placeholders at the viewport-state level
- preserve parsed fragment caches and resolved attachment render models across same-raw and placeholder fragment merges
- fix mixed self-closing/closed image parsing so self-closing images do not consume later attachments

## Verification
- `sbt -batch j2clSearchTest`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `git diff --check && git diff --cached --check`

Issue: #971
Program: #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attachments in read-only waves now hydrate server metadata post-render, enabling accurate preview, open, and download actions.
  * Improved parsing of self-closing image tags to prevent consuming subsequent markup.

* **Bug Fixes**
  * Enhanced handling of missing or failed attachment metadata with informative status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->