### PR TITLE
Record J2CL attachment parity closeout evidence

### DIFF
--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -1,9 +1,9 @@
 # J2CL GWT Parity Matrix
 
-Status: Proposed  
-Owner: Project Maintainers  
-Updated: 2026-04-22  
-Review cadence: on-change  
+Status: Proposed\
+Owner: Project Maintainers\
+Updated: 2026-04-25\
+Review cadence: on-change
 
 Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
 Task issue: [#961](https://github.com/vega113/supawave/issues/961)
@@ -134,7 +134,7 @@ Current J2CL compose is a narrow write pilot. Downstream coverage:
 | R-5.4 | Tasks and related metadata overlays | Task toggle, completion state, and associated metadata overlays preserved; state persists through live updates | Overlay visuals may change | Keyboard toggling preserved | Overlays announce state changes | Labels translate | Harness covers task-toggle fixture | Task state-change counts emitted | smoke + browser + harness | `#970` |
 | R-5.5 | Reactions and comparable interaction overlays | Reaction add/remove and counts preserved; overlays remain reachable and do not trap focus | Reaction set, chip styling, and placement may change | Keyboard add/remove preserved | Reaction counts announced | Counts localize | Harness covers at least one reaction fixture | Reaction add/remove counts emitted | smoke + browser + harness | `#970` |
 | R-5.6 | Attachment workflow | Daily attachment upload/download/open paths preserved; failure modes surface user-visible errors; attachments round-trip through the model | Attachment tile styling may change | Attachment affordances are keyboard-reachable | Attachment regions labeled; errors announced | Error text translates | Harness covers one upload and one download fixture | Attachment upload/download counts with outcomes | smoke + browser + harness | `#971` |
-| R-5.7 | Remaining rich-edit daily affordances | Daily-path rich-edit behaviors identified by the packet for `#971` (for example: lists, block quotes, inline links) preserved | Visuals may change per the design packet | Keyboard semantics for the affordances preserved | Affordances labeled | n/a | Harness covers at least one fixture per affordance | Action counts emitted | smoke + browser + harness | `#971` |
+| R-5.7 | Remaining rich-edit daily affordances | Daily-path rich-edit behaviors identified by the packet for `#971` (for example: lists and inline links) preserved | Visuals may change per the design packet | Keyboard semantics for the affordances preserved | Affordances labeled | n/a | Harness covers at least one fixture per affordance | Action counts emitted | smoke + browser + harness | `#971` |
 
 Non-daily editor edge cases that do not ship in `#971` are captured in
 Section 10 rather than silently dropped.
@@ -221,6 +221,19 @@ recorded here so it is not silently dropped:
   example: rare legacy formatting paths, one-off keyboard shortcuts that do
   not appear in the `#969`/`#971` packet) — to be revisited only after the
   gate closes or via a dedicated addendum packet linked from this section
+- #971 daily attachment/rich-edit closeout defers the GWT toolbar affordances
+  that were not part of the inspected daily command packet: superscript,
+  subscript, font size, font family, font color, highlight color / `backColor`,
+  and block quote. The block quote affordance was not present in the inspected
+  GWT `EditToolbar.java` action set, so it is not counted as a #971 daily
+  parity requirement unless a later packet adds it explicitly. This finding is
+  the reason R-5.7 no longer lists block quote as a daily-path example.
+- #971 also defers drag-and-drop attachment insertion, client-side image
+  compression, and mobile/touch-specific toolbar gestures beyond the file
+  picker and paste-image flows. These remain follow-up candidates after the
+  daily parity gate, not blockers for one-file upload, pasted-image upload,
+  caption/display-size preservation, read-surface rendering, or keyboard
+  open/download.
 - browser-harness descendants whose GWT-only assumptions are incompatible with
   the Lit/J2CL surface — accounted for in the GWT retirement issue
   (future `#5.3` per the issue map), not in the parity-acquisition chain

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -225,9 +225,11 @@ recorded here so it is not silently dropped:
   that were not part of the inspected daily command packet: superscript,
   subscript, font size, font family, font color, highlight color / `backColor`,
   and block quote. The block quote affordance was not present in the inspected
