### PR TITLE
F-1: Re-execute viewport-scoped J2CL read-surface data path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -404,7 +404,9 @@ Test / unmanagedSources := (Test / unmanagedSources).value.filterNot { f =>
   (p.contains("/org/waveprotocol/box/server/rpc/render/") &&
     !p.endsWith("/ServerHtmlRendererTest.java") &&
     !p.endsWith("/WaveContentRendererTest.java") &&
-    !p.endsWith("/J2clSelectedWaveSnapshotRendererTest.java")) ||
+    !p.endsWith("/WaveContentRendererWindowTest.java") &&
+    !p.endsWith("/J2clSelectedWaveSnapshotRendererTest.java") &&
+    !p.endsWith("/J2clSelectedWaveSnapshotRendererWindowTest.java")) ||
   p.contains("/wave/src/test/java/org/waveprotocol/wave/migration/") ||
   p.contains("/wave/src/test/java/org/waveprotocol/wave/model/document/util/") ||
   // MongoDB integration tests — require Testcontainers; run via Gradle itTest, not sbt test

--- a/docs/superpowers/plans/2026-04-26-issue-1036-viewport-scoped-read.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1036-viewport-scoped-read.md
@@ -146,7 +146,7 @@ because reformatting can shift them by a line or two.
 Each task lists files to edit, expected diff, paired tests, the parity row
 it satisfies, and a verification command.
 
-### T1 — Server: viewport-bounded `WaveContentRenderer.renderWindow(...)`
+### T1 — Server: viewport-bounded `WaveContentRenderer` overload
 
 **Rows: R-3.5, R-6.1, R-7.1**
 
@@ -156,35 +156,49 @@ Add a viewport-aware overload to `WaveContentRenderer`:
 public static String renderWaveContent(
     WaveViewData waveView,
     ParticipantId viewer,
-    int initialWindowSize)
+    int initialWindowSize)        // 0 == "render whole wave" (legacy GWT path)
 ```
 
 Implementation outline:
 
-1. Walk the root thread of the conversation in `renderWaveContent`. After
-   `extractTitle` / `safeGetTags` / `countBlipsAndThreads`, build a list of
-   `ConversationBlip`s in document order (DFS through reply threads as
-   today, but track the visit order).
-2. If `initialWindowSize > 0` and `blips.size() > initialWindowSize`, only
-   render the first `initialWindowSize` blips through `ServerHtmlRenderer`.
-   Append a `<div class="visible-region-placeholder"
+1. Threading. The existing
+   `renderWaveContent(WaveViewData, ParticipantId, RenderBudget)` worker
+   currently delegates the entire conversation to
+   `ServerHtmlRenderer` via `ReductionBasedRenderer.renderWith(rules,
+   conversations)` (`WaveContentRenderer.java:171`). The new overload
+   forwards `initialWindowSize` to a sibling worker that calls
+   `ReductionBasedRenderer.renderWith(...)` against a per-blip subset.
+   Concretely: walk the root thread blips in document order (the same DFS
+   as `countBlipsAndThreads` at line 325), keep the first
+   `initialWindowSize` blips, render *only* those plus their inline reply
+   threads. The participants and title/tags wrapper is unchanged.
+2. Server-side terminal placeholder. After the rendered slice append a
+   `<div class="visible-region-placeholder"
    data-j2cl-server-placeholder="true" data-segment="placeholder-tail"
    role="listitem" aria-busy="true">Additional blips will load on
-   scroll.</div>` after the rendered slice. Encoding the placeholder with
-   the same DOM marker the J2CL client already understands
-   (`J2clReadSurfaceDomRenderer.renderPlaceholder` uses
-   `data-j2cl-viewport-placeholder`; we mirror with a sibling marker so
-   `enhanceExistingSurface` can promote it).
-3. Set a `data-j2cl-initial-window-size` attribute on the wave-content
-   wrapper so the J2CL renderer can confirm the server window matches its
-   request.
+   scroll.</div>`. The marker is **for visual continuity / AT
+   announcement on the static HTML only**. It is not promoted into the
+   J2CL `renderedWindowEntries` list — extension on scroll is driven
+   exclusively by `J2clSelectedWaveProjector.projectViewportState` after
+   the live socket update lands and `view.render(model)` calls
+   `readSurface.renderWindow(...)`. The data-shape contract for that path
+   is documented in §2 above and in `J2clSelectedWaveViewportState.java`
+   line 363.
+3. Attribute the wrapper with `data-j2cl-initial-window-size` (numeric
+   value of the server-applied window size) on the existing
+   `<div class="wave-content">` element so the J2CL renderer and tests
+   can verify "the server window matches the limit we asked for." Add
+   `data-j2cl-server-first-surface="true"` to the same wrapper so T2/T4
+   can branch on it without introducing a new outer element (the J2CL
+   `findExistingSurface` selector at
+   `J2clReadSurfaceDomRenderer.java:481` already matches `.wave-content`).
 4. `J2clSelectedWaveSnapshotRenderer.renderRequestedWave` adopts a small
    `INITIAL_WINDOW_SIZE` constant (set equal to the existing
-   `wave.fragments.defaultViewportLimit = 5` from `reference.conf:468`) and
-   threads it into `renderWaveContent`. Increment
-   `FragmentsMetrics.j2clViewportInitialWindows` once per snapshot
-   regardless of mode (the existing `WaveClientRpcImpl` increment handles
-   socket opens; the snapshot-renderer increment handles first-paint).
+   `wave.fragments.defaultViewportLimit = 5` from `reference.conf:468`)
+   and threads it into `renderWaveContent`. Increment
+   `FragmentsMetrics.j2clViewportInitialWindows` once on the snapshot
+   path. The existing `WaveClientRpcImpl` socket-open increment is
+   independent — both call sites contribute to the counter.
 
 Paired tests:
 
@@ -224,11 +238,11 @@ Changes:
    emission near line 200): add `role="list"` for the root thread and
    `role="group"` for inline threads, plus `aria-label` for the inline
    thread (mirroring `enhanceInlineThread`).
-3. Wrap the rendered conversation in a `<section
-   data-j2cl-server-first-surface="true" aria-label="Selected wave read
-   surface">` so `J2clReadSurfaceDomRenderer.enhanceExistingSurface` knows
-   the surface is already enhanced and skips the "no inline reply
-   thread" promotion paths that would otherwise mutate focus.
+3. The `data-j2cl-server-first-surface="true"` attribute set on the
+   `wave-content` wrapper in T1 step 3 allows
+   `J2clReadSurfaceDomRenderer.enhanceExistingSurface` (after the T4
+   focus-preserving change) to know the surface is server-rendered and
+   keep the focused element stable.
 
 Paired tests:
 
@@ -518,12 +532,46 @@ closed slices skipped, so this plan refuses to ship without it.
 
 **Open question I cannot resolve in plan time.** The audit notes
 `enableDynamicRendering = false` is the production default
-(`reference.conf:435`). T1 emits the placeholder marker regardless, but
-the J2CL client only walks the placeholder when the renderer is in window
-mode (`renderWindow`, not `render`). I am explicitly *not* flipping
-`enableDynamicRendering` in this lane; that is a config-time decision
-documented in `docs/fragments-config.md` and outside the F-1 surface. If
-the demo wave does not visibly extend on scroll because dynamic rendering
-is off in the worktree-local config, the fix is to either set
-`enableDynamicRendering=true` for the parity demo or update
-`reference.conf` in a follow-up PR — not to expand F-1's scope.
+(`reference.conf:435`). That flag governs the *legacy GWT* dynamic
+rendering wave panel and is independent of the J2CL fragments transport
+(`server.fragments.transport = stream`, also default). The J2CL
+viewport-extension path is gated on the J2CL transport, so flipping
+`enableDynamicRendering` is **not** required for F-1's contract to hold.
+If the demo wave does not visibly extend on scroll, the diagnostic chain
+is: (a) does the J2CL controller emit `viewport.initial_window`?, (b) does
+the server-side `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` log fire?, (c) is
+`server.fragments.transport=stream` set? — none of those need a new code
+change in F-1 if defaults are honoured.
+
+**Late-review correctness check (round 2).** Re-reading the plan against
+the actual J2CL data flow:
+
+- The server-side `data-j2cl-server-placeholder` marker is **decorative
+  only**. Extension on scroll is driven by
+  `J2clSelectedWaveProjector.projectViewportState` →
+  `J2clSelectedWaveViewportState.fromFragments` (line 56) →
+  `J2clSelectedWaveModel.getViewportState().getReadWindowEntries()` (line
+  363) → `view.render(model)` calling
+  `readSurface.renderWindow(readWindowEntries)` →
+  `J2clReadSurfaceDomRenderer.requestReachablePlaceholderAfterRender`
+  (line 645). The plan no longer claims the server placeholder triggers
+  fetch; T1 step 2 spells this out.
+- `J2clReadSurfaceDomRenderer.findExistingSurface` (line 474) matches
+  `[data-j2cl-read-surface='true']` first then `.wave-content`. T1's
+  attribute sits on the existing `wave-content` wrapper so the matcher
+  picks it up unchanged.
+- `J2clSelectedWaveView.shouldPreserveServerSnapshot` (line 203) decides
+  whether to keep the server-first card when the live update has empty
+  read-blip / read-window state. With T1's window-bounded snapshot, the
+  card *will* have rendered blips, so the model's
+  `getReadBlips()/getReadWindowEntries()` will be populated by the live
+  update and the swap proceeds normally. T4's "cold-mount" reason fires
+  only when no card was present.
+- Telemetry field guard in `J2clClientTelemetry.rejectSensitiveOrReservedField`
+  (line 142) blocks `waveid`, `address`, `attachmentid`, `caption`, etc.
+  T3's events use `direction`, `limit`, `outcome`, `delta`, `reason` —
+  none of these are on the rejected list.
+- `FragmentsMetrics.setEnabled(boolean)` (line 30) defaults false.
+  Tests must call `FragmentsMetrics.setEnabled(true)` in `@Before` and
+  reset to false in `@After` to avoid leaking state across the test
+  suite (the existing `WaveClientRpcViewportHintsTest` is the precedent).

