### PR TITLE
Omit volatile session id from J2CL bootstrap JSON

### DIFF
--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -214,8 +214,8 @@ curl -fsS -H 'Accept: application/json' http://localhost:9900/bootstrap.json | j
 
 Expected top-level keys and fields:
 
-- `session.domain` — always present
-- `session.address` / `session.role` / `session.features` — present only when signed in
+- `session.domain` / `session.role` — always present
+- `session.address` / `session.features` — present only when signed in
 - `/bootstrap.json` intentionally omits `SessionConstants.ID_SEED`; that volatile HTML `session.id` seed remains only in the legacy inline `window.__session` bootstrap during the #978 overlap window
 - `socket.address` — the presented WebSocket `host:port`
 - `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`, `shell.routeReturnTarget`

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -216,7 +216,7 @@ Expected top-level keys and fields:
 
 - `session.domain` — always present
 - `session.address` / `session.role` / `session.features` — present only when signed in
-- `session.id` — per-request ID seed (regenerated per call by design; do not rely on equality with the HTML page's `__session.id`)
+- `/bootstrap.json` intentionally omits `SessionConstants.ID_SEED`; that volatile HTML `session.id` seed remains only in the legacy inline `window.__session` bootstrap during the #978 overlap window
 - `socket.address` — the presented WebSocket `host:port`
 - `shell.buildCommit`, `shell.serverBuildTime`, `shell.currentReleaseId`, `shell.routeReturnTarget`
 
@@ -248,8 +248,10 @@ Rollback rule: newer J2CL bundles now expect `/bootstrap.json` and do not fall
 back to HTML scraping. During the overlap window, roll the server forward
 before the client, and roll the client back before or together with any server
 rollback so clients do not land on a server that no longer matches their
-bootstrap expectations. The remaining `session.id` divergence between HTML and
-`/bootstrap.json` is tracked separately in issue `#979`.
+bootstrap expectations. The former `session.id` divergence was closed by issue
+`#979`: `/bootstrap.json` no longer publishes the volatile HTML client ID seed,
+so new J2CL/Lit clients must not use it as a session or correlation
+identifier.
 
 ## Dual-Mode Coexistence Matrix
 

--- a/docs/superpowers/plans/2026-04-25-issue-979-bootstrap-session-contract.md
+++ b/docs/superpowers/plans/2026-04-25-issue-979-bootstrap-session-contract.md
@@ -1,0 +1,629 @@
+# Issue 979 Bootstrap Session ID Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the misleading volatile `session.id` value from the J2CL `/bootstrap.json` contract while preserving legacy inline HTML bootstrap behavior for the #978 soak window.
+
+**Architecture:** Keep `WaveClientServlet` and `HtmlRenderer` behavior unchanged for GWT and rollback-safe inline globals. In `J2clBootstrapServlet`, continue reusing `WaveClientServlet#buildSessionJson(...)` for domain/address/role/features parity, but strip `SessionConstants.ID_SEED` before writing `/bootstrap.json`. Update the contract docs, servlet docs, Java tests, Lit adapter/tests, and runbook so future J2CL/Lit clients cannot treat `/bootstrap.json.session.id` as correlated with the HTML `window.__session.id` or the HTTP session.
+
+**Tech Stack:** Jakarta servlet overrides, shared Java contract constants, JUnit/Mockito tests through SBT, J2CL transport tests through SBT, Lit unit tests through the repo `j2clLitTest` SBT task, changelog fragment workflow.
+
+---
+
+## Decision
+
+Issue #979 exists because `/bootstrap.json` and the rendered HTML page currently each call `WaveClientServlet#buildSessionJson(...)`, and that helper regenerates `SessionConstants.ID_SEED` on every call. Stabilizing that value at HTTP-session scope would be unsafe because GWT/StageTwo uses it as a client ID seed and two `/bootstrap.json` consumers in the same HTTP session could then share the same seed. Keeping the volatile field in `/bootstrap.json` with only documentation would leave the same future-client footgun.
+
+The chosen contract is therefore:
+
+- `/bootstrap.json.session` exposes the existing non-seed session fields produced by `WaveClientServlet`: `domain` and `role`, plus signed-in `address` and `features`.
+- `/bootstrap.json.session` does not expose `id` / `SessionConstants.ID_SEED`.
+- Legacy inline `window.__session` continues to expose its existing `id` seed during the #978 overlap window.
+- New J2CL/Lit clients must tolerate older servers that still include `session.id` during a rolling deploy, but must not consume that field from `/bootstrap.json`.
+- If future J2CL StageTwo parity needs a client-lifecycle ID seed, add a deliberate J2CL-owned seed contract instead of reusing `/bootstrap.json.session.id`.
+
+## Files
+
+- Modify: `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+- Modify: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java`
+- Modify: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- Modify: `j2cl/lit/src/input/json-shell-input.js`
+- Modify: `j2cl/lit/test/json-shell-input.test.js`
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+- Add: `wave/config/changelog.d/2026-04-25-issue-979-bootstrap-session-contract.json`
+- Add: `journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md` (force-add because `journal/` is ignored)
+
+Do not modify:
+
+- `WaveClientServlet#getSessionJson(...)`; it remains the source of the legacy inline HTML seed.
+- `HtmlRenderer` inline `var __session` / `var __websocket_address` emission; #978 owns removing that overlap after the soak window.
+- `SidecarSessionBootstrap#fromRootHtml(...)`; #978 owns removing the legacy parser.
+- `j2cl/lit/src/input/inline-shell-input.js` and `j2cl/lit/test/inline-shell-input.test.js`. The inline shell input feeds off the legacy `window.__session` global path that #978 owns. Its `idSeed` field will surface in the Task 3 `rg "\bidSeed\b" j2cl/lit` sweep — that is intentional and the verification journal must record it as out-of-scope (today the inline path keys off `session.idSeed`, not `session.id`, so no GWT/inline rollback consumer is affected).
+
+## Task 1: Encode The Server Contract
+
+**Files:**
+- Modify: `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java`
+- Modify: `wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java`
+- Modify: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java`
+- Modify: `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java`
+
+- [ ] **Step 1: Update the servlet test to fail on the current contract**
+
+First confirm the signed-out shape from the current producer code before writing assertions:
+
+```bash
+nl -ba wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java | sed -n '467,502p'
+```
+
+Observed contract before this change: `buildSessionJson(...)` always emits `domain`, `role`, and the volatile `id` seed; it emits `address` and `features` only when a user address exists. Therefore after `J2clBootstrapServlet` strips `id`, signed-out `/bootstrap.json.session` should contain exactly `domain` and `role`.
+
+Confirm the contract constants used by the tests exist:
+
+```bash
+rg -n "SESSION_(ADDRESS|DOMAIN|ROLE|FEATURES)" wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
+rg -n 'ID_SEED = "id"' wave/src/main/java/org/waveprotocol/box/common/SessionConstants.java
+```
+
+Change `signedInRequestReturnsSessionAndSocketAndShell` so it asserts that `/bootstrap.json` omits the ID seed:
+
+```java
+assertFalse(session.has(SessionConstants.ID_SEED));
+```
+
+Keep explicit assertions for the retained keys in the same test:
+
+```java
+assertEquals("alice@example.com", session.getString(J2clBootstrapContract.SESSION_ADDRESS));
+assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
+assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+assertTrue(session.has(J2clBootstrapContract.SESSION_FEATURES));
+assertEquals(
+    Set.of(
+        J2clBootstrapContract.SESSION_ADDRESS,
+        J2clBootstrapContract.SESSION_DOMAIN,
+        J2clBootstrapContract.SESSION_ROLE,
+        J2clBootstrapContract.SESSION_FEATURES),
+    session.keySet());
+```
+
+Add the import:
+
+```java
+import java.util.Set;
+import org.waveprotocol.box.common.SessionConstants;
+```
+
+Also strengthen `signedOutRequestOmitsAddressAndFeatures`:
+
+```java
+assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
+assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+assertFalse(session.has(SessionConstants.ID_SEED));
+assertFalse(session.has(J2clBootstrapContract.SESSION_ADDRESS));
+assertFalse(session.has(J2clBootstrapContract.SESSION_FEATURES));
+assertEquals(
+    Set.of(J2clBootstrapContract.SESSION_DOMAIN, J2clBootstrapContract.SESSION_ROLE),
+    session.keySet());
+```
+
+Add a repeated-request regression that proves the formerly volatile seed stays absent across multiple `/bootstrap.json` calls on independent request mocks for the same signed-in user path:
+
+Before adding the test, confirm `J2clBootstrapServletTest` already has `signedInRequest()` and use it. If the response boilerplate is duplicated, add only the small `renderBootstrapJson(...)` helper shown by this plan.
+
+```java
+@Test
+public void repeatedBootstrapJsonResponsesDoNotExposeVolatileIdSeed() throws Exception {
+  J2clBootstrapServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"));
+
+  JSONObject firstSession =
+      renderBootstrapJson(servlet, signedInRequest())
+          .getJSONObject(J2clBootstrapContract.KEY_SESSION);
+  JSONObject secondSession =
+      renderBootstrapJson(servlet, signedInRequest())
+          .getJSONObject(J2clBootstrapContract.KEY_SESSION);
+
+  assertFalse(firstSession.has(SessionConstants.ID_SEED));
+  assertFalse(secondSession.has(SessionConstants.ID_SEED));
+  assertEquals(firstSession.keySet(), secondSession.keySet());
+  assertEquals(
+      firstSession.getString(J2clBootstrapContract.SESSION_ADDRESS),
+      secondSession.getString(J2clBootstrapContract.SESSION_ADDRESS));
+  assertEquals(
+      firstSession.getString(J2clBootstrapContract.SESSION_DOMAIN),
+      secondSession.getString(J2clBootstrapContract.SESSION_DOMAIN));
+  assertEquals(
+      firstSession.getString(J2clBootstrapContract.SESSION_ROLE),
+      secondSession.getString(J2clBootstrapContract.SESSION_ROLE));
+  assertEquals(
+      firstSession.getJSONArray(J2clBootstrapContract.SESSION_FEATURES).length(),
+      secondSession.getJSONArray(J2clBootstrapContract.SESSION_FEATURES).length());
+}
+```
+
+If adding this test would duplicate response-rendering boilerplate, extract a small private `renderBootstrapJson(J2clBootstrapServlet servlet, HttpServletRequest request)` helper inside `J2clBootstrapServletTest`.
+
+In `signedInJ2clRootShellStillExposesLegacyBootstrapGlobals`, add a rollback-safety assertion that parses the inline `__session` assignment and confirms the seed remains available for older GWT/J2CL bundles. This requires two new imports in `WaveClientServletJ2clRootShellTest.java` (the file does not yet reference either type):
+
+```java
+import org.json.JSONObject;
+import org.waveprotocol.box.common.SessionConstants;
+```
+
+Then add the assertion:
+
+```java
+int sessionStart = html.indexOf("var __session = ");
+assertTrue(sessionStart >= 0);
+int sessionEnd = html.indexOf('\n', sessionStart);
+assertTrue(sessionEnd > sessionStart);
+String inlineSession = html.substring(sessionStart, sessionEnd);
+String sessionJson = inlineSession.substring("var __session = ".length(), inlineSession.length() - 1);
+assertTrue(new JSONObject(sessionJson).has(SessionConstants.ID_SEED));
+```
+
+Run:
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"
+```
+
+Expected: FAIL before implementation because the current servlet includes `session.id`.
+
+- [ ] **Step 2: Strip the volatile ID seed in `J2clBootstrapServlet`**
+
+Add:
+
+```java
+import org.waveprotocol.box.common.SessionConstants;
+```
+
+After `buildSessionJson(...)`, remove the seed from the fresh JSON object:
+
+```java
+JSONObject sessionJson = waveClientServlet.buildSessionJson(webSession);
+// /bootstrap.json must not expose the volatile HTML client ID seed.
+sessionJson.remove(SessionConstants.ID_SEED);
+```
+
+Keep `body.put(J2clBootstrapContract.KEY_SESSION, sessionJson);` unchanged.
+
+- [ ] **Step 3: Update servlet and contract documentation**
+
+In `J2clBootstrapServlet` class javadoc, replace the current per-call ID divergence paragraph with the new contract:
+
+```java
+ * <p>The session block is produced by {@link WaveClientServlet#buildSessionJson}
+ * so the HTML and JSON surfaces cannot drift on role/feature/domain/address.
+ * This endpoint intentionally removes {@link
+ * org.waveprotocol.box.common.SessionConstants#ID_SEED}: the value is a
+ * per-render client ID seed for the legacy HTML bootstrap, not an HTTP/auth
+ * session identifier and not a cross-request correlation key. Future J2CL
+ * clients that need an ID seed must use a dedicated J2CL-owned seed contract.
+```
+
+Before removing the contract constant, run a usage sweep:
+
+```bash
+rg -n "J2clBootstrapContract\\.SESSION_ID|\\bSESSION_ID\\b" .
+```
+
+Expected before edits: only the contract declaration and the existing servlet test assertion reference the constant. If any other runtime reference appears, update the plan before implementation. This sweep is advisory; the focused SBT compile/test command is the primary guarantee that no Java static import or unqualified reference remains.
+
+In `J2clBootstrapContract`, remove `SESSION_ID` and update the schema example so the `session` object lists only:
+
+```java
+ *   "session": { "domain": "...", "address": "...", "role": "...", "features": [...] },
+```
+
+Add a short paragraph after the schema:
+
+```java
+ * <p>The J2CL JSON contract intentionally omits {@code SessionConstants.ID_SEED}
+ * even though the rollback-safe inline HTML globals still expose it during the
+ * inline-HTML rollback overlap.
+ * The remaining session fields keep the same signed-in/signed-out presence rules
+ * as {@code WaveClientServlet#buildSessionJson(WebSession)}.
+```
+
+- [ ] **Step 4: Verify the server contract test passes**
+
+Run:
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"
+```
+
+Expected: the focused servlet/root-shell tests pass with no direct Maven invocation. If the SBT resource step fails because `wave/config/changelog.json` is missing, run `python3 scripts/assemble-changelog.py` and rerun the same SBT command; the full changelog validation gate runs after the fragment is added in Task 4.
+
+## Task 2: Keep Client Decoders Tolerant But Non-Dependent
+
+**Files:**
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- Modify: `j2cl/lit/src/input/json-shell-input.js`
+- Modify: `j2cl/lit/test/json-shell-input.test.js`
+
+- [ ] **Step 1: Update Java bootstrap JSON fixtures**
+
+Scope note: only the `extractSessionBootstrapFromBootstrapJson` JSON fixture loses its `"id":"seed"` entry. The neighbouring `extractSessionBootstrapRejectsMissingAddress` test (and any other `fromRootHtml` test in this file) intentionally keeps `"id":"abc"` because that fixture is parsing the legacy inline `__session={...}` HTML format that #978 still owns. Do not touch those.
+
+In `extractSessionBootstrapFromBootstrapJson`, remove `"id":"seed"` from the JSON fixture.
+
+Add a focused compatibility test proving Java tolerates older servers that still include the legacy seed:
+
+```java
+@Test
+public void bootstrapJsonIgnoresLegacySessionIdSeed() {
+  String json =
+      "{\"session\":{\"domain\":\"example.com\",\"address\":\"user@example.com\","
+          + "\"id\":\"legacy-seed\",\"future\":\"ignored\"},"
+          + "\"socket\":{\"address\":\"socket.example.test:7443\",\"token\":\"future-933-token\"}}";
+
+  SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromBootstrapJson(json);
+
+  Assert.assertEquals("user@example.com", bootstrap.getAddress());
+  Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+}
+```
+
+Add a reflection guard that documents Java `SidecarSessionBootstrap` has no public seed-bearing API to populate from JSON:
+
+```java
+@Test
+public void bootstrapValueObjectDoesNotExposeJsonSessionSeed() {
+  for (java.lang.reflect.Method method : SidecarSessionBootstrap.class.getMethods()) {
+    if (method.getReturnType().equals(Void.TYPE)) {
+      continue;
+    }
+    String name = method.getName().toLowerCase(java.util.Locale.ROOT);
+    Assert.assertFalse(
+        "Unexpected seed accessor: " + method.getName(),
+        name.startsWith("get") && name.contains("seed"));
+    Assert.assertFalse(
+        "Unexpected session id accessor: " + method.getName(), name.equals("getsessionid"));
+  }
+}
+```
+
+Run:
+
+```bash
+sbt -batch "testOnly org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+```
+
+Expected: PASS; Java already ignores unknown session keys.
+
+Contract-source note: the Java servlet test is the producer-side source of truth that `/bootstrap.json` omits `id`; the Lit tests only prove consumer behavior for omitted and legacy fields.
+
+- [ ] **Step 2: Stop Lit JSON shell input from consuming `session.id`**
+
+Confirm no Lit shell runtime code depends on a non-empty JSON `idSeed` before changing the adapter:
+
+```bash
+rg -n "\\bidSeed\\b" j2cl/src j2cl/lit
+```
+
+Expected: uses are limited to shell input snapshot shape, adapters, and tests; no Java J2CL code, Lit element, or controller depends on a non-empty JSON seed. Record this in the verification journal.
+
+Change `json-shell-input.js` from:
+
+```javascript
+idSeed:
+  typeof session.id === "string"
+    ? session.id
+    : typeof session.idSeed === "string"
+      ? session.idSeed
+      : "",
+```
+
+to:
+
+```javascript
+// /bootstrap.json intentionally does not provide a client ID seed.
+idSeed: "",
+```
+
+This keeps the current JSON bootstrap contract from becoming an accidental seed source. A future J2CL-owned seed contract should add its own explicit field and tests when it is designed.
+
+- [ ] **Step 3: Update Lit tests for the omitted seed**
+
+Change `json-shell-input.test.js` so the main fixture omits `session.id` and asserts:
+
+```javascript
+expect(snap.idSeed).to.equal("");
+```
+
+Add a regression test:
+
+```javascript
+it("ignores legacy session.id from bootstrap JSON", () => {
+  window.__bootstrap = {
+    session: {
+      address: "a@b.c",
+      role: "owner",
+      domain: "b.c",
+      id: "legacy-seed",
+      features: []
+    },
+    socket: {
+      address: "ws.example:443"
+    }
+  };
+
+  expect(createJsonShellInput(window).read().idSeed).to.equal("");
+});
+```
+
+Test isolation requirement: keep the existing `beforeEach` that resets `window.__bootstrap` and do not share the legacy-id fixture between tests.
+
+Verify the test file uses the existing Mocha/Open WC style and cleanup hook before editing:
+
+```bash
+rg -n "beforeEach|expect\\(.*\\)\\.to\\.equal" j2cl/lit/test/json-shell-input.test.js
+```
+
+Run:
+
+```bash
+sbt -batch j2clLitTest
+```
+
+Expected: PASS.
+
+## Task 3: Update Operator Documentation
+
+**Files:**
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+
+- [ ] **Step 1: Rewrite the bootstrap contract field list**
+
+Replace the current `session.id` bullet with:
+
+```markdown
+- `/bootstrap.json` intentionally omits `SessionConstants.ID_SEED`; that volatile HTML `session.id` seed remains only in the legacy inline `window.__session` bootstrap during the #978 overlap window
+```
+
+- [ ] **Step 2: Update the rollback note**
+
+Replace the final sentence that says the divergence is tracked in #979 with:
+
+```markdown
+The former `session.id` divergence was closed by issue `#979`: `/bootstrap.json` no longer publishes the volatile HTML client ID seed, so new J2CL/Lit clients must not use it as a session or correlation identifier.
+```
+
+- [ ] **Step 3: Confirm no docs still advertise `/bootstrap.json.session.id`**
+
+Run:
+
+```bash
+rg -n "session\\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js
+```
+
+Expected: only intentional explanatory references remain; no expected-field documentation remains for `/bootstrap.json.session.id`.
+
+The runbook may mention former `session.id` behavior only in past tense. It must not say or imply that current `/bootstrap.json` responses include the field.
+
+Record this scan in the verification journal so the PR evidence captures the contract-doc regression check.
+
+## Task 4: Changelog And Verification Journal
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-25-issue-979-bootstrap-session-contract.json`
+- Add: `journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md`
+
+- [ ] **Step 1: Add the changelog fragment**
+
+Check the current fragment schema before creating the file:
+
+```bash
+ls -t wave/config/changelog.d/*.json | head -n 3
+sed -n '1,80p' "$(ls -t wave/config/changelog.d/*.json | head -n 1)"
+rg -n '"releaseId": "2026-04-25-issue-979-bootstrap-session-contract"' wave/config/changelog.d || true
+```
+
+Confirm the fragment uses the existing `releaseId` / `sections[].type` shape, that `fix` is an accepted section type, and that `2026-04-25-issue-979-bootstrap-session-contract` is not already used.
+
+Create:
+
+```json
+{
+  "releaseId": "2026-04-25-issue-979-bootstrap-session-contract",
+  "date": "2026-04-25",
+  "version": "Unreleased",
+  "title": "J2CL bootstrap JSON no longer exposes the volatile HTML client ID seed",
+  "summary": "The /bootstrap.json contract now omits the per-render SessionConstants.ID_SEED value that remains in legacy inline HTML bootstrap globals for rollback compatibility. This prevents J2CL/Lit clients from treating the value as an HTTP session identifier or as correlated with the HTML bootstrap page.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the volatile session.id client ID seed and its misleading bootstrap-contract constant from the J2CL /bootstrap.json response while preserving the legacy inline HTML bootstrap seed during the rollout overlap window"
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Add the verification journal**
+
+Create `journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md` with:
+
+```markdown
+# Issue 979 Bootstrap Session Contract Verification
+
+Date: 2026-04-25
+Worktree: /Users/vega/devroot/worktrees/issue-979-bootstrap-session-contract
+Branch: codex/issue-979-bootstrap-session-contract
+
+## Decision
+
+/bootstrap.json omits SessionConstants.ID_SEED. Legacy inline HTML globals keep their existing seed until #978 removes the overlap path.
+
+## Commands
+
+- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
+- sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+- sbt -batch j2clLitTest
+- sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild
+- rg -n "\\bidSeed\\b" j2cl/src j2cl/lit
+- rg -n "session\\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js
+- git diff --check (whitespace gate)
+
+## Results
+
+Record exact pass/fail output summaries and exit codes before PR. Do not leave this section as a stub.
+Use the form `exit=0` or `exit=<nonzero>` for each command summary.
+```
+
+Stage it with `git add -f journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md` because `journal/` is ignored.
+
+- [ ] **Step 3: Run final local verification**
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
+sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+sbt -batch j2clLitTest
+sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild
+rg -n "\\bidSeed\\b" j2cl/src j2cl/lit
+rg -n "session\\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js
+git diff --check  # whitespace gate
+```
+
+Expected: all commands pass. If SBT fails because `wave/config/changelog.json` is missing, run the changelog assemble/validate command first and rerun the SBT command.
+
+The focused SBT command also confirms `J2clBootstrapContract.SESSION_ID` has no remaining Java references after removal; any missed reference should fail compilation.
+
+## Task 5: Review, Issue Update, PR, And Monitor
+
+**Files:**
+- No additional file changes unless review finds an issue.
+
+- [ ] **Step 1: Self-review**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+rg -n "session\\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js j2cl/lit/test/json-shell-input.test.js wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
+```
+
+Confirm:
+
+- `/bootstrap.json` docs and tests do not advertise `session.id` as a response field.
+- Legacy inline HTML behavior is not edited.
+- Java bootstrap decoding remains tolerant of older `session.id` payloads.
+- Java `SidecarSessionBootstrap` still has no seed/session-id accessor that could surface `/bootstrap.json.session.id`.
+- Lit JSON shell input ignores legacy `session.id`.
+- No direct command-line Maven invocation is used; SBT is the orchestrator and may delegate to a Maven wrapper internally (e.g. `j2clSearchTest`).
+
+Before invoking the implementation review helper, replace `REVIEW_TEST_RESULTS` with the exact command summary copied from the verification journal.
+
+- [ ] **Step 2: Claude Opus implementation review loop**
+
+Run the review helper from this worktree with a focused diff:
+
+```bash
+export REVIEW_TASK="Issue #979 J2CL bootstrap session.id contract"
+export REVIEW_GOAL="Ensure /bootstrap.json no longer exposes or consumes the volatile HTML client ID seed while preserving rollback-safe inline globals."
+export REVIEW_ACCEPTANCE=$'- /bootstrap.json omits SessionConstants.ID_SEED\\n- Legacy inline window.__session emission is unchanged\\n- Java and Lit clients tolerate older JSON but do not depend on session.id\\n- Docs/tests make the contract unambiguous\\n- SBT-only verification is recorded'
+export REVIEW_RUNTIME="Jakarta servlet + J2CL Java + Lit shell"
+export REVIEW_RISKY="Bootstrap contract compatibility, GWT rollback overlap, client ID seed semantics"
+export REVIEW_TEST_COMMANDS="python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py; sbt -batch \"testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest\"; sbt -batch j2clLitTest; sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild; contract-doc rg scan; git diff --check"
+export REVIEW_TEST_RESULTS="$(sed -n '/## Results/,$p' journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md)"
+export REVIEW_DIFF_SPEC="$(git merge-base origin/main HEAD)...HEAD"
+export REVIEW_PLATFORM=claude
+export REVIEW_MODEL=claude-opus-4-7
+/Users/vega/.codex/skills/public/claude-review/scripts/review_task.sh
+```
+
+Address all blockers, important concerns, and required follow-ups. Repeat until the final review has no blockers, no important concerns, no required follow-ups, and no unresolved coverage gaps.
+
+- [ ] **Step 3: Commit and issue update**
+
+Commit with:
+
+```bash
+git add docs/superpowers/plans/2026-04-25-issue-979-bootstrap-session-contract.md
+git add wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
+git add wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java
+git add wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
+git add wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+git add j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+git add j2cl/lit/src/input/json-shell-input.js
+git add j2cl/lit/test/json-shell-input.test.js
+git add docs/runbooks/j2cl-sidecar-testing.md
+git add wave/config/changelog.d/2026-04-25-issue-979-bootstrap-session-contract.json
+git add -f journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md
+git commit -m "fix(j2cl): omit volatile session id from bootstrap json"
+```
+
+Post an issue comment with worktree, branch, plan path, commit SHA, verification commands/results, Claude review result, and PR URL after creation.
+
+- [ ] **Step 4: Open PR and monitor to merge**
+
+Create the PR body from the decision and verification evidence:
+
+```bash
+cat >/tmp/issue-979-pr-body.md <<'EOF'
+Closes #979
+Updates #904
+
+## Summary
+- Omit the volatile `SessionConstants.ID_SEED` value from `/bootstrap.json.session`.
+- Preserve legacy inline `window.__session.id` during the #978 rollback overlap.
+- Keep Java and Lit clients tolerant of older JSON payloads while preventing new JSON consumers from using `session.id`.
+
+## Verification
+- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
+- sbt -batch "testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest"
+- sbt -batch j2clLitTest
+- sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild
+- contract-doc rg scan recorded in journal
+- git diff --check
+
+## Review
+- Self-review complete.
+- Claude Opus implementation review loop complete with no blockers or required follow-ups.
+EOF
+```
+
+Push and open a PR:
+
+```bash
+gh repo view --json nameWithOwner
+git push -u origin codex/issue-979-bootstrap-session-contract
+PR=$(gh pr create --repo vega113/supawave --base main --head codex/issue-979-bootstrap-session-contract --title "Omit volatile session id from J2CL bootstrap JSON" --body-file /tmp/issue-979-pr-body.md --json number -q .number)
+gh pr merge --auto --squash --repo vega113/supawave "$PR"
+```
+
+Expected: `gh repo view --json nameWithOwner` reports `vega113/supawave`. If it does not, stop and update the PR commands to the actual repository before pushing.
+
+Monitor until merged:
+
+```bash
+gh pr view "$PR" --repo vega113/supawave --json state,mergeable,reviewDecision,statusCheckRollup,isDraft,autoMergeRequest
+gh api graphql -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{id,isResolved}}}}}' -f owner=vega113 -f repo=supawave -F number="$PR"
+gh pr checks "$PR" --repo vega113/supawave
+```
+
+If `autoMergeRequest` is `null` after `gh pr merge --auto --squash`, rerun `gh pr merge --auto --squash --repo vega113/supawave "$PR"` and recheck. Continue polling until `state` is `MERGED`; do not declare the lane complete on a one-shot mergeable result.
+
+Success criteria:
+
+- PR merged.
+- GraphQL unresolved review threads are `0`.
+- Required checks pass or auto-merge completes.
+- #979 closed.
+- #904 updated with the PR number, merge commit, and next unblocked lane decision.
+
+## Self-Review
+
+- Spec coverage: The plan decides the contract (`session.id` omitted from `/bootstrap.json`), preserves current GWT/rollback inline behavior, updates docs/tests, and keeps #978 as the owner of removing legacy inline globals.
+- Red-flag scan: No prohibited plan filler or journal template filler remains.
+- Type consistency: Uses `SessionConstants.ID_SEED` for the Java key, keeps `J2clBootstrapContract.KEY_SESSION` unchanged, removes `J2clBootstrapContract.SESSION_ID`, and keeps Lit `idSeed` as the snapshot property while no longer mapping it from JSON `session.id`.
+- Verification discipline: The plan uses SBT tasks only for Java/J2CL/Lit verification and explicitly excludes direct Maven commands.
+- Rollback safety: `HtmlRenderer`, `WaveClientServlet#getSessionJson(...)`, and `SidecarSessionBootstrap#fromRootHtml(...)` are out of scope and unchanged.

