### PR TITLE
Clarify J2CL parity closeout evidence

### DIFF
--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -225,11 +225,21 @@ recorded here so it is not silently dropped:
   that were not part of the inspected daily command packet: superscript,
   subscript, font size, font family, font color, highlight color / `backColor`,
   and block quote. The block quote affordance was not present in the inspected
-  GWT `EditToolbar.java` action set (`wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`,
-  toolbar action methods at approximately lines 364–765, commit `c4a09da3a`), so
-  it is not counted as a #971 daily parity requirement unless a later packet adds
-  it explicitly. This finding is the reason R-5.7 no longer lists block quote as
-  a daily-path example.
+  GWT `EditToolbar.java` action set. Evidence:
+  `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:319-362`
+  enumerates toolbar groups,
+  `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:364-522`
+  covers bold/italic/underline/strikethrough, superscript/subscript, font
+  size/family, text color (`createFontColorButton`), highlight / `backColor`
+  (`createFontBackColorButton`), and clear formatting
+  (`createClearFormattingButton`), and
+  `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:647-737`
+  covers link/unlink, `createClearHeadingsListener`, heading, indent/outdent,
+  and list command methods. The inspected toolbar has no `createBlockQuote*`
+  action, so block quote is not counted as a #971 daily parity requirement
+  unless a later packet adds it explicitly.
+  This finding is the reason R-5.7 no longer lists block quote as a daily-path
+  example.
 - #971 also defers drag-and-drop attachment insertion, client-side image
   compression, and mobile/touch-specific toolbar gestures beyond the file
   picker and paste-image flows. These remain follow-up candidates after the

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -223,15 +223,17 @@ recorded here so it is not silently dropped:
   gate closes or via a dedicated addendum packet linked from this section
 - #971 daily attachment/rich-edit closeout defers the GWT toolbar affordances
   that were not part of the inspected daily command packet: superscript,
-  subscript, font size, font family, font color, highlight color / `backColor`,
+  subscript, font size, font family, font color, highlight color (browser `backColor` exec-command),
   and block quote. The block quote affordance was not present in the inspected
   GWT `EditToolbar.java` action set. Evidence:
   `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:319-362`
   enumerates toolbar groups,
   `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:364-522`
   covers bold/italic/underline/strikethrough, superscript/subscript, font
-  size/family, text color (`createFontColorButton`), highlight / `backColor`
-  (`createFontBackColorButton`), and clear formatting
+  size/family, text color (`createFontColorButton`), highlight
+  (`createFontBackColorButton`, applies `backgroundColor` style key via
+  `ColorHelper.onSetBackColor` — `backColor` is the underlying browser
+  exec-command, not a Java symbol), and clear formatting
   (`createClearFormattingButton`), and
   `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java:647-737`
   covers link/unlink, `createClearHeadingsListener`, heading, indent/outdent,

--- a/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
+++ b/journal/local-verification/2026-04-25-issue-971-parity-closeout.md
@@ -4,7 +4,10 @@
 - Worktree: /Users/vega/devroot/worktrees/codex-issue-971-parity-closeout
 - Date: 2026-04-25
 - Issue: #971
-- Note: `scripts/worktree-boot.sh` would have generated `2026-04-25-branch-issue-971-parity-closeout.md` for branch `codex/issue-971-parity-closeout`; this committed evidence file was renamed afterward to `2026-04-25-issue-971-parity-closeout.md`.
+- Note: `scripts/worktree-boot.sh` would have generated
+  `2026-04-25-branch-codex-issue-971-parity-closeout.md` for branch
+  `codex/issue-971-parity-closeout`; this committed evidence file was renamed
+  afterward to `2026-04-25-issue-971-parity-closeout.md`.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Follow-up to #1028 after auto-merge completed before the final docs clarification push was included.
- Corrects the worktree-generated evidence filename note for branch `codex/issue-971-parity-closeout`.
- Replaces approximate GWT `EditToolbar.java` references with exact line-range evidence and explicit helper names for the deferred rich-edit affordances.

## Verification
- `git diff --check`
- Claude Opus review loop: final pass reported no blockers, important concerns, minor nits, coverage gaps, open items, or required follow-ups.

## Tracking
- Parent: #904
- Related: #971, #1028

skip-changelog: docs-only evidence clarification; no user-facing behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified toolbar parity notes with explicit line-range citations and clarified that highlight color maps to the browser backColor exec-command; block quote remains excluded from the inspected toolbar.
  * Updated evidence reference and reformatted local verification note for issue #971 parity tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->