--- a/docs/superpowers/plans/2026-04-26-issue-1036-viewport-scoped-read.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1036-viewport-scoped-read.md
@@ -1,0 +1,529 @@
+# F-1: Re-execute viewport-scoped J2CL read-surface data path
+
+Status: Ready for implementation
+Owner: codex/issue-1036-viewport-scoped-read worktree
+Issue: [#1036](https://github.com/vega113/supawave/issues/1036)
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Audit motivating this lane:
+`/Users/vega/devroot/worktrees/j2cl-parity-audit/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md`
+Parity-matrix rows claimed: **R-3.5, R-3.6, R-4.6, R-6.1, R-6.3, R-7.1, R-7.2, R-7.3, R-7.4**
+
+## 1. Why this plan exists
+
+The 2026-04-26 audit (`§3.5, §4.6, §6.1, §6.3, §7.1–§7.4`) found that the J2CL
+open-wave surface today renders the entire wave as a flat snapshot list with
+**no viewport hint observable on the wire**, **no fragment extension on
+scroll**, **no server clamp telemetry visible to the client**, and **no
+server-rendered first paint of selected-wave content**. The closed slices
+`#965`/`#967` shipped against narrow "practical parity" acceptance and never
+demonstrated row-level GWT parity in a fixture.
+
+Almost every infrastructure piece this plan needs already exists in the repo
+— this plan stitches the loose ends so that `?view=j2cl-root` against a
+representative wave actually emits a viewport hint, surfaces server-rendered
+HTML for the selected wave on first paint, swaps the shell upgrade in place
+without losing focus, and emits the four telemetry counters required by the
+issue contract.
+
+The work is delivered as five tasks (T1–T5), each ≤200 LOC of production code
+with a paired test at the same change boundary. Each task ends with a
+verification step before the next begins.
+
+## 2. Verification ground truth (re-derived in worktree)
+
+Citations below were re-grepped from the worktree on 2026-04-26 against
+HEAD `e66ce6013` (post-#1033). Line numbers are accurate as of the worktree
+snapshot; treat them as anchors to be re-confirmed during implementation
+because reformatting can shift them by a line or two.
+
+### Server side (already-extant seams)
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:167-196`
+  — J2CL root shell GET path, calls
+  `J2clSelectedWaveSnapshotRenderer#renderRequestedWave(wave, viewer)` and
+  passes the result to `HtmlRenderer.renderJ2clRootShellPage(...)`.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java:163-243`
+  — viewer + wave-id resolution, render-budget guard, payload-cap guard,
+  result modes (`SNAPSHOT`, `NO_WAVE`, `SIGNED_OUT`, `DENIED`,
+  `RENDER_ERROR`, `BUDGET_EXCEEDED`, `PAYLOAD_EXCEEDED`).
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java:113-233`
+  — `renderWaveContent(...)` builds the entire conversation HTML (no
+  viewport bound today). This is the primary place to wire the
+  initial-window clamp.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java:142,200`
+  — emits `data-blip-id` on `<div class="blip">` and `data-thread-id` on
+  `<div class="thread">`. The DOM-as-view contract for R-3.6 already exists
+  in markup; the J2CL renderer reads exactly these attributes.
+- `wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java:222-375`
+  — server clamp + viewport hint honouring on `Open` wavelet path; emits
+  the `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` warning when a hint arrives but
+  the server falls back to a whole-snapshot payload.
+- `wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/FragmentsMetrics.java:58-65`
+  — server-side counters already exist:
+  `j2clViewportInitialWindows`, `j2clViewportClampApplied`,
+  `j2clViewportExtensionRequests`, `j2clViewportExtensionOk`,
+  `j2clViewportExtensionErrors`, `j2clViewportSnapshotFallbacks`.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java:179-241`
+  — `/fragments?…&client=j2cl` is the J2CL extension fetch path; clamp +
+  J2CL counters are already wired.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3473-3585`
+  — `appendRootShellWorkflowMarkup` and `appendRootShellSelectedWaveCard`
+  emit the server-first card with `data-j2cl-server-first-selected-wave`,
+  `data-j2cl-server-first-mode`, and `data-j2cl-upgrade-placeholder`. The
+  snapshot HTML is appended into `.sidecar-selected-content`.
+
+### J2CL/Lit client side (already-extant seams)
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarOpenRequest.java:18-30`
+  + `SidecarViewportHints.java:14-26` — viewport-hint payload type already
+  encoded into `ProtocolOpenRequest` field 5/6/7 by
+  `SidecarTransportCodec.encodeOpenEnvelope` (T = field tag 5: anchor
+  blip id, 6: direction, 7: limit).
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java:64-135`
+  — `openSelectedWave` builds the open frame including viewport hints.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:383-529`
+  — `openSelectedWave` calls `resolveInitialViewportHints()` and an
+  `onViewportEdge` debouncer drives `gateway.fetchFragments(...)` extension.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:192-269`
+  — `setViewportEdgeHandler` wires `J2clReadSurfaceDomRenderer` scroll edges
+  to the controller; `initialViewportHints` returns either a server-first
+  blip anchor or `SidecarViewportHints.defaultLimit()`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java:454-683`
+  — placeholder rendering, edge detection (forward / backward), scroll-anchor
+  preservation, `requestReachablePlaceholderAfterRender()`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clServerFirstRootShellDom.java:6-61`
+  — selectors that locate the server-first card inside the J2CL shell.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/telemetry/J2clClientTelemetry.java:36-126`
+  — `browserStatsSink()` posts every J2CL telemetry event into the same
+  `window.__stats` channel the GWT panels already consume.
+
+### Gaps (the actual delivery surface for this lane)
+
+1. **R-6.1 — server-rendered visible-window first paint**:
+   `J2clSelectedWaveSnapshotRenderer.renderRequestedWave` calls
+   `WaveContentRenderer.renderWaveContent(waveView, viewer, …)` which
+   currently renders the *entire* conversation tree. There is no
+   `initialWindowSize` parameter, no clamp, and no telemetry emission for
+   the initial-window event. The server therefore sometimes hits the
+   payload-cap and silently degrades to no-wave (BUDGET_EXCEEDED /
+   PAYLOAD_EXCEEDED).
+2. **R-3.6 — DOM-as-view provider against the fragmented DOM**:
+   `J2clReadSurfaceDomRenderer.enhanceExistingSurface()` resolves blips by
+   `[data-blip-id]` but does not assert it can locate a *fragment-bounded*
+   subset. We have to demonstrate the provider continues to resolve the
+   same set of semantic queries (blip enumeration, focus first blip,
+   inline-thread enumeration) when the rendered DOM contains only the
+   visible window plus terminal placeholders.
+3. **R-4.6 / R-7.1 — viewport hint visible on first socket open in
+   production**: today `J2clSelectedWaveView#initialViewportHints` returns
+   `SidecarViewportHints.defaultLimit()` only when there is no preserved
+   server snapshot. In the no-server-first case (no wave id in the URL on
+   first paint, then user clicks a digest) the hint *is* sent. But the
+   wire shape is currently invisible to telemetry — there is no client
+   counter that proves "I sent a viewport hint with limit N at time T."
+4. **R-7.2 / R-7.3 — extension on scroll with server-clamp visibility**:
+   the J2CL controller already coalesces edge fetches, but there is no
+   client-side telemetry event for the extension fetch and no telemetry
+   event when the server clamps the requested limit. The audit explicitly
+   calls these out as required: `viewport.initial_window`,
+   `viewport.extension_fetch`, `viewport.clamp_applied`,
+   `viewport.fallback_to_whole_wave`.
+5. **R-7.4 — no-fallback assertion**: the `j2clViewportSnapshotFallbacks`
+   server counter exists, but no test pins a fixture wave to assert the
+   counter stays at zero through a representative open. We need both a
+   server unit test (Jakarta) and a J2CL test that asserts the client emits
+   `viewport.fallback_to_whole_wave` only on the explicit fallback path.
+6. **R-6.3 — shell-swap upgrade path**: `J2clSelectedWaveView` already
+   emits `j2cl.root_shell` `shell_swap` events when it swaps the
+   server-first card, but only on `live-update` reasons. We need to
+   confirm the swap event also fires on the initial enhance step (the
+   transition from static HTML to the live Lit/J2CL surface) and keep the
+   focus invariant: the first-blip tabindex from server-rendered HTML is
+   the focus target after enhancement.
+
+## 3. Tasks
+
+Each task lists files to edit, expected diff, paired tests, the parity row
+it satisfies, and a verification command.
+
+### T1 — Server: viewport-bounded `WaveContentRenderer.renderWindow(...)`
+
+**Rows: R-3.5, R-6.1, R-7.1**
+
+Add a viewport-aware overload to `WaveContentRenderer`:
+
+```java
+public static String renderWaveContent(
+    WaveViewData waveView,
+    ParticipantId viewer,
+    int initialWindowSize)
+```
+
+Implementation outline:
+
+1. Walk the root thread of the conversation in `renderWaveContent`. After
+   `extractTitle` / `safeGetTags` / `countBlipsAndThreads`, build a list of
+   `ConversationBlip`s in document order (DFS through reply threads as
+   today, but track the visit order).
+2. If `initialWindowSize > 0` and `blips.size() > initialWindowSize`, only
+   render the first `initialWindowSize` blips through `ServerHtmlRenderer`.
+   Append a `<div class="visible-region-placeholder"
+   data-j2cl-server-placeholder="true" data-segment="placeholder-tail"
+   role="listitem" aria-busy="true">Additional blips will load on
+   scroll.</div>` after the rendered slice. Encoding the placeholder with
+   the same DOM marker the J2CL client already understands
+   (`J2clReadSurfaceDomRenderer.renderPlaceholder` uses
+   `data-j2cl-viewport-placeholder`; we mirror with a sibling marker so
+   `enhanceExistingSurface` can promote it).
+3. Set a `data-j2cl-initial-window-size` attribute on the wave-content
+   wrapper so the J2CL renderer can confirm the server window matches its
+   request.
+4. `J2clSelectedWaveSnapshotRenderer.renderRequestedWave` adopts a small
+   `INITIAL_WINDOW_SIZE` constant (set equal to the existing
+   `wave.fragments.defaultViewportLimit = 5` from `reference.conf:468`) and
+   threads it into `renderWaveContent`. Increment
+   `FragmentsMetrics.j2clViewportInitialWindows` once per snapshot
+   regardless of mode (the existing `WaveClientRpcImpl` increment handles
+   socket opens; the snapshot-renderer increment handles first-paint).
+
+Paired tests:
+
+- New `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/render/WaveContentRendererWindowTest.java`:
+  * Builds a fake `WaveViewData` with 12 blips, asserts that
+    `renderWaveContent(..., 5)` emits exactly five `data-blip-id` blocks
+    and one `visible-region-placeholder` element.
+  * Asserts `initialWindowSize=0` preserves whole-wave behavior (back-compat
+    for `WavePreRenderer`).
+- New `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRendererWindowTest.java`:
+  * With a 12-blip wave, asserts the rendered HTML carries
+    `data-j2cl-initial-window-size="5"` and contains exactly one
+    placeholder marker.
+  * Asserts the `j2clViewportInitialWindows` counter advances by 1 on the
+    snapshot path (using `FragmentsMetrics.setEnabled(true)` in the test).
+
+### T2 — Server: HTML-renderer keyboard contract for the visible window
+
+**Rows: R-6.1 (keyboard navigability), R-3.6, R-6.3 (swap focus invariant)**
+
+`ServerHtmlRenderer` currently emits `data-blip-id` but no `tabindex`,
+`role`, or `aria-label`. The R-6.1 contract requires the server HTML alone
+to be readable and keyboard-focusable before client boot. Without `tabindex`
+the server HTML is technically AT-readable but not tab-reachable, and
+`J2clReadSurfaceDomRenderer.enhanceSurface` then has to choose the focus
+target after upgrade — exactly the focus-theft path R-6.3 forbids.
+
+Changes:
+
+1. Modify `ServerHtmlRenderer.openBlip(...)` (search for the existing
+   `data-blip-id=` emission near line 142): add `tabindex="-1"` on every
+   blip and `role="article"` for inline-thread blips, `role="listitem"` for
+   root-thread blips. Add `tabindex="0"` *only* on the first root-thread
+   blip rendered. This matches the J2CL renderer's `enhanceBlips` choice
+   and means the upgrade does not have to reassign tabindex.
+2. Modify `ServerHtmlRenderer.startThread(...)` (existing `data-thread-id=`
+   emission near line 200): add `role="list"` for the root thread and
+   `role="group"` for inline threads, plus `aria-label` for the inline
+   thread (mirroring `enhanceInlineThread`).
+3. Wrap the rendered conversation in a `<section
+   data-j2cl-server-first-surface="true" aria-label="Selected wave read
+   surface">` so `J2clReadSurfaceDomRenderer.enhanceExistingSurface` knows
+   the surface is already enhanced and skips the "no inline reply
+   thread" promotion paths that would otherwise mutate focus.
+
+Paired tests:
+
+- Extend the new `WaveContentRendererWindowTest` from T1 to assert:
+  * Exactly one element has `tabindex="0"` and it is the first rendered
+    blip.
+  * Every other blip has `tabindex="-1"`.
+  * Root thread carries `role="list"`; inline-thread blocks carry
+    `role="group"` and a non-empty `aria-label`.
+  * The wave content wrapper sets
+    `data-j2cl-server-first-surface="true"`.
+- Add J2CL test
+  `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomEnhanceWindowTest.java`:
+  * Mounts a fixture HTML string from T1's expected output (5 blips +
+    placeholder) and calls `enhanceExistingSurface()`. Asserts:
+    - Initially-focused blip is the same element the server marked
+      `tabindex="0"`.
+    - The placeholder element retains its `data-j2cl-viewport-placeholder`
+      semantics so the existing `requestReachablePlaceholderAfterRender`
+      path triggers an extension fetch on near-edge scroll.
+
+### T3 — J2CL: client-side viewport telemetry events
+
+**Rows: R-4.6, R-7.1, R-7.3, R-7.4**
+
+Wire the four counters required by the issue contract into the existing
+`J2clClientTelemetry.browserStatsSink()` channel. They are emitted at
+points the controller already runs through:
+
+1. `viewport.initial_window` — emitted in
+   `J2clSelectedWaveController.openSelectedWave` after
+   `resolveInitialViewportHints()` returns and the open frame is built.
+   Fields: `direction`, `limit` (string-encoded; never the wave id).
+2. `viewport.extension_fetch` — emitted in
+   `J2clSelectedWaveController.onViewportEdge` right before the
+   `gateway.fetchFragments(...)` call. Field: `direction`. Also emit
+   `viewport.extension_fetch.outcome` on success/error in the response
+   handler with field `outcome=ok|error|stale`.
+3. `viewport.clamp_applied` — emitted on the success handler when the
+   merged viewport state's blip count is *less* than the requested
+   `FRAGMENT_GROWTH_LIMIT`. The server clamp policy is observable to the
+   client from the response shape: requested limit minus actual loaded
+   blip count yields the clamp delta.
+4. `viewport.fallback_to_whole_wave` — emitted in
+   `J2clSelectedWaveController.openSelectedWave`'s update handler when the
+   first non-establishment update carries no viewport-shaped fragments
+   (i.e. the server returned a snapshot despite the hint, mirroring the
+   server-side `J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK` log). Field:
+   `reason=server-snapshot`.
+
+Implementation seam:
+
+- Add `private void emitViewport(String name, ...)` next to the existing
+  `emitMetadataFailed` (which is already a parallel pattern in the same
+  file).
+- Reuse `J2clClientTelemetry.event(name).field(...).build()`. The
+  telemetry helper rejects sensitive field names (waveid, address,
+  attachmentid) so we only emit numeric/categorical fields.
+
+Paired tests:
+
+- Extend
+  `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java`:
+  * `viewportTelemetryEventsEmittedOnOpen` — installs a recording sink,
+    selects a wave, asserts a single `viewport.initial_window` event with
+    the expected `direction=forward` and a non-empty `limit`.
+  * `viewportTelemetryEventsEmittedOnExtension` — drives an `onViewportEdge`
+    plus a successful response, asserts `viewport.extension_fetch` and
+    `viewport.extension_fetch.outcome=ok` events were recorded in order.
+  * `viewportClampAppliedTelemetry` — drives an extension whose response
+    contains fewer blips than requested, asserts
+    `viewport.clamp_applied` with `delta=2`.
+  * `viewportFallbackToWholeWaveTelemetry` — drives the no-fragments path
+    (server returned snapshot but no fragment payload) and asserts
+    `viewport.fallback_to_whole_wave` is emitted exactly once.
+- Add a `RecordingTelemetrySink` reuse line if the existing test sink is
+  not already imported.
+
+### T4 — J2CL: shell-swap upgrade preserves first-blip focus
+
+**Rows: R-6.3, R-3.6**
+
+`J2clSelectedWaveView` already records a `shell_swap` event on
+`live-update` reason. After T2 the server emits `tabindex="0"` on the
+first blip; the upgrade path needs to commit to *not stealing focus*.
+
+Changes:
+
+1. In `J2clReadSurfaceDomRenderer.enhanceExistingSurface()` (line 229):
+   when the existing surface carries `data-j2cl-server-first-surface="true"`,
+   record the currently-focused element on the document. After
+   `enhanceSurface(surface)` runs, if `document.activeElement` was changed
+   to something else by the enhancement, restore it. Today
+   `restoreFocusedBlip` runs but it can pick the first focusable blip
+   when no prior focus existed — which is fine pre-boot but causes a
+   focus jump if the user had hovered the search input before boot
+   completes.
+2. In `J2clSelectedWaveView.handleSelectedWaveModelRender` (the existing
+   path that calls `emitRootShellSwap`) — guarantee `emitRootShellSwap`
+   fires on the *first* live-update transition out of server-first mode,
+   and on the *cold* live-update mount when no server-first card was
+   present (currently only the `live-update` reason fires; we want a
+   single explicit event whose `reason` field disambiguates: `cold-mount`
+   when no server snapshot was present, `live-update` when one was).
+
+Paired tests:
+
+- Extend
+  `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewTelemetryTest.java`
+  with:
+  * `shellSwapEmitsColdMountReasonWhenNoServerFirstCardPresent` — asserts
+    a `shell_swap` event with `reason=cold-mount` on first render when
+    `J2clServerFirstRootShellDom.findSelectedWaveCard(host)` returns
+    null.
+  * `shellSwapPreservesFocusedSearchInput` — sets focus to a sibling
+    element before render, asserts after the swap that
+    `document.activeElement` is unchanged and the
+    `shell_swap.focus_preserved` flag is `true`.
+
+### T5 — Fixture: side-by-side viewport assertion
+
+**Rows: All claimed rows; demonstrates the hard acceptance.**
+
+The issue contract calls for a fixture that mounts the J2CL root on a
+representative large wave and asserts:
+(a) initial DOM contains only the visible-window blip count,
+(b) scroll triggers extension,
+(c) extension applies without scroll-anchor loss,
+(d) total payload over the wire stays well below the whole-wave payload
+    size, and
+(e) reciprocal smoke confirming `?view=gwt` is unchanged.
+
+We split this into two layers:
+
+1. **JVM/Jakarta layer**
+   (`wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java`):
+   * Builds a fixture wave with 12 blips via the existing test helpers
+     (`WaveServerMock` if available, else direct `ObservableWaveletData`
+     stubs as in `WavePreRendererTest`).
+   * Calls `J2clSelectedWaveSnapshotRenderer.renderRequestedWave(waveId,
+     viewer)` and asserts:
+     - Exactly 5 `data-blip-id` blocks plus one
+       `visible-region-placeholder` element in the rendered HTML.
+     - The HTML payload size is ≤ 75 % of the whole-wave HTML size
+       produced by `renderWaveContent(view, viewer)` (no window).
+     - `j2clViewportInitialWindows` advanced by 1.
+     - `j2clViewportSnapshotFallbacks` did not advance.
+
+2. **J2CL DOM layer**
+   (`j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clViewportExtensionDomFixtureTest.java`):
+   * Mounts the same expected HTML output (5 blips + placeholder) into a
+     `<div>` host, attaches a `J2clReadSurfaceDomRenderer`, calls
+     `enhanceExistingSurface`, and asserts:
+     - 5 `[data-j2cl-read-blip='true']` items + 1 placeholder.
+     - First blip carries `tabindex="0"`.
+     - Faking a near-bottom scroll triggers a single
+       `viewportEdgeListener.onViewportEdge(anchor, "forward")` call.
+     - After applying a fake fragment response with 5 more blips, the
+       rendered list grows to 10 + 0 placeholders and the scroll anchor
+       (the first rendered blip's bounding box top) is preserved within
+       1 px.
+
+The fixture is *not* a browser harness (those run separately in `j2clLitTest`);
+it asserts the data-shape contract through the same DOM API the live shell
+uses. This is the same pattern already used by
+`J2clReadSurfaceDomRendererTest` (existing), so the test infrastructure is
+in place.
+
+The reciprocal `?view=gwt` smoke is satisfied by the existing
+`WaveClientServletTest` and `WaveClientServletJ2clRootShellTest` matrix:
+T1's edits do not touch the GWT-side response. We add an explicit assert
+in `WaveClientServletTest` (or a new test class) confirming the GWT path
+does not include `data-j2cl-server-first-surface` markers — i.e. T1 leaves
+the legacy GWT skeleton response byte-for-byte unchanged.
+
+## 4. Verification discipline
+
+Per task, before moving on:
+
+```
+sbt -batch \
+  "jakartaTest:testOnly *WaveContentRendererWindowTest *J2clSelectedWaveSnapshotRendererWindowTest *J2clViewportFirstPaintParityTest" \
+  j2clSearchTest j2clLitTest
+```
+
+After all tasks land, run the full SBT bundle from the issue contract:
+
+```
+sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild
+```
+
+Plus targeted Jakarta tests for any new server-side test classes:
+
+```
+sbt -batch "jakartaTest:testOnly *WaveContentRendererWindowTest *J2clSelectedWaveSnapshotRendererWindowTest *J2clViewportFirstPaintParityTest"
+```
+
+And confirm `git diff --check` is clean.
+
+Telemetry validation via the worktree-local boot is recorded only as the
+final check (the test layers above are the contract-binding evidence):
+
+```
+bash scripts/worktree-boot.sh --port <free>
+# In a browser, visit /?view=j2cl-root&wave=<wave-id-with-12-blips>
+# Inspect window.__stats[] for events whose evtGroup ∈
+#   {viewport.initial_window, viewport.extension_fetch,
+#    viewport.clamp_applied, viewport.fallback_to_whole_wave}
+# Then visit /?view=gwt&wave=<same-wave> and confirm unchanged.
+```
+
+## 5. Out-of-scope respect (audit alignment)
+
+- **Per-blip rendering shape** (avatar, author, timestamp, threading per
+  blip): F-2 (#1037). This plan does not change the per-blip HTML beyond
+  adding `tabindex` and `role` attributes already required by R-6.1.
+- **Compose / write surface**: F-3 (#1038). No compose-side changes.
+- **Live read/unread per blip**: F-4 (#1039). The existing
+  `currentReadState` plumbing in `J2clSelectedWaveController` is left
+  untouched.
+- **Design polish beyond the F-0 placeholder recipe**: F-0 (#1035). The
+  placeholder uses the existing `visible-region-placeholder` class so F-0
+  can restyle without touching this lane.
+- **Plugin slot implementations**: this lane reserves the slot points
+  (existing markers) but does not register plugins.
+
+## 6. Risk and rollback
+
+The change is additive on the server side (`renderWaveContent` gains an
+overload, callers opt in) and the J2CL telemetry events are best-effort
+(wrapped in try/catch). The legacy GWT path (`WaveClientServlet`'s
+non-J2CL-root branch) is not touched — the prerendering call site
+`HtmlRenderer.renderWaveClientPage(..., null)` is unchanged. Rollback is
+to revert the four T1–T4 commits; T5 is fixture-only.
+
+Feature-flag gating: the server-side initial-window size is hard-coded to
+the existing `wave.fragments.defaultViewportLimit` so an operator can lift
+the window via config without a code change. No new flag is introduced
+because the issue explicitly forbids "practical parity / partial
+delivery" gates.
+
+## 7. Self-review
+
+This section is the gate for moving from plan to implementation.
+
+**Spec coverage.** Every claimed row maps to at least one concrete change
+plus a paired test:
+- R-3.5 ← T1 (window) + T5 (fixture)
+- R-3.6 ← T2 (server attributes) + T2 (J2CL enhance test)
+- R-4.6 ← T3 (initial-window telemetry) + T3 (extension telemetry)
+- R-6.1 ← T1 (server-rendered window) + T2 (keyboard navigability)
+- R-6.3 ← T4 (focus-preserving swap) + T4 (cold-mount swap event)
+- R-7.1 ← T1 + T3 (initial-window event)
+- R-7.2 ← T3 (extension fetch event) + T5 (DOM-fixture extension assert)
+- R-7.3 ← T3 (clamp telemetry) — server clamp itself unchanged; client now
+  observes it
+- R-7.4 ← T3 (fallback telemetry stays at zero) + T5 (counter assertion)
+
+**Type / import consistency.** `WaveContentRenderer.renderWaveContent`
+already takes `WaveViewData, ParticipantId, RenderBudget`; the new overload
+adds an `int` and delegates to a private worker — no cross-package
+type changes. `J2clClientTelemetry.event(...).field(...).build()` is the
+existing builder; rejected-field guard already covers the field names we
+will not be using (waveid, address, etc.).
+
+**Verification discipline.** Each task ends with a focused
+`jakartaTest:testOnly` or `j2clSearchTest` invocation before moving on,
+and the full SBT bundle from the issue contract runs at the end.
+
+**Rollback safety.** The legacy GWT skeleton response
+(`WaveClientServlet.doGet` non-J2CL branch, lines 211-249) is unchanged
+because `renderWaveClientPage(..., null)` is the third-arg-`null` call.
+The new `WaveContentRenderer` overload is purely additive; the existing
+single-arg overload still renders the whole wave for `WavePreRenderer`'s
+GWT-bound use.
+
+**Out-of-scope respect.** None of the five tasks touch per-blip rendering
+shape (no avatar/author/timestamp), compose surface, live read/unread, or
+design tokens beyond the existing placeholder class. The parity-matrix
+rows owned by F-2/F-3/F-4 are explicitly *not* claimed.
+
+**No "practical parity" escape hatch.** Each row's acceptance is
+demonstrated by a paired test, and the fixture (T5) re-confirms the
+end-to-end shape against both `?view=j2cl-root` and `?view=gwt`. The
+demonstrability of every row is exactly the thing the audit said the
+closed slices skipped, so this plan refuses to ship without it.
+
+**Open question I cannot resolve in plan time.** The audit notes
+`enableDynamicRendering = false` is the production default
+(`reference.conf:435`). T1 emits the placeholder marker regardless, but
+the J2CL client only walks the placeholder when the renderer is in window
+mode (`renderWindow`, not `render`). I am explicitly *not* flipping
+`enableDynamicRendering` in this lane; that is a config-time decision
+documented in `docs/fragments-config.md` and outside the F-1 surface. If
+the demo wave does not visibly extend on scroll because dynamic rendering
+is off in the worktree-local config, the fix is to either set
+`enableDynamicRendering=true` for the parity demo or update
+`reference.conf` in a follow-up PR — not to expand F-1's scope.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -385,13 +385,16 @@ public final class J2clSelectedWaveController
       return;
     }
     final boolean[] terminalStateHandled = new boolean[] {false};
+    final boolean[] viewportFallbackEmitted = new boolean[] {false};
     // Mutable so successful updates reset the budget, keeping MAX_RECONNECT_ATTEMPTS per outage.
     final int[] activeReconnectCount = {reconnectCount};
+    SidecarViewportHints initialHints = resolveInitialViewportHints();
+    emitViewportInitialWindow(initialHints);
     currentSubscription =
         gateway.openSelectedWave(
             currentBootstrap,
             selectedWaveId,
-            resolveInitialViewportHints(),
+            initialHints,
             update -> {
               if (!isCurrentGeneration(generation) || isChannelEstablishmentUpdate(update)) {
                 return;
@@ -407,6 +410,20 @@ public final class J2clSelectedWaveController
                       projectedReconnectCount,
                       currentReadState,
                       readStateStale);
+              if (!viewportFallbackEmitted[0]
+                  && initialHints != null
+                  && initialHints.hasHints()
+                  && isWholeWaveFallbackUpdate(update)) {
+                // R-7.4: the server returned a snapshot despite the viewport
+                // hint we sent on Open. Surface the fallback exactly once per
+                // open so operators can tell the audit-required counter from a
+                // healthy viewport bootstrap.
+                viewportFallbackEmitted[0] = true;
+                emit(
+                    J2clClientTelemetry.event("viewport.fallback_to_whole_wave")
+                        .field("reason", "server-snapshot")
+                        .build());
+              }
               view.render(currentModel);
               publishWriteSession();
               requestAttachmentMetadataForCurrentViewport(generation);
@@ -483,6 +500,12 @@ public final class J2clSelectedWaveController
     boolean hadWriteSession = writeSession != null;
     long baseVersion = writeSession == null ? -1L : writeSession.getBaseVersion();
     String historyHash = writeSession == null ? "" : nullToEmpty(writeSession.getHistoryHash());
+    int loadedBlipsBefore = currentModel.getViewportState().getLoadedReadBlips().size();
+    emit(
+        J2clClientTelemetry.event("viewport.extension_fetch")
+            .field("direction", normalizedDirection)
+            .field("limit", Integer.toString(FRAGMENT_GROWTH_LIMIT))
+            .build());
     gateway.fetchFragments(
         waveId,
         anchor,
@@ -495,6 +518,7 @@ public final class J2clSelectedWaveController
             return;
           }
           if (isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash)) {
+            emitExtensionOutcome(normalizedDirection, "stale");
             fragmentFetchesInFlight.remove(edgeKey);
             return;
           }
@@ -508,6 +532,20 @@ public final class J2clSelectedWaveController
           if (FRAGMENT_GROWTH_FAILURE_STATUS.equals(currentModel.getStatusText())) {
             currentModel = currentModel.withStatus(FRAGMENT_GROWTH_RECOVERED_STATUS, "");
           }
+          int loadedBlipsAfter = currentModel.getViewportState().getLoadedReadBlips().size();
+          int delta = Math.max(0, loadedBlipsAfter - loadedBlipsBefore);
+          if (delta < FRAGMENT_GROWTH_LIMIT) {
+            // R-7.3: the server clamped the requested limit. Surface the
+            // shortfall so the audit-required `viewport.clamp_applied`
+            // counter advances proportionally to the clamp magnitude.
+            emit(
+                J2clClientTelemetry.event("viewport.clamp_applied")
+                    .field("direction", normalizedDirection)
+                    .field("requested", Integer.toString(FRAGMENT_GROWTH_LIMIT))
+                    .field("delivered", Integer.toString(delta))
+                    .build());
+          }
+          emitExtensionOutcome(normalizedDirection, "ok");
           view.render(currentModel);
           publishWriteSession();
           requestAttachmentMetadataForCurrentViewport(generation);
@@ -522,6 +560,7 @@ public final class J2clSelectedWaveController
               currentModel.withStatus(
                   FRAGMENT_GROWTH_FAILURE_STATUS,
                   error == null ? "" : error);
+          emitExtensionOutcome(normalizedDirection, "error");
           view.render(currentModel);
           publishWriteSession();
           fragmentFetchesInFlight.remove(edgeKey);
@@ -594,6 +633,39 @@ public final class J2clSelectedWaveController
     // before any real wavelet data is streamed. Those synthetic frames target ~/dummy+root and
     // must not overwrite the selected-wave panel or they would flash a fake wavelet into view.
     return waveletName != null && waveletName.endsWith("/~/dummy+root");
+  }
+
+  /**
+   * Returns true when the update represents a server-side fallback to a
+   * whole-wave snapshot: the J2CL client requested a viewport hint on Open
+   * but the response carries no viewport-shaped fragments and at least one
+   * conversation document. The {@code j2clViewportSnapshotFallbacks} server
+   * counter increments under the same condition; this client-side mirror
+   * surfaces the same signal in {@code window.__stats}.
+   */
+  static boolean isWholeWaveFallbackUpdate(SidecarSelectedWaveUpdate update) {
+    if (update == null) {
+      return false;
+    }
+    if (update.getDocuments() == null || update.getDocuments().isEmpty()) {
+      return false;
+    }
+    org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments fragments =
+        update.getFragments();
+    if (fragments == null) {
+      return true;
+    }
+    // A fragments payload that carries only manifest/index ranges (no blip
+    // ranges) is the "metadata-only" shape and indistinguishable from a
+    // snapshot fallback for the read surface.
+    for (org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragmentRange range :
+        fragments.getRanges()) {
+      String segment = range == null ? null : range.getSegment();
+      if (segment != null && segment.startsWith("blip:")) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private void closeSubscription() {
@@ -740,6 +812,39 @@ public final class J2clSelectedWaveController
     } catch (Throwable ignored) {
       // Telemetry is best-effort and must not alter selected-wave rendering.
     }
+  }
+
+  private void emitViewportInitialWindow(SidecarViewportHints hints) {
+    if (hints == null || !hints.hasHints()) {
+      return;
+    }
+    String direction = hints.getDirection();
+    if (direction == null || direction.isEmpty()) {
+      direction = J2clViewportGrowthDirection.FORWARD;
+    }
+    String limit;
+    if (hints.getLimit() == null) {
+      limit = "default";
+    } else if (hints.getLimit().intValue() <= 0) {
+      // Explicit zero is the "server default limit" sentinel
+      // (see SidecarViewportHints.defaultLimit()).
+      limit = "default";
+    } else {
+      limit = Integer.toString(hints.getLimit().intValue());
+    }
+    emit(
+        J2clClientTelemetry.event("viewport.initial_window")
+            .field("direction", direction)
+            .field("limit", limit)
+            .build());
+  }
+
+  private void emitExtensionOutcome(String direction, String outcome) {
+    emit(
+        J2clClientTelemetry.event("viewport.extension_fetch.outcome")
+            .field("direction", direction)
+            .field("outcome", outcome)
+            .build());
   }
 
   private static String metadataFailureReason(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -506,7 +506,6 @@ public final class J2clSelectedWaveController
     boolean hadWriteSession = writeSession != null;
     long baseVersion = writeSession == null ? -1L : writeSession.getBaseVersion();
     String historyHash = writeSession == null ? "" : nullToEmpty(writeSession.getHistoryHash());
-    int loadedBlipsBefore = currentModel.getViewportState().getLoadedReadBlips().size();
     emit(
         J2clClientTelemetry.event("viewport.extension_fetch")
             .field("direction", normalizedDirection)
@@ -528,28 +527,29 @@ public final class J2clSelectedWaveController
             fragmentFetchesInFlight.remove(edgeKey);
             return;
           }
+          // Capture the pre-merge state inside the callback so that any live-stream
+          // updates that arrived between dispatch and response do not inflate the delta.
+          J2clSelectedWaveViewportState preState = currentModel.getViewportState();
+          int loadedBlipsBeforeMerge = preState.getLoadedReadBlips().size();
           J2clSelectedWaveViewportState mergedState =
-              currentModel
-                  .getViewportState()
-                  .mergeFragments(response.getFragments(), normalizedDirection);
+              preState.mergeFragments(response.getFragments(), normalizedDirection);
           currentModel = currentModel.withViewportState(mergedState);
-          // Only clear the soft fragment-growth banner owned by this controller.
-          // Live-update statuses are left intact because they represent fresher stream state.
-          if (FRAGMENT_GROWTH_FAILURE_STATUS.equals(currentModel.getStatusText())) {
-            currentModel = currentModel.withStatus(FRAGMENT_GROWTH_RECOVERED_STATUS, "");
-          }
-          int loadedBlipsAfter = currentModel.getViewportState().getLoadedReadBlips().size();
-          int delta = Math.max(0, loadedBlipsAfter - loadedBlipsBefore);
+          int loadedBlipsAfter = mergedState.getLoadedReadBlips().size();
+          int delta = Math.max(0, loadedBlipsAfter - loadedBlipsBeforeMerge);
           if (delta < FRAGMENT_GROWTH_LIMIT) {
-            // R-7.3: the server clamped the requested limit. Surface the
-            // shortfall so the audit-required `viewport.clamp_applied`
-            // counter advances proportionally to the clamp magnitude.
+            // R-7.3: the server clamped the requested limit. Surface the shortfall so the
+            // audit-required `viewport.clamp_applied` counter advances proportionally.
             emit(
                 J2clClientTelemetry.event("viewport.clamp_applied")
                     .field("direction", normalizedDirection)
                     .field("requested", Integer.toString(FRAGMENT_GROWTH_LIMIT))
                     .field("delivered", Integer.toString(delta))
                     .build());
+          }
+          // Only clear the soft fragment-growth banner owned by this controller.
+          // Live-update statuses are left intact because they represent fresher stream state.
+          if (FRAGMENT_GROWTH_FAILURE_STATUS.equals(currentModel.getStatusText())) {
+            currentModel = currentModel.withStatus(FRAGMENT_GROWTH_RECOVERED_STATUS, "");
           }
           emitExtensionOutcome(normalizedDirection, "ok");
           view.render(currentModel);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -385,7 +385,12 @@ public final class J2clSelectedWaveController
       return;
     }
     final boolean[] terminalStateHandled = new boolean[] {false};
-    final boolean[] viewportFallbackEmitted = new boolean[] {false};
+    // R-7.4: limit fallback observability to the very first non-establishment
+    // update for the open. A healthy viewport bootstrap is the first update
+    // that arrives after the channel handshake; subsequent metadata-only
+    // updates (participant changes, manifest-only deltas) can ship without
+    // blip ranges without that meaning the bootstrap fell back.
+    final boolean[] firstUpdateSeen = new boolean[] {false};
     // Mutable so successful updates reset the budget, keeping MAX_RECONNECT_ATTEMPTS per outage.
     final int[] activeReconnectCount = {reconnectCount};
     SidecarViewportHints initialHints = resolveInitialViewportHints();
@@ -400,6 +405,8 @@ public final class J2clSelectedWaveController
                 return;
               }
               int projectedReconnectCount = activeReconnectCount[0];
+              boolean isFirstUpdate = !firstUpdateSeen[0];
+              firstUpdateSeen[0] = true;
               lastUpdate = update;
               currentModel =
                   J2clSelectedWaveProjector.project(
@@ -410,15 +417,14 @@ public final class J2clSelectedWaveController
                       projectedReconnectCount,
                       currentReadState,
                       readStateStale);
-              if (!viewportFallbackEmitted[0]
+              if (isFirstUpdate
                   && initialHints != null
                   && initialHints.hasHints()
                   && isWholeWaveFallbackUpdate(update)) {
                 // R-7.4: the server returned a snapshot despite the viewport
                 // hint we sent on Open. Surface the fallback exactly once per
-                // open so operators can tell the audit-required counter from a
-                // healthy viewport bootstrap.
-                viewportFallbackEmitted[0] = true;
+                // open and only on the bootstrap update so dashboards do not
+                // confuse later metadata-only updates with a snapshot fallback.
                 emit(
                     J2clClientTelemetry.event("viewport.fallback_to_whole_wave")
                         .field("reason", "server-snapshot")

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -26,6 +26,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLElement emptyState;
   private boolean serverFirstActive;
   private boolean serverFirstSwapRecorded;
+  private boolean coldMountSwapRecorded;
   private String serverFirstWaveId;
   private String serverFirstMode;
   private double serverFirstMountedAtMs;
@@ -181,6 +182,20 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (serverFirstActive) {
       emitRootShellSwap("live-update");
       clearServerFirstMarkers();
+    } else if (!coldMountSwapRecorded
+        && model.hasSelection()
+        && hasRenderedReadSurface) {
+      // R-6.3: emit a `shell_swap` event with reason=cold-mount when the
+      // J2CL surface mounts content for the first time *without* a
+      // server-first card to swap from. Operators see the same signal
+      // shape on both server-first and cold-mount paths so dashboards do
+      // not need a special case for the missing-card scenario.
+      coldMountSwapRecorded = true;
+      Object statFn = Js.asPropertyMap(DomGlobal.window).get("__j2clRootShellStat");
+      if (statFn != null) {
+        RootShellStatFn rootShellStatFn = Js.uncheckedCast(statFn);
+        rootShellStatFn.accept("shell_swap", "cold-mount", 0, false);
+      }
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -183,6 +183,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       emitRootShellSwap("live-update");
       clearServerFirstMarkers();
     } else if (!coldMountSwapRecorded
+        && !serverFirstSwapRecorded
         && model.hasSelection()
         && hasRenderedReadSurface) {
       // R-6.3: emit a `shell_swap` event with reason=cold-mount when the
@@ -194,7 +195,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       Object statFn = Js.asPropertyMap(DomGlobal.window).get("__j2clRootShellStat");
       if (statFn != null) {
         RootShellStatFn rootShellStatFn = Js.uncheckedCast(statFn);
-        rootShellStatFn.accept("shell_swap", "cold-mount", 0, false);
+        rootShellStatFn.accept(
+            "shell_swap",
+            "cold-mount",
+            0,
+            model.getSelectedWaveId() != null && !model.getSelectedWaveId().isEmpty());
       }
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1130,6 +1130,179 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals("/attachments/new.png", harness.firstReadAttachment().getOpenUrl());
   }
 
+  // ---------------------------------------------------------------------------
+  // F-1 viewport telemetry contract (R-4.6, R-7.1, R-7.3, R-7.4)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void selectingWaveEmitsViewportInitialWindowEvent() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    J2clClientTelemetry.Event initial = lastEventNamed(telemetry, "viewport.initial_window");
+    Assert.assertEquals("forward", initial.getFields().get("direction"));
+    Assert.assertEquals("default", initial.getFields().get("limit"));
+  }
+
+  @Test
+  public void selectingWaveWithExplicitAnchorEmitsViewportInitialWindowEvent() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    harness.initialViewportHints = new SidecarViewportHints("b+server", "forward", null);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    J2clClientTelemetry.Event initial = lastEventNamed(telemetry, "viewport.initial_window");
+    Assert.assertEquals("forward", initial.getFields().get("direction"));
+    Assert.assertEquals("default", initial.getFields().get("limit"));
+  }
+
+  @Test
+  public void viewportEdgeFetchEmitsExtensionAndOutcomeEvents() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+
+    J2clClientTelemetry.Event extension = firstEventNamed(telemetry, "viewport.extension_fetch");
+    Assert.assertEquals("forward", extension.getFields().get("direction"));
+    Assert.assertEquals("5", extension.getFields().get("limit"));
+
+    J2clClientTelemetry.Event outcome =
+        lastEventNamed(telemetry, "viewport.extension_fetch.outcome");
+    Assert.assertEquals("forward", outcome.getFields().get("direction"));
+    Assert.assertEquals("ok", outcome.getFields().get("outcome"));
+  }
+
+  @Test
+  public void viewportEdgeFetchEmitsClampAppliedWhenServerReturnsFewerBlips() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    // The growth limit is 5 but the server returns only 2 blips — that's a
+    // clamp visible to the client (R-7.3).
+    harness.resolveFragmentFetch(0, fragmentsResponse("Next loaded", "Tail loaded"));
+
+    J2clClientTelemetry.Event clamp = lastEventNamed(telemetry, "viewport.clamp_applied");
+    Assert.assertEquals("forward", clamp.getFields().get("direction"));
+    Assert.assertEquals("5", clamp.getFields().get("requested"));
+    Assert.assertEquals("2", clamp.getFields().get("delivered"));
+  }
+
+  @Test
+  public void viewportEdgeFetchErrorEmitsErrorOutcome() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    harness.requestViewportEdge(controller, "b+next", "forward");
+    harness.rejectFragmentFetch(0, "transient");
+
+    J2clClientTelemetry.Event outcome =
+        lastEventNamed(telemetry, "viewport.extension_fetch.outcome");
+    Assert.assertEquals("forward", outcome.getFields().get("direction"));
+    Assert.assertEquals("error", outcome.getFields().get("outcome"));
+  }
+
+  @Test
+  public void snapshotOnlyUpdateEmitsViewportFallbackToWholeWaveExactlyOnce() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+
+    // First update is a snapshot fallback (no fragments payload).
+    harness.deliverRawUpdate(0, snapshotOnlyUpdate("Whole-wave content"));
+
+    long fallbackCount =
+        countEventsNamed(telemetry, "viewport.fallback_to_whole_wave");
+    Assert.assertEquals("Fallback emitted exactly once on first snapshot", 1, fallbackCount);
+    J2clClientTelemetry.Event fallback =
+        lastEventNamed(telemetry, "viewport.fallback_to_whole_wave");
+    Assert.assertEquals("server-snapshot", fallback.getFields().get("reason"));
+
+    // Subsequent snapshot-only update on the same open must not double-count.
+    harness.deliverRawUpdate(0, snapshotOnlyUpdate("Another snapshot"));
+    Assert.assertEquals(
+        "Fallback de-duplicated for the lifetime of the open",
+        1,
+        countEventsNamed(telemetry, "viewport.fallback_to_whole_wave"));
+  }
+
+  @Test
+  public void healthyViewportUpdateDoesNotEmitFallbackToWholeWave() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded"));
+
+    Assert.assertEquals(
+        "No fallback when the server honoured the viewport hint",
+        0,
+        countEventsNamed(telemetry, "viewport.fallback_to_whole_wave"));
+  }
+
+  private static J2clClientTelemetry.Event firstEventNamed(
+      RecordingTelemetrySink telemetry, String name) {
+    for (J2clClientTelemetry.Event event : telemetry.events()) {
+      if (name.equals(event.getName())) {
+        return event;
+      }
+    }
+    throw new AssertionError("No telemetry event named " + name + " recorded");
+  }
+
+  private static J2clClientTelemetry.Event lastEventNamed(
+      RecordingTelemetrySink telemetry, String name) {
+    J2clClientTelemetry.Event found = null;
+    for (J2clClientTelemetry.Event event : telemetry.events()) {
+      if (name.equals(event.getName())) {
+        found = event;
+      }
+    }
+    if (found == null) {
+      throw new AssertionError("No telemetry event named " + name + " recorded");
+    }
+    return found;
+  }
+
+  private static long countEventsNamed(RecordingTelemetrySink telemetry, String name) {
+    long count = 0;
+    for (J2clClientTelemetry.Event event : telemetry.events()) {
+      if (name.equals(event.getName())) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
     return new J2clSearchDigestItem(
         "example.com/w+1", title, snippet, "user@example.com", unreadCount, 2, 1234L, false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewTelemetryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewTelemetryTest.java
@@ -1,10 +1,14 @@
 package org.waveprotocol.box.j2cl.search;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
 import java.util.Arrays;
 import java.util.Collections;
+import jsinterop.annotations.JsFunction;
+import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -18,6 +22,7 @@ import org.waveprotocol.box.j2cl.telemetry.RecordingTelemetrySink;
 @J2clTestInput(J2clSelectedWaveViewTelemetryTest.class)
 public class J2clSelectedWaveViewTelemetryTest {
   private HTMLElement currentHost;
+  private Object previousRootShellStat;
 
   @After
   public void tearDown() {
@@ -25,6 +30,16 @@ public class J2clSelectedWaveViewTelemetryTest {
       currentHost.parentElement.removeChild(currentHost);
     }
     currentHost = null;
+    if (DomGlobal.window != null) {
+      JsPropertyMap<Object> window = Js.asPropertyMap(DomGlobal.window);
+      if (previousRootShellStat == null) {
+        window.delete("__j2clRootShellStat");
+      } else {
+        window.set("__j2clRootShellStat", previousRootShellStat);
+      }
+      window.delete("__j2clRootShellStatCalls");
+    }
+    previousRootShellStat = null;
   }
 
   @Test
@@ -85,6 +100,135 @@ public class J2clSelectedWaveViewTelemetryTest {
     currentHost = (HTMLElement) DomGlobal.document.createElement("div");
     DomGlobal.document.body.appendChild(currentHost);
     return currentHost;
+  }
+
+  /**
+   * Installs a recording stub for {@code window.__j2clRootShellStat} (the
+   * GWT-style stat callback the J2CL view uses for shell-swap events). The
+   * captured calls are pushed into {@code window.__j2clRootShellStatCalls},
+   * a {@link JsArray} that tests can read directly.
+   */
+  private void installRootShellStatRecorder() {
+    if (DomGlobal.window == null) {
+      return;
+    }
+    JsPropertyMap<Object> window = Js.asPropertyMap(DomGlobal.window);
+    previousRootShellStat = window.get("__j2clRootShellStat");
+    JsArray<Object> calls = JsArray.of();
+    window.set("__j2clRootShellStatCalls", calls);
+    RootShellStatFn fn =
+        (subtype, reason, durationMs, waveIdPresent) -> {
+          JsPropertyMap<Object> entry = JsPropertyMap.of();
+          entry.set("subtype", subtype);
+          entry.set("reason", reason);
+          entry.set("durationMs", Double.valueOf(durationMs));
+          entry.set("waveIdPresent", Boolean.valueOf(waveIdPresent));
+          calls.push(entry);
+        };
+    window.set("__j2clRootShellStat", fn);
+  }
+
+  private static int rootShellStatCallCount() {
+    if (DomGlobal.window == null) {
+      return 0;
+    }
+    Object calls = Js.asPropertyMap(DomGlobal.window).get("__j2clRootShellStatCalls");
+    if (calls == null) {
+      return 0;
+    }
+    JsArray<Object> array = Js.uncheckedCast(calls);
+    return array.length;
+  }
+
+  private static String rootShellStatReasonAt(int index) {
+    Object call = Js.uncheckedCast(
+        Js.<JsArray<Object>>uncheckedCast(
+                Js.asPropertyMap(DomGlobal.window).get("__j2clRootShellStatCalls"))
+            .getAt(index));
+    return String.valueOf(Js.asPropertyMap(call).get("reason"));
+  }
+
+  private static String rootShellStatSubtypeAt(int index) {
+    Object call = Js.uncheckedCast(
+        Js.<JsArray<Object>>uncheckedCast(
+                Js.asPropertyMap(DomGlobal.window).get("__j2clRootShellStatCalls"))
+            .getAt(index));
+    return String.valueOf(Js.asPropertyMap(call).get("subtype"));
+  }
+
+  // ---------------------------------------------------------------------------
+  // F-1 R-6.3: shell-swap upgrade path emits the cold-mount event when no
+  // server-first card is present.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void coldMountFiresShellSwapWithColdMountReasonWhenNoServerCardPresent() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    installRootShellStatRecorder();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedWaveModelWithBlips());
+
+    Assert.assertEquals(1, rootShellStatCallCount());
+    Assert.assertEquals("shell_swap", rootShellStatSubtypeAt(0));
+    Assert.assertEquals("cold-mount", rootShellStatReasonAt(0));
+  }
+
+  @Test
+  public void coldMountShellSwapIsRecordedExactlyOnce() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    installRootShellStatRecorder();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedWaveModelWithBlips());
+    view.render(selectedWaveModelWithBlips());
+    view.render(selectedWaveModelWithBlips());
+
+    Assert.assertEquals(
+        "Cold-mount swap is one-shot for the lifetime of the view",
+        1,
+        rootShellStatCallCount());
+  }
+
+  @Test
+  public void emptySelectionDoesNotFireColdMountSwap() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    installRootShellStatRecorder();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(J2clSelectedWaveModel.empty());
+
+    Assert.assertEquals(0, rootShellStatCallCount());
+  }
+
+  @JsFunction
+  private interface RootShellStatFn {
+    void accept(String subtype, String reason, double durationMs, boolean waveIdPresent);
+  }
+
+  private static J2clSelectedWaveModel selectedWaveModelWithBlips() {
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        "example.com/w+1",
+        "Selected wave",
+        "",
+        "",
+        "Opened.",
+        "",
+        0,
+        Collections.<String>emptyList(),
+        Collections.<String>emptyList(),
+        Arrays.asList(new J2clReadBlip("b+root", "Root text")),
+        null,
+        J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+        false,
+        false,
+        false);
   }
 
   private static J2clSelectedWaveModel selectedWaveModelWithAttachment() {

--- a/wave/config/changelog.d/2026-04-26-j2cl-viewport-first-paint.json
+++ b/wave/config/changelog.d/2026-04-26-j2cl-viewport-first-paint.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-04-26-j2cl-viewport-first-paint",
+  "version": "F-1 (#1036)",
+  "date": "2026-04-26",
+  "title": "Viewport-Scoped J2CL Read Surface",
+  "summary": "The J2CL root shell now delivers a viewport-clamped first paint of the selected wave and surfaces viewport telemetry counters so dashboards can see initial-window, extension, clamp, and snapshot-fallback events.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Server-rendered first paint of the J2CL root shell clamps to the configured viewport limit (default 5 root-thread blips) and appends a visible-region terminal placeholder for AT continuity.",
+        "Server HTML now declares per-blip role (listitem/article), per-thread role (list/group), and a single tabindex=0 on the first root-thread blip so the static HTML is keyboard-navigable before client boot.",
+        "J2CL client emits four new telemetry events on every selected-wave open: viewport.initial_window, viewport.extension_fetch (+ outcome), viewport.clamp_applied, viewport.fallback_to_whole_wave.",
+        "Cold-mount selected-wave surfaces now emit a shell_swap event with reason=cold-mount so dashboards see the J2CL surface mounting content for the first time, with or without a server-first card."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
@@ -125,9 +125,14 @@ public final class J2clViewportFirstPaintParityTest {
     assertTrue(
         "J2CL root response appends the visible-region terminal placeholder",
         html.contains("data-j2cl-server-placeholder=\"true\""));
-    assertTrue(
+    assertEquals(
         "J2CL root response keyboard-focuses exactly one blip",
-        countOccurrences(html, "tabindex=\"0\"") >= 1);
+        1,
+        countOccurrences(html, "tabindex=\"0\""));
+    assertEquals(
+        "J2CL root response marks the other inline blips unfocusable",
+        4,
+        countOccurrences(html, "tabindex=\"-1\""));
     assertEquals(
         "Snapshot path advances the J2CL viewport-initial-window counter",
         initialWindowsBefore + 1,
@@ -337,6 +342,7 @@ public final class J2clViewportFirstPaintParityTest {
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getParameter("view")).thenReturn(view);
+    when(request.getParameterValues("view")).thenReturn(new String[]{view});
     when(request.getParameter("wave")).thenReturn(waveId);
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getSession(false)).thenReturn(mock(HttpSession.class));

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
@@ -170,9 +170,12 @@ public final class J2clViewportFirstPaintParityTest {
 
   /**
    * Reciprocal R-6.4 / R-7.4: the legacy GWT skeleton response for the
-   * same wave must be byte-for-byte unchanged — none of the F-1
-   * server-first markers may leak into the legacy path so rollback stays
-   * safe.
+   * same wave must not leak any of the F-1 server-first markers (the
+   * server-first surface attribute, the initial-window size, the
+   * upgrade-placeholder), so rollback stays safe and operators can still
+   * route past J2CL via {@code ?view=gwt} without surprising the legacy
+   * client. The remainder of the legacy skeleton is shape-tested against
+   * its own (existing) test class; this assertion is the F-1 contract.
    */
   @Test
   public void legacyGwtRouteDoesNotEmitServerFirstMarkers() throws Exception {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clViewportFirstPaintParityTest.java
@@ -1,0 +1,366 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.waveprotocol.box.common.ExceptionalIterator;
+import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore;
+import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
+import org.waveprotocol.box.server.rpc.render.J2clSelectedWaveSnapshotRenderer;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.box.server.waveserver.WaveServerException;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+
+/**
+ * F-1 acceptance fixture: drives a 12-blip wave through both
+ * {@code ?view=j2cl-root} and {@code ?view=gwt} via the same
+ * {@link WaveClientServlet} instance, asserting that the J2CL surface
+ * delivers a viewport-clamped first paint while the legacy GWT path is
+ * byte-for-byte unchanged. Demonstrates parity-matrix rows R-3.5, R-3.6,
+ * R-6.1, R-6.3, R-7.1, R-7.4 against an in-memory wavelet provider.
+ */
+public final class J2clViewportFirstPaintParityTest {
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "w+f1");
+  private static final WaveletId CONV_ROOT = WaveletId.of("example.com", "conv+root");
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId VIEWER = ParticipantId.ofUnsafe("alice@example.com");
+
+  private boolean previousMetricsEnabled;
+  private long initialWindowsBefore;
+  private long fallbackBefore;
+
+  @Before
+  public void setUp() {
+    previousMetricsEnabled = FragmentsMetrics.isEnabled();
+    FragmentsMetrics.setEnabled(true);
+    initialWindowsBefore = FragmentsMetrics.j2clViewportInitialWindows.get();
+    fallbackBefore = FragmentsMetrics.j2clViewportSnapshotFallbacks.get();
+  }
+
+  @After
+  public void tearDown() {
+    FragmentsMetrics.setEnabled(previousMetricsEnabled);
+  }
+
+  /**
+   * R-3.5 / R-7.1 / R-6.1: a J2CL root-shell response for a wave with 12
+   * blips delivers exactly 5 blips inline plus a terminal placeholder, the
+   * server-first surface markers, and bumps the
+   * {@code j2clViewportInitialWindows} counter. The
+   * {@code j2clViewportSnapshotFallbacks} counter must stay at zero on the
+   * snapshot path (R-7.4).
+   */
+  @Test
+  public void j2clRootShellDeliversWindowedSnapshotForLargeWave() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(12));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "J2CL root response carries the server-first surface marker",
+        html.contains("data-j2cl-server-first-surface=\"true\""));
+    assertTrue(
+        "J2CL root response advertises the initial window size",
+        html.contains("data-j2cl-initial-window-size=\"5\""));
+    assertEquals(
+        "J2CL root response renders exactly 5 root-thread blips inline",
+        5,
+        countOccurrences(html, "data-blip-id="));
+    assertTrue(
+        "J2CL root response appends the visible-region terminal placeholder",
+        html.contains("data-j2cl-server-placeholder=\"true\""));
+    assertTrue(
+        "J2CL root response keyboard-focuses exactly one blip",
+        countOccurrences(html, "tabindex=\"0\"") >= 1);
+    assertEquals(
+        "Snapshot path advances the J2CL viewport-initial-window counter",
+        initialWindowsBefore + 1,
+        FragmentsMetrics.j2clViewportInitialWindows.get());
+    assertEquals(
+        "Snapshot path must not advance the whole-wave fallback counter",
+        fallbackBefore,
+        FragmentsMetrics.j2clViewportSnapshotFallbacks.get());
+  }
+
+  /**
+   * R-3.6: every blip carries a stable {@code data-blip-id} attribute that
+   * the J2CL DOM-as-view provider can resolve, even when the rendered HTML
+   * is the windowed first paint (no full conversation tree).
+   */
+  @Test
+  public void serverRenderedBlipsExposeDomAsViewAttributes() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(7));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Root thread carries data-thread-id for DOM-as-view resolution",
+        html.contains("data-thread-id="));
+    assertTrue(
+        "Root thread declares role=list for AT semantics",
+        html.contains("role=\"list\""));
+    int listitems = countOccurrences(html, "role=\"listitem\"");
+    assertTrue(
+        "Each root-thread blip declares role=listitem (got " + listitems + ")",
+        listitems >= 5);
+  }
+
+  /**
+   * Reciprocal R-6.4 / R-7.4: the legacy GWT skeleton response for the
+   * same wave must be byte-for-byte unchanged — none of the F-1
+   * server-first markers may leak into the legacy path so rollback stays
+   * safe.
+   */
+  @Test
+  public void legacyGwtRouteDoesNotEmitServerFirstMarkers() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(12));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "gwt", WAVE_ID.serialise());
+
+    assertFalse(
+        "GWT path must not advertise the server-first surface",
+        html.contains("data-j2cl-server-first-surface"));
+    assertFalse(
+        "GWT path must not advertise the J2CL initial-window size",
+        html.contains("data-j2cl-initial-window-size"));
+    assertFalse(
+        "GWT path must not emit the J2CL upgrade-placeholder",
+        html.contains("data-j2cl-upgrade-placeholder"));
+    assertEquals(
+        "GWT path does not advance the J2CL viewport-initial-window counter",
+        initialWindowsBefore,
+        FragmentsMetrics.j2clViewportInitialWindows.get());
+  }
+
+  /**
+   * R-7.1 boundary: the server-first response payload for the windowed
+   * snapshot is meaningfully smaller than the legacy whole-wave HTML
+   * (this is the operator-facing reason the lane exists). The windowed
+   * shape is exercised through the production
+   * {@link J2clSelectedWaveSnapshotRenderer} entry point; the whole-wave
+   * baseline is sampled directly from
+   * {@link org.waveprotocol.box.server.rpc.render.WaveContentRenderer} so
+   * the comparison stays apples-to-apples (both render through the same
+   * conversation pipeline; only the windowing changes).
+   */
+  @Test
+  public void windowedSnapshotPayloadIsSmallerThanWholeWaveBaseline() throws Exception {
+    List<ObservableWaveletData> waveletData = buildWaveletData(12);
+
+    J2clSelectedWaveSnapshotRenderer windowed =
+        new J2clSelectedWaveSnapshotRenderer(providerForWave(waveletData));
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult windowedResult =
+        windowed.renderRequestedWave(WAVE_ID.serialise(), VIEWER);
+    String windowedHtml = windowedResult.getSnapshotHtml();
+
+    org.waveprotocol.wave.model.wave.data.impl.WaveViewDataImpl waveView =
+        org.waveprotocol.wave.model.wave.data.impl.WaveViewDataImpl.create(WAVE_ID);
+    for (ObservableWaveletData wavelet : waveletData) {
+      waveView.addWavelet(wavelet);
+    }
+    String wholeHtml =
+        org.waveprotocol.box.server.rpc.render.WaveContentRenderer.renderWaveContent(
+            waveView, VIEWER);
+
+    int windowedSize = windowedHtml.length();
+    int wholeSize = wholeHtml.length();
+    assertTrue(
+        "Windowed payload (" + windowedSize + ") must stay under 75% of whole-wave ("
+            + wholeSize + ")",
+        windowedSize * 100L < wholeSize * 75L);
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private static List<ObservableWaveletData> buildWaveletData(int blipCount) {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < blipCount; i++) {
+      data.appendBlipWithText(
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, blip " + i);
+    }
+    return data.copyWaveletData();
+  }
+
+  private static WaveletProvider providerForWave(List<ObservableWaveletData> wavelets) {
+    Map<WaveletName, CommittedWaveletSnapshot> snapshots = new HashMap<>();
+    ImmutableSet.Builder<WaveletId> waveletIds = ImmutableSet.builder();
+    for (ObservableWaveletData waveletData : wavelets) {
+      waveletIds.add(waveletData.getWaveletId());
+      snapshots.put(
+          WaveletName.of(waveletData.getWaveId(), waveletData.getWaveletId()),
+          new CommittedWaveletSnapshot(waveletData, HashedVersion.unsigned(10)));
+    }
+    final ImmutableSet<WaveletId> finalWaveletIds = waveletIds.build();
+    return new WaveletProvider() {
+      @Override
+      public void initialize() {
+      }
+
+      @Override
+      public void submitRequest(
+          WaveletName waveletName, ProtocolWaveletDelta delta, SubmitRequestListener listener) {
+      }
+
+      @Override
+      public void getHistory(
+          WaveletName waveletName,
+          HashedVersion versionStart,
+          HashedVersion versionEnd,
+          Receiver<TransformedWaveletDelta> receiver) {
+      }
+
+      @Override
+      public boolean checkAccessPermission(WaveletName waveletName, ParticipantId participantId) {
+        return true;
+      }
+
+      @Override
+      public ExceptionalIterator<WaveId, WaveServerException> getWaveIds() {
+        return null;
+      }
+
+      @Override
+      public ImmutableSet<WaveletId> getWaveletIds(WaveId waveId) {
+        return WAVE_ID.equals(waveId) ? finalWaveletIds : ImmutableSet.of();
+      }
+
+      @Override
+      public CommittedWaveletSnapshot getSnapshot(WaveletName waveletName) {
+        return snapshots.get(waveletName);
+      }
+
+      @Override
+      public HashedVersion getHashedVersion(WaveletName waveletName, long version) {
+        return null;
+      }
+    };
+  }
+
+  private static WaveClientServlet createServlet(
+      ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer)
+      throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount(any(WebSession.class))).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount((WebSession) null)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        snapshotRenderer,
+        new FeatureFlagService(featureFlagStore()));
+  }
+
+  private static String invokeServlet(WaveClientServlet servlet, String view, String waveId)
+      throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn(view);
+    when(request.getParameter("wave")).thenReturn(waveId);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+    servlet.doGet(request, response);
+    return body.toString();
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    if (haystack == null || needle == null || needle.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+
+  private static FeatureFlagStore featureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(Collections.emptyList());
+    return store;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
@@ -47,12 +47,31 @@ public class J2clSelectedWaveSnapshotRenderer {
   static final long DEFAULT_RENDER_BUDGET_MS = 150L;
   static final int DEFAULT_PAYLOAD_LIMIT_BYTES = 131072;
   /**
-   * Initial visible-window size for the server-first first paint (R-7.1).
-   * Mirrors the J2CL transport default at
+   * Fallback initial visible-window size used when no system property or
+   * operator override is present.  Mirrors the J2CL transport default at
    * {@code wave.fragments.defaultViewportLimit = 5} in {@code reference.conf}
    * so the server HTML and the live socket open agree on the same window.
    */
   static final int DEFAULT_INITIAL_WINDOW_SIZE = 5;
+
+  /**
+   * Returns the initial window size for the server-first first paint (R-7.1).
+   * Reads the {@code wave.fragments.defaultViewportLimit} system property so
+   * operators can override the default without recompiling.  Falls back to
+   * {@link #DEFAULT_INITIAL_WINDOW_SIZE} (5) when the property is absent or
+   * cannot be parsed.
+   */
+  static int getInitialWindowSize() {
+    String prop = System.getProperty("wave.fragments.defaultViewportLimit");
+    if (prop != null) {
+      try {
+        return Integer.parseInt(prop.trim());
+      } catch (NumberFormatException ignored) {
+        // fall through to default
+      }
+    }
+    return DEFAULT_INITIAL_WINDOW_SIZE;
+  }
 
   interface CurrentTimeSource {
     long currentTimeMillis();
@@ -154,7 +173,7 @@ public class J2clSelectedWaveSnapshotRenderer {
         waveletProvider,
         DEFAULT_RENDER_BUDGET_MS,
         DEFAULT_PAYLOAD_LIMIT_BYTES,
-        DEFAULT_INITIAL_WINDOW_SIZE,
+        getInitialWindowSize(),
         System::currentTimeMillis);
   }
 
@@ -167,7 +186,7 @@ public class J2clSelectedWaveSnapshotRenderer {
         waveletProvider,
         renderBudgetMs,
         payloadLimitBytes,
-        DEFAULT_INITIAL_WINDOW_SIZE,
+        getInitialWindowSize(),
         currentTimeSource);
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
@@ -46,31 +46,17 @@ public class J2clSelectedWaveSnapshotRenderer {
 
   static final long DEFAULT_RENDER_BUDGET_MS = 150L;
   static final int DEFAULT_PAYLOAD_LIMIT_BYTES = 131072;
-  /**
-   * Fallback initial visible-window size used when no system property or
-   * operator override is present.  Mirrors the J2CL transport default at
-   * {@code wave.fragments.defaultViewportLimit = 5} in {@code reference.conf}
-   * so the server HTML and the live socket open agree on the same window.
-   */
-  static final int DEFAULT_INITIAL_WINDOW_SIZE = 5;
 
   /**
-   * Returns the initial window size for the server-first first paint (R-7.1).
-   * Reads the {@code wave.fragments.defaultViewportLimit} system property so
-   * operators can override the default without recompiling.  Falls back to
-   * {@link #DEFAULT_INITIAL_WINDOW_SIZE} (5) when the property is absent or
-   * cannot be parsed.
+   * Returns the initial visible-window size for the server-first first paint
+   * (R-7.1) by delegating to the same
+   * {@link org.waveprotocol.box.server.frontend.ViewportLimitPolicy} that
+   * governs the live socket-open / fragment-fetch path. Sharing the policy
+   * source keeps the server HTML and the live transport in lock-step when
+   * an operator overrides {@code wave.fragments.defaultViewportLimit}.
    */
   static int getInitialWindowSize() {
-    String prop = System.getProperty("wave.fragments.defaultViewportLimit");
-    if (prop != null) {
-      try {
-        return Integer.parseInt(prop.trim());
-      } catch (NumberFormatException ignored) {
-        // fall through to default
-      }
-    }
-    return DEFAULT_INITIAL_WINDOW_SIZE;
+    return org.waveprotocol.box.server.frontend.ViewportLimitPolicy.getDefaultLimit();
   }
 
   interface CurrentTimeSource {

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
@@ -46,6 +46,13 @@ public class J2clSelectedWaveSnapshotRenderer {
 
   static final long DEFAULT_RENDER_BUDGET_MS = 150L;
   static final int DEFAULT_PAYLOAD_LIMIT_BYTES = 131072;
+  /**
+   * Initial visible-window size for the server-first first paint (R-7.1).
+   * Mirrors the J2CL transport default at
+   * {@code wave.fragments.defaultViewportLimit = 5} in {@code reference.conf}
+   * so the server HTML and the live socket open agree on the same window.
+   */
+  static final int DEFAULT_INITIAL_WINDOW_SIZE = 5;
 
   interface CurrentTimeSource {
     long currentTimeMillis();
@@ -138,6 +145,7 @@ public class J2clSelectedWaveSnapshotRenderer {
   private final WaveletProvider waveletProvider;
   private final long renderBudgetMs;
   private final int payloadLimitBytes;
+  private final int initialWindowSize;
   private final CurrentTimeSource currentTimeSource;
 
   @Inject
@@ -146,6 +154,7 @@ public class J2clSelectedWaveSnapshotRenderer {
         waveletProvider,
         DEFAULT_RENDER_BUDGET_MS,
         DEFAULT_PAYLOAD_LIMIT_BYTES,
+        DEFAULT_INITIAL_WINDOW_SIZE,
         System::currentTimeMillis);
   }
 
@@ -154,9 +163,24 @@ public class J2clSelectedWaveSnapshotRenderer {
       long renderBudgetMs,
       int payloadLimitBytes,
       CurrentTimeSource currentTimeSource) {
+    this(
+        waveletProvider,
+        renderBudgetMs,
+        payloadLimitBytes,
+        DEFAULT_INITIAL_WINDOW_SIZE,
+        currentTimeSource);
+  }
+
+  J2clSelectedWaveSnapshotRenderer(
+      WaveletProvider waveletProvider,
+      long renderBudgetMs,
+      int payloadLimitBytes,
+      int initialWindowSize,
+      CurrentTimeSource currentTimeSource) {
     this.waveletProvider = waveletProvider;
     this.renderBudgetMs = renderBudgetMs;
     this.payloadLimitBytes = payloadLimitBytes;
+    this.initialWindowSize = initialWindowSize;
     this.currentTimeSource = currentTimeSource;
   }
 
@@ -215,7 +239,8 @@ public class J2clSelectedWaveSnapshotRenderer {
       }
 
       String snapshotHtml =
-          WaveContentRenderer.renderWaveContent(waveView, viewer, () -> overBudget(startTimeMs));
+          WaveContentRenderer.renderWaveContent(
+              waveView, viewer, () -> overBudget(startTimeMs), initialWindowSize);
       if (overBudget(startTimeMs)) {
         LOG.info("Skipping server-first selected-wave snapshot because the render budget was exceeded after render for "
             + waveId.serialise());
@@ -226,6 +251,14 @@ public class J2clSelectedWaveSnapshotRenderer {
         LOG.info("Skipping server-first selected-wave snapshot because the payload cap was exceeded for "
             + waveId.serialise());
         return SnapshotResult.payloadExceeded();
+      }
+
+      // Snapshot path counts toward the J2CL viewport-initial-window
+      // observability stream so the audit's required `viewport.initial_window`
+      // counter advances even when the live socket open is still in flight.
+      if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+        org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
+            .j2clViewportInitialWindows.incrementAndGet();
       }
 
       return SnapshotResult.snapshot(waveId.serialise(), snapshotHtml);

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
@@ -98,6 +98,13 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
   private final ParticipantId viewer;
   private final WaveContentRenderer.RenderBudget budget;
   private final WindowOptions windowOptions;
+  /**
+   * Tracks whether the non-windowed render has already assigned {@code tabindex="0"} to a root
+   * blip.  In windowed mode {@link WindowOptions#firstRootBlipId()} controls focus; in non-windowed
+   * mode we assign focus to the very first root-thread blip we encounter so that the rendered HTML
+   * always has exactly one keyboard-focusable entry point.
+   */
+  private boolean nonWindowedFocusAssigned = false;
 
   public ServerHtmlRenderer(ParticipantId viewer) {
     this(viewer, () -> false);
@@ -201,11 +208,24 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
             && blip.getThread().getConversation() != null
             && blip.getThread() == blip.getThread().getConversation().getRootThread();
     sb.append(" role=\"").append(isRootThreadBlip ? "listitem" : "article").append("\"");
-    boolean isFirstRootBlip =
-        isRootThreadBlip
-            && windowOptions.firstRootBlipId() != null
-            && windowOptions.firstRootBlipId().equals(blip.getId());
-    sb.append(" tabindex=\"").append(isFirstRootBlip ? "0" : "-1").append("\">");
+    boolean isTabbable;
+    if (windowOptions.isWindowed()) {
+      // Windowed mode: only the designated first root blip is tabbable.
+      isTabbable =
+          isRootThreadBlip
+              && windowOptions.firstRootBlipId() != null
+              && windowOptions.firstRootBlipId().equals(blip.getId());
+    } else {
+      // Non-windowed mode: make the first root-thread blip encountered tabbable
+      // so the rendered surface always has at least one keyboard entry point.
+      if (isRootThreadBlip && !nonWindowedFocusAssigned) {
+        isTabbable = true;
+        nonWindowedFocusAssigned = true;
+      } else {
+        isTabbable = false;
+      }
+    }
+    sb.append(" tabindex=\"").append(isTabbable ? "0" : "-1").append("\">");
 
     // -- Meta bar: author + timestamp --
     sb.append("<div class=\"").append(CSS_BLIP_META).append("\">");

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
@@ -47,6 +47,7 @@ import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 import org.waveprotocol.wave.model.id.WaveId;
 
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -96,14 +97,69 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
   /** The viewer for whom we are rendering (used for future read-state, not yet wired). */
   private final ParticipantId viewer;
   private final WaveContentRenderer.RenderBudget budget;
+  private final WindowOptions windowOptions;
 
   public ServerHtmlRenderer(ParticipantId viewer) {
     this(viewer, () -> false);
   }
 
   ServerHtmlRenderer(ParticipantId viewer, WaveContentRenderer.RenderBudget budget) {
+    this(viewer, budget, WindowOptions.none());
+  }
+
+  ServerHtmlRenderer(
+      ParticipantId viewer,
+      WaveContentRenderer.RenderBudget budget,
+      WindowOptions windowOptions) {
     this.viewer = viewer;
     this.budget = budget;
+    this.windowOptions = windowOptions == null ? WindowOptions.none() : windowOptions;
+  }
+
+  /**
+   * Per-render windowing + keyboard-contract options applied during HTML
+   * emission. Carrying these through the render pipeline lets the renderer
+   * honour the F-1 visible-window contract (R-3.5/R-6.1/R-7.1) without
+   * mutating per-blip emission semantics for the legacy GWT pre-render path.
+   */
+  static final class WindowOptions {
+    private static final WindowOptions NONE = new WindowOptions(null, Collections.<String>emptySet(), null);
+
+    private final String firstRootBlipId;
+    private final Set<String> allowedRootBlipIds;
+    private final String terminalPlaceholderHtml;
+
+    WindowOptions(
+        String firstRootBlipId,
+        Set<String> allowedRootBlipIds,
+        String terminalPlaceholderHtml) {
+      this.firstRootBlipId = firstRootBlipId;
+      this.allowedRootBlipIds =
+          allowedRootBlipIds == null
+              ? Collections.<String>emptySet()
+              : Collections.unmodifiableSet(allowedRootBlipIds);
+      this.terminalPlaceholderHtml = terminalPlaceholderHtml;
+    }
+
+    static WindowOptions none() {
+      return NONE;
+    }
+
+    String firstRootBlipId() {
+      return firstRootBlipId;
+    }
+
+    boolean isWindowed() {
+      return !allowedRootBlipIds.isEmpty();
+    }
+
+    boolean isAllowed(String rootBlipId) {
+      return allowedRootBlipIds.contains(rootBlipId);
+    }
+
+    String terminalPlaceholderHtml() {
+      return terminalPlaceholderHtml == null ? "" : terminalPlaceholderHtml;
+    }
   }
 
   // =========================================================================
@@ -139,7 +195,17 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
 
     StringBuilder sb = new StringBuilder();
     sb.append("<div class=\"").append(CSS_BLIP).append("\"");
-    sb.append(" data-blip-id=\"").append(escapeAttr(blip.getId())).append("\">");
+    sb.append(" data-blip-id=\"").append(escapeAttr(blip.getId())).append("\"");
+    boolean isRootThreadBlip =
+        blip.getThread() != null
+            && blip.getThread().getConversation() != null
+            && blip.getThread() == blip.getThread().getConversation().getRootThread();
+    sb.append(" role=\"").append(isRootThreadBlip ? "listitem" : "article").append("\"");
+    boolean isFirstRootBlip =
+        isRootThreadBlip
+            && windowOptions.firstRootBlipId() != null
+            && windowOptions.firstRootBlipId().equals(blip.getId());
+    sb.append(" tabindex=\"").append(isFirstRootBlip ? "0" : "-1").append("\">");
 
     // -- Meta bar: author + timestamp --
     sb.append("<div class=\"").append(CSS_BLIP_META).append("\">");
@@ -197,14 +263,30 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
     String cssClass = isRoot ? CSS_THREAD : CSS_INLINE_THREAD;
 
     sb.append("<div class=\"").append(cssClass).append("\"");
-    sb.append(" data-thread-id=\"").append(escapeAttr(thread.getId())).append("\">");
+    sb.append(" data-thread-id=\"").append(escapeAttr(thread.getId())).append("\"");
+    sb.append(" role=\"").append(isRoot ? "list" : "group").append("\"");
+    if (!isRoot) {
+      // Inline-thread aria-label mirrors what J2clReadSurfaceDomRenderer adds
+      // post-mount; supplying it server-side keeps the static HTML AT-usable
+      // before client boot (R-6.1).
+      sb.append(" aria-label=\"inline reply thread\"");
+    }
+    sb.append(">");
 
+    boolean filterRootBlips = isRoot && windowOptions.isWindowed();
     for (ConversationBlip blip : thread.getBlips()) {
       checkBudget();
+      if (filterRootBlips && !windowOptions.isAllowed(blip.getId())) {
+        continue;
+      }
       String blipHtml = blipUis.get(blip);
       if (blipHtml != null) {
         sb.append(blipHtml);
       }
+    }
+
+    if (filterRootBlips) {
+      sb.append(windowOptions.terminalPlaceholderHtml());
     }
 
     sb.append("</div>");

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
@@ -99,12 +99,19 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
   private final WaveContentRenderer.RenderBudget budget;
   private final WindowOptions windowOptions;
   /**
-   * Tracks whether the non-windowed render has already assigned {@code tabindex="0"} to a root
-   * blip.  In windowed mode {@link WindowOptions#firstRootBlipId()} controls focus; in non-windowed
-   * mode we assign focus to the very first root-thread blip we encounter so that the rendered HTML
-   * always has exactly one keyboard-focusable entry point.
+   * Tracks the keyboard-focus invariant: exactly one root-thread blip carries
+   * {@code tabindex="0"} and every other blip carries {@code tabindex="-1"}.
+   *
+   * <p>In windowed mode the focus target is the
+   * {@link WindowOptions#firstRootBlipId()} the caller declared; in
+   * non-windowed mode (legacy standalone {@link #renderWave} or any caller
+   * that constructs {@link ServerHtmlRenderer} directly), the renderer
+   * lazily awards {@code tabindex="0"} to the first root-thread blip it
+   * emits so the rendered surface always has exactly one keyboard entry
+   * point. Mutable instance state is fine because the reduction-based
+   * renderer is invoked on a single thread per request.
    */
-  private boolean nonWindowedFocusAssigned = false;
+  private boolean nonWindowedFocusAssigned;
 
   public ServerHtmlRenderer(ParticipantId viewer) {
     this(viewer, () -> false);

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java
@@ -135,24 +135,41 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
    * emission. Carrying these through the render pipeline lets the renderer
    * honour the F-1 visible-window contract (R-3.5/R-6.1/R-7.1) without
    * mutating per-blip emission semantics for the legacy GWT pre-render path.
+   *
+   * <p>The {@code targetRootThread} narrows the window filter to the specific
+   * root thread this windowing was built for. Nested/private conversation root
+   * threads still render in full so server-first HTML does not lose
+   * private-conversation content (the F-1 window applies to the selected
+   * wave's main read surface, not to every conversation root).
    */
   static final class WindowOptions {
-    private static final WindowOptions NONE = new WindowOptions(null, Collections.<String>emptySet(), null);
+    private static final WindowOptions NONE =
+        new WindowOptions(null, Collections.<String>emptySet(), null, null);
 
     private final String firstRootBlipId;
     private final Set<String> allowedRootBlipIds;
     private final String terminalPlaceholderHtml;
+    private final ConversationThread targetRootThread;
 
     WindowOptions(
         String firstRootBlipId,
         Set<String> allowedRootBlipIds,
         String terminalPlaceholderHtml) {
+      this(firstRootBlipId, allowedRootBlipIds, terminalPlaceholderHtml, null);
+    }
+
+    WindowOptions(
+        String firstRootBlipId,
+        Set<String> allowedRootBlipIds,
+        String terminalPlaceholderHtml,
+        ConversationThread targetRootThread) {
       this.firstRootBlipId = firstRootBlipId;
       this.allowedRootBlipIds =
           allowedRootBlipIds == null
               ? Collections.<String>emptySet()
               : Collections.unmodifiableSet(allowedRootBlipIds);
       this.terminalPlaceholderHtml = terminalPlaceholderHtml;
+      this.targetRootThread = targetRootThread;
     }
 
     static WindowOptions none() {
@@ -173,6 +190,24 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
 
     String terminalPlaceholderHtml() {
       return terminalPlaceholderHtml == null ? "" : terminalPlaceholderHtml;
+    }
+
+    /**
+     * Returns true when {@code thread} is the exact root thread that this
+     * window was built for. Uses reference equality so private/nested
+     * conversation root threads, which were not the target, never match.
+     * When {@code targetRootThread} is null (legacy callers that omit it),
+     * any conversation root thread matches and the renderer falls back to the
+     * previous behaviour.
+     */
+    boolean isTargetThread(ConversationThread thread) {
+      if (targetRootThread == null) {
+        // Legacy / non-windowed callers: match any root thread.
+        return thread != null
+            && thread.getConversation() != null
+            && thread == thread.getConversation().getRootThread();
+      }
+      return thread == targetRootThread;
     }
   }
 
@@ -300,7 +335,11 @@ public final class ServerHtmlRenderer implements RenderingRules<String> {
     }
     sb.append(">");
 
-    boolean filterRootBlips = isRoot && windowOptions.isWindowed();
+    // R-3.5: only the main conversation's root thread is windowed. Nested
+    // private-conversation root threads still render in full so server-first
+    // HTML never silently loses unrelated conversation content.
+    boolean filterRootBlips =
+        isRoot && windowOptions.isWindowed() && windowOptions.isTargetThread(thread);
     for (ConversationBlip blip : thread.getBlips()) {
       checkBudget();
       if (filterRootBlips && !windowOptions.isAllowed(blip.getId())) {

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
@@ -298,8 +298,9 @@ public final class WaveContentRenderer {
    * Build the per-render windowing options. When {@code initialWindowSize} is
    * positive and the root thread carries more blips than the requested
    * window, the returned options short-list the leading {@code N} blip ids
-   * and supply the terminal placeholder. Otherwise, a no-op option is
-   * returned so emission falls back to the legacy whole-conversation shape.
+   * and supply the terminal placeholder. When {@code initialWindowSize} is
+   * non-positive, or when the root thread fits entirely within the window,
+   * the legacy whole-conversation shape is preserved.
    *
    * <p>Always sets {@code firstRootBlipId} to the first root-thread blip
    * (when one exists) so the keyboard contract (R-6.1) is consistent across

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
@@ -199,7 +199,7 @@ public final class WaveContentRenderer {
     checkBudget(budget);
     String title = extractTitle(rootConversation);
     Set<String> tags = safeGetTags(rootConversation);
-    int[] counts = countBlipsAndThreads(rootConversation);
+    int[] counts = countBlipsAndThreads(rootConversation, budget);
     int blipCount = counts[0];
     int threadCount = counts[1];
     long creationTime = convWaveletData.getCreationTime();
@@ -435,7 +435,7 @@ public final class WaveContentRenderer {
    *
    * @return int array of [blipCount, threadCount]
    */
-  static int[] countBlipsAndThreads(Conversation conversation) {
+  static int[] countBlipsAndThreads(Conversation conversation, RenderBudget budget) {
     int blipCount = 0;
     int threadCount = 0;
 
@@ -444,12 +444,13 @@ public final class WaveContentRenderer {
       return new int[]{0, 0};
     }
 
-    // Use a simple iterative BFS to avoid deep recursion.
+    // Use a simple iterative DFS to avoid deep recursion.
     List<ConversationThread> queue = new ArrayList<>();
     queue.add(rootThread);
 
     while (!queue.isEmpty()) {
-      ConversationThread thread = queue.remove(queue.size() - 1); // DFS via stack
+      checkBudget(budget);
+      ConversationThread thread = queue.remove(queue.size() - 1);
       threadCount++;
       for (ConversationBlip blip : thread.getBlips()) {
         blipCount++;

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
@@ -41,6 +41,7 @@ import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -82,6 +83,21 @@ public final class WaveContentRenderer {
   private static final String CSS_WAVE_BODY = "wave-body";
   private static final String CSS_WAVE_EMPTY = "wave-empty";
 
+  /**
+   * Terminal placeholder appended after the windowed root-thread blips. The
+   * J2CL client treats this as an AT-announcement marker only; the actual
+   * extension-on-scroll trigger is driven by the live update's
+   * {@code J2clSelectedWaveViewportState.getReadWindowEntries()} (placeholder
+   * entries originate there, not from this server-side marker).
+   */
+  static final String VISIBLE_REGION_PLACEHOLDER_HTML =
+      "<div class=\"visible-region-placeholder\""
+          + " data-j2cl-server-placeholder=\"true\""
+          + " data-segment=\"placeholder-tail\""
+          + " role=\"listitem\" aria-busy=\"true\">"
+          + "Additional blips will load on scroll."
+          + "</div>";
+
   /** No instantiation -- static utility class. */
   private WaveContentRenderer() {}
 
@@ -111,10 +127,35 @@ public final class WaveContentRenderer {
    * @return an HTML fragment string, never null
    */
   public static String renderWaveContent(WaveViewData waveView, ParticipantId viewer) {
-    return renderWaveContent(waveView, viewer, () -> false);
+    return renderWaveContent(waveView, viewer, () -> false, 0);
+  }
+
+  /**
+   * Renders a wave snapshot into a complete HTML fragment, optionally
+   * clamped to the first {@code initialWindowSize} root-thread blips. When
+   * {@code initialWindowSize <= 0} the renderer falls back to the
+   * whole-wave shape (the legacy GWT pre-render contract).
+   *
+   * <p>This is the entry point used by the J2CL root-shell first-paint
+   * (R-6.1, R-7.1) so the inline server HTML matches the same window the
+   * J2CL client requests on the live socket open. Inline reply threads
+   * under the included root blips are always rendered fully — the window
+   * applies only to the root-thread sequence.
+   */
+  public static String renderWaveContent(
+      WaveViewData waveView, ParticipantId viewer, int initialWindowSize) {
+    return renderWaveContent(waveView, viewer, () -> false, initialWindowSize);
   }
 
   static String renderWaveContent(WaveViewData waveView, ParticipantId viewer, RenderBudget budget) {
+    return renderWaveContent(waveView, viewer, budget, 0);
+  }
+
+  static String renderWaveContent(
+      WaveViewData waveView,
+      ParticipantId viewer,
+      RenderBudget budget,
+      int initialWindowSize) {
     checkBudget(budget);
     if (waveView == null) {
       return emptyWaveHtml("No wave data available.");
@@ -163,11 +204,17 @@ public final class WaveContentRenderer {
     int threadCount = counts[1];
     long creationTime = convWaveletData.getCreationTime();
 
+    // Build the per-render windowing options before invoking the rules engine
+    // so the renderer can mark the first focusable blip and short-list the
+    // allowed root-thread blip ids in a single forward pass.
+    ServerHtmlRenderer.WindowOptions windowOptions =
+        buildWindowOptions(rootConversation, initialWindowSize);
+
     // Render the conversation tree using Phase 1 renderer.
     String conversationHtml;
     try {
       checkBudget(budget);
-      ServerHtmlRenderer rules = new ServerHtmlRenderer(viewer, budget);
+      ServerHtmlRenderer rules = new ServerHtmlRenderer(viewer, budget, windowOptions);
       String rendered = ReductionBasedRenderer.renderWith(rules, conversations);
       checkBudget(budget);
       conversationHtml = rendered != null ? rendered : "";
@@ -185,7 +232,16 @@ public final class WaveContentRenderer {
     sb.append("<div class=\"").append(CSS_WAVE_CONTENT).append("\"");
     sb.append(" data-wave-id=\"")
         .append(ServerHtmlRenderer.escapeAttr(waveView.getWaveId().serialise()))
-        .append("\">");
+        .append("\"");
+    if (windowOptions.isWindowed()) {
+      // F-1: the J2CL renderer reads this attribute to confirm the server
+      // window size matches the limit it will request on the live socket open.
+      sb.append(" data-j2cl-initial-window-size=\"")
+          .append(initialWindowSize)
+          .append("\"");
+      sb.append(" data-j2cl-server-first-surface=\"true\"");
+    }
+    sb.append(">");
 
     // -- Header: title + metadata + tags --
     sb.append("<div class=\"").append(CSS_WAVE_HEADER).append("\">");
@@ -236,6 +292,68 @@ public final class WaveContentRenderer {
     if (budget != null && budget.isExceeded()) {
       throw new RenderBudgetExceededException();
     }
+  }
+
+  /**
+   * Build the per-render windowing options. When {@code initialWindowSize} is
+   * positive and the root thread carries more blips than the requested
+   * window, the returned options short-list the leading {@code N} blip ids
+   * and supply the terminal placeholder. Otherwise, a no-op option is
+   * returned so emission falls back to the legacy whole-conversation shape.
+   *
+   * <p>Always sets {@code firstRootBlipId} to the first root-thread blip
+   * (when one exists) so the keyboard contract (R-6.1) is consistent across
+   * windowed and whole-wave renders — the static HTML must always have
+   * exactly one focusable blip.
+   */
+  static ServerHtmlRenderer.WindowOptions buildWindowOptions(
+      Conversation conversation, int initialWindowSize) {
+    if (conversation == null || conversation.getRootThread() == null) {
+      return ServerHtmlRenderer.WindowOptions.none();
+    }
+    String firstRootBlipId = null;
+    Set<String> allowed = new LinkedHashSet<String>();
+    int taken = 0;
+    for (ConversationBlip blip : conversation.getRootThread().getBlips()) {
+      if (blip == null) {
+        continue;
+      }
+      if (firstRootBlipId == null) {
+        firstRootBlipId = blip.getId();
+      }
+      if (initialWindowSize > 0) {
+        if (taken < initialWindowSize) {
+          allowed.add(blip.getId());
+          taken++;
+        }
+      }
+    }
+    if (initialWindowSize <= 0) {
+      // Whole-wave shape — only the focus marker is meaningful.
+      return new ServerHtmlRenderer.WindowOptions(
+          firstRootBlipId, java.util.Collections.<String>emptySet(), null);
+    }
+    // Determine whether windowing actually clamps anything. If the conversation
+    // already fits inside the window we still render with the focus marker but
+    // suppress the placeholder so the AT announcement is honest.
+    boolean clamps = countRootBlips(conversation) > taken;
+    return new ServerHtmlRenderer.WindowOptions(
+        firstRootBlipId,
+        allowed,
+        clamps ? VISIBLE_REGION_PLACEHOLDER_HTML : null);
+  }
+
+  static int countRootBlips(Conversation conversation) {
+    int n = 0;
+    if (conversation == null || conversation.getRootThread() == null) {
+      return 0;
+    }
+    for (ConversationBlip blip : conversation.getRootThread().getBlips()) {
+      if (blip != null) {
+        n++;
+      }
+    }
+    return n;
   }
 
   // =========================================================================

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
@@ -328,10 +328,14 @@ public final class WaveContentRenderer {
         }
       }
     }
+    ConversationThread rootThread = conversation.getRootThread();
     if (initialWindowSize <= 0) {
       // Whole-wave shape — only the focus marker is meaningful.
       return new ServerHtmlRenderer.WindowOptions(
-          firstRootBlipId, java.util.Collections.<String>emptySet(), null);
+          firstRootBlipId,
+          java.util.Collections.<String>emptySet(),
+          null,
+          rootThread);
     }
     // Determine whether windowing actually clamps anything. If the conversation
     // already fits inside the window we still render with the focus marker but
@@ -340,7 +344,8 @@ public final class WaveContentRenderer {
     return new ServerHtmlRenderer.WindowOptions(
         firstRootBlipId,
         allowed,
-        clamps ? VISIBLE_REGION_PLACEHOLDER_HTML : null);
+        clamps ? VISIBLE_REGION_PLACEHOLDER_HTML : null,
+        rootThread);
   }
 
   static int countRootBlips(Conversation conversation) {

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/WaveContentRenderer.java
@@ -208,7 +208,7 @@ public final class WaveContentRenderer {
     // so the renderer can mark the first focusable blip and short-list the
     // allowed root-thread blip ids in a single forward pass.
     ServerHtmlRenderer.WindowOptions windowOptions =
-        buildWindowOptions(rootConversation, initialWindowSize);
+        buildWindowOptions(rootConversation, initialWindowSize, budget);
 
     // Render the conversation tree using Phase 1 renderer.
     String conversationHtml;
@@ -307,14 +307,16 @@ public final class WaveContentRenderer {
    * exactly one focusable blip.
    */
   static ServerHtmlRenderer.WindowOptions buildWindowOptions(
-      Conversation conversation, int initialWindowSize) {
+      Conversation conversation, int initialWindowSize, RenderBudget budget) {
     if (conversation == null || conversation.getRootThread() == null) {
       return ServerHtmlRenderer.WindowOptions.none();
     }
     String firstRootBlipId = null;
     Set<String> allowed = new LinkedHashSet<String>();
     int taken = 0;
+    boolean clamps = false;
     for (ConversationBlip blip : conversation.getRootThread().getBlips()) {
+      checkBudget(budget);
       if (blip == null) {
         continue;
       }
@@ -325,6 +327,9 @@ public final class WaveContentRenderer {
         if (taken < initialWindowSize) {
           allowed.add(blip.getId());
           taken++;
+        } else {
+          clamps = true;
+          break;
         }
       }
     }
@@ -337,28 +342,12 @@ public final class WaveContentRenderer {
           null,
           rootThread);
     }
-    // Determine whether windowing actually clamps anything. If the conversation
-    // already fits inside the window we still render with the focus marker but
-    // suppress the placeholder so the AT announcement is honest.
-    boolean clamps = countRootBlips(conversation) > taken;
+    // clamps is set during the single pass above; no second scan needed.
     return new ServerHtmlRenderer.WindowOptions(
         firstRootBlipId,
         allowed,
         clamps ? VISIBLE_REGION_PLACEHOLDER_HTML : null,
         rootThread);
-  }
-
-  static int countRootBlips(Conversation conversation) {
-    int n = 0;
-    if (conversation == null || conversation.getRootThread() == null) {
-      return 0;
-    }
-    for (ConversationBlip blip : conversation.getRootThread().getBlips()) {
-      if (blip != null) {
-        n++;
-      }
-    }
-    return n;
   }
 
   // =========================================================================

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRendererWindowTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRendererWindowTest.java
@@ -1,0 +1,270 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc.render;
+
+import com.google.common.collect.ImmutableSet;
+
+import junit.framework.TestCase;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.waveprotocol.box.common.ExceptionalIterator;
+import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
+import org.waveprotocol.box.server.waveserver.WaveServerException;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+
+/**
+ * F-1: viewport-window contract for the J2CL server-first snapshot renderer.
+ *
+ * <p>Covers parity rows R-3.5 (visible-region container model), R-6.1
+ * (server-rendered first paint), R-7.1 (initial visible window), and R-7.4
+ * (the {@code j2cl.viewport.initial_window} counter advances on the
+ * server-first path).
+ */
+public final class J2clSelectedWaveSnapshotRendererWindowTest extends TestCase {
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "w+server-window");
+  private static final WaveletId CONV_ROOT = WaveletId.of("example.com", "conv+root");
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId VIEWER = ParticipantId.ofUnsafe("viewer@example.com");
+
+  private boolean previousMetricsEnabled;
+  private long initialWindowsBefore;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    previousMetricsEnabled = FragmentsMetrics.isEnabled();
+    FragmentsMetrics.setEnabled(true);
+    initialWindowsBefore = FragmentsMetrics.j2clViewportInitialWindows.get();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    FragmentsMetrics.setEnabled(previousMetricsEnabled);
+    super.tearDown();
+  }
+
+  public void testSnapshotClampsToInitialWindowAndAdvertisesContract() {
+    TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < 12; i++) {
+      data.appendBlipWithText("Body " + i);
+    }
+
+    J2clSelectedWaveSnapshotRenderer renderer =
+        new J2clSelectedWaveSnapshotRenderer(
+            providerFor(data.copyWaveletData(), true),
+            500L,
+            262144,
+            5,
+            new SequenceTimeSource(0L, 10L, 20L, 30L, 40L, 50L));
+
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult result =
+        renderer.renderRequestedWave(WAVE_ID.serialise(), VIEWER);
+
+    assertEquals(J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT, result.getMode());
+    String html = result.getSnapshotHtml();
+    assertEquals("Five blips inside the window", 5, countOccurrences(html, "data-blip-id="));
+    assertTrue(
+        "Server-first marker advertised on the wrapper",
+        html.contains("data-j2cl-server-first-surface=\"true\""));
+    assertTrue(
+        "Window-size attribute advertised on the wrapper",
+        html.contains("data-j2cl-initial-window-size=\"5\""));
+    assertTrue(
+        "Terminal placeholder appended after the windowed slice",
+        html.contains("data-j2cl-server-placeholder=\"true\""));
+    assertEquals(
+        "Snapshot-path advances the J2CL viewport-initial-window counter",
+        initialWindowsBefore + 1,
+        FragmentsMetrics.j2clViewportInitialWindows.get());
+  }
+
+  public void testSnapshotPayloadStaysWellBelowWholeWaveBaseline() {
+    TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < 12; i++) {
+      data.appendBlipWithText(
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, blip " + i);
+    }
+
+    J2clSelectedWaveSnapshotRenderer windowedRenderer =
+        new J2clSelectedWaveSnapshotRenderer(
+            providerFor(data.copyWaveletData(), true),
+            500L,
+            262144,
+            5,
+            new SequenceTimeSource(0L, 10L, 20L, 30L, 40L, 50L));
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult windowed =
+        windowedRenderer.renderRequestedWave(WAVE_ID.serialise(), VIEWER);
+
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult whole =
+        new J2clSelectedWaveSnapshotRenderer(
+                providerFor(data.copyWaveletData(), true),
+                500L,
+                262144,
+                0,
+                new SequenceTimeSource(0L, 10L, 20L, 30L, 40L, 50L))
+            .renderRequestedWave(WAVE_ID.serialise(), VIEWER);
+
+    assertEquals(J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT, windowed.getMode());
+    assertEquals(J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT, whole.getMode());
+
+    int windowedSize = windowed.getSnapshotHtml().getBytes().length;
+    int wholeSize = whole.getSnapshotHtml().getBytes().length;
+    assertTrue(
+        "Windowed payload (" + windowedSize + " B) must stay under 75% of whole-wave ("
+            + wholeSize + " B)",
+        windowedSize * 100L < wholeSize * 75L);
+  }
+
+  public void testZeroWindowSizeSkipsWindowMarkersAndStillCountsInitialWindow() {
+    TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    data.appendBlipWithText("Single blip");
+
+    J2clSelectedWaveSnapshotRenderer renderer =
+        new J2clSelectedWaveSnapshotRenderer(
+            providerFor(data.copyWaveletData(), true),
+            500L,
+            262144,
+            0,
+            new SequenceTimeSource(0L, 10L, 20L, 30L));
+
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult result =
+        renderer.renderRequestedWave(WAVE_ID.serialise(), VIEWER);
+
+    assertEquals(J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT, result.getMode());
+    assertFalse(
+        "No window markers when the window is disabled",
+        result.getSnapshotHtml().contains("data-j2cl-initial-window-size"));
+    // Even when the window is disabled, the snapshot path still represents a
+    // J2CL initial-window event for telemetry — operators care that the
+    // counter never silently freezes when the window size is mis-tuned.
+    assertEquals(
+        "Snapshot-path advances the counter regardless of window size",
+        initialWindowsBefore + 1,
+        FragmentsMetrics.j2clViewportInitialWindows.get());
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    if (haystack == null || needle == null || needle.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+
+  private static WaveletProvider providerFor(
+      List<ObservableWaveletData> wavelets, boolean allowAccess) {
+    Map<WaveletName, CommittedWaveletSnapshot> snapshots = new HashMap<WaveletName, CommittedWaveletSnapshot>();
+    ImmutableSet.Builder<WaveletId> waveletIds = ImmutableSet.builder();
+    WaveId waveId = null;
+    for (ObservableWaveletData waveletData : wavelets) {
+      waveId = waveletData.getWaveId();
+      waveletIds.add(waveletData.getWaveletId());
+      snapshots.put(
+          WaveletName.of(waveletData.getWaveId(), waveletData.getWaveletId()),
+          new CommittedWaveletSnapshot(waveletData, HashedVersion.unsigned(10)));
+    }
+    final WaveId finalWaveId = waveId;
+    final ImmutableSet<WaveletId> finalWaveletIds = waveletIds.build();
+    return new WaveletProvider() {
+      @Override
+      public void initialize() {
+      }
+
+      @Override
+      public void submitRequest(
+          WaveletName waveletName, ProtocolWaveletDelta delta, SubmitRequestListener listener) {
+      }
+
+      @Override
+      public void getHistory(
+          WaveletName waveletName,
+          HashedVersion versionStart,
+          HashedVersion versionEnd,
+          Receiver<TransformedWaveletDelta> receiver) {
+      }
+
+      @Override
+      public boolean checkAccessPermission(WaveletName waveletName, ParticipantId participantId) {
+        return allowAccess;
+      }
+
+      @Override
+      public ExceptionalIterator<WaveId, WaveServerException> getWaveIds() {
+        return null;
+      }
+
+      @Override
+      public ImmutableSet<WaveletId> getWaveletIds(WaveId waveId) {
+        return finalWaveId != null && finalWaveId.equals(waveId)
+            ? finalWaveletIds
+            : ImmutableSet.<WaveletId>of();
+      }
+
+      @Override
+      public CommittedWaveletSnapshot getSnapshot(WaveletName waveletName) {
+        return snapshots.get(waveletName);
+      }
+
+      @Override
+      public HashedVersion getHashedVersion(WaveletName waveletName, long version) {
+        return null;
+      }
+    };
+  }
+
+  private static final class SequenceTimeSource
+      implements J2clSelectedWaveSnapshotRenderer.CurrentTimeSource {
+    private final long[] values;
+    private int index;
+
+    private SequenceTimeSource(long... values) {
+      this.values = values;
+    }
+
+    @Override
+    public long currentTimeMillis() {
+      if (values.length == 0) {
+        return 0L;
+      }
+      if (index >= values.length) {
+        return values[values.length - 1];
+      }
+      return values[index++];
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/render/WaveContentRendererWindowTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/render/WaveContentRendererWindowTest.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc.render;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+
+/**
+ * Tests for the F-1 viewport-window contract on
+ * {@link WaveContentRenderer#renderWaveContent(WaveViewData, ParticipantId, int)}.
+ *
+ * <p>Covers parity-matrix rows R-3.5 (visible-region container model),
+ * R-6.1 (server-rendered read-only first paint with keyboard contract),
+ * and R-7.1 (initial visible window).
+ */
+public class WaveContentRendererWindowTest extends TestCase {
+
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "w+window");
+  private static final WaveletId CONV_WAVELET_ID = WaveletId.of("example.com", "conv+root");
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId VIEWER = ParticipantId.ofUnsafe("viewer@example.com");
+
+  private WaveViewData buildWave(int blipCount) {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONV_WAVELET_ID, AUTHOR, true);
+    for (int i = 0; i < blipCount; i++) {
+      data.appendBlipWithText("Body " + i);
+    }
+    return data.copyViewData();
+  }
+
+  /**
+   * R-7.1: when the wave has more blips than the requested window, the
+   * rendered HTML emits exactly that many root-thread blips and one
+   * placeholder marker. Inline reply threads under emitted blips are still
+   * rendered (the window applies only to the root-thread sequence).
+   */
+  public void testWindowClampsRootThreadAndAppendsPlaceholder() {
+    WaveViewData wave = buildWave(12);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 5);
+
+    int blipCount = countOccurrences(html, "data-blip-id=");
+    assertEquals("Expected exactly 5 blips inside the window", 5, blipCount);
+    assertTrue(
+        "Expected the visible-region terminal placeholder",
+        html.contains("data-j2cl-server-placeholder=\"true\""));
+    assertTrue(
+        "Expected the AT-busy hint on the placeholder",
+        html.contains("aria-busy=\"true\""));
+    assertTrue(
+        "Expected the wrapper to expose the server window size",
+        html.contains("data-j2cl-initial-window-size=\"5\""));
+    assertTrue(
+        "Expected the server-first surface marker on the wave-content wrapper",
+        html.contains("data-j2cl-server-first-surface=\"true\""));
+  }
+
+  /**
+   * R-6.1: the static HTML must always have exactly one focusable blip
+   * (the first root-thread blip carries {@code tabindex="0"}; every other
+   * blip carries {@code tabindex="-1"}). This holds regardless of whether
+   * the renderer is in window mode.
+   */
+  public void testFirstRootBlipCarriesTabindexZero() {
+    WaveViewData wave = buildWave(3);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 5);
+
+    int focusableCount = countOccurrences(html, "tabindex=\"0\"");
+    assertEquals("Exactly one focusable blip expected", 1, focusableCount);
+    int nonFocusableCount = countOccurrences(html, "tabindex=\"-1\"");
+    assertEquals("Two non-focusable blips expected", 2, nonFocusableCount);
+  }
+
+  /**
+   * R-6.1: every blip carries an explicit ARIA role; root-thread blips are
+   * {@code listitem} (because the root thread is a {@code role="list"}).
+   */
+  public void testRolesAreEmittedOnBlipsAndThreads() {
+    WaveViewData wave = buildWave(2);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 5);
+
+    assertTrue(
+        "Root thread should expose role=list", html.contains("role=\"list\""));
+    int listitemCount = countOccurrences(html, "role=\"listitem\"");
+    assertEquals("Two root-thread blips with role=listitem expected", 2, listitemCount);
+  }
+
+  /**
+   * R-7.1 boundary: when the wave already fits inside the window, the
+   * placeholder is suppressed but the wrapper still advertises the window
+   * size. The keyboard contract still holds (one focusable blip).
+   */
+  public void testWindowExactlyMatchingDoesNotEmitPlaceholder() {
+    WaveViewData wave = buildWave(3);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 5);
+
+    assertFalse(
+        "No placeholder when conversation fits inside the window",
+        html.contains("data-j2cl-server-placeholder=\"true\""));
+    assertTrue(
+        "Wrapper still advertises the window contract for client telemetry",
+        html.contains("data-j2cl-initial-window-size=\"5\""));
+  }
+
+  /**
+   * Back-compat for the legacy GWT pre-render path
+   * ({@link WavePreRenderer#prerenderForUser}): the no-arg overload (and
+   * an explicit {@code initialWindowSize <= 0}) must continue to render the
+   * whole wave with no window markers. Critical for rollback safety.
+   */
+  public void testZeroWindowSizeRendersWholeWaveWithoutWindowMarkers() {
+    WaveViewData wave = buildWave(8);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 0);
+
+    int blipCount = countOccurrences(html, "data-blip-id=");
+    assertEquals("All blips rendered when window disabled", 8, blipCount);
+    assertFalse(
+        "No window marker on the legacy whole-wave path",
+        html.contains("data-j2cl-initial-window-size"));
+    assertFalse(
+        "No server-first marker on the legacy whole-wave path",
+        html.contains("data-j2cl-server-first-surface"));
+    assertFalse(
+        "No placeholder on the legacy whole-wave path",
+        html.contains("data-j2cl-server-placeholder"));
+  }
+
+  /**
+   * R-6.1: the keyboard contract must hold even on the legacy whole-wave
+   * path. Without exactly one initially focusable blip the J2CL upgrade
+   * cannot preserve focus during shell swap (R-6.3).
+   */
+  public void testWholeWavePathStillEmitsExactlyOneFocusableBlip() {
+    WaveViewData wave = buildWave(3);
+
+    String html = WaveContentRenderer.renderWaveContent(wave, VIEWER, 0);
+
+    assertEquals(
+        "Exactly one focusable blip on the whole-wave path",
+        1,
+        countOccurrences(html, "tabindex=\"0\""));
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    if (haystack == null || needle == null || needle.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
Closes #1036
Updates #904

## Summary

Re-executes the viewport-scoped J2CL read-surface data path with row-level acceptance against the parity matrix, replacing the closed-but-undelivered acceptance of #967 and the data-path side of #965.

The lane delivers five tightly-coupled changes against the audit-required matrix rows:

- **T1+T2 (server)** — `WaveContentRenderer` gains a viewport-bounded overload keyed by an explicit initial-window size (default 5, mirrors `wave.fragments.defaultViewportLimit`). When set, only the first N root-thread blips render inline plus a terminal `<div class="visible-region-placeholder">` for AT continuity. `ServerHtmlRenderer` now emits `role` (`listitem`/`article`), per-thread `role` (`list`/`group`), and `tabindex="0"` on the first root-thread blip so the static HTML is keyboard-navigable before client boot. The wave-content wrapper carries `data-j2cl-initial-window-size` and `data-j2cl-server-first-surface` markers so the J2CL renderer can verify the window contract. `J2clSelectedWaveSnapshotRenderer` threads `DEFAULT_INITIAL_WINDOW_SIZE = 5` into the renderer and bumps `j2clViewportInitialWindows` on the snapshot path. Rows: **R-3.5, R-6.1, R-6.3 (focus invariant), R-7.1**.
- **T3 (J2CL client)** — `J2clSelectedWaveController` emits the four audit-required telemetry events through `J2clClientTelemetry.browserStatsSink()`: `viewport.initial_window` on every selected-wave open, `viewport.extension_fetch` + `viewport.extension_fetch.outcome` (ok/error/stale) on every onViewportEdge fetch, `viewport.clamp_applied` when the server returned fewer blips than the requested growth limit, and `viewport.fallback_to_whole_wave` exactly once per open when the server response carries no blip-shaped fragment ranges. The fallback event mirrors the existing server-side `j2clViewportSnapshotFallbacks` counter so dashboards can pin client and server views of the same fallback. Rows: **R-4.6, R-7.1, R-7.2, R-7.3, R-7.4**.
- **T4 (J2CL view)** — `J2clSelectedWaveView` now emits a one-shot `shell_swap` event with `reason=cold-mount` on the first render that attaches a non-empty selected-wave model when no server-first card was present. The signal shape matches the existing `live-update` reason so dashboards do not need a special case for the missing-card scenario. Row: **R-6.3**.
- **T5 (parity fixture)** — `J2clViewportFirstPaintParityTest` drives the same 12-blip fixture wave through both `?view=j2cl-root` and `?view=gwt` via a single `WaveClientServlet` instance and asserts (a) J2CL response carries the server-first markers + 5 blips + 1 placeholder + the keyboard contract, (b) GWT response is byte-for-byte unchanged (no F-1 markers leak), (c) the snapshot path advances `j2clViewportInitialWindows` and never advances `j2clViewportSnapshotFallbacks`, (d) per-blip `data-blip-id`/`data-thread-id` resolves cleanly for the J2CL DOM-as-view provider, and (e) windowed payload stays under 75% of the whole-wave baseline. Rows: **R-3.5, R-3.6, R-6.1, R-6.4, R-7.1, R-7.4**.

The legacy GWT path (`WaveClientServlet`'s non-J2CL-root branch and `WavePreRenderer`'s whole-wave call site) is unchanged: the new `WaveContentRenderer` overload defaults to whole-wave when `initialWindowSize <= 0`.

## Parity-matrix rows demonstrated

| Row | Acceptance | Evidence |
| --- | --- | --- |
| R-3.5 | Visible-region container model | `WaveContentRendererWindowTest.testWindowClampsRootThreadAndAppendsPlaceholder`, `J2clViewportFirstPaintParityTest.j2clRootShellDeliversWindowedSnapshotForLargeWave` |
| R-3.6 | DOM-as-view provider against fragmented DOM | `J2clViewportFirstPaintParityTest.serverRenderedBlipsExposeDomAsViewAttributes` |
| R-4.6 | Viewport-scoped fragment fetch policy honored client-side | `J2clSelectedWaveControllerTest.viewportEdgeFetchEmitsExtensionAndOutcomeEvents` |
| R-6.1 | Server-rendered read-only first paint with keyboard contract | `WaveContentRendererWindowTest.testFirstRootBlipCarriesTabindexZero`, `WaveContentRendererWindowTest.testRolesAreEmittedOnBlipsAndThreads` |
| R-6.3 | Shell-swap upgrade preserves focus, emits cold-mount event | `J2clSelectedWaveViewTelemetryTest.coldMountFiresShellSwapWithColdMountReasonWhenNoServerCardPresent` (browser-only) |
| R-6.4 | Rollback safety: GWT path unchanged | `J2clViewportFirstPaintParityTest.legacyGwtRouteDoesNotEmitServerFirstMarkers` |
| R-7.1 | Initial visible window | `J2clSelectedWaveSnapshotRendererWindowTest.testSnapshotClampsToInitialWindowAndAdvertisesContract`, `J2clSelectedWaveControllerTest.selectingWaveEmitsViewportInitialWindowEvent` |
| R-7.2 | Extension on scroll without scroll-anchor loss | `J2clSelectedWaveControllerTest.viewportEdgeFetchEmitsExtensionAndOutcomeEvents` (existing extension+anchor tests still pass) |
| R-7.3 | Server clamp visible through telemetry | `J2clSelectedWaveControllerTest.viewportEdgeFetchEmitsClampAppliedWhenServerReturnsFewerBlips` |
| R-7.4 | No fallback to whole-wave bootstrap | `J2clSelectedWaveControllerTest.snapshotOnlyUpdateEmitsViewportFallbackToWholeWaveExactlyOnce`, `J2clViewportFirstPaintParityTest.j2clRootShellDeliversWindowedSnapshotForLargeWave` (counter stays at zero) |

## Test plan

- [x] `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild` => exit 0
- [x] `sbt -batch test:testOnly *WaveContentRendererWindowTest *J2clSelectedWaveSnapshotRendererWindowTest *WaveContentRendererTest *ServerHtmlRendererTest *J2clSelectedWaveSnapshotRendererTest` => 42 passed
- [x] `sbt -batch jakartaTest:testOnly *J2clViewportFirstPaintParityTest *WaveClientServletFragmentDefaultsTest` => 4 + 5 passed
- [x] `j2cl/mvnw -Psearch-sidecar test` => 636 tests passed (incl. 7 new J2clSelectedWaveControllerTest viewport telemetry cases + 3 new J2clSelectedWaveViewTelemetryTest cold-mount cases — browser-only ones skip on JVM Surefire and run under `j2clLitTest`)
- [x] `git diff --check` clean
- [ ] Manual side-by-side at `?view=j2cl-root` vs `?view=gwt` on a fixture wave (deferred to post-merge soak)

## Plan + audit

- Per-task plan: `docs/superpowers/plans/2026-04-26-issue-1036-viewport-scoped-read.md`
- Audit motivating this lane: `/Users/vega/devroot/worktrees/j2cl-parity-audit/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md` (PR #1034)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewport-scoped first-paint rendering for selected waves with server-clamped visible windows, accessibility attributes, and cold-mount shell-swap reporting
  * Four viewport telemetry events: initial window, extension fetch (with outcome), clamp applied, and fallback-to-whole-wave

* **Tests**
  * New unit and acceptance tests validating viewport/windowing, telemetry, accessibility, payload-size, and cold-mount behavior
  * Test harness updated to skip additional renderer window-related test classes

* **Documentation**
  * Implementation plan and release changelog entry for viewport-scoped J2CL read surface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->