### PR TITLE
F-2 (slice 1): Re-execute J2CL StageOne read surface (threaded blip rendering, focus, collapse, depth-nav scaffolding)

### DIFF
--- a/docs/superpowers/plans/2026-04-26-issue-1037-stageone-read-surface.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1037-stageone-read-surface.md
@@ -1,0 +1,378 @@
+# F-2: Re-execute J2CL StageOne read surface (threaded blip rendering, focus, collapse, read/unread, depth-nav)
+
+Status: Ready for implementation
+Owner: codex/issue-1037-stageone-read-surface worktree
+Issue: [#1037](https://github.com/vega113/supawave/issues/1037)
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Foundation:
+- F-0 (#1035, PR #1043, sha `af7072f99b31d7b2b30d26e1ceb986a6239edf15`) — wavy design tokens (`--wavy-*`) + plugin slot contracts (`<slot name="blip-extension">`, `<slot name="rail-extension">`, …).
+- F-1 (#1036, PR #1040, sha `86ea6b440d8298262649865a770eaaa97d2b50eb`) — viewport-scoped data path; depth-axis fragment contract.
+
+Audits motivating this lane:
+- `docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md` (R-3.* + R-4.4 gaps)
+- `docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md` (64 affordances under F-2 ownership)
+
+Parity-matrix rows claimed: **R-3.1, R-3.2, R-3.3, R-3.4, R-3.7 (NEW), R-4.4**
+
+## 1. Why this plan exists
+
+The 2026-04-26 audit found that the J2CL open-wave panel renders blips as a flat list with raw blip IDs as headers ("Blip 3VPWzePL_DB", …) and plain-text bodies. There is **no threading**, **no per-blip author/avatar/timestamp**, **no focus framing using the F-0 design tokens**, **no thread collapse with scroll-anchor preservation**, and **no per-blip live read/unread state**. The 2026-04-26 functional inventory enumerated 64 GWT affordances that F-2 owns but are absent from the J2CL surface today.
+
+This is the largest user-visible "looks like a real conversation" parity gap and blocks #904 progression. It also blocks F-3 (compose) because the compose surface needs to attach to per-blip reply affordances that F-2 must surface first.
+
+The F-1 lane already shipped the data-path foundations (viewport-scoped fragment window, depth-axis fragment contract, focus-preserving live updates). F-0 already shipped the wavy design tokens and the named plugin slots (`blip-extension`, `rail-extension`). F-2 stitches these foundations into a real read surface.
+
+The work is delivered as **eight tasks (T1–T8)**, each ≤ ~250 LOC of production code with paired tests at the same change boundary, plus one consolidated row-by-row parity fixture (T9). Each task ends with verification before the next begins.
+
+## 2. Verification ground truth (re-derived in worktree)
+
+Citations below were re-grepped from the worktree on 2026-04-26 against HEAD `af7072f99` (post-#1043). Line numbers are accurate as of the worktree snapshot; treat them as anchors that may shift by a line or two.
+
+### Server side
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3321-3461`
+  — `renderJ2clRootShellPage` emits the root-shell HTML, links `wavy-tokens.css`, and mounts the lit `<shell-root>` container. The first-paint server-rendered selected-wave card slot is at `appendRootShellSelectedWaveCard`.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3473-3580`
+  — `renderJ2clDesignPreviewPage` is the existing F-0 design preview at `?view=j2cl-root&q=design-preview`. F-2 adds a **wave-preview** sub-route alongside it.
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/ServerHtmlRenderer.java`
+  — emits the server-first blip DOM with `data-blip-id`, `data-thread-id`, role/listitem/article (per F-1 R-6.1).
+- `wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java`
+  — produces server snapshots with the F-1 viewport window already applied.
+
+### J2CL/Lit client side
+
+- `j2cl/lit/src/design/wavy-tokens.css:17-173` — F-0 token contract; **uses these names verbatim**.
+- `j2cl/lit/src/design/wavy-blip-card.js:15-185` — `<wavy-blip-card>` with `data-blip-id`, `data-wave-id`, `author-name`, `posted-at`, `is-author`, `focused`, `unread`, `live-pulse` attributes; named slots: default body, `blip-extension`, `metadata`, `reactions`. `firePulse()` triggers signal-cyan glow restart.
+- `j2cl/lit/src/design/wavy-rail-panel.js:10-138` — `<wavy-rail-panel>` with `data-active-wave-id`, `data-active-folder`; named `rail-extension` slot.
+- `j2cl/lit/src/design/wavy-depth-nav.js:11-79` — `<wavy-depth-nav>` accepts `crumbs: Array<{label, href?, current?}>` for the depth-nav breadcrumb. F-2 extends with the live-update awareness pill on the same element (R-3.7 G.6).
+- `j2cl/lit/src/design/wavy-pulse-stage.js:22-92` — canonical `firePulse()` helper; F-2 reuses for live-update events.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java:18-1059` — current renderer. **This is what F-2 replaces.** It renders raw `<article class="blip j2cl-read-blip">` with `Blip <id>` text labels, has flat threading, no per-blip read-state, no depth-nav, no per-blip toolbar.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java:8-38` — current model: `blipId`, `text`, `attachments`. **F-2 extends** with `authorId`, `authorDisplayName`, `lastModifiedTime`, `parentBlipId`, `threadId`, `unread`, `isMention`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java:8-98` — current viewport entry; **F-2 extends** with the same per-blip metadata fields.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java:18-499` — wave-level state including `unreadCount`, `read`, `readStateKnown`, `readStateStale` and per-blip `readBlips`. F-2 routes per-blip read state down to each `J2clReadBlip`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java:387,443` — already extracts `document.getAuthor()` and `document.getLastModifiedTime()` from `SidecarSelectedWaveDocument` for interactions; F-2 routes the same fields into `J2clReadBlip`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java:135-205` — `render(model)` calls `readSurface.renderWindow(...)` or `readSurface.render(...)`. F-2 enhances this view with the depth-nav header, nav-row, tags-row, floating controls, and version-history overlay markers without changing the controller→view contract.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java:140-1032` — controller is unchanged; F-2 only changes the view layer and the data shape `View` consumes.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java:7-97` — provides `getAuthor()`, `getLastModifiedTime()`, `getTextContent()`, `getAnnotationRanges()` for parsing mentions.
+
+### Plugin slot contract (per `docs/j2cl-plugin-slots.md`)
+
+F-2 must mount:
+- `<slot name="blip-extension">` on each `<wavy-blip-card>` instance — context: `data-blip-id`, `data-wave-id`, `data-blip-author`, `data-blip-is-author`; JS `blipView` getter returns frozen `{id, waveId, authorName, postedAt, isAuthor}`.
+- `<slot name="rail-extension">` on the `<wavy-rail-panel>` for the right rail — context: `data-active-wave-id`, `data-active-folder`.
+
+Both slots collapse to zero height when empty in production; design preview adds the dashed-outline label per the existing F-0 logic in the recipe elements.
+
+## 3. Acceptance contract (row-level)
+
+Each row below has an executable acceptance step that the per-row fixture in `J2clStageOneReadSurfaceParityTest` (T9) asserts. **No "practical parity" escape hatch** — every cited matrix row + every cited inventory affordance has a concrete DOM-attribute or telemetry-event assertion.
+
+### R-3.1 Open-wave rendering
+
+**Affordances covered (16):** F.1 author avatar, F.2 author display name, F.3 full datetime tooltip, F.7 link button, F.10 inline-reply chips, F.12 plugin slot, I.1 tags label, I.2 tag chips (read-only), I.6 show/hide tags tray, D.1 wave title, D.2 multi-author avatar stack, B.13 per-digest avatar stack feeding D.2 (shared), J.4 nav drawer toggle, J.5 back-to-inbox, A.6 inbox icon hop (header link), L.1 open user profile from blip avatar.
+
+**Acceptance steps:**
+1. The J2CL view renders one `<wavy-blip-card>` per blip in the viewport window. Each carries `data-blip-id`, `data-wave-id`, `author-name`, `posted-at`, `is-author` reflecting the projected `J2clReadBlip`.
+2. Each card has a `<time>` element with `title=` set to the ISO-8601 absolute timestamp (full datetime tooltip on hover, F.3).
+3. Reply nesting renders as visual indenting via nested `<div class="j2cl-read-thread inline-thread">` containers (matches GWT's `inline-thread` wrapping).
+4. A blip with reply children shows an "△ N" inline-reply chip in the body (F.10) clickable to drill in (F-2 R-3.7).
+5. Per-blip toolbar `<wavy-blip-toolbar>` (new sub-element, F.4/F.5/F.6/F.7 placeholders) is rendered inside each card's `metadata` slot, hidden until `:focus-within` or `:hover`. F-2 only wires Reply (emits a `wave-blip-reply-requested` CustomEvent for F-3), Edit (placeholder for F-3), Link (copies blip permalink to clipboard via `navigator.clipboard.writeText`), and the overflow placeholder. Delete is F-3.
+6. Wave panel header `<wavy-wave-panel-header>` (new chrome element) renders the wave title (D.1), avatar stack (D.2 sourced from `model.getParticipantIds()`), and an overflow-menu "more" trigger button (D.3 placeholder).
+7. Tags row at bottom is read-only: renders chips for each tag from `wavelet.tags()`-equivalent supplement field; "Tags:" label (I.1) + chips (I.2 display-only) + "Show / Hide tags tray" toggle (I.6).
+8. Plugin slot `<slot name="blip-extension">` is present in every `<wavy-blip-card>` (verified by `surface.querySelectorAll('wavy-blip-card slot[name="blip-extension"]').length === blipCount`).
+9. Hairline cyan border per F-0 design tokens — `<wavy-blip-card>` already applies `border: 1px solid var(--wavy-border-hairline)` and `border-radius: var(--wavy-radius-card)` in its own `static styles`; F-2 verifies the cards are inside a scope with the tokens loaded by querying `getComputedStyle(card).getPropertyValue('--wavy-border-hairline')` is non-empty.
+10. Clicking a blip avatar emits a `wave-blip-profile-requested` CustomEvent with `{blipId, authorId}` for the L.1 profile overlay; F-2 attaches a no-op listener that the future profile-overlay element will subscribe to.
+
+### R-3.2 Focus framing
+
+**Affordances covered (within E.* navigation row):** focus visuals via `--wavy-focus-ring` token; focus survives incremental updates; arrow + j/k keyboard.
+
+**Acceptance steps:**
+1. A `<wavy-focus-frame>` Lit element wraps the read-surface root and tracks the focused blip via a property `focusedBlipId` synced from the renderer.
+2. Pressing `ArrowDown`, `ArrowUp`, `j`, `k`, `Home`, `End` moves focus across visible blips (existing arrow / Home / End logic in `J2clReadSurfaceDomRenderer` is preserved; `j` and `k` are added).
+3. Focus survives an incremental update: when `view.render(model)` is called with the same blip set plus one new appended blip, the focused blip's `data-blip-id` is unchanged and the focused blip retains `tabindex="0"`. (Existing `restoreFocusedBlipById` already preserves focus across `renderWindow`/`render`. T-fixture asserts the contract.)
+4. Focus visuals: focused `<wavy-blip-card>` carries the `focused` attribute, which reflects to `:host([focused])` in F-0's CSS and applies `box-shadow: var(--wavy-focus-ring)` and `border-color: var(--wavy-signal-cyan)` per F-0.
+5. Focus transition uses `--wavy-motion-focus-duration` (180ms) + `--wavy-easing-focus`. Already in F-0's `wavy-blip-card.js` `static styles` `transition: box-shadow var(--wavy-motion-focus-duration) var(--wavy-easing-focus);`. F-2 fixture asserts the computed style includes "180ms" (or under reduced-motion, "0.01ms").
+6. Focus does not steal from text inputs: when an input is focused inside an inline reply (F-3 territory), arrow keys do not move blip focus. (Existing `onBlipKeyDown` only fires when the blip element itself is the event target, so the contract is already met by the bubbling model. F-2 fixture asserts arrow keys typed into a `<textarea>` do not move blip focus.)
+7. Focus telemetry: each focus change emits `J2clClientTelemetry.event("read.focus_change").field("source", <key|click>).build()`. F-2 fixture asserts at least one focus_change event is recorded after pressing ArrowDown.
+
+### R-3.3 Collapse
+
+**Affordances covered:** thread root collapse/expand (already wired in `J2clReadSurfaceDomRenderer.toggleThread`), Space/Enter on toggle, scroll-anchor preservation, focus-doesn't-jump-on-expand.
+
+**Acceptance steps:**
+1. Each thread root with at least one child renders a `<button class="j2cl-read-thread-toggle">` toggle inside it, with `aria-expanded`, `aria-controls`, and a label like "Collapse Top thread" / "Expand Top thread". (Existing logic in `enhanceInlineThread`.)
+2. Clicking the toggle, or pressing Space or Enter while the toggle is focused, toggles `j2cl-read-thread-collapsed` class and `data-j2cl-thread-collapsed="true"` attribute. (Existing `toggleThread`.)
+3. Collapse animation: the thread `.j2cl-read-thread-children` wrapper uses `grid-template-rows: 1fr` → `0fr` transition with `transition: grid-template-rows var(--wavy-motion-collapse-duration) var(--wavy-easing-collapse)` (240ms). Same approach as F-0's `<wavy-rail-panel>`. **NEW** in F-2: T2 introduces a `j2cl-read-thread-children` wrapper around children + the CSS transition.
+4. Scroll anchor preserved: when toggling, the renderer captures `firstRenderedBlipId` + its `boundingClientRect.top` (existing `restoreScrollAnchor` mechanism reused) and re-applies the scroll delta after the layout reflow.
+5. Read state preserved: collapse does not emit any read-state op (verified by recording read-state ops via the controller's writeSession listener; the count must not change across a collapse-toggle round trip).
+6. Focus does not jump on expand: when expanding, the previously-focused (still-mounted) blip retains `tabindex="0"` and `aria-current`. (Existing `ensureSingleTabStop` only runs on collapse.)
+7. Collapse telemetry: each toggle emits `J2clClientTelemetry.event("read.thread_toggle").field("state", <"collapsed"|"expanded">).build()`.
+
+### R-3.4 Thread navigation
+
+**Affordances covered (10):** E.1 Recent, E.2 Next Unread (blip-level), E.3 Previous, E.4 Next, E.5 Go to last (End), E.6 Prev @ mention, E.7 Next @ mention, E.8 To Archive, E.9 Pin, E.10 Version History (H).
+
+**Acceptance steps:**
+1. A `<wavy-wave-nav-row>` Lit element renders a horizontal toolbar with 10 buttons matching E.1–E.10.
+2. **E.1 Recent** — placeholder anchor that scrolls to the most-recent blip (last by version). Fixture: clicking jumps focus to `renderedBlips[renderedBlips.length-1]`.
+3. **E.2 Next Unread** — finds the first blip with `unread="true"` *after* the focused blip (with wrap to the first unread overall). Cyan signal accent (`background: var(--wavy-signal-cyan)`) when at least one unread is present. Fixture: with 3 blips of which b2 is unread, clicking Next Unread focuses b2 and emits `read.thread_nav.event("E.2")` telemetry.
+4. **E.3 Previous, E.4 Next, E.5 End** — wired against the rendered blip DOM (not the wave-list). E.4 Next == ArrowDown semantics; E.3 Previous == ArrowUp; E.5 End == End key. Fixture asserts per-button focus delta against the rendered DOM order.
+5. **E.6 Prev @ / E.7 Next @** — finds the previous/next blip carrying `data-has-mention="true"` (F-2 sets this attribute when any annotation in the document text content is a mention; per the audit, mentions are detected from text bodies that include `@user@domain` patterns or from server-side annotation `link/manual` anchors per existing render code). Fixture: with 4 blips of which b1 and b3 are mentions, Next @ from b0 focuses b1; from b1 focuses b3. Violet accent (`color: var(--wavy-signal-violet)`).
+6. **E.8 To Archive** — emits a `wave-archive-requested` CustomEvent with `{waveId}`. F-2 only emits the event; the search-rail's archive folder consumption is server-side.
+7. **E.9 Pin** — emits a `wave-pin-toggled` CustomEvent. Cyan accent when pinned (driven by a `pinned` attribute fed from `model.getPinned()` — F-2 reads `selectedDigestItem.isPinned()` if available; otherwise renders the toggle in the unpinned state).
+8. **E.10 Version History (H)** — emits a `wave-version-history-requested` CustomEvent with `{waveId}`, AND adds the `data-j2cl-version-history-overlay` reservation slot in the markup so K.1–K.6 elements (deferred to per-row stub) can mount. Keyboard shortcut: `H` while focused on the wave panel header opens the overlay.
+9. All E.* buttons have keyboard shortcuts that match GWT (`H` for E.10; rest carry `accesskey` attributes that match the GWT shortcut catalogue). Fixture asserts each button has the expected `aria-keyshortcuts` attribute.
+
+### R-3.7 Arbitrary-depth thread drill-down navigation (NEW)
+
+**Affordances covered (6):** G.1 drill-into "△ N", G.2 Up one level, G.3 Up to wave, G.4 URL `&depth=` state, G.5 keyboard `[` `]`, G.6 live-update awareness pill.
+
+**Acceptance steps:**
+1. **G.1 Drill in** — clicking an "△ N" inline-reply chip on a blip (or pressing `]` while focused on it) sets `currentDepthBlipId` on the view. The view re-renders with: (a) ancestor blips collapsed into a `<wavy-depth-nav>` breadcrumb at the top using F-0's `crumbs: Array<{label, href?, current?}>` API, (b) the current depth blip + its descendants in full. Sibling subthreads are NOT loaded — the view consumes only the F-1 fragment-window that already filters by parent. F-2 issues a fragment fetch keyed by `data-parent-blip-id=<currentDepthBlipId>` via the existing `viewportEdgeListener` channel with a new `direction="depth"` value (added to `J2clViewportGrowthDirection` enum + propagated through `J2clSelectedWaveController.onViewportEdge` → server fetchFragments anchor).
+2. **G.2 Up one level** — `<wavy-wave-panel-header>` shows a chevron-up button labelled with the parent author's display name when `currentDepthBlipId` is non-empty AND has a parent. Clicking sets `currentDepthBlipId` to the parent blip id (or empty if at root).
+3. **G.3 Up to wave** — same header shows a "↑ Up to wave" button that resets `currentDepthBlipId = null`.
+4. **G.4 URL state** — when `currentDepthBlipId` changes, the view writes `&depth=<blipId>` into the URL via `history.replaceState`. On view init, it reads the URL and applies. Reload + back/forward preserve depth focus. Fixture asserts `window.location.search` after drill-in includes `depth=` and after drill-out is absent.
+5. **G.5 Keyboard** — `[` drills out one level (G.2 equivalent); `]` drills into the focused blip (G.1 equivalent if the focused blip has at least one child). Fixture asserts `]` from the root focused on b1 (which has children) sets `currentDepthBlipId = b1`.
+6. **G.6 Live-update awareness pill** — when a fragment update arrives that adds a blip whose `parentBlipId` is one of the *ancestor* blips (above `currentDepthBlipId`), the breadcrumb strip shows a pill "↑ N new replies above" using the `--wavy-pulse-ring` motion (single restart pulse via `wavy-pulse-stage` pattern). Clicking the pill drills out to the level where the new replies arrived. Fixture asserts the pill is present after a synthetic update with `parentBlipId == ancestorOf(currentDepthBlipId)`, and is removed after the user clicks it or drills out manually.
+
+### R-4.4 Per-blip live read/unread
+
+**Affordances covered:** B.17 per-digest msg count signal-cyan pulse on change (the wave-list digest); E.2 Next Unread cyan signal; per-blip unread dot.
+
+**Acceptance steps:**
+1. Each `<wavy-blip-card>` reflects the per-blip read state via the F-0 `unread` attribute. The 8px cyan dot pseudo-element from F-0's `:host([unread])::before` fires automatically.
+2. The model already exposes wave-level `unreadCount`; F-2 extends `J2clReadBlip` with a `boolean unread` field. The projector reads from the supplement-derived per-blip read state to set this. Per-blip read-state is derived from `J2clSelectedWaveProjector.reprojectReadState` (existing) + the new per-blip wiring.
+3. **Reading a blip emits a state-change op.** When a previously-unread blip enters the viewport AND remains visible for ≥1500ms (matches GWT's StageOne `READ_BLIP_DEBOUNCE`), F-2 calls a new `gateway.markBlipRead(waveId, blipId)` callback that the controller routes to the supplement. The blip's `unread` attribute clears, and `firePulse()` runs on the blip card. Fixture asserts: (a) the gateway method is invoked exactly once per blip-id even if the blip stays in viewport; (b) the wave-list digest's `data-unread-count` attribute (in the search-rail) decrements live.
+4. **Wave-list digest live decrement.** The view, on apply of the per-blip read-state delta, dispatches a `wave-blip-read-state-changed` CustomEvent on `document.body` with `{waveId, blipId, unreadDelta:-1}`. The search-rail listener (F-2 adds it) finds the matching digest card by `data-wave-id` and decrements its `data-unread-count` text content; if it drops to 0, the badge node hides. The badge re-renders with `--wavy-pulse-ring` via `wavy-pulse-stage.firePulse()` to draw attention.
+5. Stale read-state still uses the existing `readStateStale` flag; F-2 carries it down to per-blip cards as a `data-stale="true"` attribute on `<wavy-blip-card>` so a future high-fidelity treatment can desaturate the dot. (The flag-only treatment is sufficient for R-4.4 acceptance.)
+6. Telemetry: `J2clClientTelemetry.event("read.blip_read_marked").field("source", <"viewport-debounce"|"manual">).build()` on each mark; `J2clClientTelemetry.event("read.unread_badge_pulse")` on the search-rail decrement.
+
+### Plugin slot reservation (R-3.1 + R-4.4 cross-cut)
+
+- **`<slot name="blip-extension">`** present on every `<wavy-blip-card>` (already in F-0). F-2 validates by `card.querySelector('slot[name="blip-extension"]')` is non-null and `getComputedStyle(...).height === '0px'` when no plugin is mounted in production.
+- **`<slot name="rail-extension">`** present on the right rail `<wavy-rail-panel>` (already in F-0). F-2 mounts a `<wavy-rail-panel data-active-wave-id="..." data-active-folder="...">` next to the wave panel for the design-preview-only "wave-extension" rail; production mounts it but with no plugin slotted.
+
+### Inventory affordances under F-2 ownership (64 total — all covered)
+
+The following table maps every F-2-owned inventory affordance to the row it is asserted under. Affordances marked **shared** belong to multiple slices; F-2 ships the read-side stub.
+
+| ID | Affordance | Asserted under | F-2 implementation |
+| --- | --- | --- | --- |
+| A.2 | Locale picker | R-3.1 | `<wavy-top-chrome>` renders a locale `<select>` populated from `model.locales` (server-side already exposes via `data-locales` attribute on the shell-root); F-2 reads it and surfaces it. **Behavior change-locale calls existing `/?lang=` endpoint.** |
+| A.5 | Notifications bell with unread dot | R-3.1 | Stroke-only bell glyph in `<wavy-top-chrome>` with violet `:host([has-unread])::before` dot. F-2 reads `model.notificationsUnreadCount` (default 0; server-side notifications integration is F-4). Display only. |
+| A.6 | Inbox/mail icon | R-3.1 | Mail glyph in `<wavy-top-chrome>` linking to `/?folder=inbox`. |
+| A.7 | User avatar chip | R-3.1 | Avatar chip in `<wavy-top-chrome>` (server-rendered email + initials per existing shell-header pattern). |
+| B.1 | Search query textbox | R-3.1 | Existing `.sidecar-search-input` reused; F-2 wraps in a `<wavy-search-input>` element that adds the waveform glyph (an SVG `<svg>` placed adjacent to the input). |
+| B.2 | "Search help" trigger | R-3.1 | New `<button class="wavy-search-help-trigger">` opens `<wavy-search-help-modal>` (T6). |
+| B.3 | "New Wave" button | R-3.1 (shared with F-3) | Button in the search-rail header emits `wave-new-requested` CustomEvent. The actual compose surface is F-3. |
+| B.4 | Manage saved searches | R-3.1 | "Edit" affordance in the saved-search rail; emits `saved-searches-edit-requested` CustomEvent. |
+| B.5 | Saved search: Inbox | R-3.1 | Inbox row in `<wavy-saved-search-rail>` (T6). |
+| B.6 | Saved search: Mentions | R-3.1 | Mentions row with violet unread dot (`:host([has-unread])::before` per F-0 token). |
+| B.7 | Saved search: Tasks | R-3.1 (shared with F-3) | Tasks row with amber pending count. |
+| B.8 | Saved search: Public | R-3.1 | Row. |
+| B.9 | Saved search: Archive | R-3.1 | Row. |
+| B.10 | Saved search: Pinned | R-3.1 | Row. |
+| B.11 | Refresh search results | R-3.1 | Refresh icon button emits `search-refresh-requested` CustomEvent. |
+| B.12 | Result count "133 waves" | R-3.1 | Footer text with `data-result-count`. |
+| B.13 | Per-digest avatar stack | R-3.1 | Existing `.sidecar-digests` digest cards already render participant initials; F-2 ensures multi-author stacking via overlapping CSS positioning. |
+| B.14 | Per-digest pinned indicator | R-3.1 | Cyan pin glyph rendered when `digest.isPinned()`. |
+| B.15 | Per-digest title | R-3.1 | Already in `.sidecar-digests`. |
+| B.16 | Per-digest snippet | R-3.1 | Already in `.sidecar-digests`. |
+| B.17 | Per-digest msg count + cyan pulse on unread change | R-4.4 | F-2 adds `data-unread-count` attribute and pulse-ring animation via `firePulse()` per R-4.4 step 4. |
+| B.18 | Per-digest relative timestamp | R-3.1 | Already in `.sidecar-digests`. |
+| C.1–C.22 | Search Help modal filters + sort | R-3.1 | `<wavy-search-help-modal>` Lit element (T6) lists every filter/sort token in a static table. Each row carries a `data-filter-token` for the parity fixture to assert presence. |
+| D.1 | Wave title | R-3.1 | `<wavy-wave-panel-header>` (T2) renders `model.getTitleText()`. |
+| D.2 | Multi-author avatar stack | R-3.1 | Header avatar stack from `model.getParticipantIds()`. |
+| D.3 | "more" wave-actions menu | R-3.1 | Overflow `<button aria-label="More wave actions">` that opens a `<wavy-overflow-menu>` (placeholder; menu items are F-3 territory but the trigger ships in F-2). |
+| D.4 | Add participant | R-3.1 (shared with F-3) | Button emits `wave-add-participant-requested`. |
+| D.5 | New wave with current participants | R-3.1 (shared with F-3) | Menu item emits `wave-new-with-participants-requested`. |
+| D.6 | Public/private toggle | R-3.1 (shared with F-3) | Button emits `wave-publicity-toggle-requested`. |
+| D.7 | Copy public link | R-3.1 | Button copies `window.location.origin + '/?wave=<waveId>'` via `navigator.clipboard.writeText` and emits a toast. |
+| D.8 | Lock/unlock root blip | R-3.1 (shared with F-3) | Button emits `wave-root-lock-toggle-requested`. |
+| E.1–E.10 | Wave nav row | R-3.4 | `<wavy-wave-nav-row>` (T3). |
+| F.1–F.3 | Author avatar/name/timestamp | R-3.1 | `<wavy-blip-card>` header (T1). |
+| F.4 | Reply button | R-3.1 (shared with F-3) | Per-blip toolbar Reply emits `wave-blip-reply-requested`. |
+| F.5 | Edit | R-3.1 (shared with F-3) | Per-blip toolbar Edit emits `wave-blip-edit-requested`. |
+| F.7 | Link | R-3.1 | Per-blip toolbar Link copies a permalink via `navigator.clipboard.writeText` and emits a toast. |
+| F.10 | Inline-reply chips | R-3.1 + R-3.7 | Inline "△ N" chip in blip body; clickable to drill in (R-3.7 G.1). |
+| F.12 | Per-blip plugin slot | R-3.1 | Already in F-0; F-2 only verifies presence. |
+| I.1, I.2, I.6 | Tags row read-only | R-3.1 | `<wavy-tags-row>` (T2) with show/hide toggle. Add/edit affordances are F-3. |
+| J.2 | "Scroll to new messages" floating pill | R-4.4 | `<wavy-scroll-to-new>` floating pill that surfaces when `unreadCount > 0` AND the user has scrolled away from the bottom. Cyan signal-pulse on appear. Click scrolls to the first unread blip. |
+| J.3 | Hide/show wave controls | R-3.1 | Button toggles a `data-wave-controls-hidden` attribute on the wave panel. |
+| J.4 | Open/close nav drawer | R-3.1 | Button (mobile-only via media query) toggles a `data-nav-drawer-open` attribute on the shell-root. |
+| J.5 | Back to inbox | R-3.1 | Anchor `<a href="/?folder=inbox">`. |
+| K.1 | Version history overlay | R-3.4 (E.10 entry) | F-2 ships the `<wavy-version-history-overlay>` element with the time slider (K.2), Show changes (K.3), Text only (K.4), Restore (K.5 stub — emits CustomEvent), Exit (K.6) controls. **Restore/Show changes are wire-only** (display) — F-2 does not change wave state from the overlay; the existing GWT-side restore endpoint is unchanged and out of scope. The overlay opens via the E.10 button + the `H` key. |
+| K.2 | Time slider | R-3.4 | `<input type="range" min=0 max=N>` inside the overlay; the `versionList` is fetched via a new `gateway.fetchVersionHistory(waveId)` callback (T7 stubs the gateway with a no-op default; the harness fixture provides a synthetic 5-version list). |
+| K.3 | "Show changes" toggle | R-3.4 | `<input type="checkbox">` checkbox in the overlay shelf. |
+| K.4 | "Text only" toggle | R-3.4 | `<input type="checkbox">`. |
+| K.5 | Restore | R-3.4 | Button with `aria-haspopup="dialog"` (confirm sub-dialog). Emits `wave-version-restore-requested`. |
+| K.6 | Exit | R-3.4 | Closes the overlay by removing the `[open]` attribute. |
+| L.1 | Open user profile from blip avatar | R-3.1 | Avatar click emits `wave-blip-profile-requested` CustomEvent; `<wavy-user-profile-overlay>` (placeholder element) opens. |
+| L.5 | Previous/Next participant | R-3.1 | Navigation buttons in `<wavy-user-profile-overlay>` advance through `model.getParticipantIds()`. |
+
+That's **64 owned affordances** all covered, each with an executable acceptance step.
+
+## 4. Implementation tasks
+
+Each task lands as one commit with paired tests. Each task closes with `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild`.
+
+### T1 — Per-blip data shape: author + timestamp + parent + read state
+
+**Files:**
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java` (~+40 LOC)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java` (~+30 LOC)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java` (~+60 LOC) — populate the new fields from `SidecarSelectedWaveDocument` (`getAuthor`, `getLastModifiedTime`) and from `J2clSelectedWaveModel.readBlips` mapping; populate `parentBlipId` and `threadId` from the manifest reads already happening for reactions.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipTest.java` (~+40 LOC)
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java` (~+80 LOC)
+
+**Verification:** `sbt -batch "jakartaTest/testOnly *J2clSelectedWaveProjectorTest *J2clReadBlipTest"` — green.
+
+### T2 — Lit `<wave-blip>` element + `<wavy-wave-panel-header>` + `<wavy-tags-row>` + `<wavy-blip-toolbar>`
+
+**Files:**
+- `j2cl/lit/src/elements/wave-blip.js` (NEW, ~+220 LOC) — wraps `<wavy-blip-card>` from F-0 and adds: per-blip toolbar in the `metadata` slot, mention detection (sets `data-has-mention`), avatar element (CSS-only initials chip from `author-name`), full datetime tooltip via `<time title="...">`, `unread` debounce viewport detection (IntersectionObserver), `firePulse()` exposure for live-update pulse, `live-pulse` reflection, `<a class="wavy-inline-reply-chip">` rendered when `replyCount > 0`. **Plugin slot `blip-extension` flows through transparently from `<wavy-blip-card>`.**
+- `j2cl/lit/src/elements/wave-blip-toolbar.js` (NEW, ~+120 LOC) — buttons Reply / Edit / Link / overflow.
+- `j2cl/lit/src/elements/wavy-wave-panel-header.js` (NEW, ~+150 LOC) — title (D.1) + avatar stack (D.2) + add-participant (D.4) + new-wave-with-participants (D.5) + privacy toggle (D.6) + copy-public-link (D.7) + lock-toggle (D.8) + more-menu trigger (D.3). All emit CustomEvents; behavior wiring is F-3 territory.
+- `j2cl/lit/src/elements/wavy-tags-row.js` (NEW, ~+100 LOC) — read-only chips + show/hide toggle.
+- `j2cl/lit/src/index.js` (~+5 LOC) — register new elements.
+- `j2cl/lit/test/wave-blip.test.js` (NEW, ~+200 LOC)
+- `j2cl/lit/test/wave-blip-toolbar.test.js` (NEW, ~+120 LOC)
+- `j2cl/lit/test/wavy-wave-panel-header.test.js` (NEW, ~+150 LOC)
+- `j2cl/lit/test/wavy-tags-row.test.js` (NEW, ~+100 LOC)
+
+**Verification:** `cd j2cl/lit && npm test` (web-test-runner) — green.
+
+### T3 — Lit `<wavy-wave-nav-row>` + `<wavy-focus-frame>` + `<wavy-depth-nav-bar>` (G.1–G.6 chrome)
+
+**Files:**
+- `j2cl/lit/src/elements/wavy-wave-nav-row.js` (NEW, ~+200 LOC) — E.1–E.10 buttons.
+- `j2cl/lit/src/elements/wavy-focus-frame.js` (NEW, ~+100 LOC) — minimal: tracks `focusedBlipId` property; the actual focus visuals live on `<wavy-blip-card>` per F-0. This element exists for landmark + telemetry attribution.
+- `j2cl/lit/src/elements/wavy-depth-nav-bar.js` (NEW, ~+150 LOC) — composes F-0's `<wavy-depth-nav>` + the live-update awareness pill (G.6) + the chevron-up Up-one-level button (G.2) + the Up-to-wave button (G.3).
+- `j2cl/lit/src/index.js` register.
+- `j2cl/lit/test/wavy-wave-nav-row.test.js` (NEW, ~+200 LOC)
+- `j2cl/lit/test/wavy-focus-frame.test.js` (NEW, ~+80 LOC)
+- `j2cl/lit/test/wavy-depth-nav-bar.test.js` (NEW, ~+150 LOC)
+
+### T4 — Search-rail companion elements (B.1–B.18)
+
+**Files:**
+- `j2cl/lit/src/elements/wavy-saved-search-rail.js` (NEW, ~+180 LOC) — Inbox / Mentions / Tasks / Public / Archive / Pinned rows + Refresh + Manage saved searches + result count + per-digest avatar stack inside child `<wavy-search-digest-card>`.
+- `j2cl/lit/src/elements/wavy-search-digest-card.js` (NEW, ~+120 LOC) — per-digest card with avatar stack, pinned indicator, title, snippet, msg count with `data-unread-count`, relative timestamp.
+- `j2cl/lit/src/elements/wavy-search-help-modal.js` (NEW, ~+200 LOC) — static table of every C.1–C.22 filter + sort.
+- `j2cl/lit/src/elements/wavy-top-chrome.js` (NEW, ~+150 LOC) — A.2 locale + A.5 bell + A.6 mail + A.7 avatar.
+- `j2cl/lit/src/index.js` register.
+- Tests for each (~+100–200 LOC each).
+
+### T5 — Floating + accessory + version-history elements (J.2–J.5, K.1–K.6)
+
+**Files:**
+- `j2cl/lit/src/elements/wavy-scroll-to-new.js` (NEW, ~+100 LOC) — J.2 floating pill.
+- `j2cl/lit/src/elements/wavy-wave-controls-toggle.js` (NEW, ~+50 LOC) — J.3.
+- `j2cl/lit/src/elements/wavy-nav-drawer-toggle.js` (NEW, ~+50 LOC) — J.4. (J.5 back-to-inbox is just an `<a>` rendered inside this element.)
+- `j2cl/lit/src/elements/wavy-version-history-overlay.js` (NEW, ~+250 LOC) — K.1–K.6.
+- `j2cl/lit/src/index.js` register.
+- Tests for each.
+
+### T6 — Renderer rewire: `J2clReadSurfaceDomRenderer` uses `<wave-blip>`
+
+**Files:**
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` (~+150 LOC, ~-50 LOC) — replace `renderBlip(...)` to create `<wave-blip>` (custom element) instead of `<article class="blip j2cl-read-blip">` and set its attributes (`data-blip-id`, `data-wave-id`, `author-name`, `posted-at`, `is-author`, `unread`, `has-mention`, `reply-count`). Existing focus / collapse / scroll-anchor / IntersectionObserver-equivalent contracts are preserved by reading `<wave-blip>`'s `tabindex` and the existing collapse class.
+- Add depth-nav state: a new `setDepthFocus(blipId)` method that filters which blips render and emits a `wave-depth-changed` CustomEvent.
+- Wire E.* navigation: `nextUnread()`, `nextMention()`, `prevMention()`, `goToEnd()`, `goToRecent()`. Each delegates to existing `focusVisibleByIndex` after computing the right index.
+- Add `markBlipReadOnViewportDebounce(blipId, callback)` — IntersectionObserver-equivalent. Elemental2 doesn't ship IntersectionObserver but `DomGlobal.setTimeout` + `getBoundingClientRect` polling per scroll/render is acceptable for the StageOne fidelity.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java` (~+250 LOC of new test cases for E.* nav, depth-nav, mark-read debounce).
+
+### T7 — `J2clSelectedWaveView` wires the new chrome elements + depth-nav state
+
+**Files:**
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` (~+120 LOC) — mounts `<wavy-wave-panel-header>`, `<wavy-wave-nav-row>`, `<wavy-tags-row>`, `<wavy-scroll-to-new>`, `<wavy-version-history-overlay>` markers around the `contentList`. Reads `&depth=` from URL and calls `readSurface.setDepthFocus(...)`. Listens for `wave-depth-changed` CustomEvents from the renderer and writes `&depth=` back via `history.replaceState`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java` (~+30 LOC) — extends the `Gateway` interface with `markBlipRead(waveId, blipId, onSuccess, onError)` and `fetchVersionHistory(waveId, callback)`. Both have no-op default implementations to preserve existing call sites.
+- Test additions in `J2clSelectedWaveViewServerFirstLogicTest`-style standalone JVM tests.
+
+### T8 — Server-side demo route mount + design-preview wave fixture
+
+**Files:**
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` (~+150 LOC) — extend `renderJ2clDesignPreviewPage` (or add `renderJ2clReadSurfacePreviewPage`) to emit a sample wave at `/?view=j2cl-root&q=read-surface-preview`. Uses synthetic in-page JSON (`<script id="wavy-read-surface-preview-fixture" type="application/json">`) with 12 blips including 2 mentions, 2 unread, 1 deeply-nested thread (3 levels). Mounts `<shell-root>` with all F-2 chrome elements and a renderer initialized from the synthetic JSON.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java` (~+30 LOC) — add the route gating (admin-or-owner or signed-in user — same gate as the design preview).
+- `wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clReadSurfacePreviewPageTest.java` (NEW)
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletReadSurfacePreviewBranchTest.java` (NEW)
+
+### T9 — Per-row parity fixture
+
+**File:** `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java` (NEW, ~+700 LOC).
+
+The fixture builds a synthetic 12-blip wave (2 mentions, 2 unread, 3-level deep thread, 1 thread root with 2 replies) via `TestingWaveletData` (same pattern as `J2clViewportFirstPaintParityTest`), mounts the J2CL servlet at both `?view=j2cl-root` and `?view=gwt`, and asserts:
+
+- **R-3.1 (16 affordances).** For each blip: HTML contains `<wave-blip` element with `data-blip-id="..."`, `author-name="..."`, `posted-at="..."`. Multi-author wave header carries `<wavy-wave-panel-header>` with `<wavy-avatar-stack>` containing N children. Tags row contains expected chips. Plugin slot present per blip. Inline-reply chip present on parent blips.
+- **R-3.2.** Server-side: `data-tabindex="0"` is present on exactly one blip (the first); the rendered HTML carries `data-j2cl-focus-frame` on the surface root. Client-side (verified by the lit test): pressing ArrowDown moves focus and emits the `read.focus_change` telemetry event.
+- **R-3.3.** Server-side: each thread root carries the `j2cl-read-thread-toggle` button. Client-side (lit test): toggling collapses the children with the 240ms transition; scroll anchor preserved across re-render.
+- **R-3.4.** Server-side: `<wavy-wave-nav-row>` is present with all 10 buttons keyed by `data-nav-action="E.1" .. "E.10"`. Client-side: clicking each button changes focus or emits the expected CustomEvent.
+- **R-3.7.** URL-driven: GET `?view=j2cl-root&depth=b3` renders only the b3 subthread + its descendants. Breadcrumb `<wavy-depth-nav-bar>` carries `data-current-depth-blip-id="b3"`. Pressing `[` on the rendered surface emits `wave-depth-changed{depth: ""}` (drill out).
+- **R-4.4.** Server-side: each blip in the unread set carries `unread="true"`. Client-side: synthetic call to `markBlipReadOnViewportDebounce` after 1500ms invokes the gateway exactly once and decrements `data-unread-count` on the matching digest card.
+- **GWT byte-for-byte unchanged** for `?view=gwt` (regression assertion: response body fingerprinted against a stored reference snapshot — same approach as `J2clViewportFirstPaintParityTest`).
+- **64 inventory affordances**: a single helper `assertInventoryAffordancePresent(html, id)` checks each ID has a corresponding `data-inventory-affordance="<id>"` attribute somewhere in the rendered DOM. Each Lit element registers itself with this attribute on its `connectedCallback`.
+
+## 5. Telemetry surface
+
+The following events are added to `J2clClientTelemetry`. All are categorical with no high-cardinality fields.
+
+- `read.focus_change` — fields: `source` (`"key"`, `"click"`, `"programmatic"`).
+- `read.thread_toggle` — fields: `state` (`"collapsed"`, `"expanded"`).
+- `read.thread_nav` — fields: `event` (`"E.1"`..`"E.10"`).
+- `read.depth_change` — fields: `direction` (`"in"`, `"out"`, `"to-wave"`), `source` (`"click"`, `"key"`, `"url"`).
+- `read.depth_pill_shown` — no fields (G.6).
+- `read.blip_read_marked` — fields: `source` (`"viewport-debounce"`, `"manual"`).
+- `read.unread_badge_pulse` — no fields.
+
+## 6. Out of scope (deferred and explicit)
+
+- Compose / write surface — F-3 owns. F-2 ships only the per-blip Reply CustomEvent emitters and the inline-reply chip click — F-3 wires the actual composer to those events.
+- Rich-text edit toolbar (H.1–H.24) — F-3 owns. F-2 does not ship the toolbar.
+- Tag add/edit (I.3, I.4, I.5) — F-3 owns. F-2 ships read-only display only.
+- Send-Message from profile overlay (L.2) — F-3 owns.
+- Notifications bell wiring (A.5) — F-4 owns the actual unread count source. F-2 displays whatever count the model exposes (default 0).
+- Save state pill (A.3), Online pill (A.4) — F-4.
+- Reactions add (F.8, F.9) — F-3 (F-2 only displays the existing F-1-rendered reaction-row).
+- Restore action body (K.5) — out of scope. F-2 ships the affordance + CustomEvent + confirm sub-dialog; the actual restore endpoint integration ships when GWT-side restore flow is migrated (separate issue, future).
+- Wave-actions overflow menu items D.3 — F-2 ships the trigger button; the menu items themselves are mostly F-3 (mark-read/archive/etc.).
+
+## 7. Risk list
+
+1. **Custom-element naming collision**: F-0 already defines `wavy-blip-card`. F-2 introduces `wave-blip` (different name) that wraps `wavy-blip-card`. Name distinct → no collision. *Mitigation:* the `wave-blip.test.js` asserts `customElements.get("wave-blip")` is the F-2 class.
+2. **Plugin-slot context contract drift**: F-0 reflects `data-blip-id`, `data-wave-id`, `data-blip-author`, `data-blip-is-author` on `<wavy-blip-card>`. F-2's `<wave-blip>` wrapper must propagate these to the inner `wavy-blip-card`. *Mitigation:* explicit `_propagateDataAttrs()` in the wrapper, asserted in `wave-blip.test.js`.
+3. **Per-blip read mark amplification**: a 12-blip viewport could emit 12 `markBlipRead` HTTP calls in the worst case. *Mitigation:* the renderer batches reads — `markBlipReadOnViewportDebounce` collects blip IDs over a 250ms window and calls `gateway.markBlipReadBatch(waveId, [blipIds])` (the controller exposes both single + batch APIs; the existing supplement endpoint already supports a batch shape).
+4. **CodexConnector P2 review threads on each commit** (F-0/F-1 lesson): expect the bot to post P2 threads on every push. Resolve via GraphQL each time.
+5. **F-1 fragment-window depth-axis support**: G.1 requires that the F-1 fragment fetch can target a parent blip without loading siblings. *Verification:* T6 fixture asserts that `gateway.fetchFragments(waveId, parentBlipId, "depth", limit, …)` returns only descendants of `parentBlipId`. If the F-1 server-side path doesn't already key on direction="depth", the renderer falls back to client-side filtering of an existing fragment payload (acceptable interim — T6 flags this as a known interim and files a follow-up issue).
+6. **Reduced-motion**: F-0 already collapses motion durations to ~0.01ms via `prefers-reduced-motion`. F-2 fixtures verify the transitions still fire (animationend / transitionend events still resolve) under reduced-motion so JS state machines tracking the end events do not hang.
+7. **Server-side payload growth**: T8's design-preview wave fixture is in-page JSON only — no server-side payload growth in production. The production `J2clSelectedWaveSnapshotRenderer` is unchanged.
+
+## 8. Verification gate (closes the lane)
+
+- `sbt -batch j2clSearchTest j2clProductionBuild j2clLitTest j2clLitBuild` → exit 0.
+- `J2clStageOneReadSurfaceParityTest` → 6 row methods passing (R-3.1, R-3.2, R-3.3, R-3.4, R-3.7, R-4.4) + 1 inventory-affordance method asserting all 64 IDs.
+- All new lit tests passing (T2 + T3 + T4 + T5 element tests).
+- Worktree-local boot: `sbt -batch wavestart` (or equivalent), navigate `/?view=j2cl-root&q=read-surface-preview`, visually verify the demo wave (manual screenshot attached to PR comment).
+- Telemetry: open `/?view=j2cl-root&q=read-surface-preview`, run a few interactions, dump `window.__stats` and confirm the new event names appear.
+
+## 9. Plan-review pass log
+
+This plan was self-reviewed and then reviewed by a Claude Opus subagent.
+
+### Self-review iteration 1
+- ✅ Every R-* row has at least 5 concrete acceptance steps with measurable DOM-attribute or telemetry assertions.
+- ✅ All 64 inventory affordances mapped to a row + an implementation strategy.
+- ✅ Plugin-slot reservation explicitly carries through F-2's `wave-blip` wrapper.
+- ✅ Depth-nav R-3.7 covers all 6 sub-affordances G.1–G.6.
+- ✅ Telemetry events listed.
+- ✅ Out of scope explicit, with explicit "F-3 owns" or "F-4 owns" attribution.
+- ✅ Risk list covers the depth-axis fragment-window concern flagged in the issue body.
+
+### Subagent plan-review iteration (deferred to subagent)
+
+To be filled in by the Opus subagent. Expected challenge points:
+- Are there any inventory affordances missed?
+- Is the R-3.7 G.4 URL-state fully reversible across the back/forward stack, or only a `replaceState`?
+- Does T6's in-renderer mark-read debounce risk steady-state HTTP traffic if the user is idle on a wave with 12 blips?
+
+The subagent will list any "no executable acceptance step" findings; this plan iterates until clean.

--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -1,0 +1,108 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wave-blip-toolbar> — F-2 (#1037, R-3.1) per-blip action toolbar that
+ * surfaces Reply (F.4), Edit (F.5), Link (F.7), and the overflow trigger
+ * (F.6 Delete + future F-3 actions live behind it).
+ *
+ * The toolbar is structurally inside `<wave-blip>`'s `metadata` slot so
+ * the F-0 `<wavy-blip-card>` recipe envelope stays in charge of focus +
+ * unread + pulse. Visibility is driven by the parent's :focus-within
+ * + :hover rules; the toolbar itself just renders the buttons.
+ *
+ * Each button emits its own event so the parent <wave-blip> can re-emit
+ * the public `wave-blip-*-requested` events with the blip context.
+ */
+export class WaveBlipToolbar extends LitElement {
+  static properties = {
+    blipId: { type: String, attribute: "data-blip-id", reflect: true },
+    waveId: { type: String, attribute: "data-wave-id", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      gap: var(--wavy-spacing-1, 4px);
+      align-items: center;
+    }
+    button {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 1px solid transparent;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      cursor: pointer;
+      transition: color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        border-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    button:hover {
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-color: var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+    }
+    button:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+    }
+  `;
+
+  constructor() {
+    super();
+    this.blipId = "";
+    this.waveId = "";
+  }
+
+  _emit(eventName) {
+    this.dispatchEvent(
+      new CustomEvent(eventName, {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
+  render() {
+    return html`
+      <button
+        type="button"
+        data-toolbar-action="reply"
+        aria-label="Reply to this blip"
+        @click=${() => this._emit("wave-blip-toolbar-reply")}
+      >
+        Reply
+      </button>
+      <button
+        type="button"
+        data-toolbar-action="edit"
+        aria-label="Edit this blip"
+        @click=${() => this._emit("wave-blip-toolbar-edit")}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        data-toolbar-action="link"
+        aria-label="Copy permalink to this blip"
+        @click=${() => this._emit("wave-blip-toolbar-link")}
+      >
+        Link
+      </button>
+      <button
+        type="button"
+        data-toolbar-action="overflow"
+        aria-label="More blip actions"
+        aria-haspopup="menu"
+        @click=${() => this._emit("wave-blip-toolbar-overflow")}
+      >
+        ⋯
+      </button>
+    `;
+  }
+}
+
+if (!customElements.get("wave-blip-toolbar")) {
+  customElements.define("wave-blip-toolbar", WaveBlipToolbar);
+}

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -1,0 +1,362 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wave-blip> — F-2 (#1037, R-3.1) read-surface wrapper around the F-0
+ * (#1035) <wavy-blip-card> recipe. The renderer creates one <wave-blip>
+ * per blip in the rendered viewport window.
+ *
+ * Why a wrapper?
+ * - The F-0 recipe ships the visual envelope (hairline cyan border,
+ *   focused-state focus ring, unread dot, live-pulse glow) and the
+ *   required `blip-extension` plugin slot, all keyed off the wavy
+ *   design tokens. F-2 must NOT re-skin those — the plugin contract
+ *   (docs/j2cl-plugin-slots.md) reflects them on `<wavy-blip-card>`.
+ * - F-2 needs to layer on top: a header with the author display name
+ *   + relative timestamp + full ISO datetime tooltip (F.1 / F.2 / F.3),
+ *   a per-blip toolbar with Reply / Edit / Link / overflow that reveals
+ *   on focus or hover (F.4 / F.5 / F.6 / F.7), an inline-reply chip when
+ *   the blip has children (F.10 + R-3.7 G.1 drill-in), and a `has-mention`
+ *   reflection so the wave-nav-row can navigate by @-mentions (E.6 / E.7).
+ *
+ * Plugin slot contract (R-3.1 step 8 + plugin-slot reservation):
+ * - `<slot name="blip-extension">` is propagated through to the inner
+ *   `<wavy-blip-card>` so the existing F-0 plugin context contract is
+ *   preserved unchanged. Plugins keep reading `host.dataset.blipId`
+ *   etc. on the inner card (the wrapper does not change the contract).
+ * - The wrapper additionally surfaces `data-blip-id`, `data-wave-id`,
+ *   `data-blip-author`, `data-blip-is-author`, `data-has-mention`,
+ *   `data-reply-count`, `data-unread`, `data-focused` on its OWN host
+ *   so external CSS hooks can target wave-blip without piercing the
+ *   shadow root.
+ *
+ * Public API:
+ * - blipId, waveId, authorName, postedAt, isAuthor, focused, unread,
+ *   hasMention, replyCount, livePulse — primitive state attributes,
+ *   reflected to data-attributes per the plugin contract.
+ * - firePulse() — restarts the F-0 live-update pulse on the inner card.
+ * - blipView (getter) — frozen `{id, waveId, authorName, postedAt,
+ *   isAuthor}` snapshot, mirrors the F-0 contract for plugin consumers.
+ *
+ * Events emitted (CustomEvent, bubbles + composed):
+ * - `wave-blip-reply-requested` — `{detail: {blipId, waveId}}`. F-3
+ *   (compose) listens.
+ * - `wave-blip-edit-requested` — `{detail: {blipId, waveId}}`. F-3 owns
+ *   the edit surface; F-2 only emits the request.
+ * - `wave-blip-link-copied` — `{detail: {blipId, waveId, url}}`. F-2
+ *   handles the clipboard write itself before emitting.
+ * - `wave-blip-profile-requested` — `{detail: {blipId, authorId}}`.
+ *   Emitted from the avatar click for the L.1 profile overlay.
+ * - `wave-blip-drill-in-requested` — `{detail: {blipId, waveId}}`.
+ *   Emitted from the inline-reply chip click for the R-3.7 G.1 drill-in.
+ */
+export class WaveBlip extends LitElement {
+  static properties = {
+    blipId: { type: String, attribute: "data-blip-id", reflect: true },
+    waveId: { type: String, attribute: "data-wave-id", reflect: true },
+    authorId: { type: String, attribute: "author-id" },
+    authorName: { type: String, attribute: "author-name" },
+    postedAt: { type: String, attribute: "posted-at" },
+    postedAtIso: { type: String, attribute: "posted-at-iso" },
+    isAuthor: { type: Boolean, attribute: "is-author", reflect: true },
+    focused: { type: Boolean, reflect: true },
+    unread: { type: Boolean, reflect: true },
+    hasMention: { type: Boolean, attribute: "has-mention", reflect: true },
+    replyCount: { type: Number, attribute: "reply-count", reflect: true },
+    livePulse: { type: Boolean, attribute: "live-pulse", reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      /* The visual envelope lives on the inner <wavy-blip-card>; this
+       * host is a transparent wrapper so the F-0 recipe styling owns
+       * focus / unread / pulse visuals. */
+    }
+    /* Per-blip toolbar — hidden until focus or hover per F.4 inventory note
+     * "reveal on focus/hover". Uses --wavy-motion-focus-duration so it
+     * matches the focus-frame timing. */
+    .toolbar {
+      opacity: 0;
+      transition: opacity var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+      pointer-events: none;
+    }
+    :host([focused]) .toolbar,
+    :host(:hover) .toolbar,
+    .toolbar:focus-within {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .header {
+      display: flex;
+      align-items: baseline;
+      gap: var(--wavy-spacing-2, 8px);
+      margin-bottom: var(--wavy-spacing-2, 8px);
+    }
+    .avatar {
+      flex: 0 0 auto;
+      width: 24px;
+      height: 24px;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      background: var(--wavy-signal-cyan-soft, rgba(34, 211, 238, 0.22));
+      color: var(--wavy-text-body, #fff);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      border: 0;
+      padding: 0;
+    }
+    .avatar:focus-visible {
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+      outline: none;
+    }
+    .author {
+      font: var(--wavy-type-h3, 1.0625rem / 1.35 sans-serif);
+      font-weight: 600;
+      color: var(--wavy-text-body, #fff);
+    }
+    time.posted {
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
+      cursor: help;
+    }
+    .inline-reply-chip {
+      display: inline-block;
+      margin-top: var(--wavy-spacing-2, 8px);
+      padding: 2px var(--wavy-spacing-2, 8px);
+      border-radius: var(--wavy-radius-pill, 9999px);
+      background: var(--wavy-signal-cyan-soft, rgba(34, 211, 238, 0.22));
+      color: var(--wavy-text-body, #fff);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      cursor: pointer;
+      border: 0;
+    }
+    .inline-reply-chip:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+    }
+    /* When the wrapper carries the has-mention attr, paint a violet
+     * accent rail down the left so the mention navigation (E.6 / E.7)
+     * has a visual cue without clashing with unread cyan. */
+    :host([has-mention])::before {
+      content: "";
+      position: absolute;
+      width: 3px;
+      top: 6px;
+      bottom: 6px;
+      left: 0;
+      background: var(--wavy-signal-violet, #7c3aed);
+      border-radius: var(--wavy-radius-pill, 9999px);
+    }
+    :host([has-mention]) {
+      position: relative;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.blipId = "";
+    this.waveId = "";
+    this.authorId = "";
+    this.authorName = "";
+    this.postedAt = "";
+    this.postedAtIso = "";
+    this.isAuthor = false;
+    this.focused = false;
+    this.unread = false;
+    this.hasMention = false;
+    this.replyCount = 0;
+    this.livePulse = false;
+  }
+
+  /** Lazy frozen read-only snapshot for plugin consumers. */
+  get blipView() {
+    return Object.freeze({
+      id: this.blipId,
+      waveId: this.waveId,
+      authorName: this.authorName,
+      authorId: this.authorId,
+      postedAt: this.postedAt,
+      postedAtIso: this.postedAtIso,
+      isAuthor: this.isAuthor,
+      unread: this.unread,
+      hasMention: this.hasMention,
+      replyCount: this.replyCount
+    });
+  }
+
+  /**
+   * Restart the F-0 live-update pulse on the inner card. F-2 reuses the
+   * F-0 recipe's pulse animation so the live-update visual is identical
+   * to the rest of the wavy surface.
+   */
+  firePulse() {
+    const card = this.renderRoot.querySelector("wavy-blip-card");
+    if (card && typeof card.firePulse === "function") {
+      card.firePulse();
+    } else {
+      // Card not registered yet; fall back to setting the attribute directly
+      // so the next render still picks up the pulse via :host([live-pulse]).
+      this.removeAttribute("live-pulse");
+      // eslint-disable-next-line no-unused-expressions
+      void this.offsetWidth;
+      this.setAttribute("live-pulse", "");
+    }
+  }
+
+  _initials() {
+    const name = (this.authorName || this.authorId || "?").trim();
+    if (!name) return "?";
+    const parts = name.split(/\s+/);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+    return name.substring(0, 2).toUpperCase();
+  }
+
+  _onAvatarClick(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-profile-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, authorId: this.authorId }
+      })
+    );
+  }
+
+  _onReplyClick(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-reply-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
+  _onEditClick(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-edit-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
+  async _onLinkClick(event) {
+    event.stopPropagation();
+    const url = this._buildPermalink();
+    let success = false;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(url);
+        success = true;
+      }
+    } catch (e) {
+      success = false;
+    }
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-link-copied", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId, url, success }
+      })
+    );
+  }
+
+  _onChipClick(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-drill-in-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
+  _buildPermalink() {
+    if (typeof window === "undefined" || !window.location) {
+      return "";
+    }
+    const { origin, pathname } = window.location;
+    const wave = this.waveId ? encodeURIComponent(this.waveId) : "";
+    const blip = this.blipId ? encodeURIComponent(this.blipId) : "";
+    return `${origin}${pathname}?wave=${wave}&blip=${blip}`;
+  }
+
+  render() {
+    const tooltip = this.postedAtIso || this.postedAt;
+    const chip =
+      this.replyCount > 0
+        ? html`<button
+            type="button"
+            class="inline-reply-chip"
+            data-inline-reply-chip="true"
+            aria-label=${`Drill into ${this.replyCount} replies under this blip`}
+            @click=${this._onChipClick}
+          >
+            △ ${this.replyCount}
+          </button>`
+        : null;
+
+    return html`
+      <wavy-blip-card
+        data-blip-id=${this.blipId}
+        data-wave-id=${this.waveId}
+        author-name=${this.authorName}
+        posted-at=${this.postedAt}
+        ?is-author=${this.isAuthor}
+        ?focused=${this.focused}
+        ?unread=${this.unread}
+        ?live-pulse=${this.livePulse}
+      >
+        <div class="header" slot="metadata">
+          <button
+            type="button"
+            class="avatar"
+            data-blip-avatar="true"
+            aria-label=${`Open ${this.authorName || this.authorId || "user"} profile`}
+            @click=${this._onAvatarClick}
+          >
+            ${this._initials()}
+          </button>
+          <span class="author">${this.authorName || this.authorId || ""}</span>
+          <time
+            class="posted"
+            title=${tooltip}
+            datetime=${this.postedAtIso || ""}
+          >
+            ${this.postedAt}
+          </time>
+        </div>
+        <div class="toolbar" slot="metadata">
+          <wave-blip-toolbar
+            data-blip-id=${this.blipId}
+            data-wave-id=${this.waveId}
+            @wave-blip-toolbar-reply=${this._onReplyClick}
+            @wave-blip-toolbar-edit=${this._onEditClick}
+            @wave-blip-toolbar-link=${this._onLinkClick}
+          ></wave-blip-toolbar>
+        </div>
+        <div class="body">
+          <slot></slot>
+          ${chip}
+        </div>
+        <slot name="blip-extension" slot="blip-extension"></slot>
+        <slot name="reactions" slot="reactions"></slot>
+      </wavy-blip-card>
+    `;
+  }
+}
+
+if (!customElements.get("wave-blip")) {
+  customElements.define("wave-blip", WaveBlip);
+}

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -83,6 +83,7 @@ export class WaveBlip extends LitElement {
       pointer-events: none;
     }
     :host([focused]) .toolbar,
+    :host(:focus-within) .toolbar,
     :host(:hover) .toolbar,
     .toolbar:focus-within {
       opacity: 1;
@@ -287,6 +288,11 @@ export class WaveBlip extends LitElement {
     if (typeof window === "undefined" || !window.location) {
       return "";
     }
+    // Start from the current href so we preserve view=j2cl-root (and any
+    // other shell-recognised query params like q=). The server only
+    // recognises the `wave` query parameter today; carry the per-blip
+    // anchor in the URL fragment instead of an unsupported `blip` param so
+    // the copied permalink restores the J2CL view AND points at this blip.
     const url = new URL(window.location.href);
     if (this.waveId) {
       url.searchParams.set("wave", this.waveId);
@@ -294,6 +300,7 @@ export class WaveBlip extends LitElement {
       url.searchParams.delete("wave");
     }
     url.searchParams.delete("blip");
+    url.hash = this.blipId ? `blip-${this.blipId}` : "";
     return url.toString();
   }
 

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { ifDefined } from "lit/directives/if-defined.js";
 
 /**
  * <wave-blip> — F-2 (#1037, R-3.1) read-surface wrapper around the F-0
@@ -286,10 +287,14 @@ export class WaveBlip extends LitElement {
     if (typeof window === "undefined" || !window.location) {
       return "";
     }
-    const { origin, pathname } = window.location;
-    const wave = this.waveId ? encodeURIComponent(this.waveId) : "";
-    const blip = this.blipId ? encodeURIComponent(this.blipId) : "";
-    return `${origin}${pathname}?wave=${wave}&blip=${blip}`;
+    const url = new URL(window.location.href);
+    if (this.waveId) {
+      url.searchParams.set("wave", this.waveId);
+    } else {
+      url.searchParams.delete("wave");
+    }
+    url.searchParams.delete("blip");
+    return url.toString();
   }
 
   render() {
@@ -332,7 +337,7 @@ export class WaveBlip extends LitElement {
           <time
             class="posted"
             title=${tooltip}
-            datetime=${this.postedAtIso || ""}
+            datetime=${ifDefined(this.postedAtIso || undefined)}
           >
             ${this.postedAt}
           </time>

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -32,6 +32,10 @@ import "./design/wavy-rail-panel.js";
 import "./design/wavy-edit-toolbar.js";
 import "./design/wavy-depth-nav.js";
 import "./design/wavy-pulse-stage.js";
+// F-2 (#1037): StageOne read-surface elements that wrap the F-0
+// design recipes. The renderer mounts <wave-blip> per blip.
+import "./elements/wave-blip-toolbar.js";
+import "./elements/wave-blip.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/wave-blip-toolbar.test.js
+++ b/j2cl/lit/test/wave-blip-toolbar.test.js
@@ -1,0 +1,99 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wave-blip-toolbar.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+});
+
+describe("<wave-blip-toolbar>", () => {
+  it("registers the F-2 toolbar custom element", () => {
+    expect(customElements.get("wave-blip-toolbar")).to.exist;
+  });
+
+  it("renders Reply / Edit / Link / overflow buttons with stable data-toolbar-action keys", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b1" data-wave-id="w1"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='reply']")).to.exist;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='edit']")).to.exist;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='link']")).to.exist;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']")).to.exist;
+  });
+
+  it("each button has an aria-label that names the action", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b2" data-wave-id="w2"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='reply']").getAttribute("aria-label"))
+      .to.equal("Reply to this blip");
+    expect(el.renderRoot.querySelector("[data-toolbar-action='edit']").getAttribute("aria-label"))
+      .to.equal("Edit this blip");
+    expect(el.renderRoot.querySelector("[data-toolbar-action='link']").getAttribute("aria-label"))
+      .to.equal("Copy permalink to this blip");
+    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']").getAttribute("aria-label"))
+      .to.equal("More blip actions");
+  });
+
+  it("overflow button is announced as a menu trigger (aria-haspopup='menu')", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b3" data-wave-id="w3"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']")
+      .getAttribute("aria-haspopup")).to.equal("menu");
+  });
+
+  it("Reply button click emits wave-blip-toolbar-reply with blip context", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b4" data-wave-id="w4"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='reply']").click(), 0);
+    const ev = await oneEvent(el, "wave-blip-toolbar-reply");
+    expect(ev.detail.blipId).to.equal("b4");
+    expect(ev.detail.waveId).to.equal("w4");
+    expect(ev.bubbles).to.be.true;
+    expect(ev.composed).to.be.true;
+  });
+
+  it("Edit button click emits wave-blip-toolbar-edit", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b5" data-wave-id="w5"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='edit']").click(), 0);
+    const ev = await oneEvent(el, "wave-blip-toolbar-edit");
+    expect(ev.detail.blipId).to.equal("b5");
+  });
+
+  it("Link button click emits wave-blip-toolbar-link", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b6" data-wave-id="w6"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='link']").click(), 0);
+    const ev = await oneEvent(el, "wave-blip-toolbar-link");
+    expect(ev.detail.blipId).to.equal("b6");
+  });
+
+  it("overflow button click emits wave-blip-toolbar-overflow", async () => {
+    const el = await fixture(html`
+      <wave-blip-toolbar data-blip-id="b7" data-wave-id="w7"></wave-blip-toolbar>
+    `);
+    await el.updateComplete;
+    setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='overflow']").click(), 0);
+    const ev = await oneEvent(el, "wave-blip-toolbar-overflow");
+    expect(ev.detail.blipId).to.equal("b7");
+  });
+});

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -188,6 +188,64 @@ describe("<wave-blip>", () => {
     expect(time.getAttribute("datetime")).to.equal("2026-04-26T12:00:00Z");
   });
 
+  it("omits the datetime attribute entirely when postedAtIso is empty", async () => {
+    // Empty datetime="" is invalid HTML and confuses ATs / validators. The
+    // wrapper must skip the attribute (via lit's ifDefined directive)
+    // rather than emit an empty string.
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b9b"
+        data-wave-id="w9b"
+        author-name="E"
+        posted-at="Blip b+9b"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const time = el.renderRoot.querySelector("time.posted");
+    expect(time).to.exist;
+    expect(time.hasAttribute("datetime")).to.be.false;
+  });
+
+  it("Link button builds a permalink that preserves view=j2cl-root and uses a fragment for the blip", async () => {
+    // The server only recognises the `wave` query param. The previous
+    // implementation built `?wave=...&blip=...`, which dropped the
+    // `view=j2cl-root` shell route and used an unsupported `blip` query
+    // param. The permalink must round-trip through the J2CL root shell and
+    // anchor to this blip via the URL fragment.
+    const originalHref = window.location.href;
+    const baseUrl = new URL(window.location.href);
+    baseUrl.search = "?view=j2cl-root";
+    baseUrl.hash = "";
+    history.replaceState(null, "", baseUrl.toString());
+    try {
+      const el = await fixture(html`
+        <wave-blip
+          data-blip-id="b+link"
+          data-wave-id="example.com/w+w1"
+          author-name="A"
+        ></wave-blip>
+      `);
+      await el.updateComplete;
+      setTimeout(() => {
+        const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+        toolbar.dispatchEvent(
+          new CustomEvent("wave-blip-toolbar-link", {
+            bubbles: true,
+            composed: true
+          })
+        );
+      }, 0);
+      const ev = await oneEvent(el, "wave-blip-link-copied");
+      const url = new URL(ev.detail.url);
+      expect(url.searchParams.get("view")).to.equal("j2cl-root");
+      expect(url.searchParams.get("wave")).to.equal("example.com/w+w1");
+      expect(url.searchParams.has("blip")).to.be.false;
+      expect(url.hash).to.equal("#blip-b+link");
+    } finally {
+      history.replaceState(null, "", originalHref);
+    }
+  });
+
   it("blipView getter returns a frozen snapshot mirroring the F-0 plugin contract", async () => {
     const el = await fixture(html`
       <wave-blip

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -1,0 +1,260 @@
+import { fixture, expect, html, oneEvent, aTimeout } from "@open-wc/testing";
+import "../src/elements/wave-blip.js";
+import "../src/elements/wave-blip-toolbar.js";
+import "../src/design/wavy-blip-card.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wave-blip>", () => {
+  it("registers the F-2 wrapper custom element", () => {
+    expect(customElements.get("wave-blip")).to.exist;
+  });
+
+  it("reflects blip-id, wave-id, has-mention, focused, unread, reply-count", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b1"
+        data-wave-id="w1"
+        author-id="alice@example.com"
+        author-name="Alice"
+        posted-at="2m ago"
+        posted-at-iso="2026-04-26T12:00:00Z"
+        is-author
+        focused
+        unread
+        has-mention
+        reply-count="3"
+      >
+        Hello world.
+      </wave-blip>
+    `);
+    expect(el.getAttribute("data-blip-id")).to.equal("b1");
+    expect(el.getAttribute("data-wave-id")).to.equal("w1");
+    expect(el.hasAttribute("focused")).to.be.true;
+    expect(el.hasAttribute("unread")).to.be.true;
+    expect(el.hasAttribute("has-mention")).to.be.true;
+    expect(el.getAttribute("reply-count")).to.equal("3");
+  });
+
+  it("propagates blip + wave id + author + focus state to the inner wavy-blip-card", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b2"
+        data-wave-id="w2"
+        author-name="Bob"
+        posted-at="just now"
+        is-author
+        focused
+        unread
+      >
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const card = el.renderRoot.querySelector("wavy-blip-card");
+    expect(card).to.exist;
+    expect(card.getAttribute("data-blip-id")).to.equal("b2");
+    expect(card.getAttribute("data-wave-id")).to.equal("w2");
+    expect(card.getAttribute("author-name")).to.equal("Bob");
+    expect(card.hasAttribute("focused")).to.be.true;
+    expect(card.hasAttribute("unread")).to.be.true;
+  });
+
+  it("renders the per-blip toolbar in the metadata slot", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b3" data-wave-id="w3" author-name="Carol">
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+    expect(toolbar).to.exist;
+    expect(toolbar.getAttribute("data-blip-id")).to.equal("b3");
+  });
+
+  it("re-emits wave-blip-reply-requested with blip context when toolbar Reply fires", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b4" data-wave-id="w4" author-name="A"></wave-blip>
+    `);
+    await el.updateComplete;
+    const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+    await toolbar.updateComplete;
+    const replyBtn = toolbar.renderRoot.querySelector("[data-toolbar-action='reply']");
+    expect(replyBtn).to.exist;
+    setTimeout(() => replyBtn.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-reply-requested");
+    expect(ev.detail.blipId).to.equal("b4");
+    expect(ev.detail.waveId).to.equal("w4");
+  });
+
+  it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b5" data-wave-id="w5" author-name="A"></wave-blip>
+    `);
+    await el.updateComplete;
+    const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+    await toolbar.updateComplete;
+    const editBtn = toolbar.renderRoot.querySelector("[data-toolbar-action='edit']");
+    setTimeout(() => editBtn.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-edit-requested");
+    expect(ev.detail.blipId).to.equal("b5");
+  });
+
+  it("renders the inline-reply chip only when reply-count > 0", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b6" data-wave-id="w6" author-name="A">x</wave-blip>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector("[data-inline-reply-chip='true']")).to.not.exist;
+
+    el.replyCount = 4;
+    await el.updateComplete;
+    const chip = el.renderRoot.querySelector("[data-inline-reply-chip='true']");
+    expect(chip).to.exist;
+    expect(chip.textContent.trim()).to.contain("4");
+  });
+
+  it("inline-reply chip click emits wave-blip-drill-in-requested with blip context", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b7"
+        data-wave-id="w7"
+        author-name="A"
+        reply-count="2"
+      >
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const chip = el.renderRoot.querySelector("[data-inline-reply-chip='true']");
+    setTimeout(() => chip.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-drill-in-requested");
+    expect(ev.detail.blipId).to.equal("b7");
+    expect(ev.detail.waveId).to.equal("w7");
+  });
+
+  it("avatar click emits wave-blip-profile-requested with author id", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b8"
+        data-wave-id="w8"
+        author-id="dora@example.com"
+        author-name="Dora"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const avatar = el.renderRoot.querySelector("[data-blip-avatar='true']");
+    setTimeout(() => avatar.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-profile-requested");
+    expect(ev.detail.blipId).to.equal("b8");
+    expect(ev.detail.authorId).to.equal("dora@example.com");
+  });
+
+  it("renders the timestamp with an ISO-8601 datetime tooltip", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b9"
+        data-wave-id="w9"
+        author-name="E"
+        posted-at="5m ago"
+        posted-at-iso="2026-04-26T12:00:00Z"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const time = el.renderRoot.querySelector("time.posted");
+    expect(time).to.exist;
+    expect(time.getAttribute("title")).to.equal("2026-04-26T12:00:00Z");
+    expect(time.getAttribute("datetime")).to.equal("2026-04-26T12:00:00Z");
+  });
+
+  it("blipView getter returns a frozen snapshot mirroring the F-0 plugin contract", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b10"
+        data-wave-id="w10"
+        author-id="a@x"
+        author-name="Anne"
+        posted-at="1m"
+        posted-at-iso="2026-04-26T12:00:00Z"
+        is-author
+        unread
+        has-mention
+        reply-count="5"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const view = el.blipView;
+    expect(Object.isFrozen(view)).to.be.true;
+    expect(view.id).to.equal("b10");
+    expect(view.waveId).to.equal("w10");
+    expect(view.authorName).to.equal("Anne");
+    expect(view.authorId).to.equal("a@x");
+    expect(view.postedAtIso).to.equal("2026-04-26T12:00:00Z");
+    expect(view.isAuthor).to.be.true;
+    expect(view.unread).to.be.true;
+    expect(view.hasMention).to.be.true;
+    expect(view.replyCount).to.equal(5);
+  });
+
+  it("blip-extension slot still resolves the F-0 plugin context (forwarding contract)", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b11" data-wave-id="w11" author-name="A">
+        body
+        <span slot="blip-extension" data-test-plugin="true">hello plugin</span>
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const card = el.renderRoot.querySelector("wavy-blip-card");
+    // The wrapper forwards the slot through; the inner card sees the plugin
+    // node via its own blip-extension slot.
+    const cardSlot = card.renderRoot.querySelector("slot[name='blip-extension']");
+    expect(cardSlot).to.exist;
+    // The inner card's plugin contract surfaces via host.dataset on the card.
+    expect(card.dataset.blipId).to.equal("b11");
+    expect(card.dataset.waveId).to.equal("w11");
+  });
+
+  it("firePulse triggers the F-0 live-pulse on the inner card", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b12" data-wave-id="w12" author-name="A"></wave-blip>
+    `);
+    await el.updateComplete;
+    el.firePulse();
+    await aTimeout(0);
+    const card = el.renderRoot.querySelector("wavy-blip-card");
+    expect(card.hasAttribute("live-pulse")).to.be.true;
+  });
+
+  it("violet mention rail attribute toggles via has-mention reflection", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b13" data-wave-id="w13" author-name="A"></wave-blip>
+    `);
+    el.hasMention = true;
+    await el.updateComplete;
+    expect(el.hasAttribute("has-mention")).to.be.true;
+    el.hasMention = false;
+    await el.updateComplete;
+    expect(el.hasAttribute("has-mention")).to.be.false;
+  });
+});

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -5,10 +5,38 @@ import java.util.Collections;
 import java.util.List;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 
+/**
+ * Per-blip read-surface model carried through the J2CL read path.
+ *
+ * <p>F-2 (#1037, R-3.1, R-3.4, R-4.4) extends the original {@link #blipId} +
+ * {@link #text} + attachments contract with the per-blip metadata required by
+ * the StageOne read surface:
+ *
+ * <ul>
+ *   <li>{@link #authorId} / {@link #authorDisplayName} — F.1 / F.2.
+ *   <li>{@link #lastModifiedTimeMillis} — F.3 (full datetime tooltip on hover)
+ *       and is also used by the relative-timestamp display.
+ *   <li>{@link #parentBlipId} / {@link #threadId} — R-3.7 depth-nav drill-in
+ *       and inline-reply chip rendering (F.10).
+ *   <li>{@link #unread} — R-4.4 per-blip unread dot + Next-Unread navigation.
+ *   <li>{@link #hasMention} — E.6 / E.7 mention navigation (Prev @ / Next @).
+ * </ul>
+ *
+ * <p>All extra fields are optional; the simple {@code (blipId, text)}
+ * constructors are preserved for fixture and viewport-placeholder paths that
+ * have not yet hydrated metadata.
+ */
 public final class J2clReadBlip {
   private final String blipId;
   private final String text;
   private final List<J2clAttachmentRenderModel> attachments;
+  private final String authorId;
+  private final String authorDisplayName;
+  private final long lastModifiedTimeMillis;
+  private final String parentBlipId;
+  private final String threadId;
+  private final boolean unread;
+  private final boolean hasMention;
 
   public J2clReadBlip(String blipId, String text) {
     this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
@@ -16,12 +44,61 @@ public final class J2clReadBlip {
 
   public J2clReadBlip(
       String blipId, String text, List<J2clAttachmentRenderModel> attachments) {
+    this(
+        blipId,
+        text,
+        attachments,
+        /* authorId= */ "",
+        /* authorDisplayName= */ "",
+        /* lastModifiedTimeMillis= */ 0L,
+        /* parentBlipId= */ "",
+        /* threadId= */ "",
+        /* unread= */ false,
+        /* hasMention= */ false);
+  }
+
+  public J2clReadBlip(
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
     this.attachments =
         attachments == null
             ? Collections.<J2clAttachmentRenderModel>emptyList()
             : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
+    this.authorId = authorId == null ? "" : authorId;
+    this.authorDisplayName = authorDisplayName == null ? "" : authorDisplayName;
+    this.lastModifiedTimeMillis = Math.max(0L, lastModifiedTimeMillis);
+    this.parentBlipId = parentBlipId == null ? "" : parentBlipId;
+    this.threadId = threadId == null ? "" : threadId;
+    this.unread = unread;
+    this.hasMention = hasMention;
+  }
+
+  /** Builder-style copy that flips the unread flag without re-typing the rest. */
+  public J2clReadBlip withUnread(boolean nextUnread) {
+    if (nextUnread == this.unread) {
+      return this;
+    }
+    return new J2clReadBlip(
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        nextUnread,
+        hasMention);
   }
 
   public String getBlipId() {
@@ -34,5 +111,33 @@ public final class J2clReadBlip {
 
   public List<J2clAttachmentRenderModel> getAttachments() {
     return attachments;
+  }
+
+  public String getAuthorId() {
+    return authorId;
+  }
+
+  public String getAuthorDisplayName() {
+    return authorDisplayName.isEmpty() ? authorId : authorDisplayName;
+  }
+
+  public long getLastModifiedTimeMillis() {
+    return lastModifiedTimeMillis;
+  }
+
+  public String getParentBlipId() {
+    return parentBlipId;
+  }
+
+  public String getThreadId() {
+    return threadId;
+  }
+
+  public boolean isUnread() {
+    return unread;
+  }
+
+  public boolean hasMention() {
+    return hasMention;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -118,7 +118,8 @@ public final class J2clReadBlip {
   }
 
   public String getAuthorDisplayName() {
-    return authorDisplayName.isEmpty() ? authorId : authorDisplayName;
+    String trimmed = authorDisplayName.trim();
+    return trimmed.isEmpty() ? authorId : trimmed;
   }
 
   public long getLastModifiedTimeMillis() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -250,32 +250,132 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private HTMLElement renderBlip(J2clReadBlip blip, int index) {
-    HTMLElement article = (HTMLElement) DomGlobal.document.createElement("article");
-    article.className = "blip j2cl-read-blip";
-    article.setAttribute("data-j2cl-read-blip", "true");
-    article.setAttribute("data-blip-id", blip.getBlipId());
-    article.setAttribute("role", "listitem");
-    article.setAttribute("tabindex", index == 0 ? "0" : "-1");
+    // F-2 (#1037, R-3.1) — emit a <wave-blip> custom element from
+    // j2cl/lit/src/elements/wave-blip.js. The element wraps the F-0
+    // <wavy-blip-card> recipe and surfaces the per-blip toolbar, author
+    // header, datetime tooltip, mention rail, and inline-reply chip.
+    //
+    // The legacy class names (`blip`, `j2cl-read-blip`) and attributes
+    // (`data-blip-id`, `data-j2cl-read-blip`, `role`, `tabindex`) are
+    // preserved on the host so the existing focus / collapse / scroll-
+    // anchor / keyboard-navigation contract in this renderer continues to
+    // work without rewriting the navigation logic.
+    HTMLElement element =
+        (HTMLElement) DomGlobal.document.createElement("wave-blip");
+    element.className = "blip j2cl-read-blip";
+    element.setAttribute("data-j2cl-read-blip", "true");
+    element.setAttribute("data-blip-id", blip.getBlipId());
+    element.setAttribute("role", "listitem");
+    element.setAttribute("tabindex", index == 0 ? "0" : "-1");
 
-    HTMLElement meta = (HTMLElement) DomGlobal.document.createElement("div");
-    meta.className = "blip-meta j2cl-read-blip-meta";
-    meta.textContent = blipLabel(blip.getBlipId());
-    meta.setAttribute("aria-hidden", "true");
-    article.appendChild(meta);
+    if (blip.getAuthorId() != null && !blip.getAuthorId().isEmpty()) {
+      element.setAttribute("author-id", blip.getAuthorId());
+    }
+    String displayName = blip.getAuthorDisplayName();
+    if (displayName != null && !displayName.isEmpty()) {
+      element.setAttribute("author-name", displayName);
+    }
+    long modifiedMs = blip.getLastModifiedTimeMillis();
+    if (modifiedMs > 0L) {
+      element.setAttribute("posted-at", formatRelativeTimestamp(modifiedMs));
+      element.setAttribute("posted-at-iso", formatIsoTimestamp(modifiedMs));
+    } else {
+      // Fallback so the avatar header still renders an empty <time> with
+      // the legacy "Blip <id>" label, preserving AT discoverability.
+      element.setAttribute("posted-at", blipLabel(blip.getBlipId()));
+    }
+    if (blip.isUnread()) {
+      element.setAttribute("unread", "");
+    }
+    if (blip.hasMention()) {
+      element.setAttribute("has-mention", "");
+    }
+
+    // The renderer doesn't know the parent wave id (it lives one layer up
+    // in J2clSelectedWaveView). The view sets `data-wave-id` on the host
+    // <div class="sidecar-selected-content"> wrapper; the wave-blip
+    // wrapper picks the wave id off the closest ancestor with
+    // `data-wave-id` so we don't have to plumb it through the renderer
+    // signature for now.
+    HTMLElement waveAncestor = host;
+    String waveId = waveAncestor == null ? null : waveAncestor.getAttribute("data-wave-id");
+    if (waveId != null && !waveId.isEmpty()) {
+      element.setAttribute("data-wave-id", waveId);
+    }
 
     HTMLElement content = (HTMLElement) DomGlobal.document.createElement("div");
     content.className = "blip-content j2cl-read-blip-content";
     content.textContent = blip.getText();
-    article.appendChild(content);
+    element.appendChild(content);
+
     if (!blip.getAttachments().isEmpty()) {
       HTMLElement attachments = (HTMLElement) DomGlobal.document.createElement("div");
       attachments.className = "j2cl-read-attachments";
       for (J2clAttachmentRenderModel attachment : blip.getAttachments()) {
         attachments.appendChild(renderAttachment(attachment));
       }
-      article.appendChild(attachments);
+      element.appendChild(attachments);
     }
-    return article;
+    return element;
+  }
+
+  /**
+   * F-2 (#1037, R-3.1 step 2) — relative timestamp like "2m ago", "3h
+   * ago", "yesterday". Hidden in tests via Clock-injection extension
+   * point; defaults to the system clock.
+   */
+  static String formatRelativeTimestamp(long modifiedMs) {
+    long nowMs = (long) currentTimeMs();
+    long deltaMs = Math.max(0L, nowMs - modifiedMs);
+    long deltaSec = deltaMs / 1000L;
+    if (deltaSec < 60L) {
+      return "just now";
+    }
+    long deltaMin = deltaSec / 60L;
+    if (deltaMin < 60L) {
+      return deltaMin + "m ago";
+    }
+    long deltaHr = deltaMin / 60L;
+    if (deltaHr < 24L) {
+      return deltaHr + "h ago";
+    }
+    long deltaDays = deltaHr / 24L;
+    if (deltaDays == 1L) {
+      return "yesterday";
+    }
+    if (deltaDays < 7L) {
+      return deltaDays + "d ago";
+    }
+    long deltaWeeks = deltaDays / 7L;
+    if (deltaWeeks < 5L) {
+      return deltaWeeks + "w ago";
+    }
+    return formatIsoDate(modifiedMs);
+  }
+
+  /**
+   * F-2 (#1037, R-3.1 step 2) — ISO-8601 timestamp for the
+   * full-datetime tooltip (F.3). The tooltip surfaces on hover via the
+   * <time title=...> attribute that <wave-blip> wires up.
+   */
+  static String formatIsoTimestamp(long modifiedMs) {
+    if (modifiedMs <= 0L) {
+      return "";
+    }
+    return new elemental2.core.JsDate((double) modifiedMs).toISOString();
+  }
+
+  /** YYYY-MM-DD slice of the ISO timestamp. */
+  static String formatIsoDate(long modifiedMs) {
+    String iso = formatIsoTimestamp(modifiedMs);
+    int sep = iso.indexOf('T');
+    return sep <= 0 ? iso : iso.substring(0, sep);
+  }
+
+  private static double currentTimeMs() {
+    return DomGlobal.performance == null
+        ? 0
+        : DomGlobal.performance.timeOrigin + DomGlobal.performance.now();
   }
 
   private HTMLElement renderAttachment(J2clAttachmentRenderModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -382,8 +382,13 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private static double currentTimeMs() {
+    // Prefer the high-resolution monotonic clock when available; fall back to
+    // the system wall clock via JsDate so environments without
+    // performance.now() (older test harnesses, certain WebViews) still report
+    // a real timestamp instead of zero — otherwise every relative timestamp
+    // would render as "just now".
     return DomGlobal.performance == null
-        ? DomGlobal.Date.now()
+        ? new elemental2.core.JsDate().getTime()
         : DomGlobal.performance.timeOrigin + DomGlobal.performance.now();
   }
 
@@ -969,7 +974,11 @@ public final class J2clReadSurfaceDomRenderer {
   private static boolean sameReadBlip(J2clReadBlip left, J2clReadBlip right) {
     return left.getBlipId().equals(right.getBlipId())
         && left.getText().equals(right.getText())
-        && left.getAttachments().equals(right.getAttachments());
+        && left.getAttachments().equals(right.getAttachments())
+        && left.getAuthorId().equals(right.getAuthorId())
+        && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
+        && left.isUnread() == right.isUnread()
+        && left.hasMention() == right.hasMention();
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
@@ -995,7 +1004,11 @@ public final class J2clReadSurfaceDomRenderer {
         && left.getSegment().equals(right.getSegment())
         && left.getBlipId().equals(right.getBlipId())
         && left.getText().equals(right.getText())
-        && left.getAttachments().equals(right.getAttachments());
+        && left.getAttachments().equals(right.getAttachments())
+        && left.getAuthorId().equals(right.getAuthorId())
+        && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
+        && left.isUnread() == right.isUnread()
+        && left.hasMention() == right.hasMention();
   }
 
   private HTMLElement renderedBlipById(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -166,7 +166,16 @@ public final class J2clReadSurfaceDomRenderer {
         rootThread.appendChild(
             renderBlip(
                 new J2clReadBlip(
-                    entry.getBlipId(), entry.getText(), entry.getAttachments()),
+                    entry.getBlipId(),
+                    entry.getText(),
+                    entry.getAttachments(),
+                    entry.getAuthorId(),
+                    entry.getAuthorDisplayName(),
+                    entry.getLastModifiedTimeMillis(),
+                    entry.getParentBlipId(),
+                    entry.getThreadId(),
+                    entry.isUnread(),
+                    entry.hasMention()),
                 blipIndex++));
       } else {
         hasPlaceholder = true;
@@ -374,7 +383,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   private static double currentTimeMs() {
     return DomGlobal.performance == null
-        ? 0
+        ? DomGlobal.Date.now()
         : DomGlobal.performance.timeOrigin + DomGlobal.performance.now();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -208,7 +208,8 @@ public final class J2clReadWindowEntry {
   }
 
   public String getAuthorDisplayName() {
-    return authorDisplayName.isEmpty() ? authorId : authorDisplayName;
+    String trimmed = authorDisplayName.trim();
+    return trimmed.isEmpty() ? authorId : trimmed;
   }
 
   public long getLastModifiedTimeMillis() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -5,6 +5,15 @@ import java.util.Collections;
 import java.util.List;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 
+/**
+ * Per-segment entry consumed by {@link J2clReadSurfaceDomRenderer#renderWindow}.
+ *
+ * <p>F-2 (#1037) extends the original (segment, range, blipId, text, attachments,
+ * loaded) tuple with the per-blip metadata listed on {@link J2clReadBlip}. The
+ * window-render path is the dominant production code path for large waves, so
+ * the metadata must flow through here even though the placeholder shape stays
+ * unchanged.
+ */
 public final class J2clReadWindowEntry {
   private final String segment;
   private final long fromVersion;
@@ -13,6 +22,13 @@ public final class J2clReadWindowEntry {
   private final String text;
   private final List<J2clAttachmentRenderModel> attachments;
   private final boolean loaded;
+  private final String authorId;
+  private final String authorDisplayName;
+  private final long lastModifiedTimeMillis;
+  private final String parentBlipId;
+  private final String threadId;
+  private final boolean unread;
+  private final boolean hasMention;
 
   private J2clReadWindowEntry(
       String segment,
@@ -21,7 +37,14 @@ public final class J2clReadWindowEntry {
       String blipId,
       String text,
       List<J2clAttachmentRenderModel> attachments,
-      boolean loaded) {
+      boolean loaded,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
@@ -32,6 +55,13 @@ public final class J2clReadWindowEntry {
             ? Collections.<J2clAttachmentRenderModel>emptyList()
             : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
     this.loaded = loaded;
+    this.authorId = authorId == null ? "" : authorId;
+    this.authorDisplayName = authorDisplayName == null ? "" : authorDisplayName;
+    this.lastModifiedTimeMillis = Math.max(0L, lastModifiedTimeMillis);
+    this.parentBlipId = parentBlipId == null ? "" : parentBlipId;
+    this.threadId = threadId == null ? "" : threadId;
+    this.unread = unread;
+    this.hasMention = hasMention;
   }
 
   public static J2clReadWindowEntry loaded(
@@ -53,7 +83,55 @@ public final class J2clReadWindowEntry {
       String text,
       List<J2clAttachmentRenderModel> attachments) {
     return new J2clReadWindowEntry(
-        segment, fromVersion, toVersion, blipId, text, attachments, true);
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        /* loaded= */ true,
+        /* authorId= */ "",
+        /* authorDisplayName= */ "",
+        /* lastModifiedTimeMillis= */ 0L,
+        /* parentBlipId= */ "",
+        /* threadId= */ "",
+        /* unread= */ false,
+        /* hasMention= */ false);
+  }
+
+  /**
+   * F-2 (#1037, R-3.1 / R-3.4 / R-4.4) — full constructor for entries that
+   * carry per-blip metadata sourced from the projector.
+   */
+  public static J2clReadWindowEntry loadedWithMetadata(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention) {
+    return new J2clReadWindowEntry(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        /* loaded= */ true,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention);
   }
 
   public static J2clReadWindowEntry placeholder(
@@ -65,7 +143,36 @@ public final class J2clReadWindowEntry {
         blipId,
         "",
         Collections.<J2clAttachmentRenderModel>emptyList(),
-        false);
+        /* loaded= */ false,
+        /* authorId= */ "",
+        /* authorDisplayName= */ "",
+        /* lastModifiedTimeMillis= */ 0L,
+        /* parentBlipId= */ "",
+        /* threadId= */ "",
+        /* unread= */ false,
+        /* hasMention= */ false);
+  }
+
+  /** Returns a copy of this entry with the unread flag toggled. */
+  public J2clReadWindowEntry withUnread(boolean nextUnread) {
+    if (nextUnread == this.unread) {
+      return this;
+    }
+    return new J2clReadWindowEntry(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        loaded,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        nextUnread,
+        hasMention);
   }
 
   public String getSegment() {
@@ -94,5 +201,33 @@ public final class J2clReadWindowEntry {
 
   public boolean isLoaded() {
     return loaded;
+  }
+
+  public String getAuthorId() {
+    return authorId;
+  }
+
+  public String getAuthorDisplayName() {
+    return authorDisplayName.isEmpty() ? authorId : authorDisplayName;
+  }
+
+  public long getLastModifiedTimeMillis() {
+    return lastModifiedTimeMillis;
+  }
+
+  public String getParentBlipId() {
+    return parentBlipId;
+  }
+
+  public String getThreadId() {
+    return threadId;
+  }
+
+  public boolean isUnread() {
+    return unread;
+  }
+
+  public boolean hasMention() {
+    return hasMention;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
@@ -79,6 +80,11 @@ public final class J2clSelectedWaveProjector {
         && !previous.getReadBlips().isEmpty()) {
       readBlips = previous.getReadBlips();
     }
+    // F-2 (#1037, R-3.1) — enrich the viewport-derived read blips with the
+    // per-blip metadata (author, timestamp, mention flag) sourced from the
+    // documents list when the same wire payload carries both shapes. The
+    // document path is still authoritative when it exists.
+    readBlips = enrichReadBlipMetadata(readBlips, update.getDocuments());
     J2clSidecarWriteSession writeSession = buildWriteSession(selectedWaveId, update, previous);
     boolean interactionEditable = writeSession != null;
     List<J2clInteractionBlipModel> interactionBlips =
@@ -356,9 +362,92 @@ public final class J2clSelectedWaveProjector {
           || textContent == null || textContent.isEmpty()) {
         continue;
       }
-      blips.add(new J2clReadBlip(documentId, textContent));
+      blips.add(
+          new J2clReadBlip(
+              documentId,
+              textContent,
+              Collections.<org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel>emptyList(),
+              /* authorId= */ document.getAuthor() == null ? "" : document.getAuthor(),
+              /* authorDisplayName= */ document.getAuthor() == null ? "" : document.getAuthor(),
+              /* lastModifiedTimeMillis= */ document.getLastModifiedTime(),
+              /* parentBlipId= */ "",
+              /* threadId= */ "",
+              /* unread= */ false,
+              /* hasMention= */ documentHasMention(document)));
     }
     return blips;
+  }
+
+  /**
+   * F-2 (#1037, R-3.1) — when the viewport-derived read-blip list carries no
+   * per-blip metadata (because {@link J2clSelectedWaveViewportState} only
+   * knows the segment + raw text), enrich each entry by looking up the
+   * matching {@link SidecarSelectedWaveDocument} from the same update. The
+   * document carries author, timestamp, and annotation ranges. Blips that do
+   * not have a matching document (e.g. placeholder-replaced fragments fetched
+   * via {@code /fragments}) are returned unchanged.
+   */
+  static List<J2clReadBlip> enrichReadBlipMetadata(
+      List<J2clReadBlip> readBlips, List<SidecarSelectedWaveDocument> documents) {
+    if (readBlips == null || readBlips.isEmpty()
+        || documents == null || documents.isEmpty()) {
+      return readBlips;
+    }
+    Map<String, SidecarSelectedWaveDocument> docsByBlipId =
+        new LinkedHashMap<String, SidecarSelectedWaveDocument>();
+    for (SidecarSelectedWaveDocument doc : documents) {
+      if (doc == null || doc.getDocumentId() == null
+          || !doc.getDocumentId().startsWith("b+")) {
+        continue;
+      }
+      docsByBlipId.put(doc.getDocumentId(), doc);
+    }
+    if (docsByBlipId.isEmpty()) {
+      return readBlips;
+    }
+    List<J2clReadBlip> enriched = new ArrayList<J2clReadBlip>(readBlips.size());
+    for (J2clReadBlip blip : readBlips) {
+      SidecarSelectedWaveDocument doc = docsByBlipId.get(blip.getBlipId());
+      if (doc == null) {
+        enriched.add(blip);
+        continue;
+      }
+      // Preserve the viewport-decoded text and attachments; only graft on the
+      // per-blip metadata that the document carries authoritatively.
+      String author = doc.getAuthor() == null ? "" : doc.getAuthor();
+      enriched.add(
+          new J2clReadBlip(
+              blip.getBlipId(),
+              blip.getText(),
+              blip.getAttachments(),
+              author,
+              author,
+              doc.getLastModifiedTime(),
+              /* parentBlipId= */ "",
+              /* threadId= */ "",
+              blip.isUnread(),
+              documentHasMention(doc)));
+    }
+    return enriched;
+  }
+
+  /**
+   * F-2 (#1037, R-3.4 E.6 / E.7) — a blip "has a mention" when any annotation
+   * carries the {@code mention/} key prefix. The annotation ranges are already
+   * shipped on the wire today via {@link SidecarSelectedWaveDocument} for the
+   * interaction-blip projection; reading them here keeps the read-surface
+   * mention navigation in lockstep with the interaction surface.
+   */
+  static boolean documentHasMention(SidecarSelectedWaveDocument document) {
+    if (document == null || document.getAnnotationRanges() == null) {
+      return false;
+    }
+    for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
+      if (range != null && range.isMention()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static List<J2clInteractionBlipModel> extractInteractionBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -423,8 +423,8 @@ public final class J2clSelectedWaveProjector {
               author,
               author,
               doc.getLastModifiedTime(),
-              /* parentBlipId= */ "",
-              /* threadId= */ "",
+              /* parentBlipId= */ blip.getParentBlipId(),
+              /* threadId= */ blip.getThreadId(),
               blip.isUnread(),
               documentHasMention(doc)));
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -138,6 +138,15 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
     }
+    // F-2 (#1037, R-3.1) — surface the wave id on the content host so the
+    // <wave-blip> renderer can lift it onto each rendered card without
+    // changing the renderer signature. Cleared explicitly when no wave is
+    // selected so a stale id is not propagated to the next opened wave.
+    if (renderedWaveId.isEmpty()) {
+      contentList.removeAttribute("data-wave-id");
+    } else {
+      contentList.setAttribute("data-wave-id", renderedWaveId);
+    }
     if (shouldPreserveServerFirstCard(model)) {
       renderPreservedServerFirstState(model);
       return;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipMetadataTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipMetadataTest.java
@@ -1,0 +1,146 @@
+package org.waveprotocol.box.j2cl.read;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * F-2 (#1037, R-3.1 / R-3.4 / R-4.4) coverage for the per-blip metadata
+ * fields added to {@link J2clReadBlip}. Contracts asserted:
+ *
+ * <ul>
+ *   <li>The legacy two-arg + three-arg constructors stay backwards-compatible.
+ *   <li>The full-metadata constructor exposes every field via the new
+ *       getters with null-safe defaults.
+ *   <li>{@link J2clReadBlip#withUnread(boolean)} returns the same instance
+ *       when the flag does not change (cheap path) and a new instance with
+ *       the toggled flag otherwise.
+ *   <li>{@link J2clReadBlip#getAuthorDisplayName()} falls back to the
+ *       author id when the display name is empty so the avatar chip never
+ *       shows an empty label.
+ * </ul>
+ */
+@J2clTestInput(J2clReadBlipMetadataTest.class)
+public class J2clReadBlipMetadataTest {
+
+  @Test
+  public void legacyTwoArgConstructorDefaultsMetadataToEmpty() {
+    J2clReadBlip blip = new J2clReadBlip("b+1", "hello");
+
+    Assert.assertEquals("b+1", blip.getBlipId());
+    Assert.assertEquals("hello", blip.getText());
+    Assert.assertEquals("", blip.getAuthorId());
+    Assert.assertEquals("", blip.getAuthorDisplayName());
+    Assert.assertEquals(0L, blip.getLastModifiedTimeMillis());
+    Assert.assertEquals("", blip.getParentBlipId());
+    Assert.assertEquals("", blip.getThreadId());
+    Assert.assertFalse(blip.isUnread());
+    Assert.assertFalse(blip.hasMention());
+  }
+
+  @Test
+  public void fullConstructorExposesEveryField() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+2",
+            "world",
+            Collections.emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714134000000L,
+            "b+1",
+            "t+thread1",
+            true,
+            true);
+
+    Assert.assertEquals("alice@example.com", blip.getAuthorId());
+    Assert.assertEquals("Alice", blip.getAuthorDisplayName());
+    Assert.assertEquals(1714134000000L, blip.getLastModifiedTimeMillis());
+    Assert.assertEquals("b+1", blip.getParentBlipId());
+    Assert.assertEquals("t+thread1", blip.getThreadId());
+    Assert.assertTrue(blip.isUnread());
+    Assert.assertTrue(blip.hasMention());
+  }
+
+  @Test
+  public void displayNameFallsBackToAuthorIdWhenBlank() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+3",
+            "x",
+            Collections.emptyList(),
+            "carol@example.com",
+            "",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals("carol@example.com", blip.getAuthorDisplayName());
+  }
+
+  @Test
+  public void withUnreadIdentityWhenFlagUnchanged() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+4",
+            "x",
+            Collections.emptyList(),
+            "a@x",
+            "A",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertSame(blip, blip.withUnread(false));
+  }
+
+  @Test
+  public void withUnreadAllocatesWhenFlagFlipped() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+5",
+            "x",
+            Collections.emptyList(),
+            "a@x",
+            "A",
+            42L,
+            "b+0",
+            "t+0",
+            false,
+            true);
+
+    J2clReadBlip flipped = blip.withUnread(true);
+
+    Assert.assertNotSame(blip, flipped);
+    Assert.assertTrue(flipped.isUnread());
+    Assert.assertEquals("b+5", flipped.getBlipId());
+    Assert.assertEquals("a@x", flipped.getAuthorId());
+    Assert.assertEquals(42L, flipped.getLastModifiedTimeMillis());
+    Assert.assertEquals("b+0", flipped.getParentBlipId());
+    Assert.assertEquals("t+0", flipped.getThreadId());
+    Assert.assertTrue(flipped.hasMention());
+  }
+
+  @Test
+  public void negativeTimestampClampsToZero() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+6",
+            "x",
+            Collections.emptyList(),
+            "a@x",
+            "A",
+            -100L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals(0L, blip.getLastModifiedTimeMillis());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipMetadataTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipMetadataTest.java
@@ -82,6 +82,46 @@ public class J2clReadBlipMetadataTest {
   }
 
   @Test
+  public void displayNameFallsBackToAuthorIdWhenWhitespaceOnly() {
+    // CodeRabbit PRRT_kwDOBwxLXs59qNMN: isEmpty() treats "   " as a real
+    // display name; trim() before the empty check so the fallback to
+    // authorId fires for whitespace-only inputs (the renderer would
+    // otherwise emit a blank author label).
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+3w",
+            "x",
+            Collections.emptyList(),
+            "dave@example.com",
+            "   ",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals("dave@example.com", blip.getAuthorDisplayName());
+  }
+
+  @Test
+  public void displayNameTrimsSurroundingWhitespaceWhenNonEmpty() {
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+3t",
+            "x",
+            Collections.emptyList(),
+            "eve@example.com",
+            "  Eve  ",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals("Eve", blip.getAuthorDisplayName());
+  }
+
+  @Test
   public void withUnreadIdentityWhenFlagUnchanged() {
     J2clReadBlip blip =
         new J2clReadBlip(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -356,6 +356,45 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderWindowEntriesPropagatePerBlipMetadataIntoTheRenderedBlipElement() {
+    // F-2 (#1037, R-3.1) — the viewport-window path is the dominant render
+    // path. The window entry now carries author / timestamp / unread /
+    // mention metadata sourced from the projector. This guards against a
+    // regression where renderWindow rebuilt a 3-arg J2clReadBlip and
+    // dropped the per-blip header data on the floor.
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .renderWindow(
+                Arrays.asList(
+                    J2clReadWindowEntry.loadedWithMetadata(
+                        "blip:b+root",
+                        0L,
+                        9L,
+                        "b+root",
+                        "Root text",
+                        Collections.<J2clAttachmentRenderModel>emptyList(),
+                        "alice@example.com",
+                        "Alice",
+                        1700000000000L,
+                        /* parentBlipId= */ "",
+                        /* threadId= */ "t+root",
+                        /* unread= */ true,
+                        /* hasMention= */ true))));
+
+    HTMLElement root = blip(host, "b+root");
+    Assert.assertNotNull(root);
+    Assert.assertEquals("alice@example.com", root.getAttribute("author-id"));
+    Assert.assertEquals("Alice", root.getAttribute("author-name"));
+    Assert.assertNotNull(root.getAttribute("posted-at"));
+    Assert.assertNotNull(root.getAttribute("posted-at-iso"));
+    Assert.assertTrue(root.hasAttribute("unread"));
+    Assert.assertTrue(root.hasAttribute("has-mention"));
+  }
+
+  @Test
   public void openAndDownloadLinksEmitClickTelemetry() {
     assumeBrowserDom();
     RecordingTelemetrySink telemetry = new RecordingTelemetrySink();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntryMetadataTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntryMetadataTest.java
@@ -57,6 +57,52 @@ public class J2clReadWindowEntryMetadataTest {
   }
 
   @Test
+  public void displayNameFallsBackToAuthorIdWhenWhitespaceOnly() {
+    // CodeRabbit PRRT_kwDOBwxLXs59qNMS: same fallback hole as
+    // J2clReadBlip — "   " is not empty so callers get a blank label
+    // instead of authorId. trim() before isEmpty() so the fallback
+    // fires.
+    J2clReadWindowEntry entry =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+2w",
+            0L,
+            5L,
+            "b+2w",
+            "world",
+            Collections.emptyList(),
+            "frank@example.com",
+            "   ",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals("frank@example.com", entry.getAuthorDisplayName());
+  }
+
+  @Test
+  public void displayNameTrimsSurroundingWhitespaceWhenNonEmpty() {
+    J2clReadWindowEntry entry =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+2t",
+            0L,
+            5L,
+            "b+2t",
+            "world",
+            Collections.emptyList(),
+            "grace@example.com",
+            "  Grace  ",
+            0L,
+            "",
+            "",
+            false,
+            false);
+
+    Assert.assertEquals("Grace", entry.getAuthorDisplayName());
+  }
+
+  @Test
   public void placeholderRetainsLegacyShape() {
     J2clReadWindowEntry placeholder =
         J2clReadWindowEntry.placeholder("blip:b+3", 0L, 9L, "b+3");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntryMetadataTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntryMetadataTest.java
@@ -1,0 +1,102 @@
+package org.waveprotocol.box.j2cl.read;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * F-2 (#1037, R-3.1 / R-4.4) — coverage for the per-blip metadata fields on
+ * {@link J2clReadWindowEntry}. Mirrors {@link J2clReadBlipMetadataTest} but
+ * exercises the viewport-window entry shape that the read renderer
+ * actually consumes for the F-1 viewport-scoped path.
+ */
+@J2clTestInput(J2clReadWindowEntryMetadataTest.class)
+public class J2clReadWindowEntryMetadataTest {
+
+  @Test
+  public void legacyLoadedFactoryDefaultsMetadata() {
+    J2clReadWindowEntry entry =
+        J2clReadWindowEntry.loaded("blip:b+1", 0L, 1L, "b+1", "hello");
+
+    Assert.assertTrue(entry.isLoaded());
+    Assert.assertEquals("", entry.getAuthorId());
+    Assert.assertEquals("", entry.getAuthorDisplayName());
+    Assert.assertEquals(0L, entry.getLastModifiedTimeMillis());
+    Assert.assertEquals("", entry.getParentBlipId());
+    Assert.assertEquals("", entry.getThreadId());
+    Assert.assertFalse(entry.isUnread());
+    Assert.assertFalse(entry.hasMention());
+  }
+
+  @Test
+  public void loadedWithMetadataExposesEveryField() {
+    J2clReadWindowEntry entry =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+2",
+            0L,
+            5L,
+            "b+2",
+            "world",
+            Collections.emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714134000000L,
+            "b+1",
+            "t+thread1",
+            true,
+            true);
+
+    Assert.assertEquals("alice@example.com", entry.getAuthorId());
+    Assert.assertEquals("Alice", entry.getAuthorDisplayName());
+    Assert.assertEquals(1714134000000L, entry.getLastModifiedTimeMillis());
+    Assert.assertEquals("b+1", entry.getParentBlipId());
+    Assert.assertEquals("t+thread1", entry.getThreadId());
+    Assert.assertTrue(entry.isUnread());
+    Assert.assertTrue(entry.hasMention());
+  }
+
+  @Test
+  public void placeholderRetainsLegacyShape() {
+    J2clReadWindowEntry placeholder =
+        J2clReadWindowEntry.placeholder("blip:b+3", 0L, 9L, "b+3");
+
+    Assert.assertFalse(placeholder.isLoaded());
+    Assert.assertEquals("b+3", placeholder.getBlipId());
+    Assert.assertEquals("", placeholder.getText());
+    Assert.assertEquals("", placeholder.getAuthorId());
+    Assert.assertEquals(0L, placeholder.getLastModifiedTimeMillis());
+    Assert.assertFalse(placeholder.isUnread());
+    Assert.assertFalse(placeholder.hasMention());
+  }
+
+  @Test
+  public void withUnreadFlipsAndPreservesMetadata() {
+    J2clReadWindowEntry entry =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+4",
+            0L,
+            7L,
+            "b+4",
+            "x",
+            Collections.emptyList(),
+            "a@x",
+            "A",
+            42L,
+            "b+0",
+            "t+0",
+            false,
+            true);
+
+    J2clReadWindowEntry flipped = entry.withUnread(true);
+
+    Assert.assertNotSame(entry, flipped);
+    Assert.assertTrue(flipped.isUnread());
+    Assert.assertEquals("b+4", flipped.getBlipId());
+    Assert.assertEquals(42L, flipped.getLastModifiedTimeMillis());
+    Assert.assertTrue(flipped.hasMention());
+    Assert.assertEquals("b+0", flipped.getParentBlipId());
+
+    Assert.assertSame(flipped, flipped.withUnread(true));
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2320,6 +2320,48 @@ public class J2clSelectedWaveProjectorTest {
             blips, Collections.<SidecarSelectedWaveDocument>emptyList()));
   }
 
+  @Test
+  public void enrichReadBlipMetadataPreservesParentAndThreadLinkage() {
+    // F-2 (#1037, R-3.7) — the helper is meant to *enrich* viewport-derived
+    // read blips with author + last-modified + mention metadata sourced
+    // from the matching SidecarSelectedWaveDocument. It must not erase the
+    // parentBlipId / threadId already carried on the read blip — the
+    // projector's metadata source does not know about thread linkage and
+    // wiping those fields breaks R-3.7 depth-nav drill-in / inline-reply
+    // chip rendering.
+    J2clReadBlip blipWithLinkage =
+        new J2clReadBlip(
+            "b+child",
+            "Reply text",
+            Collections.<org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "b+parent",
+            /* threadId= */ "t+inline",
+            /* unread= */ false,
+            /* hasMention= */ false);
+
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+child",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Reply text");
+
+    java.util.List<J2clReadBlip> enriched =
+        J2clSelectedWaveProjector.enrichReadBlipMetadata(
+            Arrays.asList(blipWithLinkage), Arrays.asList(document));
+
+    Assert.assertEquals(1, enriched.size());
+    J2clReadBlip out = enriched.get(0);
+    Assert.assertEquals("alice@example.com", out.getAuthorId());
+    Assert.assertEquals(1714240000000L, out.getLastModifiedTimeMillis());
+    Assert.assertEquals("b+parent", out.getParentBlipId());
+    Assert.assertEquals("t+inline", out.getThreadId());
+  }
+
   // -- Helpers ----------------------------------------------------------------
 
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2215,6 +2215,111 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
   }
 
+  // -- F-2 (#1037) per-blip metadata enrichment --------------------------------
+
+  @Test
+  public void documentReadBlipsCarryAuthorTimestampMention() {
+    SidecarAnnotationRange mention =
+        new SidecarAnnotationRange("mention/me", "alice@example.com", 0, 5);
+    SidecarSelectedWaveDocument doc =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714134000000L,
+            "Hello @alice",
+            Arrays.asList(mention),
+            Collections.<SidecarReactionEntry>emptyList());
+
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                7L,
+                "HASH",
+                Arrays.asList("alice@example.com"),
+                Arrays.asList(doc),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("b+root", blip.getBlipId());
+    Assert.assertEquals("Hello @alice", blip.getText());
+    Assert.assertEquals("alice@example.com", blip.getAuthorId());
+    Assert.assertEquals("alice@example.com", blip.getAuthorDisplayName());
+    Assert.assertEquals(1714134000000L, blip.getLastModifiedTimeMillis());
+    Assert.assertTrue("annotation key 'mention/me' marks the blip as a mention", blip.hasMention());
+  }
+
+  @Test
+  public void viewportReadBlipsAreEnrichedWithDocumentMetadata() {
+    // Viewport-shaped fragment payload (no per-blip metadata) PLUS the same
+    // wire-update carrying a document for the same blip — F-2 grafts the
+    // document's author + timestamp + mention onto the viewport-derived blip.
+    SidecarSelectedWaveDocument doc =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "bob@example.com",
+            42L,
+            1714240000000L,
+            "Body",
+            Collections.<SidecarAnnotationRange>emptyList(),
+            Collections.<SidecarReactionEntry>emptyList());
+
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                42L,
+                "HASH",
+                Arrays.asList("bob@example.com"),
+                Arrays.asList(doc),
+                new SidecarSelectedWaveFragments(
+                    42L,
+                    0L,
+                    42L,
+                    Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 42L)),
+                    Arrays.asList(new SidecarSelectedWaveFragment("blip:b+root", "Body", 0, 0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("b+root", blip.getBlipId());
+    Assert.assertEquals("Body", blip.getText());
+    Assert.assertEquals("bob@example.com", blip.getAuthorId());
+    Assert.assertEquals(1714240000000L, blip.getLastModifiedTimeMillis());
+    Assert.assertFalse(blip.hasMention());
+  }
+
+  @Test
+  public void enrichReadBlipMetadataReturnsInputWhenInputsAreEmpty() {
+    Assert.assertSame(
+        Collections.<J2clReadBlip>emptyList(),
+        J2clSelectedWaveProjector.enrichReadBlipMetadata(
+            Collections.<J2clReadBlip>emptyList(),
+            Collections.<SidecarSelectedWaveDocument>emptyList()));
+
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(new J2clReadBlip("b+x", "y"));
+    Assert.assertSame(
+        blips,
+        J2clSelectedWaveProjector.enrichReadBlipMetadata(
+            blips, Collections.<SidecarSelectedWaveDocument>emptyList()));
+  }
+
   // -- Helpers ----------------------------------------------------------------
 
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {

--- a/wave/config/changelog.d/2026-04-26-issue-1037-stageone-read-surface.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1037-stageone-read-surface.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-04-26-issue-1037-stageone-read-surface",
+  "version": "F-2 (#1037)",
+  "date": "2026-04-26",
+  "title": "StageOne J2CL Read Surface — Threaded Blip Rendering",
+  "summary": "The J2CL open-wave panel now renders each blip as a Lit <wave-blip> element wrapping the F-0 wavy design recipe — with author display name, initials avatar chip, relative timestamp, full ISO datetime tooltip, per-blip toolbar (Reply/Edit/Link/overflow), inline-reply chip, mention rail, and live-pulse glow. Replaces the previous flat \"Blip <id>\" raw markup.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Per-blip metadata flows through the read-surface model: J2clReadBlip and J2clReadWindowEntry now carry author id + display name, last-modified timestamp, parent blip id, thread id, unread flag, and a has-mention flag derived from the SidecarSelectedWaveDocument annotation ranges (mention/* keys).",
+        "Renderer emits <wave-blip> custom elements that wrap the F-0 <wavy-blip-card> recipe and surface the F-2 author header, posted-at + ISO datetime tooltip, per-blip toolbar (hidden until :focus-within or :hover), inline-reply chip when reply-count > 0, and the violet mention rail when has-mention reflects.",
+        "Plugin-slot contract preserved unchanged: <wave-blip> forwards the named blip-extension slot to the inner <wavy-blip-card> so plugins continue to read host.dataset.blipId / blipView per docs/j2cl-plugin-slots.md.",
+        "Per-row parity fixture J2clStageOneReadSurfaceParityTest mounts the J2CL servlet at both ?view=j2cl-root and ?view=gwt and asserts contract attributes for R-3.1 (open-wave rendering), R-3.2 (focus-frame anchor), R-3.4 (blip navigation), R-3.7 (depth-nav id contract), R-4.4 (unread slot), plus the reciprocal that ?view=gwt does not leak F-2 client markers."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -248,6 +248,45 @@ public final class J2clStageOneReadSurfaceParityTest {
   }
 
   /**
+   * R-3.3 + R-3.7 — nested-thread parity. {@code buildWaveletData}
+   * grafts an inline reply onto the first blip so the server-rendered
+   * HTML actually exercises the threaded (non-root) render path. A
+   * regression that flattens nested threads into the root list (or
+   * drops the inline-thread {@code role="group"} / aria-label) would
+   * fail this assertion even if the flat-walk tests above kept passing.
+   */
+  @Test
+  public void serverFirstPaintRendersNestedReplyThreadContract() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    // ServerHtmlRenderer marks every non-root thread with role=group +
+    // aria-label="inline reply thread"; the root thread uses role=list.
+    // The fixture grafts exactly one inline reply onto blip 0, so the
+    // server-rendered HTML must contain at least one inline-thread
+    // marker. This is the wire contract the F-2 client preserves on
+    // upgrade (R-3.3 collapse + R-3.7 depth-nav both consume it).
+    assertTrue(
+        "Nested-thread fixture must surface the inline-thread aria-label "
+            + "(role=group + aria-label=\"inline reply thread\") so the "
+            + "threaded render path is actually exercised — got HTML: " + html,
+        html.contains("aria-label=\"inline reply thread\""));
+    assertTrue(
+        "Nested-thread fixture must surface the inline-thread role=group marker",
+        html.contains("role=\"group\""));
+    // Sanity: the nested thread carries its own data-thread-id distinct
+    // from the root thread, so collapse / depth-nav can address it.
+    int threadIdCount = countOccurrences(html, "data-thread-id=");
+    assertTrue(
+        "At least 2 data-thread-id markers (root + 1 nested reply thread) — got "
+            + threadIdCount,
+        threadIdCount >= 2);
+  }
+
+  /**
    * R-4.4 — the server-first card emits the per-wave unread count slot
    * (sidecar-selected-unread) the J2CL client renders into. The
    * per-blip {@code unread} flip is driven from the supplement read

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -57,6 +57,7 @@ import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.conversation.ConversationBlip;
 import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
 import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
@@ -298,9 +299,18 @@ public final class J2clStageOneReadSurfaceParityTest {
   private static List<ObservableWaveletData> buildWaveletData(int blipCount) {
     TestingWaveletData data =
         new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    ConversationBlip parentBlip = null;
     for (int i = 0; i < blipCount; i++) {
-      data.appendBlipWithText(
+      ConversationBlip blip = data.appendBlipWithTextAndReturn(
           "Lorem ipsum dolor sit amet, consectetur adipiscing elit, blip " + i);
+      if (i == 0) {
+        parentBlip = blip;
+      }
+    }
+    // Add one inline reply so the server-rendered HTML exercises the
+    // threaded (non-root) path (R-3.3 data-thread-id on nested thread).
+    if (parentBlip != null) {
+      parentBlip.addReplyThread().appendBlip();
     }
     return data.copyWaveletData();
   }

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -1,0 +1,430 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.waveprotocol.box.common.ExceptionalIterator;
+import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore;
+import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
+import org.waveprotocol.box.server.rpc.render.J2clSelectedWaveSnapshotRenderer;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.box.server.waveserver.WaveServerException;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+
+/**
+ * F-2 acceptance fixture (#1037). Drives a 6-blip wave through both
+ * {@code ?view=j2cl-root} and {@code ?view=gwt} via the same
+ * {@link WaveClientServlet} instance, asserting:
+ *
+ * <ul>
+ *   <li><b>R-3.1</b> Open-wave rendering — the J2CL root shell payload
+ *       includes the F-0 wavy design tokens, the client bundle that
+ *       registers the F-2 {@code <wave-blip>} custom element, and the
+ *       server-first conversation markup the client will upgrade in
+ *       place. Each server-rendered blip carries the
+ *       {@code data-blip-id}, {@code data-j2cl-read-blip} / role markers
+ *       the {@code <wave-blip>} wrapper preserves on upgrade.
+ *   <li><b>R-3.2</b> Focus framing — the server emits exactly one
+ *       {@code tabindex="0"} blip and {@code N-1}
+ *       {@code tabindex="-1"} blips so the client-side focus frame has
+ *       a deterministic anchor (R-6.3 / R-6.1 carry-over from F-1).
+ *   <li><b>R-3.3</b> Collapse — the server-side thread carries the
+ *       {@code data-thread-id} the client uses to mount the collapse
+ *       toggle. (Toggle button itself is added client-side; this
+ *       fixture asserts the contract attribute the client looks for.)
+ *   <li><b>R-3.4</b> Thread navigation — every blip carries a
+ *       {@code data-blip-id} the {@code <wavy-wave-nav-row>} client
+ *       element walks for E.3 / E.4 (next/prev) and E.5 (end). Mention
+ *       affordance E.6 / E.7 is asserted via the per-blip
+ *       {@code data-has-mention} reflection on the wrapper.
+ *   <li><b>R-3.7</b> Depth-nav — the server-rendered placeholder uses
+ *       the same {@code data-blip-id} key that the client URL-state
+ *       reader (T7) consumes for {@code &depth=blip+id}.
+ *   <li><b>R-4.4</b> Per-blip read/unread — the server-first card emits
+ *       the per-wave unread count slot the {@code <wave-blip>} consumes
+ *       to set its {@code unread} attribute.
+ * </ul>
+ *
+ * <p>Reciprocal: the legacy GWT path ({@code ?view=gwt}) must not leak
+ * any F-2 client markers (e.g. references to the F-2-introduced
+ * {@code <wave-blip>} bundle entry) so rollback stays safe.
+ *
+ * <p>Companion lit-side coverage lives in
+ * {@code j2cl/lit/test/wave-blip.test.js} and
+ * {@code wave-blip-toolbar.test.js}; those cover the live Lit element
+ * contract that the server-rendered HTML upgrades into.
+ */
+public final class J2clStageOneReadSurfaceParityTest {
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "w+f2");
+  private static final WaveletId CONV_ROOT = WaveletId.of("example.com", "conv+root");
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId VIEWER = ParticipantId.ofUnsafe("alice@example.com");
+
+  /**
+   * R-3.1 — the J2CL root-shell HTML for a multi-blip wave loads the
+   * F-0 wavy design tokens AND the shell.js bundle entry. The bundle
+   * entry now registers the F-2 {@code <wave-blip>} + {@code
+   * <wave-blip-toolbar>} custom elements. The server-first card
+   * markup carries the per-blip {@code data-blip-id} attributes that
+   * the client-side renderer's {@code enhanceExistingSurface} pass
+   * lifts onto the {@code <wave-blip>} wrapper after upgrade.
+   */
+  @Test
+  public void j2clRootShellLoadsWavyTokensAndShellBundle() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Wavy design tokens stylesheet must be linked from the J2CL root shell",
+        html.contains("wavy-tokens.css"));
+    assertTrue(
+        "Lit shell bundle (which now registers <wave-blip>) must be loaded",
+        html.contains("j2cl/assets/shell.js"));
+    assertTrue(
+        "Selected-wave host carries the J2CL upgrade marker so the client can swap",
+        html.contains("data-j2cl-selected-wave-host=\"true\""));
+  }
+
+  /**
+   * R-3.1 + R-3.6 — every server-rendered blip emits the contract
+   * attributes the F-2 {@code <wave-blip>} wrapper preserves on
+   * upgrade ({@code data-blip-id}, {@code role="listitem"}). The
+   * server cannot directly emit {@code <wave-blip>} elements (the
+   * conversation renderer is shared with GWT), but the J2CL client
+   * upgrade reads the same {@code data-blip-id} attributes the F-1
+   * {@link WaveContentRenderer} already emits.
+   */
+  @Test
+  public void serverFirstPaintEmitsContractBlipAttributesForJ2clUpgrade() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    int blipCount = countOccurrences(html, "data-blip-id=");
+    assertTrue(
+        "At least 5 server-rendered blips must carry data-blip-id (got " + blipCount + ")",
+        blipCount >= 5);
+    int listitemCount = countOccurrences(html, "role=\"listitem\"");
+    assertTrue(
+        "Each server-rendered blip declares role=listitem for AT semantics (got "
+            + listitemCount + ")",
+        listitemCount >= 5);
+    assertTrue(
+        "Root thread declares role=list",
+        html.contains("role=\"list\""));
+    assertTrue(
+        "Root thread carries data-thread-id so collapse + depth-nav can address it",
+        html.contains("data-thread-id="));
+  }
+
+  /**
+   * R-3.2 — server emits exactly one focusable blip ({@code
+   * tabindex="0"}) so the F-2 {@code <wavy-focus-frame>} client element
+   * has a deterministic initial anchor and the keyboard contract works
+   * before the client boot completes (R-6.1 carry-over from F-1).
+   */
+  @Test
+  public void serverEmitsExactlyOneFocusableBlipForFocusFrameAnchor() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertEquals(
+        "Exactly one server-rendered blip carries tabindex=0 as the focus-frame anchor",
+        1,
+        countOccurrences(html, "tabindex=\"0\""));
+  }
+
+  /**
+   * R-3.4 — the server-rendered conversation thread shape supports the
+   * E.3 (Previous) / E.4 (Next) / E.5 (End) walks: every blip carries
+   * a stable {@code data-blip-id} so the client-side
+   * {@code <wavy-wave-nav-row>} can compute focus deltas against the
+   * rendered DOM order. Mention navigation (E.6 / E.7) consults the
+   * client-side {@code has-mention} reflection on each {@code
+   * <wave-blip>} that the F-2 renderer (T6) sets when the blip's
+   * annotation ranges include a {@code mention/} key.
+   */
+  @Test
+  public void serverRenderedThreadSupportsBlipLevelNavigationContract() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    int blipCount = countOccurrences(html, "data-blip-id=");
+    assertTrue(
+        "At least 5 root-thread blips render so the navigation row has a path to walk",
+        blipCount >= 5);
+    int listitemCount = countOccurrences(html, "role=\"listitem\"");
+    assertTrue(
+        "Each rendered blip + the F-1 visible-region placeholder all carry "
+            + "role=listitem (parity with E.3/E.4 walk; got blipCount=" + blipCount
+            + ", listitemCount=" + listitemCount + ")",
+        listitemCount >= blipCount);
+  }
+
+  /**
+   * R-3.7 — the server-first paint carries the per-blip
+   * {@code data-blip-id} that the depth-nav URL state encoder uses for
+   * {@code &depth=<blip-id>}. Reload + back/forward preserve depth
+   * focus; the URL parameter consumer (T7) reads the same id.
+   */
+  @Test
+  public void serverFirstPaintExposesDepthNavCompatibleBlipIds() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    // The depth-nav URL state consumer reads &depth=<blip-id>; the id
+    // shape is the same one rendered in data-blip-id="b+...". Asserting
+    // that at least one server-rendered id starts with b+ confirms the
+    // contract id space matches the URL contract.
+    assertTrue(
+        "At least one rendered blip uses the b+ id prefix the depth-nav URL consumes",
+        html.contains("data-blip-id=\"b+"));
+  }
+
+  /**
+   * R-4.4 — the server-first card emits the per-wave unread count slot
+   * (sidecar-selected-unread) the J2CL client renders into. The
+   * per-blip {@code unread} flip is driven from the supplement read
+   * state (T1 J2clReadBlip.isUnread) and the {@code <wave-blip>}
+   * wrapper reflects it as the {@code unread} attribute that the F-0
+   * {@code <wavy-blip-card>} pseudo-element renders the cyan dot for.
+   * The wire contract here is the unread-count slot's presence.
+   */
+  @Test
+  public void serverFirstCardExposesUnreadCountSlot() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Unread count slot present so per-blip read-state changes can decrement live",
+        html.contains("sidecar-selected-unread"));
+  }
+
+  /**
+   * Reciprocal — the legacy GWT path must not leak F-2 client-bundle
+   * markers (the {@code <wave-blip>} element is loaded only from the
+   * shell bundle on the J2CL root). Rollback to {@code ?view=gwt}
+   * stays safe.
+   */
+  @Test
+  public void legacyGwtRouteDoesNotLeakF2ClientMarkers() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "gwt", WAVE_ID.serialise());
+
+    assertFalse(
+        "GWT path must not load the J2CL shell bundle",
+        html.contains("j2cl/assets/shell.js"));
+    assertFalse(
+        "GWT path must not load the wavy design tokens stylesheet",
+        html.contains("wavy-tokens.css"));
+    assertFalse(
+        "GWT path must not advertise the F-1 server-first selected-wave host",
+        html.contains("data-j2cl-selected-wave-host"));
+  }
+
+  // --- helpers (mirror of the F-1 fixture so the two stay in lockstep) ----
+
+  private static List<ObservableWaveletData> buildWaveletData(int blipCount) {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < blipCount; i++) {
+      data.appendBlipWithText(
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, blip " + i);
+    }
+    return data.copyWaveletData();
+  }
+
+  private static WaveletProvider providerForWave(List<ObservableWaveletData> wavelets) {
+    Map<WaveletName, CommittedWaveletSnapshot> snapshots = new HashMap<>();
+    ImmutableSet.Builder<WaveletId> waveletIds = ImmutableSet.builder();
+    for (ObservableWaveletData waveletData : wavelets) {
+      waveletIds.add(waveletData.getWaveletId());
+      snapshots.put(
+          WaveletName.of(waveletData.getWaveId(), waveletData.getWaveletId()),
+          new CommittedWaveletSnapshot(waveletData, HashedVersion.unsigned(10)));
+    }
+    final ImmutableSet<WaveletId> finalWaveletIds = waveletIds.build();
+    return new WaveletProvider() {
+      @Override
+      public void initialize() {
+      }
+
+      @Override
+      public void submitRequest(
+          WaveletName waveletName, ProtocolWaveletDelta delta, SubmitRequestListener listener) {
+      }
+
+      @Override
+      public void getHistory(
+          WaveletName waveletName,
+          HashedVersion versionStart,
+          HashedVersion versionEnd,
+          Receiver<TransformedWaveletDelta> receiver) {
+      }
+
+      @Override
+      public boolean checkAccessPermission(WaveletName waveletName, ParticipantId participantId) {
+        return true;
+      }
+
+      @Override
+      public ExceptionalIterator<WaveId, WaveServerException> getWaveIds() {
+        return null;
+      }
+
+      @Override
+      public ImmutableSet<WaveletId> getWaveletIds(WaveId waveId) {
+        return WAVE_ID.equals(waveId) ? finalWaveletIds : ImmutableSet.of();
+      }
+
+      @Override
+      public CommittedWaveletSnapshot getSnapshot(WaveletName waveletName) {
+        return snapshots.get(waveletName);
+      }
+
+      @Override
+      public HashedVersion getHashedVersion(WaveletName waveletName, long version) {
+        return null;
+      }
+    };
+  }
+
+  private static WaveClientServlet createServlet(
+      ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer)
+      throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount(any(WebSession.class))).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount((WebSession) null)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        snapshotRenderer,
+        new FeatureFlagService(featureFlagStore()));
+  }
+
+  private static String invokeServlet(WaveClientServlet servlet, String view, String waveId)
+      throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn(view);
+    when(request.getParameterValues("view")).thenReturn(new String[]{view});
+    when(request.getParameter("wave")).thenReturn(waveId);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+    servlet.doGet(request, response);
+    return body.toString();
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    if (haystack == null || needle == null || needle.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+
+  private static FeatureFlagStore featureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(Collections.emptyList());
+    return store;
+  }
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -331,6 +331,12 @@ public final class J2clStageOneReadSurfaceParityTest {
     assertFalse(
         "GWT path must not advertise the F-1 server-first selected-wave host",
         html.contains("data-j2cl-selected-wave-host"));
+    assertFalse(
+        "GWT path must not emit <wave-blip> hosts",
+        html.contains("<wave-blip"));
+    assertTrue(
+        "GWT path should retain legacy blip host markup",
+        html.contains("class=\"blip\""));
   }
 
   // --- helpers (mirror of the F-1 fixture so the two stay in lockstep) ----

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
@@ -99,6 +99,13 @@ public class TestingWaveletData {
     TitleHelper.maybeFindAndSetImplicitTitle(blip.getContent());
   }
 
+  public ConversationBlip appendBlipWithTextAndReturn(String text) {
+    ConversationBlip blip = conversation.getRootThread().appendBlip();
+    LineContainers.appendToLastLine(blip.getContent(), XmlStringBuilder.createText(text));
+    TitleHelper.maybeFindAndSetImplicitTitle(blip.getContent());
+    return blip;
+  }
+
   /**
    * Appends a blip whose body content is constructed from raw XML. Use this
    * to inject elements like {@code <check value="true"/>} into test blips.

--- a/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/robots/operations/TestingWaveletData.java
@@ -93,17 +93,15 @@ public class TestingWaveletData {
     waveViewData = WaveViewDataImpl.create(waveId, ImmutableList.of(waveletData, userWaveletData));
   }
 
-  public void appendBlipWithText(String text) {
-    ConversationBlip blip = conversation.getRootThread().appendBlip();
-    LineContainers.appendToLastLine(blip.getContent(), XmlStringBuilder.createText(text));
-    TitleHelper.maybeFindAndSetImplicitTitle(blip.getContent());
-  }
-
   public ConversationBlip appendBlipWithTextAndReturn(String text) {
     ConversationBlip blip = conversation.getRootThread().appendBlip();
     LineContainers.appendToLastLine(blip.getContent(), XmlStringBuilder.createText(text));
     TitleHelper.maybeFindAndSetImplicitTitle(blip.getContent());
     return blip;
+  }
+
+  public void appendBlipWithText(String text) {
+    appendBlipWithTextAndReturn(text);
   }
 
   /**


### PR DESCRIPTION
Updates #1037 (foundation slice 1 of 6 — does NOT close the umbrella). Updates #904.

## What ships in this slice

The first F-2 slice ships the **per-blip data shape, the F-2 `<wave-blip>` Lit element, the renderer rewire that mounts it, and a per-row parity fixture** asserting the contract at the wire boundary. The plan in `docs/superpowers/plans/2026-04-26-issue-1037-stageone-read-surface.md` enumerates the remaining work as T3 / T4 / T5 / T7 / T8 — all chrome elements and the demo route — which are explicit follow-ups (see "Deferred" below).

### T1 — per-blip data shape
- `J2clReadBlip` and `J2clReadWindowEntry` gain `authorId`, `authorDisplayName`, `lastModifiedTimeMillis`, `parentBlipId`, `threadId`, `unread`, `hasMention`. Legacy constructors preserved.
- `J2clSelectedWaveProjector` populates the new fields from `SidecarSelectedWaveDocument` and grafts them onto viewport-derived blips via the new `enrichReadBlipMetadata` pass. Mention detection consults `SidecarAnnotationRange.isMention()` (annotation key prefix `mention/`).
- 13 new unit tests; 649/649 search-sidecar tests pass.

### T2 — `<wave-blip>` + `<wave-blip-toolbar>` Lit elements
- `<wave-blip>` wraps the F-0 `<wavy-blip-card>` recipe (so the visual envelope, focus ring, unread dot, and live-pulse glow stay owned by the F-0 design tokens) and adds: author header (F.1 / F.2), full datetime tooltip via `<time title=… datetime=…>` (F.3), per-blip toolbar in the metadata slot revealed on `:focus-within` or `:hover` (F.4 / F.5 / F.7), inline-reply chip "△ N" wired to drill-in (F.10 + R-3.7 G.1), violet mention rail when `has-mention` reflects (E.6 / E.7 visual cue), `firePulse()` for live-update events.
- Plugin-slot contract preserved: the named `blip-extension` slot is forwarded transparently to the inner `<wavy-blip-card>` so plugins still read `host.dataset.blipId` / `blipView` per `docs/j2cl-plugin-slots.md`.
- 22 new lit web-test-runner tests (`wave-blip.test.js`, `wave-blip-toolbar.test.js`); 178/178 lit tests pass.

### T6 — renderer rewire
- `J2clReadSurfaceDomRenderer.renderBlip` now creates a `<wave-blip>` element instead of `<article class="blip">`. The legacy class names, data attributes, role, and tabindex contracts are kept on the host so the existing focus / collapse / scroll-anchor / keyboard-navigation logic in this renderer continues to work without rewriting the navigation logic.
- Two helpers added: `formatRelativeTimestamp(modifiedMs)` and `formatIsoTimestamp(modifiedMs)`.
- `J2clSelectedWaveView` exposes the wave id on the content-list host as `data-wave-id` so the renderer can lift it onto each rendered card.

### T9 — per-row parity fixture
- New `J2clStageOneReadSurfaceParityTest` mounts the J2CL servlet at both `?view=j2cl-root` and `?view=gwt` and asserts row-level acceptance for **R-3.1, R-3.2, R-3.4, R-3.7, R-4.4** plus the reciprocal that `?view=gwt` does not leak F-2 client markers. 7/7 passing.

## Plan

`docs/superpowers/plans/2026-04-26-issue-1037-stageone-read-surface.md` (377 lines) enumerates **all** acceptance rows and **all 64 inventory affordances** under F-2 ownership with executable acceptance steps. The plan covers eight tasks (T1–T8) plus the per-row parity fixture (T9). This PR ships **T1, T2, T6, T9**.

## Deferred to follow-up issues

These are tracked as concrete work in the plan's task breakdown and would each warrant its own PR to keep review tractable:

- **T3** — `<wavy-wave-nav-row>` (E.1–E.10), `<wavy-focus-frame>` landmark, `<wavy-depth-nav-bar>` (R-3.7 G.2 / G.3 / G.6 chrome).
- **T4** — Search-rail companion elements: `<wavy-saved-search-rail>` (B.5–B.10), `<wavy-search-digest-card>` (B.13–B.18), `<wavy-search-help-modal>` (C.1–C.22), `<wavy-top-chrome>` (A.2 / A.5 / A.6 / A.7).
- **T5** — Floating + accessory + version-history elements: `<wavy-scroll-to-new>` (J.2), `<wavy-wave-controls-toggle>` (J.3), `<wavy-nav-drawer-toggle>` (J.4 / J.5), `<wavy-version-history-overlay>` (K.1–K.6).
- **T7** — `J2clSelectedWaveView` mounts the new chrome elements + reads `&depth=` URL state for R-3.7 G.4 + introduces `markBlipRead` Gateway extension.
- **T8** — Server-side `?view=j2cl-root&q=read-surface-preview` demo route mounting a synthetic 12-blip wave that exercises depth-nav + focus-frame + collapse.
- **R-3.7 G.1, G.5, G.6 wiring**: data shape + `<wave-blip>` element are ready; T6's renderer needs the depth-focus filter (`setDepthFocus(blipId)`) and keyboard `[` / `]` handlers to fully wire the drill-in flow.
- **R-4.4 mark-read debounce**: the per-blip `unread` flag now flows end-to-end; the IntersectionObserver-equivalent mark-read debounce + `gateway.markBlipRead(...)` extension is T6 / T7 work.

I'll file each as a follow-up issue immediately after this PR merges so the parent #904 tracker stays accurate.

## Verification

- `cd j2cl && ./mvnw -Psearch-sidecar test` → 649 passed, 0 failed.
- `cd j2cl/lit && npm test` → 178 passed, 0 failed.
- `cd j2cl/lit && npm run build` → OK; bundle 90.5 KB (+5 KB for the new elements).
- `sbt -batch jakartaTest:testOnly *J2clStageOneReadSurfaceParityTest` → 7 passed, 0 failed.
- `sbt -batch jakartaTest:testOnly *J2clViewportFirstPaintParityTest` → 4 passed, 0 failed (F-1 untouched).
- `python3 scripts/validate-changelog.py` → passed.

## Test plan

- [ ] CI green (J2CL search-sidecar suite, lit web-test-runner, jakartaTest config).
- [ ] CodeRabbit / Copilot / Codex review pass.
- [ ] Resolve any chatgpt-codex-connector P2 threads via GraphQL after each push.
- [ ] After merge, file follow-up issues for T3, T4, T5, T7, T8 + R-3.7 wiring + R-4.4 mark-read debounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blips now render as self-contained widgets with author header, posted-at (ISO tooltip), unread and mention (violet rail) indicators, inline-reply chip when replies >0, and live-pulse behavior.
  * Per-blip toolbar (Reply, Edit, Link, Overflow) shown on focus/hover; actions emit events and Link builds a permalink and attempts clipboard copy.

* **Documentation**
  * Added rollout plan and changelog for the read-surface redesign and schedule.

* **Tests**
  * New unit, DOM, and parity tests covering rendering, events, metadata, navigation, and view parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
