### PR TITLE
fix(j2cl): gate F-2 client markers on J2CL route only (S1 regression follow-up)

### DIFF
--- a/wave/config/changelog.d/2026-04-26-issue-1050-gwt-route-guard.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1050-gwt-route-guard.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-26-issue-1050-gwt-route-guard",
+  "version": "Fix #1050 (PR #1051)",
+  "date": "2026-04-26",
+  "title": "Restore Per-Wave Server-First Paint on Legacy GWT Route",
+  "summary": "The legacy ?view=gwt fall-through now renders the requested wave as a non-windowed server-first HTML fragment so a J2CL rollback retains the legacy class=\"blip\" host markup, while keeping all F-1 / F-2 J2CL-only client surface markers gated on the J2CL route.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Wire WaveClientServlet's legacy GWT fall-through through a new J2clSelectedWaveSnapshotRenderer.renderRequestedWaveForLegacy entry point so ?view=gwt rollbacks render the same per-wave first paint as the J2CL root shell, but with no F-1 windowed-surface markers (data-j2cl-server-first-surface, data-j2cl-initial-window-size), no J2CL-only client-bundle markers (<wave-blip>, wavy-tokens.css, j2cl/assets/shell.js, data-j2cl-selected-wave-host), and no advance of the j2cl.viewport.initial_window counter."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -268,8 +268,34 @@ public class WaveClientServlet extends HttpServlet {
       // renderTopBar accepts a null username and emits the signed-out auth shell.
       String topBarHtml = HtmlRenderer.renderTopBar(username, userDomain, userRole);
 
-      // Keep the legacy rollback path on the existing skeleton load until the
-      // server-side pre-rendered fragment has an explicit sanitization boundary.
+      // Issue #1050 / F-2 S1 follow-up: render the requested wave as a
+      // non-windowed legacy server-first fragment so a ?view=gwt rollback
+      // retains the legacy `<div class="blip">` host markup that
+      // ServerHtmlRenderer emits. The J2CL-only shell surface (the
+      // `<wave-blip>` custom element host, the wavy design-tokens
+      // stylesheet, the `j2cl/assets/shell.js` bundle, and the
+      // `data-j2cl-selected-wave-host` attribute) lives exclusively in
+      // `HtmlRenderer.renderJ2clRootShellPage` so it cannot leak through
+      // `renderWaveClientPage`; the F-1 windowed surface markers
+      // (`data-j2cl-server-first-surface`, `data-j2cl-initial-window-size`,
+      // `data-j2cl-upgrade-placeholder`) are gated on the windowed render
+      // path and the `renderRequestedWaveForLegacy` overload skips both
+      // windowing and the J2CL viewport-initial-window counter increment.
+      String legacySnapshotHtml = null;
+      if (id != null && j2clSelectedWaveSnapshotRenderer != null) {
+        try {
+          J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult =
+              j2clSelectedWaveSnapshotRenderer.renderRequestedWaveForLegacy(
+                  request.getParameter("wave"), id);
+          if (snapshotResult != null && snapshotResult.hasSnapshotHtml()) {
+            legacySnapshotHtml = snapshotResult.getSnapshotHtml();
+          }
+        } catch (RuntimeException e) {
+          LOG.warning(
+              "Failed to render legacy GWT route server-first snapshot, falling back to skeleton",
+              e);
+        }
+      }
       w.write(HtmlRenderer.renderWaveClientPage(
           getSessionJson(session),
           getClientFlags(request),
@@ -279,7 +305,7 @@ public class WaveClientServlet extends HttpServlet {
           buildCommit,
           serverBuildTime,
           currentReleaseId,
-          null)); // codeql[java/xss]
+          legacySnapshotHtml)); // codeql[java/xss]
     } catch (IOException e) {
       LOG.warning("Failed to render WaveClient page", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -247,6 +247,8 @@ public class WaveClientServlet extends HttpServlet {
 
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
+    response.setHeader("Cache-Control", "private, no-store");
+    response.setHeader("Vary", "Cookie");
     response.setStatus(HttpServletResponse.SC_OK);
     try (var w = response.getWriter()) {
       String username = null;

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRenderer.java
@@ -189,7 +189,38 @@ public class J2clSelectedWaveSnapshotRenderer {
     this.currentTimeSource = currentTimeSource;
   }
 
+  /**
+   * Issue #1050 / F-2 S1 follow-up: render the requested wave as a legacy
+   * (non-windowed, non-J2CL) server-first HTML fragment. This is consumed by
+   * the {@code ?view=gwt} fall-through path in {@code WaveClientServlet} so a
+   * rollback to the legacy GWT route still gets the same per-wave first paint
+   * a J2CL viewer would, but without:
+   *
+   * <ul>
+   *   <li>the F-1 windowed surface markers ({@code data-j2cl-server-first-surface},
+   *       {@code data-j2cl-initial-window-size}) — gated on
+   *       {@link WaveContentRenderer}'s windowed render path which this entry
+   *       point bypasses by passing {@code initialWindowSize=0};</li>
+   *   <li>the F-1 / F-2 client-bundle markers ({@code <wave-blip>},
+   *       {@code wavy-tokens.css}, {@code j2cl/assets/shell.js},
+   *       {@code data-j2cl-selected-wave-host}) — only emitted by
+   *       {@code HtmlRenderer.renderJ2clRootShellPage}, which the GWT route
+   *       does not invoke;</li>
+   *   <li>the J2CL viewport-initial-window observability counter — not
+   *       advanced because the GWT route is not a J2CL viewport open.</li>
+   * </ul>
+   */
+  public SnapshotResult renderRequestedWaveForLegacy(
+      String requestedWaveId, ParticipantId viewer) {
+    return renderRequestedWaveInternal(requestedWaveId, viewer, /*windowed=*/ false);
+  }
+
   public SnapshotResult renderRequestedWave(String requestedWaveId, ParticipantId viewer) {
+    return renderRequestedWaveInternal(requestedWaveId, viewer, /*windowed=*/ true);
+  }
+
+  private SnapshotResult renderRequestedWaveInternal(
+      String requestedWaveId, ParticipantId viewer, boolean windowed) {
     if (StringUtils.isBlank(requestedWaveId)) {
       return SnapshotResult.noWave();
     }
@@ -243,9 +274,14 @@ public class J2clSelectedWaveSnapshotRenderer {
         return SnapshotResult.denied();
       }
 
+      // Issue #1050: the legacy GWT fall-through invokes this path with
+      // windowed=false so the rendered HTML carries no F-1 windowed-surface
+      // markers (data-j2cl-server-first-surface, data-j2cl-initial-window-size)
+      // and the J2CL viewport-initial-window counter does not advance.
+      int effectiveWindowSize = windowed ? initialWindowSize : 0;
       String snapshotHtml =
           WaveContentRenderer.renderWaveContent(
-              waveView, viewer, () -> overBudget(startTimeMs), initialWindowSize);
+              waveView, viewer, () -> overBudget(startTimeMs), effectiveWindowSize);
       if (overBudget(startTimeMs)) {
         LOG.info("Skipping server-first selected-wave snapshot because the render budget was exceeded after render for "
             + waveId.serialise());
@@ -261,7 +297,10 @@ public class J2clSelectedWaveSnapshotRenderer {
       // Snapshot path counts toward the J2CL viewport-initial-window
       // observability stream so the audit's required `viewport.initial_window`
       // counter advances even when the live socket open is still in flight.
-      if (org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
+      // The legacy GWT fall-through (windowed=false) is not a J2CL viewport
+      // open so it deliberately does not advance this counter.
+      if (windowed
+          && org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics.isEnabled()) {
         org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics
             .j2clViewportInitialWindows.incrementAndGet();
       }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -202,6 +202,33 @@ public final class WaveClientServletJ2clBootstrapTest {
     assertFalse(body.toString().contains("data-prerendered=\"true\""));
   }
 
+  /**
+   * Issue #1050 / PR #1051 review follow-up: the legacy GWT fall-through path embeds a
+   * per-user, session-specific server-first snapshot, so it must opt out of shared-proxy and
+   * BFCache reuse with the same `Cache-Control: private, no-store` and `Vary: Cookie` headers
+   * that the J2CL root branch already sets.
+   */
+  @Test
+  public void legacyWaveClientResponseSetsPrivateCacheHeaders() throws Exception {
+    WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    // Confirm we actually exercised the legacy GWT fall-through.
+    String html = body.toString();
+    assertTrue(html.contains("webclient/webclient.nocache.js"));
+    assertFalse(html.contains("data-j2cl-root-shell"));
+
+    verify(response).setHeader("Cache-Control", "private, no-store");
+    verify(response).setHeader("Vary", "Cookie");
+  }
+
   @Test
   public void humanLocaleRedirectUsesRequestUriInsteadOfAbsoluteRequestUrl() throws Exception {
     ParticipantId user = ParticipantId.ofUnsafe("alice@example.com");

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRendererWindowTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/render/J2clSelectedWaveSnapshotRendererWindowTest.java
@@ -145,6 +145,56 @@ public final class J2clSelectedWaveSnapshotRendererWindowTest extends TestCase {
         windowedSize * 100L < wholeSize * 75L);
   }
 
+  /**
+   * Issue #1050: the legacy {@code ?view=gwt} fall-through invokes
+   * {@link J2clSelectedWaveSnapshotRenderer#renderRequestedWaveForLegacy}
+   * with the same wave ID. The returned snapshot must:
+   *
+   * <ul>
+   *   <li>contain the legacy {@code class="blip"} host markup that
+   *       {@code ServerHtmlRenderer} emits (so a GWT rollback still renders
+   *       the per-wave first paint instead of an empty skeleton);</li>
+   *   <li>NOT carry the F-1 windowed-surface markers
+   *       ({@code data-j2cl-server-first-surface},
+   *       {@code data-j2cl-initial-window-size}) — those are J2CL-only;</li>
+   *   <li>NOT advance the {@code j2cl.viewport.initial_window} counter —
+   *       the GWT route is not a J2CL viewport open.</li>
+   * </ul>
+   */
+  public void testLegacyEntryPointEmitsLegacyMarkupAndOmitsJ2clMarkersAndCounter() {
+    TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
+    for (int i = 0; i < 6; i++) {
+      data.appendBlipWithText("Body " + i);
+    }
+
+    J2clSelectedWaveSnapshotRenderer renderer =
+        new J2clSelectedWaveSnapshotRenderer(
+            providerFor(data.copyWaveletData(), true),
+            500L,
+            262144,
+            5,
+            new SequenceTimeSource(0L, 10L, 20L, 30L, 40L, 50L));
+
+    J2clSelectedWaveSnapshotRenderer.SnapshotResult result =
+        renderer.renderRequestedWaveForLegacy(WAVE_ID.serialise(), VIEWER);
+
+    assertEquals(J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT, result.getMode());
+    assertTrue(
+        "Legacy entry point must emit ServerHtmlRenderer's class=\"blip\" host markup so "
+            + "?view=gwt rollback retains the legacy per-wave first paint",
+        result.getSnapshotHtml().contains("class=\"blip\""));
+    assertFalse(
+        "Legacy entry point must not carry the F-1 windowed-surface marker",
+        result.getSnapshotHtml().contains("data-j2cl-server-first-surface"));
+    assertFalse(
+        "Legacy entry point must not carry the F-1 initial-window-size marker",
+        result.getSnapshotHtml().contains("data-j2cl-initial-window-size"));
+    assertEquals(
+        "Legacy entry point must not advance the J2CL viewport-initial-window counter",
+        initialWindowsBefore,
+        FragmentsMetrics.j2clViewportInitialWindows.get());
+  }
+
   public void testZeroWindowSizeSkipsWindowMarkersAndStillCountsInitialWindow() {
     TestingWaveletData data = new TestingWaveletData(WAVE_ID, CONV_ROOT, AUTHOR, true);
     data.appendBlipWithText("Single blip");


### PR DESCRIPTION
Fixes #1050. Updates #1037. Updates #904.

## Summary

The S1 acceptance test
`J2clStageOneReadSurfaceParityTest.legacyGwtRouteDoesNotLeakF2ClientMarkers`
fails on `origin/main` (`f4a6cd6f5`) because the legacy `?view=gwt`
fall-through in `WaveClientServlet#doGet` writes a static skeleton with
no per-wave content (the `prerenderedHtml` argument was hard-coded to
`null` by the prior "harden legacy rollback rendering" change), so the
test's `assertTrue(html.contains("class=\"blip\""))` cannot succeed even
with a real wave attached to the request.

This PR re-feeds the same per-wave server-first snapshot the J2CL root
shell consumes through a new non-windowed legacy entry point so the GWT
route's HTML never carries the J2CL-only surface markers the test
forbids.

## Why this is a route guard, not a renderer rewrite

The audit doc framed the regression as F-2 client markers
"leaking unconditionally". The actual leak point is more subtle:

- `<wave-blip>`, `wavy-tokens.css`, `j2cl/assets/shell.js`, and
  `data-j2cl-selected-wave-host` are emitted exclusively by
  `HtmlRenderer.renderJ2clRootShellPage` (the J2CL route only). They
  cannot leak through `renderWaveClientPage`.
- `data-j2cl-server-first-surface` and `data-j2cl-initial-window-size`
  are emitted by `WaveContentRenderer` only when `windowOptions.isWindowed()`.
  The new `renderRequestedWaveForLegacy` overload passes
  `initialWindowSize=0` so the windowed branch is never entered.
- The `j2cl.viewport.initial_window` counter is gated on the
  `windowed=true` path so the GWT route does not advance it.

The result: the GWT route now renders `class="blip"` (legacy
`ServerHtmlRenderer` host markup) and continues to emit none of the
forbidden F-1/F-2 markers.

## Verification

- `sbt -batch "jakartaTest:testOnly *J2clStageOneReadSurfaceParityTest"`
  — 8/8 passing (`legacyGwtRouteDoesNotLeakF2ClientMarkers` plus all
  R-3.1 / R-3.2 / R-3.3 / R-3.4 / R-3.7 / R-4.4 assertions).
- `sbt -batch "jakartaTest:testOnly *J2clViewportFirstPaintParityTest"`
  — 4/4 passing (incl. `legacyGwtRouteDoesNotEmitServerFirstMarkers`).
- `sbt -batch "test:testOnly *J2clSelectedWaveSnapshotRenderer*"` —
  12/12 passing (incl. new
  `testLegacyEntryPointEmitsLegacyMarkupAndOmitsJ2clMarkersAndCounter`).
- `sbt -batch "jakartaTest:testOnly *WaveClientServletJ2clBootstrapTest"`
  — 10/10 passing (incl. `legacyWaveClientDoesNotInvokePreRenderer`,
  which still verifies the old `WavePreRenderer` is never invoked).
- `j2clSearchTest` — 655/655 passing (81 skipped).
- `j2clProductionBuild` — exit 0.

## Test plan

- [x] `sbt -batch "jakartaTest:testOnly *J2clStageOneReadSurfaceParityTest"`
- [x] `sbt -batch "jakartaTest:testOnly *J2clViewportFirstPaintParityTest"`
- [x] `sbt -batch "test:testOnly *J2clSelectedWaveSnapshotRenderer*"`
- [x] `sbt -batch "jakartaTest:testOnly *WaveClientServletJ2clBootstrapTest"`
- [x] `j2clSearchTest`
- [x] `j2clProductionBuild`

## Note on a pre-existing unrelated failure

`WaveClientServletJ2clRootShellTest.j2clRootViewPreservesCurrentRouteStateInSignedOutChrome`
fails on `origin/main` (verified by stashing my changes and re-running);
the failure is independent of this lane (it lives in the J2CL root view,
not the GWT route) and is out of scope for this S1 regression follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legacy wave view routing to properly render server-first HTML fragments with correct backward-compatible markup.
  * Improved compatibility for requests using legacy view parameters to ensure consistent HTML rendering and proper fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->