### PR TITLE
F-0: Refresh Lit design packet for wavy aesthetic + plugin slot contracts

### DIFF
--- a/docs/j2cl-plugin-slots.md
+++ b/docs/j2cl-plugin-slots.md
@@ -1,0 +1,175 @@
+# J2CL plugin slots
+
+Status: Draft (F-0, issue [#1035](https://github.com/vega113/supawave/issues/1035))
+Owner: F-0 design foundation lane.
+Consumers: F-2 ([#1037](https://github.com/vega113/supawave/issues/1037)) mounts blip + rail; F-3 ([#1038](https://github.com/vega113/supawave/issues/1038)) mounts compose + toolbar.
+
+## Overview
+
+The J2CL parity client reserves four named Lit slots so plugins
+registered against the forthcoming robots/data-API plugin registry
+can render content into specific seams in the read, compose, rail,
+and toolbar surfaces.
+
+F-0 specifies **only** the slot contract (mount point, slot context,
+allowed children, styling/lifecycle/accessibility/rollback). The
+plugin **registration** mechanism is a separate, future
+robots/data-API issue. The four slots exist whether or not any
+plugin is registered against them; in production they collapse to
+zero height when empty, and in design preview (`<html
+data-wavy-design-preview>` set) they render a faint dashed outline
+with the slot name so designers can see where plugins land.
+
+The four slots map to inventory rows M.2–M.5 from the 2026-04-26
+GWT functional inventory
+(`docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md`).
+
+## The four slots
+
+### `blip-extension` — per blip card (M.2)
+
+- **Mount point.** Inside the `<wavy-blip-card>` recipe element
+  (`j2cl/lit/src/design/wavy-blip-card.js`), in the slot wrapper
+  named `blip-extension` rendered between the blip body and the
+  reactions row.
+- **Slot context (read-only).** Plugins read four data attributes
+  reflected on the host element:
+  - `data-blip-id` — the blip's wave-relative ID.
+  - `data-wave-id` — the parent wave ID.
+  - `data-blip-author` — the author's display name.
+  - `data-blip-is-author` — `"true"` when the viewer authored the
+    blip, `"false"` otherwise.
+  Plugins read these via
+  `slot.assignedElements()[0].closest('wavy-blip-card').dataset`.
+  Richer plugins can also read the host element's `blipView`
+  property, which returns a frozen snapshot
+  `Object.freeze({ id, waveId, authorName, postedAt, isAuthor })`.
+  Mutation throws under strict mode.
+- **Allowed children.** Any HTML or custom-element subtree. The
+  slot does not impose tag restrictions, but plugins are expected
+  to keep DOM size small (one anchor element, a chip, an icon
+  button — not a nested editor).
+- **Owning F-* slice.** F-2 ([#1037](https://github.com/vega113/supawave/issues/1037)).
+
+### `compose-extension` — on the inline composer (M.3)
+
+- **Mount point.** Inside `<wavy-compose-card>`
+  (`j2cl/lit/src/design/wavy-compose-card.js`), in the slot wrapper
+  named `compose-extension` placed in the toolbar row, to the
+  right of the H.* edit toolbar.
+- **Slot context (read-only).** One data attribute on the host:
+  - `data-reply-target-blip-id` — when the composer is a reply,
+    the parent blip's ID; absent when composing top-of-thread.
+  Richer plugins can read two frozen JS properties on the host:
+  - `composerState` — frozen snapshot of the composer state
+    (drafts, attachments-staged, etc — populated by F-3).
+  - `activeSelection` — frozen snapshot of the current selection
+    descriptor.
+  Setting either property re-freezes the new value.
+- **Allowed children.** Inline-block children that fit in a
+  toolbar row (poll button, code-block toggle, inline-diagram
+  trigger). Long-form floating UIs should anchor a popover off
+  the slotted button rather than render inline.
+- **Owning F-* slice.** F-3 ([#1038](https://github.com/vega113/supawave/issues/1038)).
+
+### `rail-extension` — on the right rail (M.4)
+
+- **Mount point.** Inside `<wavy-rail-panel>`
+  (`j2cl/lit/src/design/wavy-rail-panel.js`), in the slot wrapper
+  named `rail-extension` rendered after the panel body and before
+  the footer.
+- **Slot context (read-only).** Two data attributes on the host:
+  - `data-active-wave-id` — the currently selected wave's ID.
+  - `data-active-folder` — the currently selected folder
+    (`inbox`, `archive`, etc).
+- **Allowed children.** Block-level panels (assistant chat, tasks
+  roll-up, integrations status). The host element handles its own
+  collapse animation; plugins should not assume their content
+  remains visible if the panel is collapsed.
+- **Owning F-* slice.** F-2 ([#1037](https://github.com/vega113/supawave/issues/1037)). F-4 may render a placeholder
+  here when active-feature surfaces appear.
+
+### `toolbar-extension` — on the H.* edit toolbar (M.5)
+
+- **Mount point.** Inside `<wavy-edit-toolbar>`
+  (`j2cl/lit/src/design/wavy-edit-toolbar.js`), in the slot wrapper
+  named `toolbar-extension` placed at the right end of the
+  formatting controls row.
+- **Slot context (read-only).** One data attribute on the host:
+  - `data-active-selection` — JSON-encoded selection descriptor.
+    The recipe debounces writes to this attribute at ~60 fps so
+    noisy selection updates from F-3 do not thrash the DOM. Plugins
+    should `JSON.parse` the value lazily on read.
+- **Allowed children.** Inline-block children that look at home in
+  a pill-shaped toolbar (icon buttons with stroke-only icons,
+  small chips). Long-form affordances should anchor a popover.
+- **Owning F-* slice.** F-3 ([#1038](https://github.com/vega113/supawave/issues/1038)).
+
+## Visual rhythm
+
+- **Production.** An empty slot collapses to zero height — the
+  surface above the slot sits flush with the surface below. No
+  plugin = no visual artefact.
+- **Design preview.** When `<html data-wavy-design-preview>` is
+  set (the design-preview route at
+  `?view=j2cl-root&q=design-preview` does this), each empty slot
+  renders a 1px dashed hairline border with the slot name as a
+  small label in the upper-left corner. This lets a designer see
+  exactly where plugins will land before any plugin ships.
+
+## Styling contract
+
+- **Default theming.** Plugins inherit the `--wavy-*` design
+  tokens through the cascade — slotted content lives in light DOM
+  and inherits host styles. A plugin that uses
+  `color: var(--wavy-text-body)` and
+  `background: var(--wavy-bg-surface)` looks at home in dark,
+  light, and contrast variants automatically.
+- **Opt-out.** A plugin that wants to paint its own visual sets
+  `data-wavy-plugin-untheme` on its slotted root element. The host
+  recipe drops the inner-glow border around the slot wrapper so
+  the plugin can present its own surface. The opt-out uses the
+  CSS `:has()` selector and requires Chromium ≥105, Safari ≥15.4,
+  Firefox ≥121; on engines below this the opt-out gracefully
+  no-ops (the inner glow remains visible behind the plugin
+  content but does not break it).
+
+## Accessibility contract
+
+- Plugin content must respect the F-0 focus frame. Apply
+  `:focus-visible` styles using `box-shadow:
+  var(--wavy-focus-ring)` so focus feels consistent with the host
+  surface.
+- Plugin content must announce its own role/label. The host
+  recipe does not add an ARIA role to the slot wrapper, so a
+  plugin's elements are responsible for their own `role`,
+  `aria-label`, and `aria-current` markup.
+- Plugin content must not steal the host's `tabindex=0`. The host
+  recipe owns keyboard navigation between blips / compose
+  affordances / rail panels; a plugin that reroutes Tab will
+  break the parity surface.
+
+## Lifecycle contract
+
+- Slots mount with their host element. A plugin's content is
+  inserted into the slot when the host first renders.
+- Slots unmount with their host element. When the host element is
+  removed from the DOM (wave switch, collapse), the plugin's
+  slotted content is removed with it. Plugins must not assume
+  persistence across wave-selection.
+- A plugin that fails to render (throws during construction or
+  first render) must not break the host. The slot stays empty and
+  the host renders normally.
+
+## Rollback semantics
+
+- F-0 does not implement a per-slot kill switch. The future
+  plugin registry will expose one (so a misbehaving plugin can be
+  disabled without a redeploy).
+- A plugin that does not render falls through to the empty-slot
+  visual rhythm above (zero height in production, dashed outline
+  in design preview).
+- The host recipe never throws on slotted content — the slot is a
+  pass-through. So a plugin that renders broken HTML does not
+  break the host's render either; the broken HTML simply paints
+  inside the slot.

--- a/docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md
@@ -1,0 +1,900 @@
+# F-0: Refresh Lit design packet for wavy aesthetic + plugin slot contracts
+
+Status: Ready for implementation
+Owner: codex/issue-1035-wavy-design-foundation worktree
+Issue: [#1035](https://github.com/vega113/supawave/issues/1035)
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Audit motivating this lane:
+`/Users/vega/devroot/worktrees/j2cl-parity-audit/docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md`
+Stitch design source of truth: project `15560635515125057401`, design system
+`assets/6962139294633729409` ("Wavy — Firefly Signal", v1).
+
+## 1. Why this plan exists
+
+The 2026-04-26 J2CL ↔ GWT parity audit and the accompanying functional
+inventory (`docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md`,
+rows A.1–A.18 + M.1–M.5) found that the existing Lit design packet (#962)
+plus the closed slice chain (#931, #966–#971) shipped against narrow
+per-issue acceptance and did not deliver a recognisable parity surface.
+The current packet ships only seven flat tokens in
+`j2cl/lit/src/tokens/shell-tokens.css` (a teal `--shell-color-accent-brand`
+surface family with one shadow) and no component recipes or plugin seams.
+
+F-2/F-3/F-4 will redo the read/compose/live work against row-level matrix
+acceptance — but they need a coherent visual + extensibility seam first,
+otherwise each slice will reinvent its own tokens and slot conventions.
+
+This plan delivers the **F-0 design packet** as five tasks (T1–T5):
+
+1. T1 — Wavy token files under `j2cl/lit/src/design/` (color, typography,
+   motion, spacing/shape) with dark + light + **high-contrast** variants
+   (issue body §Scope.1 mandates all three "from day one").
+2. T2 — Six Lit recipe elements (blip card, compose card, rail panel,
+   edit toolbar, depth-nav breadcrumb, plus a pulse-stage helper that
+   doubles as the F-3 live-update primitive) that consume the tokens
+   and expose the plugin slots.
+3. T3 — `docs/j2cl-plugin-slots.md` formalising the slot-context contract
+   for `blip-extension`, `compose-extension`, `rail-extension`,
+   `toolbar-extension`, **plus** `j2cl/lit/src/design/README.md` which
+   serves as the design packet README and links the three Stitch screens
+   (issue body §Acceptance bullet 2).
+4. T4 — Storybook-style demo route reachable at
+   `/?view=j2cl-root&q=design-preview` (per issue body §Verification)
+   that mounts every recipe in dark + light + high-contrast variants
+   plus a live-update pulse moment.
+5. T5 — A.10 user-menu wiring: rename the "Automation / APIs" group to
+   "Plugins / Integrations" in both topbars (standalone + wave-client)
+   and **update the existing `HtmlRendererTopBarTest.java:38` assertion**
+   that still hard-codes the old label, add changelog entry, and confirm
+   SBT verification.
+
+Each task ends with a paired Lit web-test-runner test or HtmlRenderer test
+at the same change boundary. SBT verification (`sbt -batch j2clLitTest
+j2clLitBuild j2clProductionBuild`) gates the lane.
+
+This issue ships **no behavior changes**. It produces a reviewed design
+packet + a documented plugin-extension contract. F-2/F-3/F-4 mount the
+slot points but do not register plugins.
+
+## 2. Verification ground truth (re-derived in worktree)
+
+Citations re-grepped in the worktree on 2026-04-26 against HEAD
+`86ea6b440` (post-#1040). Line numbers are accurate as of the worktree
+snapshot; treat them as anchors.
+
+### Existing Lit packet seams (the things F-0 extends)
+
+- `j2cl/lit/src/tokens/shell-tokens.css:1-258` — current token file.
+  Defines `--shell-color-*`, `--shell-space-*`, `--shell-shell-radius`,
+  `--shell-shell-shadow`, `--shell-font-ui`, plus per-element layout
+  rules. F-0 keeps every existing token (so #962 callers don't break)
+  and **adds** the `--wavy-*` token namespace alongside.
+- `j2cl/lit/src/index.js:1-30` — registers all 22 existing custom
+  elements and selects the JSON or inline shell-input bridge. F-0 adds
+  the six new recipe element imports here. **No** CSS import is added
+  to `index.js` — the wavy CSS is emitted as a separate esbuild entry
+  (see next bullet) so server templates can decide independently
+  whether to load it.
+- `j2cl/lit/esbuild.config.mjs:7-21` — bundles `src/index.js` and
+  `src/tokens/shell-tokens.css` into `war/j2cl/assets/shell.{js,css}`
+  with sourcemaps. F-0 adds a third entry point
+  `{ in: ".../src/design/wavy-tokens.css", out: "wavy-tokens" }` so
+  the wavy tokens emit as a sibling `war/j2cl/assets/wavy-tokens.css`
+  asset. **Critical:** the recipe `.js` files do **not** `import` the
+  CSS file; only the `<link>` tag in server-rendered HTML loads it.
+  This avoids double-emission and keeps the J2CL-root path's bundle
+  size unchanged when wavy is not loaded by F-2/F-3/F-4.
+- `j2cl/lit/src/elements/shell-header.js:1-58`,
+  `shell-nav-rail.js`, `shell-main-region.js`, `composer-shell.js`,
+  `composer-inline-reply.js`, `toolbar-button.js`, `toolbar-group.js`
+  — pattern reference for new recipe elements (LitElement, `static
+  styles`, `static properties`, named `<slot>`s, `customElements.get`
+  guard).
+- `j2cl/lit/test/shell-header.test.js:1-22` — pattern reference for
+  `@open-wc/testing` fixture-driven tests.
+
+### Existing J2CL-root shell asset emission (must also load wavy)
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3378-3380`
+  — `renderJ2clRootShellPage` emits `<link>`s for `sidecar.css` and
+  `shell.css` plus `<script>` for `shell.js`. F-0 **must** add a third
+  `<link rel="stylesheet" href="…j2cl/assets/wavy-tokens.css">` here
+  immediately after the `shell.css` link. Otherwise F-2/F-3/F-4
+  recipes mounted under `?view=j2cl-root` render with no tokens
+  loaded. The new `HtmlRendererJ2clRootShellTest` assertion path adds
+  one more `assertTrue(html.contains("/j2cl/assets/wavy-tokens.css"))`.
+
+### Existing user-menu seam (the A.10 / M.1 wiring)
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:4467-4476`
+  — the standalone-topbar dropdown emits a `menu-section` titled
+  "Automation / APIs" containing `/account/robots` ("Robot & Data API")
+  + `/api-docs`. F-0 renames the section label to **"Plugins /
+  Integrations"** and keeps the same two anchor links + their CSS
+  classes. Existing tests must still pass.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:4656-4665`
+  — same pattern for the wave-client-page topbar. Same rename.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:2535`
+  — there is also a static "Robot & Data API" `<h3>` inside the
+  account-shell page. **Out of scope** for F-0 (that is the dedicated
+  account page, not a menu entry).
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java`
+  — exists; verifies `/j2cl/assets/n` (the bundle URL). F-0 extends it
+  to assert the new `wavy-tokens.css` link as well.
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererTopBarTest.java:38`
+  — currently asserts the literal `"section-label\">Automation /
+  APIs"`. **Will fail under T5 unless updated.** F-0 rewrites this
+  assertion to `"section-label\">Plugins / Integrations"`. The same
+  test file at line 156 invokes `renderJ2clRootShellPage`, which is
+  unaffected by the menu rename.
+- F-0 adds a new `HtmlRendererPluginsMenuTest` (per §7) that asserts
+  both topbars contain the new label, do **not** contain the old label,
+  and still link to `/account/robots` and `/api-docs`.
+
+### Server-side asset emission for the design preview route
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java:167-196`
+  is the existing `?view=j2cl-root` branch. F-0 adds a sub-branch
+  inside it that checks `request.getParameter("q")` for
+  `"design-preview"` (per issue body §Verification:
+  `/?view=j2cl-root&q=design-preview`). When matched, the servlet
+  calls `HtmlRenderer.renderJ2clDesignPreviewPage(...)` instead of
+  `renderJ2clRootShellPage(...)` — same `?view` param, same auth
+  shape, same asset path, no new servlet branch.
+- The design preview is **admin-or-owner gated** to keep a designer-
+  facing route off the public surface. The branch:
+  `if ("design-preview".equals(qParam) && (id != null && isAdminOrOwner(id))) renderDesignPreview() else fall-through to existing renderJ2clRootShellPage`.
+  Non-admins requesting `?q=design-preview` get the regular root shell.
+- `HtmlRenderer.renderJ2clDesignPreviewPage` reuses the same asset
+  links emitted by `renderJ2clRootShellPage` (sidecar.css, shell.css,
+  **wavy-tokens.css**, shell.js) so the preview rides the production
+  loader; no duplicate `<link>` plumbing.
+
+### Stitch design source of truth (do not re-invent the aesthetic)
+
+The "Wavy — Firefly Signal" design system in Stitch project
+`15560635515125057401` (asset `6962139294633729409`, v1) is the source
+of truth. Its `designMd` field encodes:
+
+- **Inspiration & principles** — Firefly "send a wave" idiom; signal
+  over chrome; live-update presence; conversational warmth and density;
+  holographic depth (border glow, not shadow stacks); plugin slots are
+  first-class.
+- **Palette** — bg `#0b1320` (deep midnight blue), surface a half-shade
+  lighter with hairline signal-tone border, primary signal cyan
+  `#22d3ee`, secondary signal violet `#7c3aed`, tertiary signal amber
+  `#fb923c`, body text at ~92% opacity (never pure white).
+- **Motion** — signal pulse 600ms (max 1/sec/blip), focus transition
+  180ms (cursor-in-console), collapse 240ms, fragment-window load 300ms
+  fade-in from low-alpha signal-tone skeleton.
+- **Typography** — Space Grotesk (headline), Inter (body), Geist
+  (label), ~70 char target line in the wave panel.
+- **Roundness** — cards 12px, chips/badges full pill, inputs 12px.
+- **Plugin-slot visual rhythm** — empty slot collapses to 0 in
+  production; in design preview, faintly outlined dashed region with
+  slot-name label.
+- **Light mode** — pale near-white background, midnight ink, same
+  accents at higher saturation. Maintain the living-signal feel.
+
+F-0 reproduces these values exactly as CSS custom properties (no
+re-interpretation) so a side-by-side check against the Stitch design
+markdown stays one-to-one.
+
+## 3. Design — token contract
+
+All tokens live in `j2cl/lit/src/design/wavy-tokens.css`. The Stitch
+source of truth declares `colorMode: DARK`, so **dark is the default**:
+`:root` carries the dark values. `@media (prefers-color-scheme: light)`
+overrides them with the light values. Explicit overrides via
+`:root[data-wavy-theme="dark"]`, `:root[data-wavy-theme="light"]`,
+and `:root[data-wavy-theme="contrast"]` (or scoped wrappers carrying
+the same data attribute) win over the media query — the recipes use
+this attribute to demonstrate side-by-side variants in the demo route.
+
+Recipes consume tokens via `var(--wavy-*, fallback)` so a recipe still
+degrades sanely if loaded without `wavy-tokens.css`.
+
+### 3.1 Color tokens (exact names — F-2/F-3/F-4 reference these)
+
+Surface and chrome:
+- `--wavy-bg-base` — page background. Dark: `#0b1320`. Light: `#f6f7fb`.
+- `--wavy-bg-surface` — card / panel surface. Dark: `#11192a`. Light:
+  `#ffffff`.
+- `--wavy-border-hairline` — 1px hairline border on surfaces. Dark:
+  `rgba(34, 211, 238, 0.18)`. Light: `rgba(11, 19, 32, 0.10)`.
+
+Text:
+- `--wavy-text-body` — body text. Dark: `rgba(232, 240, 255, 0.92)`.
+  Light: `rgba(11, 19, 32, 0.92)`.
+- `--wavy-text-muted` — secondary text. Dark: `rgba(232, 240, 255,
+  0.62)`. Light: `rgba(11, 19, 32, 0.62)`.
+- `--wavy-text-quiet` — tertiary text (timestamps, labels). Dark:
+  `rgba(232, 240, 255, 0.42)`. Light: `rgba(11, 19, 32, 0.55)` (the
+  light alpha was raised from the symmetric 0.42 to 0.55 so the
+  composited color clears WCAG ≥3:1 on the `#ffffff` surface — at
+  0.42 it landed at 2.75:1).
+
+Signal accents (named after Firefly "wave" tones — see Stitch design
+markdown for usage rules):
+- `--wavy-signal-cyan` — primary signal (focus frame, pulse, primary
+  CTA, unread badge). Both modes: `#22d3ee`.
+- `--wavy-signal-cyan-soft` — alpha-tinted cyan for inner glow + pulse
+  ring. Dark: `rgba(34, 211, 238, 0.22)`. Light: `rgba(34, 211, 238,
+  0.18)`.
+- `--wavy-signal-violet` — mention/reaction tone. Both modes: `#7c3aed`.
+- `--wavy-signal-violet-soft` — alpha-tinted violet for chip
+  backgrounds. Dark: `rgba(124, 58, 237, 0.22)`. Light: `rgba(124, 58,
+  237, 0.16)`.
+- `--wavy-signal-amber` — task / time-sensitive tone. Both modes:
+  `#fb923c`.
+- `--wavy-signal-amber-soft` — alpha-tinted amber for background fills.
+  Dark: `rgba(251, 146, 60, 0.22)`. Light: `rgba(251, 146, 60, 0.16)`.
+
+Focus + pulse derived tokens:
+- `--wavy-focus-ring` — focus frame outline. Both modes:
+  `0 0 0 2px var(--wavy-signal-cyan)` (consumed via `box-shadow`).
+- `--wavy-pulse-ring` — outer glow on live-update pulse. Both modes:
+  `0 0 0 4px var(--wavy-signal-cyan-soft)`.
+
+### 3.2 Typography tokens
+
+Font family stacks (web-safe fallbacks for environments without the
+named fonts loaded — F-0 does not add a webfont loader; the recipes
+gracefully fall back):
+
+- `--wavy-font-headline` — `"Space Grotesk", "Inter", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", sans-serif`.
+- `--wavy-font-body` — `"Inter", -apple-system, BlinkMacSystemFont,
+  "Segoe UI", Roboto, sans-serif`.
+- `--wavy-font-label` — `"Geist", "Inter", -apple-system,
+  BlinkMacSystemFont, "Segoe UI", sans-serif`.
+
+Type scale (line-height baked in; ratios picked to give the
+~70-char-per-line target in the read surface at the default 16px root):
+
+- `--wavy-type-display` — `clamp(1.875rem, 1.4rem + 1.6vw, 2.25rem) /
+  1.18 var(--wavy-font-headline)`.
+- `--wavy-type-h1` — `1.5rem / 1.25 var(--wavy-font-headline)`.
+- `--wavy-type-h2` — `1.25rem / 1.3 var(--wavy-font-headline)`.
+- `--wavy-type-h3` — `1.0625rem / 1.35 var(--wavy-font-headline)`.
+- `--wavy-type-body` — `0.9375rem / 1.55 var(--wavy-font-body)`.
+- `--wavy-type-label` — `0.75rem / 1.35 var(--wavy-font-label)` with
+  `letter-spacing: 0.04em` applied via the recipes' selectors (token
+  carries the `font` shorthand only).
+- `--wavy-type-meta` — `0.6875rem / 1.4 var(--wavy-font-label)`.
+
+**Caveat — `font` shorthand reset.** Each `--wavy-type-*` value is a
+CSS `font` shorthand, which when applied via
+`font: var(--wavy-type-display);` resets `font-style`, `font-variant`,
+`font-weight`, `font-stretch`, and `font-size-adjust` to initial.
+Recipes that need a non-default weight or italic must declare it
+**after** the shorthand in the same rule:
+```
+font: var(--wavy-type-display);
+font-weight: 600;
+```
+The token test asserts `getComputedStyle(...).fontWeight` matches the
+recipe's declared weight to catch accidental overrides via the
+shorthand.
+
+### 3.3 Motion tokens
+
+- `--wavy-motion-pulse-duration` — `600ms` (signal pulse on
+  live-update).
+- `--wavy-motion-focus-duration` — `180ms` (focus frame slide).
+- `--wavy-motion-collapse-duration` — `240ms` (collapse/expand height
+  + opacity).
+- `--wavy-motion-fragment-fade-duration` — `300ms` (fragment-window
+  load fade-in).
+
+Easings:
+- `--wavy-easing-pulse` — `cubic-bezier(0.32, 0.72, 0.32, 1)` (outward
+  bloom that decays).
+- `--wavy-easing-focus` — `cubic-bezier(0.2, 0.0, 0.2, 1)` (ease-out;
+  cursor-in-console feel).
+- `--wavy-easing-collapse` — `cubic-bezier(0.4, 0.0, 0.2, 1)` (standard
+  ease-in-out).
+
+Reduced-motion: a `@media (prefers-reduced-motion: reduce)` block in
+`wavy-tokens.css` resets all four `--wavy-motion-*-duration` tokens to
+`0.01ms` so animations are effectively skipped while still firing
+`animationend` / `transitionend` so JS state machines tracking the
+end event still resolve. The blip-card live-pulse is implemented as a
+CSS `@keyframes` animation (so it fires `animationend`); other
+recipes use `transition` (firing `transitionend`).
+
+**Pulse restart pattern.** A CSS animation does not restart when the
+same attribute value is re-applied without a layout flush. The
+recipe-side helper for `live-pulse` removes the attribute, forces
+layout via `void this.offsetWidth`, then re-adds — so back-to-back
+pulses (from F-3 live-update) animate every time. The
+`<wavy-pulse-stage>` test asserts this pattern.
+
+### 3.4 Spacing + shape tokens
+
+Spacing scale (4-px-base):
+- `--wavy-spacing-1` = `4px`
+- `--wavy-spacing-2` = `8px`
+- `--wavy-spacing-3` = `12px`
+- `--wavy-spacing-4` = `16px`
+- `--wavy-spacing-5` = `20px`
+- `--wavy-spacing-6` = `24px`
+- `--wavy-spacing-7` = `32px`
+- `--wavy-spacing-8` = `40px`
+
+Shape:
+- `--wavy-radius-card` = `12px` (cards, inputs).
+- `--wavy-radius-pill` = `9999px` (chips, badges, signal dots).
+
+### 3.5 Light + dark variant strategy
+
+`wavy-tokens.css` declares dark as the default (matches Stitch
+`colorMode: DARK`). `@media (prefers-color-scheme: light)` overrides
+the surface + text + soft-accent triads to the light values. Explicit
+override via the `data-wavy-theme="dark"` / `data-wavy-theme="light"`
+attribute on `<html>` (or any ancestor scope element) wins over the
+media query.
+
+The recipe elements never read raw colors; they only consume
+`--wavy-*` tokens, so flipping the attribute swaps the whole packet.
+
+### 3.6 High-contrast variant (issue body §Scope.1 mandate)
+
+Issue body §Scope.1: "dark-mode and high-contrast variants from day
+one". F-0 ships a third variant that swaps the chrome for WCAG-AAA
+contrast under `prefers-contrast: more` and the explicit
+`data-wavy-theme="contrast"` attribute:
+
+- Surfaces: `--wavy-bg-base: #000000`, `--wavy-bg-surface: #0b1320`.
+- Borders: `--wavy-border-hairline` becomes a solid 1.5px
+  `rgba(255, 255, 255, 0.85)` border (no hairline tinting).
+- Text: `--wavy-text-body: #ffffff`, `--wavy-text-muted:
+  rgba(255, 255, 255, 0.85)`, `--wavy-text-quiet:
+  rgba(255, 255, 255, 0.7)` — none drop below WCAG AAA (7:1) on the
+  black surface.
+- Signal accents: same hex values, but the `*-soft` companions become
+  more saturated (`rgba(34, 211, 238, 0.45)` etc) so the inner-glow
+  does not blend into the surface.
+- Inner-glow border on cards is suppressed (replaced by the solid
+  border above) so contrast is carried by edges, not light.
+- `--wavy-focus-ring` thickens to `0 0 0 3px var(--wavy-signal-cyan)`
+  for visibility without inner glow.
+
+A recipe test mounts each recipe under `data-wavy-theme="contrast"`
+and asserts the computed `outline` / `border` values reflect the
+solid-border treatment.
+
+### 3.7 Plugin-slot styling contract (renumbered from 3.6)
+
+Plugins inherit `--wavy-*` tokens by default through the cascade
+(plugin content rendered into a slot lives in light DOM and inherits
+host styles). Plugins opt out by setting `data-wavy-plugin-untheme`
+on their slotted root element; recipes add a
+`:has([data-wavy-plugin-untheme])` guard on the slot wrapper that
+suppresses the inner-glow border so an opt-out plugin can present its
+own visual. Note: the `:has()` selector requires Chromium ≥105,
+Safari ≥15.4, Firefox ≥121; on engines below this the opt-out
+gracefully no-ops (the inner-glow remains visible behind the plugin
+content but does not break it).
+
+## 4. Component recipes (T2)
+
+Five Lit elements added under `j2cl/lit/src/design/`. Each is a
+self-contained recipe consumable by F-2/F-3/F-4. Existing shell
+elements stay untouched (#962 callers continue to work).
+
+### 4.1 `<wavy-blip-card>` (F-2 consumer)
+
+- File: `j2cl/lit/src/design/wavy-blip-card.js`.
+- Properties: `focused: Boolean`, `unread: Boolean`, `live-pulse:
+  Boolean`, `author-name: String`, `posted-at: String` (ISO),
+  `blip-id: String` (reflected to `data-blip-id`), `wave-id: String`.
+- Slots:
+  - default — blip body content (text, attachments, embeds);
+  - `name="reactions"` — reaction-chip rail;
+  - `name="metadata"` — timestamp + read-status row;
+  - **`name="blip-extension"`** — the M.2 plugin slot, rendered between
+    the body and the reactions rail (per inventory M.2 spec).
+- Visual: holographic card with hairline cyan-soft border; focused
+  state shifts the border to `--wavy-signal-cyan` and adds the focus
+  ring. Live-update pulse triggered by toggling the `live-pulse`
+  attribute for one frame; CSS animation runs once and the attribute
+  is dropped by F-2 telemetry.
+- Plugin-slot context (documented in `docs/j2cl-plugin-slots.md`):
+  `{ blipId, blipView (read-only proxy), waveId, isAuthor }`. The
+  recipe surfaces the contract two ways:
+  1. **Data attributes** (string-only, for declarative plugins):
+     `data-blip-id`, `data-wave-id`, `data-blip-author`,
+     `data-blip-is-author`. Plugins read these from
+     `slot.assignedElements()[0].closest('wavy-blip-card').dataset`.
+  2. **`blipView` JS property** (structured, for richer plugins): the
+     host element exposes `wavyBlipCard.blipView`, returning a frozen
+     read-only `Object.freeze({ id, authorName, postedAt, body, ... })`
+     proxy. Mutating the proxy throws in strict mode (default for
+     custom elements). The property accessor lazily snapshots the
+     view from the host's internal state on read so plugins always
+     see fresh data.
+- Test: `j2cl/lit/test/wavy-blip-card.test.js` — asserts the four data
+  attributes, the four named slot names exist, the focused state
+  applies the focus ring class, the empty `blip-extension` slot
+  collapses to zero height when `data-wavy-design-preview` is **not**
+  set on the document and renders a dashed outline label when it is,
+  the `blipView` property returns a frozen object, and mutating the
+  property throws under strict mode. The recipe is mounted under
+  three theme attributes (`dark`, `light`, `contrast`) and the test
+  asserts at least one computed style differs across all three (e.g.,
+  `getComputedStyle(card).backgroundColor` differs between dark and
+  light).
+
+### 4.2 `<wavy-compose-card>` (F-3 consumer)
+
+- File: `j2cl/lit/src/design/wavy-compose-card.js`.
+- Properties: `focused: Boolean`, `submitting: Boolean`, `reply-target-blip-id:
+  String`.
+- Slots: default (composer surface), `name="toolbar"` (the H.* edit
+  toolbar), **`name="compose-extension"`** (M.3, right of the
+  toolbar), `name="affordance"` (submit button row).
+- Plugin-slot context: `{ composerState, activeSelection,
+  replyTargetBlipId }`. Recipe reflects `data-reply-target-blip-id`
+  on the host; `composerState` and `activeSelection` are exposed as
+  frozen JS properties on the host element (`wavyComposeCard
+  .composerState`, `wavyComposeCard.activeSelection`).
+- Test: assert slot names, focused style, submitting state disables
+  pointer events on the affordance slot wrapper, all three theme
+  variants (`dark`/`light`/`contrast`) flip a computed style, the
+  empty `compose-extension` slot collapses in production and shows
+  the dashed outline under `data-wavy-design-preview`, and
+  `composerState` / `activeSelection` properties return frozen
+  objects.
+
+### 4.3 `<wavy-rail-panel>` (F-2 consumer)
+
+- File: `j2cl/lit/src/design/wavy-rail-panel.js`.
+- Properties: `panel-title: String`, `collapsed: Boolean`,
+  `active-wave-id: String`, `active-folder: String`.
+- Slots: default (panel body), `name="header-actions"`,
+  **`name="rail-extension"`** (M.4), `name="footer"`.
+- Visual: column of stacked surface cards with collapse animation
+  using `--wavy-motion-collapse-duration` + `--wavy-easing-collapse`.
+- Plugin-slot context: `{ activeWaveId, activeFolder }` exposed via
+  `data-active-wave-id` / `data-active-folder`.
+- Test: assert the rail-extension slot exists, collapse toggles
+  `aria-expanded`, the data attributes propagate, all three theme
+  variants flip a computed style, and the empty `rail-extension`
+  slot collapses in production and shows the dashed outline under
+  `data-wavy-design-preview`.
+
+### 4.4 `<wavy-edit-toolbar>` (F-3 consumer)
+
+- File: `j2cl/lit/src/design/wavy-edit-toolbar.js`.
+- Properties: `active-selection: String` (JSON-encoded selection
+  descriptor — opaque to the recipe; plugins parse it).
+- Slots: default (formatting controls — bold/italic/etc),
+  **`name="toolbar-extension"`** (M.5, right of the formatting
+  controls).
+- Visual: pill-shaped row, signal-cyan accent on the active control;
+  uses `--wavy-radius-pill`, `--wavy-spacing-2`.
+- Plugin-slot context: `{ activeSelection }`. The recipe writes the
+  attribute only when `active-selection` changes, debounced at 60 fps
+  (≈16 ms minimum gap), so a noisy selection update from F-3 does not
+  thrash the DOM. For long selections, plugins should re-read from
+  the data attribute lazily.
+- Test: assert the toolbar-extension slot exists, the data attribute
+  is reflected after the debounce window, the active control class
+  swaps on `aria-pressed`, all three theme variants flip a computed
+  style, and the empty `toolbar-extension` slot collapses in
+  production / dashed-outlines under `data-wavy-design-preview`.
+
+### 4.5 `<wavy-depth-nav>` (no plugin slot — purely chrome)
+
+- File: `j2cl/lit/src/design/wavy-depth-nav.js`.
+- Property: `crumbs: Array` of `{ label: string, href?: string,
+  current?: boolean }`.
+- Renders a breadcrumb row with chevron separators using
+  `--wavy-font-label` and `--wavy-text-muted`. Current crumb uses
+  `--wavy-text-body` and `aria-current="page"`. Used by F-2 to show
+  Inbox › Wave › Thread context.
+- Test: asserts crumb count and that exactly one crumb carries
+  `aria-current`.
+
+### 4.6 `<wavy-pulse-stage>` (demo route helper — also used as a F-3 helper)
+
+- File: `j2cl/lit/src/design/wavy-pulse-stage.js`.
+- Tiny LitElement that, on a button press, sets the `live-pulse`
+  attribute on a target child for 600ms and then removes it. Used by
+  the design preview to demonstrate the live-update pulse moment;
+  F-3 may reuse this as the canonical "fire a pulse on an arriving
+  blip" helper rather than re-implementing the timing.
+- Test: resolves `--wavy-motion-pulse-duration` at test time via
+  `getComputedStyle(document.documentElement).getPropertyValue(...)`
+  and asserts the attribute toggles within `(resolvedDuration + 50)
+  ms`. This makes the test stable on CI hosts that announce
+  `prefers-reduced-motion: reduce` (where the duration collapses to
+  ~0ms and the budget is ~50ms) without flaking.
+
+## 5. Plugin-slot doc + design packet README (T3)
+
+Two markdown files. The plugin-slot doc is the slot contract; the
+design packet README is the design-packet "front page" that the
+issue body's §Acceptance bullet 2 ("at least three Stitch screens
+generated and linked from the design packet") needs.
+
+### 5.1 `docs/j2cl-plugin-slots.md` (plugin-slot contract)
+
+Single doc owned by F-0 that F-2/F-3/F-4 link from their plans. Sections:
+
+1. **Overview** — what a plugin slot is, why it exists, and the
+   relationship to the forthcoming robots/data-API plugin registry
+   (F-0 specifies the slot contract only; registration is a separate
+   future issue).
+2. **The four slots** — one subsection each for `blip-extension`,
+   `compose-extension`, `rail-extension`, `toolbar-extension`. Each
+   subsection covers:
+   - **Mount point** — the F-* recipe element that owns the slot
+     and where in its render tree the slot sits.
+   - **Slot context (read-only)** — the data attributes a plugin can
+     read from the host element. Exact attribute names listed.
+   - **Allowed children** — markup the slot accepts (HTML elements,
+     custom elements that respect the styling contract).
+   - **Owning F-* slice** — F-2 (#1037) for blip + rail; F-3 (#1038)
+     for compose + toolbar.
+3. **Visual rhythm** — empty slots collapse to zero height in
+   production; in design preview (set `data-wavy-design-preview`
+   attribute on `<html>`), each empty slot renders a dashed outline
+   with the slot name label so designers can see where plugins land.
+4. **Styling contract** — plugins inherit `--wavy-*` tokens by default;
+   to opt out, the plugin sets `data-wavy-plugin-untheme` on its root
+   element, which suppresses the recipe's inner-glow border and lets
+   the plugin paint its own visual.
+5. **Accessibility contract** — plugin content must respect the F-0
+   focus-frame (use `:focus-visible` with the `--wavy-focus-ring`
+   custom property if drawing focus state) and announce its own
+   role/label. Plugins must not steal the parent's `tabindex=0`.
+6. **Lifecycle contract** — slots mount with their host element and
+   unmount on host removal. Plugins must not assume persistence
+   across wave-selection: if the host element is destroyed, the
+   plugin's content is destroyed with it.
+7. **Rollback semantics** — a plugin that fails to render must not
+   break the host; the slot stays empty and the host renders normally.
+   The future plugin registry will expose a per-slot kill switch; F-0
+   does not implement it.
+
+The doc is reviewable in isolation (no code references that would rot)
+and is the source of truth that F-2/F-3/F-4 quote from in their plans.
+
+### 5.2 `j2cl/lit/src/design/README.md` (design packet README)
+
+Front-page doc for the wavy design packet, satisfying issue body
+§Acceptance bullets 1 + 2. Sections:
+
+1. **Source of truth** — the Stitch project / asset IDs (project
+   `15560635515125057401`, design system `assets/6962139294633729409`,
+   v1 "Wavy — Firefly Signal"), with the design markdown reproduced
+   verbatim so the packet stays self-contained even if Stitch
+   becomes unavailable.
+2. **Stitch screens** — three screens generated via
+   `mcp__stitch__generate_screen_from_text` (or pulled from the
+   project) with the IDs/URLs listed:
+   - **Read surface** — focused blip in a wave thread with rail.
+   - **Compose surface** — composer with edit toolbar and the four
+     plugin-slot dashed outlines visible.
+   - **Live-update pulse moment** — incoming blip mid-animation with
+     the cyan signal glow.
+   The screens are generated by T3 (the `mcp__stitch__*` tool calls
+   are implementation tasks for the implementer subagent).
+3. **Token reference** — pointer to `wavy-tokens.css` and the
+   namespacing rule (only `--wavy-*` is part of the F-0 contract;
+   `--shell-*` is the legacy #962 packet, kept for back-compat).
+4. **Recipe reference** — pointer to the six recipe elements and
+   their per-recipe README sections (one paragraph each).
+5. **Variant reference** — dark / light / contrast switching rules
+   and the `data-wavy-theme` attribute.
+6. **How F-2/F-3/F-4 consume the packet** — a copy-paste of §11
+   from this plan.
+
+## 6. Demo route (T4)
+
+A new server route renders the design preview without auth coupling:
+the page is a static HTML doc that imports `shell.js` + the wavy CSS
+files and mounts each recipe with sample content.
+
+### 6.1 Server seam
+
+`HtmlRenderer.renderJ2clDesignPreviewPage(...)` (signature mirrors
+`renderJ2clRootShellPage` — same context path, build commit, build
+time, release id) returns the full HTML page as a String. It:
+
+- emits `<link rel="stylesheet" href="<base>j2cl/assets/sidecar.css">`,
+  `<link rel="stylesheet" href="<base>j2cl/assets/shell.css">`, and
+  `<link rel="stylesheet" href="<base>j2cl/assets/wavy-tokens.css">`
+  (same three the production root shell loads after T1),
+- emits `<script type="module" src="<base>j2cl/assets/shell.js">`,
+- sets `<html data-wavy-design-preview>` so empty slots render with
+  the dashed outline,
+- mounts three `<section>`s in order: dark variant (no theme
+  attribute), light variant (`<section data-wavy-theme="light">`),
+  and contrast variant (`<section data-wavy-theme="contrast">`).
+  The recipes pick up the scope override at the section level.
+
+`WaveClientServlet` (Jakarta override) extends its existing
+`?view=j2cl-root` branch (line 167) with a sub-branch. The role check
+mirrors the existing pattern at `HtmlRenderer.java:3347-3348`
+(`HumanAccountData.ROLE_ADMIN.equals(role) || HumanAccountData.ROLE_OWNER.equals(role)`):
+the servlet fetches `AccountData` for `id` via the existing
+`accountStore.getAccount(id)` call (already used at
+`WaveClientServlet.java:222-228`) and checks the role on the
+`HumanAccountData`:
+
+```
+boolean designPreviewRequested =
+    "design-preview".equals(request.getParameter("q"));
+if (designPreviewRequested && id != null) {
+  AccountData acct = accountStore.getAccount(id);
+  if (acct != null && acct.isHuman()) {
+    String role = acct.asHuman().getRole();
+    if (HumanAccountData.ROLE_ADMIN.equals(role)
+        || HumanAccountData.ROLE_OWNER.equals(role)) {
+      w.write(HtmlRenderer.renderJ2clDesignPreviewPage(...));
+      return;
+    }
+  }
+}
+// fall through to existing renderJ2clRootShellPage(...) call
+```
+
+The route is **admin-or-owner gated** to keep a designer-facing
+surface off the public menu. A non-admin requesting
+`?view=j2cl-root&q=design-preview` gets the regular root shell with
+no error, no leak. Discovery is via the documentation in
+`docs/j2cl-plugin-slots.md` and the README. The route is **not**
+added to the user menu (which keeps the menu rename in T5 minimal
+and on-spec).
+
+### 6.2 What the demo route mounts (per issue acceptance)
+
+Each of the three theme sections (dark / light / contrast) renders
+the same content block:
+
+1. A `<wavy-depth-nav>` showing `Inbox › Sample wave › Top thread`.
+2. A `<wavy-blip-card>` in the **focused** state with the focus ring
+   and an example `blip-extension` slot child rendered as a sample
+   plugin.
+3. A `<wavy-blip-card>` in the **unfocused / unread** state with no
+   plugin (so the empty slot's design-preview dashed outline shows).
+4. A `<wavy-compose-card>` with a `<wavy-edit-toolbar>` in its toolbar
+   slot, an example `compose-extension` plugin chip, and an example
+   `toolbar-extension` plugin chip in the inner toolbar slot.
+5. A `<wavy-rail-panel>` titled "Saved searches" with one
+   `rail-extension` sample plugin chip.
+6. A `<wavy-pulse-stage>` wrapping a third blip card with a "Fire
+   pulse" button — this demonstrates the live-update pulse moment
+   required by the issue acceptance.
+
+Above the three sections, the page includes a header strip that
+identifies the page as the design preview and links to
+`docs/j2cl-plugin-slots.md` (rendered as a relative path comment) so
+a designer reaching the route knows the context.
+
+### 6.3 Demo route test
+
+A new server-side test
+`wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clDesignPreviewPageTest.java`
+asserts:
+
+- the page references `/j2cl/assets/sidecar.css`,
+  `/j2cl/assets/shell.css`, `/j2cl/assets/wavy-tokens.css`,
+  `/j2cl/assets/shell.js`,
+- the page contains every recipe element name (`<wavy-blip-card`,
+  `<wavy-compose-card`, `<wavy-rail-panel`, `<wavy-edit-toolbar`,
+  `<wavy-depth-nav`, `<wavy-pulse-stage`),
+- the page contains the `data-wavy-design-preview` attribute,
+- the page contains all three section markers
+  (`data-wavy-theme="light"` and `data-wavy-theme="contrast"`; the
+  dark section is the default with no attribute),
+- the page contains the four plugin-slot sample plugins.
+
+A second test `WaveClientServletDesignPreviewBranchTest` asserts the
+admin-gating: a non-admin GET returns the regular root shell HTML
+(no design-preview markers), and an admin GET returns the design
+preview HTML (with markers).
+
+The demo route is **server-rendered HTML only** — no new J2CL or Lit
+behavior; the recipes' web-test-runner tests cover the client-side
+rendering.
+
+## 7. A.10 user-menu wiring (T5)
+
+In `HtmlRenderer.java`:
+
+- Lines `4467-4476` (standalone topbar): replace
+  `"Automation / APIs"` section label with `"Plugins / Integrations"`.
+  Keep the same two anchor links (`/account/robots`, `/api-docs`)
+  and CSS classes intact. **No** new "Design preview" link in the
+  user menu — the design preview is admin-or-owner gated and reached
+  via the documented URL only (see §6.1).
+- Lines `4656-4665` (wave-client topbar): same rename, no other
+  changes.
+
+In `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererTopBarTest.java`:
+
+- Line `38` currently asserts the literal `"section-label\">Automation
+  / APIs"`. **Update** the assertion to
+  `"section-label\">Plugins / Integrations"`. Without this update the
+  test fails immediately under T5.
+
+A new test
+`wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererPluginsMenuTest.java`
+asserts:
+
+- Both topbars (`renderTopBar(...)` and the standalone-topbar
+  fragment from `renderJ2clRootShellPage(...)`) render the section
+  label `"Plugins / Integrations"`.
+- Both topbars **do not** contain the literal `"Automation / APIs"`
+  anywhere (assertFalse).
+- Both topbars still link to `/account/robots` and `/api-docs` and
+  preserve the `section-link-strong` CSS class on the
+  `/account/robots` anchor.
+
+A changelog entry under
+`wave/config/changelog.d/2026-04-26-issue-1035-wavy-design-foundation.json`
+captures the design-packet bump and the user-menu rename.
+
+## 8. Test plan
+
+### 8.1 Lit web-test-runner (T1, T2, T4 client-side)
+
+- `j2cl/lit/test/wavy-tokens.test.js` (new) — mounts a probe element
+  under each of the three themes (default-dark, `data-wavy-theme=
+  "light"`, `data-wavy-theme="contrast"`) and asserts:
+  - every token name from §3 is non-empty,
+  - every token uses the `--wavy-` prefix (no
+    accidental `--shell-` overlap),
+  - text-on-surface contrast for `--wavy-text-body` and
+    `--wavy-text-muted` against `--wavy-bg-surface` exceeds the
+    per-theme floor (WCAG AA = 4.5 for dark/light, AAA = 7 for
+    contrast). `--wavy-text-quiet` (the tertiary tier reserved for
+    timestamps / decorative meta) is intentionally low-contrast and
+    only required to clear 3:1 on dark/light (WCAG AA for incidental
+    UI / large text) and 4.5:1 on contrast. The test ships a small
+    `relativeLuminance(rgb)` + composite helper; ~30 lines.
+- `j2cl/lit/test/wavy-blip-card.test.js` (new) — see §4.1.
+- `j2cl/lit/test/wavy-compose-card.test.js` (new) — see §4.2.
+- `j2cl/lit/test/wavy-rail-panel.test.js` (new) — see §4.3.
+- `j2cl/lit/test/wavy-edit-toolbar.test.js` (new) — see §4.4.
+- `j2cl/lit/test/wavy-depth-nav.test.js` (new) — see §4.5.
+- `j2cl/lit/test/wavy-pulse-stage.test.js` (new) — see §4.6.
+
+Each recipe test mounts the recipe under all three theme attributes
+and asserts at least one computed style differs across each pair, so
+a recipe that hardcodes a hex value trips CI.
+
+All existing tests under `j2cl/lit/test/*.test.js` must continue to
+pass unchanged. F-0 does not edit any existing Lit element; it only
+adds new files in `j2cl/lit/src/design/`.
+
+### 8.2 Server-side JUnit (T4, T5)
+
+All under `wave/src/test/java/org/waveprotocol/box/server/rpc/`:
+
+- `HtmlRendererJ2clDesignPreviewPageTest.java` (new) — see §6.3.
+- `WaveClientServletDesignPreviewBranchTest.java` (new) — admin
+  gating, see §6.3.
+- `HtmlRendererPluginsMenuTest.java` (new) — see §7.
+- `HtmlRendererTopBarTest.java` (existing, **edited**) — line 38
+  assertion updated to `"Plugins / Integrations"`.
+- `HtmlRendererJ2clRootShellTest.java` (existing, **edited**) — adds
+  one assertion that the page references `/j2cl/assets/wavy-tokens.css`.
+
+### 8.3 SBT verification commands (run in order)
+
+```
+sbt -batch j2clLitTest
+sbt -batch j2clLitBuild
+sbt -batch j2clProductionBuild
+```
+
+All three must pass with zero new warnings introduced by F-0. The
+production build re-bundles the J2CL assets; F-0 only adds new CSS +
+JS so the bundle should grow but not regress.
+
+## 9. Implementation order (T1 → T5)
+
+1. **T1 — Tokens.** Add `j2cl/lit/src/design/wavy-tokens.css` with
+   every `--wavy-*` token from §3 (dark default, light + contrast
+   overrides, reduced-motion override); wire it into
+   `j2cl/lit/esbuild.config.mjs` as a third output entry; add
+   `wavy-tokens.test.js` covering all three themes + WCAG contrast
+   floors; **also add the wavy-tokens.css `<link>` to
+   `renderJ2clRootShellPage` (HtmlRenderer.java:3378-3380)** and
+   extend `HtmlRendererJ2clRootShellTest` with the new assertion.
+   Run `sbt -batch j2clLitTest j2clLitBuild` and confirm
+   `war/j2cl/assets/wavy-tokens.css` exists. ≤120 LOC production +
+   ≤80 LOC test.
+2. **T2 — Recipes.** Add the six recipe elements under
+   `j2cl/lit/src/design/` (blip card, compose card, rail panel, edit
+   toolbar, depth-nav breadcrumb, pulse stage helper); register them
+   in `src/index.js`; add the six paired tests covering all three
+   themes, slot data attributes, frozen JS properties, and the
+   pulse-restart pattern. Run `sbt -batch j2clLitTest j2clLitBuild`.
+   ≤500 LOC production + ≤350 LOC test (six small recipes, ~80 LOC
+   each).
+3. **T3 — Docs.** Add `docs/j2cl-plugin-slots.md` per §5.1 and
+   `j2cl/lit/src/design/README.md` per §5.2. T3 also makes the three
+   Stitch screen calls (`mcp__stitch__generate_screen_from_text`)
+   for read surface, compose surface, and live-update pulse moment;
+   the resulting screen IDs are pasted into the README. No
+   verification beyond build (markdown + Stitch only).
+4. **T4 — Demo route.** Add `HtmlRenderer.renderJ2clDesignPreviewPage`
+   + the admin-gated `q=design-preview` sub-branch in
+   `WaveClientServlet`; add `HtmlRendererJ2clDesignPreviewPageTest`
+   and `WaveClientServletDesignPreviewBranchTest`. Run
+   `sbt -batch j2clProductionBuild` and the JUnit tests via the
+   established Ant path used by other HtmlRenderer tests. ≤220 LOC
+   production + ≤140 LOC test.
+5. **T5 — User-menu rename.** Edit the two `menu-section` blocks in
+   `HtmlRenderer.java` (lines 4467-4476 + 4656-4665). Update
+   `HtmlRendererTopBarTest.java:38`. Add
+   `HtmlRendererPluginsMenuTest`. Add the changelog entry. Run the
+   full SBT chain again. ≤20 LOC production + ≤80 LOC test.
+
+After T5, the lane is implementation-complete. Self-review the diff,
+run the implementation-review subagent, address feedback, then open
+the PR.
+
+## 10. Risks + non-goals
+
+### Risks
+
+- **Token name collisions.** F-0 uses the `--wavy-*` namespace
+  exclusively; the existing `--shell-*` tokens are untouched. F-2/F-3/F-4
+  consume `--wavy-*` directly. **Mitigation:** namespace check in the
+  token test (`wavy-tokens.test.js` asserts the prefix on every probe).
+- **Plugin-slot context drift.** The four data-attribute names are the
+  contract; renaming any of them is a breaking change for plugins.
+  **Mitigation:** the per-recipe test asserts the exact attribute
+  names, so an accidental rename trips CI before it ships.
+- **Demo route being mistaken for a feature flag surface.** The demo
+  route is documented in `docs/j2cl-plugin-slots.md` as a design
+  scaffold, not a user-facing surface. **Mitigation:** the
+  user-menu link is labelled "Design preview" (not "Plugins") so
+  end-users won't expect plugin-management UX there.
+- **Light-mode contrast regressions.** The light variant inverts
+  surfaces and text but keeps the same accent saturation, which can
+  reduce contrast for the muted text. **Mitigation:** the
+  `wavy-tokens.test.js` test in §8.1 mechanically computes the WCAG
+  relative luminance for body / muted / quiet text against the
+  surface for all three themes and asserts each pair clears the
+  per-theme floor (4.5:1 for dark/light, 7:1 for contrast). The demo
+  route lets a reviewer eyeball it as well, but CI catches drift.
+
+### Non-goals
+
+- **No** behavior changes to the read / compose / live surfaces. F-2,
+  F-3, F-4 own those.
+- **No** plugin-registration mechanism. F-0 specifies the slot
+  contract only. The robots/data-API plugin registry is a separate
+  future issue.
+- **No** modernization of the legacy GWT root. Out of scope per
+  parity matrix §1.
+- **No** default-root cutover. Gated by the parity gate per issue
+  map §5.
+- **No** webfont loader. The font-family stacks gracefully fall back
+  to the system stack already used by the legacy chrome. A future
+  issue can add @font-face declarations for Space Grotesk / Inter /
+  Geist.
+
+## 11. Closeout
+
+- PR title: `F-0: Refresh Lit design packet for wavy aesthetic +
+  plugin slot contracts`.
+- PR body: closes #1035, updates #904.
+- Auto-merge: squash on green CI.
+- Evidence comments on #1035 (plan, implementation summary, PR opened,
+  merged) and on #904 (PR opened, merged).
+- F-2/F-3/F-4 lanes consume the packet by:
+  - importing `j2cl/lit/src/design/wavy-tokens.css` via the bundle
+    (already wired by F-0; consumers do nothing extra),
+  - wrapping their per-blip / per-composer / per-rail / per-toolbar
+    Lit elements in the corresponding F-0 recipe (or composing the
+    recipe inside their elements) so the named slots are exposed,
+  - reading the slot-context contract from `docs/j2cl-plugin-slots.md`.

--- a/j2cl/lit/esbuild.config.mjs
+++ b/j2cl/lit/esbuild.config.mjs
@@ -8,7 +8,11 @@ const out = resolve(here, "../../war/j2cl/assets");
 await build({
   entryPoints: [
     { in: resolve(here, "src/index.js"), out: "shell" },
-    { in: resolve(here, "src/tokens/shell-tokens.css"), out: "shell" }
+    { in: resolve(here, "src/tokens/shell-tokens.css"), out: "shell" },
+    // F-0 (#1035): wavy design tokens emit as a sibling asset so server
+    // templates load them with their own <link>. Recipe .js files do
+    // NOT import this CSS (avoids double-emission into shell.css).
+    { in: resolve(here, "src/design/wavy-tokens.css"), out: "wavy-tokens" }
   ],
   bundle: true,
   format: "esm",

--- a/j2cl/lit/src/design/README.md
+++ b/j2cl/lit/src/design/README.md
@@ -1,0 +1,196 @@
+# Wavy — Firefly Signal design packet
+
+Status: F-0 (issue [#1035](https://github.com/vega113/supawave/issues/1035))
+Owner: F-0 design foundation lane.
+Consumers: F-2, F-3, F-4 mount the recipes; future robots/data-API
+plugins fill the named slot points.
+
+## Source of truth
+
+The packet's aesthetic, palette, motion language, and roundness
+choices are pinned to the Stitch design system **"Wavy — Firefly
+Signal"** in project
+[`15560635515125057401`](https://stitch.withgoogle.com/projects/15560635515125057401)
+(asset `assets/6962139294633729409`, version 1). The full design
+markdown is reproduced below verbatim so the packet stays
+self-contained even if Stitch becomes unavailable.
+
+> # Wavy — Firefly Signal Design System
+>
+> **Inspiration:** the 'send a wave' communication idiom from the
+> Firefly TV series. Messages travel through space as living signals
+> — distant, warm, and alive. The UI should feel like an open
+> channel: the surface listens, glows when a wave arrives, and stays
+> out of the way when it doesn't.
+>
+> ## Core principles
+> - **Signal over chrome.** The UI is mostly negative space; the
+>   wave content is the signal. Chrome recedes.
+> - **Live-update presence.** When a wave arrives or a blip updates,
+>   the surface acknowledges it with a brief pulse on the
+>   signal-tone accent. Movement is purposeful, never decorative.
+> - **Conversational warmth.** This is not a corporate inbox. Blips
+>   feel like voices in a room — soft cards with breathing room,
+>   not stacked rows.
+> - **Conversational density.** Read-mode is reading-first: long-form
+>   line lengths, optical reading rhythm, not a feed of tiles.
+> - **Holographic depth.** Cards have a faint inner-glow border on
+>   the signal tone; depth comes from light, not shadow stacks.
+> - **Plugin slots are first-class.** Blip-extension,
+>   compose-extension, rail-extension, toolbar-extension slots are
+>   part of the visual rhythm, not afterthoughts.
+>
+> ## Palette
+> - Background: deep midnight blue (`#0b1320`) — feels like looking
+>   out a ship porthole.
+> - Surface: a half-shade lighter, with a hairline signal-tone border.
+> - Primary signal: cyan (`#22d3ee`) — the 'wave just landed' tone.
+>   Use sparingly: focus frame, live-update pulse, unread badge,
+>   primary action.
+> - Secondary signal: violet (`#7c3aed`) — for mention chips and
+>   reactions.
+> - Tertiary signal: warm amber (`#fb923c`) — for tasks and
+>   time-sensitive flags.
+> - Text: neutral cool whites; never pure white. Body text at ~92%
+>   opacity for warmth.
+>
+> ## Motion language
+> - **Signal pulse**: 600ms outward glow on the signal tone when a
+>   live-update applies. Limited to one pulse per blip per second to
+>   avoid noise.
+> - **Focus transition**: 180ms ease-out; focus frame slides between
+>   blips like a cursor in a console.
+> - **Collapse animation**: 240ms ease-in-out height + opacity;
+>   never instant.
+> - **Fragment-window load**: 300ms fade-in from a low-contrast
+>   skeleton; skeleton uses the signal tone at low alpha.
+>
+> ## Iconography
+> - Waveform / signal motif preferred over generic Material icons
+>   where possible (reply = sound-wave-and-arrow, send =
+>   chevron-with-trail).
+> - Stroke-only icons; never filled.
+>
+> ## Typography
+> - Headline: Space Grotesk — slightly geometric, gives the chrome a
+>   'flight deck' feel without being silly.
+> - Body: Inter — high readability at small sizes, the wave
+>   content's home.
+> - Label: Geist — used for chips, badges, timestamps.
+> - Reading-density target: ~70 characters per line in the wave
+>   panel.
+>
+> ## Roundness
+> - Cards: 12px (subtle, not playful).
+> - Chips and badges: full pill.
+> - Inputs: 12px to match cards.
+>
+> ## Plugin-slot visual rhythm
+> - A slot looks like a faintly outlined region with a slot-name
+>   label in the corner when empty in design previews; in
+>   production, an empty slot collapses to zero height.
+> - Plugins inherit the design tokens by default but can opt out
+>   per the plugin contract.
+>
+> ## Light mode
+> - Inverted: pale near-white background, midnight ink for text,
+>   same accents but at higher saturation. Maintain the 'living
+>   signal' feel; do not flatten.
+
+## Stitch screens (issue body §Acceptance bullet 2)
+
+The Stitch project hosts three desktop screens that act as visual
+references for the packet. They predate this lane in some cases
+(the project was bootstrapped before F-0); use the live demo route
+at `?view=j2cl-root&q=design-preview` (admin-or-owner gated, see
+plan §6.1) as the canonical interactive reference for the recipes
+implemented in this packet.
+
+| Title | Stitch screen ID | Purpose |
+| --- | --- | --- |
+| SupaWave — Reading Surface | `projects/15560635515125057401/screens/f7867d161cfc4b7ba1c1af37e7b75d5b` | Read surface — focused blip in a wave thread with rail. |
+| SupaWave — Reading Surface (alt) | `projects/15560635515125057401/screens/cbd4a9e7a9f54eae85f8304aedf95e41` | Compose surface and live-update pulse moment hints (alt composition of the read surface). |
+| SupaWave — Depth-Navigation | `projects/15560635515125057401/screens/7f0b4a1dee01438997019e4ff7948cc1` | Depth-nav breadcrumb ("Inbox › Sample wave › Top thread"). |
+
+Future bumps to the design system version will add screens for the
+compose surface and the live-update pulse moment as standalone
+generations; the demo route already mounts both as live recipes.
+
+## Tokens
+
+`wavy-tokens.css` ships every CSS custom property that F-2/F-3/F-4
+consume. **Only `--wavy-*` is part of the F-0 contract**;
+`--shell-*` is the legacy #962 packet, kept for back-compatibility
+but not the design language for new surfaces.
+
+The full token contract lives in
+[`docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md`
+§3](../../../docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md).
+At a glance:
+
+- Color (14 tokens): bg-base / bg-surface / border-hairline; text
+  body / muted / quiet; signal cyan / violet / amber (each with a
+  -soft alpha companion); focus-ring + pulse-ring derived tokens.
+- Typography (10 tokens): three font-family stacks (Space Grotesk
+  headline, Inter body, Geist label) and a seven-step type scale
+  (display through meta).
+- Motion (7 tokens): four durations (pulse 600ms, focus 180ms,
+  collapse 240ms, fragment-fade 300ms) and three easings.
+- Spacing + shape (10 tokens): an 8-step 4-px-base spacing scale
+  and two roundness presets (`--wavy-radius-card` 12px,
+  `--wavy-radius-pill` full).
+
+The tokens emit as a separate esbuild entry
+(`war/j2cl/assets/wavy-tokens.css`) and are loaded by the J2CL
+root shell via `<link>` so the recipes can resolve them.
+
+## Recipes
+
+`wavy-tokens.css` is paired with six Lit recipe elements that
+consume the tokens. Each is a small, tested LitElement that exposes
+the appropriate plugin slot.
+
+| Recipe | File | Plugin slot | Owning consumer |
+| --- | --- | --- | --- |
+| `<wavy-blip-card>` | `wavy-blip-card.js` | `blip-extension` (M.2) | F-2 |
+| `<wavy-compose-card>` | `wavy-compose-card.js` | `compose-extension` (M.3) | F-3 |
+| `<wavy-rail-panel>` | `wavy-rail-panel.js` | `rail-extension` (M.4) | F-2 (F-4 placeholder) |
+| `<wavy-edit-toolbar>` | `wavy-edit-toolbar.js` | `toolbar-extension` (M.5) | F-3 |
+| `<wavy-depth-nav>` | `wavy-depth-nav.js` | — (chrome only) | F-2 |
+| `<wavy-pulse-stage>` | `wavy-pulse-stage.js` | — (live-update helper) | F-3 (and the demo route) |
+
+See [`docs/j2cl-plugin-slots.md`](../../../docs/j2cl-plugin-slots.md)
+for the full per-slot contract (mount point, slot context,
+allowed children, owning slice).
+
+## Variants (dark / light / contrast)
+
+The packet ships three theme variants:
+
+- **Dark** (default; matches Stitch `colorMode: DARK`). Selectors:
+  `:root`, `[data-wavy-theme="dark"]`.
+- **Light** (auto under `prefers-color-scheme: light`, override
+  via `[data-wavy-theme="light"]`). Inverts surfaces and text;
+  signal accents stay constant per Stitch.
+- **High contrast** (auto under `prefers-contrast: more`, override
+  via `[data-wavy-theme="contrast"]`). Issue body §Scope.1
+  mandate. Surfaces go to true black, borders solidify, text raises
+  to ≥7:1 contrast (WCAG AAA), focus-ring thickens to 3px.
+
+A scope element (`<section data-wavy-theme="light">`) overrides the
+media query inside its subtree, so the design preview can mount
+all three side-by-side.
+
+## How F-2 / F-3 / F-4 consume the packet
+
+- **CSS tokens.** No action needed — the J2CL root shell HTML
+  template loads `wavy-tokens.css` as a sibling stylesheet, and the
+  recipes resolve `var(--wavy-*)` automatically when mounted under
+  `?view=j2cl-root`.
+- **Recipes.** Wrap per-blip / per-composer / per-rail / per-toolbar
+  Lit elements in the corresponding F-0 recipe (or compose the
+  recipe inside their elements) so the named slots are exposed.
+- **Slot contract.** Read
+  [`docs/j2cl-plugin-slots.md`](../../../docs/j2cl-plugin-slots.md)
+  for the per-slot mount point, slot context, and allowed
+  children.

--- a/j2cl/lit/src/design/wavy-blip-card.js
+++ b/j2cl/lit/src/design/wavy-blip-card.js
@@ -84,7 +84,7 @@ export class WavyBlipCard extends LitElement {
     }
     /* The blip-extension slot wrapper — empty in production, dashed
      * outline with label when the document is in design preview. */
-    .ext-slot-wrapper:not(:has(slot[name="blip-extension"]:empty)) {
+    :host(:has([slot="blip-extension"])) .ext-slot-wrapper {
       display: block;
       margin-top: var(--wavy-spacing-3, 12px);
     }
@@ -108,7 +108,7 @@ export class WavyBlipCard extends LitElement {
     }
     /* Plugin opt-out: a slotted root with data-wavy-plugin-untheme
      * suppresses the inner glow border so the plugin paints its own. */
-    :host(:has(.ext-slot-wrapper [data-wavy-plugin-untheme])) {
+    :host(:has([slot="blip-extension"][data-wavy-plugin-untheme])) {
       border-color: transparent;
     }
   `;

--- a/j2cl/lit/src/design/wavy-blip-card.js
+++ b/j2cl/lit/src/design/wavy-blip-card.js
@@ -1,0 +1,185 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-blip-card> — F-0 (#1035) recipe for a single blip card in the
+ * read surface. F-2 (#1037) consumes this element to render each blip
+ * in the J2CL read surface; the named slots provide the data + the
+ * `blip-extension` plugin slot point (M.2).
+ *
+ * Plugin-slot context (per docs/j2cl-plugin-slots.md):
+ *   - data attributes (string-only, declarative): data-blip-id,
+ *     data-wave-id, data-blip-author, data-blip-is-author.
+ *   - JS property `blipView` returns a frozen read-only snapshot of
+ *     the blip view (lazy on read; mutation throws under strict mode).
+ */
+export class WavyBlipCard extends LitElement {
+  static properties = {
+    // F-0 (#1035): plugin slot-context attributes use the data-* form
+    // (per docs/j2cl-plugin-slots.md) so plugins read them via
+    // `host.dataset.blipId` / `dataset.waveId` without a JS API surface.
+    blipId: { type: String, attribute: "data-blip-id", reflect: true },
+    waveId: { type: String, attribute: "data-wave-id", reflect: true },
+    authorName: { type: String, attribute: "author-name" },
+    postedAt: { type: String, attribute: "posted-at" },
+    isAuthor: { type: Boolean, attribute: "is-author", reflect: true },
+    focused: { type: Boolean, reflect: true },
+    unread: { type: Boolean, reflect: true },
+    livePulse: { type: Boolean, attribute: "live-pulse", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-4, 16px);
+      margin-bottom: var(--wavy-spacing-3, 12px);
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-radius: var(--wavy-radius-card, 12px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      transition: box-shadow var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+    }
+    :host([focused]) {
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    :host([unread])::before {
+      content: "";
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      background: var(--wavy-signal-cyan, #22d3ee);
+      margin-right: var(--wavy-spacing-2, 8px);
+      vertical-align: middle;
+    }
+    :host([live-pulse]) {
+      animation: wavy-pulse var(--wavy-motion-pulse-duration, 600ms)
+        var(--wavy-easing-pulse, cubic-bezier(0.32, 0.72, 0.32, 1)) 1;
+    }
+    @keyframes wavy-pulse {
+      0% {
+        box-shadow: 0 0 0 0 var(--wavy-signal-cyan-soft, rgba(34, 211, 238, 0.22));
+      }
+      70% {
+        box-shadow: var(--wavy-pulse-ring, 0 0 0 4px rgba(34, 211, 238, 0.22));
+      }
+      100% {
+        box-shadow: 0 0 0 0 transparent;
+      }
+    }
+    .author {
+      font: var(--wavy-type-h3, 1.0625rem / 1.35 sans-serif);
+      font-weight: 600;
+      margin-right: var(--wavy-spacing-2, 8px);
+    }
+    .timestamp {
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+    }
+    .body {
+      margin-top: var(--wavy-spacing-2, 8px);
+    }
+    /* The blip-extension slot wrapper — empty in production, dashed
+     * outline with label when the document is in design preview. */
+    .ext-slot-wrapper:not(:has(slot[name="blip-extension"]:empty)) {
+      display: block;
+      margin-top: var(--wavy-spacing-3, 12px);
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper {
+      display: block;
+      margin-top: var(--wavy-spacing-3, 12px);
+      padding: var(--wavy-spacing-2, 8px);
+      border: 1px dashed var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      position: relative;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper::before {
+      content: "blip-extension";
+      position: absolute;
+      top: -10px;
+      left: 8px;
+      padding: 0 4px;
+      background: var(--wavy-bg-surface, #11192a);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+    }
+    /* Plugin opt-out: a slotted root with data-wavy-plugin-untheme
+     * suppresses the inner glow border so the plugin paints its own. */
+    :host(:has(.ext-slot-wrapper [data-wavy-plugin-untheme])) {
+      border-color: transparent;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.blipId = "";
+    this.waveId = "";
+    this.authorName = "";
+    this.postedAt = "";
+    this.isAuthor = false;
+    this.focused = false;
+    this.unread = false;
+    this.livePulse = false;
+  }
+
+  /** Lazy frozen read-only snapshot for plugin consumers. */
+  get blipView() {
+    return Object.freeze({
+      id: this.blipId,
+      waveId: this.waveId,
+      authorName: this.authorName,
+      postedAt: this.postedAt,
+      isAuthor: this.isAuthor
+    });
+  }
+
+  /** Reflect the four data attributes for plugin discoverability. */
+  updated(changed) {
+    if (changed.has("authorName")) {
+      this._reflectDataAttr("data-blip-author", this.authorName);
+    }
+    if (changed.has("isAuthor")) {
+      this._reflectDataAttr("data-blip-is-author", this.isAuthor ? "true" : "false");
+    }
+  }
+
+  _reflectDataAttr(name, value) {
+    if (value == null || value === "") {
+      this.removeAttribute(name);
+    } else {
+      this.setAttribute(name, String(value));
+    }
+  }
+
+  /** Trigger a single live-update pulse. Restart pattern: remove
+   * attribute, force layout, re-add — so back-to-back pulses animate. */
+  firePulse() {
+    this.removeAttribute("live-pulse");
+    void this.offsetWidth;
+    this.setAttribute("live-pulse", "");
+  }
+
+  render() {
+    return html`
+      <article role="article" aria-labelledby="author">
+        <header>
+          <span class="author" id="author">${this.authorName || ""}</span>
+          <time class="timestamp">${this.postedAt || ""}</time>
+        </header>
+        <div class="body"><slot></slot></div>
+        <div class="ext-slot-wrapper">
+          <slot name="blip-extension"></slot>
+        </div>
+        <div class="metadata"><slot name="metadata"></slot></div>
+        <div class="reactions"><slot name="reactions"></slot></div>
+      </article>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-blip-card")) {
+  customElements.define("wavy-blip-card", WavyBlipCard);
+}

--- a/j2cl/lit/src/design/wavy-compose-card.js
+++ b/j2cl/lit/src/design/wavy-compose-card.js
@@ -1,0 +1,129 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-compose-card> — F-0 (#1035) recipe for the inline composer
+ * surface. F-3 (#1038) consumes this for the compose surface; the
+ * `compose-extension` slot is the M.3 plugin slot point.
+ *
+ * Plugin-slot context (per docs/j2cl-plugin-slots.md):
+ *   - data attribute: data-reply-target-blip-id.
+ *   - JS properties: composerState (frozen), activeSelection (frozen).
+ */
+export class WavyComposeCard extends LitElement {
+  static properties = {
+    focused: { type: Boolean, reflect: true },
+    submitting: { type: Boolean, reflect: true },
+    // F-0 (#1035): plugin slot-context attribute uses the data-* form
+    // (per docs/j2cl-plugin-slots.md) so plugins read it via
+    // `host.dataset.replyTargetBlipId`.
+    replyTargetBlipId: {
+      type: String,
+      attribute: "data-reply-target-blip-id",
+      reflect: true
+    }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-4, 16px);
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-radius: var(--wavy-radius-card, 12px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      transition: box-shadow var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+    }
+    :host([focused]) {
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    .body {
+      min-height: var(--wavy-spacing-7, 32px);
+    }
+    .toolbar-row {
+      display: flex;
+      align-items: center;
+      gap: var(--wavy-spacing-3, 12px);
+      margin-top: var(--wavy-spacing-2, 8px);
+      flex-wrap: wrap;
+    }
+    .ext-slot-wrapper {
+      display: contents;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper {
+      display: inline-block;
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      border: 1px dashed var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      position: relative;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper::before {
+      content: "compose-extension";
+      position: absolute;
+      top: -10px;
+      left: 6px;
+      padding: 0 4px;
+      background: var(--wavy-bg-surface, #11192a);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+    }
+    .affordance-row {
+      margin-top: var(--wavy-spacing-3, 12px);
+      display: flex;
+      justify-content: flex-end;
+    }
+    :host([submitting]) .affordance-row {
+      pointer-events: none;
+      opacity: 0.6;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.focused = false;
+    this.submitting = false;
+    this.replyTargetBlipId = "";
+    this._composerState = Object.freeze({});
+    this._activeSelection = Object.freeze({});
+  }
+
+  /** Frozen lazy snapshot of composer state for plugin consumers. */
+  get composerState() {
+    return this._composerState;
+  }
+  set composerState(value) {
+    this._composerState = Object.freeze({ ...(value || {}) });
+  }
+
+  /** Frozen lazy snapshot of active selection for plugin consumers. */
+  get activeSelection() {
+    return this._activeSelection;
+  }
+  set activeSelection(value) {
+    this._activeSelection = Object.freeze({ ...(value || {}) });
+  }
+
+  render() {
+    return html`
+      <section role="form">
+        <div class="body"><slot></slot></div>
+        <div class="toolbar-row">
+          <slot name="toolbar"></slot>
+          <span class="ext-slot-wrapper">
+            <slot name="compose-extension"></slot>
+          </span>
+        </div>
+        <div class="affordance-row">
+          <slot name="affordance"></slot>
+        </div>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-compose-card")) {
+  customElements.define("wavy-compose-card", WavyComposeCard);
+}

--- a/j2cl/lit/src/design/wavy-depth-nav.js
+++ b/j2cl/lit/src/design/wavy-depth-nav.js
@@ -1,0 +1,79 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-depth-nav> — F-0 (#1035) recipe for the depth-nav breadcrumb
+ * (Inbox › Sample wave › Top thread). No plugin slot — purely chrome
+ * for orienting the user inside a deep wave/thread structure.
+ *
+ * Property:
+ *   - crumbs: Array<{ label: string, href?: string, current?: boolean }>
+ */
+export class WavyDepthNav extends LitElement {
+  static properties = {
+    crumbs: { attribute: false }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      letter-spacing: 0.04em;
+    }
+    nav {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      flex-wrap: wrap;
+    }
+    a {
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      text-decoration: none;
+      transition: color var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    a:hover,
+    a:focus-visible {
+      color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    .crumb-current {
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    .sep {
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+      user-select: none;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.crumbs = [];
+  }
+
+  render() {
+    const items = Array.isArray(this.crumbs) ? this.crumbs : [];
+    return html`
+      <nav aria-label="Breadcrumb">
+        ${items.map((c, i) => {
+          const isLast = i === items.length - 1;
+          const sep = isLast
+            ? null
+            : html`<span class="sep" aria-hidden="true">›</span>`;
+          if (c.current) {
+            return html`<span class="crumb-current" aria-current="page"
+                >${c.label}</span
+              >${sep}`;
+          }
+          if (c.href) {
+            return html`<a href=${c.href}>${c.label}</a>${sep}`;
+          }
+          return html`<span>${c.label}</span>${sep}`;
+        })}
+      </nav>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-depth-nav")) {
+  customElements.define("wavy-depth-nav", WavyDepthNav);
+}

--- a/j2cl/lit/src/design/wavy-edit-toolbar.js
+++ b/j2cl/lit/src/design/wavy-edit-toolbar.js
@@ -1,0 +1,107 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-edit-toolbar> — F-0 (#1035) recipe for the H.* edit toolbar.
+ * F-3 (#1038) consumes this; the `toolbar-extension` slot is M.5.
+ *
+ * Plugin-slot context: data-active-selection (JSON-encoded selection
+ * descriptor; debounced at ~60 fps so noisy updates from F-3 do not
+ * thrash the DOM).
+ */
+export class WavyEditToolbar extends LitElement {
+  static properties = {
+    activeSelection: { type: String, attribute: "active-selection" }
+  };
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-3, 12px);
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-radius: var(--wavy-radius-pill, 9999px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+    }
+    .ext-slot-wrapper {
+      display: contents;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px var(--wavy-spacing-2, 8px);
+      border: 1px dashed var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-pill, 9999px);
+      position: relative;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper::before {
+      content: "toolbar-extension";
+      position: absolute;
+      top: -12px;
+      left: 6px;
+      padding: 0 4px;
+      background: var(--wavy-bg-surface, #11192a);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.activeSelection = "";
+    this._pendingSelection = null;
+    this._frameHandle = 0;
+  }
+
+  /**
+   * Override property setter so writes to `activeSelection` are
+   * debounced to once per animation frame (~60 fps) before reflecting
+   * to the data attribute. F-3 may push selection updates faster than
+   * the DOM should churn.
+   */
+  attributeChangedCallback(name, old, val) {
+    super.attributeChangedCallback(name, old, val);
+    if (name === "active-selection") {
+      this._scheduleAttrFlush(val);
+    }
+  }
+
+  _scheduleAttrFlush(value) {
+    this._pendingSelection = value;
+    if (this._frameHandle) return;
+    this._frameHandle = requestAnimationFrame(() => {
+      this._frameHandle = 0;
+      const v = this._pendingSelection;
+      if (v == null || v === "") {
+        this.removeAttribute("data-active-selection");
+      } else {
+        this.setAttribute("data-active-selection", v);
+      }
+    });
+  }
+
+  disconnectedCallback() {
+    if (this._frameHandle) {
+      cancelAnimationFrame(this._frameHandle);
+      this._frameHandle = 0;
+    }
+    super.disconnectedCallback();
+  }
+
+  render() {
+    return html`
+      <div role="toolbar" aria-label="Formatting toolbar">
+        <slot></slot>
+        <span class="ext-slot-wrapper">
+          <slot name="toolbar-extension"></slot>
+        </span>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-edit-toolbar")) {
+  customElements.define("wavy-edit-toolbar", WavyEditToolbar);
+}

--- a/j2cl/lit/src/design/wavy-edit-toolbar.js
+++ b/j2cl/lit/src/design/wavy-edit-toolbar.js
@@ -55,16 +55,9 @@ export class WavyEditToolbar extends LitElement {
     this._frameHandle = 0;
   }
 
-  /**
-   * Override property setter so writes to `activeSelection` are
-   * debounced to once per animation frame (~60 fps) before reflecting
-   * to the data attribute. F-3 may push selection updates faster than
-   * the DOM should churn.
-   */
-  attributeChangedCallback(name, old, val) {
-    super.attributeChangedCallback(name, old, val);
-    if (name === "active-selection") {
-      this._scheduleAttrFlush(val);
+  updated(changed) {
+    if (changed.has("activeSelection")) {
+      this._scheduleAttrFlush(this.activeSelection);
     }
   }
 

--- a/j2cl/lit/src/design/wavy-pulse-stage.js
+++ b/j2cl/lit/src/design/wavy-pulse-stage.js
@@ -1,0 +1,80 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-pulse-stage> — F-0 (#1035) demo helper that drives a single
+ * live-update pulse on its child target. Used by the design preview
+ * route to demonstrate the live-update pulse moment, and reusable by
+ * F-3 as the canonical "fire a pulse on an arriving blip" helper so
+ * F-3 doesn't re-implement the timing.
+ *
+ * Property:
+ *   - target-selector: CSS selector applied within light-DOM children
+ *     to find the element that should receive the `live-pulse`
+ *     attribute. Defaults to `wavy-blip-card`.
+ *
+ * Public API:
+ *   - firePulse(): toggles the `live-pulse` attribute on the resolved
+ *     target using the restart pattern (remove → force layout → add)
+ *     so back-to-back pulses animate every time. Removes the attribute
+ *     after `--wavy-motion-pulse-duration` resolves at the test/runtime
+ *     scope.
+ */
+export class WavyPulseStage extends LitElement {
+  static properties = {
+    targetSelector: { type: String, attribute: "target-selector" }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+    button {
+      display: inline-block;
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-4, 16px);
+      background: var(--wavy-signal-cyan, #22d3ee);
+      color: var(--wavy-bg-base, #0b1320);
+      border: 0;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      font-weight: 600;
+      cursor: pointer;
+      margin-bottom: var(--wavy-spacing-3, 12px);
+    }
+    button:focus-visible {
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+      outline: none;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.targetSelector = "wavy-blip-card";
+  }
+
+  firePulse() {
+    const target = this.querySelector(this.targetSelector);
+    if (!target) return;
+    target.removeAttribute("live-pulse");
+    void target.offsetWidth;
+    target.setAttribute("live-pulse", "");
+    const cs = getComputedStyle(this);
+    const raw = cs.getPropertyValue("--wavy-motion-pulse-duration").trim();
+    const ms = raw.endsWith("ms")
+      ? parseFloat(raw)
+      : raw.endsWith("s")
+        ? parseFloat(raw) * 1000
+        : 600;
+    setTimeout(() => target.removeAttribute("live-pulse"), Math.max(ms, 1) + 50);
+  }
+
+  render() {
+    return html`
+      <button type="button" @click=${this.firePulse}>Fire pulse</button>
+      <slot></slot>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-pulse-stage")) {
+  customElements.define("wavy-pulse-stage", WavyPulseStage);
+}

--- a/j2cl/lit/src/design/wavy-pulse-stage.js
+++ b/j2cl/lit/src/design/wavy-pulse-stage.js
@@ -49,9 +49,22 @@ export class WavyPulseStage extends LitElement {
   constructor() {
     super();
     this.targetSelector = "wavy-blip-card";
+    this._pulseTimer = null;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._pulseTimer !== null) {
+      clearTimeout(this._pulseTimer);
+      this._pulseTimer = null;
+    }
   }
 
   firePulse() {
+    if (this._pulseTimer !== null) {
+      clearTimeout(this._pulseTimer);
+      this._pulseTimer = null;
+    }
     const target = this.querySelector(this.targetSelector);
     if (!target) return;
     target.removeAttribute("live-pulse");
@@ -64,7 +77,10 @@ export class WavyPulseStage extends LitElement {
       : raw.endsWith("s")
         ? parseFloat(raw) * 1000
         : 600;
-    setTimeout(() => target.removeAttribute("live-pulse"), Math.max(ms, 1) + 50);
+    this._pulseTimer = setTimeout(() => {
+      target.removeAttribute("live-pulse");
+      this._pulseTimer = null;
+    }, Math.max(ms, 1) + 50);
   }
 
   render() {

--- a/j2cl/lit/src/design/wavy-rail-panel.js
+++ b/j2cl/lit/src/design/wavy-rail-panel.js
@@ -1,0 +1,137 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-rail-panel> — F-0 (#1035) recipe for a right-rail panel
+ * (saved searches, assistant, integrations status). F-2 (#1037)
+ * mounts this for rail surfaces; the `rail-extension` slot is M.4.
+ *
+ * Plugin-slot context: data-active-wave-id, data-active-folder.
+ */
+export class WavyRailPanel extends LitElement {
+  static properties = {
+    panelTitle: { type: String, attribute: "panel-title" },
+    collapsed: { type: Boolean, reflect: true },
+    // F-0 (#1035): plugin slot-context attributes use the data-* form
+    // (per docs/j2cl-plugin-slots.md) so plugins read them via
+    // `host.dataset.activeWaveId` / `host.dataset.activeFolder`.
+    activeWaveId: { type: String, attribute: "data-active-wave-id", reflect: true },
+    activeFolder: { type: String, attribute: "data-active-folder", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-4, 16px);
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-radius: var(--wavy-radius-card, 12px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      margin-bottom: var(--wavy-spacing-3, 12px);
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-2, 8px);
+    }
+    h2 {
+      margin: 0;
+      font: var(--wavy-type-h3, 1.0625rem / 1.35 sans-serif);
+      font-weight: 600;
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    button.toggle {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 0;
+      cursor: pointer;
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+    }
+    .body {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows var(--wavy-motion-collapse-duration, 240ms)
+        var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1));
+      overflow: hidden;
+      margin-top: var(--wavy-spacing-3, 12px);
+    }
+    :host([collapsed]) .body {
+      grid-template-rows: 0fr;
+    }
+    .body > .body-inner {
+      min-height: 0;
+    }
+    .ext-slot-wrapper {
+      display: contents;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper {
+      display: block;
+      margin-top: var(--wavy-spacing-3, 12px);
+      padding: var(--wavy-spacing-2, 8px);
+      border: 1px dashed var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      position: relative;
+    }
+    :host-context([data-wavy-design-preview]) .ext-slot-wrapper::before {
+      content: "rail-extension";
+      position: absolute;
+      top: -10px;
+      left: 8px;
+      padding: 0 4px;
+      background: var(--wavy-bg-surface, #11192a);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.panelTitle = "";
+    this.collapsed = false;
+    this.activeWaveId = "";
+    this.activeFolder = "";
+  }
+
+  toggleCollapsed() {
+    this.collapsed = !this.collapsed;
+  }
+
+  render() {
+    return html`
+      <section
+        role="region"
+        aria-labelledby="panel-title"
+        aria-expanded=${String(!this.collapsed)}
+      >
+        <header>
+          <h2 id="panel-title">${this.panelTitle || ""}</h2>
+          <span class="header-actions"><slot name="header-actions"></slot></span>
+          <button
+            class="toggle"
+            type="button"
+            aria-label=${this.collapsed ? "Expand panel" : "Collapse panel"}
+            @click=${this.toggleCollapsed}
+          >
+            ${this.collapsed ? "+" : "–"}
+          </button>
+        </header>
+        <div class="body">
+          <div class="body-inner">
+            <slot></slot>
+            <div class="ext-slot-wrapper">
+              <slot name="rail-extension"></slot>
+            </div>
+            <footer><slot name="footer"></slot></footer>
+          </div>
+        </div>
+      </section>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-rail-panel")) {
+  customElements.define("wavy-rail-panel", WavyRailPanel);
+}

--- a/j2cl/lit/src/design/wavy-tokens.css
+++ b/j2cl/lit/src/design/wavy-tokens.css
@@ -1,0 +1,173 @@
+/* Wavy — Firefly Signal design tokens (issue #1035, F-0).
+ *
+ * Source of truth: Stitch project 15560635515125057401 / asset
+ * 6962139294633729409 (v1, "Wavy — Firefly Signal"). The values below
+ * reproduce the Stitch designMd field exactly — do not re-interpret
+ * without an updated source-of-truth bump.
+ *
+ * Dark is the default (matches Stitch colorMode: DARK). Light overrides
+ * apply via prefers-color-scheme media query OR explicit
+ * data-wavy-theme="light" attribute on a scope element. Contrast
+ * variant applies via prefers-contrast: more OR explicit
+ * data-wavy-theme="contrast".
+ *
+ * Recipe elements consume only --wavy-* tokens; flipping the data
+ * attribute on any ancestor scope swaps the whole packet.
+ */
+:root {
+  /* Color — surface + chrome (DARK default) */
+  --wavy-bg-base: #0b1320;
+  --wavy-bg-surface: #11192a;
+  --wavy-border-hairline: rgba(34, 211, 238, 0.18);
+
+  /* Color — text (DARK default) */
+  --wavy-text-body: rgba(232, 240, 255, 0.92);
+  --wavy-text-muted: rgba(232, 240, 255, 0.62);
+  --wavy-text-quiet: rgba(232, 240, 255, 0.42);
+
+  /* Color — signal accents (constant across light/dark) */
+  --wavy-signal-cyan: #22d3ee;
+  --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.22);
+  --wavy-signal-violet: #7c3aed;
+  --wavy-signal-violet-soft: rgba(124, 58, 237, 0.22);
+  --wavy-signal-amber: #fb923c;
+  --wavy-signal-amber-soft: rgba(251, 146, 60, 0.22);
+
+  /* Color — derived focus + pulse */
+  --wavy-focus-ring: 0 0 0 2px var(--wavy-signal-cyan);
+  --wavy-pulse-ring: 0 0 0 4px var(--wavy-signal-cyan-soft);
+
+  /* Typography — font families */
+  --wavy-font-headline: "Space Grotesk", "Inter", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --wavy-font-body: "Inter", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, sans-serif;
+  --wavy-font-label: "Geist", "Inter", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+
+  /* Typography — type scale (font shorthand: size/line-height family) */
+  --wavy-type-display: clamp(1.875rem, 1.4rem + 1.6vw, 2.25rem) / 1.18
+    var(--wavy-font-headline);
+  --wavy-type-h1: 1.5rem / 1.25 var(--wavy-font-headline);
+  --wavy-type-h2: 1.25rem / 1.3 var(--wavy-font-headline);
+  --wavy-type-h3: 1.0625rem / 1.35 var(--wavy-font-headline);
+  --wavy-type-body: 0.9375rem / 1.55 var(--wavy-font-body);
+  --wavy-type-label: 0.75rem / 1.35 var(--wavy-font-label);
+  --wavy-type-meta: 0.6875rem / 1.4 var(--wavy-font-label);
+
+  /* Motion — durations */
+  --wavy-motion-pulse-duration: 600ms;
+  --wavy-motion-focus-duration: 180ms;
+  --wavy-motion-collapse-duration: 240ms;
+  --wavy-motion-fragment-fade-duration: 300ms;
+
+  /* Motion — easings */
+  --wavy-easing-pulse: cubic-bezier(0.32, 0.72, 0.32, 1);
+  --wavy-easing-focus: cubic-bezier(0.2, 0, 0.2, 1);
+  --wavy-easing-collapse: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Spacing — 4px base */
+  --wavy-spacing-1: 4px;
+  --wavy-spacing-2: 8px;
+  --wavy-spacing-3: 12px;
+  --wavy-spacing-4: 16px;
+  --wavy-spacing-5: 20px;
+  --wavy-spacing-6: 24px;
+  --wavy-spacing-7: 32px;
+  --wavy-spacing-8: 40px;
+
+  /* Shape */
+  --wavy-radius-card: 12px;
+  --wavy-radius-pill: 9999px;
+}
+
+/* Light variant — applies under prefers-color-scheme: light unless an
+ * explicit data-wavy-theme overrides. Surface, border, and text triads
+ * flip; accents stay constant per Stitch markdown. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-wavy-theme]) {
+    --wavy-bg-base: #f6f7fb;
+    --wavy-bg-surface: #ffffff;
+    --wavy-border-hairline: rgba(11, 19, 32, 0.10);
+    --wavy-text-body: rgba(11, 19, 32, 0.92);
+    --wavy-text-muted: rgba(11, 19, 32, 0.62);
+    --wavy-text-quiet: rgba(11, 19, 32, 0.55);
+    --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.18);
+    --wavy-signal-violet-soft: rgba(124, 58, 237, 0.16);
+    --wavy-signal-amber-soft: rgba(251, 146, 60, 0.16);
+  }
+}
+
+/* Explicit dark override — wins over media query so a light-OS user
+ * can still see the dark variant in a scoped section. Applies to any
+ * scope element carrying the attribute (not just :root). */
+[data-wavy-theme="dark"] {
+  --wavy-bg-base: #0b1320;
+  --wavy-bg-surface: #11192a;
+  --wavy-border-hairline: rgba(34, 211, 238, 0.18);
+  --wavy-text-body: rgba(232, 240, 255, 0.92);
+  --wavy-text-muted: rgba(232, 240, 255, 0.62);
+  --wavy-text-quiet: rgba(232, 240, 255, 0.42);
+  --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.22);
+  --wavy-signal-violet-soft: rgba(124, 58, 237, 0.22);
+  --wavy-signal-amber-soft: rgba(251, 146, 60, 0.22);
+}
+
+/* Explicit light override — wins over media query and over :root.
+ * text-quiet uses alpha 0.55 (vs the symmetric 0.42 used in dark) so
+ * it composites to ≥3:1 contrast on #ffffff. */
+[data-wavy-theme="light"] {
+  --wavy-bg-base: #f6f7fb;
+  --wavy-bg-surface: #ffffff;
+  --wavy-border-hairline: rgba(11, 19, 32, 0.10);
+  --wavy-text-body: rgba(11, 19, 32, 0.92);
+  --wavy-text-muted: rgba(11, 19, 32, 0.62);
+  --wavy-text-quiet: rgba(11, 19, 32, 0.55);
+  --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.18);
+  --wavy-signal-violet-soft: rgba(124, 58, 237, 0.16);
+  --wavy-signal-amber-soft: rgba(251, 146, 60, 0.16);
+}
+
+/* High-contrast variant — issue body §Scope.1 mandates from day one.
+ * WCAG-AAA targets (7:1) for body/muted/quiet text on the black
+ * surface. Inner-glow border replaced with a solid 1.5px hairline so
+ * contrast is carried by edges, not light. */
+@media (prefers-contrast: more) {
+  :root:not([data-wavy-theme]) {
+    --wavy-bg-base: #000000;
+    --wavy-bg-surface: #0b1320;
+    --wavy-border-hairline: rgba(255, 255, 255, 0.85);
+    --wavy-text-body: #ffffff;
+    --wavy-text-muted: rgba(255, 255, 255, 0.85);
+    --wavy-text-quiet: rgba(255, 255, 255, 0.7);
+    --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.45);
+    --wavy-signal-violet-soft: rgba(124, 58, 237, 0.45);
+    --wavy-signal-amber-soft: rgba(251, 146, 60, 0.45);
+    --wavy-focus-ring: 0 0 0 3px var(--wavy-signal-cyan);
+  }
+}
+
+[data-wavy-theme="contrast"] {
+  --wavy-bg-base: #000000;
+  --wavy-bg-surface: #0b1320;
+  --wavy-border-hairline: rgba(255, 255, 255, 0.85);
+  --wavy-text-body: #ffffff;
+  --wavy-text-muted: rgba(255, 255, 255, 0.85);
+  --wavy-text-quiet: rgba(255, 255, 255, 0.7);
+  --wavy-signal-cyan-soft: rgba(34, 211, 238, 0.45);
+  --wavy-signal-violet-soft: rgba(124, 58, 237, 0.45);
+  --wavy-signal-amber-soft: rgba(251, 146, 60, 0.45);
+  --wavy-focus-ring: 0 0 0 3px var(--wavy-signal-cyan);
+}
+
+/* Reduced motion — collapse durations to ~0 so animations are
+ * effectively skipped while still firing animationend / transitionend
+ * so JS state machines tracking the end event resolve. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --wavy-motion-pulse-duration: 0.01ms;
+    --wavy-motion-focus-duration: 0.01ms;
+    --wavy-motion-collapse-duration: 0.01ms;
+    --wavy-motion-fragment-fade-duration: 0.01ms;
+  }
+}

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -22,6 +22,16 @@ import "./elements/task-metadata-popover.js";
 import "./elements/reaction-row.js";
 import "./elements/reaction-picker-popover.js";
 import "./elements/reaction-authors-popover.js";
+// F-0 (#1035): wavy design recipe elements. CSS tokens are loaded
+// separately via <link rel="stylesheet" href="…wavy-tokens.css"> by
+// the server template (renderJ2clRootShellPage and the design preview
+// route) so esbuild does NOT inline the CSS into shell.css.
+import "./design/wavy-blip-card.js";
+import "./design/wavy-compose-card.js";
+import "./design/wavy-rail-panel.js";
+import "./design/wavy-edit-toolbar.js";
+import "./design/wavy-depth-nav.js";
+import "./design/wavy-pulse-stage.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/wavy-blip-card.test.js
+++ b/j2cl/lit/test/wavy-blip-card.test.js
@@ -1,0 +1,147 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-blip-card.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-blip-card>", () => {
+  it("reflects the four contract data attributes (data-* form per slot contract)", async () => {
+    const el = await fixture(html`
+      <wavy-blip-card
+        data-blip-id="b1"
+        data-wave-id="w1"
+        author-name="Alice"
+        is-author
+        posted-at="2026-04-26T12:00Z"
+      ></wavy-blip-card>
+    `);
+    // Plugins read these via host.dataset.* per docs/j2cl-plugin-slots.md.
+    expect(el.dataset.blipId).to.equal("b1");
+    expect(el.dataset.waveId).to.equal("w1");
+    expect(el.dataset.blipAuthor).to.equal("Alice");
+    expect(el.dataset.blipIsAuthor).to.equal("true");
+    // Defensive: also assert the canonical attribute names exist.
+    expect(el.getAttribute("data-blip-id")).to.equal("b1");
+    expect(el.getAttribute("data-wave-id")).to.equal("w1");
+  });
+
+  it("exposes the four named slots", async () => {
+    const el = await fixture(html`<wavy-blip-card></wavy-blip-card>`);
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='blip-extension']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='reactions']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='metadata']")).to.exist;
+  });
+
+  it("empty blip-extension slot in design preview shows the dashed outline label", async () => {
+    document.documentElement.dataset.wavyDesignPreview = "true";
+    try {
+      const el = await fixture(html`<wavy-blip-card></wavy-blip-card>`);
+      const wrapper = el.renderRoot.querySelector(".ext-slot-wrapper");
+      const cs = getComputedStyle(wrapper);
+      // The :host-context([data-wavy-design-preview]) rule should make
+      // the wrapper render as a block with a dashed border.
+      expect(cs.borderStyle).to.equal("dashed");
+      expect(cs.display).to.equal("block");
+    } finally {
+      delete document.documentElement.dataset.wavyDesignPreview;
+    }
+  });
+
+  it("focused state applies the cyan focus ring border-color", async () => {
+    const dark = await fixture(
+      html`<div data-wavy-theme="dark">
+        <wavy-blip-card focused></wavy-blip-card>
+      </div>`
+    );
+    const card = dark.querySelector("wavy-blip-card");
+    const cs = getComputedStyle(card);
+    // border-color should resolve to the cyan signal (#22d3ee = rgb(34, 211, 238))
+    expect(cs.borderColor.replace(/\s+/g, "")).to.match(/rgb\(34,211,238\)/);
+  });
+
+  it("blipView returns a frozen read-only snapshot of the card state", async () => {
+    const el = await fixture(html`
+      <wavy-blip-card
+        data-blip-id="b1"
+        data-wave-id="w1"
+        author-name="Alice"
+        is-author
+      ></wavy-blip-card>
+    `);
+    const view = el.blipView;
+    expect(view.id).to.equal("b1");
+    expect(view.waveId).to.equal("w1");
+    expect(view.authorName).to.equal("Alice");
+    expect(view.isAuthor).to.equal(true);
+    expect(Object.isFrozen(view)).to.equal(true);
+  });
+
+  it("blipView mutation throws under strict mode (custom-element default)", async () => {
+    const el = await fixture(html`
+      <wavy-blip-card data-blip-id="b1"></wavy-blip-card>
+    `);
+    const view = el.blipView;
+    expect(() => {
+      view.id = "mutated";
+    }).to.throw();
+  });
+
+  it("dark / light / contrast variants flip the surface background", async () => {
+    const variants = ["dark", "light", "contrast"];
+    const surfaces = new Set();
+    for (const v of variants) {
+      const wrap = await fixture(
+        html`<div data-wavy-theme=${v}>
+          <wavy-blip-card></wavy-blip-card>
+        </div>`
+      );
+      const card = wrap.querySelector("wavy-blip-card");
+      surfaces.add(getComputedStyle(card).backgroundColor);
+    }
+    // At least dark vs light must differ; contrast may share with dark
+    // when the wrapper is itself dark (#0b1320). Require ≥2 distinct.
+    expect(surfaces.size).to.be.greaterThanOrEqual(2);
+  });
+
+  it("firePulse() sets the live-pulse attribute", async () => {
+    const el = await fixture(html`<wavy-blip-card></wavy-blip-card>`);
+    el.firePulse();
+    expect(el.hasAttribute("live-pulse")).to.equal(true);
+  });
+
+  it("back-to-back firePulse() restarts the animation (remove → force layout → add)", async () => {
+    const el = await fixture(html`<wavy-blip-card></wavy-blip-card>`);
+    el.firePulse();
+    expect(el.hasAttribute("live-pulse")).to.equal(true);
+    // Spy on removeAttribute to confirm the restart pattern fires.
+    let removed = 0;
+    const original = el.removeAttribute.bind(el);
+    el.removeAttribute = (name, ...rest) => {
+      if (name === "live-pulse") removed += 1;
+      return original(name, ...rest);
+    };
+    el.firePulse();
+    expect(removed, "restart should call removeAttribute('live-pulse') once").to.equal(1);
+    expect(el.hasAttribute("live-pulse")).to.equal(true);
+  });
+});

--- a/j2cl/lit/test/wavy-blip-card.test.js
+++ b/j2cl/lit/test/wavy-blip-card.test.js
@@ -16,6 +16,7 @@ async function waitForStylesheet() {
     if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
     await new Promise((r) => setTimeout(r, 20));
   }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
 }
 
 before(async () => {

--- a/j2cl/lit/test/wavy-blip-card.test.js
+++ b/j2cl/lit/test/wavy-blip-card.test.js
@@ -68,6 +68,15 @@ describe("<wavy-blip-card>", () => {
     }
   });
 
+  it("empty blip-extension slot without design preview collapses to zero height (no dashed outline)", async () => {
+    delete document.documentElement.dataset.wavyDesignPreview;
+    const el = await fixture(html`<wavy-blip-card></wavy-blip-card>`);
+    const wrapper = el.renderRoot.querySelector(".ext-slot-wrapper");
+    const cs = getComputedStyle(wrapper);
+    expect(cs.borderStyle).to.not.equal("dashed");
+    expect(parseInt(cs.height, 10)).to.equal(0);
+  });
+
   it("focused state applies the cyan focus ring border-color", async () => {
     const dark = await fixture(
       html`<div data-wavy-theme="dark">

--- a/j2cl/lit/test/wavy-compose-card.test.js
+++ b/j2cl/lit/test/wavy-compose-card.test.js
@@ -1,0 +1,105 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-compose-card.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-compose-card>", () => {
+  it("exposes the four named slots", async () => {
+    const el = await fixture(html`<wavy-compose-card></wavy-compose-card>`);
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='toolbar']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='compose-extension']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='affordance']")).to.exist;
+  });
+
+  it("reflects reply-target-blip-id as a data attribute (data-* form per slot contract)", async () => {
+    const el = await fixture(html`
+      <wavy-compose-card data-reply-target-blip-id="b42"></wavy-compose-card>
+    `);
+    // Plugins read this via host.dataset.replyTargetBlipId per
+    // docs/j2cl-plugin-slots.md.
+    expect(el.dataset.replyTargetBlipId).to.equal("b42");
+    expect(el.getAttribute("data-reply-target-blip-id")).to.equal("b42");
+  });
+
+  it("empty compose-extension slot in design preview shows the dashed outline label", async () => {
+    document.documentElement.dataset.wavyDesignPreview = "true";
+    try {
+      const el = await fixture(html`<wavy-compose-card></wavy-compose-card>`);
+      const wrapper = el.renderRoot.querySelector(".ext-slot-wrapper");
+      const cs = getComputedStyle(wrapper);
+      expect(cs.borderStyle).to.equal("dashed");
+    } finally {
+      delete document.documentElement.dataset.wavyDesignPreview;
+    }
+  });
+
+  it("focused state applies the cyan focus ring border-color", async () => {
+    const wrap = await fixture(
+      html`<div data-wavy-theme="dark">
+        <wavy-compose-card focused></wavy-compose-card>
+      </div>`
+    );
+    const card = wrap.querySelector("wavy-compose-card");
+    const cs = getComputedStyle(card);
+    expect(cs.borderColor.replace(/\s+/g, "")).to.match(/rgb\(34,211,238\)/);
+  });
+
+  it("submitting state suppresses pointer-events on the affordance row", async () => {
+    const el = await fixture(html`
+      <wavy-compose-card submitting>
+        <button slot="affordance">Submit</button>
+      </wavy-compose-card>
+    `);
+    const row = el.renderRoot.querySelector(".affordance-row");
+    expect(getComputedStyle(row).pointerEvents).to.equal("none");
+  });
+
+  it("composerState and activeSelection setters return frozen objects", async () => {
+    const el = await fixture(html`<wavy-compose-card></wavy-compose-card>`);
+    el.composerState = { drafts: 3 };
+    el.activeSelection = { start: 0, end: 4 };
+    expect(Object.isFrozen(el.composerState)).to.equal(true);
+    expect(Object.isFrozen(el.activeSelection)).to.equal(true);
+    expect(el.composerState.drafts).to.equal(3);
+    expect(el.activeSelection.end).to.equal(4);
+    expect(() => {
+      el.composerState.drafts = 99;
+    }).to.throw();
+  });
+
+  it("dark / light / contrast variants flip the surface background", async () => {
+    const variants = ["dark", "light", "contrast"];
+    const surfaces = new Set();
+    for (const v of variants) {
+      const wrap = await fixture(
+        html`<div data-wavy-theme=${v}>
+          <wavy-compose-card></wavy-compose-card>
+        </div>`
+      );
+      const card = wrap.querySelector("wavy-compose-card");
+      surfaces.add(getComputedStyle(card).backgroundColor);
+    }
+    expect(surfaces.size).to.be.greaterThanOrEqual(2);
+  });
+});

--- a/j2cl/lit/test/wavy-compose-card.test.js
+++ b/j2cl/lit/test/wavy-compose-card.test.js
@@ -16,6 +16,7 @@ async function waitForStylesheet() {
     if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
     await new Promise((r) => setTimeout(r, 20));
   }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
 }
 
 before(async () => {

--- a/j2cl/lit/test/wavy-depth-nav.test.js
+++ b/j2cl/lit/test/wavy-depth-nav.test.js
@@ -1,0 +1,34 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-depth-nav.js";
+
+describe("<wavy-depth-nav>", () => {
+  it("renders one nav element with the breadcrumb landmark", async () => {
+    const el = await fixture(html`<wavy-depth-nav></wavy-depth-nav>`);
+    const nav = el.renderRoot.querySelector("nav[aria-label='Breadcrumb']");
+    expect(nav).to.exist;
+  });
+
+  it("renders one entry per crumb", async () => {
+    const el = await fixture(html`<wavy-depth-nav></wavy-depth-nav>`);
+    el.crumbs = [
+      { label: "Inbox", href: "/inbox" },
+      { label: "Sample wave", href: "/wave/1" },
+      { label: "Top thread", current: true }
+    ];
+    await el.updateComplete;
+    const nav = el.renderRoot.querySelector("nav");
+    const anchors = nav.querySelectorAll("a");
+    const currentSpans = nav.querySelectorAll("[aria-current='page']");
+    expect(anchors.length).to.equal(2);
+    expect(currentSpans.length).to.equal(1);
+    expect(currentSpans[0].textContent.trim()).to.equal("Top thread");
+  });
+
+  it("crumb without href and not current renders a plain span", async () => {
+    const el = await fixture(html`<wavy-depth-nav></wavy-depth-nav>`);
+    el.crumbs = [{ label: "Plain" }];
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("a")).to.equal(null);
+    expect(el.renderRoot.querySelector("[aria-current]")).to.equal(null);
+  });
+});

--- a/j2cl/lit/test/wavy-edit-toolbar.test.js
+++ b/j2cl/lit/test/wavy-edit-toolbar.test.js
@@ -1,0 +1,76 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-edit-toolbar.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-edit-toolbar>", () => {
+  it("exposes the default and toolbar-extension slots", async () => {
+    const el = await fixture(html`<wavy-edit-toolbar></wavy-edit-toolbar>`);
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='toolbar-extension']")).to.exist;
+  });
+
+  it("uses the toolbar landmark role", async () => {
+    const el = await fixture(html`<wavy-edit-toolbar></wavy-edit-toolbar>`);
+    expect(el.renderRoot.querySelector("div[role='toolbar']")).to.exist;
+  });
+
+  it("debounces active-selection writes to the data attribute via rAF", async () => {
+    const el = await fixture(html`
+      <wavy-edit-toolbar active-selection='{"start":0,"end":4}'></wavy-edit-toolbar>
+    `);
+    // The attribute set via the literal triggers the rAF; wait one frame
+    // plus a tick so the data attribute reflects.
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    // Plugins read via host.dataset.activeSelection per docs/j2cl-plugin-slots.md.
+    expect(el.dataset.activeSelection).to.equal('{"start":0,"end":4}');
+    expect(el.getAttribute("data-active-selection")).to.equal('{"start":0,"end":4}');
+  });
+
+  it("empty toolbar-extension slot in design preview shows the dashed outline label", async () => {
+    document.documentElement.dataset.wavyDesignPreview = "true";
+    try {
+      const el = await fixture(html`<wavy-edit-toolbar></wavy-edit-toolbar>`);
+      const wrapper = el.renderRoot.querySelector(".ext-slot-wrapper");
+      const cs = getComputedStyle(wrapper);
+      expect(cs.borderStyle).to.equal("dashed");
+    } finally {
+      delete document.documentElement.dataset.wavyDesignPreview;
+    }
+  });
+
+  it("dark / light / contrast variants flip the surface background", async () => {
+    const variants = ["dark", "light", "contrast"];
+    const surfaces = new Set();
+    for (const v of variants) {
+      const wrap = await fixture(
+        html`<div data-wavy-theme=${v}>
+          <wavy-edit-toolbar></wavy-edit-toolbar>
+        </div>`
+      );
+      const tb = wrap.querySelector("wavy-edit-toolbar");
+      surfaces.add(getComputedStyle(tb).backgroundColor);
+    }
+    expect(surfaces.size).to.be.greaterThanOrEqual(2);
+  });
+});

--- a/j2cl/lit/test/wavy-edit-toolbar.test.js
+++ b/j2cl/lit/test/wavy-edit-toolbar.test.js
@@ -16,6 +16,7 @@ async function waitForStylesheet() {
     if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
     await new Promise((r) => setTimeout(r, 20));
   }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
 }
 
 before(async () => {

--- a/j2cl/lit/test/wavy-pulse-stage.test.js
+++ b/j2cl/lit/test/wavy-pulse-stage.test.js
@@ -1,0 +1,66 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-pulse-stage.js";
+import "../src/design/wavy-blip-card.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-pulse-stage>", () => {
+  it("firePulse() sets live-pulse on the resolved target", async () => {
+    const stage = await fixture(html`
+      <wavy-pulse-stage>
+        <wavy-blip-card></wavy-blip-card>
+      </wavy-pulse-stage>
+    `);
+    const card = stage.querySelector("wavy-blip-card");
+    expect(card.hasAttribute("live-pulse")).to.equal(false);
+    stage.firePulse();
+    expect(card.hasAttribute("live-pulse")).to.equal(true);
+  });
+
+  it("firePulse() removes the attribute after the resolved duration + 50ms", async () => {
+    const stage = await fixture(html`
+      <wavy-pulse-stage>
+        <wavy-blip-card></wavy-blip-card>
+      </wavy-pulse-stage>
+    `);
+    const card = stage.querySelector("wavy-blip-card");
+    stage.firePulse();
+    expect(card.hasAttribute("live-pulse")).to.equal(true);
+    // Resolve --wavy-motion-pulse-duration at test time so the budget
+    // adapts to prefers-reduced-motion (where it collapses to ~0ms).
+    const cs = getComputedStyle(document.documentElement);
+    const raw = cs.getPropertyValue("--wavy-motion-pulse-duration").trim();
+    const ms = raw.endsWith("ms")
+      ? parseFloat(raw)
+      : raw.endsWith("s")
+        ? parseFloat(raw) * 1000
+        : 600;
+    await new Promise((r) => setTimeout(r, Math.max(ms, 1) + 100));
+    expect(card.hasAttribute("live-pulse")).to.equal(false);
+  });
+
+  it("targetSelector defaults to wavy-blip-card", async () => {
+    const stage = await fixture(html`<wavy-pulse-stage></wavy-pulse-stage>`);
+    expect(stage.targetSelector).to.equal("wavy-blip-card");
+  });
+});

--- a/j2cl/lit/test/wavy-pulse-stage.test.js
+++ b/j2cl/lit/test/wavy-pulse-stage.test.js
@@ -17,6 +17,7 @@ async function waitForStylesheet() {
     if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
     await new Promise((r) => setTimeout(r, 20));
   }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
 }
 
 before(async () => {

--- a/j2cl/lit/test/wavy-rail-panel.test.js
+++ b/j2cl/lit/test/wavy-rail-panel.test.js
@@ -1,0 +1,95 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/design/wavy-rail-panel.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-rail-panel>", () => {
+  it("exposes the named slots including rail-extension", async () => {
+    const el = await fixture(html`<wavy-rail-panel></wavy-rail-panel>`);
+    expect(el.renderRoot.querySelector("slot:not([name])")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='header-actions']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='rail-extension']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='footer']")).to.exist;
+  });
+
+  it("reflects active-wave-id and active-folder as data-* attributes per slot contract", async () => {
+    const el = await fixture(html`
+      <wavy-rail-panel
+        panel-title="Saved searches"
+        data-active-wave-id="w1"
+        data-active-folder="inbox"
+      ></wavy-rail-panel>
+    `);
+    // Plugins read via host.dataset.* per docs/j2cl-plugin-slots.md.
+    expect(el.dataset.activeWaveId).to.equal("w1");
+    expect(el.dataset.activeFolder).to.equal("inbox");
+    expect(el.getAttribute("data-active-wave-id")).to.equal("w1");
+    expect(el.getAttribute("data-active-folder")).to.equal("inbox");
+  });
+
+  it("empty rail-extension slot in design preview shows the dashed outline label", async () => {
+    document.documentElement.dataset.wavyDesignPreview = "true";
+    try {
+      const el = await fixture(html`<wavy-rail-panel></wavy-rail-panel>`);
+      const wrapper = el.renderRoot.querySelector(".ext-slot-wrapper");
+      const cs = getComputedStyle(wrapper);
+      expect(cs.borderStyle).to.equal("dashed");
+      expect(cs.display).to.equal("block");
+    } finally {
+      delete document.documentElement.dataset.wavyDesignPreview;
+    }
+  });
+
+  it("toggleCollapsed flips the collapsed attribute and aria-expanded", async () => {
+    const el = await fixture(html`<wavy-rail-panel></wavy-rail-panel>`);
+    const region = el.renderRoot.querySelector("section[role='region']");
+    expect(region.getAttribute("aria-expanded")).to.equal("true");
+    el.toggleCollapsed();
+    await el.updateComplete;
+    expect(el.hasAttribute("collapsed")).to.equal(true);
+    expect(region.getAttribute("aria-expanded")).to.equal("false");
+  });
+
+  it("renders the panel title in the header", async () => {
+    const el = await fixture(html`
+      <wavy-rail-panel panel-title="Saved"></wavy-rail-panel>
+    `);
+    const h2 = el.renderRoot.querySelector("h2");
+    expect(h2.textContent.trim()).to.equal("Saved");
+  });
+
+  it("dark / light / contrast variants flip the surface background", async () => {
+    const variants = ["dark", "light", "contrast"];
+    const surfaces = new Set();
+    for (const v of variants) {
+      const wrap = await fixture(
+        html`<div data-wavy-theme=${v}>
+          <wavy-rail-panel></wavy-rail-panel>
+        </div>`
+      );
+      const card = wrap.querySelector("wavy-rail-panel");
+      surfaces.add(getComputedStyle(card).backgroundColor);
+    }
+    expect(surfaces.size).to.be.greaterThanOrEqual(2);
+  });
+});

--- a/j2cl/lit/test/wavy-rail-panel.test.js
+++ b/j2cl/lit/test/wavy-rail-panel.test.js
@@ -16,6 +16,7 @@ async function waitForStylesheet() {
     if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
     await new Promise((r) => setTimeout(r, 20));
   }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
 }
 
 before(async () => {

--- a/j2cl/lit/test/wavy-tokens.test.js
+++ b/j2cl/lit/test/wavy-tokens.test.js
@@ -1,0 +1,272 @@
+import { fixture, expect, html } from "@open-wc/testing";
+
+// Load the wavy-tokens stylesheet into the test document so getComputedStyle
+// can resolve --wavy-* custom properties. Web-test-runner serves files
+// relative to the project root via @web/dev-server; the stylesheet sits at
+// /src/design/wavy-tokens.css.
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  // Wait for the stylesheet to apply by polling getComputedStyle.
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
+}
+
+// Color-token name list (from plan §3.1). The six --wavy-type-*,
+// --wavy-spacing-* etc. lists are checked separately below.
+const COLOR_TOKENS = [
+  "--wavy-bg-base",
+  "--wavy-bg-surface",
+  "--wavy-border-hairline",
+  "--wavy-text-body",
+  "--wavy-text-muted",
+  "--wavy-text-quiet",
+  "--wavy-signal-cyan",
+  "--wavy-signal-cyan-soft",
+  "--wavy-signal-violet",
+  "--wavy-signal-violet-soft",
+  "--wavy-signal-amber",
+  "--wavy-signal-amber-soft",
+  "--wavy-focus-ring",
+  "--wavy-pulse-ring"
+];
+
+const TYPOGRAPHY_TOKENS = [
+  "--wavy-font-headline",
+  "--wavy-font-body",
+  "--wavy-font-label",
+  "--wavy-type-display",
+  "--wavy-type-h1",
+  "--wavy-type-h2",
+  "--wavy-type-h3",
+  "--wavy-type-body",
+  "--wavy-type-label",
+  "--wavy-type-meta"
+];
+
+const MOTION_TOKENS = [
+  "--wavy-motion-pulse-duration",
+  "--wavy-motion-focus-duration",
+  "--wavy-motion-collapse-duration",
+  "--wavy-motion-fragment-fade-duration",
+  "--wavy-easing-pulse",
+  "--wavy-easing-focus",
+  "--wavy-easing-collapse"
+];
+
+const SPACING_SHAPE_TOKENS = [
+  "--wavy-spacing-1",
+  "--wavy-spacing-2",
+  "--wavy-spacing-3",
+  "--wavy-spacing-4",
+  "--wavy-spacing-5",
+  "--wavy-spacing-6",
+  "--wavy-spacing-7",
+  "--wavy-spacing-8",
+  "--wavy-radius-card",
+  "--wavy-radius-pill"
+];
+
+const ALL_TOKENS = [
+  ...COLOR_TOKENS,
+  ...TYPOGRAPHY_TOKENS,
+  ...MOTION_TOKENS,
+  ...SPACING_SHAPE_TOKENS
+];
+
+// Parse `rgb(...)` / `rgba(...)` strings returned by getComputedStyle.
+// Returns [r, g, b, a] in the 0..255 / 0..1 range, or null if not parseable.
+function parseColor(str) {
+  const m = String(str).trim().match(
+    /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*(\d+(?:\.\d+)?))?\s*\)$/
+  );
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), m[4] === undefined ? 1 : Number(m[4])];
+}
+
+// WCAG 2.1 relative luminance, 0..1.
+function relativeLuminance([r, g, b]) {
+  const channel = (c) => {
+    const v = c / 255;
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+// Composite a foreground color (with alpha) over an opaque background and
+// return the resulting RGB. Necessary because text tokens are alpha-tinted.
+function composite(fg, bg) {
+  const [fr, fg_, fb, fa] = fg;
+  const [br, bg_, bb] = bg;
+  return [
+    Math.round(fr * fa + br * (1 - fa)),
+    Math.round(fg_ * fa + bg_ * (1 - fa)),
+    Math.round(fb * fa + bb * (1 - fa))
+  ];
+}
+
+function contrastRatio(fgRgb, bgRgb) {
+  const lFg = relativeLuminance(fgRgb);
+  const lBg = relativeLuminance(bgRgb);
+  const lighter = Math.max(lFg, lBg);
+  const darker = Math.min(lFg, lBg);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+async function probeAt(themeAttr) {
+  const wrapper = await fixture(html`
+    <div data-wavy-theme=${themeAttr}>
+      <div class="probe">probe</div>
+    </div>
+  `);
+  return getComputedStyle(wrapper);
+}
+
+before(() => {
+  ensureWavyTokensLoaded();
+});
+
+describe("wavy-tokens.css", () => {
+  before(async () => {
+    await waitForStylesheet();
+  });
+
+  it("defines every contract token from plan §3 (default scope)", () => {
+    const cs = getComputedStyle(document.documentElement);
+    for (const name of ALL_TOKENS) {
+      const v = cs.getPropertyValue(name).trim();
+      expect(v, `expected ${name} to be defined at :root`).to.not.equal("");
+    }
+  });
+
+  it("uses only the --wavy- prefix (no accidental --shell- overlap)", () => {
+    for (const name of ALL_TOKENS) {
+      expect(name.startsWith("--wavy-")).to.equal(true);
+    }
+  });
+
+  it("pins signal accent hex values from the Stitch source of truth", () => {
+    const cs = getComputedStyle(document.documentElement);
+    expect(cs.getPropertyValue("--wavy-signal-cyan").trim().toLowerCase()).to.equal("#22d3ee");
+    expect(cs.getPropertyValue("--wavy-signal-violet").trim().toLowerCase()).to.equal("#7c3aed");
+    expect(cs.getPropertyValue("--wavy-signal-amber").trim().toLowerCase()).to.equal("#fb923c");
+  });
+
+  it("pins motion durations and shape tokens to the spec values", () => {
+    const cs = getComputedStyle(document.documentElement);
+    expect(cs.getPropertyValue("--wavy-motion-pulse-duration").trim()).to.equal("600ms");
+    expect(cs.getPropertyValue("--wavy-motion-focus-duration").trim()).to.equal("180ms");
+    expect(cs.getPropertyValue("--wavy-motion-collapse-duration").trim()).to.equal("240ms");
+    expect(cs.getPropertyValue("--wavy-motion-fragment-fade-duration").trim()).to.equal("300ms");
+    expect(cs.getPropertyValue("--wavy-radius-card").trim()).to.equal("12px");
+    expect(cs.getPropertyValue("--wavy-radius-pill").trim()).to.equal("9999px");
+  });
+
+  it("dark and light variants resolve to different surface colors", async () => {
+    const csDark = await probeAt("dark");
+    const csLight = await probeAt("light");
+    const dark = csDark.getPropertyValue("--wavy-bg-surface").trim().toLowerCase();
+    const light = csLight.getPropertyValue("--wavy-bg-surface").trim().toLowerCase();
+    expect(dark).to.not.equal(light);
+  });
+
+  it("contrast variant raises text-body to a higher saturation than dark", async () => {
+    const csDark = await probeAt("dark");
+    const csContrast = await probeAt("contrast");
+    const darkBody = csDark.getPropertyValue("--wavy-text-body").trim();
+    const contrastBody = csContrast.getPropertyValue("--wavy-text-body").trim();
+    // Contrast body is plain #ffffff, dark is rgba(232,240,255,0.92);
+    // so they must differ.
+    expect(darkBody).to.not.equal(contrastBody);
+  });
+
+  // Resolve a CSS color string (any form) to opaque RGB triplet by
+  // round-tripping through getComputedStyle on a probe element.
+  function resolveColor(cssValue) {
+    const probe = document.createElement("span");
+    probe.style.color = cssValue;
+    document.body.appendChild(probe);
+    const rgba = parseColor(getComputedStyle(probe).color);
+    probe.remove();
+    return rgba;
+  }
+
+  // WCAG floors per theme + tier:
+  //   - body and muted: AA 4.5:1 for normal-size text on dark/light,
+  //     AAA 7:1 on contrast.
+  //   - quiet: 3:1 (WCAG AA for incidental/large UI text — quiet is the
+  //     tertiary tier reserved for timestamps and decorative meta and
+  //     is intentionally low-contrast). On contrast theme, raised to
+  //     4.5:1 to match the contrast variant's stricter intent.
+  function assertContrastFloors(themeAttr, bodyFloor, mutedFloor, quietFloor) {
+    return (async () => {
+      const cs = await probeAt(themeAttr);
+      // Always use the explicit --wavy-bg-surface token as the
+      // background — the wrapper element's backgroundColor is
+      // rgba(0,0,0,0) by default and would skew the composite.
+      const surfaceCss = cs.getPropertyValue("--wavy-bg-surface").trim();
+      const opaqueBg = resolveColor(surfaceCss).slice(0, 3);
+
+      const tiers = [
+        ["--wavy-text-body", bodyFloor],
+        ["--wavy-text-muted", mutedFloor],
+        ["--wavy-text-quiet", quietFloor]
+      ];
+      for (const [tokenName, floor] of tiers) {
+        const raw = cs.getPropertyValue(tokenName).trim();
+        const fgRgba = resolveColor(raw);
+        const fgComposited = composite(fgRgba, opaqueBg);
+        const ratio = contrastRatio(fgComposited, opaqueBg);
+        expect(
+          ratio,
+          `${themeAttr} theme: ${tokenName} contrast ratio ${ratio.toFixed(2)} below floor ${floor}`
+        ).to.be.greaterThanOrEqual(floor);
+      }
+    })();
+  }
+
+  it("dark variant clears WCAG floors (body/muted AA 4.5:1, quiet 3:1)", async () => {
+    await assertContrastFloors("dark", 4.5, 4.5, 3.0);
+  });
+
+  it("light variant clears WCAG floors (body/muted AA 4.5:1, quiet 3:1)", async () => {
+    await assertContrastFloors("light", 4.5, 4.5, 3.0);
+  });
+
+  it("contrast variant clears WCAG AAA (body/muted 7:1, quiet 4.5:1)", async () => {
+    await assertContrastFloors("contrast", 7, 7, 4.5);
+  });
+
+  it("reduced motion can be exercised by reading the resolved duration token", () => {
+    // Sanity check: the test environment may or may not announce
+    // prefers-reduced-motion. Either way, the duration token must
+    // resolve to a positive parseable time value.
+    const cs = getComputedStyle(document.documentElement);
+    const raw = cs.getPropertyValue("--wavy-motion-pulse-duration").trim();
+    expect(raw.endsWith("ms") || raw.endsWith("s")).to.equal(true);
+  });
+
+  it("font shorthand caveat: declaring font-weight after the type token sticks", async () => {
+    // Plan §3.2 "Caveat — `font` shorthand reset" — recipes must
+    // declare font-weight AFTER the var(--wavy-type-*) shorthand or
+    // the weight resets to 'normal' / 400. This test mounts a probe
+    // that does it the right way and asserts the computed weight; if
+    // a future recipe drops the explicit font-weight after the
+    // shorthand, the same pattern would compute as "400" here.
+    const probe = await fixture(html`
+      <div style="font: var(--wavy-type-h3); font-weight: 600;">Probe</div>
+    `);
+    expect(getComputedStyle(probe).fontWeight).to.equal("600");
+  });
+});

--- a/wave/config/changelog.d/2026-04-26-issue-1035-wavy-design-foundation.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1035-wavy-design-foundation.json
@@ -1,0 +1,19 @@
+{
+  "releaseId": "2026-04-26-issue-1035-wavy-design-foundation",
+  "version": "F-0 (#1035)",
+  "date": "2026-04-26",
+  "title": "Wavy Design Foundation + Plugin Slot Contracts",
+  "summary": "The J2CL parity client gains the Wavy — Firefly Signal design packet (CSS tokens + six Lit recipe elements) and a documented contract for the four plugin slot points that future robots/data-API plugins will mount into. The user menu's API group is renamed to make the plugin surface visible.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "New Lit design packet (j2cl/lit/src/design/) ships --wavy-* CSS custom properties (color, typography, motion, spacing, shape) with dark / light / high-contrast variants and reduced-motion support.",
+        "Six new Lit recipe elements (<wavy-blip-card>, <wavy-compose-card>, <wavy-rail-panel>, <wavy-edit-toolbar>, <wavy-depth-nav>, <wavy-pulse-stage>) consume the tokens and expose four named plugin slots: blip-extension, compose-extension, rail-extension, toolbar-extension.",
+        "New docs/j2cl-plugin-slots.md formalises the slot context (data attributes + frozen JS properties), styling contract, accessibility contract, lifecycle, and rollback semantics for each of the four slots.",
+        "Admin/owner-only design preview route at /?view=j2cl-root&q=design-preview mounts every recipe under all three theme variants plus a live-update pulse moment, with dashed outlines around empty plugin slots so designers see where plugins will land.",
+        "User-menu group renamed from \"Automation / APIs\" to \"Plugins / Integrations\" in both the wave-client and standalone topbars; the existing /account/robots and /api-docs links are preserved."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3377,6 +3377,10 @@ public final class HtmlRenderer {
     sb.append("<meta name=\"current-release-id\" content=\"").append(escapeHtml(currentReleaseId == null ? "" : currentReleaseId)).append("\">\n");
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/sidecar.css\">\n");
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.css\">\n");
+    // F-0 (#1035): wavy design tokens for the F-2/F-3/F-4 recipe surfaces.
+    // Loaded alongside shell.css so the recipes' --wavy-* var() lookups
+    // resolve under the J2CL root shell view.
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-tokens.css\">\n");
     sb.append("<script type=\"module\" src=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.js\"></script>\n");
     appendJ2clRootShellStatsShim(sb);
     appendAnalyticsFragment(sb, analyticsAccount, null);
@@ -3453,6 +3457,126 @@ public final class HtmlRenderer {
     }
     sb.append("</body>\n</html>\n");
     return sb.toString();
+  }
+
+  /**
+   * F-0 (#1035): renders the design-preview page that mounts every
+   * wavy recipe in dark / light / contrast variants plus the four
+   * plugin-slot dashed-outline previews. Reachable at
+   * {@code /?view=j2cl-root&q=design-preview} when the viewer is
+   * admin or owner; the gating happens in {@code WaveClientServlet}.
+   *
+   * <p>The page is server-rendered HTML — no new J2CL or Lit
+   * behaviour ships from this route. The recipes' web-test-runner
+   * tests cover the client-side rendering.
+   */
+  public static String renderJ2clDesignPreviewPage(
+      String contextPath, String buildCommit, long serverBuildTime, String currentReleaseId) {
+    String resolvedBasePath = contextPath == null ? "/" : contextPath;
+    if (!resolvedBasePath.endsWith("/")) {
+      resolvedBasePath = resolvedBasePath + "/";
+    }
+    String safeResolvedBasePath = StringEscapeUtils.escapeHtml4(resolvedBasePath);
+    StringBuilder sb = new StringBuilder(4096);
+    sb.append("<!DOCTYPE html>\n<html lang=\"en\" data-wavy-design-preview>\n<head>\n");
+    sb.append("<meta charset=\"UTF-8\">\n");
+    sb.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=5.0\">\n");
+    sb.append("<title>SupaWave J2CL Design Preview</title>\n");
+    sb.append("<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">\n");
+    sb.append("<link rel=\"alternate icon\" href=\"/static/favicon.ico\">\n");
+    sb.append("<meta name=\"build-commit\" content=\"").append(escapeHtml(buildCommit == null ? "" : buildCommit)).append("\">\n");
+    sb.append("<meta name=\"server-build-time\" content=\"").append(serverBuildTime).append("\">\n");
+    sb.append("<meta name=\"current-release-id\" content=\"").append(escapeHtml(currentReleaseId == null ? "" : currentReleaseId)).append("\">\n");
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/sidecar.css\">\n");
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.css\">\n");
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-tokens.css\">\n");
+    sb.append("<script type=\"module\" src=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.js\"></script>\n");
+    sb.append("<style>\n");
+    sb.append("body{margin:0;background:var(--wavy-bg-base);color:var(--wavy-text-body);font:var(--wavy-type-body);min-height:100vh;}\n");
+    sb.append(".wavy-design-preview-header{padding:var(--wavy-spacing-5) var(--wavy-spacing-6);border-bottom:1px solid var(--wavy-border-hairline);}\n");
+    sb.append(".wavy-design-preview-header h1{margin:0;font:var(--wavy-type-h1);font-weight:600;color:var(--wavy-text-body);}\n");
+    sb.append(".wavy-design-preview-header p{margin:var(--wavy-spacing-2) 0 0;color:var(--wavy-text-muted);font:var(--wavy-type-body);}\n");
+    sb.append(".wavy-design-preview-section{padding:var(--wavy-spacing-6);background:var(--wavy-bg-base);}\n");
+    sb.append(".wavy-design-preview-section h2{margin:0 0 var(--wavy-spacing-4);font:var(--wavy-type-h2);font-weight:600;color:var(--wavy-text-body);}\n");
+    sb.append(".wavy-design-preview-grid{display:grid;grid-template-columns:1fr 280px;gap:var(--wavy-spacing-5);}\n");
+    sb.append(".wavy-design-preview-content{min-width:0;}\n");
+    sb.append(".wavy-design-preview-rail{min-width:0;}\n");
+    sb.append("@media (max-width:860px){.wavy-design-preview-grid{grid-template-columns:1fr;}}\n");
+    sb.append("</style>\n");
+    sb.append("</head>\n<body>\n");
+    sb.append("<header class=\"wavy-design-preview-header\">\n");
+    sb.append("  <h1>Wavy design preview</h1>\n");
+    sb.append("  <p>Reference layout for the F-0 design packet (issue #1035). See <code>docs/j2cl-plugin-slots.md</code> for the slot contract and <code>j2cl/lit/src/design/README.md</code> for the design system source of truth. Variants below: dark (default), light, and high-contrast.</p>\n");
+    sb.append("</header>\n");
+    appendDesignPreviewSection(sb, "Dark variant", null);
+    appendDesignPreviewSection(sb, "Light variant", "light");
+    appendDesignPreviewSection(sb, "High-contrast variant", "contrast");
+    sb.append("</body>\n</html>\n");
+    return sb.toString();
+  }
+
+  /**
+   * Appends one design-preview section for the given theme variant.
+   * Each section mounts: depth-nav crumb, focused blip card with a
+   * sample {@code blip-extension} plugin, unfocused unread blip card
+   * with an empty slot (showing the dashed-outline preview), compose
+   * card with edit toolbar + sample compose/toolbar plugins, rail
+   * panel with a sample rail plugin, and a pulse-stage with a third
+   * blip card so a designer can fire the live-update pulse moment.
+   *
+   * @param themeAttr null/empty for the dark default; otherwise
+   *     applied as {@code data-wavy-theme="…"} on the section
+   *     wrapper so the recipes resolve scope-overridden tokens.
+   */
+  private static void appendDesignPreviewSection(StringBuilder sb, String label, String themeAttr) {
+    String safeLabel = escapeHtml(label);
+    String themeAttrSnippet =
+        (themeAttr == null || themeAttr.isEmpty())
+            ? ""
+            : " data-wavy-theme=\"" + escapeHtml(themeAttr) + "\"";
+    sb.append("<section class=\"wavy-design-preview-section\"").append(themeAttrSnippet).append(">\n");
+    sb.append("  <h2>").append(safeLabel).append("</h2>\n");
+    sb.append("  <div class=\"wavy-design-preview-grid\">\n");
+    sb.append("    <div class=\"wavy-design-preview-content\">\n");
+    sb.append("      <wavy-depth-nav id=\"wavy-design-preview-crumb-").append(escapeHtml(themeAttr == null ? "dark" : themeAttr)).append("\"></wavy-depth-nav>\n");
+    // F-0 (#1035): plugin slot-context attributes use the data-* form
+    // (per docs/j2cl-plugin-slots.md) — see the property declarations
+    // in the recipe element classes for the canonical names.
+    sb.append("      <wavy-blip-card data-blip-id=\"b1\" data-wave-id=\"w1\" author-name=\"Alice\" posted-at=\"2026-04-26T12:00Z\" focused>\n");
+    sb.append("        Sample focused blip body — long-form reading rhythm at the wavy ~70 character target line length.\n");
+    sb.append("        <span slot=\"blip-extension\" data-wavy-design-preview-plugin=\"blip\">[plugin: poll]</span>\n");
+    sb.append("        <span slot=\"reactions\">👍 ✨ 🌊</span>\n");
+    sb.append("      </wavy-blip-card>\n");
+    sb.append("      <wavy-blip-card data-blip-id=\"b2\" data-wave-id=\"w1\" author-name=\"Bob\" posted-at=\"2026-04-26T12:05Z\" unread>\n");
+    sb.append("        Sample unfocused unread blip body — empty blip-extension slot shows the dashed outline preview.\n");
+    sb.append("      </wavy-blip-card>\n");
+    sb.append("      <wavy-compose-card focused data-reply-target-blip-id=\"b1\">\n");
+    sb.append("        <p>Sample composer body — type your reply…</p>\n");
+    sb.append("        <wavy-edit-toolbar slot=\"toolbar\" active-selection='{\"start\":0,\"end\":0}'>\n");
+    sb.append("          <button type=\"button\" aria-pressed=\"false\">B</button>\n");
+    sb.append("          <button type=\"button\" aria-pressed=\"false\">I</button>\n");
+    sb.append("          <span slot=\"toolbar-extension\" data-wavy-design-preview-plugin=\"toolbar\">[plugin: code]</span>\n");
+    sb.append("        </wavy-edit-toolbar>\n");
+    sb.append("        <span slot=\"compose-extension\" data-wavy-design-preview-plugin=\"compose\">[plugin: poll]</span>\n");
+    sb.append("        <button slot=\"affordance\" type=\"button\">Send wave</button>\n");
+    sb.append("      </wavy-compose-card>\n");
+    sb.append("      <wavy-pulse-stage>\n");
+    sb.append("        <wavy-blip-card data-blip-id=\"b3\" data-wave-id=\"w1\" author-name=\"Carol\" posted-at=\"now\">\n");
+    sb.append("          Sample arriving blip — press <em>Fire pulse</em> to see the live-update glow.\n");
+    sb.append("        </wavy-blip-card>\n");
+    sb.append("      </wavy-pulse-stage>\n");
+    sb.append("    </div>\n");
+    sb.append("    <div class=\"wavy-design-preview-rail\">\n");
+    sb.append("      <wavy-rail-panel panel-title=\"Saved searches\" data-active-wave-id=\"w1\" data-active-folder=\"inbox\">\n");
+    sb.append("        <ul style=\"list-style:none;padding:0;margin:0;\"><li>Inbox</li><li>Mentions</li><li>Tasks</li></ul>\n");
+    sb.append("        <span slot=\"rail-extension\" data-wavy-design-preview-plugin=\"rail\">[plugin: assistant]</span>\n");
+    sb.append("      </wavy-rail-panel>\n");
+    sb.append("    </div>\n");
+    sb.append("  </div>\n");
+    sb.append("  <script type=\"text/javascript\">\n");
+    sb.append("(function(){var n=document.getElementById('wavy-design-preview-crumb-").append(escapeHtml(themeAttr == null ? "dark" : themeAttr)).append("');if(n)n.crumbs=[{label:'Inbox',href:'#'},{label:'Sample wave',href:'#'},{label:'Top thread',current:true}];})();\n");
+    sb.append("  </script>\n");
+    sb.append("</section>\n");
   }
 
   private static void appendJ2clRootShellStatsShim(StringBuilder sb) {
@@ -4470,7 +4594,10 @@ public final class HtmlRenderer {
     sb.append("          <a href=\"").append(safeCtx).append("/account/settings\">Account Settings</a>\n");
     sb.append("        </div>\n");
     sb.append("        <div class=\"menu-section\">\n");
-    sb.append("          <div class=\"section-label\">Automation / APIs</div>\n");
+    // F-0 (#1035, A.10/M.1): renamed from "Automation / APIs" so the
+    // group is the user-facing surface for the forthcoming
+    // robots/data-API plugin registry. Anchor URLs unchanged.
+    sb.append("          <div class=\"section-label\">Plugins / Integrations</div>\n");
     sb.append("          <a class=\"section-link-strong\" href=\"").append(safeCtx).append("/account/robots\">Robot &amp; Data API</a>\n");
     sb.append("          <a href=\"").append(safeCtx).append("/api-docs\" target=\"_blank\" rel=\"noopener noreferrer\">API Docs</a>\n");
     sb.append("        </div>\n");
@@ -4659,7 +4786,9 @@ public final class HtmlRenderer {
       sb.append("          <a href=\"/account/settings\">Account Settings</a>\n");
       sb.append("        </div>\n");
       sb.append("        <div class=\"menu-section\">\n");
-      sb.append("          <div class=\"section-label\">Automation / APIs</div>\n");
+      // F-0 (#1035, A.10/M.1): renamed from "Automation / APIs". See
+      // companion rename in the standalone topbar above.
+      sb.append("          <div class=\"section-label\">Plugins / Integrations</div>\n");
       sb.append("          <a class=\"section-link-strong\" href=\"/account/robots\">Robot &amp; Data API</a>\n");
       sb.append("          <a href=\"/api-docs\" target=\"_blank\" rel=\"noopener noreferrer\">API Docs</a>\n");
       sb.append("        </div>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3508,7 +3508,7 @@ public final class HtmlRenderer {
     sb.append("  <h1>Wavy design preview</h1>\n");
     sb.append("  <p>Reference layout for the F-0 design packet (issue #1035). See <code>docs/j2cl-plugin-slots.md</code> for the slot contract and <code>j2cl/lit/src/design/README.md</code> for the design system source of truth. Variants below: dark (default), light, and high-contrast.</p>\n");
     sb.append("</header>\n");
-    appendDesignPreviewSection(sb, "Dark variant", null);
+    appendDesignPreviewSection(sb, "Dark variant", "dark");
     appendDesignPreviewSection(sb, "Light variant", "light");
     appendDesignPreviewSection(sb, "High-contrast variant", "contrast");
     sb.append("</body>\n</html>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3574,7 +3574,7 @@ public final class HtmlRenderer {
     sb.append("    </div>\n");
     sb.append("  </div>\n");
     sb.append("  <script type=\"text/javascript\">\n");
-    sb.append("(function(){var n=document.getElementById('wavy-design-preview-crumb-").append(escapeHtml(themeAttr == null ? "dark" : themeAttr)).append("');if(n)n.crumbs=[{label:'Inbox',href:'#'},{label:'Sample wave',href:'#'},{label:'Top thread',current:true}];})();\n");
+    sb.append("(function(){var id='wavy-design-preview-crumb-").append(escapeHtml(themeAttr == null ? "dark" : themeAttr)).append("';customElements.whenDefined('wavy-depth-nav').then(function(){var n=document.getElementById(id);if(n)n.crumbs=[{label:'Inbox',href:'#'},{label:'Sample wave',href:'#'},{label:'Top thread',current:true}];});})();\n");
     sb.append("  </script>\n");
     sb.append("</section>\n");
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -166,6 +166,43 @@ public class WaveClientServlet extends HttpServlet {
 
     if (VIEW_J2CL_ROOT.equals(requestedView)
         || (StringUtils.isEmpty(requestedView) && j2clRootBootstrapEnabled)) {
+      // F-0 (#1035): admin-or-owner gated design preview sub-branch.
+      // Reachable at ?view=j2cl-root&q=design-preview per issue body
+      // §Verification. A non-admin requesting q=design-preview falls
+      // through to the regular root shell with no error / no leak.
+      if ("design-preview".equals(request.getParameter("q")) && id != null) {
+        boolean isAdminOrOwner = false;
+        try {
+          AccountData acct = accountStore.getAccount(id);
+          if (acct != null && acct.isHuman()) {
+            String role = acct.asHuman().getRole();
+            isAdminOrOwner =
+                HumanAccountData.ROLE_ADMIN.equals(role)
+                    || HumanAccountData.ROLE_OWNER.equals(role);
+          }
+        } catch (Exception e) {
+          LOG.warning("Failed to look up role for design-preview gate " + id.getAddress(), e);
+        }
+        if (isAdminOrOwner) {
+          response.setContentType("text/html");
+          response.setCharacterEncoding("UTF-8");
+          response.setHeader("Cache-Control", "private, no-store");
+          response.setHeader("Vary", "Cookie");
+          response.setStatus(HttpServletResponse.SC_OK);
+          try (var w = response.getWriter()) {
+            w.write(HtmlRenderer.renderJ2clDesignPreviewPage(
+                request.getContextPath(),
+                buildCommit,
+                serverBuildTime,
+                currentReleaseId)); // codeql[java/xss]
+          } catch (IOException e) {
+            LOG.warning("Failed to render J2CL design preview page", e);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+          }
+          return;
+        }
+        // Fall through: non-admin reaches the regular root shell.
+      }
       String rootShellReturnTarget = buildJ2clRootShellReturnTarget(request);
       J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult =
           j2clSelectedWaveSnapshotRenderer == null

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletDesignPreviewBranchTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletDesignPreviewBranchTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import org.junit.Test;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore;
+import org.waveprotocol.box.server.rpc.render.J2clSelectedWaveSnapshotRenderer;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+/**
+ * F-0 (#1035): admin-or-owner gating for the wavy design preview
+ * sub-branch (?view=j2cl-root&q=design-preview). Confirms that:
+ *   - admin/owner viewers see the design preview HTML,
+ *   - regular users fall through to the standard root shell,
+ *   - signed-out viewers also fall through (no info leak),
+ *   - a stray ?q value other than "design-preview" never triggers
+ *     the design preview, regardless of role.
+ */
+public final class WaveClientServletDesignPreviewBranchTest {
+  @Test
+  public void adminGetsDesignPreviewHtml() throws Exception {
+    String html = doDesignPreviewGet(
+        ParticipantId.ofUnsafe("admin@example.com"), HumanAccountData.ROLE_ADMIN);
+    assertTrue("admin must see the design-preview marker",
+        html.contains("data-wavy-design-preview"));
+    assertTrue("admin must see the design preview header",
+        html.contains("Wavy design preview"));
+    // Design preview replaces the root shell — no shell-root mount.
+    assertFalse("admin design preview must NOT mount shell-root",
+        html.contains("data-j2cl-root-shell"));
+  }
+
+  @Test
+  public void ownerGetsDesignPreviewHtml() throws Exception {
+    String html = doDesignPreviewGet(
+        ParticipantId.ofUnsafe("owner@example.com"), HumanAccountData.ROLE_OWNER);
+    assertTrue(html.contains("data-wavy-design-preview"));
+  }
+
+  @Test
+  public void regularUserFallsThroughToRootShell() throws Exception {
+    String html = doDesignPreviewGet(
+        ParticipantId.ofUnsafe("alice@example.com"), HumanAccountData.ROLE_USER);
+    assertFalse("regular user must NOT see the design preview marker",
+        html.contains("data-wavy-design-preview"));
+    assertTrue("regular user must see the standard root shell instead",
+        html.contains("data-j2cl-root-shell"));
+  }
+
+  @Test
+  public void signedOutUserFallsThroughToRootShell() throws Exception {
+    WaveClientServlet servlet = createServlet(null, HumanAccountData.ROLE_USER);
+    HttpServletRequest request = mockGetRequest("design-preview");
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertFalse("signed-out user must NOT see the design preview marker",
+        html.contains("data-wavy-design-preview"));
+    // Signed-out chrome still uses the shell-root-signed-out custom element.
+    assertTrue(html.contains("data-j2cl-root-shell")
+        || html.contains("shell-root-signed-out"));
+  }
+
+  @Test
+  public void adminWithUnrelatedQValueDoesNotTriggerDesignPreview() throws Exception {
+    WaveClientServlet servlet = createServlet(
+        ParticipantId.ofUnsafe("admin@example.com"), HumanAccountData.ROLE_ADMIN);
+    HttpServletRequest request = mockGetRequest("with:@");
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertFalse("non-design-preview ?q must NOT trigger the design preview",
+        html.contains("data-wavy-design-preview"));
+    assertTrue(html.contains("data-j2cl-root-shell"));
+  }
+
+  // --- helpers -----------------------------------------------------------
+
+  private static String doDesignPreviewGet(ParticipantId user, String role) throws Exception {
+    WaveClientServlet servlet = createServlet(user, role);
+    HttpServletRequest request = mockGetRequest("design-preview");
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+    return body.toString();
+  }
+
+  private static HttpServletRequest mockGetRequest(String qParam) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getParameter("view")).thenReturn("j2cl-root");
+    when(request.getParameter("q")).thenReturn(qParam);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(request.getContextPath()).thenReturn("");
+    return request;
+  }
+
+  private static WaveClientServlet createServlet(ParticipantId user, String role)
+      throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(role);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        defaultSnapshotRenderer(),
+        new FeatureFlagService(featureFlagStore()));
+  }
+
+  private static J2clSelectedWaveSnapshotRenderer defaultSnapshotRenderer() {
+    J2clSelectedWaveSnapshotRenderer snapshotRenderer =
+        mock(J2clSelectedWaveSnapshotRenderer.class);
+    when(snapshotRenderer.renderRequestedWave(any(), any()))
+        .thenReturn(J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave());
+    return snapshotRenderer;
+  }
+
+  private static FeatureFlagStore featureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(Collections.emptyList());
+    return store;
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clDesignPreviewPageTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clDesignPreviewPageTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import junit.framework.TestCase;
+
+/**
+ * F-0 (#1035): renderer-level test for the wavy design preview page.
+ * Asserts that the page mounts every recipe element, references the
+ * three asset bundles, and emits all three theme-variant section
+ * markers.
+ */
+public final class HtmlRendererJ2clDesignPreviewPageTest extends TestCase {
+  public void testReferencesAllThreeAssetBundles() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    assertTrue("design preview page must reference sidecar.css",
+        html.contains("/j2cl/assets/sidecar.css"));
+    assertTrue("design preview page must reference shell.css",
+        html.contains("/j2cl/assets/shell.css"));
+    assertTrue("design preview page must reference wavy-tokens.css",
+        html.contains("/j2cl/assets/wavy-tokens.css"));
+    assertTrue("design preview page must reference shell.js",
+        html.contains("/j2cl/assets/shell.js"));
+  }
+
+  public void testMountsEveryRecipeElement() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    assertTrue("must mount <wavy-blip-card>", html.contains("<wavy-blip-card"));
+    assertTrue("must mount <wavy-compose-card>", html.contains("<wavy-compose-card"));
+    assertTrue("must mount <wavy-rail-panel>", html.contains("<wavy-rail-panel"));
+    assertTrue("must mount <wavy-edit-toolbar>", html.contains("<wavy-edit-toolbar"));
+    assertTrue("must mount <wavy-depth-nav>", html.contains("<wavy-depth-nav"));
+    assertTrue("must mount <wavy-pulse-stage>", html.contains("<wavy-pulse-stage"));
+  }
+
+  public void testSetsDesignPreviewMarkerOnHtml() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    assertTrue("design preview must mark <html data-wavy-design-preview>",
+        html.contains("<html lang=\"en\" data-wavy-design-preview>"));
+  }
+
+  public void testEmitsAllThreeThemeSections() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    // Dark variant has no data-wavy-theme attribute (default scope).
+    assertTrue("dark variant section header", html.contains("Dark variant"));
+    assertTrue("light variant section attribute",
+        html.contains("data-wavy-theme=\"light\""));
+    assertTrue("light variant header", html.contains("Light variant"));
+    assertTrue("contrast variant section attribute",
+        html.contains("data-wavy-theme=\"contrast\""));
+    assertTrue("high-contrast variant header",
+        html.contains("High-contrast variant"));
+  }
+
+  public void testEmitsTheFourPluginSlotSamplePlugins() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    assertTrue("blip plugin sample",
+        html.contains("data-wavy-design-preview-plugin=\"blip\""));
+    assertTrue("compose plugin sample",
+        html.contains("data-wavy-design-preview-plugin=\"compose\""));
+    assertTrue("rail plugin sample",
+        html.contains("data-wavy-design-preview-plugin=\"rail\""));
+    assertTrue("toolbar plugin sample",
+        html.contains("data-wavy-design-preview-plugin=\"toolbar\""));
+  }
+
+  public void testHandlesEmptyContextPathByDefaulting() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage(null, "commit", 0L, "rel");
+    // null context path should resolve to "/" so absolute paths remain
+    // absolute (and not "j2cl/assets/..." which would be relative).
+    assertTrue("null contextPath should resolve to /j2cl/assets",
+        html.contains("\"/j2cl/assets/wavy-tokens.css\""));
+  }
+
+  public void testDoesNotIncludeShellRootBootstrap() {
+    String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
+    // Design preview is intentionally not the production shell — no
+    // shell-root, no bootstrap script.
+    assertFalse("design preview must NOT mount shell-root",
+        html.contains("<shell-root data-j2cl-root-shell"));
+    assertFalse("design preview must NOT include the root shell bootstrap script",
+        html.contains("normalizeLegacyHashDeepLink()"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clDesignPreviewPageTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clDesignPreviewPageTest.java
@@ -58,7 +58,8 @@ public final class HtmlRendererJ2clDesignPreviewPageTest extends TestCase {
 
   public void testEmitsAllThreeThemeSections() {
     String html = HtmlRenderer.renderJ2clDesignPreviewPage("/", "commit", 0L, "rel");
-    // Dark variant has no data-wavy-theme attribute (default scope).
+    assertTrue("dark variant section attribute",
+        html.contains("data-wavy-theme=\"dark\""));
     assertTrue("dark variant section header", html.contains("Dark variant"));
     assertTrue("light variant section attribute",
         html.contains("data-wavy-theme=\"light\""));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -40,6 +40,9 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(html.contains("<shell-skip-link slot=\"skip-link\""));
     assertTrue(html.contains("/j2cl/assets/shell.js"));
     assertTrue(html.contains("/j2cl/assets/shell.css"));
+    // F-0 (#1035): wavy design tokens must load alongside shell.css so
+    // F-2/F-3/F-4 recipes resolve --wavy-* under the J2CL root view.
+    assertTrue(html.contains("/j2cl/assets/wavy-tokens.css"));
     assertTrue(html.contains("data-j2cl-server-first-workflow=\"true\""));
     assertTrue(html.contains("window.__j2clRootShellStat"));
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererPluginsMenuTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererPluginsMenuTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import junit.framework.TestCase;
+
+/**
+ * F-0 (#1035, A.10/M.1): the user-menu group previously labelled
+ * "Automation / APIs" is renamed to "Plugins / Integrations" in both
+ * the wave-client topbar (renderTopBar) and the standalone topbar
+ * (renderSharedTopBarHtml). The anchor URLs are unchanged.
+ */
+public final class HtmlRendererPluginsMenuTest extends TestCase {
+  public void testWaveClientTopBarRendersPluginsIntegrationsLabel() {
+    String html = HtmlRenderer.renderTopBar("vega", "example.com", "user");
+    assertTrue("wave-client topbar must render the new label",
+        html.contains("section-label\">Plugins / Integrations"));
+  }
+
+  public void testWaveClientTopBarDoesNotRenderTheOldAutomationLabel() {
+    String html = HtmlRenderer.renderTopBar("vega", "example.com", "user");
+    assertFalse("wave-client topbar must NOT contain the old label",
+        html.contains("Automation / APIs"));
+  }
+
+  public void testWaveClientTopBarStillLinksToRobotAndApiDocs() {
+    String html = HtmlRenderer.renderTopBar("vega", "example.com", "user");
+    assertTrue(html.contains("href=\"/account/robots\""));
+    assertTrue(html.contains("href=\"/api-docs\""));
+    assertTrue("Robot anchor preserves the section-link-strong CSS class",
+        html.contains("section-link-strong"));
+  }
+
+  public void testStandaloneTopBarRendersPluginsIntegrationsLabel() {
+    String html = HtmlRenderer.renderSharedTopBarHtml("vega@example.com", "/wave", "user");
+    assertTrue("standalone topbar must render the new label",
+        html.contains("section-label\">Plugins / Integrations"));
+  }
+
+  public void testStandaloneTopBarDoesNotRenderTheOldAutomationLabel() {
+    String html = HtmlRenderer.renderSharedTopBarHtml("vega@example.com", "/wave", "user");
+    assertFalse("standalone topbar must NOT contain the old label",
+        html.contains("Automation / APIs"));
+  }
+
+  public void testStandaloneTopBarStillLinksToRobotAndApiDocs() {
+    String html = HtmlRenderer.renderSharedTopBarHtml("vega@example.com", "/wave", "user");
+    assertTrue(html.contains("href=\"/wave/account/robots\""));
+    assertTrue(html.contains("href=\"/wave/api-docs\""));
+    assertTrue(html.contains("section-link-strong"));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererTopBarTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererTopBarTest.java
@@ -35,7 +35,10 @@ public final class HtmlRendererTopBarTest extends TestCase {
     String topBarHtml = HtmlRenderer.renderTopBar("vega", "example.com", "admin");
 
     assertTrue(topBarHtml.contains("section-label\">Account"));
-    assertTrue(topBarHtml.contains("section-label\">Automation / APIs"));
+    // F-0 (#1035): renamed from "Automation / APIs" to "Plugins / Integrations"
+    // so the section reads as the user-facing surface for the forthcoming
+    // robots/data-API plugin registry.
+    assertTrue(topBarHtml.contains("section-label\">Plugins / Integrations"));
     assertTrue(topBarHtml.contains("section-label\">Product / Support"));
     assertTrue(topBarHtml.contains("section-label\">Legal"));
     assertTrue(topBarHtml.contains("href=\"/admin\""));


### PR DESCRIPTION
## Summary

- Adds the **Wavy — Firefly Signal** design packet under `j2cl/lit/src/design/` (color, typography, motion, spacing, shape tokens with dark / light / high-contrast variants and reduced-motion support; sourced from Stitch project `15560635515125057401`, asset `6962139294633729409`).
- Ships six Lit recipe elements (`<wavy-blip-card>`, `<wavy-compose-card>`, `<wavy-rail-panel>`, `<wavy-edit-toolbar>`, `<wavy-depth-nav>`, `<wavy-pulse-stage>`) that consume the tokens and expose the four named plugin slots (`blip-extension`, `compose-extension`, `rail-extension`, `toolbar-extension`).
- Documents the slot contract in `docs/j2cl-plugin-slots.md` and the design packet in `j2cl/lit/src/design/README.md`.
- Wires an admin/owner-gated design preview route at `/?view=j2cl-root&q=design-preview` that mounts every recipe under all three theme variants.
- Renames the user-menu group from "Automation / APIs" to "Plugins / Integrations" in both topbars (A.10 / M.1 inventory entries); existing `/account/robots` and `/api-docs` anchors preserved.

Closes #1035; updates #904.

## Plan

[`docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md`](https://github.com/vega113/supawave/blob/codex/issue-1035-wavy-design-foundation/docs/superpowers/plans/2026-04-26-issue-1035-wavy-design-foundation.md)

Plan was reviewed by an Opus subagent twice (REQUEST-CHANGES → revised → APPROVE-WITH-NITS) before implementation.
Implementation diff was reviewed by an Opus subagent (REQUEST-CHANGES → applied fixes → all data-* / dashed-outline / font-shorthand findings addressed).

## Verification

- `sbt -batch j2clLitTest j2clLitBuild j2clProductionBuild` — all green.
- 155 Lit web-test-runner tests pass (149 existing + 6 new test files for tokens + recipes).
- 43 server-side JUnit tests in scope pass (`HtmlRendererJ2clRootShellTest`, `HtmlRendererTopBarTest`, `HtmlRendererJ2clDesignPreviewPageTest`, `HtmlRendererPluginsMenuTest`, `WaveClientServletDesignPreviewBranchTest`).

## Test plan

- [x] `sbt -batch j2clLitTest j2clLitBuild j2clProductionBuild` succeeds.
- [x] Design preview admin gating: admin/owner sees the preview, regular user / signed-out / unrelated `?q` falls through to the regular root shell.
- [x] User-menu rename verified in both `renderTopBar` (wave-client) and `renderSharedTopBarHtml` (standalone), with `/account/robots` and `/api-docs` anchors preserved.
- [x] Plugin slot data-* attributes assert via `host.dataset.*` so plugins reading per the documented contract resolve real values.
- [x] WCAG contrast floors machine-checked per theme (AA 4.5:1 / 3:1 for dark+light, AAA 7:1 / 4.5:1 for contrast).
- [x] Pulse-stage timing budget reads `--wavy-motion-pulse-duration` at runtime so `prefers-reduced-motion` does not flake CI.

## Notes for downstream slices (F-2 / F-3 / F-4)

- The recipe elements expose plugin slot context via `data-*` attributes (e.g. `data-blip-id`, `data-active-wave-id`) so plugins read them via `host.dataset.*` — see [`docs/j2cl-plugin-slots.md`](https://github.com/vega113/supawave/blob/codex/issue-1035-wavy-design-foundation/docs/j2cl-plugin-slots.md).
- `wavy-tokens.css` is loaded by `renderJ2clRootShellPage` as a sibling stylesheet, so mounting the recipes under `?view=j2cl-root` requires no extra plumbing in the consumer slices.
- F-3 may reuse `<wavy-pulse-stage>` as the canonical "fire a pulse on an arriving blip" helper rather than re-implementing the timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wavy design system: new --wavy-* tokens (dark/light/contrast + reduced-motion), six Lit UI recipes, four plugin slots, admin-only design‑preview route, and user-menu rename to “Plugins / Integrations”.
* **Documentation**
  * Added design packet and plugin-slot contract covering slot context, styling/untheming, accessibility, lifecycle, failure isolation, and rollback semantics.
* **Tests**
  * Added suites validating tokens, components, themes, design‑preview rendering, servlet gating, and topbar label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->