### PR TITLE
F-2 (slice 3): Search rail + search-help modal + wavy header chrome

### DIFF
--- a/docs/superpowers/plans/2026-04-26-issue-1047-search-rail.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1047-search-rail.md
@@ -1,0 +1,291 @@
+# F-2.S3: Search rail + search-help modal + wavy header chrome
+
+Status: Ready for implementation
+Owner: codex/issue-1047-search-rail worktree
+Issue: [#1047](https://github.com/vega113/supawave/issues/1047)
+Parent umbrella: [#1037](https://github.com/vega113/supawave/issues/1037) (slice 3 of 6 — does NOT close the umbrella)
+Tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Inventory: `docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md`
+
+Foundation in place (all merged to main):
+- F-0 (#1035, sha `af7072f9`) — wavy design tokens (`--wavy-*`), `wavy-blip-card` / `wavy-rail-panel` / `wavy-depth-nav` recipes, plugin-slot contracts.
+- F-1 (#1036, sha `86ea6b44`) — viewport-scoped data path; depth-axis fragment contract.
+- F-2.S1 (#1045, sha `f4a6cd6f`) — `<wave-blip>` + `<wave-blip-toolbar>` Lit elements with the per-blip server-first contract; J2clStageOneReadSurfaceParityTest (8 cases) covering the StageOne read-surface server contract.
+
+Sibling slices (touch different files; safe to land in any order):
+- S2 (#1046) — `wavy-wave-nav-row.js`, `wavy-focus-frame.js`, `wavy-depth-nav-bar.js`.
+- S4 (#1048) — `wavy-version-history.js`, `wavy-profile-overlay.js`, floating control elements.
+
+## 1. Why this slice exists
+
+S1 lit up the per-blip read surface. S3 lights up the **left rail and the top chrome** that sit around it: the search query box with saved-search folder rail, the search-help modal that documents every filter/sort token, and the wavy header end-region (locale picker, notifications bell, mail icon, user-menu trigger, brand link).
+
+Today on `?view=j2cl-root` the header is the placeholder `<shell-header>` from #964 ("Signed in as <email> · Admin · Sign out"). There is no search rail at all — clicking through the placeholder leads to the legacy GWT search panel, which means none of the inventory rows B.* / C.* are reachable from the J2CL surface.
+
+This slice ships the wavy `<wavy-header>`, `<wavy-search-rail>`, and `<wavy-search-help>` Lit elements, a server-side mounting in `renderJ2clRootShellPage`, and a parity fixture that asserts each of the 45 inventory affordances. The 22 search filter/sort tokens are server-side-tested through the existing `QueryHelper.parseQuery` parser to confirm the help modal advertises only tokens that actually parse.
+
+## 2. Verification ground truth (re-derived in worktree, HEAD `f4a6cd6f`)
+
+### Server side
+
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/TokenQueryType.java:30-42` — canonical token enum (IN, ORDERBY, WITH, CREATOR, ID, TAG, UNREAD, CONTENT, TITLE, MENTIONS, TASKS).
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java:204-244` — `OrderByValueType` (DATEASC, DATEDESC, CREATEDASC, CREATEDDESC, CREATORASC, CREATORDESC).
+- `wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java:315-362` — `parseQuery(String)` is the contract surface. Throws `InvalidQueryException` on unknown tokens / values; tokens without `:` fall back to CONTENT.
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java:118` — `DEFAULT_SEARCH = "in:inbox"`.
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java:596,679,689` — saved-search defaults: Inbox = `in:inbox`, Archive = `in:archive`, Pinned = `in:pinned`.
+- `wave/src/main/resources/org/waveprotocol/box/webclient/search/SearchWidget.ui.xml` — every example chip in the GWT search-help panel; this is the authoritative C.1–C.22 token list.
+- `wave/src/main/java/org/waveprotocol/box/webclient/search/i18n/SearchWidgetMessages_en.properties` — saved-search labels (Public, Inbox, Archive). The other folders (Mentions, Tasks, Pinned) are constructed in `SearchPresenter` Java.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java:3320-3460` — `renderJ2clRootShellPage` is the J2CL root template. S3 extends the header + nav slot to mount `<wavy-header>` + `<wavy-search-rail>`; the `<shell-skip-link>` / `<shell-status-strip>` framing remains intact.
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java` — the F-2.S1 fixture. S3 adds a sibling fixture, `J2clSearchRailParityTest`, in the same package; the per-row pattern (mock servlet → assert tokens in HTML) carries over verbatim.
+
+### J2CL/Lit client side
+
+- `j2cl/lit/src/design/wavy-tokens.css:17-173` — F-0 token contract (`--wavy-bg-base`, `--wavy-bg-surface`, `--wavy-text-body`, `--wavy-text-muted`, `--wavy-text-quiet`, `--wavy-signal-cyan`, `--wavy-accent-violet`, `--wavy-accent-amber`, `--wavy-pulse-ring`, `--wavy-radius-card`, `--wavy-spacing-{1..6}`, `--wavy-type-{body,h2,h3,label,meta}`, `--wavy-motion-focus-duration`, `--wavy-easing-focus`).
+- `j2cl/lit/src/design/wavy-rail-panel.js:10-138` — F-0 recipe; S3's `<wavy-search-rail>` is composed *next to* this (it is its own element so it can own the search textbox + saved-search folder selection state without inheriting the rail-panel collapse behaviour).
+- `j2cl/lit/src/elements/shell-header.js:3-58` — the existing #964 placeholder `<shell-header>` keeps its slot contract; S3's `<wavy-header>` mounts inside the `actions-signed-in` slot of `<shell-header>`. Backwards-compatible: nothing in S2/S4/S5/S6 needs the inner `<shell-header>` markup to change.
+- `j2cl/lit/src/elements/wave-blip.js`, `wave-blip-toolbar.js` — F-2.S1 wrapper pattern that S3 mirrors for its own elements (LitElement, attribute reflection, CustomEvent emission, light DOM slots for plugin extensions, `customElements.get(...)` register-once guard).
+- `j2cl/lit/src/index.js` — must register the three new elements (`wavy-header`, `wavy-search-rail`, `wavy-search-help`) so the bundled `shell.js` upgrades them on the J2CL root shell page.
+- `j2cl/lit/test/wave-blip.test.js`, `wave-blip-toolbar.test.js` — testing pattern: `@open-wc/testing` `fixture(html...)`, register-check, attribute reflection, slot propagation, event emission.
+
+## 3. Token contract — the wavy CSS variables S3 consumes (re-confirm same as F-0)
+
+| Token | Use in S3 |
+| --- | --- |
+| `--wavy-bg-base` | Page background under header + rail |
+| `--wavy-bg-surface` | Header band, rail panel, modal sheet |
+| `--wavy-text-body` | Default body text |
+| `--wavy-text-muted` | Secondary labels (timestamps, result count) |
+| `--wavy-text-quiet` | Slot-extension labels in design preview |
+| `--wavy-signal-cyan` | Brand accent dot, focused folder, primary buttons (New Wave), pulse-ring on per-digest unread badge change |
+| `--wavy-signal-violet` | Mentions unread dot (header bell + Mentions folder) |
+| `--wavy-signal-amber` | Tasks pending count chip |
+| `--wavy-pulse-ring` | Signal-cyan box-shadow ring composition (used by `firePulse()` `data-pulse="ring"` styling) |
+| `--wavy-motion-pulse-duration` | Duration the `data-pulse="ring"` attribute stays active (600ms) |
+| `--wavy-radius-card` | Card / modal corner radius |
+| `--wavy-border-hairline` | Card / modal hairline border |
+| `--wavy-spacing-{1..6}` | Layout spacing |
+| `--wavy-type-{body,h2,h3,label,meta}` | Type scale |
+| `--wavy-motion-focus-duration` + `--wavy-easing-focus` | Folder selection + modal open transitions |
+
+S3 DOES NOT introduce new tokens. Anywhere a token is consumed, the element provides a literal fallback in the `var(...)` call so the elements work in isolation tests without `wavy-tokens.css` (mirrors the F-0 + S1 pattern).
+
+## 4. Acceptance contract — every cited inventory affordance
+
+No "practical parity" escape hatch. Each item below has a concrete assertion in either the per-row JS test (`*.test.js`) or the per-row server fixture (`J2clSearchRailParityTest`).
+
+### Header chrome — `<wavy-header>`
+
+| # | Affordance | Assertion |
+| --- | --- | --- |
+| A.1 | SupaWave brand link → landing | `<wavy-header>` renders `a.brand[href]` with `href="/"`, signal-cyan dot via `<span class="brand-dot" aria-hidden="true"></span>` before logotype text. `wavy-header.test.js` asserts `getComputedStyle(brandDot).backgroundColor` resolves to a non-empty value AND that the dot's inline CSS uses `background: var(--wavy-signal-cyan, #22d3ee)` (a substring assertion on `el.shadowRoot.adoptedStyleSheets[0].cssRules` text suffices when computed color is degraded under headless tests). |
+| A.2 | Locale picker (en/de/es/fr/ru/sl/zh_TW) | `<wavy-header>` renders `<select class="locale" aria-label="Language">` with one `<option>` per locale; default value reflects `locale` property. Server-side: `J2clSearchRailParityTest.headerEmitsLocalePicker` asserts the `<wavy-header locale="en">` token + the seven `<option value="...">` tokens. |
+| A.5 | Notifications bell (with unread dot) | `<wavy-header>` renders `<button type="button" class="bell" aria-label="Notifications">` containing an inline SVG bell glyph and `<span class="dot violet" hidden>` that becomes visible when `unread-count > 0`. Asserted in `wavy-header.test.js`. |
+| A.6 | Inbox/mail icon | `<wavy-header>` renders `<a class="mail" href="/?q=in:inbox" aria-label="Inbox">` containing an inline SVG envelope glyph. Asserted in `wavy-header.test.js`. |
+| A.7 | User-menu trigger (avatar chip + email) | `<wavy-header>` renders `<button type="button" class="user-menu" aria-haspopup="menu" aria-expanded="false">` wrapping an avatar `<span class="avatar">` (initials from `user-name` attribute) AND a visible `<span class="user-email">${address}</span>` next to the avatar (matches GWT inventory A.7 "avatar + email"). Click emits `wavy-user-menu-requested` CustomEvent with `{detail: {address}}` so the F-0 menu sheet (already on main) can mount. Asserted in `wavy-header.test.js`. |
+
+A.7 mounts the *trigger* only; the menu items themselves come from F-0 and are out of scope for this slice.
+
+### Search rail — `<wavy-search-rail>`
+
+| # | Affordance | Assertion |
+| --- | --- | --- |
+| B.1 | Search query textbox (default `in:inbox`) | `<wavy-search-rail>` renders `<input type="search" name="q" class="query" .value=${query}>` (default value `in:inbox`). Adjacent `<span class="waveform" aria-hidden>` with inline SVG waveform glyph. Pressing Enter emits `wavy-search-submit` CustomEvent `{detail: {query}}`. Asserted in `wavy-search-rail.test.js`. |
+| B.2 | Search-help trigger (`?` button) → opens modal | Renders `<button type="button" class="help-trigger" aria-label="Search help" aria-haspopup="dialog" aria-controls="wavy-search-help">?</button>`. Click emits `wavy-search-help-toggle` CustomEvent (composed + bubbles) so the document-level `<wavy-search-help id="wavy-search-help">` singleton (mounted by T5 in the root shell, NOT inside the rail) can flip its `open` attribute. Asserted in `wavy-search-rail.test.js` (the rail does NOT own the modal instance — see §8 mount decision). |
+| B.3 | New Wave button (Shift+Cmd+O) | Renders `<button type="button" class="new-wave" data-shortcut="Shift+Cmd+O" aria-keyshortcuts="Shift+Meta+O Shift+Control+O">New Wave</button>`. Click emits `wavy-new-wave-requested` CustomEvent (composed + bubbles). The keyboard shortcut handler is intentionally OUT OF SCOPE for S3 — it ships with S6 (URL state + global keymap) so we don't conflict with S2's per-blip arrow / j / k handler. Asserted in `wavy-search-rail.test.js` for click + `aria-keyshortcuts` attribute presence. |
+| B.4 | Manage saved searches | Renders `<button type="button" class="manage-saved">Manage saved searches</button>` inside the saved-search rail header; click emits `wavy-manage-saved-searches-requested`. Asserted in `wavy-search-rail.test.js`. |
+| B.5–B.10 | Saved-search folders (Inbox selected by default, Mentions with violet unread dot, Tasks with amber pending count, Public, Archive, Pinned) | Renders an `<ul class="folders">` with one `<li><button class="folder" data-query="..." aria-current=${selected ? "page" : "false"}>` per folder. Folder query strings (single source of truth, used by both the rail and the parser fixture): Inbox=`in:inbox`, Mentions=`mentions:me`, Tasks=`tasks:me`, Public=`with:@`, Archive=`in:archive`, Pinned=`in:pinned`. Inbox carries `aria-current="page"` by default. Mentions carries a violet `<span class="dot mentions-dot" hidden>`; when `mentions-unread > 0` the `hidden` attribute is dropped. Tasks carries an amber `<span class="chip tasks-chip">N</span>`; visible when `tasks-pending > 0`. Active-folder derivation: when the rail's `query` attribute changes, an internal `deriveActiveFolderFromQuery(q)` pass picks the first folder whose query string is a prefix of the rail's query (case-insensitive); the matched folder's button gets `aria-current="page"`. Asserted in `wavy-search-rail.test.js`: (a) all six folder buttons render with the canonical `data-query` strings, (b) Inbox is `aria-current="page"` by default, (c) setting `query="in:archive orderby:datedesc"` flips `aria-current="page"` to the Archive folder. |
+| B.11 | Refresh search results | Renders `<button class="refresh" aria-label="Refresh search results">⟳</button>`. Click emits `wavy-search-refresh-requested`. Asserted in `wavy-search-rail.test.js`. |
+| B.12 | Result count "N waves" | Renders `<p class="result-count" aria-live="polite">${count} waves</p>` with low-emphasis (`color: var(--wavy-text-muted)`). When `count` is `null/undefined` the element renders an empty `<p>` (no count yet). Asserted in `wavy-search-rail.test.js`. |
+| B.13 | Per-digest avatar stack (multi-author) | New child element `<wavy-search-rail-card>`: renders `<div class="avatar-stack">` containing one `<span class="avatar" data-initials="..">` per author (max 3 visible + `+N`). Asserted in `wavy-search-rail-card.test.js`. |
+| B.14 | Per-digest pinned indicator | `<wavy-search-rail-card>` reflects the `pinned` boolean attribute. When set, renders `<span class="pin" aria-label="Pinned">📌</span>` (literal `<svg class="pin">` cyan pin glyph) styled via `color: var(--wavy-signal-cyan)`. Asserted in `wavy-search-rail-card.test.js`. |
+| B.15 | Per-digest title | `<wavy-search-rail-card>` renders `<h3 class="title">${title}</h3>`. Asserted in `wavy-search-rail-card.test.js`. |
+| B.16 | Per-digest snippet (multiline truncation) | `<wavy-search-rail-card>` renders `<p class="snippet">${snippet}</p>` styled with `display: -webkit-box; -webkit-line-clamp: 3; overflow: hidden;` so the snippet truncates at three lines. Asserted by computed style in `wavy-search-rail-card.test.js`. |
+| B.17 | Per-digest msg count + unread badge with cyan signal-pulse | `<wavy-search-rail-card>` renders `<span class="msg-count">${msgCount}</span>`. When `unread-count > 0` it appends `<span class="badge unread"><span class="pulse"></span>${unread}</span>`. The `firePulse()` method on the card sets `data-pulse="ring"` for `--wavy-pulse-ring-duration` ms then clears it. Mirrors the `firePulse()` contract from `wavy-blip-card`. Asserted in `wavy-search-rail-card.test.js`. |
+| B.18 | Per-digest relative timestamp | `<wavy-search-rail-card>` renders `<time class="ts" datetime=${iso} title=${iso}>${rel}</time>`. Asserted in `wavy-search-rail-card.test.js`. |
+
+### Search-help modal — `<wavy-search-help>`
+
+`<wavy-search-help>` is a `role="dialog"` modal with `aria-modal="true"`. It mounts its content into `<dialog>` if available, falling back to a fixed-position `<div role="dialog">` for environments without `<dialog>` support.
+
+**Mount point (single-source-of-truth):** A SINGLE `<wavy-search-help id="wavy-search-help">` instance lives at the document level (sibling of `<wavy-search-rail>`, mounted by T5 inside the `nav` slot of `<shell-root>`). The rail's help-trigger fires a `wavy-search-help-toggle` CustomEvent (composed + bubbles); a small `connectedCallback`-installed listener on the help element flips its own `open` attribute. The rail does NOT own a child `<wavy-search-help>` — this avoids duplicate dialogs and matches the GWT pattern of a single backdrop appended to `document.body`.
+
+**`tasks:*` rows scope clarification (issue C.13–C.15):** The modal LISTS `tasks:all`, `tasks:me`, `tasks:user@domain` as discoverable tokens because the GWT modal already advertises them and the parser already accepts them through `TokenQueryType.TASKS` (no F-3 dependency). The behavioral plumbing (filtering search results by `tasks:me` and showing actual task chips on result cards) is owned by F-3. S3's contract for C.13–C.15 is exclusively "the help modal advertises the token literally, and the parser accepts it." This is consistent with the C.* parser fixture which only asserts that `parseQuery("tasks:me")` does not throw — it does NOT assert any task-result-filtering behaviour.
+
+| # | Token / Affordance | Assertion |
+| --- | --- | --- |
+| C.1 | Filter `in:inbox` | Modal body table contains `<code>in:inbox</code>` row. Click on the example fires `wavy-search-help-example` CustomEvent `{detail: {query: "in:inbox"}}` so the rail can populate the textbox. |
+| C.2 | Filter `in:archive` | Same as C.1 with `in:archive`. |
+| C.3 | Filter `in:all` | Same with `in:all`. |
+| C.4 | Filter `in:pinned` | Same with `in:pinned`. |
+| C.5 | Filter `with:user@domain` | Description column shows `<code>with:user@domain</code>`; example chip is `with:alice@example.com`. |
+| C.6 | Filter `with:@` (public) | `<code>with:@</code>` row. |
+| C.7 | Filter `creator:user@domain` | `<code>creator:user@domain</code>` row, example chip `creator:bob@example.com`. |
+| C.8 | Filter `tag:name` | `<code>tag:name</code>` row, example chip `tag:important`. |
+| C.9 | Filter `unread:true` | `<code>unread:true</code>` row. |
+| C.10 | Filter `title:text` | `<code>title:text</code>` row, example chip `title:meeting`. |
+| C.11 | Filter `content:text` | `<code>content:text</code>` row, example chip `content:agenda`. |
+| C.12 | Filter `mentions:me` | `<code>mentions:me</code>` row. |
+| C.13 | Filter `tasks:all` | `<code>tasks:all</code>` row. |
+| C.14 | Filter `tasks:me` | `<code>tasks:me</code>` row. |
+| C.15 | Filter `tasks:user@domain` | `<code>tasks:user@domain</code>` row, example chip `tasks:alice@example.com`. |
+| C.16 | Free text (implicit `content:`) | Row labelled `free text`, example chip `meeting notes`. |
+| C.17 | Sort `orderby:datedesc` (default) | Sort table row with `<code>orderby:datedesc</code>` and "(default)" callout. |
+| C.18 | Sort `orderby:dateasc` | Sort table row. |
+| C.19 | Sort `orderby:createddesc` / `createdasc` | Two adjacent rows. |
+| C.20 | Sort `orderby:creatordesc` / `creatorasc` | Two adjacent rows. |
+| C.21 | Combinations examples | A `<section class="combinations">` containing seven `<code class="example">` chips (mirrors GWT panel: `in:inbox tag:important`, `in:all orderby:createdasc`, `with:alice@example.com tag:project`, `in:pinned orderby:creatordesc`, `creator:bob in:archive`, `mentions:me unread:true`, `tasks:all unread:true`). Each chip click emits `wavy-search-help-example`. |
+| C.22 | "Got it" dismiss | `<button class="dismiss">Got it</button>` closes the dialog (`open=false`) and emits `wavy-search-help-dismissed`. |
+
+#### C.* server-side parser test
+
+A second new fixture, `J2clSearchHelpTokenParseTest` (in `wave/src/test/java/org/waveprotocol/box/server/waveserver/`), feeds each of the 22 token strings advertised by `<wavy-search-help>` through `QueryHelper.parseQuery` and asserts:
+
+1. The advertised token strings (`in:inbox`, `in:archive`, …, `orderby:datedesc`, …) all parse without `InvalidQueryException`.
+2. Each filter token deposits the expected `TokenQueryType` key in the result map.
+3. Each `orderby:` value resolves to a non-null `OrderByValueType.fromToken(value)`.
+4. Free text (`meeting notes`, `agenda`) parses into the `CONTENT` bucket.
+5. Each combination example string (the seven C.21 chips) parses without exception.
+6. NEGATIVE: `in:bogus` is accepted as `in:bogus` by `parseQuery` (in/with/etc. accept arbitrary value strings), but `orderby:bogus` throws `InvalidQueryException`. This guards the contract that the help modal must NOT advertise `orderby:` values that are not in `OrderByValueType`.
+
+The fixture is the contract enforcer: if the modal ever advertises a token the parser rejects, the test fails. This is the "do NOT invent new tokens" guard.
+
+### Per-row server fixture — `J2clSearchRailParityTest`
+
+`wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java` — sibling of `J2clStageOneReadSurfaceParityTest` (mirrors the helper plumbing exactly: same `WaveletProvider` mock, same `WaveClientServlet` + `invokeServlet` helpers, same `countOccurrences` helper). Drives a 6-blip wave (so the snapshot path stays the same) through both `?view=j2cl-root` and `?view=gwt`.
+
+**Server-first contract (mirrors S1's `<wavy-blip-card>` design-preview path):** The fixture asserts on the SERVER-RENDERED HTML, not on a post-upgrade DOM. So T5 must SSR the inner light DOM of each new element directly into the page (the Lit elements upgrade in place, replacing their server-rendered light DOM with the rendered template; both representations carry the same data-attributes and inner text the fixture asserts on). This is the same contract S1 uses: `J2clStageOneReadSurfaceParityTest.serverFirstPaintEmitsContractBlipAttributesForJ2clUpgrade` asserts on `data-blip-id=` substrings the server renders, and the client `<wave-blip>` upgrade preserves them.
+
+Concretely T5 emits, server-side:
+
+1. `<wavy-header signed-in locale="en" data-address="${safeAddress}" user-name="${safeAddress}" unread-count="0">` containing the FULL inner markup the client would render (brand link with `<span class="brand-dot">`, `<select class="locale">` with the seven `<option value="..">`, notifications bell button with class `bell`, mail icon `<a class="mail">`, user-menu button with `<span class="avatar">` and `<span class="user-email">`).
+2. `<wavy-search-rail query="in:inbox" data-active-folder="inbox" result-count="">` containing the full inner markup (`<input type="search" class="query" value="in:inbox">`, help-trigger button, New Wave button, Manage saved searches button, `<ul class="folders">` with the six `<li><button class="folder" data-query="..." aria-current="${...}">` rows, refresh button, `<p class="result-count" aria-live="polite">`).
+3. `<wavy-search-help id="wavy-search-help">` (initially without `open`) containing the FULL modal body — title "Search Help", filter table with all 22 tokens as `<code>` substrings, sort table, combinations section, `<button class="dismiss">Got it</button>`. The element renders the same markup client-side; the upgrade is a no-op for content (only event handlers wire up).
+
+Per-test cases:
+
+1. `j2clRootShellEmitsWavyHeaderHostWithLocaleAndAddressAttributes` — server HTML contains exactly one `<wavy-header` host with `signed-in`, `locale="en"`, `data-address="${address}"`, `user-name="${address}"` attributes.
+2. `wavyHeaderInnerLightDomEmitsAllSevenLocales` — header inner light DOM contains `<option value="en"`, `<option value="de"`, `<option value="es"`, `<option value="fr"`, `<option value="ru"`, `<option value="sl"`, `<option value="zh_TW"` substrings.
+3. `wavyHeaderInnerLightDomEmitsBrandLocaleBellMailUserMenuChrome` — header inner light DOM contains `class="brand"`, `class="brand-dot"`, `class="locale"`, `class="bell"`, `class="mail"`, `class="user-menu"`, `class="avatar"`, `class="user-email"` substrings (one assertion per affordance).
+4. `j2clRootShellEmitsWavySearchRailHostWithDefaultQuery` — server HTML contains exactly one `<wavy-search-rail` host with `query="in:inbox"` and `data-active-folder="inbox"`.
+5. `wavySearchRailInnerLightDomEmitsAllSixSavedSearchFolders` — rail inner light DOM contains the six folder buttons with the canonical query strings (`data-query="in:inbox"`, `data-query="mentions:me"`, `data-query="tasks:me"`, `data-query="with:@"`, `data-query="in:archive"`, `data-query="in:pinned"`) AND the six visible labels ("Inbox", "Mentions", "Tasks", "Public", "Archive", "Pinned").
+6. `wavySearchRailInnerLightDomEmitsHelpTriggerNewWaveManageRefreshAndCountSlots` — rail inner light DOM contains `class="help-trigger"`, `class="new-wave"`, `class="manage-saved"`, `class="refresh"`, `class="result-count"`, plus `aria-keyshortcuts="Shift+Meta+O Shift+Control+O"` on the New Wave button.
+7. `j2clRootShellEmitsWavySearchHelpModalWithAll22TokenLiterals` — server HTML contains exactly one `<wavy-search-help` host (no `open` attribute), and its inner markup contains every one of the 22 token literals: the four `in:` tokens, `with:user@domain`, `with:@`, `creator:user@domain`, `tag:name`, `unread:true`, `title:text`, `content:text`, `mentions:me`, `tasks:all`, `tasks:me`, `tasks:user@domain`, the six `orderby:` values, plus the `free text` row marker, plus the seven combination examples (`in:inbox tag:important`, `in:all orderby:createdasc`, `with:alice@example.com tag:project`, `in:pinned orderby:creatordesc`, `creator:bob in:archive`, `mentions:me unread:true`, `tasks:all unread:true`), plus the `Got it` literal.
+8. `legacyGwtRouteDoesNotLeakF2S3Markers` — `?view=gwt` HTML contains none of `<wavy-header`, `<wavy-search-rail`, `<wavy-search-help`, `class="brand-dot"`. The legacy `<g:HTMLPanel>` GWT search panel is unchanged.
+9. `signedOutJ2clRootShellDoesNotMountSearchRailOrHeaderChrome` — passing a `null` viewer to the same servlet yields a signed-out `<shell-root-signed-out>` page that contains NEITHER `<wavy-header` NOR `<wavy-search-rail` NOR `<wavy-search-help`. The signed-out branch keeps its existing `<shell-header>` placeholder and the simple Sign-in link. (Defends against accidentally regressing the unauthenticated landing into emitting search/help to anonymous users.)
+
+### S3 saved-search query strings (clarification re: B.5–B.10)
+
+GWT today has only Inbox / Archive / Pinned / Public as named tokens (`in:inbox` / `in:archive` / `in:pinned` / `with:@`). Mentions and Tasks reuse the existing query language: Mentions = `mentions:me`, Tasks = `tasks:me`. The wavy rail therefore advertises:
+
+- Inbox → `in:inbox` (selected by default)
+- Mentions → `mentions:me`
+- Tasks → `tasks:me`
+- Public → `with:@`
+- Archive → `in:archive`
+- Pinned → `in:pinned`
+
+All six query strings parse through `QueryHelper.parseQuery`; the parity fixture asserts the strings appear in the rail HTML, and `J2clSearchHelpTokenParseTest` (C.* fixture above) asserts the parser accepts each.
+
+## 5. Tasks (T1–T5; each ≤ ~250 LOC of production code with paired tests)
+
+### T1 — `<wavy-search-help>` Lit element + 22-token parser test
+
+Files added:
+
+- `j2cl/lit/src/elements/wavy-search-help.js` — modal element with the 22 token rows + 7 combination examples + Got-it dismiss.
+- `j2cl/lit/test/wavy-search-help.test.js` — registration + open/close + every-token-row-present + chip-click-fires-event + dismiss-button + dialog `aria-modal` + reduced-motion.
+- `wave/src/test/java/org/waveprotocol/box/server/waveserver/J2clSearchHelpTokenParseTest.java` — parser fixture per §4 C.* server-side test.
+- `j2cl/lit/src/index.js` — register the element.
+
+Verification: `cd j2cl/lit && npm test` and `sbt -batch j2clLitTest test` (the JUnit fixture lives under `wave/src/test/...` which `sbt test` runs).
+
+### T2 — `<wavy-search-rail-card>` digest card + tests
+
+Files added:
+
+- `j2cl/lit/src/elements/wavy-search-rail-card.js` — single-card element wrapping author stack, pinned indicator, title, snippet, msg count + unread pulse, timestamp.
+- `j2cl/lit/test/wavy-search-rail-card.test.js` — registration + attribute reflection + multi-author stack truncation at 3 + pinned reflection + unread pulse fires + snippet 3-line clamp + timestamp `<time datetime=...>`.
+- `j2cl/lit/src/index.js` — register.
+
+Verification: `cd j2cl/lit && npm test`.
+
+### T3 — `<wavy-search-rail>` Lit element + tests
+
+Files added:
+
+- `j2cl/lit/src/elements/wavy-search-rail.js` — query textbox + waveform glyph + help trigger (emits `wavy-search-help-toggle`; does NOT own the modal) + New Wave button (emits `wavy-new-wave-requested`; carries `aria-keyshortcuts` but does NOT install a global keyboard listener) + Manage saved searches + 6 folder rows + Refresh + result-count + a `<slot>` for the digest list (callers populate with `<wavy-search-rail-card>` instances).
+- `j2cl/lit/test/wavy-search-rail.test.js` — registration + default `in:inbox` query + Enter submits + help-trigger click emits `wavy-search-help-toggle` (no inline modal) + New Wave click emits `wavy-new-wave-requested` + New Wave button has `aria-keyshortcuts="Shift+Meta+O Shift+Control+O"` attribute + folder click sets `aria-current="page"` and emits `wavy-saved-search-selected` + setting `query="in:archive ..."` flips Archive folder to `aria-current="page"` (active-folder derivation) + Mentions violet dot uses `--wavy-signal-violet` + Tasks amber count uses `--wavy-signal-amber` + Refresh emits + result-count `aria-live="polite"`.
+- `j2cl/lit/src/index.js` — register.
+
+Verification: `cd j2cl/lit && npm test`.
+
+### T4 — `<wavy-header>` Lit element + tests
+
+Files added:
+
+- `j2cl/lit/src/elements/wavy-header.js` — brand link with cyan signal dot + locale picker `<select>` (7 options, emits `wavy-locale-changed` on change) + notifications bell with violet unread dot + mail icon + user-menu trigger button (avatar chip with initials + visible email span).
+- `j2cl/lit/test/wavy-header.test.js` — registration + brand link with cyan dot (cssRules contains `var(--wavy-signal-cyan`) + locale picker has 7 `<option>` entries with the canonical codes + locale `change` emits `wavy-locale-changed` + notifications bell unread dot toggles on `unread-count > 0` + bell unread dot CSS uses `var(--wavy-signal-violet` (NOT cyan) — assert via cssRules substring + mail icon `href="/?q=in:inbox"` + user-menu trigger renders both `<span class="avatar">` initials AND visible `<span class="user-email">` matching `data-address` + user-menu click emits `wavy-user-menu-requested`.
+- `j2cl/lit/src/index.js` — register.
+
+Verification: `cd j2cl/lit && npm test`.
+
+### T5 — Server SSR in `renderJ2clRootShellPage` + `J2clSearchRailParityTest`
+
+Files modified:
+
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` — inside the `signedIn` branch of `renderJ2clRootShellPage`:
+  1. Inside the `<shell-header slot="header" signed-in>` block, replace the placeholder `<span slot="actions-signed-in">Signed in as ${safeAddress}</span>` with a `<wavy-header slot="actions-signed-in" signed-in locale="en" data-address="${safeAddress}" user-name="${safeAddress}" unread-count="0">` host element WHOSE INNER LIGHT DOM IS SERVER-RENDERED IN FULL. The server emits the brand link, locale `<select>` with the seven `<option value="...">` entries, the bell button, the mail icon, and the user-menu trigger (avatar + email span). Lit upgrade re-renders the same content into the shadow DOM and wires event handlers; the server-rendered light DOM is what `J2clSearchRailParityTest` asserts on (mirrors S1 `<wavy-blip-card>` server-render contract).
+  2. Replace the single `<a href="${returnTarget}">Inbox</a>` child of `<shell-nav-rail slot="nav" label="Primary">` with `<wavy-search-rail query="in:inbox" data-active-folder="inbox" result-count="">` containing the FULL inner light DOM (search input, help-trigger, New Wave, Manage saved searches, six folder rows, refresh, result-count `<p>` slot). The `<shell-nav-rail>` wrapper is preserved so future slices can co-mount additional nav-area elements alongside the search rail.
+  3. After the `<shell-nav-rail>` replacement, mount EXACTLY ONE document-level `<wavy-search-help id="wavy-search-help">` (no `open` attribute initially) AS A DIRECT CHILD OF `<shell-root>` (NOT inside any slot) so it can `dialog.showModal()` over everything. Inner light DOM contains the full title bar, filters table (16 rows), sort table (6 rows), combinations section (7 chips), Got-it dismiss.
+  4. The inline `Admin` link and inline `Sign out` link in `actions-signed-in` are PRESERVED unchanged (alongside the new `<wavy-header>`) — F-0's user-menu sheet element is NOT yet on main, so removing the inline links would orphan affordances A.15 (Admin) and A.17 (Sign out) on the J2CL route. Once F-0's `<wavy-user-menu-sheet>` ships (separate issue), a follow-up slice deletes the inline duplicates. The S3 parity test asserts BOTH `<wavy-header>` and the legacy inline `Admin` / `Sign out` `<a>` tags remain present.
+
+The signed-out branch is NOT touched in this slice (search rail + help modal only mount when signed in; the locale picker for the signed-out flow is a future slice or already covered by the legacy GWT signed-out shell). `J2clSearchRailParityTest.signedOutJ2clRootShellDoesNotMountSearchRailOrHeaderChrome` enforces that.
+
+Files added:
+
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java` — sibling fixture per §4 list (8 cases).
+
+Verification: `sbt -batch jakartaTest:testOnly *J2clSearchRailParityTest *J2clStageOneReadSurfaceParityTest j2clLitTest j2clProductionBuild`.
+
+## 6. Out of scope (deferred to other slices / issues)
+
+- Wave panel chrome (D.1–D.8): owned by S2 (#1046).
+- Per-blip controls (F.1–F.12): already shipped in S1 (#1045).
+- Floating + version-history controls (J.1–J.5, K.1–K.6): owned by S4 (#1048).
+- URL state + read state (G.1–G.6 depth-nav URL / R-4.4 live unread): owned by S5.
+- New filter / sort tokens beyond what GWT supports: explicitly forbidden by the slice brief.
+- A.3 "All changes saved" + A.4 "Online" connection state: owned by F-4.
+- A.7 menu items themselves (A.8–A.18): owned by F-0; S3 only mounts the trigger.
+- Locale picker actually changing the locale: F-2.S1 / F-2.S6 own the routing wiring; S3 only renders the picker. The selection emits a `wavy-locale-changed` CustomEvent that S6 wires to `window.location.search` updates.
+
+## 7. Risk register
+
+- **Risk: GWT search-help and wavy search-help diverge over time.** Mitigation: `J2clSearchHelpTokenParseTest` parses every advertised token through the canonical `QueryHelper.parseQuery`. Anyone adding a new token to either side that isn't in `TokenQueryType` / `OrderByValueType` fails the test.
+- **Risk: `<wavy-header>` end-region overflows on narrow viewports.** Mitigation: the element CSS uses `flex-wrap: wrap` on the host and shrinks the locale picker / hides the email span under `(max-width: 600px)`. The host-level wrap behavior is purely declarative CSS — no Lit logic — so the test surface stays at the per-affordance level (locale picker emits 7 options, mail link href is `/?q=in:inbox`, etc.). A future visual-regression slice can add the viewport-resize assertion if it becomes load-bearing.
+- **Risk: `<wavy-search-help>` `<dialog>` polyfill lock-up under iOS Safari.** Mitigation: feature-detect `HTMLDialogElement.prototype.showModal` and fall back to a fixed-position div with `aria-modal="true"`. Test asserts both code paths.
+- **Risk: Saved-search default selection drifts when the user lands with `?q=in:archive`.** Mitigation: `<wavy-search-rail>` reflects `data-active-folder` based on current `query` — if the query starts with `in:archive` the Archive folder gets `aria-current="page"`. Pure-derivation logic with a unit test.
+- **Risk: `J2clSearchRailParityTest` becomes flaky if HTML order changes.** Mitigation: assertions use `String.contains(...)` on stable substrings (element-name + key attribute), not regex on whitespace.
+
+## 8. Verification before PR
+
+1. `cd j2cl/lit && npm test` — all new + existing Lit tests pass.
+2. `sbt -batch jakartaTest:testOnly *J2clSearchRailParityTest *J2clStageOneReadSurfaceParityTest` — both parity fixtures pass.
+3. `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild` — all three SBT tasks exit 0.
+4. `sbt -batch testOnly *J2clSearchHelpTokenParseTest *QueryHelperTest` — parser fixtures pass; existing QueryHelperTest is not regressed.
+5. Worktree-local server boot:
+   - `./mvnw -Psearch-sidecar -DskipTests package` then run the staged server (per `feedback_local_server_verification_before_pr.md`).
+   - Hit `https://localhost/?view=j2cl-root` after registering a fresh user — confirm header chrome (A.1, A.2, A.5, A.6, A.7) renders, search rail (B.1–B.18) renders with default `in:inbox` query, click `?` opens the modal with all 22 tokens.
+   - Side-by-side at `?view=gwt` — confirm the legacy GWT search panel still renders unchanged (no F-2.S3 leakage).
+
+PR title: `F-2 (slice 3): Search rail + search-help modal + wavy header chrome`.
+
+PR body must start with: `Updates #1037 (slice 3 of 6 — does NOT close the umbrella). Updates #904. References #1047.`
+
+Auto-merge: squash.
+
+## 9. Closeout (after merge)
+
+1. `/tmp/parity-chain/f2-s3-merged.txt` written with PR number + sha.
+2. Comment on #1047 with the 45 affordances shipped + any deviations.
+3. Comment on #904 with the slice 3 evidence.
+4. Issue #1047 closes when the auto-merge lands; the umbrella #1037 stays open until S6.

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -239,7 +239,6 @@ export class WavyHeader extends LitElement {
               type="button"
               class="user-menu"
               aria-haspopup="menu"
-              aria-expanded="false"
               aria-label="Open user menu"
               @click=${this._onUserMenuClick}
             >

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -1,0 +1,254 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-header> — F-2 (#1037, #1047 slice 3) header end-region chrome.
+ *
+ * Inventory affordances covered (from the 2026-04-26 GWT functional
+ * inventory):
+ * - A.1 SupaWave brand link with cyan signal-dot accent
+ * - A.2 Locale picker (en/de/es/fr/ru/sl/zh_TW)
+ * - A.5 Notifications bell with violet unread dot (uses
+ *       --wavy-signal-violet, NOT cyan)
+ * - A.6 Inbox/mail icon — jumps to inbox via /?q=in:inbox
+ * - A.7 User-menu trigger: avatar chip (initials) + visible email span;
+ *       click emits wavy-user-menu-requested for the F-0 menu sheet
+ *       (the menu items A.8–A.18 themselves are owned by F-0 and are
+ *       NOT mounted by this slice — only the trigger is)
+ *
+ * Public API:
+ * - signedIn      — boolean (controls visibility of A.5/A.6/A.7)
+ * - locale        — current locale code (defaults to "en")
+ * - address       — user's email address (data-address; reflected so
+ *                   server-side templates can pass it through)
+ * - userName      — display name fallback for initials (defaults to address)
+ * - unreadCount   — number; A.5 dot becomes visible when > 0
+ *
+ * Events:
+ * - wavy-locale-changed     — `{detail: {locale}}` on <select> change
+ * - wavy-user-menu-requested — `{detail: {address}}` on user-menu click
+ */
+export class WavyHeader extends LitElement {
+  static properties = {
+    signedIn: { type: Boolean, attribute: "signed-in", reflect: true },
+    locale: { type: String, reflect: true },
+    address: { type: String, attribute: "data-address", reflect: true },
+    userName: { type: String, attribute: "user-name" },
+    unreadCount: { type: Number, attribute: "unread-count" }
+  };
+
+  // Locale set re-derived from the GWT locale build set; matches the
+  // SearchWidgetMessages_*.properties files in the resources tree.
+  static LOCALES = [
+    { code: "en", label: "English" },
+    { code: "de", label: "Deutsch" },
+    { code: "es", label: "Español" },
+    { code: "fr", label: "Français" },
+    { code: "ru", label: "Русский" },
+    { code: "sl", label: "Slovenščina" },
+    { code: "zh_TW", label: "繁體中文" }
+  ];
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-3, 12px);
+      flex-wrap: wrap;
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .brand-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--wavy-signal-cyan, #22d3ee);
+      display: inline-block;
+    }
+    .locale {
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-pill, 9999px);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+    }
+    .bell,
+    .mail,
+    .user-menu {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 0;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      border-radius: var(--wavy-radius-pill, 9999px);
+      text-decoration: none;
+    }
+    .bell:hover,
+    .bell:focus-visible,
+    .mail:hover,
+    .mail:focus-visible,
+    .user-menu:hover,
+    .user-menu:focus-visible {
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      outline: none;
+      background: rgba(34, 211, 238, 0.06);
+    }
+    .bell {
+      position: relative;
+    }
+    .dot.violet {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--wavy-signal-violet, #7c3aed);
+    }
+    .avatar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: var(--wavy-bg-base, #0b1120);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      font-weight: 600;
+    }
+    .user-email {
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+    @media (max-width: 600px) {
+      .user-email,
+      .locale option {
+        font-size: 0;
+      }
+    }
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.signedIn = false;
+    this.locale = "en";
+    this.address = "";
+    this.userName = "";
+    this.unreadCount = 0;
+  }
+
+  _initials() {
+    const source = (this.userName || this.address || "").trim();
+    if (!source) return "?";
+    const local = source.split("@")[0];
+    if (!local) return "?";
+    if (local.includes(".")) {
+      const [a, b] = local.split(".");
+      return ((a[0] || "") + (b[0] || "")).toUpperCase();
+    }
+    return local.slice(0, 2).toUpperCase();
+  }
+
+  _onLocaleChange(evt) {
+    const next = evt.target.value;
+    this.locale = next;
+    this.dispatchEvent(
+      new CustomEvent("wavy-locale-changed", {
+        bubbles: true,
+        composed: true,
+        detail: { locale: next }
+      })
+    );
+  }
+
+  _onUserMenuClick() {
+    this.dispatchEvent(
+      new CustomEvent("wavy-user-menu-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { address: this.address }
+      })
+    );
+  }
+
+  render() {
+    const initials = this._initials();
+    const hasUnread = (this.unreadCount || 0) > 0;
+    return html`
+      <a class="brand" href="/" aria-label="SupaWave home">
+        <span class="brand-dot" aria-hidden="true"></span>
+        <span class="brand-text">SupaWave</span>
+      </a>
+
+      <select
+        class="locale"
+        aria-label="Language"
+        .value=${this.locale}
+        @change=${this._onLocaleChange}
+      >
+        ${WavyHeader.LOCALES.map(
+          (loc) =>
+            html`<option value=${loc.code} ?selected=${loc.code === this.locale}>
+              ${loc.label}
+            </option>`
+        )}
+      </select>
+
+      ${this.signedIn
+        ? html`
+            <button
+              type="button"
+              class="bell"
+              aria-label="Notifications"
+            >
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
+                <path d="M3 12h10l-1.4-1.4A2 2 0 0 1 11 9.2V7a3 3 0 0 0-6 0v2.2a2 2 0 0 1-.6 1.4L3 12z" stroke-linecap="round" stroke-linejoin="round"/>
+                <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" stroke-linecap="round"/>
+              </svg>
+              <span class="dot violet" ?hidden=${!hasUnread} aria-hidden="true"></span>
+            </button>
+
+            <a class="mail" href="/?q=in:inbox" aria-label="Inbox">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
+                <rect x="2" y="3.5" width="12" height="9" rx="1.4"/>
+                <path d="M2.5 4.5l5.5 4 5.5-4" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </a>
+
+            <button
+              type="button"
+              class="user-menu"
+              aria-haspopup="menu"
+              aria-expanded="false"
+              aria-label="Open user menu"
+              @click=${this._onUserMenuClick}
+            >
+              <span class="avatar" aria-hidden="true">${initials}</span>
+              <span class="user-email">${this.address || ""}</span>
+            </button>
+          `
+        : null}
+    `;
+  }
+}
+
+if (!customElements.get("wavy-header")) {
+  customElements.define("wavy-header", WavyHeader);
+}

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -135,7 +135,7 @@ export class WavyHeader extends LitElement {
     }
     @media (max-width: 600px) {
       .user-email {
-        font-size: 0;
+        display: none;
       }
     }
     svg {

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -33,7 +33,8 @@ export class WavyHeader extends LitElement {
     locale: { type: String, reflect: true },
     address: { type: String, attribute: "data-address", reflect: true },
     userName: { type: String, attribute: "user-name" },
-    unreadCount: { type: Number, attribute: "unread-count" }
+    unreadCount: { type: Number, attribute: "unread-count" },
+    basePath: { type: String, attribute: "base-path" }
   };
 
   // Locale set re-derived from the GWT locale build set; matches the
@@ -151,6 +152,14 @@ export class WavyHeader extends LitElement {
     this.address = "";
     this.userName = "";
     this.unreadCount = 0;
+    this.basePath = "/";
+  }
+
+  _normalizedBasePath() {
+    const raw = (this.basePath || "/").trim();
+    if (!raw || raw === "/") return "/";
+    const withLeading = raw.startsWith("/") ? raw : `/${raw}`;
+    return withLeading.endsWith("/") ? withLeading.slice(0, -1) : withLeading;
   }
 
   _initials() {
@@ -194,8 +203,9 @@ export class WavyHeader extends LitElement {
   render() {
     const initials = this._initials();
     const hasUnread = (this.unreadCount || 0) > 0;
+    const base = this._normalizedBasePath();
     return html`
-      <a class="brand" href="/" aria-label="SupaWave home">
+      <a class="brand" href=${base} aria-label="SupaWave home">
         <span class="brand-dot" aria-hidden="true"></span>
         <span class="brand-text">SupaWave</span>
       </a>
@@ -228,7 +238,7 @@ export class WavyHeader extends LitElement {
               <span class="dot violet" ?hidden=${!hasUnread} aria-hidden="true"></span>
             </button>
 
-            <a class="mail" href="/?q=in:inbox" aria-label="Inbox">
+            <a class="mail" href=${`${base}?q=in:inbox`} aria-label="Inbox">
               <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
                 <rect x="2" y="3.5" width="12" height="9" rx="1.4"/>
                 <path d="M2.5 4.5l5.5 4 5.5-4" stroke-linecap="round" stroke-linejoin="round"/>

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -134,8 +134,7 @@ export class WavyHeader extends LitElement {
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
     }
     @media (max-width: 600px) {
-      .user-email,
-      .locale option {
+      .user-email {
         font-size: 0;
       }
     }
@@ -160,8 +159,12 @@ export class WavyHeader extends LitElement {
     const local = source.split("@")[0];
     if (!local) return "?";
     if (local.includes(".")) {
-      const [a, b] = local.split(".");
-      return ((a[0] || "") + (b[0] || "")).toUpperCase();
+      const parts = local.split(".").filter((part) => part);
+      if (parts.length > 0) {
+        const first = parts[0];
+        const last = parts[parts.length - 1];
+        return ((first[0] || "") + (last[0] || "")).toUpperCase();
+      }
     }
     return local.slice(0, 2).toUpperCase();
   }

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -9,7 +9,7 @@ import { LitElement, css, html } from "lit";
  * - A.2 Locale picker (en/de/es/fr/ru/sl/zh_TW)
  * - A.5 Notifications bell with violet unread dot (uses
  *       --wavy-signal-violet, NOT cyan)
- * - A.6 Inbox/mail icon — jumps to inbox via /?q=in:inbox
+ * - A.6 Inbox/mail icon — jumps to inbox via /?view=j2cl-root&q=in:inbox
  * - A.7 User-menu trigger: avatar chip (initials) + visible email span;
  *       click emits wavy-user-menu-requested for the F-0 menu sheet
  *       (the menu items A.8–A.18 themselves are owned by F-0 and are
@@ -238,7 +238,7 @@ export class WavyHeader extends LitElement {
               <span class="dot violet" ?hidden=${!hasUnread} aria-hidden="true"></span>
             </button>
 
-            <a class="mail" href=${`${base}?q=in:inbox`} aria-label="Inbox">
+            <a class="mail" href=${`${base}?view=j2cl-root&q=in:inbox`} aria-label="Inbox">
               <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
                 <rect x="2" y="3.5" width="12" height="9" rx="1.4"/>
                 <path d="M2.5 4.5l5.5 4 5.5-4" stroke-linecap="round" stroke-linejoin="round"/>

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -222,6 +222,7 @@ export class WavySearchHelp extends LitElement {
         this._lastFocused = this._deepActiveElement();
         // Move focus to the first focusable element inside the modal.
         this.updateComplete.then(() => {
+          if (!this.open) return;
           const first = this._focusable()[0];
           if (first) first.focus();
         });

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -43,9 +43,9 @@ import { LitElement, css, html } from "lit";
  *   clicked. <wavy-search-rail> listens and populates its textbox.
  * - `wavy-search-help-dismissed` — when "Got it" closes the dialog.
  *
- * Accessibility: role="dialog", aria-modal="true". Uses native
- * <dialog> when supported, falls back to a fixed-position
- * role="dialog" div otherwise (iOS Safari pre-15.4).
+ * Accessibility: role="dialog", aria-modal="true". Renders a
+ * fixed-position backdrop and sheet-based custom modal; it does not use
+ * the native <dialog> element.
  */
 export class WavySearchHelp extends LitElement {
   static properties = {

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -205,13 +205,21 @@ export class WavySearchHelp extends LitElement {
   disconnectedCallback() {
     document.removeEventListener("wavy-search-help-toggle", this._onToggle);
     document.removeEventListener("keydown", this._onKey);
+    // Defensive: _onTrapTab is only attached while open, but disconnect can
+    // race with open=true (singleton detached mid-modal); make removal idempotent.
+    document.removeEventListener("keydown", this._onTrapTab);
     super.disconnectedCallback();
   }
 
   updated(changed) {
     if (changed.has("open")) {
       if (this.open) {
-        this._lastFocused = document.activeElement;
+        // Walk through nested shadow roots so we capture the actual focused
+        // element (e.g. the help-trigger inside <wavy-search-rail>'s shadow
+        // DOM), not just the top-level shadow host. Without this, restore
+        // focus would land on the host and the trigger button would never
+        // regain focus on close.
+        this._lastFocused = this._deepActiveElement();
         // Move focus to the first focusable element inside the modal.
         this.updateComplete.then(() => {
           const first = this._focusable()[0];
@@ -226,6 +234,14 @@ export class WavySearchHelp extends LitElement {
         this._lastFocused = null;
       }
     }
+  }
+
+  _deepActiveElement() {
+    let active = document.activeElement;
+    while (active && active.shadowRoot && active.shadowRoot.activeElement) {
+      active = active.shadowRoot.activeElement;
+    }
+    return active;
   }
 
   _focusable() {

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -175,8 +175,10 @@ export class WavySearchHelp extends LitElement {
   constructor() {
     super();
     this.open = false;
+    this._lastFocused = null;
     this._onToggle = this._onToggle.bind(this);
     this._onKey = this._onKey.bind(this);
+    this._onTrapTab = this._onTrapTab.bind(this);
   }
 
   connectedCallback() {
@@ -204,6 +206,51 @@ export class WavySearchHelp extends LitElement {
     document.removeEventListener("wavy-search-help-toggle", this._onToggle);
     document.removeEventListener("keydown", this._onKey);
     super.disconnectedCallback();
+  }
+
+  updated(changed) {
+    if (changed.has("open")) {
+      if (this.open) {
+        this._lastFocused = document.activeElement;
+        // Move focus to the first focusable element inside the modal.
+        this.updateComplete.then(() => {
+          const first = this._focusable()[0];
+          if (first) first.focus();
+        });
+        document.addEventListener("keydown", this._onTrapTab);
+      } else {
+        document.removeEventListener("keydown", this._onTrapTab);
+        if (this._lastFocused && typeof this._lastFocused.focus === "function") {
+          this._lastFocused.focus();
+        }
+        this._lastFocused = null;
+      }
+    }
+  }
+
+  _focusable() {
+    return Array.from(
+      this.shadowRoot.querySelectorAll('button, [tabindex="0"]')
+    ).filter((el) => !el.hasAttribute("disabled") && !el.hasAttribute("hidden"));
+  }
+
+  _onTrapTab(evt) {
+    if (!this.open || evt.key !== "Tab") return;
+    const items = this._focusable();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+    if (evt.shiftKey) {
+      if (document.activeElement === first || this.shadowRoot.activeElement === first) {
+        evt.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last || this.shadowRoot.activeElement === last) {
+        evt.preventDefault();
+        first.focus();
+      }
+    }
   }
 
   _onToggle() {

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -1,0 +1,429 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-search-help> — F-2 (#1037, #1047 slice 3) modal that documents
+ * the search query language.
+ *
+ * Inventory affordances covered (C.1–C.22 from the 2026-04-26 GWT
+ * functional inventory):
+ *
+ * - C.1–C.4 in:inbox/in:archive/in:all/in:pinned filters
+ * - C.5–C.6 with:user@domain / with:@ (public)
+ * - C.7    creator:user@domain
+ * - C.8    tag:name
+ * - C.9    unread:true
+ * - C.10   title:text
+ * - C.11   content:text
+ * - C.12   mentions:me
+ * - C.13–C.15 tasks:all / tasks:me / tasks:user@domain
+ *   (informational only; behavioral filtering owned by F-3 — this slice
+ *   only asserts the modal lists the tokens and the parser accepts them)
+ * - C.16   free text (implicit content:)
+ * - C.17–C.20 orderby:datedesc/dateasc/createddesc/createdasc/creatordesc/creatorasc
+ * - C.21   combinations example chips
+ * - C.22   "Got it" dismiss
+ *
+ * Token contract: every advertised token MUST parse through
+ * QueryHelper.parseQuery. The companion JUnit fixture
+ * J2clSearchHelpTokenParseTest enforces this — any new token added
+ * here that is not in TokenQueryType / OrderByValueType will fail the
+ * parser fixture (the "do NOT invent new tokens" guard from issue
+ * #1047).
+ *
+ * Mount contract: a SINGLE <wavy-search-help id="wavy-search-help">
+ * lives at the document level (mounted by HtmlRenderer in the J2CL
+ * root shell). The <wavy-search-rail> help-trigger emits a
+ * `wavy-search-help-toggle` CustomEvent (composed + bubbles); a
+ * connectedCallback-installed listener on this element flips the
+ * `open` attribute. Avoids duplicate-dialog issues seen in the GWT
+ * panel before backdrops were re-parented to document.body.
+ *
+ * Events emitted:
+ * - `wavy-search-help-example`  — `{detail: {query}}` when a chip is
+ *   clicked. <wavy-search-rail> listens and populates its textbox.
+ * - `wavy-search-help-dismissed` — when "Got it" closes the dialog.
+ *
+ * Accessibility: role="dialog", aria-modal="true". Uses native
+ * <dialog> when supported, falls back to a fixed-position
+ * role="dialog" div otherwise (iOS Safari pre-15.4).
+ */
+export class WavySearchHelp extends LitElement {
+  static properties = {
+    open: { type: Boolean, reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      position: fixed;
+      inset: 0;
+      display: none;
+      z-index: 9000;
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    :host([open]) {
+      display: block;
+    }
+    .backdrop {
+      position: absolute;
+      inset: 0;
+      background: rgba(2, 8, 23, 0.55);
+    }
+    .sheet {
+      position: relative;
+      max-width: 880px;
+      max-height: 86vh;
+      margin: 6vh auto 0;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-5, 20px);
+      background: var(--wavy-bg-surface, #11192a);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      box-shadow: 0 12px 48px rgba(2, 8, 23, 0.45);
+      overflow: auto;
+    }
+    header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-3, 12px);
+      margin-bottom: var(--wavy-spacing-4, 16px);
+    }
+    h2 {
+      margin: 0;
+      font: var(--wavy-type-h2, 1.25rem / 1.3 sans-serif);
+      font-weight: 600;
+    }
+    .dismiss {
+      background: var(--wavy-signal-cyan, #22d3ee);
+      color: var(--wavy-bg-base, #0b1120);
+      border: 0;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      font-weight: 600;
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-4, 16px);
+      cursor: pointer;
+    }
+    .dismiss:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-pulse-ring, 0 0 0 4px rgba(34, 211, 238, 0.22));
+    }
+    .columns {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--wavy-spacing-5, 20px);
+    }
+    @media (max-width: 720px) {
+      .columns {
+        grid-template-columns: 1fr;
+      }
+    }
+    .section-title {
+      font: var(--wavy-type-h3, 1.0625rem / 1.35 sans-serif);
+      font-weight: 600;
+      margin: 0 0 var(--wavy-spacing-2, 8px);
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+    }
+    th {
+      text-align: left;
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      border-bottom: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+    }
+    td {
+      padding: var(--wavy-spacing-2, 8px);
+      vertical-align: top;
+      border-bottom: 1px solid rgba(34, 211, 238, 0.06);
+    }
+    code,
+    .example {
+      font-family: var(--wavy-type-mono-family, ui-monospace, "SF Mono", monospace);
+      font-size: 0.85em;
+      background: rgba(34, 211, 238, 0.08);
+      color: var(--wavy-signal-cyan, #22d3ee);
+      padding: 1px 6px;
+      border-radius: 4px;
+    }
+    .example {
+      cursor: pointer;
+      border: 1px solid transparent;
+    }
+    .example:hover,
+    .example:focus-visible {
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+      outline: none;
+    }
+    .combinations {
+      margin-top: var(--wavy-spacing-4, 16px);
+    }
+    .combinations .grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wavy-spacing-2, 8px);
+    }
+    .free-text-row td:first-child {
+      font-style: italic;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.open = false;
+    this._onToggle = this._onToggle.bind(this);
+    this._onKey = this._onKey.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // The server-side render emits a `hidden` attribute so the SSR
+    // light-DOM modal body does not flash before the J2CL bundle
+    // upgrades the element. Once Lit takes over, the shadow-DOM
+    // `:host { display: none }` rule (gated on the `open` attribute)
+    // drives visibility, so we drop the SSR `hidden` here. We also
+    // assign the singleton id so client-only mounts (design preview /
+    // future test harness) still satisfy the rail's aria-controls.
+    if (this.hasAttribute("hidden")) {
+      this.removeAttribute("hidden");
+    }
+    if (!this.id) {
+      this.id = "wavy-search-help";
+    }
+    // Listen at document level so the rail's help-trigger can toggle us
+    // even though it lives in a different shadow root.
+    document.addEventListener("wavy-search-help-toggle", this._onToggle);
+    document.addEventListener("keydown", this._onKey);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener("wavy-search-help-toggle", this._onToggle);
+    document.removeEventListener("keydown", this._onKey);
+    super.disconnectedCallback();
+  }
+
+  _onToggle() {
+    this.open = !this.open;
+  }
+
+  _onKey(evt) {
+    if (this.open && evt.key === "Escape") {
+      this._dismiss();
+    }
+  }
+
+  _dismiss() {
+    this.open = false;
+    this.dispatchEvent(
+      new CustomEvent("wavy-search-help-dismissed", {
+        bubbles: true,
+        composed: true
+      })
+    );
+  }
+
+  _emitExample(query) {
+    this.dispatchEvent(
+      new CustomEvent("wavy-search-help-example", {
+        bubbles: true,
+        composed: true,
+        detail: { query }
+      })
+    );
+  }
+
+  _example(query) {
+    return html`<span
+      class="example"
+      role="button"
+      tabindex="0"
+      @click=${() => this._emitExample(query)}
+      @keydown=${(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          this._emitExample(query);
+        }
+      }}
+      >${query}</span
+    >`;
+  }
+
+  render() {
+    return html`
+      <div class="backdrop" @click=${this._dismiss}></div>
+      <div
+        class="sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wavy-search-help-title"
+      >
+        <header>
+          <h2 id="wavy-search-help-title">Search Help</h2>
+          <button
+            type="button"
+            class="dismiss"
+            @click=${this._dismiss}
+            aria-label="Close search help"
+          >
+            Got it
+          </button>
+        </header>
+        <div class="columns">
+          <section>
+            <p class="section-title">Filters</p>
+            <table>
+              <thead>
+                <tr><th>Filter</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>${this._example("in:inbox")}</td>
+                  <td>Waves in your inbox</td>
+                </tr>
+                <tr>
+                  <td>${this._example("in:archive")}</td>
+                  <td>Archived waves</td>
+                </tr>
+                <tr>
+                  <td>${this._example("in:all")}</td>
+                  <td>All waves including public</td>
+                </tr>
+                <tr>
+                  <td>${this._example("in:pinned")}</td>
+                  <td>Pinned waves</td>
+                </tr>
+                <tr>
+                  <td><code>with:user@domain</code></td>
+                  <td>
+                    Waves with a participant — try:
+                    ${this._example("with:alice@example.com")}
+                  </td>
+                </tr>
+                <tr>
+                  <td>${this._example("with:@")}</td>
+                  <td>Public waves (shared domain)</td>
+                </tr>
+                <tr>
+                  <td><code>creator:user@domain</code></td>
+                  <td>
+                    Waves created by someone — try:
+                    ${this._example("creator:bob@example.com")}
+                  </td>
+                </tr>
+                <tr>
+                  <td><code>tag:name</code></td>
+                  <td>
+                    Waves with a specific tag — try:
+                    ${this._example("tag:important")}
+                  </td>
+                </tr>
+                <tr>
+                  <td>${this._example("unread:true")}</td>
+                  <td>Only waves with unread blips</td>
+                </tr>
+                <tr>
+                  <td><code>title:text</code></td>
+                  <td>
+                    Waves whose title contains text — try:
+                    ${this._example("title:meeting")}
+                  </td>
+                </tr>
+                <tr>
+                  <td><code>content:text</code></td>
+                  <td>
+                    Waves containing text in any blip — try:
+                    ${this._example("content:agenda")}
+                  </td>
+                </tr>
+                <tr>
+                  <td>${this._example("mentions:me")}</td>
+                  <td>Waves where you are @mentioned</td>
+                </tr>
+                <tr>
+                  <td>${this._example("tasks:all")}</td>
+                  <td>Waves you can access that contain any task</td>
+                </tr>
+                <tr>
+                  <td>${this._example("tasks:me")}</td>
+                  <td>Waves with tasks assigned to you</td>
+                </tr>
+                <tr>
+                  <td><code>tasks:user@domain</code></td>
+                  <td>
+                    Tasks assigned to someone specific — try:
+                    ${this._example("tasks:alice@example.com")}
+                  </td>
+                </tr>
+                <tr class="free-text-row">
+                  <td>free text</td>
+                  <td>
+                    Implicit content: search — try:
+                    ${this._example("meeting notes")}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <p class="section-title">Sort Options</p>
+            <table>
+              <thead>
+                <tr><th>Sort</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>${this._example("orderby:datedesc")}</td>
+                  <td>Last modified, newest first (default)</td>
+                </tr>
+                <tr>
+                  <td>${this._example("orderby:dateasc")}</td>
+                  <td>Last modified, oldest first</td>
+                </tr>
+                <tr>
+                  <td>${this._example("orderby:createddesc")}</td>
+                  <td>Created time, newest first</td>
+                </tr>
+                <tr>
+                  <td>${this._example("orderby:createdasc")}</td>
+                  <td>Created time, oldest first</td>
+                </tr>
+                <tr>
+                  <td>${this._example("orderby:creatordesc")}</td>
+                  <td>Creator email Z→A</td>
+                </tr>
+                <tr>
+                  <td>${this._example("orderby:creatorasc")}</td>
+                  <td>Creator email A→Z</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="combinations">
+              <p class="section-title">Combinations</p>
+              <p>
+                Filters combine freely. The default sort is
+                <code>orderby:datedesc</code> (newest first).
+              </p>
+              <div class="grid">
+                ${this._example("in:inbox tag:important")}
+                ${this._example("in:all orderby:createdasc")}
+                ${this._example("with:alice@example.com tag:project")}
+                ${this._example("in:pinned orderby:creatordesc")}
+                ${this._example("creator:bob in:archive")}
+                ${this._example("mentions:me unread:true")}
+                ${this._example("tasks:all unread:true")}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-search-help")) {
+  customElements.define("wavy-search-help", WavySearchHelp);
+}

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -1,0 +1,270 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-search-rail-card> — F-2 (#1037, #1047 slice 3) per-digest card
+ * inside the saved-search rail. One card per wave in the active
+ * folder's search results.
+ *
+ * Inventory affordances covered (B.13–B.18 from the 2026-04-26 GWT
+ * functional inventory):
+ *
+ * - B.13 multi-author avatar stack (overlapping, max 3 visible + +N)
+ * - B.14 pinned indicator (cyan pin glyph when pinned attribute set)
+ * - B.15 title
+ * - B.16 snippet (multi-line truncated at 3 lines)
+ * - B.17 msg count + unread badge with cyan signal-pulse on change
+ *        (the pulse uses --wavy-pulse-ring composed by F-0)
+ * - B.18 relative timestamp with full ISO datetime tooltip
+ *
+ * The card emits `wavy-search-rail-card-selected` on click (bubbles +
+ * composed) so the rail / surrounding shell can route to the wave.
+ *
+ * Public API:
+ * - waveId        — string, reflected to data-wave-id
+ * - title         — string (defaults to "(no title)")
+ * - snippet       — string
+ * - postedAt      — string, e.g. "2m ago"
+ * - postedAtIso   — string, ISO-8601 timestamp for tooltip
+ * - msgCount      — number (defaults to 0)
+ * - unreadCount   — number (defaults to 0); when > 0 the unread badge
+ *                   shows and firePulse() restarts the cyan signal-ring
+ * - pinned        — boolean
+ * - authors       — string (comma-separated display names; the card
+ *                   parses into avatar chips with initials)
+ *
+ * Methods:
+ * - firePulse() — sets data-pulse="ring" for --wavy-motion-pulse-duration
+ *                 then clears it. The CSS uses --wavy-pulse-ring as the
+ *                 box-shadow during the pulse so the badge matches the
+ *                 F-0 wavy-blip-card live-pulse contract.
+ */
+export class WavySearchRailCard extends LitElement {
+  static properties = {
+    waveId: { type: String, attribute: "data-wave-id", reflect: true },
+    title: { type: String },
+    snippet: { type: String },
+    postedAt: { type: String, attribute: "posted-at" },
+    postedAtIso: { type: String, attribute: "posted-at-iso" },
+    msgCount: { type: Number, attribute: "msg-count" },
+    unreadCount: { type: Number, attribute: "unread-count" },
+    pinned: { type: Boolean, reflect: true },
+    authors: { type: String }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-3, 12px);
+      margin-bottom: var(--wavy-spacing-2, 8px);
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      cursor: pointer;
+      transition: border-color var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    :host(:hover),
+    :host(:focus-within) {
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    .top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-2, 8px);
+      margin-bottom: var(--wavy-spacing-1, 4px);
+    }
+    .avatar-stack {
+      display: inline-flex;
+    }
+    .avatar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: var(--wavy-bg-base, #0b1120);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      font-weight: 600;
+    }
+    .avatar + .avatar {
+      margin-left: -6px;
+    }
+    .avatar.more {
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+    .pin {
+      color: var(--wavy-signal-cyan, #22d3ee);
+      font-size: 14px;
+      line-height: 1;
+    }
+    h3.title {
+      margin: 0 0 var(--wavy-spacing-1, 4px);
+      font: var(--wavy-type-h3, 1.0625rem / 1.35 sans-serif);
+      font-weight: 600;
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    p.snippet {
+      margin: 0 0 var(--wavy-spacing-2, 8px);
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+    .footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-2, 8px);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+    .msg-count {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-1, 4px);
+    }
+    .badge.unread {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      padding: 0 6px;
+      height: 16px;
+      border-radius: 9999px;
+      background: var(--wavy-signal-cyan, #22d3ee);
+      color: var(--wavy-bg-base, #0b1120);
+      font-weight: 600;
+      transition: box-shadow var(--wavy-motion-pulse-duration, 600ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    :host([data-pulse="ring"]) .badge.unread {
+      box-shadow: var(--wavy-pulse-ring, 0 0 0 4px rgba(34, 211, 238, 0.22));
+    }
+    time.ts {
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.waveId = "";
+    this.title = "";
+    this.snippet = "";
+    this.postedAt = "";
+    this.postedAtIso = "";
+    this.msgCount = 0;
+    this.unreadCount = 0;
+    this.pinned = false;
+    this.authors = "";
+  }
+
+  firePulse() {
+    this.dataset.pulse = "ring";
+    // Clear the pulse marker after the configured duration (matches the
+    // wavy-blip-card pattern from F-0). Using setTimeout instead of
+    // animationend so we don't depend on a CSS animation declaration.
+    const dur =
+      parseInt(
+        getComputedStyle(this).getPropertyValue("--wavy-motion-pulse-duration") || "600",
+        10
+      ) || 600;
+    setTimeout(() => {
+      delete this.dataset.pulse;
+    }, dur);
+  }
+
+  _emitSelected() {
+    this.dispatchEvent(
+      new CustomEvent("wavy-search-rail-card-selected", {
+        bubbles: true,
+        composed: true,
+        detail: { waveId: this.waveId }
+      })
+    );
+  }
+
+  _initials(name) {
+    if (!name) return "?";
+    const parts = String(name).trim().split(/\s+/);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+
+  _authorList() {
+    return (this.authors || "")
+      .split(",")
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+  }
+
+  render() {
+    const authors = this._authorList();
+    const visible = authors.slice(0, 3);
+    const overflow = Math.max(0, authors.length - 3);
+    return html`
+      <article
+        @click=${this._emitSelected}
+        @keydown=${(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            this._emitSelected();
+          }
+        }}
+        tabindex="0"
+        role="article"
+        aria-label=${this.title || "(no title)"}
+      >
+        <div class="top">
+          <div class="avatar-stack" aria-label="Authors">
+            ${visible.map(
+              (name) =>
+                html`<span class="avatar" data-initials=${this._initials(name)} title=${name}
+                  >${this._initials(name)}</span
+                >`
+            )}
+            ${overflow > 0
+              ? html`<span class="avatar more" title="and ${overflow} more">+${overflow}</span>`
+              : null}
+          </div>
+          ${this.pinned
+            ? html`<span class="pin" aria-label="Pinned" title="Pinned">📌</span>`
+            : null}
+        </div>
+        <h3 class="title">${this.title || "(no title)"}</h3>
+        <p class="snippet">${this.snippet || ""}</p>
+        <div class="footer">
+          <span class="msg-count" aria-label="Message count">
+            <span>${this.msgCount}</span>
+            ${this.unreadCount > 0
+              ? html`<span class="badge unread" aria-label="${this.unreadCount} unread"
+                  >${this.unreadCount}</span
+                >`
+              : null}
+          </span>
+          ${this.postedAtIso
+            ? html`<time
+                class="ts"
+                datetime=${this.postedAtIso}
+                title=${this.postedAtIso}
+                >${this.postedAt || ""}</time
+              >`
+            : html`<time class="ts">${this.postedAt || ""}</time>`}
+        </div>
+      </article>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-search-rail-card")) {
+  customElements.define("wavy-search-rail-card", WavySearchRailCard);
+}

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -268,6 +268,10 @@ export class WavySearchRail extends LitElement {
     }
   }
 
+  _onQueryInput(evt) {
+    this.query = evt.target.value;
+  }
+
   _onFolderClick(folder) {
     this.query = folder.query;
     this.activeFolder = folder.id;
@@ -292,6 +296,7 @@ export class WavySearchRail extends LitElement {
           aria-label="Search waves"
           .value=${this.query}
           @keydown=${this._onQueryKey}
+          @input=${this._onQueryInput}
         />
         <button
           type="button"

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -1,0 +1,380 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-search-rail> — F-2 (#1037, #1047 slice 3) left-rail search
+ * surface that hosts the query textbox, the saved-search folder list,
+ * and the inline header controls (help trigger, New Wave, Manage
+ * saved searches, Refresh, result count).
+ *
+ * Inventory affordances covered (B.1–B.12 from the 2026-04-26 GWT
+ * functional inventory). Per-digest cards (B.13–B.18) are owned by
+ * <wavy-search-rail-card> and slotted into this rail's default slot.
+ *
+ * - B.1  query textbox (default: in:inbox; waveform glyph; Enter
+ *        emits wavy-search-submit)
+ * - B.2  search-help trigger (?)  — emits wavy-search-help-toggle;
+ *        does NOT own the modal (single document-level instance lives
+ *        under <shell-root> and listens for the toggle event)
+ * - B.3  New Wave button — emits wavy-new-wave-requested; carries
+ *        aria-keyshortcuts metadata. The global Shift+Cmd+O keyboard
+ *        listener is intentionally OUT OF SCOPE for this slice (S6
+ *        wires the URL state + global keymap)
+ * - B.4  Manage saved searches — emits wavy-manage-saved-searches-requested
+ * - B.5–B.10 Six saved-search folders (Inbox/Mentions/Tasks/Public/
+ *        Archive/Pinned) with the canonical query strings; Inbox is
+ *        the default selection. Mentions has a violet unread dot
+ *        (revealed when mentions-unread > 0 via --wavy-signal-violet);
+ *        Tasks has an amber pending count chip (revealed when
+ *        tasks-pending > 0 via --wavy-signal-amber)
+ * - B.11 Refresh search results
+ * - B.12 Result count "N waves" (low-emphasis, aria-live=polite)
+ *
+ * Active-folder derivation: when the `query` attribute changes, the
+ * rail picks the folder whose canonical query string is a prefix of
+ * the current query (case-insensitive) and reflects the match through
+ * `data-active-folder` and the matched folder's `aria-current="page"`.
+ * If nothing matches, no folder gets aria-current=page (the user is
+ * running a custom query).
+ */
+export class WavySearchRail extends LitElement {
+  static properties = {
+    query: { type: String, reflect: true },
+    activeFolder: { type: String, attribute: "data-active-folder", reflect: true },
+    resultCount: { type: String, attribute: "result-count", reflect: true },
+    mentionsUnread: { type: Number, attribute: "mentions-unread" },
+    tasksPending: { type: Number, attribute: "tasks-pending" }
+  };
+
+  static FOLDERS = [
+    { id: "inbox", label: "Inbox", query: "in:inbox" },
+    { id: "mentions", label: "Mentions", query: "mentions:me" },
+    { id: "tasks", label: "Tasks", query: "tasks:me" },
+    { id: "public", label: "Public", query: "with:@" },
+    { id: "archive", label: "Archive", query: "in:archive" },
+    { id: "pinned", label: "Pinned", query: "in:pinned" }
+  ];
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      padding: var(--wavy-spacing-3, 12px);
+      background: var(--wavy-bg-base, #0b1120);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      min-width: 240px;
+    }
+    .search {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      margin-bottom: var(--wavy-spacing-3, 12px);
+    }
+    .query {
+      flex: 1 1 auto;
+      box-sizing: border-box;
+      width: 100%;
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-3, 12px);
+      padding-left: 32px;
+      background: var(--wavy-bg-surface, #11192a);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+    }
+    .query:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-pulse-ring, 0 0 0 2px rgba(34, 211, 238, 0.22));
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    .waveform {
+      position: absolute;
+      left: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--wavy-signal-cyan, #22d3ee);
+      pointer-events: none;
+      width: 14px;
+      height: 14px;
+    }
+    .help-trigger {
+      flex: 0 0 auto;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .help-trigger:hover,
+    .help-trigger:focus-visible {
+      color: var(--wavy-signal-cyan, #22d3ee);
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+      outline: none;
+    }
+    .actions {
+      display: flex;
+      gap: var(--wavy-spacing-2, 8px);
+      margin-bottom: var(--wavy-spacing-3, 12px);
+    }
+    .new-wave {
+      flex: 1 1 auto;
+      background: var(--wavy-signal-cyan, #22d3ee);
+      color: var(--wavy-bg-base, #0b1120);
+      border: 0;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-3, 12px);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .manage-saved {
+      flex: 0 0 auto;
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-pill, 9999px);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-3, 12px);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      cursor: pointer;
+    }
+    .folders-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: var(--wavy-spacing-1, 4px);
+    }
+    .folders-header h2 {
+      margin: 0;
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .refresh {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 0;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    .refresh:hover,
+    .refresh:focus-visible {
+      color: var(--wavy-signal-cyan, #22d3ee);
+      outline: none;
+    }
+    ul.folders {
+      list-style: none;
+      margin: 0 0 var(--wavy-spacing-3, 12px);
+      padding: 0;
+    }
+    .folder {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-2, 8px);
+      background: transparent;
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 0;
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      border-radius: var(--wavy-radius-pill, 9999px);
+      cursor: pointer;
+      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      text-align: left;
+    }
+    .folder[aria-current="page"] {
+      background: rgba(34, 211, 238, 0.12);
+      color: var(--wavy-signal-cyan, #22d3ee);
+      font-weight: 600;
+    }
+    .folder:hover,
+    .folder:focus-visible {
+      outline: none;
+      background: rgba(34, 211, 238, 0.06);
+    }
+    .dot.mentions-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--wavy-signal-violet, #7c3aed);
+    }
+    .chip.tasks-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 18px;
+      height: 16px;
+      padding: 0 6px;
+      border-radius: 9999px;
+      background: var(--wavy-signal-amber, #fb923c);
+      color: var(--wavy-bg-base, #0b1120);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      font-weight: 600;
+    }
+    p.result-count {
+      margin: 0 0 var(--wavy-spacing-3, 12px);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+  `;
+
+  constructor() {
+    super();
+    this.query = "in:inbox";
+    this.activeFolder = "inbox";
+    this.resultCount = "";
+    this.mentionsUnread = 0;
+    this.tasksPending = 0;
+  }
+
+  willUpdate(changed) {
+    if (changed.has("query")) {
+      this.activeFolder = this._deriveActiveFolder(this.query);
+    }
+  }
+
+  _deriveActiveFolder(q) {
+    const text = (q || "").trim().toLowerCase();
+    if (text.length === 0) return "";
+    for (const folder of WavySearchRail.FOLDERS) {
+      const fq = folder.query.toLowerCase();
+      if (text === fq || text.startsWith(fq + " ")) {
+        return folder.id;
+      }
+    }
+    return "";
+  }
+
+  _emit(name, detail) {
+    this.dispatchEvent(
+      new CustomEvent(name, {
+        bubbles: true,
+        composed: true,
+        detail: detail || {}
+      })
+    );
+  }
+
+  _onQueryKey(evt) {
+    if (evt.key === "Enter") {
+      evt.preventDefault();
+      const value = evt.target.value;
+      this.query = value;
+      this._emit("wavy-search-submit", { query: value });
+    }
+  }
+
+  _onFolderClick(folder) {
+    this.query = folder.query;
+    this.activeFolder = folder.id;
+    this._emit("wavy-saved-search-selected", {
+      folderId: folder.id,
+      query: folder.query
+    });
+  }
+
+  render() {
+    return html`
+      <div class="search">
+        <span class="waveform" aria-hidden="true">
+          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6">
+            <path d="M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </span>
+        <input
+          type="search"
+          class="query"
+          name="q"
+          aria-label="Search waves"
+          .value=${this.query}
+          @keydown=${this._onQueryKey}
+        />
+        <button
+          type="button"
+          class="help-trigger"
+          aria-label="Search help"
+          aria-haspopup="dialog"
+          aria-controls="wavy-search-help"
+          @click=${() => this._emit("wavy-search-help-toggle")}
+        >
+          ?
+        </button>
+      </div>
+
+      <div class="actions">
+        <button
+          type="button"
+          class="new-wave"
+          data-shortcut="Shift+Cmd+O"
+          aria-keyshortcuts="Shift+Meta+O Shift+Control+O"
+          @click=${() => this._emit("wavy-new-wave-requested")}
+        >
+          New Wave
+        </button>
+        <button
+          type="button"
+          class="manage-saved"
+          @click=${() => this._emit("wavy-manage-saved-searches-requested")}
+        >
+          Manage saved searches
+        </button>
+      </div>
+
+      <div class="folders-header">
+        <h2 id="folders-title">Saved searches</h2>
+        <button
+          type="button"
+          class="refresh"
+          aria-label="Refresh search results"
+          @click=${() => this._emit("wavy-search-refresh-requested")}
+        >
+          ⟳
+        </button>
+      </div>
+      <ul class="folders" aria-labelledby="folders-title">
+        ${WavySearchRail.FOLDERS.map((folder) => {
+          const selected = folder.id === this.activeFolder;
+          return html`
+            <li>
+              <button
+                type="button"
+                class="folder"
+                data-folder-id=${folder.id}
+                data-query=${folder.query}
+                aria-current=${selected ? "page" : "false"}
+                @click=${() => this._onFolderClick(folder)}
+              >
+                <span class="label">${folder.label}</span>
+                ${folder.id === "mentions"
+                  ? html`<span
+                      class="dot mentions-dot"
+                      aria-label="${this.mentionsUnread || 0} unread mentions"
+                      ?hidden=${!this.mentionsUnread || this.mentionsUnread <= 0}
+                    ></span>`
+                  : null}
+                ${folder.id === "tasks"
+                  ? html`<span
+                      class="chip tasks-chip"
+                      aria-label="${this.tasksPending || 0} pending tasks"
+                      ?hidden=${!this.tasksPending || this.tasksPending <= 0}
+                      >${this.tasksPending || 0}</span
+                    >`
+                  : null}
+              </button>
+            </li>
+          `;
+        })}
+      </ul>
+      <p class="result-count" aria-live="polite">${this.resultCount || ""}</p>
+      <slot></slot>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-search-rail")) {
+  customElements.define("wavy-search-rail", WavySearchRail);
+}

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -44,6 +44,14 @@ import "./elements/wave-blip.js";
 import "./elements/wavy-focus-frame.js";
 import "./elements/wavy-wave-nav-row.js";
 import "./elements/wavy-depth-nav-bar.js";
+// F-2 slice 3 (#1047): search rail + search-help modal + wavy header
+// chrome. <wavy-search-help> mounts as a single document-level
+// instance under <shell-root>; <wavy-search-rail> drives it via the
+// wavy-search-help-toggle CustomEvent.
+import "./elements/wavy-search-help.js";
+import "./elements/wavy-search-rail-card.js";
+import "./elements/wavy-search-rail.js";
+import "./elements/wavy-header.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -128,6 +128,16 @@ describe("<wavy-header>", () => {
     const avatar = el.renderRoot.querySelector(".avatar");
     expect(avatar.textContent.trim()).to.equal("?");
   });
+
+  it("avatar initials use first + last segment for multi-dot addresses (SSR parity)", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="john.q.public@x.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const avatar = el.renderRoot.querySelector(".avatar");
+    // first="john" → J, last="public" → P (not second segment "q")
+    expect(avatar.textContent.trim()).to.equal("JP");
+  });
 });
 
 function WavyHeader_styleText() {

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -127,6 +127,9 @@ describe("<wavy-header>", () => {
     await el.updateComplete;
     const avatar = el.renderRoot.querySelector(".avatar");
     expect(avatar.textContent.trim()).to.equal("?");
+    const email = el.renderRoot.querySelector(".user-email");
+    expect(email).to.exist;
+    expect(email.textContent.trim()).to.equal("");
   });
 
   it("avatar initials use first + last segment for multi-dot addresses (SSR parity)", async () => {

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -1,0 +1,138 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-header.js";
+
+describe("<wavy-header>", () => {
+  it("registers the F-2.S3 wavy-header element", () => {
+    expect(customElements.get("wavy-header")).to.exist;
+  });
+
+  it("renders the brand link with cyan signal-dot accent (A.1)", async () => {
+    const el = await fixture(html`<wavy-header></wavy-header>`);
+    await el.updateComplete;
+    const brand = el.renderRoot.querySelector("a.brand");
+    expect(brand).to.exist;
+    expect(brand.getAttribute("href")).to.equal("/");
+    expect(brand.querySelector(".brand-dot")).to.exist;
+    expect(brand.querySelector(".brand-text").textContent.trim()).to.equal("SupaWave");
+  });
+
+  it("brand-dot CSS uses --wavy-signal-cyan token (A.1 contract)", () => {
+    const cssText = WavyHeader_styleText();
+    expect(cssText).to.include("var(--wavy-signal-cyan");
+    // Sanity: ensure the dot rule itself uses the cyan token (not just
+    // present elsewhere in the stylesheet for unrelated rules).
+    expect(cssText).to.match(/\.brand-dot\s*\{[^}]*var\(--wavy-signal-cyan/);
+  });
+
+  it("locale picker emits 7 options with the canonical codes (A.2)", async () => {
+    const el = await fixture(html`<wavy-header></wavy-header>`);
+    await el.updateComplete;
+    const select = el.renderRoot.querySelector("select.locale");
+    expect(select).to.exist;
+    expect(select.getAttribute("aria-label")).to.equal("Language");
+    const options = Array.from(select.querySelectorAll("option")).map((o) => o.value);
+    expect(options).to.deep.equal(["en", "de", "es", "fr", "ru", "sl", "zh_TW"]);
+  });
+
+  it("change on locale picker emits wavy-locale-changed (A.2)", async () => {
+    const el = await fixture(html`<wavy-header></wavy-header>`);
+    await el.updateComplete;
+    const select = el.renderRoot.querySelector("select.locale");
+    select.value = "de";
+    setTimeout(() => select.dispatchEvent(new Event("change", { bubbles: true })), 0);
+    const evt = await oneEvent(el, "wavy-locale-changed");
+    expect(evt.detail.locale).to.equal("de");
+    expect(el.locale).to.equal("de");
+  });
+
+  it("notifications bell renders only when signed-in (A.5)", async () => {
+    const elOut = await fixture(html`<wavy-header></wavy-header>`);
+    await elOut.updateComplete;
+    expect(elOut.renderRoot.querySelector(".bell")).to.be.null;
+
+    const elIn = await fixture(
+      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
+    );
+    await elIn.updateComplete;
+    expect(elIn.renderRoot.querySelector(".bell")).to.exist;
+  });
+
+  it("bell unread dot toggles on unread-count > 0 (A.5)", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const dot = el.renderRoot.querySelector(".bell .dot.violet");
+    expect(dot).to.exist;
+    expect(dot.hasAttribute("hidden")).to.be.true;
+    el.unreadCount = 4;
+    await el.updateComplete;
+    expect(dot.hasAttribute("hidden")).to.be.false;
+  });
+
+  it("bell unread dot uses --wavy-signal-violet, NOT cyan (A.5)", () => {
+    const cssText = WavyHeader_styleText();
+    expect(cssText).to.match(/\.dot\.violet\s*\{[^}]*var\(--wavy-signal-violet/);
+  });
+
+  it("mail icon links to /?q=in:inbox (A.6)", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const mail = el.renderRoot.querySelector("a.mail");
+    expect(mail).to.exist;
+    expect(mail.getAttribute("href")).to.equal("/?q=in:inbox");
+    expect(mail.getAttribute("aria-label")).to.equal("Inbox");
+  });
+
+  it("user-menu trigger renders avatar with initials AND visible email span (A.7)", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="alice.smith@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const userMenu = el.renderRoot.querySelector("button.user-menu");
+    expect(userMenu).to.exist;
+    expect(userMenu.getAttribute("aria-haspopup")).to.equal("menu");
+    const avatar = userMenu.querySelector(".avatar");
+    expect(avatar).to.exist;
+    expect(avatar.textContent.trim()).to.equal("AS"); // alice.smith → A + S
+    const email = userMenu.querySelector(".user-email");
+    expect(email).to.exist;
+    expect(email.textContent.trim()).to.equal("alice.smith@example.com");
+  });
+
+  it("user-menu click emits wavy-user-menu-requested with the address (A.7)", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const userMenu = el.renderRoot.querySelector("button.user-menu");
+    setTimeout(() => userMenu.click(), 0);
+    const evt = await oneEvent(el, "wavy-user-menu-requested");
+    expect(evt.detail.address).to.equal("alice@example.com");
+  });
+
+  it("avatar initials handle single-name emails", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in data-address="bob@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const avatar = el.renderRoot.querySelector(".avatar");
+    expect(avatar.textContent.trim()).to.equal("BO");
+  });
+
+  it("missing address falls back to ? for initials and empty email span", async () => {
+    const el = await fixture(html`<wavy-header signed-in></wavy-header>`);
+    await el.updateComplete;
+    const avatar = el.renderRoot.querySelector(".avatar");
+    expect(avatar.textContent.trim()).to.equal("?");
+  });
+});
+
+function WavyHeader_styleText() {
+  const cls = customElements.get("wavy-header");
+  const styles = cls.styles;
+  const arr = Array.isArray(styles) ? styles : [styles];
+  return arr.map((s) => (s && s.cssText) || "").join("\n");
+}

--- a/j2cl/lit/test/wavy-search-help.test.js
+++ b/j2cl/lit/test/wavy-search-help.test.js
@@ -1,0 +1,154 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-search-help.js";
+
+describe("<wavy-search-help>", () => {
+  it("registers the F-2.S3 modal element", () => {
+    expect(customElements.get("wavy-search-help")).to.exist;
+  });
+
+  it("strips SSR `hidden` attribute on connectedCallback (no-flicker upgrade)", async () => {
+    // Construct a host with the SSR-shape attribute to confirm Lit
+    // drops `hidden` so the modal can later be opened via the toggle.
+    const el = await fixture(html`<wavy-search-help hidden></wavy-search-help>`);
+    await el.updateComplete;
+    expect(el.hasAttribute("hidden")).to.be.false;
+  });
+
+  it("auto-assigns id=wavy-search-help when SSR mounted without id", async () => {
+    const el = await fixture(html`<wavy-search-help></wavy-search-help>`);
+    await el.updateComplete;
+    expect(el.id).to.equal("wavy-search-help");
+  });
+
+  it("renders closed by default and opens via the document-level toggle event", async () => {
+    const el = await fixture(html`<wavy-search-help></wavy-search-help>`);
+    expect(el.hasAttribute("open")).to.be.false;
+    document.dispatchEvent(new CustomEvent("wavy-search-help-toggle"));
+    await el.updateComplete;
+    expect(el.hasAttribute("open")).to.be.true;
+    document.dispatchEvent(new CustomEvent("wavy-search-help-toggle"));
+    await el.updateComplete;
+    expect(el.hasAttribute("open")).to.be.false;
+  });
+
+  it("renders dialog semantics (role=dialog, aria-modal)", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const sheet = el.renderRoot.querySelector(".sheet");
+    expect(sheet.getAttribute("role")).to.equal("dialog");
+    expect(sheet.getAttribute("aria-modal")).to.equal("true");
+  });
+
+  // C.1–C.16 filter rows, C.17–C.20 sort rows, C.21 combination chips, C.22 dismiss
+  const ADVERTISED_TOKENS = [
+    // Filters (C.1–C.15)
+    "in:inbox",
+    "in:archive",
+    "in:all",
+    "in:pinned",
+    "with:user@domain",
+    "with:alice@example.com",
+    "with:@",
+    "creator:user@domain",
+    "creator:bob@example.com",
+    "tag:name",
+    "tag:important",
+    "unread:true",
+    "title:text",
+    "title:meeting",
+    "content:text",
+    "content:agenda",
+    "mentions:me",
+    "tasks:all",
+    "tasks:me",
+    "tasks:user@domain",
+    "tasks:alice@example.com",
+    // Free text marker (C.16)
+    "meeting notes",
+    // Sort (C.17–C.20)
+    "orderby:datedesc",
+    "orderby:dateasc",
+    "orderby:createddesc",
+    "orderby:createdasc",
+    "orderby:creatordesc",
+    "orderby:creatorasc",
+    // Combination examples (C.21)
+    "in:inbox tag:important",
+    "in:all orderby:createdasc",
+    "with:alice@example.com tag:project",
+    "in:pinned orderby:creatordesc",
+    "creator:bob in:archive",
+    "mentions:me unread:true",
+    "tasks:all unread:true"
+  ];
+
+  ADVERTISED_TOKENS.forEach((token) => {
+    it(`advertises the ${token} token literal in the modal body`, async () => {
+      const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+      await el.updateComplete;
+      const text = el.renderRoot.textContent || "";
+      expect(text).to.include(token);
+    });
+  });
+
+  it("each filter example chip emits wavy-search-help-example with the token", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const examples = Array.from(el.renderRoot.querySelectorAll(".example"));
+    expect(examples.length).to.be.greaterThan(20);
+    const inboxChip = examples.find((e) => e.textContent.trim() === "in:inbox");
+    expect(inboxChip, "in:inbox chip exists").to.exist;
+    setTimeout(() => inboxChip.click(), 0);
+    const evt = await oneEvent(el, "wavy-search-help-example");
+    expect(evt.detail.query).to.equal("in:inbox");
+  });
+
+  it("Got it dismiss closes the dialog and emits wavy-search-help-dismissed", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const dismiss = el.renderRoot.querySelector(".dismiss");
+    expect(dismiss).to.exist;
+    expect(dismiss.textContent.trim()).to.equal("Got it");
+    setTimeout(() => dismiss.click(), 0);
+    const evt = await oneEvent(el, "wavy-search-help-dismissed");
+    expect(evt).to.exist;
+    expect(el.hasAttribute("open")).to.be.false;
+  });
+
+  it("Escape key dismisses when open", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await el.updateComplete;
+    expect(el.hasAttribute("open")).to.be.false;
+  });
+
+  it("backdrop click dismisses", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const backdrop = el.renderRoot.querySelector(".backdrop");
+    expect(backdrop).to.exist;
+    backdrop.click();
+    await el.updateComplete;
+    expect(el.hasAttribute("open")).to.be.false;
+  });
+
+  it("renders both Filters and Sort Options sections", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const titles = Array.from(el.renderRoot.querySelectorAll(".section-title")).map(
+      (n) => n.textContent.trim()
+    );
+    expect(titles).to.include("Filters");
+    expect(titles).to.include("Sort Options");
+    expect(titles).to.include("Combinations");
+  });
+
+  it("renders the free-text row marker", async () => {
+    const el = await fixture(html`<wavy-search-help open></wavy-search-help>`);
+    await el.updateComplete;
+    const row = el.renderRoot.querySelector(".free-text-row");
+    expect(row).to.exist;
+    expect(row.textContent).to.include("free text");
+  });
+});

--- a/j2cl/lit/test/wavy-search-rail-card.test.js
+++ b/j2cl/lit/test/wavy-search-rail-card.test.js
@@ -1,0 +1,172 @@
+import { fixture, expect, html, oneEvent, aTimeout } from "@open-wc/testing";
+import "../src/elements/wavy-search-rail-card.js";
+
+describe("<wavy-search-rail-card>", () => {
+  it("registers the F-2.S3 digest card element", () => {
+    expect(customElements.get("wavy-search-rail-card")).to.exist;
+  });
+
+  it("reflects wave-id, pinned, msg-count, unread-count attributes", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card
+        data-wave-id="w1"
+        title="Hello"
+        snippet="Lorem ipsum"
+        posted-at="2m ago"
+        posted-at-iso="2026-04-26T12:00:00Z"
+        msg-count="5"
+        unread-count="2"
+        pinned
+        authors="Alice, Bob, Carol, Dave"
+      ></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    expect(el.getAttribute("data-wave-id")).to.equal("w1");
+    expect(el.hasAttribute("pinned")).to.be.true;
+    expect(el.msgCount).to.equal(5);
+    expect(el.unreadCount).to.equal(2);
+  });
+
+  it("renders title and snippet (B.15, B.16)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card title="Project meeting" snippet="Agenda for the week">
+      </wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const title = el.renderRoot.querySelector("h3.title");
+    const snippet = el.renderRoot.querySelector("p.snippet");
+    expect(title.textContent.trim()).to.equal("Project meeting");
+    expect(snippet.textContent.trim()).to.equal("Agenda for the week");
+  });
+
+  it("multi-author avatar stack truncates to 3 visible + overflow chip (B.13)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card authors="Alice Smith, Bob Jones, Carol White, Dave Black, Eve Green">
+      </wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const avatars = el.renderRoot.querySelectorAll(".avatar");
+    expect(avatars.length).to.equal(4); // 3 visible + 1 overflow chip
+    const overflow = el.renderRoot.querySelector(".avatar.more");
+    expect(overflow).to.exist;
+    expect(overflow.textContent.trim()).to.equal("+2");
+  });
+
+  it("avatar stack uses initials from each author display name (B.13)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card authors="Alice Smith, Bob"></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const avatars = Array.from(el.renderRoot.querySelectorAll(".avatar:not(.more)"));
+    expect(avatars[0].textContent.trim()).to.equal("AS");
+    expect(avatars[1].textContent.trim()).to.equal("BO");
+  });
+
+  it("renders cyan pin glyph only when pinned (B.14)", async () => {
+    const elUnpinned = await fixture(html`<wavy-search-rail-card></wavy-search-rail-card>`);
+    await elUnpinned.updateComplete;
+    expect(elUnpinned.renderRoot.querySelector(".pin")).to.be.null;
+
+    const elPinned = await fixture(html`<wavy-search-rail-card pinned></wavy-search-rail-card>`);
+    await elPinned.updateComplete;
+    const pin = elPinned.renderRoot.querySelector(".pin");
+    expect(pin).to.exist;
+    expect(pin.getAttribute("aria-label")).to.equal("Pinned");
+  });
+
+  it("snippet uses 3-line clamp via -webkit-line-clamp (B.16)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card snippet="A long snippet that would overflow."></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const snippet = el.renderRoot.querySelector("p.snippet");
+    const cs = getComputedStyle(snippet);
+    // Cross-browser: -webkit-line-clamp on most engines, line-clamp on
+    // newer ones. Either having "3" satisfies the contract.
+    const wkClamp = cs.getPropertyValue("-webkit-line-clamp").trim();
+    const stdClamp = cs.getPropertyValue("line-clamp").trim();
+    expect(
+      wkClamp === "3" || stdClamp === "3",
+      `expected line-clamp:3 (got webkit=${wkClamp}, std=${stdClamp})`
+    ).to.be.true;
+    expect(cs.overflow).to.equal("hidden");
+  });
+
+  it("unread badge appears only when unread-count > 0 (B.17)", async () => {
+    const elZero = await fixture(html`
+      <wavy-search-rail-card msg-count="3" unread-count="0"></wavy-search-rail-card>
+    `);
+    await elZero.updateComplete;
+    expect(elZero.renderRoot.querySelector(".badge.unread")).to.be.null;
+
+    const elTwo = await fixture(html`
+      <wavy-search-rail-card msg-count="3" unread-count="2"></wavy-search-rail-card>
+    `);
+    await elTwo.updateComplete;
+    const badge = elTwo.renderRoot.querySelector(".badge.unread");
+    expect(badge).to.exist;
+    expect(badge.textContent.trim()).to.equal("2");
+  });
+
+  it("firePulse() sets data-pulse=ring then clears it (B.17 cyan signal-pulse)", async () => {
+    // Use a short pulse duration override to keep the test fast.
+    const el = await fixture(html`
+      <wavy-search-rail-card
+        unread-count="1"
+        style="--wavy-motion-pulse-duration: 80;"
+      ></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    el.firePulse();
+    expect(el.dataset.pulse).to.equal("ring");
+    await aTimeout(150);
+    expect(el.dataset.pulse).to.be.undefined;
+  });
+
+  it("relative timestamp uses <time datetime=...> with title tooltip (B.18)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card
+        posted-at="2m ago"
+        posted-at-iso="2026-04-26T12:00:00Z"
+      ></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const time = el.renderRoot.querySelector("time.ts");
+    expect(time).to.exist;
+    expect(time.getAttribute("datetime")).to.equal("2026-04-26T12:00:00Z");
+    expect(time.getAttribute("title")).to.equal("2026-04-26T12:00:00Z");
+    expect(time.textContent.trim()).to.equal("2m ago");
+  });
+
+  it("click emits wavy-search-rail-card-selected with waveId", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card data-wave-id="w-7" title="Hello"></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    setTimeout(() => el.renderRoot.querySelector("article").click(), 0);
+    const evt = await oneEvent(el, "wavy-search-rail-card-selected");
+    expect(evt.detail.waveId).to.equal("w-7");
+  });
+
+  it("Enter/Space on the card emits selection (keyboard a11y)", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail-card data-wave-id="w-9"></wavy-search-rail-card>
+    `);
+    await el.updateComplete;
+    const article = el.renderRoot.querySelector("article");
+    setTimeout(() => {
+      article.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      );
+    }, 0);
+    const evt = await oneEvent(el, "wavy-search-rail-card-selected");
+    expect(evt.detail.waveId).to.equal("w-9");
+  });
+
+  it("falls back to (no title) when title is empty", async () => {
+    const el = await fixture(html`<wavy-search-rail-card></wavy-search-rail-card>`);
+    await el.updateComplete;
+    const title = el.renderRoot.querySelector("h3.title");
+    expect(title.textContent.trim()).to.equal("(no title)");
+  });
+});

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -1,0 +1,209 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-search-rail.js";
+
+describe("<wavy-search-rail>", () => {
+  it("registers the F-2.S3 search-rail element", () => {
+    expect(customElements.get("wavy-search-rail")).to.exist;
+  });
+
+  it("defaults to query=in:inbox and active folder=inbox", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    expect(el.query).to.equal("in:inbox");
+    expect(el.activeFolder).to.equal("inbox");
+    const inbox = el.renderRoot.querySelector('[data-folder-id="inbox"]');
+    expect(inbox.getAttribute("aria-current")).to.equal("page");
+  });
+
+  it("renders all six saved-search folders with canonical query strings (B.5–B.10)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const folders = Array.from(el.renderRoot.querySelectorAll("button.folder"));
+    const map = new Map(folders.map((b) => [b.dataset.folderId, b.dataset.query]));
+    expect(map.get("inbox")).to.equal("in:inbox");
+    expect(map.get("mentions")).to.equal("mentions:me");
+    expect(map.get("tasks")).to.equal("tasks:me");
+    expect(map.get("public")).to.equal("with:@");
+    expect(map.get("archive")).to.equal("in:archive");
+    expect(map.get("pinned")).to.equal("in:pinned");
+    const labels = folders.map((b) => b.querySelector(".label").textContent.trim());
+    expect(labels).to.deep.equal(["Inbox", "Mentions", "Tasks", "Public", "Archive", "Pinned"]);
+  });
+
+  it("Enter in the query box emits wavy-search-submit (B.1)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const input = el.renderRoot.querySelector("input.query");
+    input.value = "in:archive tag:work";
+    setTimeout(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    }, 0);
+    const evt = await oneEvent(el, "wavy-search-submit");
+    expect(evt.detail.query).to.equal("in:archive tag:work");
+  });
+
+  it("renders waveform glyph next to the query input (B.1)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector(".waveform svg")).to.exist;
+  });
+
+  it("help-trigger click emits wavy-search-help-toggle (B.2; modal not owned by rail)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const help = el.renderRoot.querySelector(".help-trigger");
+    expect(help).to.exist;
+    expect(help.getAttribute("aria-haspopup")).to.equal("dialog");
+    expect(help.getAttribute("aria-controls")).to.equal("wavy-search-help");
+    setTimeout(() => help.click(), 0);
+    const evt = await oneEvent(el, "wavy-search-help-toggle");
+    expect(evt).to.exist;
+    // The rail does NOT own a child <wavy-search-help> instance — the
+    // singleton lives at document level.
+    expect(el.renderRoot.querySelector("wavy-search-help")).to.be.null;
+  });
+
+  it("New Wave button click emits wavy-new-wave-requested and carries aria-keyshortcuts (B.3)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const newWave = el.renderRoot.querySelector(".new-wave");
+    expect(newWave).to.exist;
+    expect(newWave.getAttribute("aria-keyshortcuts")).to.equal(
+      "Shift+Meta+O Shift+Control+O"
+    );
+    expect(newWave.dataset.shortcut).to.equal("Shift+Cmd+O");
+    setTimeout(() => newWave.click(), 0);
+    const evt = await oneEvent(el, "wavy-new-wave-requested");
+    expect(evt).to.exist;
+  });
+
+  it("Manage saved searches click emits wavy-manage-saved-searches-requested (B.4)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const manage = el.renderRoot.querySelector(".manage-saved");
+    setTimeout(() => manage.click(), 0);
+    const evt = await oneEvent(el, "wavy-manage-saved-searches-requested");
+    expect(evt).to.exist;
+  });
+
+  it("Refresh click emits wavy-search-refresh-requested (B.11)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const refresh = el.renderRoot.querySelector(".refresh");
+    setTimeout(() => refresh.click(), 0);
+    const evt = await oneEvent(el, "wavy-search-refresh-requested");
+    expect(evt).to.exist;
+  });
+
+  it("clicking a folder flips aria-current and emits wavy-saved-search-selected", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const archive = el.renderRoot.querySelector('[data-folder-id="archive"]');
+    setTimeout(() => archive.click(), 0);
+    const evt = await oneEvent(el, "wavy-saved-search-selected");
+    expect(evt.detail.folderId).to.equal("archive");
+    expect(evt.detail.query).to.equal("in:archive");
+    await el.updateComplete;
+    expect(archive.getAttribute("aria-current")).to.equal("page");
+    expect(
+      el.renderRoot
+        .querySelector('[data-folder-id="inbox"]')
+        .getAttribute("aria-current")
+    ).to.equal("false");
+  });
+
+  it("setting query=in:archive ... derives Archive as active folder (programmatic)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    el.query = "in:archive orderby:datedesc";
+    await el.updateComplete;
+    expect(el.activeFolder).to.equal("archive");
+    expect(
+      el.renderRoot
+        .querySelector('[data-folder-id="archive"]')
+        .getAttribute("aria-current")
+    ).to.equal("page");
+  });
+
+  it("custom query that doesn't match a folder leaves no aria-current", async () => {
+    const el = await fixture(
+      html`<wavy-search-rail query="title:meeting"></wavy-search-rail>`
+    );
+    await el.updateComplete;
+    expect(el.activeFolder).to.equal("");
+    const folders = el.renderRoot.querySelectorAll("button.folder");
+    folders.forEach((b) => expect(b.getAttribute("aria-current")).to.equal("false"));
+  });
+
+  it("Mentions violet dot is hidden by default and revealed when mentions-unread > 0", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const dot = el.renderRoot
+      .querySelector('[data-folder-id="mentions"]')
+      .querySelector(".mentions-dot");
+    expect(dot).to.exist;
+    expect(dot.hasAttribute("hidden")).to.be.true;
+    el.mentionsUnread = 3;
+    await el.updateComplete;
+    expect(dot.hasAttribute("hidden")).to.be.false;
+  });
+
+  it("Mentions dot uses --wavy-signal-violet (NOT cyan)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const cssText = WavySearchRail_styleText();
+    expect(cssText).to.include("var(--wavy-signal-violet");
+  });
+
+  it("Tasks amber chip is hidden by default and revealed when tasks-pending > 0", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const chip = el.renderRoot
+      .querySelector('[data-folder-id="tasks"]')
+      .querySelector(".tasks-chip");
+    expect(chip).to.exist;
+    expect(chip.hasAttribute("hidden")).to.be.true;
+    el.tasksPending = 7;
+    await el.updateComplete;
+    expect(chip.hasAttribute("hidden")).to.be.false;
+    expect(chip.textContent.trim()).to.equal("7");
+  });
+
+  it("Tasks chip uses --wavy-signal-amber", async () => {
+    const cssText = WavySearchRail_styleText();
+    expect(cssText).to.include("var(--wavy-signal-amber");
+  });
+
+  it("result-count <p> is aria-live polite (B.12)", async () => {
+    const el = await fixture(
+      html`<wavy-search-rail result-count="133 waves"></wavy-search-rail>`
+    );
+    await el.updateComplete;
+    const p = el.renderRoot.querySelector("p.result-count");
+    expect(p).to.exist;
+    expect(p.getAttribute("aria-live")).to.equal("polite");
+    expect(p.textContent.trim()).to.equal("133 waves");
+  });
+
+  it("default slot accepts <wavy-search-rail-card> children", async () => {
+    const el = await fixture(html`
+      <wavy-search-rail>
+        <div data-stub-card="1">card</div>
+      </wavy-search-rail>
+    `);
+    await el.updateComplete;
+    const slot = el.renderRoot.querySelector("slot");
+    expect(slot).to.exist;
+    const assigned = slot.assignedElements();
+    expect(assigned.length).to.equal(1);
+    expect(assigned[0].dataset.stubCard).to.equal("1");
+  });
+});
+
+// Helper: read the element's static stylesheet text so we can assert
+// the wavy token names actually appear (defends against silent renames).
+function WavySearchRail_styleText() {
+  const cls = customElements.get("wavy-search-rail");
+  const styles = cls.styles;
+  const arr = Array.isArray(styles) ? styles : [styles];
+  return arr.map((s) => (s && s.cssText) || "").join("\n");
+}

--- a/wave/config/changelog.d/2026-04-26-search-rail-and-help-modal.json
+++ b/wave/config/changelog.d/2026-04-26-search-rail-and-help-modal.json
@@ -1,0 +1,19 @@
+{
+  "releaseId": "2026-04-26-search-rail-and-help-modal",
+  "version": "PR #1049",
+  "date": "2026-04-26",
+  "title": "Search rail, search-help modal, and wavy header chrome on the J2CL root shell",
+  "summary": "Slice 3 of the F-2 StageOne read surface lights up the wavy left rail (search box, six saved-search folders, refresh, result count), the search-help modal documenting every supported filter and sort token, and the wavy header end-region (brand link, locale picker, notifications bell, mail icon, and user-menu trigger) on ?view=j2cl-root.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Wavy left rail with search query box, waveform glyph, help trigger, New Wave shortcut, Manage saved searches, refresh, and result-count slot",
+        "Six saved-search folders (Inbox, Mentions, Tasks, Public, Archive, Pinned) with the canonical query strings; Inbox selected by default; Mentions violet unread dot and Tasks amber pending count",
+        "Per-digest result card with multi-author avatar stack (truncated at 3 + overflow chip), pinned indicator, title, 3-line snippet clamp, msg-count + signal-cyan unread pulse, and relative timestamp tooltip",
+        "Search-help modal advertising every filter (in:, with:, creator:, tag:, unread:, title:, content:, mentions:, tasks:) and sort (orderby:date / created / creator desc/asc) token, with combination examples and a Got-it dismiss",
+        "Wavy header chrome on the J2CL root shell: SupaWave brand link with cyan signal-dot, locale picker for the seven supported locales, notifications bell with violet unread dot, inbox/mail icon, and user-menu trigger (avatar + visible email)"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3403,9 +3403,22 @@ public final class HtmlRenderer {
           .append("\" aria-label=\"J2CL root shell\">\n");
       sb.append("      <span aria-hidden=\"true\">J2</span><span>SupaWave J2CL Root Shell</span>\n");
       sb.append("    </a>\n");
-      sb.append("    <span slot=\"actions-signed-in\">Signed in as ")
-          .append(safeAddress)
-          .append("</span>\n");
+      // F-2 slice 3 (#1047): wavy header chrome (A.1, A.2, A.5, A.6,
+      // A.7) is mounted as a <wavy-header> custom element inside the
+      // signed-in actions slot. Server-side we emit the FULL inner
+      // light DOM (brand link, locale select with seven options, bell
+      // button, mail icon, user-menu trigger). The Lit upgrade
+      // re-renders the same content into the shadow DOM and wires
+      // event handlers; the server-rendered light DOM is what
+      // J2clSearchRailParityTest asserts on (mirrors the F-2 S1
+      // <wavy-blip-card> server-render contract). The raw address is
+      // passed through alongside the safe (HTML-escaped) form so
+      // computeUserInitials can run on the unescaped local part.
+      appendWavyHeaderActionsSlot(sb, address, safeAddress);
+      // The legacy inline Admin and Sign out links are PRESERVED until
+      // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
+      // A.8–A.18 are F-0). Removing them now would orphan affordances
+      // A.15 and A.17 on the J2CL route.
       if (isAdminOrOwner) {
         sb.append("    <a slot=\"actions-signed-in\" data-j2cl-root-admin-link=\"true\" href=\"/admin\">Admin</a>\n");
       }
@@ -3413,9 +3426,20 @@ public final class HtmlRenderer {
           .append(safeEncodedReturnTarget)
           .append("\">Sign out</a>\n");
       sb.append("  </shell-header>\n");
+      // F-2 slice 3 (#1047): replace the Inbox-link placeholder with a
+      // full wavy-search-rail SSR'd into the existing nav slot. The
+      // <shell-nav-rail> wrapper is preserved so future slices can
+      // co-mount additional nav-area elements alongside the rail.
       sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-      sb.append("    <a href=\"").append(safeResolvedReturnTarget).append("\">Inbox</a>\n");
+      appendWavySearchRail(sb);
       sb.append("  </shell-nav-rail>\n");
+      // Single document-level <wavy-search-help> instance. The rail's
+      // help-trigger emits wavy-search-help-toggle (composed +
+      // bubbles); a connectedCallback-installed listener on this
+      // element flips the open attribute. Mounted as a direct child
+      // of <shell-root> (NOT inside any slot) so it can dialog.showModal
+      // over everything.
+      appendWavySearchHelpModal(sb);
       sb.append("  <shell-main-region slot=\"main\">\n");
       sb.append("    <section id=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
       appendRootShellWorkflowMarkup(sb, resolvedSnapshotResult, true);
@@ -3598,6 +3622,231 @@ public final class HtmlRenderer {
     sb.append("  return window.__gwtStatsEvent({module:'j2cl.root_shell', subtype:subtype, reason:reason, durationMs:durationMs || 0, waveIdPresent:!!waveIdPresent});\n");
     sb.append("};\n");
     sb.append("</script>\n");
+  }
+
+  /**
+   * F-2 slice 3 (#1047): emit the {@code <wavy-header>} chrome into
+   * the {@code actions-signed-in} slot of the existing
+   * {@code <shell-header>}. The server-rendered light DOM mirrors
+   * what the Lit element renders client-side so the J2CL upgrade is
+   * a content-preserving in-place upgrade and so
+   * {@code J2clSearchRailParityTest} can assert against the
+   * server-rendered HTML directly.
+   *
+   * <p>Affordances: A.1 brand link, A.2 locale picker (seven
+   * options), A.5 notifications bell, A.6 inbox/mail icon,
+   * A.7 user-menu trigger (avatar + email).
+   */
+  private static void appendWavyHeaderActionsSlot(
+      StringBuilder sb, String rawAddress, String safeAddress) {
+    String escapedAddress = safeAddress == null ? "" : safeAddress;
+    // computeUserInitials runs on the RAW address so the local-part
+    // splitting matches the JS Lit element exactly (the Lit element
+    // also splits the unescaped string). The result is then HTML-
+    // escaped before being written into the avatar text node.
+    String initialsRaw = computeUserInitials(rawAddress);
+    String initials = StringEscapeUtils.escapeHtml4(initialsRaw);
+    sb.append("    <wavy-header slot=\"actions-signed-in\" signed-in locale=\"en\" data-address=\"")
+        .append(escapedAddress)
+        .append("\" user-name=\"")
+        .append(escapedAddress)
+        .append("\" unread-count=\"0\">\n");
+    sb.append("      <a class=\"brand\" href=\"/\" aria-label=\"SupaWave home\">")
+        .append("<span class=\"brand-dot\" aria-hidden=\"true\"></span>")
+        .append("<span class=\"brand-text\">SupaWave</span></a>\n");
+    sb.append("      <select class=\"locale\" aria-label=\"Language\">\n");
+    sb.append("        <option value=\"en\" selected>English</option>\n");
+    sb.append("        <option value=\"de\">Deutsch</option>\n");
+    sb.append("        <option value=\"es\">Español</option>\n");
+    sb.append("        <option value=\"fr\">Français</option>\n");
+    sb.append("        <option value=\"ru\">Русский</option>\n");
+    sb.append("        <option value=\"sl\">Slovenščina</option>\n");
+    sb.append("        <option value=\"zh_TW\">繁體中文</option>\n");
+    sb.append("      </select>\n");
+    // A.5 notifications bell — server-renders the same SVG glyph the
+    // Lit element renders so the icon does not appear empty pre-upgrade.
+    sb.append("      <button type=\"button\" class=\"bell\" aria-label=\"Notifications\">")
+        .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
+        .append("<path d=\"M3 12h10l-1.4-1.4A2 2 0 0 1 11 9.2V7a3 3 0 0 0-6 0v2.2a2 2 0 0 1-.6 1.4L3 12z\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>")
+        .append("<path d=\"M6.5 13.5a1.5 1.5 0 0 0 3 0\" stroke-linecap=\"round\"/></svg>")
+        .append("<span class=\"dot violet\" hidden aria-hidden=\"true\"></span></button>\n");
+    // A.6 inbox/mail icon — server-renders the envelope SVG.
+    sb.append("      <a class=\"mail\" href=\"/?q=in:inbox\" aria-label=\"Inbox\">")
+        .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
+        .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
+        .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");
+    sb.append("      <button type=\"button\" class=\"user-menu\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Open user menu\">")
+        .append("<span class=\"avatar\" aria-hidden=\"true\">")
+        .append(initials)
+        .append("</span>")
+        .append("<span class=\"user-email\">")
+        .append(escapedAddress)
+        .append("</span></button>\n");
+    sb.append("    </wavy-header>\n");
+  }
+
+  /**
+   * F-2 slice 3 (#1047): emit the {@code <wavy-search-rail>} into the
+   * existing {@code <shell-nav-rail slot="nav">} wrapper. SSR'd inner
+   * light DOM covers B.1–B.12.
+   */
+  private static void appendWavySearchRail(StringBuilder sb) {
+    sb.append("    <wavy-search-rail query=\"in:inbox\" data-active-folder=\"inbox\" result-count=\"\">\n");
+    sb.append("      <div class=\"search\">\n");
+    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"></span>\n");
+    sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"in:inbox\">\n");
+    sb.append("        <button type=\"button\" class=\"help-trigger\" aria-label=\"Search help\" aria-haspopup=\"dialog\" aria-controls=\"wavy-search-help\">?</button>\n");
+    sb.append("      </div>\n");
+    sb.append("      <div class=\"actions\">\n");
+    sb.append("        <button type=\"button\" class=\"new-wave\" data-shortcut=\"Shift+Cmd+O\" aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\">New Wave</button>\n");
+    sb.append("        <button type=\"button\" class=\"manage-saved\">Manage saved searches</button>\n");
+    sb.append("      </div>\n");
+    sb.append("      <div class=\"folders-header\">\n");
+    sb.append("        <h2 id=\"folders-title\">Saved searches</h2>\n");
+    sb.append("        <button type=\"button\" class=\"refresh\" aria-label=\"Refresh search results\">⟳</button>\n");
+    sb.append("      </div>\n");
+    sb.append("      <ul class=\"folders\" aria-labelledby=\"folders-title\">\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"page\"><span class=\"label\">Inbox</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"mentions\" data-query=\"mentions:me\" aria-current=\"false\"><span class=\"label\">Mentions</span><span class=\"dot mentions-dot\" hidden></span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"tasks\" data-query=\"tasks:me\" aria-current=\"false\"><span class=\"label\">Tasks</span><span class=\"chip tasks-chip\" hidden>0</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"public\" data-query=\"with:@\" aria-current=\"false\"><span class=\"label\">Public</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"archive\" data-query=\"in:archive\" aria-current=\"false\"><span class=\"label\">Archive</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"pinned\" data-query=\"in:pinned\" aria-current=\"false\"><span class=\"label\">Pinned</span></button></li>\n");
+    sb.append("      </ul>\n");
+    sb.append("      <p class=\"result-count\" aria-live=\"polite\"></p>\n");
+    sb.append("    </wavy-search-rail>\n");
+  }
+
+  /**
+   * F-2 slice 3 (#1047): emit the singleton {@code <wavy-search-help>}
+   * modal as a direct child of {@code <shell-root>}. SSR'd inner
+   * light DOM contains every one of the 22 token literals (C.1–C.22)
+   * the GWT search-help panel advertises today; the parser fixture
+   * {@code J2clSearchHelpTokenParseTest} pins the token contract.
+   */
+  private static void appendWavySearchHelpModal(StringBuilder sb) {
+    // The SSR'd light DOM stays hidden until the Lit upgrade replaces
+    // it with the shadow-DOM render — `hidden` keeps the modal body
+    // invisible across both legacy renderers (display:none) and
+    // browsers that have not yet executed the J2CL bundle. The Lit
+    // element drops `hidden` (the `open` reflection takes over) when
+    // the user toggles the modal.
+    sb.append("  <wavy-search-help id=\"wavy-search-help\" hidden>\n");
+    sb.append("    <div class=\"sheet\" role=\"dialog\" aria-modal=\"true\">\n");
+    sb.append("      <header><h2>Search Help</h2><button type=\"button\" class=\"dismiss\" aria-label=\"Close search help\">Got it</button></header>\n");
+    sb.append("      <div class=\"columns\">\n");
+    // Each clickable example uses <code class="example"> so the
+    // pre-upgrade SSR matches the Lit element's clickable chip
+    // contract (the Lit element's render also tags clickable example
+    // tokens with class="example"). The plain <code> form is used
+    // only for the abstract "with:user@domain"-style row labels that
+    // are NOT meant to be clicked.
+    sb.append("        <section><p class=\"section-title\">Filters</p><table>\n");
+    sb.append("          <tbody>\n");
+    sb.append("            <tr><td><code class=\"example\">in:inbox</code></td><td>Waves in your inbox</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">in:archive</code></td><td>Archived waves</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">in:all</code></td><td>All waves including public</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">in:pinned</code></td><td>Pinned waves</td></tr>\n");
+    sb.append("            <tr><td><code>with:user@domain</code></td><td>Waves with a participant &mdash; try: <code class=\"example\">with:alice@example.com</code></td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">with:@</code></td><td>Public waves (shared domain)</td></tr>\n");
+    sb.append("            <tr><td><code>creator:user@domain</code></td><td>Waves created by someone &mdash; try: <code class=\"example\">creator:bob@example.com</code></td></tr>\n");
+    sb.append("            <tr><td><code>tag:name</code></td><td>Waves with a specific tag &mdash; try: <code class=\"example\">tag:important</code></td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">unread:true</code></td><td>Only waves with unread blips</td></tr>\n");
+    sb.append("            <tr><td><code>title:text</code></td><td>Waves whose title contains text &mdash; try: <code class=\"example\">title:meeting</code></td></tr>\n");
+    sb.append("            <tr><td><code>content:text</code></td><td>Waves containing text in any blip &mdash; try: <code class=\"example\">content:agenda</code></td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">mentions:me</code></td><td>Waves where you are @mentioned</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">tasks:all</code></td><td>Waves you can access that contain any task</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">tasks:me</code></td><td>Waves with tasks assigned to you</td></tr>\n");
+    sb.append("            <tr><td><code>tasks:user@domain</code></td><td>Tasks assigned to someone specific &mdash; try: <code class=\"example\">tasks:alice@example.com</code></td></tr>\n");
+    sb.append("            <tr class=\"free-text-row\"><td>free text</td><td>Implicit content: search &mdash; try: <code class=\"example\">meeting notes</code></td></tr>\n");
+    sb.append("          </tbody>\n");
+    sb.append("        </table></section>\n");
+    sb.append("        <section><p class=\"section-title\">Sort Options</p><table>\n");
+    sb.append("          <tbody>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:datedesc</code></td><td>Last modified, newest first (default)</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:dateasc</code></td><td>Last modified, oldest first</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:createddesc</code></td><td>Created time, newest first</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:createdasc</code></td><td>Created time, oldest first</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:creatordesc</code></td><td>Creator email Z&rarr;A</td></tr>\n");
+    sb.append("            <tr><td><code class=\"example\">orderby:creatorasc</code></td><td>Creator email A&rarr;Z</td></tr>\n");
+    sb.append("          </tbody>\n");
+    sb.append("        </table>\n");
+    sb.append("        <div class=\"combinations\"><p class=\"section-title\">Combinations</p>\n");
+    sb.append("          <div class=\"grid\">\n");
+    sb.append("            <code class=\"example\">in:inbox tag:important</code>\n");
+    sb.append("            <code class=\"example\">in:all orderby:createdasc</code>\n");
+    sb.append("            <code class=\"example\">with:alice@example.com tag:project</code>\n");
+    sb.append("            <code class=\"example\">in:pinned orderby:creatordesc</code>\n");
+    sb.append("            <code class=\"example\">creator:bob in:archive</code>\n");
+    sb.append("            <code class=\"example\">mentions:me unread:true</code>\n");
+    sb.append("            <code class=\"example\">tasks:all unread:true</code>\n");
+    sb.append("          </div>\n");
+    sb.append("        </div>\n");
+    sb.append("        </section>\n");
+    sb.append("      </div>\n");
+    sb.append("    </div>\n");
+    sb.append("  </wavy-search-help>\n");
+  }
+
+  /**
+   * Compute the two-letter uppercase initials used by {@code
+   * <wavy-header>}'s avatar chip when the J2CL client has not yet
+   * upgraded the element. Mirrors the Lit element's _initials()
+   * helper EXACTLY: split the local part by "." and take the first
+   * character of the first segment + the first character of the LAST
+   * segment. Falls back to first-two-characters for single-segment
+   * locals. Avoids avatar flicker on multi-dot emails like
+   * "john.q.public@x.com" (both sides yield "JP").
+   *
+   * <p>NOTE: input must be the RAW (unescaped) email address — the
+   * caller is responsible for HTML-escaping the result before writing
+   * it into the markup. Operating on the raw string keeps the
+   * computation deterministic when local parts contain HTML-special
+   * characters.
+   */
+  private static String computeUserInitials(String rawAddress) {
+    if (rawAddress == null) {
+      return "?";
+    }
+    String trimmed = rawAddress.trim();
+    if (trimmed.isEmpty()) {
+      return "?";
+    }
+    int at = trimmed.indexOf('@');
+    String local = at < 0 ? trimmed : trimmed.substring(0, at);
+    if (local.isEmpty()) {
+      return "?";
+    }
+    if (local.indexOf('.') >= 0) {
+      String[] segments = local.split("\\.");
+      String first = "";
+      String last = "";
+      for (String s : segments) {
+        if (!s.isEmpty()) {
+          if (first.isEmpty()) {
+            first = s.substring(0, 1);
+          }
+          last = s.substring(0, 1);
+        }
+      }
+      if (!first.isEmpty()) {
+        // first == last when only one non-empty segment survives
+        // (e.g. ".bob" or "bob." or "bob..smith" all collapse to one
+        // unique non-empty segment in the JS split).
+        if (first.equals(last)) {
+          if (local.length() >= 2 && !local.startsWith(".")) {
+            return local.substring(0, 2).toUpperCase(java.util.Locale.ROOT);
+          }
+          return first.toUpperCase(java.util.Locale.ROOT);
+        }
+        return (first + last).toUpperCase(java.util.Locale.ROOT);
+      }
+      return "?";
+    }
+    if (local.length() >= 2) {
+      return local.substring(0, 2).toUpperCase(java.util.Locale.ROOT);
+    }
+    return local.toUpperCase(java.util.Locale.ROOT);
   }
 
   private static void appendRootShellWorkflowMarkup(

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3414,7 +3414,7 @@ public final class HtmlRenderer {
       // <wavy-blip-card> server-render contract). The raw address is
       // passed through alongside the safe (HTML-escaped) form so
       // computeUserInitials can run on the unescaped local part.
-      appendWavyHeaderActionsSlot(sb, address, safeAddress);
+      appendWavyHeaderActionsSlot(sb, address, safeAddress, safeResolvedBasePath);
       // The legacy inline Admin and Sign out links are PRESERVED until
       // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
       // A.8–A.18 are F-0). Removing them now would orphan affordances
@@ -3638,7 +3638,7 @@ public final class HtmlRenderer {
    * A.7 user-menu trigger (avatar + email).
    */
   private static void appendWavyHeaderActionsSlot(
-      StringBuilder sb, String rawAddress, String safeAddress) {
+      StringBuilder sb, String rawAddress, String safeAddress, String safeBasePath) {
     String escapedAddress = safeAddress == null ? "" : safeAddress;
     // computeUserInitials runs on the RAW address so the local-part
     // splitting matches the JS Lit element exactly (the Lit element
@@ -3651,7 +3651,9 @@ public final class HtmlRenderer {
         .append("\" user-name=\"")
         .append(escapedAddress)
         .append("\" unread-count=\"0\">\n");
-    sb.append("      <a class=\"brand\" href=\"/\" aria-label=\"SupaWave home\">")
+    sb.append("      <a class=\"brand\" href=\"")
+        .append(safeBasePath)
+        .append("\" aria-label=\"SupaWave home\">")
         .append("<span class=\"brand-dot\" aria-hidden=\"true\"></span>")
         .append("<span class=\"brand-text\">SupaWave</span></a>\n");
     sb.append("      <select class=\"locale\" aria-label=\"Language\">\n");
@@ -3671,7 +3673,9 @@ public final class HtmlRenderer {
         .append("<path d=\"M6.5 13.5a1.5 1.5 0 0 0 3 0\" stroke-linecap=\"round\"/></svg>")
         .append("<span class=\"dot violet\" hidden aria-hidden=\"true\"></span></button>\n");
     // A.6 inbox/mail icon — server-renders the envelope SVG.
-    sb.append("      <a class=\"mail\" href=\"/?q=in:inbox\" aria-label=\"Inbox\">")
+    sb.append("      <a class=\"mail\" href=\"")
+        .append(safeBasePath)
+        .append("?q=in:inbox\" aria-label=\"Inbox\">")
         .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
         .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
         .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3686,7 +3686,7 @@ public final class HtmlRenderer {
         .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
         .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
         .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");
-    sb.append("      <button type=\"button\" class=\"user-menu\" aria-haspopup=\"menu\" aria-expanded=\"false\" aria-label=\"Open user menu\">")
+    sb.append("      <button type=\"button\" class=\"user-menu\" aria-haspopup=\"menu\" aria-label=\"Open user menu\">")
         .append("<span class=\"avatar\" aria-hidden=\"true\">")
         .append(initials)
         .append("</span>")
@@ -3805,8 +3805,10 @@ public final class HtmlRenderer {
 
   /**
    * Extract the value of a named query parameter from a URL-like string.
-   * Returns null if the parameter is absent. Does not URL-decode the value —
-   * callers should HTML-escape before writing into markup.
+   * Returns null if the parameter is absent. URL-decodes the value (UTF-8)
+   * so callers see plain tokens like {@code mentions:me} instead of
+   * {@code mentions%3Ame}; callers should still HTML-escape before writing
+   * into markup. Falls back to the raw value on malformed percent-escapes.
    */
   private static String extractQueryParam(String url, String name) {
     if (url == null) return null;
@@ -3816,7 +3818,12 @@ public final class HtmlRenderer {
     String prefix = name + "=";
     for (String part : query.split("&")) {
       if (part.startsWith(prefix)) {
-        return part.substring(prefix.length());
+        String value = part.substring(prefix.length());
+        try {
+          return java.net.URLDecoder.decode(value, java.nio.charset.StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+          return value;
+        }
       }
     }
     return null;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3657,7 +3657,9 @@ public final class HtmlRenderer {
         .append(escapedAddress)
         .append("\" user-name=\"")
         .append(escapedAddress)
-        .append("\" unread-count=\"0\">\n");
+        .append("\" unread-count=\"0\" base-path=\"")
+        .append(safeBasePath)
+        .append("\">\n");
     sb.append("      <a class=\"brand\" href=\"")
         .append(safeBasePath)
         .append("\" aria-label=\"SupaWave home\">")

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3437,8 +3437,8 @@ public final class HtmlRenderer {
       // help-trigger emits wavy-search-help-toggle (composed +
       // bubbles); a connectedCallback-installed listener on this
       // element flips the open attribute. Mounted as a direct child
-      // of <shell-root> (NOT inside any slot) so it can dialog.showModal
-      // over everything.
+      // of <shell-root> (NOT inside any slot) so its open-state/CSS
+      // overlay can render above the rest of the shell.
       appendWavySearchHelpModal(sb);
       sb.append("  <shell-main-region slot=\"main\">\n");
       sb.append("    <section id=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
@@ -3693,7 +3693,7 @@ public final class HtmlRenderer {
   private static void appendWavySearchRail(StringBuilder sb) {
     sb.append("    <wavy-search-rail query=\"in:inbox\" data-active-folder=\"inbox\" result-count=\"\">\n");
     sb.append("      <div class=\"search\">\n");
-    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"></span>\n");
+    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" focusable=\"false\" aria-hidden=\"true\"><path d=\"M2 12c2.2 0 2.8-6 5-6s2.8 12 5 12 2.8-12 5-12 2.8 6 5 6\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></span>\n");
     sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"in:inbox\">\n");
     sb.append("        <button type=\"button\" class=\"help-trigger\" aria-label=\"Search help\" aria-haspopup=\"dialog\" aria-controls=\"wavy-search-help\">?</button>\n");
     sb.append("      </div>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3354,6 +3354,13 @@ public final class HtmlRenderer {
     // Query-only client routes reuse this path prefix when updating return targets.
     String resolvedBasePath = queryStart >= 0 ? resolvedReturnTarget.substring(0, queryStart) : resolvedReturnTarget;
     String safeResolvedBasePath = StringEscapeUtils.escapeHtml4(resolvedBasePath);
+    // Extract the `q` search parameter from the return target so the SSR search
+    // rail reflects the current query rather than always defaulting to "in:inbox".
+    String resolvedInitialQuery = extractQueryParam(resolvedReturnTarget, "q");
+    if (resolvedInitialQuery == null || resolvedInitialQuery.isEmpty()) {
+      resolvedInitialQuery = "in:inbox";
+    }
+    String safeInitialQuery = StringEscapeUtils.escapeHtml4(resolvedInitialQuery);
 
     String safeAddress = escapeHtml(address);
 
@@ -3431,7 +3438,7 @@ public final class HtmlRenderer {
       // <shell-nav-rail> wrapper is preserved so future slices can
       // co-mount additional nav-area elements alongside the rail.
       sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-      appendWavySearchRail(sb);
+      appendWavySearchRail(sb, safeInitialQuery);
       sb.append("  </shell-nav-rail>\n");
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
@@ -3694,11 +3701,15 @@ public final class HtmlRenderer {
    * existing {@code <shell-nav-rail slot="nav">} wrapper. SSR'd inner
    * light DOM covers B.1–B.12.
    */
-  private static void appendWavySearchRail(StringBuilder sb) {
-    sb.append("    <wavy-search-rail query=\"in:inbox\" data-active-folder=\"inbox\" result-count=\"\">\n");
+  private static void appendWavySearchRail(StringBuilder sb, String safeInitialQuery) {
+    // Derive the active folder from the initial query so the SSR folder highlight
+    // matches the query pre-upgrade (mirrors WavySearchRail._deriveActiveFolder).
+    String activeFolder = deriveActiveFolder(safeInitialQuery);
+    sb.append("    <wavy-search-rail query=\"").append(safeInitialQuery)
+        .append("\" data-active-folder=\"").append(activeFolder).append("\" result-count=\"\">\n");
     sb.append("      <div class=\"search\">\n");
-    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" width=\"24\" height=\"24\" focusable=\"false\" aria-hidden=\"true\"><path d=\"M2 12c2.2 0 2.8-6 5-6s2.8 12 5 12 2.8-12 5-12 2.8 6 5 6\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></span>\n");
-    sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"in:inbox\">\n");
+    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"><svg viewBox=\"0 0 14 14\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.6\" aria-hidden=\"true\"><path d=\"M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></span>\n");
+    sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"").append(safeInitialQuery).append("\">\n");
     sb.append("        <button type=\"button\" class=\"help-trigger\" aria-label=\"Search help\" aria-haspopup=\"dialog\" aria-controls=\"wavy-search-help\">?</button>\n");
     sb.append("      </div>\n");
     sb.append("      <div class=\"actions\">\n");
@@ -3710,12 +3721,12 @@ public final class HtmlRenderer {
     sb.append("        <button type=\"button\" class=\"refresh\" aria-label=\"Refresh search results\">⟳</button>\n");
     sb.append("      </div>\n");
     sb.append("      <ul class=\"folders\" aria-labelledby=\"folders-title\">\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"page\"><span class=\"label\">Inbox</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"mentions\" data-query=\"mentions:me\" aria-current=\"false\"><span class=\"label\">Mentions</span><span class=\"dot mentions-dot\" hidden></span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"tasks\" data-query=\"tasks:me\" aria-current=\"false\"><span class=\"label\">Tasks</span><span class=\"chip tasks-chip\" hidden>0</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"public\" data-query=\"with:@\" aria-current=\"false\"><span class=\"label\">Public</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"archive\" data-query=\"in:archive\" aria-current=\"false\"><span class=\"label\">Archive</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"pinned\" data-query=\"in:pinned\" aria-current=\"false\"><span class=\"label\">Pinned</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"").append("inbox".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Inbox</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"mentions\" data-query=\"mentions:me\" aria-current=\"").append("mentions".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Mentions</span><span class=\"dot mentions-dot\" hidden></span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"tasks\" data-query=\"tasks:me\" aria-current=\"").append("tasks".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Tasks</span><span class=\"chip tasks-chip\" hidden>0</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"public\" data-query=\"with:@\" aria-current=\"").append("public".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Public</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"archive\" data-query=\"in:archive\" aria-current=\"").append("archive".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Archive</span></button></li>\n");
+    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"pinned\" data-query=\"in:pinned\" aria-current=\"").append("pinned".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Pinned</span></button></li>\n");
     sb.append("      </ul>\n");
     sb.append("      <p class=\"result-count\" aria-live=\"polite\"></p>\n");
     sb.append("    </wavy-search-rail>\n");
@@ -3793,6 +3804,50 @@ public final class HtmlRenderer {
   }
 
   /**
+   * Extract the value of a named query parameter from a URL-like string.
+   * Returns null if the parameter is absent. Does not URL-decode the value —
+   * callers should HTML-escape before writing into markup.
+   */
+  private static String extractQueryParam(String url, String name) {
+    if (url == null) return null;
+    int q = url.indexOf('?');
+    if (q < 0) return null;
+    String query = url.substring(q + 1);
+    String prefix = name + "=";
+    for (String part : query.split("&")) {
+      if (part.startsWith(prefix)) {
+        return part.substring(prefix.length());
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Derive the active-folder id from an initial query string. Mirrors
+   * {@code WavySearchRail._deriveActiveFolder} in the Lit component so the
+   * SSR folder highlight matches pre-upgrade.
+   */
+  private static String deriveActiveFolder(String query) {
+    String text = query == null ? "" : query.trim().toLowerCase(java.util.Locale.ROOT);
+    if (text.isEmpty()) return "inbox";
+    String[][] folders = {
+      {"inbox",    "in:inbox"},
+      {"mentions", "mentions:me"},
+      {"tasks",    "tasks:me"},
+      {"public",   "with:@"},
+      {"archive",  "in:archive"},
+      {"pinned",   "in:pinned"},
+    };
+    for (String[] f : folders) {
+      String fq = f[1];
+      if (text.equals(fq) || text.startsWith(fq + " ")) {
+        return f[0];
+      }
+    }
+    return "";
+  }
+
+  /**
    * Compute the two-letter uppercase initials used by {@code
    * <wavy-header>}'s avatar chip when the J2CL client has not yet
    * upgraded the element. Mirrors the Lit element's _initials()
@@ -3834,15 +3889,10 @@ public final class HtmlRenderer {
         }
       }
       if (!first.isEmpty()) {
-        // first == last when only one non-empty segment survives
-        // (e.g. ".bob" or "bob." or "bob..smith" all collapse to one
-        // unique non-empty segment in the JS split).
-        if (first.equals(last)) {
-          if (local.length() >= 2 && !local.startsWith(".")) {
-            return local.substring(0, 2).toUpperCase(java.util.Locale.ROOT);
-          }
-          return first.toUpperCase(java.util.Locale.ROOT);
-        }
+        // first == last when only one non-empty segment survives (e.g.
+        // ".bob", "bob.", "bob.."). Mirror the JS behaviour: duplicate
+        // the first character (JS: parts[0][0] + parts[last][0] where
+        // both sides are the same segment).
         return (first + last).toUpperCase(java.util.Locale.ROOT);
       }
       return "?";

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3421,7 +3421,7 @@ public final class HtmlRenderer {
       // <wavy-blip-card> server-render contract). The raw address is
       // passed through alongside the safe (HTML-escaped) form so
       // computeUserInitials can run on the unescaped local part.
-      appendWavyHeaderActionsSlot(sb, address, safeAddress, safeResolvedBasePath);
+      appendWavyHeaderActionsSlot(sb, address, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath);
       // The legacy inline Admin and Sign out links are PRESERVED until
       // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
       // A.8–A.18 are F-0). Removing them now would orphan affordances
@@ -3645,7 +3645,8 @@ public final class HtmlRenderer {
    * A.7 user-menu trigger (avatar + email).
    */
   private static void appendWavyHeaderActionsSlot(
-      StringBuilder sb, String rawAddress, String safeAddress, String safeBasePath) {
+      StringBuilder sb, String rawAddress, String safeAddress,
+      String safeResolvedReturnTarget, String safeBasePath) {
     String escapedAddress = safeAddress == null ? "" : safeAddress;
     // computeUserInitials runs on the RAW address so the local-part
     // splitting matches the JS Lit element exactly (the Lit element
@@ -3661,7 +3662,7 @@ public final class HtmlRenderer {
         .append(safeBasePath)
         .append("\">\n");
     sb.append("      <a class=\"brand\" href=\"")
-        .append(safeBasePath)
+        .append(safeResolvedReturnTarget)
         .append("\" aria-label=\"SupaWave home\">")
         .append("<span class=\"brand-dot\" aria-hidden=\"true\"></span>")
         .append("<span class=\"brand-text\">SupaWave</span></a>\n");
@@ -3684,7 +3685,7 @@ public final class HtmlRenderer {
     // A.6 inbox/mail icon — server-renders the envelope SVG.
     sb.append("      <a class=\"mail\" href=\"")
         .append(safeBasePath)
-        .append("?q=in:inbox\" aria-label=\"Inbox\">")
+        .append("?view=j2cl-root&amp;q=in%3Ainbox\" aria-label=\"Inbox\">")
         .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
         .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
         .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -1,0 +1,538 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.waveprotocol.box.common.ExceptionalIterator;
+import org.waveprotocol.box.common.Receiver;
+import org.waveprotocol.box.server.account.AccountData;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.FeatureFlagStore;
+import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
+import org.waveprotocol.box.server.rpc.render.J2clSelectedWaveSnapshotRenderer;
+import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
+import org.waveprotocol.box.server.waveserver.WaveServerException;
+import org.waveprotocol.box.server.waveserver.WaveletProvider;
+import org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.operation.wave.TransformedWaveletDelta;
+import org.waveprotocol.wave.model.version.HashedVersion;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+
+/**
+ * F-2 slice 3 (#1047) acceptance fixture. Drives the same servlet
+ * as {@link J2clStageOneReadSurfaceParityTest} but asserts on the
+ * NEW search rail + search-help modal + wavy header chrome that
+ * slice 3 mounts inside {@code renderJ2clRootShellPage}.
+ *
+ * <p>Inventory affordances asserted (45 total, organised below):
+ *
+ * <ul>
+ *   <li><b>A.1 / A.2 / A.5 / A.6 / A.7</b> — wavy header chrome:
+ *       brand link with cyan signal-dot, locale picker (seven
+ *       options), notifications bell with violet unread dot,
+ *       inbox/mail icon, user-menu trigger (avatar + visible email).
+ *   <li><b>B.1–B.12</b> — search rail: query box (default
+ *       {@code in:inbox}) + waveform glyph; help-trigger; New Wave
+ *       button with {@code aria-keyshortcuts}; Manage saved searches;
+ *       six saved-search folders with the canonical query strings;
+ *       refresh; result-count {@code aria-live}.
+ *   <li><b>B.13–B.18</b> — per-digest cards live in
+ *       {@code j2cl/lit/test/wavy-search-rail-card.test.js}; this
+ *       fixture asserts only that the slot under
+ *       {@code <wavy-search-rail>} accepts them.
+ *   <li><b>C.1–C.22</b> — every advertised search-help token literal
+ *       is present in the server-rendered modal body (mirrors the
+ *       parser-side {@code J2clSearchHelpTokenParseTest}).
+ * </ul>
+ *
+ * <p>The fixture asserts on the RAW server-rendered HTML, not on a
+ * post-upgrade DOM. T5 SSRs the inner light DOM of every new element
+ * so the J2CL client upgrade is content-preserving (mirrors the F-2
+ * S1 {@code <wavy-blip-card>} server-render contract).
+ *
+ * <p>Reciprocal: {@code legacyGwtRouteDoesNotLeakF2S3Markers} ensures
+ * none of the new elements appear on {@code ?view=gwt} so rollback
+ * stays safe; {@code signedOutJ2clRootShellDoesNotMountSearchRailOrHeaderChrome}
+ * defends against accidentally regressing the unauthenticated landing
+ * into emitting search/help to anonymous users.
+ */
+public final class J2clSearchRailParityTest {
+
+  private static final WaveId WAVE_ID = WaveId.of("example.com", "w+f2s3");
+  private static final WaveletId CONV_ROOT = WaveletId.of("example.com", "conv+root");
+  private static final ParticipantId AUTHOR = ParticipantId.ofUnsafe("alice@example.com");
+  private static final ParticipantId VIEWER = ParticipantId.ofUnsafe("alice@example.com");
+
+  // ---------- A.* wavy header chrome ----------
+
+  /** A.1, A.2, A.7 wrapper — wavy-header host element with the contract attributes. */
+  @Test
+  public void j2clRootShellEmitsWavyHeaderHostWithLocaleAndAddressAttributes() throws Exception {
+    String html = renderJ2clRootShell();
+    assertEquals(
+        "Exactly one <wavy-header> host is mounted in the J2CL root shell",
+        1,
+        countOccurrences(html, "<wavy-header"));
+    assertTrue("Header carries signed-in flag", html.contains("signed-in"));
+    assertTrue("Header defaults to locale=en", html.contains("locale=\"en\""));
+    assertTrue(
+        "Header carries data-address with the viewer's email",
+        html.contains("data-address=\"alice@example.com\""));
+    assertTrue(
+        "Header carries user-name (used for the avatar initials fallback)",
+        html.contains("user-name=\"alice@example.com\""));
+  }
+
+  /** A.2 — every locale supported by the GWT i18n bundle is offered. */
+  @Test
+  public void wavyHeaderInnerLightDomEmitsAllSevenLocales() throws Exception {
+    String html = renderJ2clRootShell();
+    String[] codes = {"en", "de", "es", "fr", "ru", "sl", "zh_TW"};
+    for (String code : codes) {
+      assertTrue(
+          "Locale picker must emit <option value=\"" + code + "\">",
+          html.contains("<option value=\"" + code + "\""));
+    }
+  }
+
+  /** A.1, A.2, A.5, A.6, A.7 — every chrome class marker present in light DOM. */
+  @Test
+  public void wavyHeaderInnerLightDomEmitsBrandLocaleBellMailUserMenuChrome()
+      throws Exception {
+    String html = renderJ2clRootShell();
+    assertTrue("A.1 brand link class", html.contains("class=\"brand\""));
+    assertTrue(
+        "A.1 cyan signal-dot accent (uses --wavy-signal-cyan in the element CSS)",
+        html.contains("class=\"brand-dot\""));
+    assertTrue("A.2 locale picker class", html.contains("class=\"locale\""));
+    assertTrue("A.5 notifications bell class", html.contains("class=\"bell\""));
+    assertTrue(
+        "A.5 violet unread dot (initially hidden)",
+        html.contains("class=\"dot violet\" hidden"));
+    assertTrue("A.6 mail icon class", html.contains("class=\"mail\""));
+    assertTrue(
+        "A.6 mail icon links to inbox query",
+        html.contains("href=\"/?q=in:inbox\""));
+    assertTrue("A.7 user-menu trigger class", html.contains("class=\"user-menu\""));
+    assertTrue(
+        "A.7 user-menu trigger advertises menu popup semantics",
+        html.contains("aria-haspopup=\"menu\""));
+    assertTrue("A.7 avatar chip class", html.contains("class=\"avatar\""));
+    assertTrue(
+        "A.7 visible user-email span (matches GWT inventory \"avatar + email\")",
+        html.contains("class=\"user-email\""));
+    assertTrue(
+        "A.7 user-email content matches viewer address",
+        html.contains(">alice@example.com</span>"));
+    // A.5 / A.6 SVG glyphs must SSR so the icons are visible
+    // pre-upgrade (matches the no-flicker contract used by the help
+    // modal's hidden attribute and the avatar initials parity).
+    assertTrue(
+        "A.5 bell button server-renders an SVG glyph (no empty pre-upgrade icon)",
+        html.contains("<button type=\"button\" class=\"bell\" aria-label=\"Notifications\"><svg"));
+    assertTrue(
+        "A.6 mail icon server-renders an SVG glyph (no empty pre-upgrade icon)",
+        html.contains("class=\"mail\" href=\"/?q=in:inbox\" aria-label=\"Inbox\"><svg"));
+  }
+
+  // ---------- B.* search rail ----------
+
+  /** B.1 wrapper — search-rail host element with the default query. */
+  @Test
+  public void j2clRootShellEmitsWavySearchRailHostWithDefaultQuery() throws Exception {
+    String html = renderJ2clRootShell();
+    assertEquals(
+        "Exactly one <wavy-search-rail> host is mounted in the J2CL root shell",
+        1,
+        countOccurrences(html, "<wavy-search-rail"));
+    assertTrue(
+        "Rail defaults to query=in:inbox", html.contains("query=\"in:inbox\""));
+    assertTrue(
+        "Rail defaults to data-active-folder=inbox",
+        html.contains("data-active-folder=\"inbox\""));
+  }
+
+  /**
+   * B.5–B.10 — six saved-search folders with the canonical query
+   * strings AND the canonical visible labels. Each folder carries a
+   * {@code data-folder-id} so the client-side rail can route clicks
+   * back to the F-1 search sidecar without re-parsing the query.
+   */
+  @Test
+  public void wavySearchRailInnerLightDomEmitsAllSixSavedSearchFolders() throws Exception {
+    String html = renderJ2clRootShell();
+    String[][] folders = {
+      {"inbox", "in:inbox", "Inbox"},
+      {"mentions", "mentions:me", "Mentions"},
+      {"tasks", "tasks:me", "Tasks"},
+      {"public", "with:@", "Public"},
+      {"archive", "in:archive", "Archive"},
+      {"pinned", "in:pinned", "Pinned"}
+    };
+    for (String[] folder : folders) {
+      String id = folder[0];
+      String query = folder[1];
+      String label = folder[2];
+      assertTrue(
+          "Folder " + id + " carries data-folder-id=\"" + id + "\"",
+          html.contains("data-folder-id=\"" + id + "\""));
+      assertTrue(
+          "Folder " + id + " carries data-query=\"" + query + "\"",
+          html.contains("data-query=\"" + query + "\""));
+      assertTrue("Folder " + id + " label \"" + label + "\"", html.contains(">" + label + "<"));
+    }
+    // Inbox is selected by default; the others are aria-current="false".
+    assertTrue(
+        "Default Inbox folder is aria-current=\"page\"",
+        html.contains("data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"page\""));
+  }
+
+  /** B.2/B.3/B.4/B.11/B.12 — the rail header controls + result-count slot. */
+  @Test
+  public void wavySearchRailInnerLightDomEmitsHelpTriggerNewWaveManageRefreshAndCountSlots()
+      throws Exception {
+    String html = renderJ2clRootShell();
+    assertTrue("B.2 help-trigger class", html.contains("class=\"help-trigger\""));
+    assertTrue(
+        "B.2 help-trigger advertises dialog-popup semantics",
+        html.contains("aria-haspopup=\"dialog\""));
+    assertTrue(
+        "B.2 help-trigger references the modal id",
+        html.contains("aria-controls=\"wavy-search-help\""));
+    assertTrue("B.3 New Wave button class", html.contains("class=\"new-wave\""));
+    assertTrue(
+        "B.3 New Wave button carries the keyboard-shortcut metadata "
+            + "(global listener intentionally deferred to S6)",
+        html.contains("aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\""));
+    assertTrue("B.4 Manage saved searches class", html.contains("class=\"manage-saved\""));
+    assertTrue("B.11 Refresh button class", html.contains("class=\"refresh\""));
+    assertTrue(
+        "B.11 Refresh button has descriptive aria-label",
+        html.contains("aria-label=\"Refresh search results\""));
+    assertTrue(
+        "B.12 result-count <p> with aria-live=\"polite\"",
+        html.contains("class=\"result-count\" aria-live=\"polite\""));
+    assertTrue(
+        "Saved-searches list announces its name to screen readers via "
+            + "aria-labelledby pointing to the folders header h2",
+        html.contains("<h2 id=\"folders-title\">Saved searches</h2>"));
+    assertTrue(
+        "Saved-searches list aria-labelledby relationship intact",
+        html.contains("<ul class=\"folders\" aria-labelledby=\"folders-title\""));
+  }
+
+  // ---------- C.* search-help modal ----------
+
+  /**
+   * C.1–C.22 — the SSR'd modal body MUST contain every one of the
+   * 22 token literals advertised in the GWT search-help panel today.
+   * Sister fixture {@code J2clSearchHelpTokenParseTest} (under
+   * {@code wave/src/test/...}) asserts the parser also accepts each;
+   * the two together pin the contract that the modal cannot drift
+   * away from the parser.
+   */
+  @Test
+  public void j2clRootShellEmitsWavySearchHelpModalWithAll22TokenLiterals() throws Exception {
+    String html = renderJ2clRootShell();
+    assertEquals(
+        "Exactly one <wavy-search-help> host (singleton) is mounted",
+        1,
+        countOccurrences(html, "<wavy-search-help"));
+    assertTrue(
+        "Modal carries the singleton id the rail's help-trigger references",
+        html.contains("id=\"wavy-search-help\""));
+    assertTrue(
+        "Modal SSR carries the `hidden` attribute so the SSR'd light-DOM body "
+            + "does not flash before the J2CL bundle upgrades the element "
+            + "(connectedCallback drops `hidden` on upgrade so the open/close "
+            + "flow takes over).",
+        html.contains("<wavy-search-help id=\"wavy-search-help\" hidden"));
+    assertFalse(
+        "Modal renders closed by default (no open attribute on initial mount)",
+        html.contains("<wavy-search-help id=\"wavy-search-help\" open"));
+    String[] filterTokens = {
+        // C.1–C.4
+        ">in:inbox<", ">in:archive<", ">in:all<", ">in:pinned<",
+        // C.5–C.8
+        ">with:user@domain<", ">with:@<", ">creator:user@domain<", ">tag:name<",
+        // C.9–C.11
+        ">unread:true<", ">title:text<", ">content:text<",
+        // C.12
+        ">mentions:me<",
+        // C.13–C.15
+        ">tasks:all<", ">tasks:me<", ">tasks:user@domain<"
+    };
+    for (String token : filterTokens) {
+      assertTrue(
+          "Search-help modal must advertise filter token " + token,
+          html.contains(token));
+    }
+    // C.16 free-text marker.
+    assertTrue("C.16 free-text row marker", html.contains("free text"));
+    // C.17–C.20 sort tokens.
+    String[] sortTokens = {
+        ">orderby:datedesc<", ">orderby:dateasc<",
+        ">orderby:createddesc<", ">orderby:createdasc<",
+        ">orderby:creatordesc<", ">orderby:creatorasc<"
+    };
+    for (String token : sortTokens) {
+      assertTrue(
+          "Search-help modal must advertise sort token " + token, html.contains(token));
+    }
+    // C.21 combinations — the seven canonical example chips.
+    String[] combinations = {
+        ">in:inbox tag:important<",
+        ">in:all orderby:createdasc<",
+        ">with:alice@example.com tag:project<",
+        ">in:pinned orderby:creatordesc<",
+        ">creator:bob in:archive<",
+        ">mentions:me unread:true<",
+        ">tasks:all unread:true<"
+    };
+    for (String chip : combinations) {
+      assertTrue(
+          "Search-help modal must advertise combination chip " + chip,
+          html.contains(chip));
+    }
+    // C.22 dismiss.
+    assertTrue("C.22 \"Got it\" dismiss text", html.contains(">Got it<"));
+  }
+
+  // ---------- Negative guards ----------
+
+  /**
+   * The legacy GWT path must not load any of the F-2.S3 elements so a
+   * rollback to {@code ?view=gwt} stays safe. The legacy GWT search
+   * panel (g:HTMLPanel + SearchWidget.ui.xml) is unchanged.
+   */
+  @Test
+  public void legacyGwtRouteDoesNotLeakF2S3Markers() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+    String html = invokeServlet(servlet, "gwt", WAVE_ID.serialise());
+
+    assertFalse(
+        "GWT path must not emit <wavy-header> hosts",
+        html.contains("<wavy-header"));
+    assertFalse(
+        "GWT path must not emit <wavy-search-rail> hosts",
+        html.contains("<wavy-search-rail"));
+    assertFalse(
+        "GWT path must not emit <wavy-search-help> hosts",
+        html.contains("<wavy-search-help"));
+    assertFalse(
+        "GWT path must not emit the brand-dot accent",
+        html.contains("class=\"brand-dot\""));
+  }
+
+  /**
+   * The signed-out J2CL root shell must NOT mount the search rail,
+   * help modal, or header chrome — those are signed-in-only
+   * affordances. Defends against accidentally regressing the
+   * unauthenticated landing into emitting search/help to anonymous
+   * users.
+   */
+  @Test
+  public void signedOutJ2clRootShellDoesNotMountSearchRailOrHeaderChrome() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(/* user= */ null, renderer);
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertFalse(
+        "Signed-out branch must not emit <wavy-header>", html.contains("<wavy-header"));
+    assertFalse(
+        "Signed-out branch must not emit <wavy-search-rail>",
+        html.contains("<wavy-search-rail"));
+    assertFalse(
+        "Signed-out branch must not emit <wavy-search-help>",
+        html.contains("<wavy-search-help"));
+    assertTrue(
+        "Signed-out branch keeps its existing shell-root-signed-out element",
+        html.contains("<shell-root-signed-out"));
+  }
+
+  // --- helpers (mirror of the F-1 / F-2.S1 fixtures) ---
+
+  private static String renderJ2clRootShell() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+    return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+  }
+
+  private static List<ObservableWaveletData> buildWaveletData(int blipCount) {
+    TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < blipCount; i++) {
+      data.appendBlipWithText("Body " + i);
+    }
+    return data.copyWaveletData();
+  }
+
+  private static WaveletProvider providerForWave(List<ObservableWaveletData> wavelets) {
+    Map<WaveletName, CommittedWaveletSnapshot> snapshots = new HashMap<>();
+    ImmutableSet.Builder<WaveletId> waveletIds = ImmutableSet.builder();
+    for (ObservableWaveletData waveletData : wavelets) {
+      waveletIds.add(waveletData.getWaveletId());
+      snapshots.put(
+          WaveletName.of(waveletData.getWaveId(), waveletData.getWaveletId()),
+          new CommittedWaveletSnapshot(waveletData, HashedVersion.unsigned(10)));
+    }
+    final ImmutableSet<WaveletId> finalWaveletIds = waveletIds.build();
+    return new WaveletProvider() {
+      @Override
+      public void initialize() {
+      }
+
+      @Override
+      public void submitRequest(
+          WaveletName waveletName, ProtocolWaveletDelta delta, SubmitRequestListener listener) {
+      }
+
+      @Override
+      public void getHistory(
+          WaveletName waveletName,
+          HashedVersion versionStart,
+          HashedVersion versionEnd,
+          Receiver<TransformedWaveletDelta> receiver) {
+      }
+
+      @Override
+      public boolean checkAccessPermission(WaveletName waveletName, ParticipantId participantId) {
+        return true;
+      }
+
+      @Override
+      public ExceptionalIterator<WaveId, WaveServerException> getWaveIds() {
+        return null;
+      }
+
+      @Override
+      public ImmutableSet<WaveletId> getWaveletIds(WaveId waveId) {
+        return WAVE_ID.equals(waveId) ? finalWaveletIds : ImmutableSet.of();
+      }
+
+      @Override
+      public CommittedWaveletSnapshot getSnapshot(WaveletName waveletName) {
+        return snapshots.get(waveletName);
+      }
+
+      @Override
+      public HashedVersion getHashedVersion(WaveletName waveletName, long version) {
+        return null;
+      }
+    };
+  }
+
+  private static WaveClientServlet createServlet(
+      ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer) throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount(any(WebSession.class))).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount((WebSession) null)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        snapshotRenderer,
+        new FeatureFlagService(featureFlagStore()));
+  }
+
+  private static String invokeServlet(WaveClientServlet servlet, String view, String waveId)
+      throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn(view);
+    when(request.getParameterValues("view")).thenReturn(new String[]{view});
+    when(request.getParameter("wave")).thenReturn(waveId);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+    servlet.doGet(request, response);
+    return body.toString();
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    if (haystack == null || needle == null || needle.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = haystack.indexOf(needle, idx)) != -1) {
+      count++;
+      idx += needle.length();
+    }
+    return count;
+  }
+
+  private static FeatureFlagStore featureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(Collections.emptyList());
+    return store;
+  }
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -155,8 +155,8 @@ public final class J2clSearchRailParityTest {
         html.contains("class=\"dot violet\" hidden"));
     assertTrue("A.6 mail icon class", html.contains("class=\"mail\""));
     assertTrue(
-        "A.6 mail icon links to inbox query",
-        html.contains("href=\"/?q=in:inbox\""));
+        "A.6 mail icon links to inbox query with J2CL root routing",
+        html.contains("href=\"/?view=j2cl-root&amp;q=in%3Ainbox\""));
     assertTrue("A.7 user-menu trigger class", html.contains("class=\"user-menu\""));
     assertTrue(
         "A.7 user-menu trigger advertises menu popup semantics",
@@ -176,7 +176,7 @@ public final class J2clSearchRailParityTest {
         html.contains("<button type=\"button\" class=\"bell\" aria-label=\"Notifications\"><svg"));
     assertTrue(
         "A.6 mail icon server-renders an SVG glyph (no empty pre-upgrade icon)",
-        html.contains("class=\"mail\" href=\"/?q=in:inbox\" aria-label=\"Inbox\"><svg"));
+        html.contains("class=\"mail\" href=\"/?view=j2cl-root&amp;q=in%3Ainbox\" aria-label=\"Inbox\"><svg"));
   }
 
   // ---------- B.* search rail ----------

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/J2clSearchHelpTokenParseTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/J2clSearchHelpTokenParseTest.java
@@ -1,0 +1,302 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import junit.framework.TestCase;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * F-2 slice 3 (#1047) parser-contract fixture.
+ *
+ * <p>The {@code <wavy-search-help>} Lit element advertises 22
+ * inventory rows (C.1–C.22) of search query tokens — the same set the
+ * GWT search-help panel advertises today. This fixture asserts that
+ * EVERY advertised token still parses through {@link
+ * QueryHelper#parseQuery(String)}, the canonical query parser shared
+ * by both the legacy GWT search and the J2CL search sidecar.
+ *
+ * <p>Why this matters: the slice brief explicitly forbids inventing
+ * new search tokens. If a future change to either {@code
+ * <wavy-search-help>} or {@code TokenQueryType} drifts the two
+ * sources out of lockstep, this test fails before the help modal
+ * starts advertising tokens the parser rejects.
+ *
+ * <p>Sister fixture: {@code
+ * J2clSearchRailParityTest} (under {@code wave/src/jakarta-test/...})
+ * asserts that the server-rendered HTML actually contains every one
+ * of these token literals inside the {@code <wavy-search-help>} host.
+ *
+ * @author claude (#1047 implementation lane)
+ */
+public class J2clSearchHelpTokenParseTest extends TestCase {
+
+  /** C.1 — in:inbox */
+  public void testParseInInboxFilterDepositsInBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:inbox");
+    Set<String> values = tokens.get(TokenQueryType.IN);
+    assertNotNull("in:inbox must populate the IN bucket", values);
+    assertTrue(values.contains("inbox"));
+  }
+
+  /** C.2 — in:archive */
+  public void testParseInArchiveFilterDepositsInBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:archive");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("archive"));
+  }
+
+  /** C.3 — in:all */
+  public void testParseInAllFilterDepositsInBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:all");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("all"));
+  }
+
+  /** C.4 — in:pinned */
+  public void testParseInPinnedFilterDepositsInBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:pinned");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("pinned"));
+  }
+
+  /** C.5 — with:user@domain (advertised example chip uses with:alice@example.com) */
+  public void testParseWithUserAtDomainFilterDepositsWithBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens =
+        QueryHelper.parseQuery("with:alice@example.com");
+    assertTrue(tokens.get(TokenQueryType.WITH).contains("alice@example.com"));
+  }
+
+  /** C.6 — with:@ (public, shared domain). */
+  public void testParseWithSharedDomainFilterDepositsWithBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("with:@");
+    assertTrue(tokens.get(TokenQueryType.WITH).contains("@"));
+  }
+
+  /** C.7 — creator:user@domain. */
+  public void testParseCreatorFilterDepositsCreatorBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens =
+        QueryHelper.parseQuery("creator:bob@example.com");
+    assertTrue(tokens.get(TokenQueryType.CREATOR).contains("bob@example.com"));
+  }
+
+  /** C.8 — tag:name. */
+  public void testParseTagFilterDepositsTagBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("tag:important");
+    assertTrue(tokens.get(TokenQueryType.TAG).contains("important"));
+  }
+
+  /** C.9 — unread:true. */
+  public void testParseUnreadTrueFilterDepositsUnreadBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("unread:true");
+    assertTrue(tokens.get(TokenQueryType.UNREAD).contains("true"));
+  }
+
+  /** C.10 — title:text. */
+  public void testParseTitleFilterDepositsTitleBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("title:meeting");
+    assertTrue(tokens.get(TokenQueryType.TITLE).contains("meeting"));
+  }
+
+  /** C.11 — content:text. */
+  public void testParseContentFilterDepositsContentBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("content:agenda");
+    assertTrue(tokens.get(TokenQueryType.CONTENT).contains("agenda"));
+  }
+
+  /** C.12 — mentions:me. */
+  public void testParseMentionsFilterDepositsMentionsBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("mentions:me");
+    assertTrue(tokens.get(TokenQueryType.MENTIONS).contains("me"));
+  }
+
+  /** C.13 — tasks:all (informational only; behavior owned by F-3). */
+  public void testParseTasksAllFilterDepositsTasksBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("tasks:all");
+    assertTrue(tokens.get(TokenQueryType.TASKS).contains("all"));
+  }
+
+  /** C.14 — tasks:me. */
+  public void testParseTasksMeFilterDepositsTasksBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("tasks:me");
+    assertTrue(tokens.get(TokenQueryType.TASKS).contains("me"));
+  }
+
+  /** C.15 — tasks:user@domain. */
+  public void testParseTasksUserAtDomainFilterDepositsTasksBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens =
+        QueryHelper.parseQuery("tasks:alice@example.com");
+    assertTrue(tokens.get(TokenQueryType.TASKS).contains("alice@example.com"));
+  }
+
+  /** C.16 — free text falls into the implicit content bucket. */
+  public void testParseFreeTextFallsIntoContentBucket() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("meeting notes");
+    Set<String> values = tokens.get(TokenQueryType.CONTENT);
+    assertNotNull(values);
+    assertTrue(values.contains("meeting"));
+    assertTrue(values.contains("notes"));
+  }
+
+  // C.17–C.20: every advertised orderby: value must resolve to an
+  // OrderByValueType (the QueryHelper parser eagerly validates these
+  // and throws InvalidQueryException on unknown values, so the modal
+  // MUST advertise only canonical values).
+
+  /** C.17 default sort. */
+  public void testParseOrderByDateDescResolves() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("orderby:datedesc");
+    assertTrue(tokens.get(TokenQueryType.ORDERBY).contains("datedesc"));
+    assertEquals(QueryHelper.OrderByValueType.DATEDESC,
+        QueryHelper.OrderByValueType.fromToken("datedesc"));
+  }
+
+  /** C.18 — orderby:dateasc. */
+  public void testParseOrderByDateAscResolves() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("orderby:dateasc");
+    assertTrue(tokens.get(TokenQueryType.ORDERBY).contains("dateasc"));
+    assertEquals(QueryHelper.OrderByValueType.DATEASC,
+        QueryHelper.OrderByValueType.fromToken("dateasc"));
+  }
+
+  /** C.19 — orderby:createddesc and orderby:createdasc. */
+  public void testParseOrderByCreatedDescAndCreatedAscResolve() throws Exception {
+    Map<TokenQueryType, Set<String>> descTokens =
+        QueryHelper.parseQuery("orderby:createddesc");
+    assertTrue(descTokens.get(TokenQueryType.ORDERBY).contains("createddesc"));
+    assertEquals(QueryHelper.OrderByValueType.CREATEDDESC,
+        QueryHelper.OrderByValueType.fromToken("createddesc"));
+
+    Map<TokenQueryType, Set<String>> ascTokens =
+        QueryHelper.parseQuery("orderby:createdasc");
+    assertTrue(ascTokens.get(TokenQueryType.ORDERBY).contains("createdasc"));
+    assertEquals(QueryHelper.OrderByValueType.CREATEDASC,
+        QueryHelper.OrderByValueType.fromToken("createdasc"));
+  }
+
+  /** C.20 — orderby:creatordesc and orderby:creatorasc. */
+  public void testParseOrderByCreatorDescAndCreatorAscResolve() throws Exception {
+    Map<TokenQueryType, Set<String>> descTokens =
+        QueryHelper.parseQuery("orderby:creatordesc");
+    assertTrue(descTokens.get(TokenQueryType.ORDERBY).contains("creatordesc"));
+    assertEquals(QueryHelper.OrderByValueType.CREATORDESC,
+        QueryHelper.OrderByValueType.fromToken("creatordesc"));
+
+    Map<TokenQueryType, Set<String>> ascTokens =
+        QueryHelper.parseQuery("orderby:creatorasc");
+    assertTrue(ascTokens.get(TokenQueryType.ORDERBY).contains("creatorasc"));
+    assertEquals(QueryHelper.OrderByValueType.CREATORASC,
+        QueryHelper.OrderByValueType.fromToken("creatorasc"));
+  }
+
+  // C.21 — every combination example string from the modal must parse
+  // without an InvalidQueryException. We do not assert on the resulting
+  // bucket shape here (the per-token tests above already cover that);
+  // we only assert that the parser accepts the combined string.
+
+  public void testParseCombinationInboxTagImportant() throws Exception {
+    QueryHelper.parseQuery("in:inbox tag:important");
+  }
+
+  public void testParseCombinationInAllOrderByCreatedAsc() throws Exception {
+    QueryHelper.parseQuery("in:all orderby:createdasc");
+  }
+
+  public void testParseCombinationWithUserTagProject() throws Exception {
+    QueryHelper.parseQuery("with:alice@example.com tag:project");
+  }
+
+  public void testParseCombinationInPinnedOrderByCreatorDesc() throws Exception {
+    QueryHelper.parseQuery("in:pinned orderby:creatordesc");
+  }
+
+  public void testParseCombinationCreatorBobInArchive() throws Exception {
+    QueryHelper.parseQuery("creator:bob in:archive");
+  }
+
+  public void testParseCombinationMentionsMeUnreadTrue() throws Exception {
+    QueryHelper.parseQuery("mentions:me unread:true");
+  }
+
+  public void testParseCombinationTasksAllUnreadTrue() throws Exception {
+    QueryHelper.parseQuery("tasks:all unread:true");
+  }
+
+  // The six saved-search rail folder query strings (B.5–B.10) MUST all
+  // parse cleanly. The modal does not list them as their own row, but
+  // the rail uses them as the canonical "click this folder" payload.
+
+  public void testParseSavedSearchInboxFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:inbox");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("inbox"));
+  }
+
+  public void testParseSavedSearchMentionsFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("mentions:me");
+    assertTrue(tokens.get(TokenQueryType.MENTIONS).contains("me"));
+  }
+
+  public void testParseSavedSearchTasksFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("tasks:me");
+    assertTrue(tokens.get(TokenQueryType.TASKS).contains("me"));
+  }
+
+  public void testParseSavedSearchPublicFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("with:@");
+    assertTrue(tokens.get(TokenQueryType.WITH).contains("@"));
+  }
+
+  public void testParseSavedSearchArchiveFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:archive");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("archive"));
+  }
+
+  public void testParseSavedSearchPinnedFolder() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("in:pinned");
+    assertTrue(tokens.get(TokenQueryType.IN).contains("pinned"));
+  }
+
+  /**
+   * Negative guard: orderby: with a value not in OrderByValueType MUST
+   * throw {@link QueryHelper.InvalidQueryException}. This is the
+   * test that fails if the help modal ever advertises a sort token
+   * the parser does not recognise.
+   */
+  public void testParseOrderByBogusValueThrowsInvalidQueryException() {
+    try {
+      QueryHelper.parseQuery("orderby:bogus");
+      fail("Expected InvalidQueryException for unknown orderby value");
+    } catch (QueryHelper.InvalidQueryException expected) {
+      // Expected.
+    }
+  }
+
+  /**
+   * Negative guard: an unknown token prefix falls into CONTENT (it
+   * does NOT throw). This documents the parser's current behaviour:
+   * adding a NEW filter prefix to <wavy-search-help> without adding
+   * it to TokenQueryType silently degrades to a content search rather
+   * than throwing — the slice brief forbids this, and the modal MUST
+   * stay restricted to TokenQueryType-backed prefixes. This test
+   * pins the contract so we know what the safety net is.
+   */
+  public void testUnknownPrefixFallsThroughToContent() throws Exception {
+    Map<TokenQueryType, Set<String>> tokens = QueryHelper.parseQuery("bogus:value");
+    assertTrue(tokens.get(TokenQueryType.CONTENT).contains("bogus:value"));
+  }
+}


### PR DESCRIPTION
Updates #1037 (slice 3 of 6 — does NOT close the umbrella). Updates #904. References #1047.

## Summary

Three new Lit elements + a per-digest card + server SSR + two acceptance fixtures wire up the wavy left rail, the search-help modal, and the wavy header end-region on the J2CL root shell. Covers **45 affordances** cited in `docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md`.

### Inventory affordances shipped
- **A.1** SupaWave brand link with cyan signal-dot accent
- **A.2** Locale picker (en/de/es/fr/ru/sl/zh_TW)
- **A.5** Notifications bell with violet (`--wavy-signal-violet`) unread dot
- **A.6** Inbox/mail icon → `/?q=in:inbox`
- **A.7** User-menu trigger (avatar chip + visible email span); the menu sheet itself comes from F-0
- **B.1–B.18** search rail (query + waveform glyph, help trigger, New Wave with `aria-keyshortcuts`, Manage saved searches, six saved-search folders with the canonical query strings, refresh, result-count) and per-digest card (multi-author avatar stack truncated at 3 + overflow chip, cyan pin glyph when pinned, title, 3-line snippet clamp, msg-count + unread badge with the F-0 `firePulse()` signal-cyan ring, relative timestamp with `<time datetime>` tooltip)
- **C.1–C.22** search-help modal advertising every search query token from the GWT search panel; `J2clSearchHelpTokenParseTest` pins the contract that the modal cannot drift away from `QueryHelper.parseQuery` / `TokenQueryType` / `OrderByValueType`

### Mount points
- `<wavy-header slot="actions-signed-in">` → inside `<shell-header>`
- `<wavy-search-rail>` → inside `<shell-nav-rail>`
- `<wavy-search-help id="wavy-search-help" hidden>` → direct child of `<shell-root>` (singleton, document-level dialog)

### Server-first contract
The server SSR mirrors the inner light DOM each Lit element renders client-side so the upgrade is content-preserving (mirrors the F-2.S1 `<wavy-blip-card>` server-render contract). The search-help modal SSR emits `hidden` so the body does not flash before the J2CL bundle upgrades the element; `connectedCallback` drops `hidden`. Avatar initials helper (Java) and `_initials()` (JS) are aligned to use first-segment + last-segment splitting so multi-dot emails like `john.q.public@x.com` avoid flicker between SSR and post-upgrade renders.

### Out of scope
- Wave panel chrome (D.*) — owned by S2 (#1046)
- Per-blip controls (F.*) — already shipped in S1 (#1045)
- Floating + version-history controls (J.*, K.*) — owned by S4 (#1048)
- URL state + read state — owned by S5
- Locale picker actually changing locale (the picker emits `wavy-locale-changed`; routing wiring deferred to S6)
- Shift+Cmd+O global keymap — deferred to S6 (`aria-keyshortcuts` metadata is present on the New Wave button)
- Inline `Admin` and `Sign out` links remain in the header until F-0's `<wavy-user-menu-sheet>` ships (otherwise A.15 / A.17 would be orphaned)

## Test plan
- [x] `sbt -batch jakartaTest:testOnly *J2clSearchRailParityTest` → 9/9 passed
- [x] `sbt -batch testOnly *J2clSearchHelpTokenParseTest *QueryHelperTest` → 47/47 passed (35 new + 12 existing)
- [x] `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild` → 270 Lit tests passed (was 178, +92), search-sidecar smoke and production build clean
- [ ] Worktree-local server boot + side-by-side at `?view=j2cl-root` vs `?view=gwt`: confirm header chrome, search rail, search-help modal, folder switching, every filter token parses, refresh works (manual verification reserved for the PR monitor lane)

### Notes
- A pre-existing unrelated failure (`J2clStageOneReadSurfaceParityTest.legacyGwtRouteDoesNotLeakF2ClientMarkers`) is present on `origin/main` HEAD (`f4a6cd6f5`); confirmed by stashing S3 changes and re-running. Filed separately if it isn't already.
- Plan and implementation went through one Opus plan-review pass (10 issues addressed) and one Opus impl-review pass (8 issues addressed) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New header with locale selector, notifications/unread indicator, inbox link, and user menu
  * Left search rail with query box, saved-search folders, help trigger, refresh, result count, and mentions/tasks indicators
  * Search-help modal with filter/sort tokens, example chips, focus/trap accessibility, and dismiss controls
  * Result cards with title/snippet, avatar stack, unread/pinned states, pulse animation, and timestamps

* **Tests**
  * Comprehensive component tests plus server-rendered parity and query-parser validation

* **Documentation**
  * New spec and changelog documenting acceptance criteria and advertised tokens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->