### PR TITLE
ci: treat chatgpt-codex-connector as a bot reviewer in review gate

### DIFF
--- a/.github/scripts/codex-review-gate.js
+++ b/.github/scripts/codex-review-gate.js
@@ -11,6 +11,8 @@ const BOT_REVIEWER_LOGINS = new Set([
   "copilot-pull-request-reviewer[bot]",
   "github-advanced-security",
   "codex",
+  "chatgpt-codex-connector",
+  "chatgpt-codex-connector[bot]",
 ]);
 
 function evaluateCodexReviewGate({

--- a/.github/scripts/codex-review-gate.test.js
+++ b/.github/scripts/codex-review-gate.test.js
@@ -158,6 +158,94 @@ test("fails with unresolved threads even after window", () => {
   assert.match(result.message, /unresolved review thread/);
 });
 
+// --- skipCodexCheck: chatgpt-codex-connector bot filtering ---
+
+test("skipCodexCheck: passes when only chatgpt-codex-connector thread is unresolved", () => {
+  const result = evaluateCodexReviewGate({
+    defaultBranchName: "main",
+    nowMs: AFTER_WINDOW,
+    skipCodexCheck: true,
+    pullRequest: buildPullRequest({
+      reviewThreads: {
+        nodes: [
+          {
+            isResolved: false,
+            comments: { nodes: [{ author: { login: "chatgpt-codex-connector" } }] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.message, /Codex quota exhausted/);
+});
+
+test("skipCodexCheck: passes when only chatgpt-codex-connector[bot] thread is unresolved", () => {
+  const result = evaluateCodexReviewGate({
+    defaultBranchName: "main",
+    nowMs: AFTER_WINDOW,
+    skipCodexCheck: true,
+    pullRequest: buildPullRequest({
+      reviewThreads: {
+        nodes: [
+          {
+            isResolved: false,
+            comments: { nodes: [{ author: { login: "chatgpt-codex-connector[bot]" } }] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.match(result.message, /Codex quota exhausted/);
+});
+
+test("skipCodexCheck: fails when human reviewer thread is unresolved alongside bot thread", () => {
+  const result = evaluateCodexReviewGate({
+    defaultBranchName: "main",
+    nowMs: AFTER_WINDOW,
+    skipCodexCheck: true,
+    pullRequest: buildPullRequest({
+      reviewThreads: {
+        nodes: [
+          {
+            isResolved: false,
+            comments: { nodes: [{ author: { login: "chatgpt-codex-connector" } }] },
+          },
+          {
+            isResolved: false,
+            comments: { nodes: [{ author: { login: "human-reviewer" } }] },
+          },
+        ],
+      },
+    }),
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.message, /unresolved review thread/);
+  assert.match(result.message, /bot thread\(s\) skipped/);
+});
+
+test("skipCodexCheck: shouldRequeue true when only chatgpt-codex-connector thread blocks", () => {
+  assert.equal(
+    shouldRequeueCodexReviewGate({
+      defaultBranchName: "main",
+      nowMs: AFTER_WINDOW,
+      skipCodexCheck: true,
+      pullRequest: buildPullRequest({
+        reviewThreads: {
+          nodes: [
+            {
+              isResolved: false,
+              comments: { nodes: [{ author: { login: "chatgpt-codex-connector" } }] },
+            },
+          ],
+        },
+      }),
+    }),
+    true,
+  );
+});
+
 // --- shouldRequeueCodexReviewGate ---
 
 test("shouldRequeue: true after window, no unresolved threads, not yet passed", () => {


### PR DESCRIPTION
## Summary
- Adds `chatgpt-codex-connector` and `chatgpt-codex-connector[bot]` to `BOT_REVIEWER_LOGINS` in `.github/scripts/codex-review-gate.js`.
- Without this, when `CODEX_QUOTA_EXHAUSTED=true` the gate treats unresolved chatgpt-codex-connector review threads as human reviewer threads and blocks auto-merge.

## Test plan
- [x] `node --test .github/scripts/codex-review-gate.test.js` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the code review gate to ignore unresolved review threads from automated reviewer accounts when the "skip" option is enabled, preventing those threads from blocking reviews or re-queuing.
* **Tests**
  * Added test coverage validating the skip behavior and confirming re-queue decisions when only automated reviewer threads remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->