-  GWT `EditToolbar.java` action set, so it is not counted as a #971 daily
-  parity requirement unless a later packet adds it explicitly. This finding is
-  the reason R-5.7 no longer lists block quote as a daily-path example.
+  GWT `EditToolbar.java` action set (`wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`,
+  toolbar action methods at approximately lines 364–765, commit `c4a09da3a`), so
+  it is not counted as a #971 daily parity requirement unless a later packet adds
+  it explicitly. This finding is the reason R-5.7 no longer lists block quote as
+  a daily-path example.
 - #971 also defers drag-and-drop attachment insertion, client-side image
   compression, and mobile/touch-specific toolbar gestures beyond the file
   picker and paste-image flows. These remain follow-up candidates after the

--- a/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
+++ b/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
@@ -1,0 +1,75 @@
+# Local Verification
+
+- Branch: codex/issue-971-parity-closeout
+- Worktree: /Users/vega/devroot/worktrees/codex-issue-971-parity-closeout
+- Date: 2026-04-25
+- Issue: #971
+
+## Commands
+
+- `bash scripts/worktree-boot.sh --port 9971`
+- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild`
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
+- `git diff --check`
+- `PORT=9971 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/codex-issue-971-parity-closeout/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/codex-issue-971-parity-closeout/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
+- `PORT=9971 bash scripts/wave-smoke.sh check`
+- Immediate staged-server route probe while the process was alive:
+  - `GET /`
+  - `GET /?view=j2cl-root`
+  - `GET /j2cl/index.html`
+  - `GET /j2cl-search/sidecar/j2cl-sidecar.js`
+  - `GET /webclient/webclient.nocache.js`
+
+## Results
+
+- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild`: passed.
+  - J2CL search test completed successfully.
+  - J2CL production build completed successfully.
+  - Lit tests passed: 23 files, 110 tests, 0 failures.
+  - Lit build completed.
+  - Note: the SBT J2CL build phase emitted a Vertispan `DiskCacheThread` `RejectedExecutionException` after a success line, then continued through the remaining tasks and exited 0. Follow-up #1027 tracks whether this is benign cache-shutdown noise or a repo-owned build hygiene issue.
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`: passed; assembled 255 entries and validation passed.
+- `git diff --check`: passed.
+- `bash scripts/worktree-boot.sh --port 9971`: passed; staged GWT and J2CL assets, wrote the port-specific runtime config, and created this evidence file.
+- `wave-smoke.sh start`: reported `PROBE_HTTP=200`, `READY`, and resolved a server PID.
+- `wave-smoke.sh check`: failed because the staged server process exited after readiness before the check command could connect.
+- `scripts/worktree-diagnostics.sh --port 9971`: confirmed all endpoint probes returned `000` after the process exit, while startup logs showed Jetty had started on `127.0.0.1:9971` and served one root request.
+- Immediate route probe while the staged server was alive passed:
+  - `ROOT_STATUS=200`
+  - `ROOT_GWT=present`
+  - `J2CL_ROOT_STATUS=200`
+  - `J2CL_ROOT_SHELL=present`
+  - `J2CL_INDEX_STATUS=200`
+  - `SIDECAR_STATUS=200`
+  - `WEBCLIENT_STATUS=200`
+
+## Runtime Limitation
+
+The local staged server did not remain alive long enough for manual browser
+verification. The observed runtime behavior is consistent with
+`ServerMain.run(...)` returning immediately after
+`server.startWebSocketServer(injector)` in the Jakarta entry point, with no
+blocking `join()` call in the started server path. This was recorded as a
+closeout limitation rather than treated as an attachment/rich-edit regression:
+the immediate route probe proved the default GWT root, explicit J2CL root,
+production J2CL asset, sidecar asset, and legacy webclient asset were all
+served while the staged process was alive.
+
+## Gate Status
+
+This record does not claim final browser-harness closure for R-5.6 or R-5.7.
+The daily attachment/rich-edit implementation slices are merged and their
+targeted SBT/Lit/CI evidence is recorded in #971, but the persistent local
+browser-smoke path remains blocked by #1026 and the shared telemetry channel
+work remains tracked in #1025. Keep #971 open until those follow-ups are either
+completed or explicitly accepted as non-blocking by the #904 tracker.
+
+## Follow-Up
+
+- Issue: #971.
+- Follow-up #1026: repair the local staged-server lifecycle or smoke harness
+  so browser verification can run against a persistent process.
+- Follow-up #1025: wire #971 attachment/rich-edit telemetry into the shared
+  J2CL client stats channel.
+- Follow-up #1027: classify and, if repo-owned, fix the Vertispan
+  `DiskCacheThread` exception emitted by successful SBT J2CL build runs.