--- a/j2cl/lit/src/input/json-shell-input.js
+++ b/j2cl/lit/src/input/json-shell-input.js
@@ -21,12 +21,8 @@ export function createJsonShellInput(win) {
         address,
         role: normalizeRole(session.role),
         domain: typeof session.domain === "string" ? session.domain : "",
-        idSeed:
-          typeof session.id === "string"
-            ? session.id
-            : typeof session.idSeed === "string"
-              ? session.idSeed
-              : "",
+        // /bootstrap.json intentionally does not provide a client ID seed.
+        idSeed: "",
         features: Array.isArray(session.features) ? [...session.features] : [],
         websocketAddress:
           typeof socket.address === "string"

--- a/j2cl/lit/test/json-shell-input.test.js
+++ b/j2cl/lit/test/json-shell-input.test.js
@@ -12,7 +12,6 @@ describe("json-shell-input", () => {
         address: "a@b.c",
         role: "owner",
         domain: "b.c",
-        id: "seed-1",
         features: []
       },
       socket: {
@@ -22,7 +21,24 @@ describe("json-shell-input", () => {
     const snap = createJsonShellInput(window).read();
     expect(snap.signedIn).to.equal(true);
     expect(snap.role).to.equal("owner");
-    expect(snap.idSeed).to.equal("seed-1");
+    expect(snap.idSeed).to.equal("");
     expect(snap.websocketAddress).to.equal("ws.example:443");
+  });
+
+  it("ignores legacy session.id from bootstrap JSON", () => {
+    window.__bootstrap = {
+      session: {
+        address: "a@b.c",
+        role: "owner",
+        domain: "b.c",
+        id: "legacy-seed",
+        features: []
+      },
+      socket: {
+        address: "ws.example:443"
+      }
+    };
+
+    expect(createJsonShellInput(window).read().idSeed).to.equal("");
   });
 });

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -442,7 +442,7 @@ public class SidecarTransportCodecTest {
   public void extractSessionBootstrapFromBootstrapJson() {
     String json =
         "{\"session\":{\"domain\":\"example.com\",\"address\":\"user@example.com\","
-            + "\"id\":\"seed\",\"role\":\"user\",\"features\":[\"mentions-search\"]},"
+            + "\"role\":\"user\",\"features\":[\"mentions-search\"]},"
             + "\"socket\":{\"address\":\"socket.example.test:7443\"},"
             + "\"shell\":{\"buildCommit\":\"abc\",\"serverBuildTime\":1700000000000,"
             + "\"currentReleaseId\":\"r1\",\"routeReturnTarget\":\"/?view=j2cl-root\"}}";
@@ -451,6 +451,34 @@ public class SidecarTransportCodecTest {
 
     Assert.assertEquals("user@example.com", bootstrap.getAddress());
     Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+  }
+
+  @Test
+  public void bootstrapJsonIgnoresLegacySessionIdSeed() {
+    String json =
+        "{\"session\":{\"domain\":\"example.com\",\"address\":\"user@example.com\","
+            + "\"id\":\"legacy-seed\",\"future\":\"ignored\"},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\",\"token\":\"future-933-token\"}}";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromBootstrapJson(json);
+
+    Assert.assertEquals("user@example.com", bootstrap.getAddress());
+    Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+  }
+
+  @Test
+  public void bootstrapValueObjectDoesNotExposeJsonSessionSeed() {
+    for (java.lang.reflect.Method method : SidecarSessionBootstrap.class.getMethods()) {
+      if (method.getReturnType().equals(Void.TYPE)) {
+        continue;
+      }
+      String name = method.getName().toLowerCase(java.util.Locale.ROOT);
+      Assert.assertFalse(
+          "Unexpected seed accessor: " + method.getName(),
+          name.startsWith("get") && name.contains("seed"));
+      Assert.assertFalse(
+          "Unexpected session id accessor: " + method.getName(), name.equals("getsessionid"));
+    }
   }
 
   @Test

--- a/journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md
+++ b/journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md
@@ -1,0 +1,45 @@
+# Issue 979 Bootstrap Session Contract Verification
+
+Date: 2026-04-25
+Worktree: /Users/vega/devroot/worktrees/issue-979-bootstrap-session-contract
+Branch: codex/issue-979-bootstrap-session-contract
+
+## Decision
+
+/bootstrap.json omits SessionConstants.ID_SEED. Legacy inline HTML globals keep their existing seed until #978 removes the overlap path.
+
+## Commands
+
+- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
+- sbt -batch "jakartaTest:testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"
+- sbt -batch j2clSearchTest
+- sbt -batch j2clLitTest
+- sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild
+- rg -n "\bidSeed\b" j2cl/src j2cl/lit
+- rg -n "session\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js
+- git diff --check (whitespace gate)
+
+## Notes On SBT Routing
+
+The plan's sample command used `testOnly ... org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest`. That test is owned by the J2CL Maven wrapper (j2cl/pom.xml, search-sidecar profile), not the SBT JUnit harness. It is exercised here through `sbt j2clSearchTest`, which delegates to the Maven wrapper internally — still SBT-orchestrated, no direct command-line Maven invocation. Surefire report at `j2cl/target/surefire-reports/TEST-org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest.xml` is the per-test evidence (36 tests, 0 failures including the new `bootstrapJsonIgnoresLegacySessionIdSeed` and `bootstrapValueObjectDoesNotExposeJsonSessionSeed`).
+
+The Jakarta JUnit suites (`J2clBootstrapServletTest`, `WaveClientServletJ2clRootShellTest`) live under the `JakartaTest` SBT config, so they are run via `sbt jakartaTest:testOnly ...` rather than the default `Test / testOnly` (which has no sources).
+
+## Pre-existing Unrelated Failure
+
+`WaveClientServletJ2clRootShellTest.j2clRootViewPreservesCurrentRouteStateInSignedOutChrome` fails on `origin/main` at HEAD (94e3a5025) prior to any #979 edits. Confirmed by stashing the working tree and rerunning the same focused command; the failure is independent of this change and out of scope.
+
+## Out-Of-Scope idSeed Mention
+
+`rg "\bidSeed\b" j2cl/src j2cl/lit` still surfaces `j2cl/lit/src/input/inline-shell-input.js` and its `inline-shell-input.test.js`. Per the plan and the "Do not modify" list, the inline shell input feeds off the legacy `window.__session` global path that issue #978 owns. The inline path keys off `session.idSeed`, not `session.id`, so no GWT/inline rollback consumer is affected by this change.
+
+## Results
+
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — exit=0; assembled 259 entries -> wave/config/changelog.json; validated 259 entries.
+- `sbt -batch "jakartaTest:testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"` — exit=1 with the only failure being the pre-existing `j2clRootViewPreservesCurrentRouteStateInSignedOutChrome` baseline failure on origin/main; the 6/6 J2clBootstrapServletTest tests (including the new `signedInRequestReturnsSessionAndSocketAndShell`, `signedOutRequestOmitsAddressAndFeatures`, `repeatedBootstrapJsonResponsesDoNotExposeVolatileIdSeed`) and 15/16 root-shell tests (including the new rollback-safety assertion in `signedInJ2clRootShellStillExposesLegacyBootstrapGlobals`) pass.
+- `sbt -batch j2clSearchTest` — exit=0; surefire `TEST-org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest.xml` reports `tests="36" errors="0" failures="0"`.
+- `sbt -batch j2clLitTest` — exit=0; "Chromium: 23/23 test files | 111 passed, 0 failed".
+- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild` — exit=0; per-task results recorded; benign Vertispan DiskCache shutdown noise per #1027/#1032 is acceptable when the final SBT exit is 0 and every requested task succeeds.
+- `rg -n "\bidSeed\b" j2cl/src j2cl/lit` — exit=0; matches limited to `json-shell-input.js` (assigned ""), `lit-shell-input.js` (snapshot type/default), inline-shell-input adapter+test (out-of-scope per #978), and json-shell-input test assertions.
+- `rg -n "session\.id|SESSION_ID|ID_SEED|idSeed" docs/runbooks/j2cl-sidecar-testing.md wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java j2cl/lit/src/input/json-shell-input.js` — exit=0; remaining hits are intentional explanatory references documenting the omission. No documentation advertises `/bootstrap.json.session.id` as a current response field.
+- `git diff --check` — exit=0; no whitespace errors.

--- a/wave/config/changelog.d/2026-04-25-issue-979-bootstrap-session-contract.json
+++ b/wave/config/changelog.d/2026-04-25-issue-979-bootstrap-session-contract.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-25-issue-979-bootstrap-session-contract",
+  "date": "2026-04-25",
+  "version": "Unreleased",
+  "title": "J2CL bootstrap JSON no longer exposes the volatile HTML client ID seed",
+  "summary": "The /bootstrap.json contract now omits the per-render SessionConstants.ID_SEED value that remains in legacy inline HTML bootstrap globals for rollback compatibility. This prevents J2CL/Lit clients from treating the value as an HTTP session identifier or as correlated with the HTML bootstrap page.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the volatile session.id client ID seed and its misleading bootstrap-contract constant from the J2CL /bootstrap.json response while preserving the legacy inline HTML bootstrap seed during the rollout overlap window"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/J2clBootstrapServlet.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.waveprotocol.box.common.J2clBootstrapContract;
+import org.waveprotocol.box.common.SessionConstants;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.authentication.WebSessions;
 import org.waveprotocol.wave.util.logging.Log;
@@ -51,12 +52,11 @@ import org.waveprotocol.wave.util.logging.Log;
  *
  * <p>The session block is produced by {@link WaveClientServlet#buildSessionJson}
  * so the HTML and JSON surfaces cannot drift on role/feature/domain/address.
- * Note that {@link org.waveprotocol.box.common.SessionConstants#ID_SEED} is
- * regenerated per call by that helper; the {@code session.id} returned here
- * therefore need not match the one a concurrent HTML page load emits. The
- * historical J2CL scraping path only ever consumed address/domain/role/features,
- * so this divergence is behaviorally safe and is documented here so future
- * maintainers do not "fix" the divergence by introducing a shared cache.
+ * This endpoint intentionally removes {@link
+ * org.waveprotocol.box.common.SessionConstants#ID_SEED}: the value is a
+ * per-render client ID seed for the legacy HTML bootstrap, not an HTTP/auth
+ * session identifier and not a cross-request correlation key. Future J2CL
+ * clients that need an ID seed must use a dedicated J2CL-owned seed contract.
  *
  * <p>This endpoint is read-only. Non-GET requests return HTTP 405. It relies on
  * the same {@link jakarta.servlet.http.HttpSession} authn contract as {@link
@@ -97,6 +97,8 @@ public final class J2clBootstrapServlet extends HttpServlet {
       throws IOException {
     WebSession webSession = WebSessions.from(request, false);
     JSONObject sessionJson = waveClientServlet.buildSessionJson(webSession);
+    // /bootstrap.json must not expose the volatile HTML client ID seed.
+    sessionJson.remove(SessionConstants.ID_SEED);
     String websocketAddress = waveClientServlet.presentedWebsocketAddress();
     String routeReturnTarget = buildRouteReturnTarget(request);
 

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
@@ -32,12 +32,14 @@ import com.typesafe.config.ConfigFactory;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
+import java.util.Set;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.waveprotocol.box.common.J2clBootstrapContract;
+import org.waveprotocol.box.common.SessionConstants;
 import org.waveprotocol.box.server.account.AccountData;
 import org.waveprotocol.box.server.account.HumanAccountData;
 import org.waveprotocol.box.server.authentication.SessionManager;
@@ -65,9 +67,16 @@ public final class J2clBootstrapServletTest {
     assertEquals("alice@example.com", session.getString(J2clBootstrapContract.SESSION_ADDRESS));
     assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
     assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
-    assertTrue(session.has(J2clBootstrapContract.SESSION_ID));
+    assertFalse(session.has(SessionConstants.ID_SEED));
     assertTrue(session.has(J2clBootstrapContract.SESSION_FEATURES));
     assertFalse(session.isNull(J2clBootstrapContract.SESSION_FEATURES));
+    assertEquals(
+        Set.of(
+            J2clBootstrapContract.SESSION_ADDRESS,
+            J2clBootstrapContract.SESSION_DOMAIN,
+            J2clBootstrapContract.SESSION_ROLE,
+            J2clBootstrapContract.SESSION_FEATURES),
+        session.keySet());
 
     JSONObject socket = json.getJSONObject(J2clBootstrapContract.KEY_SOCKET);
     assertEquals("127.0.0.1:9898", socket.getString(J2clBootstrapContract.SOCKET_ADDRESS));
@@ -116,12 +125,54 @@ public final class J2clBootstrapServletTest {
     JSONObject json = new JSONObject(body.toString());
     JSONObject session = json.getJSONObject(J2clBootstrapContract.KEY_SESSION);
     assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
+    assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+    assertFalse(session.has(SessionConstants.ID_SEED));
     assertFalse(session.has(J2clBootstrapContract.SESSION_ADDRESS));
     assertFalse(session.has(J2clBootstrapContract.SESSION_FEATURES));
+    assertEquals(
+        Set.of(J2clBootstrapContract.SESSION_DOMAIN, J2clBootstrapContract.SESSION_ROLE),
+        session.keySet());
     assertEquals(
         "127.0.0.1:9898",
         json.getJSONObject(J2clBootstrapContract.KEY_SOCKET)
             .getString(J2clBootstrapContract.SOCKET_ADDRESS));
+  }
+
+  @Test
+  public void repeatedBootstrapJsonResponsesDoNotExposeVolatileIdSeed() throws Exception {
+    J2clBootstrapServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"));
+
+    JSONObject firstSession =
+        renderBootstrapJson(servlet, signedInRequest())
+            .getJSONObject(J2clBootstrapContract.KEY_SESSION);
+    JSONObject secondSession =
+        renderBootstrapJson(servlet, signedInRequest())
+            .getJSONObject(J2clBootstrapContract.KEY_SESSION);
+
+    assertFalse(firstSession.has(SessionConstants.ID_SEED));
+    assertFalse(secondSession.has(SessionConstants.ID_SEED));
+    assertEquals(firstSession.keySet(), secondSession.keySet());
+    assertEquals(
+        firstSession.getString(J2clBootstrapContract.SESSION_ADDRESS),
+        secondSession.getString(J2clBootstrapContract.SESSION_ADDRESS));
+    assertEquals(
+        firstSession.getString(J2clBootstrapContract.SESSION_DOMAIN),
+        secondSession.getString(J2clBootstrapContract.SESSION_DOMAIN));
+    assertEquals(
+        firstSession.getString(J2clBootstrapContract.SESSION_ROLE),
+        secondSession.getString(J2clBootstrapContract.SESSION_ROLE));
+    assertEquals(
+        firstSession.getJSONArray(J2clBootstrapContract.SESSION_FEATURES).length(),
+        secondSession.getJSONArray(J2clBootstrapContract.SESSION_FEATURES).length());
+  }
+
+  private static JSONObject renderBootstrapJson(
+      J2clBootstrapServlet servlet, HttpServletRequest request) throws Exception {
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+    servlet.doGet(request, response);
+    return new JSONObject(body.toString());
   }
 
   @Test

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
@@ -34,7 +34,9 @@ import java.io.StringWriter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.json.JSONObject;
 import org.junit.Test;
+import org.waveprotocol.box.common.SessionConstants;
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.account.AccountData;
@@ -292,6 +294,14 @@ public final class WaveClientServletJ2clRootShellTest {
     assertTrue(html.contains("\"address\":\"alice@example.com\""));
     assertTrue(html.contains("var __websocket_address = "));
     assertTrue(html.contains("\"127.0.0.1:9898\""));
+
+    int sessionStart = html.indexOf("var __session = ");
+    assertTrue(sessionStart >= 0);
+    int sessionEnd = html.indexOf('\n', sessionStart);
+    assertTrue(sessionEnd > sessionStart);
+    String inlineSession = html.substring(sessionStart, sessionEnd);
+    String sessionJson = inlineSession.substring("var __session = ".length(), inlineSession.length() - 1);
+    assertTrue(new JSONObject(sessionJson).has(SessionConstants.ID_SEED));
   }
 
   @Test

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
@@ -31,6 +31,8 @@ import com.typesafe.config.ConfigFactory;
 import java.util.Collections;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -290,18 +292,14 @@ public final class WaveClientServletJ2clRootShellTest {
     servlet.doGet(request, response);
 
     String html = body.toString();
-    assertTrue(html.contains("var __session = "));
+    Pattern inlineSession = Pattern.compile("var\\s+__session\\s*=\\s*(\\{.*?\\})\\s*;", Pattern.DOTALL);
+    Matcher matcher = inlineSession.matcher(html);
+    assertTrue(matcher.find());
+    String sessionJson = matcher.group(1);
+    assertTrue(new JSONObject(sessionJson).has(SessionConstants.ID_SEED));
     assertTrue(html.contains("\"address\":\"alice@example.com\""));
     assertTrue(html.contains("var __websocket_address = "));
     assertTrue(html.contains("\"127.0.0.1:9898\""));
-
-    int sessionStart = html.indexOf("var __session = ");
-    assertTrue(sessionStart >= 0);
-    int sessionEnd = html.indexOf('\n', sessionStart);
-    assertTrue(sessionEnd > sessionStart);
-    String inlineSession = html.substring(sessionStart, sessionEnd);
-    String sessionJson = inlineSession.substring("var __session = ".length(), inlineSession.length() - 1);
-    assertTrue(new JSONObject(sessionJson).has(SessionConstants.ID_SEED));
   }
 
   @Test

--- a/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
@@ -28,12 +28,18 @@ package org.waveprotocol.box.common;
  *
  * <pre>
  * {
- *   "session": { "domain": "...", "address": "...", "id": "...", "role": "...", "features": [...] },
+ *   "session": { "domain": "...", "address": "...", "role": "...", "features": [...] },
  *   "socket":  { "address": "..." },
  *   "shell":   { "buildCommit": "...", "serverBuildTime": 0,
  *                "currentReleaseId": "...", "routeReturnTarget": "..." }
  * }
  * </pre>
+ *
+ * <p>The J2CL JSON contract intentionally omits {@code SessionConstants.ID_SEED}
+ * even though the rollback-safe inline HTML globals still expose it during the
+ * inline-HTML rollback overlap.
+ * The remaining session fields keep the same signed-in/signed-out presence rules
+ * as {@code WaveClientServlet#buildSessionJson(WebSession)}.
  *
  * <p>Forward compatibility: follow-up work under issue #933 may add more fields
  * under {@code socket} (e.g. a signed bootstrap token). Clients must therefore
@@ -48,7 +54,6 @@ public final class J2clBootstrapContract {
 
   public static final String SESSION_DOMAIN = "domain";
   public static final String SESSION_ADDRESS = "address";
-  public static final String SESSION_ID = "id";
   public static final String SESSION_ROLE = "role";
   public static final String SESSION_FEATURES = "features";
 


### PR DESCRIPTION
Closes #979
Updates #904

## Summary
- Stop emitting the volatile `SessionConstants.ID_SEED` value from `/bootstrap.json.session`. The seed is a per-render client ID for the legacy HTML bootstrap, not an HTTP/auth session identifier and not a cross-request correlation key.
- Preserve the legacy inline `window.__session.id` global so the GWT bootstrap and #978's rollback overlap window stay unaffected.
- Keep Java `SidecarSessionBootstrap` and the Lit JSON shell input tolerant of older servers that still include the field, while preventing new JSON consumers from depending on it.
- Document the contract in `J2clBootstrapContract`, `J2clBootstrapServlet`, and the J2CL sidecar runbook so future J2CL/Lit clients cannot misinterpret the field.

## Out of scope (preserved as the plan requires)
- `WaveClientServlet#getSessionJson(...)` — still the source of the inline HTML seed.
- `HtmlRenderer` `var __session` / `var __websocket_address` emission — owned by #978.
- `SidecarSessionBootstrap#fromRootHtml(...)` — owned by #978.
- `j2cl/lit/src/input/inline-shell-input.js` and its test — that path keys off `session.idSeed` (legacy `window.__session`, not `/bootstrap.json`) and is owned by #978.

## Verification (SBT-only; full evidence in `journal/local-verification/2026-04-25-issue-979-bootstrap-session-contract.md`)
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — exit 0.
- `sbt -batch "jakartaTest:testOnly org.waveprotocol.box.server.rpc.J2clBootstrapServletTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"` — 6/6 `J2clBootstrapServletTest` pass + 15/16 root-shell tests pass; the single failure (`j2clRootViewPreservesCurrentRouteStateInSignedOutChrome`) is a confirmed pre-existing baseline failure on `origin/main` (94e3a5025), independently reproduced in a detached worktree by both the implementation lane and the implementation reviewer.
- `sbt -batch j2clSearchTest` — exit 0; `SidecarTransportCodecTest` tests=36 errors=0 failures=0 (new `bootstrapJsonIgnoresLegacySessionIdSeed` and `bootstrapValueObjectDoesNotExposeJsonSessionSeed` green).
- `sbt -batch j2clLitTest` — exit 0 (Chromium 23/23 files | 111 passed).
- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild` — exit 0 (full chained gate).
- Contract-doc `rg` sweeps — only intentional explanatory references remain; nothing advertises `/bootstrap.json.session.id` as a current response field.
- `git diff --check` — exit 0.

## Reviews
- Plan review (Claude Opus 4.7): APPROVE WITH MINOR CHANGES; three minor concerns folded into the in-worktree plan before implementation.
- Implementation review (Claude Opus 4.7): READY FOR PR; reviewer independently re-ran the chained gate and independently reproduced the baseline failure on `origin/main` to confirm it is not a regression. No blockers, no required follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * J2CL/Lit bootstrap JSON no longer exposes the volatile per-render session ID seed, preventing clients from receiving that transient identifier.

* **Tests**
  * Added and updated tests to assert the bootstrap JSON omits the session seed and that legacy inline seeds are ignored.

* **Documentation**
  * Updated contract docs, runbook, verification journal, implementation plan, and changelog to reflect the new bootstrap session structure and rollout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->