### PR TITLE
docs: J2CL ↔ GWT parity audit (2026-04-26)

### DIFF
--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -2,7 +2,7 @@
 
 Status: Proposed\
 Owner: Project Maintainers\
-Updated: 2026-04-22\
+Updated: 2026-04-25\
 Review cadence: on-change
 
 Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)

--- a/docs/j2cl-gwt-parity-matrix.md
+++ b/docs/j2cl-gwt-parity-matrix.md
@@ -2,7 +2,7 @@
 
 Status: Proposed\
 Owner: Project Maintainers\
-Updated: 2026-04-25\
+Updated: 2026-04-22\
 Review cadence: on-change
 
 Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)

--- a/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
+++ b/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
@@ -2,6 +2,7 @@
 
 Status: Final — input to F-2 / F-3 / F-4 acceptance criteria  
 Source: live `https://supawave.ai/?view=gwt` accessibility tree + screen capture (signed-in account `vega@supawave.ai`)  
+Ref notation: identifiers such as ref_1, ref_4, ref_28 are sequential accessibility-tree node IDs from the live session export; the full id → element mapping is in the exported accessibility node list captured alongside the screen capture.  
 Companion: `2026-04-26-j2cl-gwt-parity-audit.md`
 
 ## Why this exists
@@ -252,6 +253,6 @@ When a blip enters edit mode (or when the inline reply composer is active), the 
 2. → Update F-2 (#1037) issue body to enumerate affordances under its ownership and to add a new acceptance row **R-3.7 Arbitrary-depth drill-down navigation** with G.1–G.6 as concrete affordances.
 3. → Update F-3 (#1038) issue body to enumerate affordances under its ownership including the full edit-mode toolbar (H.1–H.24), tag affordances (I.1–I.6), and "Send Message" (L.2).
 4. → Update F-2 (#1037) to reference C.* search-help and B.* saved-search affordances explicitly so reviewers cannot accept "practical search parity" without the help modal + saved-search rail.
-5. → Update F-1 (#1036) data-path scope to confirm fragment-window contract supports fragmenting along the depth axis (G.1 prerequisite).
+5. → Update F-1 (#1036) data-path scope to confirm fragment-window contract supports fragmenting along the depth axis (G.1 prerequisite; see §G opening paragraph: "replaces the depth-clamp UI with infinite-depth support … load the subthread under a chosen blip without loading sibling subthreads").
 6. → Update F-0 (#1035) to specify the plugin slot points as M.2–M.5 with the slot-context contracts described above.
 7. → Generate Stitch screens for: Edit-mode toolbar in detail; Search-help modal + saved-search rail; Depth-navigation pattern.

--- a/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
+++ b/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
@@ -238,10 +238,10 @@ When a blip enters edit mode (or when the inline reply composer is active), the 
 
 ## N. Coverage summary
 
-- **Total enumerated affordances**: 96 (A:18, B:18, C:22, D:8, E:10, F:12, G:6, H:24, I:6, J:5, K:6, L:5, M:5)
+- **Total enumerated affordances**: 145 (A:18, B:18, C:22, D:8, E:10, F:12, G:6, H:24, I:6, J:5, K:6, L:5, M:5)
 - **Per-issue ownership** (excluding the F-0 design/plugin foundation, which underlies all):
-  - F-2 read surface: 64 affordances
-  - F-3 compose / edit / mentions / tasks / reactions / attachments / tags: 32 affordances
+  - F-2 read surface: 87 affordances (72 exclusive + 15 shared with F-3/F-4/F-0)
+  - F-3 compose / edit / mentions / tasks / reactions / attachments / tags: 46 affordances (35 exclusive + 11 shared with F-2/F-4/F-0)
   - F-4 live read/unread + feature activation: cross-cuts E.2, B.17, A.3, A.4, A.5, H.23
 - **New / additive (not in GWT today)**: G.1–G.6 depth-navigation pattern (6 affordances); F-2 takes on a new acceptance row **R-3.7** (depth-navigation drill-down).
 - **Plugin slots**: 4 (M.2–M.5), all reserved by F-0; specific F-* issues mount the slot points but do not register plugins.

--- a/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
+++ b/docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md
@@ -1,0 +1,257 @@
+# GWT functional inventory + Wavy design coverage matrix (2026-04-26)
+
+Status: Final — input to F-2 / F-3 / F-4 acceptance criteria  
+Source: live `https://supawave.ai/?view=gwt` accessibility tree + screen capture (signed-in account `vega@supawave.ai`)  
+Companion: `2026-04-26-j2cl-gwt-parity-audit.md`
+
+## Why this exists
+
+The original parity matrix (`docs/j2cl-gwt-parity-matrix.md`) describes *behaviors* at the row level (e.g. R-3.1 "Open-wave rendering"). The 2026-04-26 audit found that even closed slices missed concrete affordances because nobody enumerated them. This inventory is the explicit list of every interactive GWT control, mapped to its functional purpose, the F-* issue that owns it in the new chain, and the corresponding wavy design surface where it lives.
+
+The wavy design language may *render* these affordances differently — the contract is that every functional capability stays present and reachable.
+
+## Legend
+
+- **Surface** — where the control lives in the GWT UI today.
+- **Affordance** — the user-facing function (button, menu, region).
+- **Owner slice** — the new F-* issue that reproduces it.
+- **Wavy design home** — where it lives in the new design (specific Stitch screen / Lit element / slot).
+- **Status** — Present = covered by the design as-is; Restyled = restyled per wavy spec; New = additive beyond GWT (e.g. depth navigation); Plugin-slot = exposed via the F-0 plugin contract.
+
+## A. Top chrome (header)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| A.1 | "SupaWave" brand link → landing | ref_1 | F-0 | Header band, signal-cyan accent dot before logotype | Restyled |
+| A.2 | Locale picker (en/de/es/fr/ru/sl/zh_TW) | ref_28–36 | F-0 / F-2 | Header end region, compact globe glyph | Restyled |
+| A.3 | "All changes saved" save state | ref_37 | F-4 | Header end, low-emphasis live status pill | Restyled |
+| A.4 | "Online" connection state | ref_38 | F-4 | Header end, live-channel pill with pulsing cyan dot | Restyled |
+| A.5 | Notifications bell (with unread dot) | (visible icon) | F-4 | Header end, stroke-only bell, violet unread dot | Restyled |
+| A.6 | Inbox/mail icon | (visible) | F-2 | Header end, stroke-only mail glyph, jumps to inbox | Restyled |
+| A.7 | User menu trigger (avatar + email) | ref_3, ref_39, ref_40 | F-0 | Header end, avatar chip; opens menu sheet | Restyled |
+| A.8 | "Edit Profile" menu item | ref_42 | F-0 | User menu sheet | Present |
+| A.9 | "Account Settings" menu item | ref_43 | F-0 | User menu sheet | Present |
+| A.10 | "Robot & Data API" menu item | ref_45 | F-0 / **plugin foundation** | User menu sheet — also surfaced as "Plugins / Integrations" entry | Restyled (groundwork for plugin registry) |
+| A.11 | "API Docs" menu item | ref_46 | F-0 | User menu sheet | Present |
+| A.12 | "Version History" menu item | ref_48 | F-0 | User menu sheet | Present |
+| A.13 | "What's New" / changelog link | ref_49 | F-0 | User menu sheet | Present |
+| A.14 | "Contact Us" link | ref_50 | F-0 | User menu sheet | Present |
+| A.15 | "Admin" link (gated) | ref_51 | F-0 | User menu sheet (visible when admin) | Present |
+| A.16 | "Terms of Service" / "Privacy Policy" links | ref_53, ref_54 | F-0 | User menu sheet, Legal section | Present |
+| A.17 | "Sign out" link | ref_55 | F-0 | User menu sheet, footer | Present |
+| A.18 | Admin-only "Contact messages" link | ref_2 | F-0 | Header end (admin-gated) | Present |
+
+## B. Search panel (left rail)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| B.1 | Search query textbox (`in:inbox` etc.) | ref_4 | F-2 | Left rail header, with waveform glyph | Restyled |
+| B.2 | "Search help" trigger (`?`) → modal | ref_57 → ref_335 | F-2 | Inline ⓘ button → wavy modal | Restyled |
+| B.3 | "New Wave" button (Shift+Cmd+O) | ref_58 | F-2 / F-3 | Header end button, primary cyan signal | Restyled |
+| B.4 | "Manage saved searches" | ref_59 | F-2 | Saved-search row, edit affordance | Restyled |
+| B.5 | Saved search: Inbox | ref_60 | F-2 | Folder rail, default-selected | Restyled |
+| B.6 | Saved search: Mentions | ref_61 | F-2 | Folder rail, with violet unread dot | Restyled |
+| B.7 | Saved search: Tasks | ref_62 | F-2 / F-3 | Folder rail, with amber pending count | Restyled |
+| B.8 | Saved search: Public waves | ref_63 | F-2 | Folder rail | Restyled |
+| B.9 | Saved search: Archive | ref_64 | F-2 | Folder rail | Restyled |
+| B.10 | Saved search: Pinned waves | ref_65 | F-2 | Folder rail | Restyled |
+| B.11 | "Refresh search results" | ref_66 | F-2 | Folder rail header | Restyled |
+| B.12 | Result count "133 waves" | ref_67 | F-2 | Folder rail footer, low-emphasis | Restyled |
+| B.13 | Per-digest avatar stack (multi-author) | ref_68, ref_73, ref_74, ref_84, ref_85, ref_91, ref_111, ref_112, ref_117, ref_118, ref_126, ref_127, ref_150, ref_151, ref_156, ref_157 | F-2 | Digest card top-left | Restyled |
+| B.14 | Per-digest pinned indicator | (red pin glyph) | F-2 | Digest card top-right, cyan pin glyph | Restyled |
+| B.15 | Per-digest title | ref_71, ref_77, ref_82, ref_88, ref_94, ref_99, … | F-2 | Digest card title | Restyled |
+| B.16 | Per-digest snippet | ref_72, ref_78, ref_83, ref_89, ref_95, … | F-2 | Digest card body, multiline truncation | Restyled |
+| B.17 | Per-digest msg count | ref_70, ref_76, ref_81, ref_87, ref_93, … | F-2 | Digest card footer, with unread badge when > 0 (signal-cyan pulse on change) | Restyled, F-4 owns the live unread badge |
+| B.18 | Per-digest relative timestamp | ref_69, ref_75, ref_80, ref_86, ref_92, … | F-2 | Digest card footer, low-emphasis | Restyled |
+
+## C. Search Help modal (filters + sort)
+
+Triggered from B.2; the modal enumerates the search query language. Every filter/sort token must continue to parse and to be discoverable from the help modal.
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| C.1 | Filter: `in:inbox` | ref_341 | F-2 | Help modal, Filters table | Present |
+| C.2 | Filter: `in:archive` | ref_343 | F-2 | Help modal | Present |
+| C.3 | Filter: `in:all` | ref_345 | F-2 | Help modal | Present |
+| C.4 | Filter: `in:pinned` | ref_347 | F-2 | Help modal | Present |
+| C.5 | Filter: `with:user@domain` | ref_349 | F-2 | Help modal | Present |
+| C.6 | Filter: `with:@` (public, shared domain) | ref_352 | F-2 | Help modal | Present |
+| C.7 | Filter: `creator:user@domain` | ref_354 | F-2 | Help modal | Present |
+| C.8 | Filter: `tag:name` | ref_357 | F-2 | Help modal | Present |
+| C.9 | Filter: `unread:true` | ref_360 | F-2 / F-4 | Help modal | Present |
+| C.10 | Filter: `title:text` | ref_362 | F-2 | Help modal | Present |
+| C.11 | Filter: `content:text` | ref_365 | F-2 | Help modal | Present |
+| C.12 | Filter: `mentions:me` | ref_368 | F-2 | Help modal | Present |
+| C.13 | Filter: `tasks:all` | ref_370 | F-3 | Help modal | Present |
+| C.14 | Filter: `tasks:me` | ref_372 | F-3 | Help modal | Present |
+| C.15 | Filter: `tasks:user@domain` | ref_374 | F-3 | Help modal | Present |
+| C.16 | Filter: free text (implicit `content:`) | ref_378 | F-2 | Help modal | Present |
+| C.17 | Sort: `orderby:datedesc` (default) | ref_385 | F-2 | Help modal | Present |
+| C.18 | Sort: `orderby:dateasc` | ref_387 | F-2 | Help modal | Present |
+| C.19 | Sort: `orderby:createddesc` / `createdasc` | ref_389, ref_391 | F-2 | Help modal | Present |
+| C.20 | Sort: `orderby:creatordesc` / `creatorasc` | ref_393, ref_395 | F-2 | Help modal | Present |
+| C.21 | Combination examples table | ref_398 + chips | F-2 | Help modal | Present |
+| C.22 | "Got it" dismiss | ref_336 | F-2 | Help modal close | Present |
+
+## D. Wave panel header (top of opened wave)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| D.1 | Wave title (current open wave) | header text | F-2 | Wave panel header | Restyled |
+| D.2 | Multi-author avatar stack | ref_5 | F-2 | Wave panel header, overlapping stack | Restyled |
+| D.3 | "more" wave-actions menu | ref_211, ref_218 | F-2 | Header overflow menu (move/archive/mark-read/etc.) | Restyled |
+| D.4 | "Add participant" button | ref_6, ref_10 | F-2 / F-3 | Header end, person-plus glyph | Restyled |
+| D.5 | "New wave with current participants" | ref_7, ref_11 | F-2 / F-3 | Header overflow menu | Restyled |
+| D.6 | "This wave is private. Click to make public" toggle | ref_8, ref_12 | F-2 / F-3 | Header end, lock/globe glyph | Restyled |
+| D.7 | "Copy public link" | ref_212, ref_213 | F-2 | Header end, link glyph | Restyled |
+| D.8 | "Wave is unlocked. Click to lock root blip" | ref_9, ref_13 | F-2 / F-3 | Header end, padlock glyph | Restyled |
+
+## E. Wave panel navigation row (per-wave navigation toolbar)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| E.1 | "Recent" jump | ref_221 | F-2 | Nav toolbar, leading | Restyled |
+| E.2 | "Next Unread" jump (blip-level) | ref_222 | F-2 / F-4 | Nav toolbar, primary cyan when unread present | Restyled |
+| E.3 | "Previous" blip | ref_223 | F-2 | Nav toolbar | Restyled |
+| E.4 | "Next" blip | ref_224 | F-2 | Nav toolbar | Restyled |
+| E.5 | "Go to last message (End)" | ref_225 | F-2 | Nav toolbar trailing | Restyled |
+| E.6 | "Prev @" mention | ref_226 | F-2 | Nav toolbar, violet accent | Restyled |
+| E.7 | "Next @" mention | ref_227 | F-2 | Nav toolbar, violet accent | Restyled |
+| E.8 | "To Archive" | ref_228 | F-2 | Nav toolbar | Restyled |
+| E.9 | "Pin" wave | ref_229 | F-2 | Nav toolbar, pin glyph (cyan when pinned) | Restyled |
+| E.10 | "Version History (H)" | ref_230 | F-2 | Nav toolbar, opens version-history overlay | Restyled |
+
+## F. Per-blip controls (per-card)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| F.1 | Author avatar | ref_231, ref_240, ref_248, … | F-2 | Blip card header | Restyled |
+| F.2 | Author display name | ref_237, ref_246, ref_254, … | F-2 | Blip card header | Restyled |
+| F.3 | Full datetime tooltip on hover | ref_236, ref_245, ref_253, … | F-2 | Blip card header timestamp | Restyled |
+| F.4 | "Reply" (inline reply at this blip) | ref_232, ref_241, ref_249, … | F-3 | Blip card per-blip toolbar (reveal on focus/hover) | Restyled |
+| F.5 | "Edit" (rich-text edit mode) | ref_233, ref_242, ref_250, … | F-3 | Blip card per-blip toolbar | Restyled |
+| F.6 | "Delete" | ref_234, ref_243, ref_251, … | F-3 | Blip card per-blip toolbar (with confirm) | Restyled |
+| F.7 | "Link" (copy blip permalink) | ref_235, ref_244, ref_252, … | F-2 | Blip card per-blip toolbar | Restyled |
+| F.8 | "Add reaction" | ref_15..ref_24 | F-3 | Blip card footer, reaction-chip rail | Restyled |
+| F.9 | Existing reaction chips (e.g. `👍 1`) | (visible) | F-3 | Blip card footer, reaction chips with live count | Restyled |
+| F.10 | Inline-reply chips below blip body | (visible) | F-2 | Blip card body, attached inline reply badges | Restyled |
+| F.11 | Inline thread depth badge "△ N" (collapsed depth indicator) | (visible) | F-2 | **Replaced by depth-navigation pattern (G.1)** | New |
+| F.12 | Per-blip plugin slot for gadget-equivalent content | n/a | F-2 / F-0 | `<slot name="blip-extension">` per blip card | Plugin-slot |
+
+## G. Depth navigation (NEW — additive beyond GWT)
+
+GWT clamps thread depth and shows a "△ N" collapsed badge for replies past the depth limit. The wavy design lifts the clamp by introducing a **drill-down navigation** pattern.
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| G.1 | Drill-into deep thread: clicking a "△ N" badge zooms the wave panel to that subthread; outer ancestor blips slide out and stack at the top as collapsed-context breadcrumb headers | n/a (new) | F-2 (new acceptance row R-3.7) | Wave panel; ancestors render as compact header strip; current depth blips render in full; immediate children inline | New |
+| G.2 | "Up one level" navigation control | n/a (new) | F-2 | Wave panel header, leading; chevron-up + parent author label | New |
+| G.3 | "Back to top of wave" jump | n/a (new) | F-2 | Wave panel header, leading | New |
+| G.4 | Depth-aware URL state (deep-link to a specific subthread root) | n/a (new) | F-2 | URL `&depth=blip+id` param; survives reload and back/forward | New |
+| G.5 | Keyboard: `[` / `]` to drill out / drill in along the focused path | n/a (new) | F-2 | Keyboard contract documented with E.* nav | New |
+| G.6 | Live updates surface across depth levels: when a reply lands inside a subthread the user is currently focused below, a subtle "↑ 2 new replies above" pill appears in the breadcrumb context strip | n/a (new) | F-2 / F-4 | Breadcrumb context strip | New |
+
+This is purely additive: it replaces the depth-clamp UI with infinite-depth support, but the data model (conversation tree) is unchanged. F-1 must be aware that the fragment-window contract has to support fragmenting *along the depth axis* (load the subthread under a chosen blip without loading sibling subthreads).
+
+## H. Compose / edit mode toolbar (StageThree)
+
+When a blip enters edit mode (or when the inline reply composer is active), the formatting toolbar replaces the wave nav row at the top of the wave panel.
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| H.1 | Bold (B) | (toolbar) | F-3 | Floating selection toolbar attached to active range | Restyled |
+| H.2 | Italic (I) | (toolbar) | F-3 | same | Restyled |
+| H.3 | Underline (U) | (toolbar) | F-3 | same | Restyled |
+| H.4 | Strikethrough (S) | (toolbar) | F-3 | same | Restyled |
+| H.5 | Superscript (X²) | (toolbar) | F-3 | same | Restyled |
+| H.6 | Subscript (X₂) | (toolbar) | F-3 | same | Restyled |
+| H.7 | Font family dropdown (A▾) | (toolbar) | F-3 | overflow menu within toolbar | Restyled |
+| H.8 | Font size dropdown (T▾) | (toolbar) | F-3 | overflow menu within toolbar | Restyled |
+| H.9 | Heading dropdown (H▾) | (toolbar) | F-3 | overflow menu within toolbar | Restyled |
+| H.10 | Text color (A) | (toolbar) | F-3 | colorpicker popover | Restyled |
+| H.11 | Highlight color (▢) | (toolbar) | F-3 | colorpicker popover | Restyled |
+| H.12 | Align left / center / right | (toolbar) | F-3 | grouped segmented control | Restyled |
+| H.13 | Bulleted list | (toolbar) | F-3 | list segmented control | Restyled |
+| H.14 | Numbered list | (toolbar) | F-3 | list segmented control | Restyled |
+| H.15 | Indent decrease / increase | (toolbar) | F-3 | indent segmented control | Restyled |
+| H.16 | RTL toggle | (toolbar) | F-3 | format menu | Restyled |
+| H.17 | Insert link | (toolbar) | F-3 | link affordance opens wavy modal | Restyled |
+| H.18 | Remove link | (toolbar) | F-3 | link affordance | Restyled |
+| H.19 | Attachment (paperclip) | (toolbar) | F-3 | drag-drop friendly button | Restyled |
+| H.20 | Insert task / checkbox | (toolbar) | F-3 | inline task affordance | Restyled |
+| H.21 | Mention (`@`) trigger | (typed in body) | F-3 | suggestion popover, violet accent | Restyled |
+| H.22 | "Shift+Enter to finish, Esc to exit" hint | (footer) | F-3 | low-emphasis hint strip | Restyled |
+| H.23 | Save indicator / draft state | (footer) | F-3 / F-4 | low-emphasis chip; ties to A.3 "All changes saved" | Restyled |
+| H.24 | Compose plugin slot for compose extensions (poll, code-block, inline diagram) | n/a | F-3 / F-0 | `<slot name="compose-extension">` on the composer | Plugin-slot |
+
+## I. Tags row (bottom of wave)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| I.1 | "Tags:" label | ref_214 | F-2 | Wave panel footer | Restyled |
+| I.2 | Tag chips with × remove | (visible) | F-2 / F-3 | Tag chips in wave footer | Restyled |
+| I.3 | "Add tag" button | ref_216, ref_219, ref_220 | F-3 | "+" pill that expands to textbox | Restyled |
+| I.4 | "Add tags" textbox | ref_215 | F-3 | inline textbox with locale-aware suggestions | Restyled |
+| I.5 | "Cancel tag entry" | ref_217 | F-3 | × beside textbox | Restyled |
+| I.6 | "Show tags tray" / "Hide tags tray" toggle | ref_324, ref_325 | F-2 | mobile-friendly tray reveal | Restyled |
+
+## J. Floating + accessory controls
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| J.1 | "Click here to reply" inline composer affordance at bottom of wave | ref_317 | F-3 | Bottom of conversation; expands inline composer | Restyled |
+| J.2 | "Scroll to new messages" floating button | ref_319 | F-2 | Floating bottom-right pill, signal-cyan when unread present | Restyled |
+| J.3 | "Hide wave controls" / "Show wave controls" | ref_321, ref_323 | F-2 | Visibility toggle for compact mode | Restyled |
+| J.4 | Open / close navigation drawer | ref_25, ref_320 | F-2 | Mobile-friendly nav drawer | Restyled |
+| J.5 | "Back to inbox" | ref_26 | F-2 | Header back affordance on mobile | Restyled |
+
+## K. Version history / time slider
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| K.1 | Version history overlay (entered via E.10) | ref_412–414 | F-2 | Full-bleed overlay, dark wash | Restyled |
+| K.2 | Time slider (range 0..N) | ref_408 | F-2 | Wavy slider with playhead, signal-cyan handle | Restyled |
+| K.3 | "Show changes" toggle | ref_410, ref_411 | F-2 | Slider shelf | Restyled |
+| K.4 | "Text only" toggle | ref_409 | F-2 | Slider shelf | Restyled |
+| K.5 | "Restore" action | ref_412 | F-2 | Slider shelf, primary destructive — confirm dialog | Restyled |
+| K.6 | "Exit" version history | ref_407 | F-2 | Overlay close | Restyled |
+
+## L. User profile overlay (avatar click)
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| L.1 | Open user profile from blip avatar | (avatar click) | F-2 | Wavy modal | Restyled |
+| L.2 | "Send Message" → start a 1:1 wave | ref_329 | F-3 | Profile modal | Restyled |
+| L.3 | "Edit Profile" (own avatar) | ref_330 | F-0 | Profile modal | Restyled |
+| L.4 | Close profile modal | ref_331 | F-0 | Modal close | Restyled |
+| L.5 | "Previous" / "Next" participant | ref_332, ref_333 | F-2 | Profile modal participant nav | Restyled |
+
+## M. Plugin / extensibility groundwork
+
+| # | Affordance | Source ref | Owner slice | Wavy design home | Status |
+| --- | --- | --- | --- | --- | --- |
+| M.1 | Robot & Data API entry (A.10) | ref_45 | F-0 | User menu sheet, "Plugins / Integrations" group | Plugin-foundation |
+| M.2 | Per-blip plugin slot (replaces legacy gadgets) | n/a | F-0 / F-2 | `<slot name="blip-extension">` per blip card | Plugin-slot |
+| M.3 | Compose plugin slot | n/a | F-0 / F-3 | `<slot name="compose-extension">` on composer | Plugin-slot |
+| M.4 | Right-rail plugin slot | n/a | F-0 / F-2 | `<slot name="rail-extension">` on right rail (assistant, tasks roll-up, integrations status) | Plugin-slot |
+| M.5 | Toolbar plugin slot | n/a | F-0 / F-3 | `<slot name="toolbar-extension">` on edit toolbar | Plugin-slot |
+
+## N. Coverage summary
+
+- **Total enumerated affordances**: 96 (A:18, B:18, C:22, D:8, E:10, F:12, G:6, H:24, I:6, J:5, K:6, L:5, M:5)
+- **Per-issue ownership** (excluding the F-0 design/plugin foundation, which underlies all):
+  - F-2 read surface: 64 affordances
+  - F-3 compose / edit / mentions / tasks / reactions / attachments / tags: 32 affordances
+  - F-4 live read/unread + feature activation: cross-cuts E.2, B.17, A.3, A.4, A.5, H.23
+- **New / additive (not in GWT today)**: G.1–G.6 depth-navigation pattern (6 affordances); F-2 takes on a new acceptance row **R-3.7** (depth-navigation drill-down).
+- **Plugin slots**: 4 (M.2–M.5), all reserved by F-0; specific F-* issues mount the slot points but do not register plugins.
+
+## O. Action items (this session)
+
+1. ✅ Inventory committed (this file).
+2. → Update F-2 (#1037) issue body to enumerate affordances under its ownership and to add a new acceptance row **R-3.7 Arbitrary-depth drill-down navigation** with G.1–G.6 as concrete affordances.
+3. → Update F-3 (#1038) issue body to enumerate affordances under its ownership including the full edit-mode toolbar (H.1–H.24), tag affordances (I.1–I.6), and "Send Message" (L.2).
+4. → Update F-2 (#1037) to reference C.* search-help and B.* saved-search affordances explicitly so reviewers cannot accept "practical search parity" without the help modal + saved-search rail.
+5. → Update F-1 (#1036) data-path scope to confirm fragment-window contract supports fragmenting along the depth axis (G.1 prerequisite).
+6. → Update F-0 (#1035) to specify the plugin slot points as M.2–M.5 with the slot-context contracts described above.
+7. → Generate Stitch screens for: Edit-mode toolbar in detail; Search-help modal + saved-search rail; Depth-navigation pattern.

--- a/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
+++ b/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
@@ -2,7 +2,7 @@
 
 Status: Final — follow-up chain filed 2026-04-26  
 Audited by: J2CL parity lead session  
-Audited against: `docs/j2cl-gwt-parity-matrix.md` (Updated 2026-04-22)  
+Audited against: `docs/j2cl-gwt-parity-matrix.md` (Updated 2026-04-25)  
 Live deployment: `https://supawave.ai/`  
 Build: `e66ce6013` (post-#1033 merge)  
 Account: `vega@supawave.ai` (signed-in, `j2cl-root-bootstrap` feature flag enabled)

--- a/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
+++ b/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
@@ -1,0 +1,167 @@
+# J2CL ↔ GWT Parity Audit (2026-04-26)
+
+Status: Final  
+Audited by: J2CL parity lead session  
+Audited against: `docs/j2cl-gwt-parity-matrix.md` (Updated 2026-04-22)  
+Live deployment: `https://supawave.ai/`  
+Build: `e66ce6013` (post-#1033 merge)  
+Account: `vega@supawave.ai` (signed-in, `j2cl-root-bootstrap` feature flag enabled)
+
+## 1. Why this audit exists
+
+The parity issue chain in `docs/j2cl-parity-issue-map.md` §6 is marked **completely closed** in GitHub (#931, #933, #936, #961–#971 all CLOSED). The lived experience of the J2CL root, however, is far from GWT parity. This audit walks the parity matrix row by row against the live deployment to surface the actual gap, so a follow-up issue chain can be filed against concrete deficiencies rather than against a “done” chain or a vague “redo the editor” framing.
+
+## 2. Method
+
+1. Open `https://supawave.ai/?view=j2cl-root` (J2CL surface) and `https://supawave.ai/?view=gwt` (forces the legacy GWT path past the `j2cl-root-bootstrap` flag, per `WaveClientServlet#resolveRequestedView` + `doGet` line 167).
+2. Sign-in state and feature flag held constant across both surfaces.
+3. For each parity-matrix row in §3–§7, observe current behavior on both surfaces side-by-side, capture the deficit, and assign one of:
+   - **PASS** — J2CL meets the row.
+   - **PARTIAL** — present but does not match GWT for the daily flow.
+   - **FAIL** — not implemented on the J2CL surface.
+   - **N/A** — not testable today against this deployment (e.g. requires harness fixture).
+4. Collect a sequenced follow-up issue list scoped to "redo the slice with explicit GWT-parity acceptance," not new architecture.
+
+Browser-test evidence stored as Chrome screenshots taken during the audit (J2CL inbox empty, J2CL inbox loaded, J2CL wave-open `ewlip`, GWT inbox + same wave `ewlip` open).
+
+## 3. Read Surface (StageOne origin) — Section 3
+
+| Row | Behavior | Status | Evidence |
+| --- | --- | --- | --- |
+| R-3.1 | Open-wave rendering — blip/thread DOM from conversation view | **FAIL** | J2CL renders all blips as a flat list with **raw blip IDs as section headings** ("Blip 3VPWzePL_DB", "Blip 8b1dxf0BXMA", …) and the blip content as plain text. There is no thread DOM, no nesting, no per-blip author/timestamp/avatar. GWT renders the same wave with author name + avatar + relative timestamp per blip, threaded indenting for replies, per-blip action toolbar (reply/edit/delete/link), and tags row at the bottom. |
+| R-3.2 | Focus framing (`FocusFramePresenter`-equivalent) | **FAIL** | J2CL has no visible per-blip selection indicator. Arrow/`j`/`k` keys do not move a focus frame across blips. The "Recent / Next unread / Previous / Next / Last" buttons are present in the right panel but do not move a frame on the rendered content; they appear to drive the open-wave selection at the *list* level, not the *blip* level. |
+| R-3.3 | Collapse — thread collapse/expand toggles | **FAIL** | No collapse affordance is rendered on any blip. Threads cannot be collapsed; replies cannot be hidden. |
+| R-3.4 | Thread navigation — next/previous unread, deep-reply jumps | **PARTIAL** | The "Next unread / Previous mention / Next mention" buttons exist as labels but operate at the *wave list* level (jumping between waves in the search results) rather than blip-level navigation inside the open wave. The matrix row asks for blip-level unread-aware navigation; that is missing. |
+| R-3.5 | Visible-region container model — viewport-scoped fragments | **FAIL** | The whole wave (all 30+ blips for the test wave) renders as a single flat scroll list. There is no visible-window placeholder, no scroll-driven extension, no loading placeholder. The transport is whole-wave. |
+| R-3.6 | DOM-as-view provider — semantic queries against the rendered DOM | **FAIL (consequence of R-3.1)** | Without a real conversation DOM, there is no semantic view provider for keyboard, focus, collapse, or menus to query. The flat blip list has no role/label structure that semantic queries could traverse. |
+
+**Read surface verdict: 0/6 PASS, 1/6 PARTIAL, 5/6 FAIL.** The closed slice #966 ("Port StageOne read-surface parity") did not deliver; what shipped is a flat read-out of conversation blip IDs, not a parity-equivalent read surface.
+
+## 4. Live Surface (StageTwo origin) — Section 4
+
+| Row | Behavior | Status | Evidence |
+| --- | --- | --- | --- |
+| R-4.1 | Socket / session lifecycle | **PASS** | J2CL displays "Live updates connected. supawave.ai/w+3VPWzePL_DA/-/conv+root · channel ch13 · snapshot v125" — socket opens and identifies the session. Auth landed (#933 closed). |
+| R-4.2 | Bootstrap contract — no HTML scraping | **PASS** | `/bootstrap.json` contract is in place (#963 + #979 just merged). J2CL no longer scrapes root HTML for session/socket metadata. |
+| R-4.3 | Reconnect — transient-loss recovery | **N/A (untested in this session)** | Not exercised in this audit; should be covered by a fixture once the read surface lands. Live banner styling for reconnect is not present on the J2CL shell today. |
+| R-4.4 | Read/unread state live updates | **FAIL** | The wave list shows `12 messages` / `86 messages` etc. as raw counts — no per-user read/unread state, no unread badge styling, no count change indicators. GWT shows unread counts that decrement as the user opens waves. #931 ("Add live unread/read state") was closed but the behavior is not present on the J2CL list or open-wave panel. |
+| R-4.5 | Route / history integration | **PARTIAL** | Selecting a wave updates the URL (`?wave=supawave.ai%2Fw%2B…`) and the open-wave region updates without page reload. Back/forward navigation appears to work for wave selection. Folder/tag navigation has no equivalent because the J2CL shell has no folders other than Inbox. Signed-in/out transitions not exercised. |
+| R-4.6 | Fragment fetch policy — viewport-scoped loading | **FAIL** | Same as R-3.5 — whole-wave payload arrives as a single snapshot. No viewport hint is sent, no fragment extension fires on scroll. |
+| R-4.7 | Feature activation and live-update application | **PARTIAL** | Live updates do apply (the snapshot version `v125` indicates server-side incremental application), but features like search, supplement, diff controller, reader are not visibly activated in the J2CL surface — there is no diff control, no search beyond a single text box, no reader mode. |
+| R-4.8 | Selected-wave version/hash basis atomicity | **N/A (not testable in this audit)** | This is a write-path correctness property; would need a controlled race fixture or harness test. #936 closed without a J2CL-side write surface that exercises it meaningfully. |
+
+**Live surface verdict: 2/8 PASS, 2/8 PARTIAL, 2/8 FAIL, 2/8 N/A.** The bootstrap and socket lanes are real wins; #931's read/unread work is the most prominent claimed-closed-but-missing item.
+
+## 5. Compose / Edit Surface (StageThree origin) — Section 5
+
+| Row | Behavior | Status | Evidence |
+| --- | --- | --- | --- |
+| R-5.1 | Compose / reply flow | **PARTIAL** | A reply textarea + "Send reply" button exist in the right-panel `OPENED WAVE` region with `Reply target: b+<blip-id>`. There is also a "New wave" textarea + "Create wave" button on the left panel. The composer is **not** an inline editor; it is a single textarea attached to the bottom of the right rail. There is no caret integration with the rendered conversation, no inline reply at a specific blip, no quote/draft preservation across blip selection, no Enter-to-send semantics distinct from newline. GWT inserts the composer inline at the chosen reply position with formatting + caret survival across live updates. |
+| R-5.2 | View and edit toolbars | **PARTIAL** | The toolbar buttons (Bold, Italic, Underline, Strikethrough, Heading, Bulleted list, Numbered list, Align left/center/right, Right-to-left, Create link, Remove link, Clear formatting) are rendered in the right rail, but they are **detached** from the textarea — there is no rich-text input, no selection range, no toggle state. The buttons act as global affordances rather than contextual selection-driven toggles. The reply textarea is plain `<textarea>`, no contenteditable. So the formatting controls cannot apply formatting to the reply being composed in any user-visible way. |
+| R-5.3 | Mentions and autocomplete | **FAIL** | No `@`-trigger behavior in the reply textarea. Typing `@` inserts a literal character. No suggestion popover. GWT has working `@<participant>` autocomplete with arrow-key + enter. |
+| R-5.4 | Tasks and related metadata overlays | **FAIL** | No task affordance on any blip. No checkbox-style toggle. No task metadata overlays. GWT has visible task UI. |
+| R-5.5 | Reactions and comparable interaction overlays | **FAIL** | No reaction affordance on any blip. No reaction chip styling. No add/remove reaction control. GWT has reactions. |
+| R-5.6 | Attachment workflow | **PARTIAL** | The right-rail toolbar shows "Attach file / Upload queue / Cancel upload / Paste image / Small / Medium / Large attachment" buttons. They appear functional in isolation. The rendered open-wave does not show attachments inline against the originating blip — attachments existing on a wave (e.g. the `clop_2026-04-08_3163.png pasted-image.png` strings visible in the `@vega` digest snippet) are not visibly resolved as image previews in the J2CL open-wave panel. GWT renders attachments inline with thumbnail/download controls. |
+| R-5.7 | Remaining rich-edit daily affordances (lists, block quotes, inline links, etc.) | **FAIL** | None of these are usable today because R-5.2 makes the formatting toolbar non-functional against the plain-textarea composer. |
+
+**Compose verdict: 0/7 PASS, 3/7 PARTIAL, 4/7 FAIL.** This section is the largest user-facing gap. #969 ("Port StageThree compose and toolbar parity") and #970/#971 (overlays + attachment + rich-edit) are all marked closed but the toolbar buttons exist as labels disconnected from a real editor.
+
+## 6. Server-First First Paint and Shell Swap — Section 6
+
+| Row | Behavior | Status | Evidence |
+| --- | --- | --- | --- |
+| R-6.1 | Server-rendered read-only first paint | **FAIL** | First paint of the J2CL root shell is a "Hosted workflow" placeholder card with "Waiting for the first sidecar search response." The selected wave region says "Select a wave" until the user clicks. There is no server-rendered selected-wave HTML on initial load. The `J2clSelectedWaveSnapshotRenderer` exists in the servlet but the rendered snapshot is not visibly present in the right panel before client boot — i.e. the snapshot is either empty or rendered into a hidden seam that the live region replaces immediately. The R-6.1 "content is readable without JS for the visible region" is not satisfied. |
+| R-6.2 | Bootstrap JSON contract | **PASS** | `/bootstrap.json` is live, versioned, and (post-#979) no longer leaks the volatile session ID seed. |
+| R-6.3 | Shell-swap upgrade path | **PARTIAL** | The shell does upgrade in place from the static HTML to the live-updates-connected state. There is no unstyled flash. But because R-6.1 fails, the upgrade is from "Select a wave" placeholder to a flat blip list, not from server-rendered wave content to a richer client surface. |
+| R-6.4 | Rollback-safe coexistence | **PASS** | `/?view=gwt` (or any non-empty non-`j2cl-root` view value) routes to the legacy GWT root. `/?view=j2cl-root` is the explicit J2CL route. The `j2cl-root-bootstrap` feature flag flips the *default* for empty `view`, which matches the matrix's "operator-level toggle remains reversible" requirement. |
+
+**Server-first verdict: 2/4 PASS, 1/4 PARTIAL, 1/4 FAIL.** The bootstrap contract and route safety are real wins. The actual server-side first paint of wave content (#965's headline goal) is not visible to the user.
+
+## 7. Viewport-Scoped Fragment Windows — Section 7
+
+| Row | Behavior | Status | Evidence |
+| --- | --- | --- | --- |
+| R-7.1 | Initial visible window | **FAIL** | Test wave `ewlip` opens with the entire conversation rendered as a flat list at once. No initial-window clamp visible to the user. |
+| R-7.2 | Extension on scroll | **FAIL** | Scrolling the right rail does not trigger a fragment extension fetch. There is nothing to extend — everything is already in the DOM. |
+| R-7.3 | Server clamp behavior | **N/A** | Not exercised against a wave large enough to trip the existing server clamps. |
+| R-7.4 | No regression to whole-wave bootstrap | **FAIL** | The current J2CL surface **is** the whole-wave bootstrap path. There is no viewport-scoped path to fall back from. |
+
+**Fragments verdict: 0/4 PASS, 0/4 PARTIAL, 3/4 FAIL, 1/4 N/A.** #967 ("Drive the Lit read surface from viewport-scoped fragment windows") is marked closed but the user-visible behavior is whole-wave-only.
+
+## 8. Aggregate score
+
+| Section | PASS | PARTIAL | FAIL | N/A | Gate-row pass rate |
+| --- | ---: | ---: | ---: | ---: | --- |
+| §3 Read | 0 | 1 | 5 | 0 | 0/5 gate rows |
+| §4 Live | 2 | 2 | 2 | 2 | 2/7 gate rows |
+| §5 Compose | 0 | 3 | 4 | 0 | 0/6 gate rows |
+| §6 Server-first | 2 | 1 | 1 | 0 | 2/4 gate rows |
+| §7 Fragments | 0 | 0 | 3 | 1 | 0/4 gate rows |
+| **Total** | **4** | **7** | **15** | **3** | **4/26 gate rows pass** |
+
+The §8 parity gate in the matrix requires *all* gate rows to be closed before §5.1 (opt-in default-root bootstrap) may even be opened. By that contract, **22 of 26 gate rows are not yet met**, despite the source-issue chain being marked closed. The closed status reflects narrow per-issue acceptance ("practical read-surface parity, not full editor parity") rather than the matrix's "must not regress against GWT" contract.
+
+## 9. Why the chain closed without delivering
+
+Pattern observed across slices: every closed Section-4 issue used a phrase like *"practical read-surface parity, not full editor parity"* or *"closes the high-value gap that still blocks root cutover, stays bounded to overlays/interactions"*. These are bound-the-blast-radius escape hatches that let each issue declare success against a narrow per-slice acceptance instead of against the row-level matrix contract. The matrix says *"required to match GWT"*; the issue text says *"practical parity"*; reviewers accepted the latter; users see the gap.
+
+This is not a moral failure of any one slice. It is a process gap between the matrix (which is the actual contract) and the per-issue acceptance (which is what reviewers signed off against).
+
+## 10. Recommended follow-up — re-execute four slices, gate on matrix rows
+
+Rather than open one giant "redo the editor" issue or restart the chain from scratch, propose four tightly-scoped re-execution issues that each cite the **specific failed matrix row IDs** as their hard acceptance criteria. No more "practical parity" language. The acceptance is row-level: every cited row must demonstrate the exact required-to-match-GWT behavior in a fixture that mounts both `/?view=j2cl-root` and `/?view=gwt` and asserts the contract.
+
+Proposed sequencing (data-path-first → UI):
+
+### F-1. Re-execute viewport-scoped read surface (replaces #967 / #965 acceptance)
+
+- Cite rows: R-3.5, R-3.6, R-4.6, R-6.1, R-6.3, R-7.1, R-7.2, R-7.3, R-7.4.
+- Acceptance: the J2CL open-wave surface opens with a viewport-scoped initial window (not whole-wave); scroll triggers fragment extension; server clamps are honoured; server-rendered first paint contains visible-region wave HTML before client boot; fixture asserts both paths.
+- Why first: the data path is the hard part to retrofit later. Every UI feature inherits the loading model.
+
+### F-2. Re-execute StageOne read surface (replaces #966 acceptance)
+
+- Cite rows: R-3.1, R-3.2, R-3.3, R-3.4 (blip-level), R-4.4 (per-blip read state).
+- Acceptance: rendered conversation DOM with author + avatar + timestamp + threading per blip; focus frame moves with arrow/`j`/`k`; thread collapse toggles work; #931 unread state visibly decrements when blips are read; fixture asserts each behavior against both surfaces.
+- Why second: requires F-1's data shape to be in place, but is the largest user-visible "looks like an actual conversation" win.
+
+### F-3. Re-execute StageThree compose surface (replaces #969 / #970 / #971 acceptance for daily-path rows)
+
+- Cite rows: R-5.1, R-5.2, R-5.3, R-5.4, R-5.5, R-5.6, R-5.7.
+- Acceptance: composer is contenteditable / rich-text, not a plain textarea; toolbar buttons toggle on selection and apply on the active range; `@` trigger opens autocomplete; tasks toggle on a blip; reactions add/remove on a blip; attachments render inline; daily-path rich-edit affordances actually format. Fixture for each row.
+- Why third: requires F-2's per-blip rendering to be in place so the composer can attach to a real blip surface.
+
+### F-4. Re-instate live read/unread + per-blip live updates (cleans up #931 / R-4.7)
+
+- Cite rows: R-4.4, R-4.7.
+- Acceptance: opening a blip decrements the wave's unread count without page reload; the digest list reflects updates from other clients; features (search, supplement, diff, reader) become visibly active in the live surface.
+- Why fourth: smaller in scope, but depends on F-2's blip-level rendering to attach state to.
+
+After F-1..F-4 close against row-level acceptance, the existing parity gate row coverage should jump from 4/26 to ~22/26 and the matrix's §5.1/§5.2/§5.3 future issues become opener-eligible.
+
+## 11. Out-of-scope for this audit
+
+- Browser-harness fixture work — surfaced where relevant but the audit is matrix-row coverage, not fixture coverage. Matrix-row acceptance assumes a fixture lands with each follow-up.
+- Lit design-system / Stitch packet (#962) — visual modernization is decoupled from row-level parity per matrix §1 "what may change visually."
+- Default-root cutover (issue map §5.1/5.2/5.3) — explicitly gated by the parity gate; cannot be opened until F-1..F-4 close.
+- #978 (`fromRootHtml` removal) — tail-end soak-gated cleanup, not on the parity-acquisition critical path. Independent of this audit's recommendations.
+
+## 12. Verification of audit method
+
+- J2CL surface URL `https://supawave.ai/?view=j2cl-root` — confirmed routes to the J2CL root shell (`SupaWave J2CL Root Shell` brand visible).
+- GWT surface URL `https://supawave.ai/?view=gwt` — confirmed routes to the legacy GWT path (`SupaWave` brand, full toolbar, threaded wave content visible).
+- Both surfaces signed in as the same `vega@supawave.ai` account from the same browser session, so account state is held constant.
+- Same wave (`ewlip` at `supawave.ai/w+3VPWzePL_DA`) opened on both surfaces for direct side-by-side comparison.
+- Routing verified against `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:155-196` which establishes that `view=j2cl-root` OR (`view` empty AND `j2cl-root-bootstrap` flag enabled) selects the J2CL path; any other non-empty `view` value falls through to GWT.
+
+## 13. Appendix — observed shell chrome contrast
+
+| Surface element | GWT | J2CL |
+| --- | --- | --- |
+| Top brand | `SupaWave` | `SupaWave J2CL Root Shell` (developer-facing brand) |
+| Top toolbar | Search, user menu, notifications, settings, chat icons | Admin button, Sign out — no app affordances |
+| Left rail | Search box + filter/sort/refresh buttons + multi-folder navigation + rich digests with avatars + multi-author avatars + relative timestamps + unread badges | One folder (Inbox) + search box + plain-text digest cards (title, author email, snippet, message count) |
+| Center | (used by GWT for combined list+wave) | "Hosted workflow" explainer card |
+| Right rail | (n/a — GWT uses the center) | Open-wave region with flat blip list (raw blip IDs as headers), reply textarea, large detached toolbar, navigation buttons |
+| Open-wave per-blip chrome | Avatar + author name + timestamp + per-blip action toolbar (reply/edit/delete/link), threaded indenting | Just `Blip <id>` as heading + raw text body |
+| Bottom of open wave | "Click here to reply" affordance + Tags row | "Reply target: b+<id>" label + Send reply button |

--- a/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
+++ b/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
@@ -1,11 +1,19 @@
 # J2CL ↔ GWT Parity Audit (2026-04-26)
 
-Status: Final  
+Status: Final — follow-up chain filed 2026-04-26  
 Audited by: J2CL parity lead session  
 Audited against: `docs/j2cl-gwt-parity-matrix.md` (Updated 2026-04-22)  
 Live deployment: `https://supawave.ai/`  
 Build: `e66ce6013` (post-#1033 merge)  
 Account: `vega@supawave.ai` (signed-in, `j2cl-root-bootstrap` feature flag enabled)
+
+Follow-up issues filed against this audit (each cites specific matrix row IDs as hard acceptance):
+
+- [#1035](https://github.com/vega113/supawave/issues/1035) F-0: Refresh Lit design packet for wavy aesthetic + plugin slot contracts
+- [#1036](https://github.com/vega113/supawave/issues/1036) F-1: Re-execute viewport-scoped J2CL read-surface data path
+- [#1037](https://github.com/vega113/supawave/issues/1037) F-2: Re-execute J2CL StageOne read surface (threaded blip rendering, focus, collapse, read/unread)
+- [#1038](https://github.com/vega113/supawave/issues/1038) F-3: Re-execute J2CL StageThree compose surface (inline rich-text editor, mentions, tasks, reactions, attachments)
+- [#1039](https://github.com/vega113/supawave/issues/1039) F-4: J2CL live read/unread state + feature activation visibility
 
 ## 1. Why this audit exists
 

--- a/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
+++ b/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
@@ -129,7 +129,7 @@ Proposed sequencing (data-path-first → UI):
 
 ### F-2. Re-execute StageOne read surface (replaces #966 acceptance)
 
-- Cite rows: R-3.1, R-3.2, R-3.3, R-3.4 (blip-level), R-4.4 (per-blip read state).
+- Cite rows: R-3.1, R-3.2, R-3.3, R-3.4 (blip-level), R-4.4 (per-user read/unread live state).
 - Acceptance: rendered conversation DOM with author + avatar + timestamp + threading per blip; focus frame moves with arrow/`j`/`k`; thread collapse toggles work; #931 unread state visibly decrements when blips are read; fixture asserts each behavior against both surfaces.
 - Why second: requires F-1's data shape to be in place, but is the largest user-visible "looks like an actual conversation" win.
 

--- a/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
+++ b/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md
@@ -13,7 +13,7 @@ The parity issue chain in `docs/j2cl-parity-issue-map.md` §6 is marked **comple
 
 ## 2. Method
 
-1. Open `https://supawave.ai/?view=j2cl-root` (J2CL surface) and `https://supawave.ai/?view=gwt` (forces the legacy GWT path past the `j2cl-root-bootstrap` flag, per `WaveClientServlet#resolveRequestedView` + `doGet` line 167).
+1. Open `https://supawave.ai/?view=j2cl-root` (J2CL surface) and `https://supawave.ai/?view=gwt` (forces the legacy GWT path past the `j2cl-root-bootstrap` flag, per `WaveClientServlet#resolveRequestedView` and `WaveClientServlet#doGet`).
 2. Sign-in state and feature flag held constant across both surfaces.
 3. For each parity-matrix row in §3–§7, observe current behavior on both surfaces side-by-side, capture the deficit, and assign one of:
    - **PASS** — J2CL meets the row.
@@ -22,7 +22,7 @@ The parity issue chain in `docs/j2cl-parity-issue-map.md` §6 is marked **comple
    - **N/A** — not testable today against this deployment (e.g. requires harness fixture).
 4. Collect a sequenced follow-up issue list scoped to "redo the slice with explicit GWT-parity acceptance," not new architecture.
 
-Browser-test evidence stored as Chrome screenshots taken during the audit (J2CL inbox empty, J2CL inbox loaded, J2CL wave-open `ewlip`, GWT inbox + same wave `ewlip` open).
+Browser-test evidence stored as Chrome screenshots taken during the audit: J2CL inbox empty ([PR #1034 artifact](https://github.com/vega113/incubator-wave/pull/1034)), J2CL inbox loaded ([PR #1034 artifact](https://github.com/vega113/incubator-wave/pull/1034)), J2CL wave-open `ewlip` ([PR #1034 artifact](https://github.com/vega113/incubator-wave/pull/1034)), GWT inbox + same wave `ewlip` open ([PR #1034 artifact](https://github.com/vega113/incubator-wave/pull/1034)).
 
 ## 3. Read Surface (StageOne origin) — Section 3
 
@@ -37,7 +37,7 @@ Browser-test evidence stored as Chrome screenshots taken during the audit (J2CL 
 
 **Read surface verdict: 0/6 PASS, 1/6 PARTIAL, 5/6 FAIL.** The closed slice #966 ("Port StageOne read-surface parity") did not deliver; what shipped is a flat read-out of conversation blip IDs, not a parity-equivalent read surface.
 
-## 4. Live Surface (StageTwo origin) — Section 4
+## 4. Live Surface (Stage Two origin) — Section 4
 
 | Row | Behavior | Status | Evidence |
 | --- | --- | --- | --- |
@@ -152,7 +152,7 @@ After F-1..F-4 close against row-level acceptance, the existing parity gate row 
 - GWT surface URL `https://supawave.ai/?view=gwt` — confirmed routes to the legacy GWT path (`SupaWave` brand, full toolbar, threaded wave content visible).
 - Both surfaces signed in as the same `vega@supawave.ai` account from the same browser session, so account state is held constant.
 - Same wave (`ewlip` at `supawave.ai/w+3VPWzePL_DA`) opened on both surfaces for direct side-by-side comparison.
-- Routing verified against `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:155-196` which establishes that `view=j2cl-root` OR (`view` empty AND `j2cl-root-bootstrap` flag enabled) selects the J2CL path; any other non-empty `view` value falls through to GWT.
+- Routing verified against `WaveClientServlet#resolveRequestedView` and `WaveClientServlet#doGet` (commit `e66ce6013`) which establishes that `view=j2cl-root` OR (`view` empty AND `j2cl-root-bootstrap` flag enabled) selects the J2CL path; any other non-empty `view` value falls through to GWT.
 
 ## 13. Appendix — observed shell chrome contrast
 


### PR DESCRIPTION
Updates #904

## Summary
J2CL ↔ GWT parity audit walking `docs/j2cl-gwt-parity-matrix.md` row by row against the live deployment.

Side-by-side comparison method: `https://supawave.ai/?view=j2cl-root` (current J2CL surface) vs `https://supawave.ai/?view=gwt` (forces the GWT path past the `j2cl-root-bootstrap` flag, per `WaveClientServlet#resolveRequestedView`). Same account, same browser session, same wave.

## Headline finding
**4/26 parity gate rows pass** (4 PASS, 7 PARTIAL, 15 FAIL, 3 N/A) — despite the source-issue chain in `docs/j2cl-parity-issue-map.md` §6 being marked **completely closed** in GitHub (#931, #933, #936, #961–#971). The gap is structural, not cosmetic: the J2CL open-wave panel renders blips as a flat list with raw blip IDs as headers and plain-text bodies, with no threading, no per-blip author/avatar/timestamp, no focus framing, no collapse, no viewport-scoped fragments, no inline rich-text composer, no mentions/tasks/reactions, no inline attachments.

The closed status reflects narrow per-issue acceptance ("practical parity, not full editor parity") rather than the matrix's "must not regress against GWT" contract.

## Recommended follow-up

Four re-execution issues that cite specific matrix row IDs as hard acceptance criteria, sequenced data-path-first then UI:

- **F-1** Re-execute viewport-scoped read surface — R-3.5, R-3.6, R-4.6, R-6.1, R-6.3, R-7.1, R-7.2, R-7.3, R-7.4
- **F-2** Re-execute StageOne read surface — R-3.1, R-3.2, R-3.3, R-3.4, R-4.4
- **F-3** Re-execute StageThree compose surface — R-5.1, R-5.2, R-5.3, R-5.4, R-5.5, R-5.6, R-5.7
- **F-4** Re-instate live read/unread + per-blip live updates — R-4.4, R-4.7

After F-1..F-4 close against row-level acceptance, gate-row coverage should jump from 4/26 to ~22/26 and the matrix's §5.1/§5.2/§5.3 future cutover items become opener-eligible.

## Out of scope
- #978 (`fromRootHtml` soak cleanup) — unrelated to the parity gap; remains soak-gated independently.
- Lit design-system / Stitch packet (#962) — visual modernization is decoupled from row-level parity per matrix §1.

## Verification
- Live-deployment browser comparison against `vega@supawave.ai` account; same wave (`ewlip` at `supawave.ai/w+3VPWzePL_DA`) opened on both surfaces.
- Routing verified against `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:155-196`.
- No code changes; docs-only artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a finalized parity audit report with row-by-row comparisons, section verdicts, evidence, an aggregate gate-row tally (4/26), commentary on closure vs. matrix mismatch, and four focused re‑execution follow-ups with concrete acceptance criteria and verification notes.
  * Updated parity matrix metadata timestamp (no content or requirement changes).
  * Added a GWT functional inventory and design-coverage matrix mapping UI affordances, depth-navigation pattern, plugin-slot points, and follow-up action items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->