--- a/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
+++ b/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
@@ -4,12 +4,14 @@
 - Worktree: /Users/vega/devroot/worktrees/codex-issue-971-parity-closeout
 - Date: 2026-04-25
 - Issue: #971
+- Note: `scripts/worktree-boot.sh` would have generated `2026-04-25-branch-issue-971-parity-closeout.md` for branch `codex/issue-971-parity-closeout`; this committed evidence file was renamed afterward to `2026-04-25-issue-971-parity-closeout.md`.
 
 ## Commands
 
 - `bash scripts/worktree-boot.sh --port 9971`
 - `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild`
 - `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
+- `git diff --cached --check`
 - `git diff --check`
 - `PORT=9971 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/codex-issue-971-parity-closeout/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/codex-issue-971-parity-closeout/wave/config/jaas.config' bash scripts/wave-smoke.sh start`
 - `PORT=9971 bash scripts/wave-smoke.sh check`
@@ -29,6 +31,7 @@
   - Lit build completed.
   - Note: the SBT J2CL build phase emitted a Vertispan `DiskCacheThread` `RejectedExecutionException` after a success line, then continued through the remaining tasks and exited 0. Follow-up #1027 tracks whether this is benign cache-shutdown noise or a repo-owned build hygiene issue.
 - `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`: passed; assembled 255 entries and validation passed.
+- `git diff --cached --check`: passed.
 - `git diff --check`: passed.
 - `bash scripts/worktree-boot.sh --port 9971`: passed; staged GWT and J2CL assets, wrote the port-specific runtime config, and created this evidence file.
 - `wave-smoke.sh start`: reported `PROBE_HTTP=200`, `READY`, and resolved a server PID.


### PR DESCRIPTION
## Summary
- update the J2CL/GWT parity matrix with the #971 deferred edge-case addendum
- remove block quote from the R-5.7 daily example set because it was not present in the inspected GWT `EditToolbar.java` action set
- add #971 local verification evidence and explicitly avoid claiming final browser-harness closure while #1025/#1026 remain open

## Verification
- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild` - passed; Lit reported 23 files / 110 tests / 0 failures; SBT exited 0 while emitting the Vertispan DiskCache warning now tracked by #1027
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` - passed; assembled 255 entries
- `git diff --cached --check` / `git diff --check` - passed
- `bash scripts/worktree-boot.sh --port 9971` - passed; staged GWT/J2CL assets
- `PORT=9971 ... bash scripts/wave-smoke.sh start` - reached `PROBE_HTTP=200` / `READY`, but `wave-smoke.sh check` failed after the staged process exited; #1026 tracks the persistent server lifecycle issue
- immediate route probe while the staged process was alive passed for `/`, `/?view=j2cl-root`, `/j2cl/index.html`, `/j2cl-search/sidecar/j2cl-sidecar.js`, and `/webclient/webclient.nocache.js`

## Review
- self-review: staged diff scope and whitespace checks passed
- Claude Opus 4.7 review loop: rounds 1-3 addressed clarity/nit concerns; round 4 verdict was ship-ready with zero required comments

Refs #971
Refs #904
Refs #1025
Refs #1026
Refs #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated parity matrix metadata and clarified daily rich-edit example scope (removed block-quote from the daily examples) and added deferred edge-case entries for toolbar affordances, drag-and-drop attachments, client-side image compression, and extra mobile/touch gestures.
  * Added a local verification record summarizing test runs, build/check outcomes, startup readiness observations, diagnostic findings, and noted follow-up items to complete parity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->