### PR TITLE
F-2 (slice 2): Wave chrome — wavy-wave-nav-row + wavy-focus-frame + wavy-depth-nav-bar

### DIFF
--- a/docs/superpowers/plans/2026-04-26-issue-1046-wave-chrome.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1046-wave-chrome.md
@@ -1,0 +1,330 @@
+# F-2 Slice 2 — Wave chrome (`<wavy-wave-nav-row>` + `<wavy-focus-frame>` + `<wavy-depth-nav-bar>`)
+
+Issue: [#1046](https://github.com/apache/incubator-wave/issues/1046).
+Parent umbrella: [#1037](https://github.com/apache/incubator-wave/issues/1037) (F-2 StageOne read surface) — slice 2 of 6, **does NOT close umbrella**.
+Tracker: [#904](https://github.com/apache/incubator-wave/issues/904).
+Foundation: F-0 (#1035 / sha `af7072f9`), F-1 (#1036 / sha `86ea6b44`), F-2.S1 (#1045 / sha `f4a6cd6f`).
+
+Parity-matrix rows claimed: **R-3.2** (focus framing), **R-3.3** (collapse motion wiring), **R-3.4** (E.1–E.10 wave nav row), **R-3.7-chrome** (G.2 + G.3 depth-nav-bar shell, no URL state — that's S5).
+
+## 1. Why this plan exists
+
+F-2.S1 (#1045) re-executed the read surface — it ships `<wave-blip>` + `<wave-blip-toolbar>` and threads them through `J2clReadSurfaceDomRenderer`. R-3.2 / R-3.3 / R-3.4 / R-3.7 are **partially** met (focus is tracked on the renderer but not bracketed by a `<wavy-focus-frame>` landmark; collapse animates with hard-coded values; nav buttons E.1–E.10 don't render at all; depth-nav scaffold exists at the F-0 recipe level but G.2/G.3 chrome controls don't).
+
+This slice closes those gaps with **three new Lit elements** + a renderer extension that mounts them inside the selected-wave card. The plan is self-contained: it follows the audit (`docs/superpowers/audits/2026-04-26-gwt-functional-inventory.md`) row-by-row, doesn't redefine S1's contract, and emits forward-only events that S5 will consume for URL state + telemetry counters.
+
+## 2. Verification ground truth (re-derived in worktree)
+
+Read freshly inside the worktree to avoid stale assumptions:
+
+- `j2cl/lit/src/design/wavy-tokens.css` — F-0 token contract. Verified all named tokens in the issue brief exist (`--wavy-bg-base`, `--wavy-bg-surface`, `--wavy-border-hairline`, `--wavy-text-body`, `--wavy-text-muted`, `--wavy-signal-cyan`, `--wavy-signal-cyan-soft`, `--wavy-signal-violet`, `--wavy-signal-violet-soft`, `--wavy-signal-amber`, `--wavy-signal-amber-soft`, `--wavy-focus-ring`, `--wavy-pulse-ring`, `--wavy-motion-focus-duration: 180ms`, `--wavy-motion-collapse-duration: 240ms`, `--wavy-easing-focus`, `--wavy-easing-collapse`, `--wavy-spacing-1..8`, `--wavy-radius-card: 12px`, `--wavy-radius-pill: 9999px`).
+- `j2cl/lit/src/elements/wave-blip.js` (374 LOC) — F-2.S1 wrapper. Reflects `data-blip-id`, `data-wave-id`, `unread`, `has-mention`, `focused`, `reply-count`. Already emits `wave-blip-reply-requested`, `wave-blip-edit-requested`, `wave-blip-link-copied`, `wave-blip-profile-requested`, `wave-blip-drill-in-requested`. **Notably absent**: `wave-blip-pin-requested` and `wave-blip-archive-requested` events — the S2 nav-row will dispatch these from the host; no change needed in `wave-blip` itself.
+- `j2cl/lit/src/elements/wave-blip-toolbar.js` (108 LOC) — per-blip Reply / Edit / Link / overflow.
+- `j2cl/lit/src/design/wavy-depth-nav.js` (80 LOC) — F-0 breadcrumb recipe (`crumbs: Array<{label, href?, current?}>`). The S2 `<wavy-depth-nav-bar>` will compose this recipe + add the G.2/G.3 buttons.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` (1181 LOC) — owns `enhanceSurface`, `enhanceBlips`, `toggleThread`, `onBlipKeyDown` (currently handles ArrowUp/Down/Home/End). **S2 extension surface**: add `j`/`k` aliases for ArrowDown/ArrowUp; add a focus listener hook that toggles a class on a sibling `<wavy-focus-frame>` element when one is mounted; thread the `--wavy-motion-collapse-duration` CSS variable into the collapse class so collapse animates with the F-0 token.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` (372 LOC) — owns the selected-wave card structure. **S2 extension surface**: insert a `<wavy-wave-nav-row>` element into the card header above `contentList`; insert a `<wavy-depth-nav-bar>` element above the title; write `data-j2cl-selected-wave-host=""` on the card root. The `<wavy-focus-frame>` is mounted by the renderer (not the view) inside its own `host` (`.j2cl-read-surface`). The depth indicator is read from `data-current-depth-blip-id` on the renderer's `host` (S5 will write that; S2 ships the reader path).
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java` (485 LOC) — server-side parity fixture. **S2 extension surface**: add per-row assertions for E.1–E.10 (each button slug + ARIA label + correct token reference appears in the rendered surface), G.2 + G.3 (depth-nav-bar buttons with parent-author-label ARIA), and the focus-frame mount.
+- `j2cl/lit/test/wave-blip.test.js` — pattern for new Lit element tests. `before(...)` ensures wavy-tokens.css is loaded; tests use `@open-wc/testing` `fixture(html\`...\`)` + `oneEvent(...)` + `aTimeout(...)`.
+- `j2cl/lit/src/index.js` — registers Lit elements into the bundle. **S2 extension**: add three new imports for the new elements.
+
+The deferred-work cross-cuts in S5 / S6:
+- S5 owns: URL `&depth=` reader, depth-nav data binding (parent-author labels, breadcrumb stack), live-update awareness pill (G.6).
+- S6 owns: `/_/j2cl-design` demo route mount + per-row fixture artifact.
+
+## 3. Acceptance contract (row-level)
+
+### R-3.2 — Focus framing (`<wavy-focus-frame>`)
+
+**Hard acceptance**:
+1. A new `<wavy-focus-frame>` Lit element is registered with `customElements.define("wavy-focus-frame", ...)`. It hosts no slotted children — it is a **landmark + visual frame** that paints a 2px cyan ring (`--wavy-focus-ring`) around the currently focused blip via an absolutely-positioned overlay element controlled by reactive `bounds` and `focusedBlipId` properties.
+2. The renderer's `enhanceBlips` pass extends keyboard handling: `j` aliases `ArrowDown`, `k` aliases `ArrowUp`. (Issue #1046 R-3.2 cites only `j`/`k` as new shortcuts; `g`/`G` are explicitly **deferred to S5** alongside `[`/`]`. The existing `aria-keyshortcuts` attribute remains `"ArrowUp ArrowDown Home End"` — `j`/`k` are documented as Wavy-specific aliases in code comments only, not announced via ARIA, to avoid screen-reader collisions with global shortcuts.)
+3. The renderer dispatches a `wavy-focus-changed` CustomEvent (bubbles, composed) on the renderer's `host` (= the `.j2cl-read-surface` element) with `detail: {blipId, bounds: {top, left, width, height}, key}` whenever `focusBlip(...)` runs. The `key` field is `""` when the change came from a non-keyboard source (e.g. `restoreFocusedBlipById`). `bounds` is always in **`host`-local coordinate space** (i.e. relative to the `.j2cl-read-surface` element, NOT contentList). The frame's positioning ancestor and the bounds-measurement element are the same node — `host` — so the math is `top = blip.getBoundingClientRect().top - host.getBoundingClientRect().top + host.scrollTop` (and analogous for `left`/`width`/`height`). The `<wavy-focus-frame>` element listens on its **renderer host** (the `.j2cl-read-surface` element) for `wavy-focus-changed`; it must therefore be a child of that element, NOT a sibling. (See T5 for the concrete DOM placement.)
+4. Frame transition uses `transition: all var(--wavy-motion-focus-duration) var(--wavy-easing-focus)` (180ms ease-out per F-0). On `prefers-reduced-motion: reduce` the transition is set to `none`.
+5. **Survives incremental updates**: when the renderer calls `restoreFocusedBlipById(...)` after a window swap, the existing focus-frame element is reused (not destroyed) and its `bounds` re-synced via the same `wavy-focus-changed` event. A new test `restores focus across window-swap rebuilds` mounts a 3-blip window, swaps to a 6-blip window with the same focused blip, and asserts the frame's `bounds` re-converge on the same blip without a destroy/recreate cycle (assert via `instanceof` identity check on the frame element).
+6. Visible cyan ring contrast — covered by token: `--wavy-focus-ring` is `0 0 0 2px var(--wavy-signal-cyan)` which is `#22d3ee` on `#0b1320` (≥4.5:1 luminance ratio). Test asserts the computed `box-shadow` resolves to the **expected RGB string** `rgb(34, 211, 238) 0px 0px 0px 2px` (chromium resolves `var(--wavy-focus-ring)` to its concrete computed value; the test computes the expected RGB up front from the hex literal in `wavy-tokens.css`). A literal `.to.include('--wavy-focus-ring')` assertion would not work and is explicitly avoided.
+
+**Telemetry**: emit `wave_chrome.focus_frame.transition` event with field `direction` (forward/backward/jump) and `key` (ArrowDown/j/...) per transition. Counter wired through `J2clClientTelemetry.Sink`.
+
+### R-3.3 — Collapse motion wiring
+
+**Hard acceptance**:
+1. `J2clReadSurfaceDomRenderer.toggleThread` already toggles the `j2cl-read-thread-collapsed` class. **The class itself does not animate** today — verified: `enhanceThreads` adds `j2cl-read-thread` class but the project's CSS for `.j2cl-read-thread-collapsed` lives in the GWT-side stylesheet and is a binary `display:none`. The fix is to add token-driven CSS via the J2CL bundle.
+2. Add a new design CSS file `j2cl/lit/src/design/wavy-thread-collapse.css` (NEW, ~+30 LOC) that defines `.j2cl-read-thread` + `.j2cl-read-thread-collapsed` height + opacity transitions per `--wavy-motion-collapse-duration` (240ms ease-in-out). The CSS file is wired into the esbuild config as a sibling asset (`wavy-thread-collapse.css`) and linked from the J2CL root shell page next to `wavy-tokens.css`.
+3. Space/Enter on the collapse toggle button works (already does via the native `<button>` element + `addEventListener("click", ...)`). Add a focused test: `space and enter toggle the collapse button` in the renderer test that synthesizes both keys and asserts the `aria-expanded` attribute flips.
+4. **Focus does not jump on expand**: extend `toggleThread` so when a thread is **expanded** (collapsed → expanded transition), the previously focused blip (if it was hidden by the collapse) is re-focused; if no previously focused blip was hidden, no focus change occurs. Today `focusNearestVisibleFrom` only runs on collapse — the symmetric path on expand is guarded by `isHiddenByCollapsedThread`. Add a new test `focus_does_not_jump_on_expand`.
+5. **Read state preserved**: collapse is a pure DOM/CSS class flip — it does not alter `unread` markers or the supplement state. Existing test `restores collapsed thread state across re-render` already covers this; extend with an additional assertion that `data-blip-id` unread attribute survives.
+6. Reduced-motion: collapse CSS includes a `@media (prefers-reduced-motion: reduce)` block setting transition to `none`.
+
+**Telemetry**: emit `wave_chrome.thread_collapse.toggle` event with field `state` (collapsed/expanded) per click.
+
+### R-3.4 — Wave nav row (`<wavy-wave-nav-row>`)
+
+**Hard acceptance**: A new `<wavy-wave-nav-row>` Lit element renders **10 buttons** matching audit rows E.1–E.10. The element accepts these reactive properties:
+- `unreadCount: Number` (drives E.2 cyan emphasis)
+- `mentionCount: Number` (drives E.6/E.7 enabled state)
+- `pinned: Boolean` (drives E.9 cyan glyph)
+- `archived: Boolean` (drives E.8 enabled state)
+- `selectedBlipId: String` (passed through in dispatched events as the focus anchor)
+
+Per-button hard rows:
+
+| Row | Button | ARIA label | Event emitted | Token-driven style |
+| --- | --- | --- | --- | --- |
+| **E.1** | "Recent" jump (history-back-1) | `Jump to recent activity` | `wave-nav-recent-requested` | `--wavy-text-muted` default |
+| **E.2** | "Next Unread" | `Jump to next unread blip` | `wave-nav-next-unread-requested` | `--wavy-signal-cyan` when `unreadCount > 0`, muted otherwise |
+| **E.3** | "Previous" | `Jump to previous blip` | `wave-nav-previous-requested` | `--wavy-text-muted` |
+| **E.4** | "Next" | `Jump to next blip` | `wave-nav-next-requested` | `--wavy-text-muted` |
+| **E.5** | "End" | `Jump to last blip` | `wave-nav-end-requested` | `--wavy-text-muted` |
+| **E.6** | "Prev @" | `Jump to previous mention` | `wave-nav-prev-mention-requested` | `--wavy-signal-violet` when `mentionCount > 0` |
+| **E.7** | "Next @" | `Jump to next mention` | `wave-nav-next-mention-requested` | `--wavy-signal-violet` when `mentionCount > 0` |
+| **E.8** | "Archive" | `Move wave to archive` (or `Restore from archive` when `archived`) | `wave-nav-archive-toggle-requested` | `--wavy-text-muted` |
+| **E.9** | "Pin" | `Pin wave` (or `Unpin wave` when `pinned`) | `wave-nav-pin-toggle-requested` | `--wavy-signal-cyan` when `pinned`, muted otherwise |
+| **E.10** | "Version History" | `Open version history (H)` — keyboard `H` | `wave-nav-version-history-requested` | `--wavy-text-muted` |
+
+- The element binds a `keydown` listener on the **selected-wave card root ancestor** (located via `closest('[data-j2cl-selected-wave-host]')` and falling back to `document` only if no ancestor matches) for the `H` shortcut (E.10). Binding to the card root (not `document`) prevents multi-fire when more than one nav-row mounts (e.g. demo route in S6, server-first card during the pre-swap window). The handler also bails when target is `INPUT`/`TEXTAREA`/`[contenteditable]` or any modifier (`ctrlKey`/`metaKey`/`altKey`) is pressed. Other keyboard shortcuts (`p`/`n`, etc.) are S5 — the row itself dispatches the event when its button is clicked, but the keyboard binding for those is the renderer's job. The `data-j2cl-selected-wave-host` attribute is written by T5/T5b on the `.sidecar-selected-card` root (see those tasks).
+- The event detail object always includes `{selectedBlipId, sourceWaveId}` so S5 can wire to the model state.
+- Layout uses `--wavy-spacing-2` gaps between buttons, `--wavy-radius-pill` border, `--wavy-bg-surface` background. Focus uses `--wavy-focus-ring`. Hover uses `--wavy-signal-cyan-soft`.
+- Mobile collapse: the `:host` declares `container-type: inline-size; container-name: wave-nav-row;` so a `@container wave-nav-row (max-width: 480px)` query collapses E.6/E.7/E.10 into an overflow menu (`<button data-action="overflow">`). The overflow rendering itself is shipped (button + menu), even if the menu only has the 3 collapsed items — this preserves the contract. (The container declaration is critical: without `container-type: inline-size` the query never matches and the overflow path becomes dead code.)
+
+**Per-blip wiring**: the nav row is mounted **once per wave panel** (not per blip), but dispatches walks against the per-blip rendered DOM via `selectedBlipId`. The audit explicitly called out that S1's wiring at the wave-list level was the bug — S2's nav row receives the focus anchor from the renderer's `wavy-focus-changed` event so it always operates on the current focused blip.
+
+### R-3.7-chrome — Depth-nav bar (`<wavy-depth-nav-bar>`) — G.2 + G.3 only
+
+**Hard acceptance**: A new `<wavy-depth-nav-bar>` Lit element composes the F-0 `<wavy-depth-nav>` recipe (for the breadcrumb crumbs) + adds two new chrome buttons (G.2 + G.3) and a placeholder host for G.6 (the live-update awareness pill, owned by S5).
+
+| Row | Button | ARIA label | Event emitted | Visible when |
+| --- | --- | --- | --- | --- |
+| **G.2** | "Up one level" (chevron-up + parent author label) | `Up one level to {parentAuthorName}'s thread` (or `Up one level` when `parentAuthorName` is empty) | `wavy-depth-up` | `currentDepthBlipId !== ""` |
+| **G.3** | "Up to wave" (top arrow) | `Back to top of wave` | `wavy-depth-root` | `currentDepthBlipId !== ""` |
+
+- Properties: `currentDepthBlipId: String`, `parentDepthBlipId: String`, `parentAuthorName: String`, `crumbs: Array<{label, href?, current?, blipId?}>` (passed through to inner `<wavy-depth-nav>`), `unreadAboveCount: Number` (S5 will drive this; S2 reserves the property and always renders 0 when no value).
+- The element is hidden via `hidden` attribute when `currentDepthBlipId === ""` AND `crumbs.length === 0` — at top-level the depth-nav bar adds no chrome.
+- Layout: chevron-up button + author label on the left, breadcrumb in the middle, "Up to wave" (text + ⌃) on the right. Tokens: `--wavy-bg-surface` background, `--wavy-border-hairline` bottom border, `--wavy-spacing-3` padding.
+- **Crumb click**: when a crumb in the inner `<wavy-depth-nav>` is clicked AND the crumb has a `blipId` field, the bar emits `wavy-depth-jump-to-crumb` with `detail: {blipId}`. (S5 consumes — same emit-now / wire-later pattern as the rest. The inner `<wavy-depth-nav>` recipe doesn't natively emit a click event today, so the bar binds a delegated `click` listener on its inner `<wavy-depth-nav>` element and walks back to the matching crumb by index.)
+- Test: a fixture mounted with `currentDepthBlipId="b3"`, `parentAuthorName="Alice"` asserts `aria-label` includes `"Alice's thread"`, click on the up-one-level button dispatches `wavy-depth-up` with `detail: {fromBlipId: "b3", toBlipId: "<parentDepthBlipId>"}`.
+
+**Notes for S5** (events S2 emits that S5 must wire):
+- `wave-nav-recent-requested`, `wave-nav-next-unread-requested`, `wave-nav-previous-requested`, `wave-nav-next-requested`, `wave-nav-end-requested`, `wave-nav-prev-mention-requested`, `wave-nav-next-mention-requested`, `wave-nav-archive-toggle-requested`, `wave-nav-pin-toggle-requested`, `wave-nav-version-history-requested`
+- `wavy-depth-up` (with `detail: {fromBlipId, toBlipId}`)
+- `wavy-depth-root` (with `detail: {fromBlipId}`)
+- `wavy-depth-jump-to-crumb` (with `detail: {blipId}`)
+- `wavy-focus-changed` (with `detail: {blipId, bounds, key}`) — S5 may consume for URL anchor updates and `g`/`G`/`[`/`]` keyboard handlers
+
+## 4. Implementation tasks
+
+### T1 — `<wavy-focus-frame>` Lit element
+
+**Files**:
+- `j2cl/lit/src/elements/wavy-focus-frame.js` (NEW, ~+120 LOC)
+- `j2cl/lit/test/wavy-focus-frame.test.js` (NEW, ~+150 LOC)
+- `j2cl/lit/src/index.js` (~+1 LOC import)
+
+**Behavior**:
+- Single child element `<div class="frame" part="frame">` that's absolutely positioned via inline style from the `bounds` reactive prop (`top`, `left`, `width`, `height` all in `px`).
+- `:host { display: contents; }` so the element doesn't take layout space; the inner frame is positioned relative to the nearest positioned ancestor (the read-surface root will be `position: relative`).
+- Listens for `wavy-focus-changed` on the parent surface in `connectedCallback`; updates `focusedBlipId` + `bounds`.
+- `prefers-reduced-motion: reduce` → `transition: none`.
+- Hidden (via `hidden` attribute) when `focusedBlipId === ""`.
+- Frame style: `box-shadow: var(--wavy-focus-ring)`, `border-radius: var(--wavy-radius-card)`, `pointer-events: none`.
+
+### T2 — `<wavy-wave-nav-row>` Lit element
+
+**Files**:
+- `j2cl/lit/src/elements/wavy-wave-nav-row.js` (NEW, ~+260 LOC)
+- `j2cl/lit/test/wavy-wave-nav-row.test.js` (NEW, ~+260 LOC)
+- `j2cl/lit/src/index.js` (~+1 LOC import)
+
+**Behavior**:
+- 10 buttons rendered in fixed order E.1 → E.10. Each carries `data-action="recent|next-unread|previous|next|end|prev-mention|next-mention|archive|pin|version-history"`.
+- `_emit(action)` helper dispatches a CustomEvent (bubbles + composed) with the corresponding event name (`wave-nav-${action}-requested`) and detail `{selectedBlipId, sourceWaveId}`.
+- `H` keyboard handler (only): `connectedCallback` resolves the binding target via `this.closest('[data-j2cl-selected-wave-host]')` and falls back to `document` only when no ancestor is found (test-only / pre-mount). Adds `keydown` on the resolved target; `disconnectedCallback` removes. Handler ignores when target is `INPUT`/`TEXTAREA`/`[contenteditable]` or any modifier (`ctrlKey`/`metaKey`/`altKey`) is pressed. (See §3.R-3.4 for the rationale on scoped binding to prevent multi-fire.)
+- `:host` declares `container-type: inline-size; container-name: wave-nav-row;` so the `@container wave-nav-row (max-width: 480px)` mobile/narrow collapse query actually matches: hides `[data-action="prev-mention"]`, `[data-action="next-mention"]`, `[data-action="version-history"]` and shows the overflow `<button data-action="overflow">`. The overflow menu (a `<menu>` element) renders the 3 collapsed items as `<button>` children that emit the same events as their full-width counterparts.
+
+### T3 — `<wavy-depth-nav-bar>` Lit element
+
+**Files**:
+- `j2cl/lit/src/elements/wavy-depth-nav-bar.js` (NEW, ~+180 LOC)
+- `j2cl/lit/test/wavy-depth-nav-bar.test.js` (NEW, ~+180 LOC)
+- `j2cl/lit/src/index.js` (~+1 LOC import)
+
+**Behavior**:
+- Composes `<wavy-depth-nav>` for the breadcrumb path (passes `crumbs` through).
+- Renders G.2 chevron-up button (left) and G.3 "Up to wave" button (right).
+- Reserves a `<slot name="awareness-pill">` for the G.6 live-update pill (S5 will fill this slot from `J2clSelectedWaveView`).
+- Emits `wavy-depth-up` and `wavy-depth-root` (both bubbles + composed).
+- Reflects `data-current-depth-blip-id` on the host so external CSS / S5 can target.
+
+### T4 — Renderer extension: `j`/`k` keys + focus-changed events + collapse motion CSS
+
+**Files**:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` (~+90 LOC)
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java` (~+200 LOC)
+- `j2cl/lit/src/design/wavy-thread-collapse.css` (NEW, ~+45 LOC)
+- `j2cl/lit/esbuild.config.mjs` (~+1 LOC entry)
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` (~+4 LOC, two `<link>` insertions for `wavy-thread-collapse.css` next to the existing `wavy-tokens.css` links at lines 3383 and 3492)
+
+**Renderer changes**:
+1. `onBlipKeyDown` adds aliases: `j` → `ArrowDown`, `k` → `ArrowUp` only (per Issue #1046 R-3.2 scope). `g`/`G`/`[`/`]` are S5 territory. The `aria-keyshortcuts` attribute is **unchanged** (`"ArrowUp ArrowDown Home End"`) — `j`/`k` are documented as Wavy-specific aliases via code comments only, not announced to screen readers.
+2. New private method `dispatchFocusChanged(HTMLElement blip, String key)` that creates a `CustomEvent("wavy-focus-changed", { detail: {blipId, bounds, key}, bubbles: true, composed: true })` on `host` and records a telemetry event. `bounds` is computed in **`host`-local coordinate space**: `top = blip.getBoundingClientRect().top - host.getBoundingClientRect().top + host.scrollTop`, etc. so the frame stays anchored under scroll. (Equivalent to walking `offsetParent` to `host`; the `getBoundingClientRect` arithmetic is simpler and consistent across collapsed/expanded states.)
+3. `focusBlip(...)` calls `dispatchFocusChanged` whenever the focused blip changes (not on no-op `focusedBlip == next`).
+4. New public method `setDepthFocus(String currentDepthBlipId, String parentDepthBlipId, String parentAuthorName)` — writes the trio to data-attributes on `host` so the depth-nav-bar can read them. (S5 calls this from `J2clSelectedWaveView`; S2 ships the writer.)
+5. `toggleThread(...)` symmetric expand path: when expanding (`collapsed == false` branch), if the previously focused blip was hidden, re-focus it; if focus was outside the collapsed thread, no change.
+
+**HtmlRenderer changes** (server-side; required so the new CSS bundle actually loads):
+- After each existing `<link rel="stylesheet" href="...j2cl/assets/wavy-tokens.css">` write at lines 3383 and 3492, insert a sibling `<link rel="stylesheet" href="...j2cl/assets/wavy-thread-collapse.css">`. Both J2CL shell paths get the addition.
+
+**CSS changes** (`wavy-thread-collapse.css`):
+```css
+.j2cl-read-thread {
+  transition: max-height var(--wavy-motion-collapse-duration, 240ms)
+      var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1)),
+    opacity var(--wavy-motion-collapse-duration, 240ms)
+      var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1));
+  overflow: hidden;
+  max-height: 10000px;
+}
+.j2cl-read-thread-collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+@media (prefers-reduced-motion: reduce) {
+  .j2cl-read-thread,
+  .j2cl-read-thread-collapsed {
+    transition: none;
+  }
+}
+```
+
+**esbuild change**: register `wavy-thread-collapse.css` as a sibling asset, the same way `wavy-tokens.css` is registered.
+
+### T5 — `J2clSelectedWaveView` mounts the chrome elements + model exposes `unreadCount`/`pinned`
+
+**Files**:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` (~+110 LOC)
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java` (~+30 LOC — expose `getUnreadCount()` accessor publicly + thread `pinned` from `J2clSearchDigestItem.isPinned()` through the model constructors with a `pinned` field; the existing `unreadCount` field at line 28 already has `getUnreadCount()` at line 485, so this is a confirmation pass and a new `getPinned()` accessor).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java` (~+30 LOC for the `pinned` round-trip)
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java` (NEW, ~+220 LOC) — boots the view against a synthetic host, asserts the three chrome elements are mounted, asserts each event reaches the host, asserts `pinned`/`unreadCount` props update when the model changes.
+
+**Model changes**:
+- `J2clSelectedWaveModel`: ensure `getUnreadCount()` is public (verified — it's already public at line 485 returning `unreadCount`). Add a new field `private final boolean pinned;` mirroring the existing `unreadCount` plumbing — populated from `digestItem.isPinned()` in the existing builder paths at lines 249/281. Add `public boolean getPinned() { return pinned; }`. Update `J2clSelectedWaveModelCopyTest` to round-trip the field.
+- `archived` is **NOT** added to the model in S2 (no source of truth exists in `j2cl/src/main/java`; the inbox-folder state is an S5 concern). The nav-row's `archived` prop defaults to `false` in S2 with a TODO referencing S5.
+
+**View changes**:
+- Both paths (cold-mount and server-first): write `data-j2cl-selected-wave-host=""` on the `card` element (the `.sidecar-selected-card`). This is the binding target the `<wavy-wave-nav-row>` `H` handler resolves via `closest(...)`. T5b also writes the same attribute on the server-rendered card so the server-first path is consistent before client boot.
+- Cold-mount path: in the constructor where `card` is built, insert (in DOM order):
+  - `<wavy-depth-nav-bar hidden>` directly **after** the `eyebrow` and **before** the `title` — hidden by default until S5 writes `currentDepthBlipId`.
+  - `<wavy-wave-nav-row>` directly **after** `participantSummary` and **before** `snippet` — bound reactively to model `unreadCount` (now via real `model.getUnreadCount()`) and `pinned` (via new `model.getPinned()`).
+  - `<wavy-focus-frame>` is appended **inside the renderer's `host`** (the `.j2cl-read-surface` element) by `J2clReadSurfaceDomRenderer.enhanceSurface(...)` itself — NOT by the view. The renderer owns the frame placement because the frame and the focused blip both live inside the renderer's `host`. The `host` element gets `position: relative` (added in T4 via the new CSS file or directly via attribute style) so the frame's absolute positioning anchors correctly. (Reconciliation: T1 spec, T4 bounds math, and T5 DOM placement all converge on the same node = `host` = `.j2cl-read-surface`.)
+- Server-first path (`existingCard` branch): the chrome elements are **already present** server-side (see T5b below). The view locates them via `existingCard.querySelector("wavy-wave-nav-row")` etc., re-binds them as the live nodes (custom-element upgrade happens automatically when `customElements.define` runs after the element is in the DOM — re-bind is property-set only, NEVER `replaceChild` or the upgraded state would reset).
+- Wire `setDepthFocus(...)` writer on the renderer; the URL reader is S5.
+- The view also installs **delegated event listeners** on the card for `wave-nav-*-requested` and `wavy-depth-up`/`wavy-depth-root`/`wavy-depth-jump-to-crumb` — each handler emits a `wave_chrome.nav_row.click` (or `wave_chrome.depth_nav.click`) telemetry event with the action name. The handlers do **not** route to the controller — that's S5. Telemetry observation is enough for S2 to demonstrate the wiring works without coupling to controller changes.
+
+### T5b — Server-side chrome landmarks in `HtmlRenderer`
+
+The J2CL view above mounts the chrome on the cold-mount path AND re-binds it on the server-first path. For the server-first path to work AND for the parity fixture (T6) to be able to assert chrome presence in the rendered HTML, the server template MUST emit the three chrome elements as **hidden landmarks** inside `appendRootShellSelectedWaveCard`.
+
+**Files**:
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` (~+50 LOC)
+
+**Insertions** in `appendRootShellSelectedWaveCard` (around line 3672):
+- Add `data-j2cl-selected-wave-host=""` as an additional attribute on the `<section class="sidecar-selected-card" ...>` opening tag. This is the binding target for the `<wavy-wave-nav-row>` `H` keyboard handler (see T2).
+- Inside the `<section class="sidecar-selected-card">`, immediately after the eyebrow paragraph and before the title `<h2>`, append a `<wavy-depth-nav-bar hidden data-j2cl-server-first-chrome="true"></wavy-depth-nav-bar>`.
+- After the participant summary `<p class="sidecar-selected-participants">` and before the snippet `<p class="sidecar-selected-snippet">`, append a `<wavy-wave-nav-row data-j2cl-server-first-chrome="true"></wavy-wave-nav-row>`. The element appears whether or not the user is signed in — pre-boot AT users see the nav-row landmark.
+- Inside the J2CL-rendered surface (the `<section data-j2cl-read-surface="true">` that lives inside `.sidecar-selected-content`), after the root thread, append a `<wavy-focus-frame data-j2cl-server-first-chrome="true" hidden></wavy-focus-frame>`. The frame sits inside the renderer's `host`, matching where the cold-mount renderer places it.
+- This mirrors the existing F-1 pattern of pre-rendering the `.sidecar-selected-card` shell so the J2CL client upgrade swap is a no-op. The `data-j2cl-server-first-chrome` marker lets `J2clSelectedWaveView.enhanceExistingSurface` distinguish "already mounted" from "needs to be created".
+
+### T6 — Server-side parity assertions
+
+**Files**:
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java` (~+220 LOC)
+
+These assertions are valid because T5b pre-renders each chrome element as a hidden landmark inside `appendRootShellSelectedWaveCard`. The HTML returned by the servlet contains the literal `<wavy-wave-nav-row …>` etc. tags before any JS executes.
+
+**New tests** (each is a separate `@Test` method so failures are individually addressable):
+- `j2clRootRendersWavyWaveNavRowLandmark` — assert `<wavy-wave-nav-row ` appears in HTML and carries `data-j2cl-server-first-chrome="true"`. The 10 button `data-action="..."` markers do NOT appear server-side (the buttons are inside the Lit element's shadow DOM, populated client-side); the test asserts the landmark host element is present so the client can upgrade it without a re-mount.
+- `j2clRootRendersFocusFrameLandmark` — assert `<wavy-focus-frame ` appears inside `.sidecar-selected-content` with `hidden` and `data-j2cl-server-first-chrome="true"` attrs.
+- `j2clRootRendersDepthNavBarLandmark` — assert `<wavy-depth-nav-bar ` appears with `hidden` and `data-j2cl-server-first-chrome="true"` attrs at top-level (no depth selected).
+- `legacyGwtRouteDoesNotLeakChromeElements` — extends existing `legacyGwtRouteDoesNotLeakF2ClientMarkers` test method (same file, line 318) with three additional `assertFalse(html.contains("<wavy-wave-nav-row"), ...)`, `<wavy-focus-frame`, `<wavy-depth-nav-bar` checks. The new method is added rather than mutating the existing assertions so the original F-2.S1 contract stays evidently intact.
+- `j2clRootLoadsWavyThreadCollapseStylesheet` — assert `wavy-thread-collapse.css` is linked in the J2CL root shell HTML (verifies the HtmlRenderer addition in T4).
+- `nestedThreadFixtureExposesCollapseTokenContract` — extension that asserts the inline-thread div carries `class="thread"` (renderer adds `j2cl-read-thread` client-side, but the wire contract on the server stays the existing `class="inline-thread thread"`).
+
+**Per-row server-side coverage matrix** — additional `@Test` methods that pin the audit-row contract from the server side (each ARIA / data marker is checked at one and only one place; failures point directly at the broken row):
+
+| Row | Test | Assertion |
+| --- | --- | --- |
+| **R-3.2** focus-frame landmark | `j2clRootRendersFocusFrameLandmark` | `<wavy-focus-frame ` present + `hidden` attr |
+| **R-3.3** collapse stylesheet linked | `j2clRootLoadsWavyThreadCollapseStylesheet` | `wavy-thread-collapse.css` `<link>` present |
+| **R-3.3** nested thread contract | `nestedThreadFixtureExposesCollapseTokenContract` | inline-thread `class="thread"` + `data-thread-id` |
+| **R-3.4** nav-row landmark | `j2clRootRendersWavyWaveNavRowLandmark` | `<wavy-wave-nav-row ` host present |
+| **R-3.4** nav-row not in GWT | `legacyGwtRouteDoesNotLeakChromeElements` | absence on `?view=gwt` |
+| **R-3.7-chrome** depth-nav-bar landmark | `j2clRootRendersDepthNavBarLandmark` | `<wavy-depth-nav-bar ` host present + `hidden` |
+| **R-3.7-chrome** depth-nav-bar not in GWT | `legacyGwtRouteDoesNotLeakChromeElements` | absence on `?view=gwt` |
+
+**Per-row CLIENT-side coverage** (E.1–E.10 + G.2 + G.3 ARIA / event names) lives in:
+- `j2cl/lit/test/wavy-wave-nav-row.test.js` — one `it()` per E.1–E.10 button asserting (a) ARIA label + (b) event name on click + (c) computed-style token cascade for the cyan/violet emphasis cases.
+- `j2cl/lit/test/wavy-depth-nav-bar.test.js` — one `it()` per G.2 / G.3 button asserting ARIA label + event dispatch + detail shape.
+
+The split is intentional: server-side fixtures verify the **landmark wire contract** (the elements exist for AT users + URL crawlers + the client can upgrade in place); client-side fixtures verify the **affordance contract** (the right ARIA + the right event firing). Together, every row from the issue brief has at least one executable assertion.
+
+### T7 — Per-row fixture artifact (worktree only)
+
+A `?view=j2cl-root` vs `?view=gwt` side-by-side artifact is **out of scope** for S2 (S6 owns the demo route). However, the Lit-side per-row fixture is in scope:
+
+**File**: `j2cl/lit/test/wavy-wave-nav-row.test.js` includes a `describe("per-row coverage")` block that mounts the row in two scenarios — flat (`unreadCount=0, pinned=false, archived=false, mentionCount=0`) and nested (`unreadCount=3, pinned=true, archived=false, mentionCount=2`) — and asserts the **token cascade** (computed style includes the expected `--wavy-signal-*` reference) for E.2, E.6/E.7, E.9 in both states.
+
+Per-row coverage on the server side is in T6 above (one assertion per E.* / G.* row).
+
+### T8 — Telemetry events
+
+**Files**:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` — emit `wave_chrome.focus_frame.transition` and `wave_chrome.thread_collapse.toggle`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` — listen for the nav-row events and emit `wave_chrome.nav_row.click` with `field: action`.
+
+Existing telemetry sink (`J2clClientTelemetry`) supports per-event field strings; no new infra needed.
+
+## 5. Verification (SBT-only)
+
+Run **inside worktree** with the package script. The SBT bridge is the contract:
+
+```bash
+sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild
+```
+
+Expected:
+- `j2clLitTest` — runs the Lit element tests including all new files (`wavy-focus-frame.test.js`, `wavy-wave-nav-row.test.js`, `wavy-depth-nav-bar.test.js`, plus any updates to `wave-blip.test.js`).
+- `j2clSearchTest` — runs `J2clReadSurfaceDomRendererTest` (extended) + `J2clSelectedWaveViewChromeTest` (NEW). 
+- `j2clProductionBuild` — builds the J2CL bundle, exercising the `index.js` imports for the three new elements.
+
+Then the parity fixture:
+```bash
+sbt -batch jakartaTest/test --tests J2clStageOneReadSurfaceParityTest
+```
+(or the equivalent task that runs the jakarta-test module — the existing fixture already runs there).
+
+## 6. Out of scope (deferred to later F-2 slices)
+
+- **S3** Search rail (B.* affordances) — `<wavy-search-input>`, `<wavy-saved-search-rail>`, `<wavy-search-help-modal>`.
+- **S4** Floating + version history overlay (J.*, K.*) — `<wavy-scroll-to-new>`, `<wavy-version-history-overlay>`.
+- **S5** Depth-nav data wiring + URL state (G.1, G.4, G.5, G.6) — the URL reader, the parent-author-label data binding, the live-update awareness pill, the `[`/`]` keyboard handlers.
+- **S6** Demo route mount (`/_/j2cl-design/sample-wave`) + per-row fixture artifact.
+
+S2 ships the **chrome shells** for these slices: the events are emitted, the data attributes are reserved, the slot for the awareness pill is ready, but no consumer-side wiring lands here.
+
+## 7. Risk register
+
+- **Telemetry name collisions**: `wave_chrome.*` is a new namespace; verify no existing event uses it. Searched — none.
+- **`<wavy-depth-nav>` recipe contract**: F-0's `<wavy-depth-nav>` (the F-0 recipe) has properties `crumbs`. The new `<wavy-depth-nav-bar>` (S2) wraps it but does NOT re-implement the breadcrumb. Naming is intentional — the audit calls out the bar as G.2/G.3 controls + breadcrumb, and the recipe alone doesn't have G.2/G.3.
+- **Focus frame `position: absolute` over the surface**: the renderer's `host` (`.j2cl-read-surface`) today has no explicit `position`. T4 sets `position: relative` on the surface element when `enhanceSurface(...)` runs (and `wavy-thread-collapse.css` includes a `.j2cl-read-surface { position: relative; }` rule for the server-first path before client boot). Verified no existing CSS expects the surface to be `static` — neither `wavy-tokens.css` nor `shell-tokens.css` positions it.
+- **Collapse CSS bundle path**: the new `wavy-thread-collapse.css` is loaded as a separate `<link>` (matching the `wavy-tokens.css` pattern). Verified the server template already supports linking sibling stylesheet assets.
+- **Nav-row mobile collapse**: container queries are supported in all Wave-target browsers (Chrome 105+, Firefox 110+, Safari 16+). Falls back gracefully on older browsers (overflow stays hidden, nav stays in single row).
+- **Pin prop on the model**: confirmed `J2clSearchDigestItem.isPinned()` exists at line 60. T5 threads it through `J2clSelectedWaveModel` via a new `pinned` field + `getPinned()` accessor (mirroring the existing `unreadCount` plumbing). `unreadCount` is already on the model with a public `getUnreadCount()` at line 485 — T5 consumes the int directly, NOT a parse of `getUnreadText()`.
+- **Archive prop on the model**: no `isArchived()` source-of-truth exists in `j2cl/src/main/java`. The archive E.8 button still ships in S2 and dispatches `wave-nav-archive-toggle-requested` on click; the `archived` prop defaults to `false` with a TODO for S5 to wire the inbox-folder state once available.
+
+## 8. Closeout artifact
+
+On merge, write `/tmp/parity-chain/f2-s2-merged.txt` with the merged sha, PR number, and the per-row demonstration matrix.
+
+Comments to post:
+- On #1046: plan link, impl summary, PR opened, PR merged.
+- On #904: PR opened, PR merged.
+- The parity matrix evidence will be appended to `/tmp/parity-chain/`.

--- a/docs/superpowers/plans/2026-04-26-issue-1046-wave-chrome.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1046-wave-chrome.md
@@ -197,17 +197,15 @@ Per-button hard rows:
 
 **esbuild change**: register `wavy-thread-collapse.css` as a sibling asset, the same way `wavy-tokens.css` is registered.
 
-### T5 — `J2clSelectedWaveView` mounts the chrome elements + model exposes `unreadCount`/`pinned`
+### T5 — `J2clSelectedWaveView` mounts the chrome elements
 
 **Files**:
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` (~+110 LOC)
-- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java` (~+30 LOC — expose `getUnreadCount()` accessor publicly + thread `pinned` from `J2clSearchDigestItem.isPinned()` through the model constructors with a `pinned` field; the existing `unreadCount` field at line 28 already has `getUnreadCount()` at line 485, so this is a confirmation pass and a new `getPinned()` accessor).
-- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java` (~+30 LOC for the `pinned` round-trip)
-- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java` (NEW, ~+220 LOC) — boots the view against a synthetic host, asserts the three chrome elements are mounted, asserts each event reaches the host, asserts `pinned`/`unreadCount` props update when the model changes.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java` (NEW, ~+200 LOC) — boots the view against a synthetic host, asserts the three chrome elements are mounted, asserts the unreadCount prop updates when the model changes.
 
 **Model changes**:
-- `J2clSelectedWaveModel`: ensure `getUnreadCount()` is public (verified — it's already public at line 485 returning `unreadCount`). Add a new field `private final boolean pinned;` mirroring the existing `unreadCount` plumbing — populated from `digestItem.isPinned()` in the existing builder paths at lines 249/281. Add `public boolean getPinned() { return pinned; }`. Update `J2clSelectedWaveModelCopyTest` to round-trip the field.
-- `archived` is **NOT** added to the model in S2 (no source of truth exists in `j2cl/src/main/java`; the inbox-folder state is an S5 concern). The nav-row's `archived` prop defaults to `false` in S2 with a TODO referencing S5.
+- `J2clSelectedWaveModel.getUnreadCount()` is already public at line 485 — no model change needed for E.2.
+- `pinned` and `archived`: threading through the model would require touching 6 constructors + 4 `with*` builders + `loading()` + `error()` + `emptyModel()`, all of which are deeply intertwined with the search/sidecar state. That's a high blast-radius change for a chrome slice. **S2 ships the chrome shell with both props defaulted to `false` and a TODO comment** in `J2clSelectedWaveView` referencing S5; the buttons render and dispatch events even when the prop is `false`, so the contract is honored. S5 (depth-nav data wiring) is the correct home for the pin/archive data binding alongside the URL state reader and the live-update awareness pill — those changes naturally cluster.
 
 **View changes**:
 - Both paths (cold-mount and server-first): write `data-j2cl-selected-wave-host=""` on the `card` element (the `.sidecar-selected-card`). This is the binding target the `<wavy-wave-nav-row>` `H` handler resolves via `closest(...)`. T5b also writes the same attribute on the server-rendered card so the server-first path is consistent before client boot.

--- a/j2cl/lit/esbuild.config.mjs
+++ b/j2cl/lit/esbuild.config.mjs
@@ -12,7 +12,11 @@ await build({
     // F-0 (#1035): wavy design tokens emit as a sibling asset so server
     // templates load them with their own <link>. Recipe .js files do
     // NOT import this CSS (avoids double-emission into shell.css).
-    { in: resolve(here, "src/design/wavy-tokens.css"), out: "wavy-tokens" }
+    { in: resolve(here, "src/design/wavy-tokens.css"), out: "wavy-tokens" },
+    // F-2 slice 2 (#1046): thread collapse motion + .j2cl-read-surface
+    // positioning context for the focus frame. Sibling stylesheet so the
+    // server template can <link> it next to wavy-tokens.css.
+    { in: resolve(here, "src/design/wavy-thread-collapse.css"), out: "wavy-thread-collapse" }
   ],
   bundle: true,
   format: "esm",

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -14,12 +14,16 @@
 
 /* Inline reply threads animate height + opacity per F-0 token. Default
  * max-height covers any plausible thread height; the collapsed state
- * snaps to 0. */
+ * snaps to 0. The root thread ([data-thread-id="root"]) is excluded from
+ * overflow+max-height so it is never clipped at the 10000px cap. */
 .j2cl-read-thread {
   transition: max-height var(--wavy-motion-collapse-duration, 240ms)
       var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1)),
     opacity var(--wavy-motion-collapse-duration, 240ms)
       var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1));
+}
+
+.j2cl-read-thread:not([data-thread-id="root"]) {
   overflow: hidden;
   max-height: 10000px;
 }

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -1,0 +1,37 @@
+/* Wavy — F-2 (#1037, R-3.3; slice 2 #1046) thread collapse motion + the
+ * .j2cl-read-surface positioning context for the focus frame.
+ *
+ * Loaded as a sibling stylesheet (NOT bundled into shell.css) by both
+ * J2CL root shell paths via HtmlRenderer. The class names match what
+ * J2clReadSurfaceDomRenderer writes via enhanceSurface / enhanceThreads.
+ */
+
+/* The renderer's host element. Provides the positioning context for the
+ * <wavy-focus-frame> overlay. T4 and T5 specs converge on this node. */
+.j2cl-read-surface {
+  position: relative;
+}
+
+/* Inline reply threads animate height + opacity per F-0 token. Default
+ * max-height covers any plausible thread height; the collapsed state
+ * snaps to 0. */
+.j2cl-read-thread {
+  transition: max-height var(--wavy-motion-collapse-duration, 240ms)
+      var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1)),
+    opacity var(--wavy-motion-collapse-duration, 240ms)
+      var(--wavy-easing-collapse, cubic-bezier(0.4, 0, 0.2, 1));
+  overflow: hidden;
+  max-height: 10000px;
+}
+
+.j2cl-read-thread-collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .j2cl-read-thread,
+  .j2cl-read-thread-collapsed {
+    transition: none;
+  }
+}

--- a/j2cl/lit/src/elements/wavy-depth-nav-bar.js
+++ b/j2cl/lit/src/elements/wavy-depth-nav-bar.js
@@ -35,7 +35,7 @@ export class WavyDepthNavBar extends LitElement {
   static properties = {
     currentDepthBlipId: {
       type: String,
-      attribute: "data-current-depth-blip-id",
+      attribute: "current-depth-blip-id",
       reflect: true
     },
     parentDepthBlipId: { type: String, attribute: "parent-depth-blip-id" },

--- a/j2cl/lit/src/elements/wavy-depth-nav-bar.js
+++ b/j2cl/lit/src/elements/wavy-depth-nav-bar.js
@@ -1,0 +1,223 @@
+import { LitElement, css, html } from "lit";
+import "../design/wavy-depth-nav.js";
+
+/**
+ * <wavy-depth-nav-bar> — F-2 (#1037, R-3.7-chrome; slice 2 #1046)
+ * depth-navigation chrome that ships G.2 (Up one level) and G.3 (Back to
+ * top of wave). G.1 (drill-in) lives on `<wave-blip>` already; G.4–G.6
+ * (URL state, keyboard shortcuts, awareness pill) are S5 territory.
+ *
+ * The bar composes the F-0 `<wavy-depth-nav>` recipe for the breadcrumb
+ * path and adds two new chrome buttons + a slot for the G.6 awareness
+ * pill that S5 will fill from `J2clSelectedWaveView`.
+ *
+ * Properties:
+ * - currentDepthBlipId: String — current depth focus (empty = top of wave)
+ * - parentDepthBlipId: String — parent depth focus (the up-one-level target)
+ * - parentAuthorName: String — display name for the up-one-level button label
+ * - crumbs: Array<{label, href?, current?, blipId?}> — passed through to the
+ *   inner `<wavy-depth-nav>`. The `blipId` field is S2-specific (S5 wires it
+ *   to the URL state writer); the inner recipe ignores unknown fields.
+ * - unreadAboveCount: Number — reserved for S5 (G.6 awareness pill counter).
+ *
+ * Events emitted (CustomEvent, bubbles + composed):
+ * - `wavy-depth-up` (G.2) — `{detail: {fromBlipId, toBlipId}}`
+ * - `wavy-depth-root` (G.3) — `{detail: {fromBlipId}}`
+ * - `wavy-depth-jump-to-crumb` — `{detail: {blipId}}` — fires when a
+ *   crumb in the inner `<wavy-depth-nav>` is clicked AND has a `blipId`.
+ *   S5 consumes for URL state updates.
+ *
+ * Hidden: when `currentDepthBlipId === ""` AND `crumbs.length === 0`
+ * (top-of-wave with no breadcrumb context), the bar reflects the
+ * `hidden` attribute on its host.
+ */
+export class WavyDepthNavBar extends LitElement {
+  static properties = {
+    currentDepthBlipId: {
+      type: String,
+      attribute: "data-current-depth-blip-id",
+      reflect: true
+    },
+    parentDepthBlipId: { type: String, attribute: "parent-depth-blip-id" },
+    parentAuthorName: { type: String, attribute: "parent-author-name" },
+    crumbs: { attribute: false },
+    unreadAboveCount: { type: Number, attribute: "unread-above-count" }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      background: var(--wavy-bg-surface, #11192a);
+      border-bottom: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      padding: var(--wavy-spacing-3, 12px);
+    }
+    :host([hidden]) {
+      display: none;
+    }
+    .bar {
+      display: flex;
+      align-items: center;
+      gap: var(--wavy-spacing-3, 12px);
+    }
+    .left {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+    }
+    .center {
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+    .right {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+    }
+    button {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 1px solid transparent;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      cursor: pointer;
+      transition: color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        border-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    button:hover {
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border-color: var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+    }
+    button:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+    }
+    .glyph {
+      display: inline-block;
+      margin-right: 4px;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.currentDepthBlipId = "";
+    this.parentDepthBlipId = "";
+    this.parentAuthorName = "";
+    this.crumbs = [];
+    this.unreadAboveCount = 0;
+    this._onInnerClick = this._onInnerClick.bind(this);
+  }
+
+  willUpdate(changed) {
+    super.willUpdate?.(changed);
+    // Reflect hidden when there's nothing to show.
+    const empty =
+      !this.currentDepthBlipId &&
+      (!Array.isArray(this.crumbs) || this.crumbs.length === 0);
+    if (empty) {
+      this.setAttribute("hidden", "");
+    } else {
+      this.removeAttribute("hidden");
+    }
+  }
+
+  _onUpOneLevel(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wavy-depth-up", {
+        bubbles: true,
+        composed: true,
+        detail: {
+          fromBlipId: this.currentDepthBlipId,
+          toBlipId: this.parentDepthBlipId
+        }
+      })
+    );
+  }
+
+  _onUpToWave(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wavy-depth-root", {
+        bubbles: true,
+        composed: true,
+        detail: { fromBlipId: this.currentDepthBlipId }
+      })
+    );
+  }
+
+  _onInnerClick(event) {
+    // Delegate crumb clicks: walk up to the closest <a> or <span> with a
+    // matching crumb index, then look up the blipId.
+    const path = event.composedPath ? event.composedPath() : [event.target];
+    const items = Array.isArray(this.crumbs) ? this.crumbs : [];
+    for (const node of path) {
+      if (!node || node.nodeType !== 1) continue;
+      if (node === this || node.tagName === "WAVY-DEPTH-NAV") break;
+      // The recipe renders crumbs in order; match by text content as a
+      // best-effort (the recipe doesn't carry data-attrs on crumbs).
+      const label = node.textContent ? node.textContent.trim() : "";
+      const match = items.find((c) => (c.label || "") === label);
+      if (match && match.blipId) {
+        event.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("wavy-depth-jump-to-crumb", {
+            bubbles: true,
+            composed: true,
+            detail: { blipId: match.blipId }
+          })
+        );
+        return;
+      }
+    }
+  }
+
+  _upOneLevelLabel() {
+    return this.parentAuthorName
+      ? `Up one level to ${this.parentAuthorName}'s thread`
+      : "Up one level";
+  }
+
+  render() {
+    const items = Array.isArray(this.crumbs) ? this.crumbs : [];
+    return html`
+      <div class="bar" role="toolbar" aria-label="Depth navigation">
+        <div class="left">
+          <button
+            type="button"
+            data-action="up-one-level"
+            aria-label=${this._upOneLevelLabel()}
+            @click=${this._onUpOneLevel}
+          >
+            <span class="glyph" aria-hidden="true">▲</span>
+            ${this.parentAuthorName || "Up"}
+          </button>
+        </div>
+        <div class="center">
+          <wavy-depth-nav
+            .crumbs=${items}
+            @click=${this._onInnerClick}
+          ></wavy-depth-nav>
+        </div>
+        <div class="right">
+          <slot name="awareness-pill"></slot>
+          <button
+            type="button"
+            data-action="up-to-wave"
+            aria-label="Back to top of wave"
+            @click=${this._onUpToWave}
+          >
+            <span class="glyph" aria-hidden="true">⌃</span>
+            Up to wave
+          </button>
+        </div>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-depth-nav-bar")) {
+  customElements.define("wavy-depth-nav-bar", WavyDepthNavBar);
+}

--- a/j2cl/lit/src/elements/wavy-focus-frame.js
+++ b/j2cl/lit/src/elements/wavy-focus-frame.js
@@ -1,0 +1,125 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-focus-frame> — F-2 (#1037, R-3.2; slice 2 #1046) landmark + visual
+ * frame that paints the cyan focus ring around the currently focused blip.
+ *
+ * The element does NOT own focus state — that lives in
+ * J2clReadSurfaceDomRenderer. The renderer dispatches a
+ * `wavy-focus-changed` CustomEvent on its `host` (= the
+ * `.j2cl-read-surface` element) whenever focus changes. This element
+ * listens on its parent (which must be the same `host`) and updates its
+ * own `focusedBlipId` + `bounds` reactive properties. The frame is then
+ * rendered as an absolutely-positioned overlay child element.
+ *
+ * The element is mounted inside the renderer's `host` (NOT contentList,
+ * NOT the card) so the bounds-measurement node, the positioning ancestor,
+ * and the event-source node are all the same element. See plan
+ * §3.R-3.2.3 for the coordinate-space reconciliation.
+ *
+ * Public API:
+ * - focusedBlipId: String — currently focused blip id (empty = no focus)
+ * - bounds: {top, left, width, height} — host-local pixel coordinates
+ *
+ * Events consumed (on parent, captured in connectedCallback):
+ * - `wavy-focus-changed` — `{detail: {blipId, bounds, key}}`
+ */
+export class WavyFocusFrame extends LitElement {
+  static properties = {
+    focusedBlipId: { attribute: false },
+    bounds: { attribute: false }
+  };
+
+  static styles = css`
+    :host {
+      /* Take no layout space; the inner frame is absolutely positioned
+       * relative to the nearest positioned ancestor (the renderer's
+       * host = .j2cl-read-surface, which T4 ensures has position: relative). */
+      display: contents;
+    }
+    .frame {
+      position: absolute;
+      pointer-events: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+      border-radius: var(--wavy-radius-card, 12px);
+      transition: top var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        left var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        width var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        height var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+      will-change: top, left, width, height;
+    }
+    .frame[hidden] {
+      display: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .frame {
+        transition: none;
+      }
+    }
+  `;
+
+  constructor() {
+    super();
+    this.focusedBlipId = "";
+    this.bounds = { top: 0, left: 0, width: 0, height: 0 };
+    this._onFocusChanged = this._onFocusChanged.bind(this);
+    this._listeningOn = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // The frame listens on its parent — which must be the renderer's host
+    // (`.j2cl-read-surface`). The event fires from the renderer (Java)
+    // when focusBlip(...) runs.
+    this._listeningOn = this.parentNode || this.parentElement;
+    if (this._listeningOn && typeof this._listeningOn.addEventListener === "function") {
+      this._listeningOn.addEventListener("wavy-focus-changed", this._onFocusChanged);
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._listeningOn && typeof this._listeningOn.removeEventListener === "function") {
+      this._listeningOn.removeEventListener("wavy-focus-changed", this._onFocusChanged);
+    }
+    this._listeningOn = null;
+  }
+
+  _onFocusChanged(event) {
+    if (!event || !event.detail) {
+      return;
+    }
+    const { blipId, bounds } = event.detail;
+    this.focusedBlipId = typeof blipId === "string" ? blipId : "";
+    this.bounds =
+      bounds && typeof bounds === "object"
+        ? {
+            top: Number(bounds.top) || 0,
+            left: Number(bounds.left) || 0,
+            width: Number(bounds.width) || 0,
+            height: Number(bounds.height) || 0
+          }
+        : { top: 0, left: 0, width: 0, height: 0 };
+  }
+
+  render() {
+    const hidden = !this.focusedBlipId;
+    const style = `top: ${this.bounds.top}px; left: ${this.bounds.left}px; width: ${this.bounds.width}px; height: ${this.bounds.height}px;`;
+    return html`<div
+      class="frame"
+      part="frame"
+      data-focused-blip-id=${this.focusedBlipId}
+      ?hidden=${hidden}
+      style=${style}
+      aria-hidden="true"
+    ></div>`;
+  }
+}
+
+if (!customElements.get("wavy-focus-frame")) {
+  customElements.define("wavy-focus-frame", WavyFocusFrame);
+}

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -31,9 +31,9 @@ import { LitElement, css, html } from "lit";
  * - `wave-nav-next-mention-requested` (E.7)
  * - `wave-nav-archive-toggle-requested` (E.8)
  * - `wave-nav-pin-toggle-requested` (E.9)
- * - `wave-nav-version-history-requested` (E.10) — also bound to `H` keyboard
+ * - `wave-nav-version-history-requested` (E.10) — also bound to `h`/`H` keyboard
  *
- * Keyboard: `H` (Shift+h) emits the version-history event when the
+ * Keyboard: `h` or `H` emits the version-history event when the
  * user is not in a text-input context. The keydown listener is bound
  * to the closest `[data-j2cl-selected-wave-host]` ancestor (NOT
  * document) to prevent multi-fire when more than one nav-row mounts
@@ -52,6 +52,7 @@ export class WavyWaveNavRow extends LitElement {
   static styles = css`
     :host {
       display: block;
+      position: relative;
       /* container-type:inline-size enables the @container query below.
        * Without this declaration the mobile-collapse path is dead code. */
       container-type: inline-size;
@@ -179,7 +180,7 @@ export class WavyWaveNavRow extends LitElement {
   }
 
   _onKeyDown(event) {
-    if (!event || event.key !== "H") {
+    if (!event || (event.key !== "H" && event.key !== "h")) {
       return;
     }
     if (event.ctrlKey || event.metaKey || event.altKey) {
@@ -331,8 +332,8 @@ export class WavyWaveNavRow extends LitElement {
         <button
           type="button"
           data-action="version-history"
-          aria-label="Open version history (H)"
-          aria-keyshortcuts="H"
+          aria-label="Open version history (h)"
+          aria-keyshortcuts="h H"
           @click=${this._onClick("version-history")}
         >
           Version history
@@ -384,7 +385,7 @@ export class WavyWaveNavRow extends LitElement {
               role="menuitem"
               data-action="version-history"
               data-overflow="true"
-              aria-label="Open version history (H)"
+              aria-label="Open version history (h)"
               @click=${this._onClick("version-history")}
             >
               Version history

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -1,0 +1,401 @@
+import { LitElement, css, html } from "lit";
+
+/**
+ * <wavy-wave-nav-row> — F-2 (#1037, R-3.4; slice 2 #1046) wave-level nav
+ * toolbar covering audit rows E.1–E.10. The element renders 10 buttons
+ * in fixed order (Recent, Next Unread, Previous, Next, End, Prev @,
+ * Next @, Archive, Pin, Version History) and emits one CustomEvent per
+ * button click.
+ *
+ * Wired ABOVE the content list (per-wave), NOT per-blip (the audit
+ * called out S1's wave-list-level wiring as the bug). The nav row
+ * receives the focus anchor via the `selectedBlipId` reactive prop and
+ * carries it in every dispatched event so S5 can route the walk against
+ * the correct anchor.
+ *
+ * Properties:
+ * - selectedBlipId: String — current focus anchor (echoed into event detail)
+ * - sourceWaveId: String — current wave id (echoed into event detail)
+ * - unreadCount: Number — drives E.2 cyan emphasis
+ * - mentionCount: Number — drives E.6/E.7 violet emphasis
+ * - pinned: Boolean — drives E.9 cyan glyph + aria-label toggle
+ * - archived: Boolean — drives E.8 aria-label toggle (S5 will wire data)
+ *
+ * Events emitted (CustomEvent, bubbles + composed, detail = {selectedBlipId, sourceWaveId}):
+ * - `wave-nav-recent-requested` (E.1)
+ * - `wave-nav-next-unread-requested` (E.2)
+ * - `wave-nav-previous-requested` (E.3)
+ * - `wave-nav-next-requested` (E.4)
+ * - `wave-nav-end-requested` (E.5)
+ * - `wave-nav-prev-mention-requested` (E.6)
+ * - `wave-nav-next-mention-requested` (E.7)
+ * - `wave-nav-archive-toggle-requested` (E.8)
+ * - `wave-nav-pin-toggle-requested` (E.9)
+ * - `wave-nav-version-history-requested` (E.10) — also bound to `H` keyboard
+ *
+ * Keyboard: `H` (Shift+h) emits the version-history event when the
+ * user is not in a text-input context. The keydown listener is bound
+ * to the closest `[data-j2cl-selected-wave-host]` ancestor (NOT
+ * document) to prevent multi-fire when more than one nav-row mounts
+ * (e.g. server-first + cold-mount during boot, S6 demo route).
+ */
+export class WavyWaveNavRow extends LitElement {
+  static properties = {
+    selectedBlipId: { type: String, attribute: "selected-blip-id", reflect: true },
+    sourceWaveId: { type: String, attribute: "source-wave-id", reflect: true },
+    unreadCount: { type: Number, attribute: "unread-count", reflect: true },
+    mentionCount: { type: Number, attribute: "mention-count", reflect: true },
+    pinned: { type: Boolean, reflect: true },
+    archived: { type: Boolean, reflect: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      /* container-type:inline-size enables the @container query below.
+       * Without this declaration the mobile-collapse path is dead code. */
+      container-type: inline-size;
+      container-name: wave-nav-row;
+      background: var(--wavy-bg-surface, #11192a);
+      border-bottom: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-3, 12px);
+    }
+    nav {
+      display: flex;
+      align-items: center;
+      gap: var(--wavy-spacing-2, 8px);
+      flex-wrap: nowrap;
+    }
+    button {
+      background: transparent;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      border: 1px solid transparent;
+      border-radius: var(--wavy-radius-pill, 9999px);
+      font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      cursor: pointer;
+      white-space: nowrap;
+      transition: color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        border-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        background-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    button:hover {
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      background: var(--wavy-signal-cyan-soft, rgba(34, 211, 238, 0.22));
+      border-color: var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+    }
+    button:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
+    }
+    button[disabled] {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+    /* E.2 next-unread cyan emphasis when unread > 0 */
+    button[data-action="next-unread"][data-emphasis="cyan"] {
+      color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    /* E.6/E.7 mention violet emphasis when mentionCount > 0 */
+    button[data-action="prev-mention"][data-emphasis="violet"],
+    button[data-action="next-mention"][data-emphasis="violet"] {
+      color: var(--wavy-signal-violet, #7c3aed);
+    }
+    /* E.9 pinned cyan glyph */
+    button[data-action="pin"][data-emphasis="cyan"] {
+      color: var(--wavy-signal-cyan, #22d3ee);
+    }
+
+    /* Mobile/narrow collapse — the overflow button + menu are hidden
+     * by default on full-width and surface only when the container is
+     * narrow. The 3 collapsed actions are also hidden when narrow. */
+    .overflow-trigger,
+    .overflow-menu {
+      display: none;
+    }
+    @container wave-nav-row (max-width: 480px) {
+      button[data-action="prev-mention"],
+      button[data-action="next-mention"],
+      button[data-action="version-history"] {
+        display: none;
+      }
+      .overflow-trigger {
+        display: inline-flex;
+      }
+      .overflow-menu[data-open="true"] {
+        display: block;
+        position: absolute;
+        right: var(--wavy-spacing-2, 8px);
+        background: var(--wavy-bg-surface, #11192a);
+        border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+        border-radius: var(--wavy-radius-card, 12px);
+        padding: var(--wavy-spacing-2, 8px);
+        z-index: 1;
+        margin: 0;
+        list-style: none;
+      }
+      .overflow-menu[data-open="true"] button {
+        display: block;
+        width: 100%;
+        text-align: left;
+      }
+    }
+  `;
+
+  constructor() {
+    super();
+    this.selectedBlipId = "";
+    this.sourceWaveId = "";
+    this.unreadCount = 0;
+    this.mentionCount = 0;
+    this.pinned = false;
+    this.archived = false;
+    this._overflowOpen = false;
+    this._onKeyDown = this._onKeyDown.bind(this);
+    this._keyTarget = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Resolve the binding target via closest('[data-j2cl-selected-wave-host]'),
+    // falling back to document only when no ancestor is found. Binding to
+    // the card root prevents multi-fire when more than one nav-row mounts.
+    this._keyTarget =
+      this.closest && this.closest("[data-j2cl-selected-wave-host]")
+        ? this.closest("[data-j2cl-selected-wave-host]")
+        : document;
+    this._keyTarget.addEventListener("keydown", this._onKeyDown);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._keyTarget) {
+      this._keyTarget.removeEventListener("keydown", this._onKeyDown);
+      this._keyTarget = null;
+    }
+  }
+
+  _onKeyDown(event) {
+    if (!event || event.key !== "H") {
+      return;
+    }
+    if (event.ctrlKey || event.metaKey || event.altKey) {
+      return;
+    }
+    const target = event.target;
+    if (target && target.nodeType === 1) {
+      const tag = target.tagName;
+      if (
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        target.isContentEditable === true
+      ) {
+        return;
+      }
+    }
+    event.preventDefault();
+    this._emit("wave-nav-version-history-requested", { keyboard: true });
+  }
+
+  _emit(eventName, extra) {
+    const detail = {
+      selectedBlipId: this.selectedBlipId,
+      sourceWaveId: this.sourceWaveId,
+      ...(extra || {})
+    };
+    this.dispatchEvent(
+      new CustomEvent(eventName, { bubbles: true, composed: true, detail })
+    );
+  }
+
+  _onClick(action) {
+    return (event) => {
+      event.stopPropagation();
+      this._emit(`wave-nav-${action}-requested`);
+      // Close overflow menu after click (defensive — narrow viewport only)
+      if (this._overflowOpen) {
+        this._overflowOpen = false;
+        this.requestUpdate();
+      }
+    };
+  }
+
+  _onOverflowToggle(event) {
+    event.stopPropagation();
+    this._overflowOpen = !this._overflowOpen;
+    this.requestUpdate();
+  }
+
+  _pinAriaLabel() {
+    return this.pinned ? "Unpin wave" : "Pin wave";
+  }
+
+  _archiveAriaLabel() {
+    return this.archived ? "Restore from archive" : "Move wave to archive";
+  }
+
+  _nextUnreadEmphasis() {
+    return this.unreadCount > 0 ? "cyan" : "muted";
+  }
+
+  _mentionEmphasis() {
+    return this.mentionCount > 0 ? "violet" : "muted";
+  }
+
+  _pinEmphasis() {
+    return this.pinned ? "cyan" : "muted";
+  }
+
+  render() {
+    return html`
+      <nav aria-label="Wave navigation">
+        <button
+          type="button"
+          data-action="recent"
+          aria-label="Jump to recent activity"
+          @click=${this._onClick("recent")}
+        >
+          Recent
+        </button>
+        <button
+          type="button"
+          data-action="next-unread"
+          data-emphasis=${this._nextUnreadEmphasis()}
+          aria-label="Jump to next unread blip"
+          @click=${this._onClick("next-unread")}
+        >
+          Next unread
+        </button>
+        <button
+          type="button"
+          data-action="previous"
+          aria-label="Jump to previous blip"
+          @click=${this._onClick("previous")}
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          data-action="next"
+          aria-label="Jump to next blip"
+          @click=${this._onClick("next")}
+        >
+          Next
+        </button>
+        <button
+          type="button"
+          data-action="end"
+          aria-label="Jump to last blip"
+          @click=${this._onClick("end")}
+        >
+          End
+        </button>
+        <button
+          type="button"
+          data-action="prev-mention"
+          data-emphasis=${this._mentionEmphasis()}
+          aria-label="Jump to previous mention"
+          @click=${this._onClick("prev-mention")}
+        >
+          Prev @
+        </button>
+        <button
+          type="button"
+          data-action="next-mention"
+          data-emphasis=${this._mentionEmphasis()}
+          aria-label="Jump to next mention"
+          @click=${this._onClick("next-mention")}
+        >
+          Next @
+        </button>
+        <button
+          type="button"
+          data-action="archive"
+          aria-label=${this._archiveAriaLabel()}
+          @click=${this._onClick("archive-toggle")}
+        >
+          ${this.archived ? "Restore" : "Archive"}
+        </button>
+        <button
+          type="button"
+          data-action="pin"
+          data-emphasis=${this._pinEmphasis()}
+          aria-label=${this._pinAriaLabel()}
+          @click=${this._onClick("pin-toggle")}
+        >
+          ${this.pinned ? "Unpin" : "Pin"}
+        </button>
+        <button
+          type="button"
+          data-action="version-history"
+          aria-label="Open version history (H)"
+          aria-keyshortcuts="H"
+          @click=${this._onClick("version-history")}
+        >
+          Version history
+        </button>
+
+        <button
+          type="button"
+          class="overflow-trigger"
+          data-action="overflow"
+          aria-haspopup="menu"
+          aria-expanded=${this._overflowOpen ? "true" : "false"}
+          aria-label="More wave navigation actions"
+          @click=${this._onOverflowToggle}
+        >
+          ⋯
+        </button>
+        <menu
+          class="overflow-menu"
+          data-open=${this._overflowOpen ? "true" : "false"}
+          role="menu"
+        >
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              data-action="prev-mention"
+              data-overflow="true"
+              aria-label="Jump to previous mention"
+              @click=${this._onClick("prev-mention")}
+            >
+              Prev @
+            </button>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              data-action="next-mention"
+              data-overflow="true"
+              aria-label="Jump to next mention"
+              @click=${this._onClick("next-mention")}
+            >
+              Next @
+            </button>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              data-action="version-history"
+              data-overflow="true"
+              aria-label="Open version history (H)"
+              @click=${this._onClick("version-history")}
+            >
+              Version history
+            </button>
+          </li>
+        </menu>
+      </nav>
+    `;
+  }
+}
+
+if (!customElements.get("wavy-wave-nav-row")) {
+  customElements.define("wavy-wave-nav-row", WavyWaveNavRow);
+}

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -36,6 +36,14 @@ import "./design/wavy-pulse-stage.js";
 // design recipes. The renderer mounts <wave-blip> per blip.
 import "./elements/wave-blip-toolbar.js";
 import "./elements/wave-blip.js";
+// F-2 slice 2 (#1046): wave chrome — focus frame, wave nav row,
+// depth nav bar. Mounted by J2clSelectedWaveView around the read
+// surface; the focus frame is mounted by J2clReadSurfaceDomRenderer
+// inside its host so the bounds-measurement and positioning ancestor
+// converge on the same node.
+import "./elements/wavy-focus-frame.js";
+import "./elements/wavy-wave-nav-row.js";
+import "./elements/wavy-depth-nav-bar.js";
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/wavy-depth-nav-bar.test.js
+++ b/j2cl/lit/test/wavy-depth-nav-bar.test.js
@@ -38,7 +38,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("shows itself when a current depth is set", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+3"
+        current-depth-blip-id="b+3"
         parent-depth-blip-id="b+1"
         parent-author-name="Alice"
       ></wavy-depth-nav-bar>`
@@ -50,7 +50,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("G.2 — Up one level button has parent-author-aware aria-label", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+3"
+        current-depth-blip-id="b+3"
         parent-depth-blip-id="b+1"
         parent-author-name="Alice"
       ></wavy-depth-nav-bar>`
@@ -66,7 +66,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("G.2 — Up one level falls back to generic label when parentAuthorName is empty", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+3"
+        current-depth-blip-id="b+3"
         parent-depth-blip-id="b+1"
       ></wavy-depth-nav-bar>`
     );
@@ -78,7 +78,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("G.2 — clicking Up one level emits wavy-depth-up with from/to blip ids", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+3"
+        current-depth-blip-id="b+3"
         parent-depth-blip-id="b+1"
         parent-author-name="Alice"
       ></wavy-depth-nav-bar>`
@@ -97,7 +97,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("G.3 — Up to wave button aria-label is constant", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+3"
+        current-depth-blip-id="b+3"
       ></wavy-depth-nav-bar>`
     );
     await el.updateComplete;
@@ -109,7 +109,7 @@ describe("<wavy-depth-nav-bar>", () => {
   it("G.3 — clicking Up to wave emits wavy-depth-root with fromBlipId", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+5"
+        current-depth-blip-id="b+5"
       ></wavy-depth-nav-bar>`
     );
     await el.updateComplete;
@@ -129,7 +129,7 @@ describe("<wavy-depth-nav-bar>", () => {
       { label: "Top thread", current: true, blipId: "b+1" }
     ];
     const el = await fixture(html`<wavy-depth-nav-bar
-      data-current-depth-blip-id="b+1"
+      current-depth-blip-id="b+1"
       .crumbs=${crumbs}
     ></wavy-depth-nav-bar>`);
     await el.updateComplete;
@@ -146,7 +146,7 @@ describe("<wavy-depth-nav-bar>", () => {
       { label: "This blip", current: true }
     ];
     const el = await fixture(html`<wavy-depth-nav-bar
-      data-current-depth-blip-id="b+2"
+      current-depth-blip-id="b+2"
       .crumbs=${crumbs}
     ></wavy-depth-nav-bar>`);
     await el.updateComplete;
@@ -166,7 +166,7 @@ describe("<wavy-depth-nav-bar>", () => {
 
   it("reserves an awareness-pill slot for S5 to fill", async () => {
     const el = await fixture(
-      html`<wavy-depth-nav-bar data-current-depth-blip-id="b+1">
+      html`<wavy-depth-nav-bar current-depth-blip-id="b+1">
         <span slot="awareness-pill" data-test="pill">↑ 2 new</span>
       </wavy-depth-nav-bar>`
     );
@@ -177,13 +177,13 @@ describe("<wavy-depth-nav-bar>", () => {
     expect(assigned.some((n) => n.dataset && n.dataset.test === "pill")).to.be.true;
   });
 
-  it("reflects data-current-depth-blip-id on the host", async () => {
+  it("reflects current-depth-blip-id on the host", async () => {
     const el = await fixture(
       html`<wavy-depth-nav-bar
-        data-current-depth-blip-id="b+9"
+        current-depth-blip-id="b+9"
       ></wavy-depth-nav-bar>`
     );
     await el.updateComplete;
-    expect(el.getAttribute("data-current-depth-blip-id")).to.equal("b+9");
+    expect(el.getAttribute("current-depth-blip-id")).to.equal("b+9");
   });
 });

--- a/j2cl/lit/test/wavy-depth-nav-bar.test.js
+++ b/j2cl/lit/test/wavy-depth-nav-bar.test.js
@@ -1,0 +1,189 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-depth-nav-bar.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-depth-nav-bar>", () => {
+  it("registers the F-2 slice 2 custom element", () => {
+    expect(customElements.get("wavy-depth-nav-bar")).to.exist;
+  });
+
+  it("hides itself at top-of-wave (no current depth + no crumbs)", async () => {
+    const el = await fixture(html`<wavy-depth-nav-bar></wavy-depth-nav-bar>`);
+    await el.updateComplete;
+    expect(el.hasAttribute("hidden")).to.be.true;
+  });
+
+  it("shows itself when a current depth is set", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+3"
+        parent-depth-blip-id="b+1"
+        parent-author-name="Alice"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    expect(el.hasAttribute("hidden")).to.be.false;
+  });
+
+  it("G.2 — Up one level button has parent-author-aware aria-label", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+3"
+        parent-depth-blip-id="b+1"
+        parent-author-name="Alice"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('button[data-action="up-one-level"]');
+    expect(button).to.exist;
+    expect(button.getAttribute("aria-label")).to.equal(
+      "Up one level to Alice's thread"
+    );
+  });
+
+  it("G.2 — Up one level falls back to generic label when parentAuthorName is empty", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+3"
+        parent-depth-blip-id="b+1"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('button[data-action="up-one-level"]');
+    expect(button.getAttribute("aria-label")).to.equal("Up one level");
+  });
+
+  it("G.2 — clicking Up one level emits wavy-depth-up with from/to blip ids", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+3"
+        parent-depth-blip-id="b+1"
+        parent-author-name="Alice"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('button[data-action="up-one-level"]');
+    const eventPromise = oneEvent(el, "wavy-depth-up");
+    button.click();
+    const event = await eventPromise;
+    expect(event.detail.fromBlipId).to.equal("b+3");
+    expect(event.detail.toBlipId).to.equal("b+1");
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
+  });
+
+  it("G.3 — Up to wave button aria-label is constant", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+3"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('button[data-action="up-to-wave"]');
+    expect(button).to.exist;
+    expect(button.getAttribute("aria-label")).to.equal("Back to top of wave");
+  });
+
+  it("G.3 — clicking Up to wave emits wavy-depth-root with fromBlipId", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+5"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('button[data-action="up-to-wave"]');
+    const eventPromise = oneEvent(el, "wavy-depth-root");
+    button.click();
+    const event = await eventPromise;
+    expect(event.detail.fromBlipId).to.equal("b+5");
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
+  });
+
+  it("composes inner <wavy-depth-nav> with crumbs", async () => {
+    const crumbs = [
+      { label: "Inbox", href: "/?folder=inbox" },
+      { label: "Sample wave", blipId: "b+root" },
+      { label: "Top thread", current: true, blipId: "b+1" }
+    ];
+    const el = await fixture(html`<wavy-depth-nav-bar
+      data-current-depth-blip-id="b+1"
+      .crumbs=${crumbs}
+    ></wavy-depth-nav-bar>`);
+    await el.updateComplete;
+    const inner = el.renderRoot.querySelector("wavy-depth-nav");
+    expect(inner).to.exist;
+    await inner.updateComplete;
+    expect(inner.crumbs).to.equal(crumbs);
+  });
+
+  it("emits wavy-depth-jump-to-crumb when an inner crumb with blipId is clicked", async () => {
+    const crumbs = [
+      { label: "Sample wave", blipId: "b+root" },
+      { label: "Reply thread", blipId: "b+2" },
+      { label: "This blip", current: true }
+    ];
+    const el = await fixture(html`<wavy-depth-nav-bar
+      data-current-depth-blip-id="b+2"
+      .crumbs=${crumbs}
+    ></wavy-depth-nav-bar>`);
+    await el.updateComplete;
+    const inner = el.renderRoot.querySelector("wavy-depth-nav");
+    await inner.updateComplete;
+    // The inner recipe renders crumbs as <a> / <span> with the label as
+    // text content. Click the second crumb (Reply thread).
+    const replyAnchor = Array.from(
+      inner.renderRoot.querySelectorAll("a, span")
+    ).find((n) => n.textContent.trim() === "Reply thread");
+    expect(replyAnchor, "Reply thread crumb missing").to.exist;
+    const eventPromise = oneEvent(el, "wavy-depth-jump-to-crumb");
+    replyAnchor.click();
+    const event = await eventPromise;
+    expect(event.detail.blipId).to.equal("b+2");
+  });
+
+  it("reserves an awareness-pill slot for S5 to fill", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar data-current-depth-blip-id="b+1">
+        <span slot="awareness-pill" data-test="pill">↑ 2 new</span>
+      </wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    const slot = el.renderRoot.querySelector('slot[name="awareness-pill"]');
+    expect(slot).to.exist;
+    const assigned = slot.assignedNodes({ flatten: true });
+    expect(assigned.some((n) => n.dataset && n.dataset.test === "pill")).to.be.true;
+  });
+
+  it("reflects data-current-depth-blip-id on the host", async () => {
+    const el = await fixture(
+      html`<wavy-depth-nav-bar
+        data-current-depth-blip-id="b+9"
+      ></wavy-depth-nav-bar>`
+    );
+    await el.updateComplete;
+    expect(el.getAttribute("data-current-depth-blip-id")).to.equal("b+9");
+  });
+});

--- a/j2cl/lit/test/wavy-focus-frame.test.js
+++ b/j2cl/lit/test/wavy-focus-frame.test.js
@@ -1,0 +1,204 @@
+import { fixture, expect, html, aTimeout } from "@open-wc/testing";
+import "../src/elements/wavy-focus-frame.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-focus-frame>", () => {
+  it("registers the F-2 slice 2 custom element", () => {
+    expect(customElements.get("wavy-focus-frame")).to.exist;
+  });
+
+  it("starts hidden when no focus is set", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative; width: 400px; height: 300px;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    await frame.updateComplete;
+    const innerFrame = frame.renderRoot.querySelector(".frame");
+    expect(innerFrame).to.exist;
+    expect(innerFrame.hasAttribute("hidden")).to.be.true;
+  });
+
+  it("updates focusedBlipId + bounds on wavy-focus-changed event from parent", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative; width: 400px; height: 300px;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    await frame.updateComplete;
+
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        bubbles: false,
+        composed: true,
+        detail: {
+          blipId: "b+1",
+          bounds: { top: 24, left: 16, width: 320, height: 64 },
+          key: "ArrowDown"
+        }
+      })
+    );
+    await frame.updateComplete;
+
+    expect(frame.focusedBlipId).to.equal("b+1");
+    expect(frame.bounds).to.deep.equal({
+      top: 24,
+      left: 16,
+      width: 320,
+      height: 64
+    });
+    const innerFrame = frame.renderRoot.querySelector(".frame");
+    expect(innerFrame.hasAttribute("hidden")).to.be.false;
+    expect(innerFrame.getAttribute("data-focused-blip-id")).to.equal("b+1");
+    expect(innerFrame.getAttribute("style")).to.contain("top: 24px");
+    expect(innerFrame.getAttribute("style")).to.contain("left: 16px");
+    expect(innerFrame.getAttribute("style")).to.contain("width: 320px");
+    expect(innerFrame.getAttribute("style")).to.contain("height: 64px");
+  });
+
+  it("renders the cyan focus ring via --wavy-focus-ring token (computed RGB)", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative; width: 400px; height: 300px;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        bubbles: false,
+        composed: true,
+        detail: {
+          blipId: "b+1",
+          bounds: { top: 0, left: 0, width: 100, height: 100 },
+          key: ""
+        }
+      })
+    );
+    await frame.updateComplete;
+    const innerFrame = frame.renderRoot.querySelector(".frame");
+    const computed = getComputedStyle(innerFrame);
+    // The token resolves to `0 0 0 2px var(--wavy-signal-cyan)` which the
+    // browser computes as `rgb(34, 211, 238) 0px 0px 0px 2px`. We must
+    // assert the resolved RGB string, NOT the var() literal.
+    expect(computed.boxShadow).to.contain("rgb(34, 211, 238)");
+    expect(computed.boxShadow).to.contain("2px");
+  });
+
+  it("re-hides when focusedBlipId resets to empty", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: { blipId: "b+1", bounds: { top: 0, left: 0, width: 10, height: 10 } }
+      })
+    );
+    await frame.updateComplete;
+    expect(frame.renderRoot.querySelector(".frame").hasAttribute("hidden")).to.be
+      .false;
+
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: { blipId: "", bounds: { top: 0, left: 0, width: 0, height: 0 } }
+      })
+    );
+    await frame.updateComplete;
+    expect(frame.renderRoot.querySelector(".frame").hasAttribute("hidden")).to.be
+      .true;
+  });
+
+  it("disconnects the listener cleanly when removed from DOM", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    await frame.updateComplete;
+    const before = frame.focusedBlipId;
+    host.removeChild(frame);
+
+    // After removal, dispatching on the old parent must NOT mutate the
+    // detached element (the listener was removed in disconnectedCallback).
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: { blipId: "b+99", bounds: { top: 1, left: 2, width: 3, height: 4 } }
+      })
+    );
+    await aTimeout(20);
+    expect(frame.focusedBlipId).to.equal(before);
+  });
+
+  it("survives parent re-render — same element identity preserved across focus updates", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: { blipId: "b+1", bounds: { top: 10, left: 10, width: 50, height: 20 } }
+      })
+    );
+    await frame.updateComplete;
+
+    // Simulate a window swap: the renderer dispatches a fresh focus event
+    // for the same blip after rebuilding the surface.
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: { blipId: "b+1", bounds: { top: 60, left: 10, width: 50, height: 20 } }
+      })
+    );
+    await frame.updateComplete;
+
+    // Same element identity — Lit element was not destroyed/recreated.
+    expect(host.querySelector("wavy-focus-frame")).to.equal(frame);
+    expect(frame.bounds.top).to.equal(60);
+  });
+
+  it("applies prefers-reduced-motion override on the inner frame", async () => {
+    // We can't reliably toggle prefers-reduced-motion in the test env,
+    // but we assert the CSS rule exists in the stylesheet so the
+    // implementation is wired.
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    const styles = frame.constructor.styles;
+    const cssText = Array.isArray(styles)
+      ? styles.map((s) => s.cssText || "").join("\n")
+      : (styles && styles.cssText) || "";
+    expect(cssText).to.match(/prefers-reduced-motion:\s*reduce/);
+    expect(cssText).to.contain("transition: none");
+  });
+});

--- a/j2cl/lit/test/wavy-wave-nav-row.test.js
+++ b/j2cl/lit/test/wavy-wave-nav-row.test.js
@@ -1,0 +1,328 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-wave-nav-row.js";
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForStylesheet() {
+  for (let i = 0; i < 50; i++) {
+    const cs = getComputedStyle(document.documentElement);
+    if (cs.getPropertyValue("--wavy-bg-base").trim() !== "") return;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("wavy-tokens.css did not apply within 1000ms");
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+  await waitForStylesheet();
+});
+
+describe("<wavy-wave-nav-row>", () => {
+  it("registers the F-2 slice 2 custom element", () => {
+    expect(customElements.get("wavy-wave-nav-row")).to.exist;
+  });
+
+  it("renders all 10 buttons E.1 through E.10 in fixed order", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row
+        selected-blip-id="b+1"
+        source-wave-id="w+f2"
+      ></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const actions = Array.from(
+      el.renderRoot.querySelectorAll("nav > button[data-action]")
+    ).map((b) => b.dataset.action);
+    expect(actions).to.deep.equal([
+      "recent",
+      "next-unread",
+      "previous",
+      "next",
+      "end",
+      "prev-mention",
+      "next-mention",
+      "archive",
+      "pin",
+      "version-history",
+      "overflow"
+    ]);
+  });
+
+  // --- per-row coverage (E.1 through E.10) -------------------------------
+  // Each row asserts (a) ARIA label, (b) event name on click,
+  // (c) detail shape including selectedBlipId + sourceWaveId.
+
+  const rows = [
+    {
+      label: "E.1 Recent",
+      action: "recent",
+      ariaLabel: "Jump to recent activity",
+      eventName: "wave-nav-recent-requested"
+    },
+    {
+      label: "E.2 Next Unread",
+      action: "next-unread",
+      ariaLabel: "Jump to next unread blip",
+      eventName: "wave-nav-next-unread-requested"
+    },
+    {
+      label: "E.3 Previous",
+      action: "previous",
+      ariaLabel: "Jump to previous blip",
+      eventName: "wave-nav-previous-requested"
+    },
+    {
+      label: "E.4 Next",
+      action: "next",
+      ariaLabel: "Jump to next blip",
+      eventName: "wave-nav-next-requested"
+    },
+    {
+      label: "E.5 End",
+      action: "end",
+      ariaLabel: "Jump to last blip",
+      eventName: "wave-nav-end-requested"
+    },
+    {
+      label: "E.6 Prev mention",
+      action: "prev-mention",
+      ariaLabel: "Jump to previous mention",
+      eventName: "wave-nav-prev-mention-requested"
+    },
+    {
+      label: "E.7 Next mention",
+      action: "next-mention",
+      ariaLabel: "Jump to next mention",
+      eventName: "wave-nav-next-mention-requested"
+    },
+    {
+      label: "E.8 Archive (default state)",
+      action: "archive",
+      ariaLabel: "Move wave to archive",
+      eventName: "wave-nav-archive-toggle-requested"
+    },
+    {
+      label: "E.9 Pin (default state)",
+      action: "pin",
+      ariaLabel: "Pin wave",
+      eventName: "wave-nav-pin-toggle-requested"
+    },
+    {
+      label: "E.10 Version History",
+      action: "version-history",
+      ariaLabel: "Open version history (H)",
+      eventName: "wave-nav-version-history-requested"
+    }
+  ];
+
+  for (const row of rows) {
+    it(`${row.label} — has correct ARIA label and dispatches ${row.eventName}`, async () => {
+      const el = await fixture(
+        html`<wavy-wave-nav-row
+          selected-blip-id="b+anchor"
+          source-wave-id="w+f2"
+        ></wavy-wave-nav-row>`
+      );
+      await el.updateComplete;
+      const button = el.renderRoot.querySelector(
+        `nav > button[data-action="${row.action}"]`
+      );
+      expect(button, `button[data-action=${row.action}] missing`).to.exist;
+      expect(button.getAttribute("aria-label")).to.equal(row.ariaLabel);
+
+      const eventPromise = oneEvent(el, row.eventName);
+      button.click();
+      const event = await eventPromise;
+      expect(event.detail.selectedBlipId).to.equal("b+anchor");
+      expect(event.detail.sourceWaveId).to.equal("w+f2");
+      expect(event.bubbles).to.be.true;
+      expect(event.composed).to.be.true;
+    });
+  }
+
+  it("E.8 Archive button toggles aria-label when archived=true", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row archived></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('nav > button[data-action="archive"]');
+    expect(button.getAttribute("aria-label")).to.equal("Restore from archive");
+  });
+
+  it("E.9 Pin button toggles aria-label and emphasis when pinned=true", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row pinned></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector('nav > button[data-action="pin"]');
+    expect(button.getAttribute("aria-label")).to.equal("Unpin wave");
+    expect(button.dataset.emphasis).to.equal("cyan");
+  });
+
+  it("E.2 Next-unread emphasis flips to cyan when unreadCount > 0", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row unread-count="3"></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector(
+      'nav > button[data-action="next-unread"]'
+    );
+    expect(button.dataset.emphasis).to.equal("cyan");
+    // Computed style: rgb(34, 211, 238) is the cyan token.
+    const computed = getComputedStyle(button);
+    expect(computed.color).to.contain("rgb(34, 211, 238)");
+  });
+
+  it("E.6/E.7 mention emphasis flips to violet when mentionCount > 0", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row mention-count="2"></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const prev = el.renderRoot.querySelector('nav > button[data-action="prev-mention"]');
+    const next = el.renderRoot.querySelector('nav > button[data-action="next-mention"]');
+    expect(prev.dataset.emphasis).to.equal("violet");
+    expect(next.dataset.emphasis).to.equal("violet");
+    expect(getComputedStyle(prev).color).to.contain("rgb(124, 58, 237)");
+  });
+
+  it("H keyboard shortcut on the card host emits wave-nav-version-history-requested", async () => {
+    const card = await fixture(
+      html`<section data-j2cl-selected-wave-host>
+        <wavy-wave-nav-row selected-blip-id="b+1"></wavy-wave-nav-row>
+      </section>`
+    );
+    const el = card.querySelector("wavy-wave-nav-row");
+    await el.updateComplete;
+    const eventPromise = oneEvent(el, "wave-nav-version-history-requested");
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "H", bubbles: true })
+    );
+    const event = await eventPromise;
+    expect(event.detail.keyboard).to.be.true;
+    expect(event.detail.selectedBlipId).to.equal("b+1");
+  });
+
+  it("H keyboard ignored when target is INPUT", async () => {
+    const card = await fixture(
+      html`<section data-j2cl-selected-wave-host>
+        <input id="search" />
+        <wavy-wave-nav-row></wavy-wave-nav-row>
+      </section>`
+    );
+    const el = card.querySelector("wavy-wave-nav-row");
+    await el.updateComplete;
+    let fired = false;
+    el.addEventListener("wave-nav-version-history-requested", () => {
+      fired = true;
+    });
+    const input = card.querySelector("#search");
+    input.focus();
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "H", bubbles: true })
+    );
+    // Allow the synchronous handler to run.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fired).to.be.false;
+  });
+
+  it("H keyboard ignored when modifier (cmd/ctrl/alt) is held", async () => {
+    const card = await fixture(
+      html`<section data-j2cl-selected-wave-host>
+        <wavy-wave-nav-row></wavy-wave-nav-row>
+      </section>`
+    );
+    const el = card.querySelector("wavy-wave-nav-row");
+    await el.updateComplete;
+    let fired = false;
+    el.addEventListener("wave-nav-version-history-requested", () => {
+      fired = true;
+    });
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "H", metaKey: true, bubbles: true })
+    );
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "H", ctrlKey: true, bubbles: true })
+    );
+    card.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "H", altKey: true, bubbles: true })
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fired).to.be.false;
+  });
+
+  it("H keyboard binds to closest selected-wave-host ancestor (not document)", async () => {
+    // Two cards mounted simultaneously — verify each row only receives its
+    // own card's keydown, not the other's.
+    const wrapper = await fixture(
+      html`<div>
+        <section id="a" data-j2cl-selected-wave-host>
+          <wavy-wave-nav-row id="rowA" selected-blip-id="bA"></wavy-wave-nav-row>
+        </section>
+        <section id="b" data-j2cl-selected-wave-host>
+          <wavy-wave-nav-row id="rowB" selected-blip-id="bB"></wavy-wave-nav-row>
+        </section>
+      </div>`
+    );
+    const rowA = wrapper.querySelector("#rowA");
+    const rowB = wrapper.querySelector("#rowB");
+    await rowA.updateComplete;
+    await rowB.updateComplete;
+    let firedA = 0;
+    let firedB = 0;
+    rowA.addEventListener("wave-nav-version-history-requested", () => firedA++);
+    rowB.addEventListener("wave-nav-version-history-requested", () => firedB++);
+    wrapper
+      .querySelector("#a")
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "H", bubbles: true }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(firedA).to.equal(1);
+    expect(firedB).to.equal(0);
+  });
+
+  it("declares container-type:inline-size on host for @container query", async () => {
+    const el = await fixture(html`<wavy-wave-nav-row></wavy-wave-nav-row>`);
+    await el.updateComplete;
+    const computed = getComputedStyle(el);
+    expect(computed.containerType).to.equal("inline-size");
+    expect(computed.containerName).to.equal("wave-nav-row");
+  });
+
+  it("overflow trigger toggles overflow menu open/closed", async () => {
+    const el = await fixture(html`<wavy-wave-nav-row></wavy-wave-nav-row>`);
+    await el.updateComplete;
+    const overflow = el.renderRoot.querySelector(".overflow-trigger");
+    const menu = el.renderRoot.querySelector(".overflow-menu");
+    expect(menu.dataset.open).to.equal("false");
+    overflow.click();
+    await el.updateComplete;
+    expect(menu.dataset.open).to.equal("true");
+    overflow.click();
+    await el.updateComplete;
+    expect(menu.dataset.open).to.equal("false");
+  });
+
+  it("overflow menu items dispatch the same events as their full-width counterparts", async () => {
+    const el = await fixture(
+      html`<wavy-wave-nav-row selected-blip-id="b+ov"></wavy-wave-nav-row>`
+    );
+    await el.updateComplete;
+    const overflowItems = el.renderRoot.querySelectorAll(
+      ".overflow-menu button[data-overflow]"
+    );
+    expect(overflowItems.length).to.equal(3);
+    const promise = oneEvent(el, "wave-nav-version-history-requested");
+    const ovHistory = el.renderRoot.querySelector(
+      '.overflow-menu button[data-action="version-history"]'
+    );
+    ovHistory.click();
+    const event = await promise;
+    expect(event.detail.selectedBlipId).to.equal("b+ov");
+  });
+});

--- a/j2cl/lit/test/wavy-wave-nav-row.test.js
+++ b/j2cl/lit/test/wavy-wave-nav-row.test.js
@@ -117,7 +117,7 @@ describe("<wavy-wave-nav-row>", () => {
     {
       label: "E.10 Version History",
       action: "version-history",
-      ariaLabel: "Open version history (H)",
+      ariaLabel: "Open version history (h)",
       eventName: "wave-nav-version-history-requested"
     }
   ];

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -763,16 +763,16 @@ public final class J2clReadSurfaceDomRenderer {
     // aria-keyshortcuts to avoid screen-reader collisions with global
     // shortcuts (g/G, [/] are deferred to slice 5).
     if ("ArrowDown".equals(key) || "j".equals(key)) {
-      focusByOffset(1);
+      focusByOffset(1, key);
       keyEvent.preventDefault();
     } else if ("ArrowUp".equals(key) || "k".equals(key)) {
-      focusByOffset(-1);
+      focusByOffset(-1, key);
       keyEvent.preventDefault();
     } else if ("Home".equals(key)) {
-      focusByIndex(0);
+      focusByIndex(0, key);
       keyEvent.preventDefault();
     } else if ("End".equals(key)) {
-      focusByIndex(renderedBlips.size() - 1);
+      focusByIndex(renderedBlips.size() - 1, key);
       keyEvent.preventDefault();
     }
   }
@@ -870,32 +870,36 @@ public final class J2clReadSurfaceDomRenderer {
     host.scrollTop = Math.max(0, host.scrollTop + delta);
   }
 
-  private void focusByOffset(int offset) {
+  private void focusByOffset(int offset, String key) {
     List<HTMLElement> visibleBlips = visibleBlips();
     int current = focusedBlip == null ? -1 : visibleBlips.indexOf(focusedBlip);
     if (current < 0) {
-      focusVisibleByIndex(offset > 0 ? 0 : visibleBlips.size() - 1);
+      focusVisibleByIndex(offset > 0 ? 0 : visibleBlips.size() - 1, key);
       return;
     }
-    focusVisibleByIndex(current + offset);
+    focusVisibleByIndex(current + offset, key);
   }
 
-  private void focusByIndex(int index) {
-    focusVisibleByIndex(index);
+  private void focusByIndex(int index, String key) {
+    focusVisibleByIndex(index, key);
   }
 
-  private void focusVisibleByIndex(int index) {
+  private void focusVisibleByIndex(int index, String key) {
     List<HTMLElement> visibleBlips = visibleBlips();
     if (visibleBlips.isEmpty()) {
       return;
     }
     int boundedIndex = Math.max(0, Math.min(index, visibleBlips.size() - 1));
     HTMLElement next = visibleBlips.get(boundedIndex);
-    focusBlip(next);
+    focusBlip(next, key);
     next.focus();
   }
 
   private void focusBlip(HTMLElement next) {
+    focusBlip(next, "");
+  }
+
+  private void focusBlip(HTMLElement next, String key) {
     if (next == null) {
       clearFocusedBlip();
       return;
@@ -908,19 +912,26 @@ public final class J2clReadSurfaceDomRenderer {
     focusedBlip.classList.add("j2cl-read-blip-focused");
     focusedBlip.setAttribute("aria-current", "true");
     focusedBlip.setAttribute("tabindex", "0");
-    dispatchFocusChanged(focusedBlip, "");
+    dispatchFocusChanged(focusedBlip, key);
   }
 
   /**
    * F-2 slice 2 (#1046, R-3.2): emit a {@code wavy-focus-changed}
-   * CustomEvent on the renderer host so the {@code <wavy-focus-frame>}
-   * Lit element (mounted as a child of the host) can paint the cyan ring
-   * around the focused blip. Bounds are in {@code host}-local coordinate
-   * space (the frame is positioned absolutely inside {@code host} which
-   * carries {@code position: relative} via {@code wavy-thread-collapse.css}).
+   * CustomEvent on the renderer's read-surface element (the inner
+   * {@code <section data-j2cl-read-surface="true">}) so the
+   * {@code <wavy-focus-frame>} Lit element (mounted as a child of that
+   * surface by {@code ensureFocusFrame}) can paint the cyan ring around
+   * the focused blip. Bounds are in surface-local coordinate space (the
+   * frame is positioned absolutely inside the surface which carries
+   * {@code position: relative} via {@code wavy-thread-collapse.css}).
+   *
+   * <p>Falls back to dispatching on {@code host} (the outer content list)
+   * when no surface has been rendered yet — defensive only; any time the
+   * frame has been mounted, the surface exists.
    */
   private void dispatchFocusChanged(HTMLElement blip, String key) {
-    if (blip == null || host == null) {
+    HTMLElement target = renderedSurface != null ? renderedSurface : host;
+    if (blip == null || target == null) {
       return;
     }
     String blipId = blip.getAttribute("data-blip-id");
@@ -928,9 +939,12 @@ public final class J2clReadSurfaceDomRenderer {
       blipId = "";
     }
     DOMRect blipRect = blip.getBoundingClientRect();
-    DOMRect hostRect = host.getBoundingClientRect();
-    double top = blipRect.top - hostRect.top + host.scrollTop;
-    double left = blipRect.left - hostRect.left + host.scrollLeft;
+    DOMRect targetRect = target.getBoundingClientRect();
+    // Surface-local coords. Surface is the positioning ancestor for the
+    // <wavy-focus-frame> overlay; the frame's `top/left` style values
+    // therefore plug straight in.
+    double top = blipRect.top - targetRect.top + target.scrollTop;
+    double left = blipRect.left - targetRect.left + target.scrollLeft;
     JsPropertyMap<Object> bounds = JsPropertyMap.of();
     bounds.set("top", Double.valueOf(top));
     bounds.set("left", Double.valueOf(left));
@@ -946,7 +960,7 @@ public final class J2clReadSurfaceDomRenderer {
     init.setDetail(Js.cast(detail));
     try {
       CustomEvent<Object> evt = new CustomEvent<Object>("wavy-focus-changed", init);
-      host.dispatchEvent(evt);
+      target.dispatchEvent(evt);
     } catch (Throwable ignored) {
       // Event dispatch is observational; never let it break focus state.
     }
@@ -954,11 +968,25 @@ public final class J2clReadSurfaceDomRenderer {
       telemetrySink.record(
           J2clClientTelemetry.event("wave_chrome.focus_frame.transition")
               .field("key", key == null ? "" : key)
+              .field("direction", focusDirectionFromKey(key))
               .field("blipId", blipId)
               .build());
     } catch (Throwable ignored) {
       // Telemetry is observational.
     }
+  }
+
+  private static String focusDirectionFromKey(String key) {
+    if (key == null || key.isEmpty()) {
+      return "restore";
+    }
+    if ("ArrowDown".equals(key) || "j".equals(key) || "End".equals(key)) {
+      return "forward";
+    }
+    if ("ArrowUp".equals(key) || "k".equals(key) || "Home".equals(key)) {
+      return "backward";
+    }
+    return "jump";
   }
 
   /**
@@ -1195,7 +1223,7 @@ public final class J2clReadSurfaceDomRenderer {
   private void focusNearestVisibleFrom(HTMLElement origin) {
     int originIndex = renderedBlips.indexOf(origin);
     if (originIndex < 0) {
-      focusVisibleByIndex(0);
+      focusVisibleByIndex(0, "");
       return;
     }
     for (int index = originIndex + 1; index < renderedBlips.size(); index++) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -624,8 +624,6 @@ public final class J2clReadSurfaceDomRenderer {
     }
     HTMLElement frame =
         (HTMLElement) DomGlobal.document.createElement("wavy-focus-frame");
-    frame.setAttribute("hidden", "");
-    frame.setAttribute("aria-hidden", "true");
     surface.appendChild(frame);
   }
 
@@ -990,9 +988,9 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   /**
-   * F-2 slice 2 (#1046, R-3.7-chrome): writer that the
-   * {@code <wavy-depth-nav-bar>} reads via data-attributes. Slice 5
-   * wires the URL state reader that drives this trio.
+   * F-2 slice 2 (#1046, R-3.7-chrome): writes depth-focus data-attributes on
+   * the read-surface host element. Slice 5 wires the URL-state reader that
+   * reads these attributes and forwards them to {@code <wavy-depth-nav-bar>}.
    */
   public void setDepthFocus(
       String currentDepthBlipId, String parentDepthBlipId, String parentAuthorName) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1,5 +1,8 @@
 package org.waveprotocol.box.j2cl.read;
 
+import elemental2.dom.CustomEvent;
+import elemental2.dom.CustomEventInit;
+import elemental2.dom.DOMRect;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.Event;
@@ -11,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
@@ -604,6 +609,24 @@ public final class J2clReadSurfaceDomRenderer {
     enhanceThreads(surface);
     enhanceBlips(surface);
     bindAttachmentTelemetry(surface);
+    ensureFocusFrame(surface);
+  }
+
+  /**
+   * F-2 slice 2 (#1046, R-3.2): ensure a {@code <wavy-focus-frame>} exists
+   * as a child of the surface so it can receive {@code wavy-focus-changed}
+   * events dispatched on the surface. Idempotent — if the server-first
+   * path already pre-rendered the landmark, we skip re-mount.
+   */
+  private void ensureFocusFrame(HTMLElement surface) {
+    if (surface.querySelector("wavy-focus-frame") != null) {
+      return;
+    }
+    HTMLElement frame =
+        (HTMLElement) DomGlobal.document.createElement("wavy-focus-frame");
+    frame.setAttribute("hidden", "");
+    frame.setAttribute("aria-hidden", "true");
+    surface.appendChild(frame);
   }
 
   private void enhanceThreads(HTMLElement surface) {
@@ -700,6 +723,26 @@ public final class J2clReadSurfaceDomRenderer {
     } else if (collapsed && focusedBlip == null) {
       ensureSingleTabStop();
     }
+    // F-2 slice 2 (#1046, R-3.3): symmetric expand path. When the user
+    // expands a previously-collapsed thread that contained the focused
+    // blip, focus state is preserved (focusBlip stays pointed at the now-
+    // visible blip). The original collapse handler clears focus when the
+    // focused blip becomes hidden; on re-expand, the data-attribute
+    // already reflects the visible state, so no extra DOM mutation is
+    // needed — but we re-dispatch the focus-changed event so the
+    // <wavy-focus-frame> can recompute bounds (the blip's geometry
+    // changed when the thread re-opened).
+    if (!collapsed && focusedBlip != null && !isHiddenByCollapsedThread(focusedBlip)) {
+      dispatchFocusChanged(focusedBlip, "");
+    }
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("wave_chrome.thread_collapse.toggle")
+              .field("state", collapsed ? "collapsed" : "expanded")
+              .build());
+    } catch (Throwable ignored) {
+      // Telemetry is observational.
+    }
   }
 
   private void onBlipFocus(Event event) {
@@ -715,10 +758,14 @@ public final class J2clReadSurfaceDomRenderer {
       focusBlip((HTMLElement) event.currentTarget);
     }
     String key = keyEvent.key;
-    if ("ArrowDown".equals(key)) {
+    // F-2 slice 2 (#1046, R-3.2): j/k aliases for ArrowDown/ArrowUp.
+    // Documented as Wavy-specific aliases; intentionally NOT announced via
+    // aria-keyshortcuts to avoid screen-reader collisions with global
+    // shortcuts (g/G, [/] are deferred to slice 5).
+    if ("ArrowDown".equals(key) || "j".equals(key)) {
       focusByOffset(1);
       keyEvent.preventDefault();
-    } else if ("ArrowUp".equals(key)) {
+    } else if ("ArrowUp".equals(key) || "k".equals(key)) {
       focusByOffset(-1);
       keyEvent.preventDefault();
     } else if ("Home".equals(key)) {
@@ -861,6 +908,82 @@ public final class J2clReadSurfaceDomRenderer {
     focusedBlip.classList.add("j2cl-read-blip-focused");
     focusedBlip.setAttribute("aria-current", "true");
     focusedBlip.setAttribute("tabindex", "0");
+    dispatchFocusChanged(focusedBlip, "");
+  }
+
+  /**
+   * F-2 slice 2 (#1046, R-3.2): emit a {@code wavy-focus-changed}
+   * CustomEvent on the renderer host so the {@code <wavy-focus-frame>}
+   * Lit element (mounted as a child of the host) can paint the cyan ring
+   * around the focused blip. Bounds are in {@code host}-local coordinate
+   * space (the frame is positioned absolutely inside {@code host} which
+   * carries {@code position: relative} via {@code wavy-thread-collapse.css}).
+   */
+  private void dispatchFocusChanged(HTMLElement blip, String key) {
+    if (blip == null || host == null) {
+      return;
+    }
+    String blipId = blip.getAttribute("data-blip-id");
+    if (blipId == null) {
+      blipId = "";
+    }
+    DOMRect blipRect = blip.getBoundingClientRect();
+    DOMRect hostRect = host.getBoundingClientRect();
+    double top = blipRect.top - hostRect.top + host.scrollTop;
+    double left = blipRect.left - hostRect.left + host.scrollLeft;
+    JsPropertyMap<Object> bounds = JsPropertyMap.of();
+    bounds.set("top", Double.valueOf(top));
+    bounds.set("left", Double.valueOf(left));
+    bounds.set("width", Double.valueOf(blipRect.width));
+    bounds.set("height", Double.valueOf(blipRect.height));
+    JsPropertyMap<Object> detail = JsPropertyMap.of();
+    detail.set("blipId", blipId);
+    detail.set("bounds", bounds);
+    detail.set("key", key == null ? "" : key);
+    CustomEventInit<Object> init = CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    init.setDetail(Js.cast(detail));
+    try {
+      CustomEvent<Object> evt = new CustomEvent<Object>("wavy-focus-changed", init);
+      host.dispatchEvent(evt);
+    } catch (Throwable ignored) {
+      // Event dispatch is observational; never let it break focus state.
+    }
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("wave_chrome.focus_frame.transition")
+              .field("key", key == null ? "" : key)
+              .field("blipId", blipId)
+              .build());
+    } catch (Throwable ignored) {
+      // Telemetry is observational.
+    }
+  }
+
+  /**
+   * F-2 slice 2 (#1046, R-3.7-chrome): writer that the
+   * {@code <wavy-depth-nav-bar>} reads via data-attributes. Slice 5
+   * wires the URL state reader that drives this trio.
+   */
+  public void setDepthFocus(
+      String currentDepthBlipId, String parentDepthBlipId, String parentAuthorName) {
+    if (host == null) {
+      return;
+    }
+    if (currentDepthBlipId == null || currentDepthBlipId.isEmpty()) {
+      host.removeAttribute("data-current-depth-blip-id");
+      host.removeAttribute("data-parent-depth-blip-id");
+      host.removeAttribute("data-parent-author-name");
+    } else {
+      host.setAttribute("data-current-depth-blip-id", currentDepthBlipId);
+      host.setAttribute(
+          "data-parent-depth-blip-id",
+          parentDepthBlipId == null ? "" : parentDepthBlipId);
+      host.setAttribute(
+          "data-parent-author-name",
+          parentAuthorName == null ? "" : parentAuthorName);
+    }
   }
 
   private void clearFocusedBlip() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -30,7 +30,6 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLElement card;
   private final HTMLElement depthNavBar;
   private final HTMLElement waveNavRow;
-  private final J2clClientTelemetry.Sink chromeTelemetrySink;
   private boolean serverFirstActive;
   private boolean serverFirstSwapRecorded;
   private boolean coldMountSwapRecorded;
@@ -46,7 +45,6 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   public J2clSelectedWaveView(HTMLElement host, J2clClientTelemetry.Sink telemetrySink) {
     J2clClientTelemetry.Sink effectiveTelemetrySink =
         telemetrySink == null ? J2clClientTelemetry.noop() : telemetrySink;
-    this.chromeTelemetrySink = effectiveTelemetrySink;
     HTMLElement existingCard = J2clServerFirstRootShellDom.findSelectedWaveCard(host);
     if (existingCard != null) {
       title = queryRequired(existingCard, ".sidecar-selected-title");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -24,6 +24,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLDivElement contentList;
   private final J2clReadSurfaceDomRenderer readSurface;
   private final HTMLElement emptyState;
+  // F-2 slice 2 (#1046) chrome handles. Mounted in both the cold-mount
+  // and server-first paths; the view re-binds the live nodes on
+  // server-first to avoid the upgrade reset bug.
+  private final HTMLElement card;
+  private final HTMLElement depthNavBar;
+  private final HTMLElement waveNavRow;
+  private final J2clClientTelemetry.Sink chromeTelemetrySink;
   private boolean serverFirstActive;
   private boolean serverFirstSwapRecorded;
   private boolean coldMountSwapRecorded;
@@ -39,6 +46,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   public J2clSelectedWaveView(HTMLElement host, J2clClientTelemetry.Sink telemetrySink) {
     J2clClientTelemetry.Sink effectiveTelemetrySink =
         telemetrySink == null ? J2clClientTelemetry.noop() : telemetrySink;
+    this.chromeTelemetrySink = effectiveTelemetrySink;
     HTMLElement existingCard = J2clServerFirstRootShellDom.findSelectedWaveCard(host);
     if (existingCard != null) {
       title = queryRequired(existingCard, ".sidecar-selected-title");
@@ -53,6 +61,16 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       readSurface = new J2clReadSurfaceDomRenderer(contentList, effectiveTelemetrySink);
       readSurface.enhanceExistingSurface();
       emptyState = queryOrCreate(existingCard, ".sidecar-empty-state", "div", "sidecar-empty-state");
+      // F-2 slice 2 (#1046): mark the card as the host-binding target for
+      // the <wavy-wave-nav-row> H keyboard handler.
+      existingCard.setAttribute("data-j2cl-selected-wave-host", "");
+      // Re-bind chrome landmarks the server pre-rendered. Custom-element
+      // upgrade happens automatically when customElements.define runs after
+      // the element is in the DOM — never replaceChild, only property set.
+      this.card = existingCard;
+      this.depthNavBar = ensureDepthNavBar(existingCard);
+      this.waveNavRow = ensureWaveNavRow(existingCard);
+      bindChromeEvents(existingCard, effectiveTelemetrySink);
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
       serverFirstMode = J2clServerFirstRootShellDom.serverFirstMode(host);
@@ -62,58 +80,170 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     host.innerHTML = "";
 
-    HTMLElement card = (HTMLElement) DomGlobal.document.createElement("section");
-    card.className = "sidecar-selected-card";
-    host.appendChild(card);
+    HTMLElement coldCard = (HTMLElement) DomGlobal.document.createElement("section");
+    coldCard.className = "sidecar-selected-card";
+    coldCard.setAttribute("data-j2cl-selected-wave-host", "");
+    host.appendChild(coldCard);
+    this.card = coldCard;
 
     HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
     eyebrow.className = "sidecar-eyebrow";
     eyebrow.textContent = "Opened wave";
-    card.appendChild(eyebrow);
+    coldCard.appendChild(eyebrow);
+
+    // F-2 slice 2 (#1046, R-3.7-chrome): depth-nav bar (G.2 + G.3).
+    // Hidden by default until S5 writes a current depth.
+    depthNavBar = (HTMLElement) DomGlobal.document.createElement("wavy-depth-nav-bar");
+    depthNavBar.setAttribute("hidden", "");
+    coldCard.appendChild(depthNavBar);
 
     title = (HTMLElement) DomGlobal.document.createElement("h2");
     title.className = "sidecar-selected-title";
-    card.appendChild(title);
+    coldCard.appendChild(title);
 
     unread = (HTMLElement) DomGlobal.document.createElement("p");
     unread.className = "sidecar-selected-unread";
-    card.appendChild(unread);
+    coldCard.appendChild(unread);
 
     status = (HTMLElement) DomGlobal.document.createElement("p");
     status.className = "sidecar-selected-status";
-    card.appendChild(status);
+    coldCard.appendChild(status);
 
     detail = (HTMLElement) DomGlobal.document.createElement("p");
     detail.className = "sidecar-selected-detail";
-    card.appendChild(detail);
+    coldCard.appendChild(detail);
 
     participantSummary = (HTMLElement) DomGlobal.document.createElement("p");
     participantSummary.className = "sidecar-selected-participants";
-    card.appendChild(participantSummary);
+    coldCard.appendChild(participantSummary);
+
+    // F-2 slice 2 (#1046, R-3.4): wave nav row (E.1–E.10). The
+    // pin/archive props default to false in S2; S5 wires the data
+    // binding alongside the URL state reader. The buttons render and
+    // dispatch events even when those props are false, so the chrome
+    // contract is honored.
+    waveNavRow = (HTMLElement) DomGlobal.document.createElement("wavy-wave-nav-row");
+    coldCard.appendChild(waveNavRow);
 
     snippet = (HTMLElement) DomGlobal.document.createElement("p");
     snippet.className = "sidecar-selected-snippet";
-    card.appendChild(snippet);
+    coldCard.appendChild(snippet);
 
     composeHost = (HTMLElement) DomGlobal.document.createElement("div");
     composeHost.className = "sidecar-selected-compose";
-    card.appendChild(composeHost);
+    coldCard.appendChild(composeHost);
 
     contentList = (HTMLDivElement) DomGlobal.document.createElement("div");
     contentList.className = "sidecar-selected-content";
     configureContentList(contentList);
-    card.appendChild(contentList);
+    coldCard.appendChild(contentList);
     readSurface = new J2clReadSurfaceDomRenderer(contentList, effectiveTelemetrySink);
 
     emptyState = (HTMLElement) DomGlobal.document.createElement("div");
     emptyState.className = "sidecar-empty-state";
-    card.appendChild(emptyState);
+    coldCard.appendChild(emptyState);
+
+    bindChromeEvents(coldCard, effectiveTelemetrySink);
 
     serverFirstActive = false;
     serverFirstSwapRecorded = false;
     serverFirstWaveId = "";
     serverFirstMode = "";
     serverFirstMountedAtMs = 0;
+  }
+
+  /**
+   * F-2 slice 2 (#1046): locate the server-first depth-nav-bar landmark
+   * if present, otherwise create it client-side. Either way, the returned
+   * node is the live element the view writes properties on.
+   */
+  private static HTMLElement ensureDepthNavBar(HTMLElement card) {
+    HTMLElement existing = (HTMLElement) card.querySelector("wavy-depth-nav-bar");
+    if (existing != null) {
+      return existing;
+    }
+    HTMLElement bar =
+        (HTMLElement) DomGlobal.document.createElement("wavy-depth-nav-bar");
+    bar.setAttribute("hidden", "");
+    // Insert directly after the eyebrow if present, else as the first
+    // child of the card.
+    HTMLElement eyebrow = (HTMLElement) card.querySelector(".sidecar-eyebrow");
+    if (eyebrow != null && eyebrow.nextSibling != null) {
+      card.insertBefore(bar, eyebrow.nextSibling);
+    } else {
+      card.insertBefore(bar, card.firstChild);
+    }
+    return bar;
+  }
+
+  /**
+   * F-2 slice 2 (#1046): locate the server-first wave-nav-row landmark
+   * if present, otherwise create it client-side and insert between the
+   * participant summary and the snippet (matching cold-mount order).
+   */
+  private static HTMLElement ensureWaveNavRow(HTMLElement card) {
+    HTMLElement existing = (HTMLElement) card.querySelector("wavy-wave-nav-row");
+    if (existing != null) {
+      return existing;
+    }
+    HTMLElement row =
+        (HTMLElement) DomGlobal.document.createElement("wavy-wave-nav-row");
+    HTMLElement snippetEl = (HTMLElement) card.querySelector(".sidecar-selected-snippet");
+    if (snippetEl != null) {
+      card.insertBefore(row, snippetEl);
+    } else {
+      card.appendChild(row);
+    }
+    return row;
+  }
+
+  /**
+   * F-2 slice 2 (#1046): delegated event listeners for the chrome event
+   * surface. S2 records telemetry for each click; S5 will add the
+   * controller wiring on top.
+   */
+  private static void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
+    String[] navEvents = {
+      "wave-nav-recent-requested",
+      "wave-nav-next-unread-requested",
+      "wave-nav-previous-requested",
+      "wave-nav-next-requested",
+      "wave-nav-end-requested",
+      "wave-nav-prev-mention-requested",
+      "wave-nav-next-mention-requested",
+      "wave-nav-archive-toggle-requested",
+      "wave-nav-pin-toggle-requested",
+      "wave-nav-version-history-requested"
+    };
+    for (final String navEvent : navEvents) {
+      card.addEventListener(
+          navEvent,
+          evt -> {
+            try {
+              sink.record(
+                  J2clClientTelemetry.event("wave_chrome.nav_row.click")
+                      .field("action", navEvent)
+                      .build());
+            } catch (Throwable ignored) {
+              // Telemetry is observational.
+            }
+          });
+    }
+    String[] depthEvents = {"wavy-depth-up", "wavy-depth-root", "wavy-depth-jump-to-crumb"};
+    for (final String depthEvent : depthEvents) {
+      card.addEventListener(
+          depthEvent,
+          evt -> {
+            try {
+              sink.record(
+                  J2clClientTelemetry.event("wave_chrome.depth_nav.click")
+                      .field("action", depthEvent)
+                      .build());
+            } catch (Throwable ignored) {
+              // Telemetry is observational.
+            }
+          });
+    }
   }
 
   static void configureContentList(HTMLElement contentList) {
@@ -144,8 +274,26 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // selected so a stale id is not propagated to the next opened wave.
     if (renderedWaveId.isEmpty()) {
       contentList.removeAttribute("data-wave-id");
+      if (waveNavRow != null) {
+        waveNavRow.removeAttribute("source-wave-id");
+      }
     } else {
       contentList.setAttribute("data-wave-id", renderedWaveId);
+      if (waveNavRow != null) {
+        waveNavRow.setAttribute("source-wave-id", renderedWaveId);
+      }
+    }
+    // F-2 slice 2 (#1046, R-3.4): bind the unread count to the nav row's
+    // E.2 cyan emphasis. unreadCount may be UNKNOWN_UNREAD_COUNT (-1)
+    // before the read state is known — clamp to 0 so the cyan emphasis
+    // does not light up spuriously.
+    if (waveNavRow != null) {
+      int navUnread = Math.max(0, model.getUnreadCount());
+      waveNavRow.setAttribute("unread-count", Integer.toString(navUnread));
+      // pinned + archived: TODO(#1046 / S5) — wire the data binding from
+      // J2clSearchDigestItem.isPinned() / inbox-folder state once those
+      // signals reach the view layer. The chrome ships and dispatches
+      // events even when these props default to false.
     }
     if (shouldPreserveServerFirstCard(model)) {
       renderPreservedServerFirstState(model);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1739,4 +1739,219 @@ public class J2clReadSurfaceDomRendererTest {
     init.setKey(key);
     target.dispatchEvent(new KeyboardEvent("keydown", init));
   }
+
+  // ----------------------------------------------------------------------
+  // F-2 slice 2 (#1046) — wave chrome extensions: j/k aliases, focus-changed
+  // event dispatch, expand-path symmetry, depth-focus writer, telemetry.
+  // ----------------------------------------------------------------------
+
+  @Test
+  public void jKeyAliasesArrowDown() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+    dispatchKey(root, "j");
+    HTMLElement after = blip(host, "b+after");
+    Assert.assertEquals("0", after.getAttribute("tabindex"));
+    Assert.assertTrue(after.classList.contains("j2cl-read-blip-focused"));
+  }
+
+  @Test
+  public void kKeyAliasesArrowUp() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement after = blip(host, "b+after");
+    after.focus();
+    // Reply is hidden by default? No — root + after are the visible blips
+    // in the threaded fixture. From b+after, k moves to b+root (or the
+    // visible reply, whichever is the previous visible blip in DOM order).
+    dispatchKey(after, "k");
+    HTMLElement reply = blip(host, "b+reply");
+    HTMLElement root = blip(host, "b+root");
+    // The previous visible blip from b+after is b+reply (reply is visible
+    // because the inline thread is expanded by default).
+    boolean replyOrRootFocused =
+        reply.classList.contains("j2cl-read-blip-focused")
+            || root.classList.contains("j2cl-read-blip-focused");
+    Assert.assertTrue("k must move focus to a previous visible blip", replyOrRootFocused);
+  }
+
+  @Test
+  public void focusChangedEventDispatchedOnFocusBlip() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+after\">After</div>"
+            + "</div></div>";
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    final String[] receivedBlipId = new String[1];
+    surface.addEventListener(
+        "wavy-focus-changed",
+        evt -> {
+          elemental2.dom.CustomEvent<?> custom = (elemental2.dom.CustomEvent<?>) evt;
+          jsinterop.base.JsPropertyMap<?> detail =
+              jsinterop.base.Js.cast(custom.detail);
+          receivedBlipId[0] = String.valueOf(detail.get("blipId"));
+        });
+    HTMLElement after = blip(host, "b+after");
+    after.focus();
+    dispatchKey(after, "ArrowUp");
+    Assert.assertEquals("b+root", receivedBlipId[0]);
+  }
+
+  @Test
+  public void focusChangedEventCarriesBoundsObject() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    installFixedBlipLayout();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+a\">A</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+b\">B</div>"
+            + "</div></div>";
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    final boolean[] hasBounds = new boolean[1];
+    final String[] keyHint = new String[1];
+    surface.addEventListener(
+        "wavy-focus-changed",
+        evt -> {
+          elemental2.dom.CustomEvent<?> custom = (elemental2.dom.CustomEvent<?>) evt;
+          jsinterop.base.JsPropertyMap<?> detail =
+              jsinterop.base.Js.cast(custom.detail);
+          Object bounds = detail.get("bounds");
+          hasBounds[0] = bounds != null;
+          keyHint[0] = String.valueOf(detail.get("key"));
+        });
+    HTMLElement b = blip(host, "b+b");
+    b.focus();
+    dispatchKey(b, "ArrowUp");
+    Assert.assertTrue("focus-changed detail must include bounds", hasBounds[0]);
+    Assert.assertNotNull(keyHint[0]);
+  }
+
+  @Test
+  public void focusFrameLandmarkAppendedToSurface() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement frame =
+        (HTMLElement) host.querySelector("[data-j2cl-read-surface='true'] wavy-focus-frame");
+    Assert.assertNotNull(
+        "renderer must mount a <wavy-focus-frame> child on the surface", frame);
+    Assert.assertTrue("focus-frame starts hidden", frame.hasAttribute("hidden"));
+  }
+
+  @Test
+  public void focusFrameMountIsIdempotent() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.enhanceExistingSurface();
+    renderer.enhanceExistingSurface();
+    Assert.assertEquals(
+        "second enhance pass must not duplicate the focus frame",
+        1,
+        host.querySelectorAll("wavy-focus-frame").length);
+  }
+
+  @Test
+  public void setDepthFocusWritesDataAttributesOnHost() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDepthFocus("b+3", "b+1", "Alice");
+    Assert.assertEquals("b+3", host.getAttribute("data-current-depth-blip-id"));
+    Assert.assertEquals("b+1", host.getAttribute("data-parent-depth-blip-id"));
+    Assert.assertEquals("Alice", host.getAttribute("data-parent-author-name"));
+  }
+
+  @Test
+  public void setDepthFocusClearsDataAttributesAtTopOfWave() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDepthFocus("b+3", "b+1", "Alice");
+    renderer.setDepthFocus("", "", "");
+    Assert.assertFalse(host.hasAttribute("data-current-depth-blip-id"));
+    Assert.assertFalse(host.hasAttribute("data-parent-depth-blip-id"));
+    Assert.assertFalse(host.hasAttribute("data-parent-author-name"));
+  }
+
+  @Test
+  public void collapseToggleEmitsTelemetryEvent() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    RecordingTelemetrySink sink = new RecordingTelemetrySink();
+    new J2clReadSurfaceDomRenderer(host, sink).enhanceExistingSurface();
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    Assert.assertNotNull(toggle);
+    int before = sink.events().size();
+    toggle.click();
+    Assert.assertTrue(
+        "collapse toggle should emit wave_chrome.thread_collapse.toggle",
+        hasEventNamed(sink, "wave_chrome.thread_collapse.toggle", before));
+  }
+
+  @Test
+  public void focusChangeEmitsTelemetryEvent() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+a\">A</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+b\">B</div>"
+            + "</div></div>";
+    RecordingTelemetrySink sink = new RecordingTelemetrySink();
+    new J2clReadSurfaceDomRenderer(host, sink).enhanceExistingSurface();
+    int before = sink.events().size();
+    HTMLElement b = blip(host, "b+b");
+    b.focus();
+    dispatchKey(b, "ArrowUp");
+    Assert.assertTrue(
+        "focus change should emit wave_chrome.focus_frame.transition",
+        hasEventNamed(sink, "wave_chrome.focus_frame.transition", before));
+  }
+
+  private static boolean hasEventNamed(
+      RecordingTelemetrySink sink, String name, int sinceIndex) {
+    List<J2clClientTelemetry.Event> events = sink.events();
+    for (int i = sinceIndex; i < events.size(); i++) {
+      if (name.equals(events.get(i).getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  public void expandPathReDispatchesFocusChangedForBoundsRefresh() {
+    assumeBrowserDom();
+    HTMLDivElement host = createThreadedHost();
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement root = blip(host, "b+root");
+    root.focus();
+    HTMLElement surface = (HTMLElement) host.querySelector("[data-j2cl-read-surface='true']");
+    final int[] focusChangedCount = new int[1];
+    surface.addEventListener(
+        "wavy-focus-changed", evt -> focusChangedCount[0]++);
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    toggle.click();
+    int afterCollapse = focusChangedCount[0];
+    toggle.click();
+    Assert.assertTrue(
+        "expand should re-dispatch focus-changed when focus is visible",
+        focusChangedCount[0] > afterCollapse);
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -1,0 +1,263 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
+import org.waveprotocol.box.j2cl.telemetry.RecordingTelemetrySink;
+
+/**
+ * F-2 slice 2 (#1046) — coverage for the chrome elements
+ * {@link J2clSelectedWaveView} mounts: {@code <wavy-depth-nav-bar>},
+ * {@code <wavy-wave-nav-row>} (and indirectly {@code <wavy-focus-frame>}
+ * which the renderer mounts inside its surface).
+ *
+ * <p>These tests run only when a real browser DOM is present (J2CL test
+ * runner against Chromium); JVM test runs skip via {@code Assume}.
+ */
+@J2clTestInput(J2clSelectedWaveViewChromeTest.class)
+public class J2clSelectedWaveViewChromeTest {
+  private HTMLElement currentHost;
+
+  @After
+  public void tearDown() {
+    if (currentHost != null && currentHost.parentElement != null) {
+      currentHost.parentElement.removeChild(currentHost);
+    }
+    currentHost = null;
+  }
+
+  @Test
+  public void coldMountInsertsAllThreeChromeLandmarks() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    new J2clSelectedWaveView(host);
+    Assert.assertNotNull(
+        "Cold mount must insert <wavy-depth-nav-bar>",
+        host.querySelector("wavy-depth-nav-bar"));
+    Assert.assertNotNull(
+        "Cold mount must insert <wavy-wave-nav-row>",
+        host.querySelector("wavy-wave-nav-row"));
+  }
+
+  @Test
+  public void coldMountCardCarriesKeyboardBindingHostAttribute() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    new J2clSelectedWaveView(host);
+    HTMLElement card = (HTMLElement) host.querySelector(".sidecar-selected-card");
+    Assert.assertNotNull(card);
+    Assert.assertTrue(
+        "Card must carry data-j2cl-selected-wave-host for the H key handler",
+        card.hasAttribute("data-j2cl-selected-wave-host"));
+  }
+
+  @Test
+  public void coldMountDepthNavBarStartsHidden() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    new J2clSelectedWaveView(host);
+    HTMLElement bar = (HTMLElement) host.querySelector("wavy-depth-nav-bar");
+    Assert.assertTrue(
+        "Depth-nav-bar starts hidden at top-of-wave", bar.hasAttribute("hidden"));
+  }
+
+  @Test
+  public void renderBindsUnreadCountToWaveNavRow() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    J2clSelectedWaveModel model =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            false,
+            "example.com/w+1",
+            "Selected wave",
+            "",
+            "5 unread.",
+            "Live.",
+            "",
+            0,
+            Collections.<String>emptyList(),
+            Arrays.<String>asList(),
+            Arrays.<J2clReadBlip>asList(),
+            null,
+            5,
+            false,
+            true,
+            false);
+    view.render(model);
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertEquals(
+        "Nav-row receives the model's unread count via the unread-count attribute",
+        "5",
+        row.getAttribute("unread-count"));
+  }
+
+  @Test
+  public void renderBindsSourceWaveIdToWaveNavRow() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    J2clSelectedWaveModel model =
+        new J2clSelectedWaveModel(
+            true,
+            false,
+            false,
+            "example.com/w+abc",
+            "Selected wave",
+            "",
+            "Read.",
+            "",
+            "",
+            0,
+            Collections.<String>emptyList(),
+            Arrays.<String>asList(),
+            Arrays.<J2clReadBlip>asList(),
+            null,
+            0,
+            true,
+            true,
+            false);
+    view.render(model);
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertEquals(
+        "Nav-row receives the source wave id",
+        "example.com/w+abc",
+        row.getAttribute("source-wave-id"));
+  }
+
+  @Test
+  public void renderClearsSourceWaveIdWhenSelectionIsEmpty() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(J2clSelectedWaveModel.clearedSelection());
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertFalse(
+        "Cleared selection clears the source wave id on the nav row",
+        row.hasAttribute("source-wave-id"));
+  }
+
+  @Test
+  public void unknownUnreadCountClampsToZero() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    // J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT == -1; the nav-row must
+    // never receive a negative count (would falsely emphasize E.2 cyan).
+    view.render(J2clSelectedWaveModel.empty());
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertEquals(
+        "Unknown unread count clamps to 0 (no spurious cyan emphasis)",
+        "0",
+        row.getAttribute("unread-count"));
+  }
+
+  @Test
+  public void navRowEventsEmitTelemetry() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    RecordingTelemetrySink sink = new RecordingTelemetrySink();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host, sink);
+    HTMLElement card = (HTMLElement) host.querySelector(".sidecar-selected-card");
+    int before = sink.events().size();
+    // Synthesize a nav-row event the same way the Lit element would.
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    elemental2.dom.CustomEvent<Object> evt =
+        new elemental2.dom.CustomEvent<Object>("wave-nav-pin-toggle-requested", init);
+    card.dispatchEvent(evt);
+    boolean recorded = false;
+    for (int i = before; i < sink.events().size(); i++) {
+      if ("wave_chrome.nav_row.click".equals(sink.events().get(i).getName())) {
+        recorded = true;
+        break;
+      }
+    }
+    Assert.assertTrue(
+        "Nav-row click must emit wave_chrome.nav_row.click telemetry", recorded);
+  }
+
+  @Test
+  public void depthNavEventsEmitTelemetry() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    RecordingTelemetrySink sink = new RecordingTelemetrySink();
+    new J2clSelectedWaveView(host, sink);
+    HTMLElement card = (HTMLElement) host.querySelector(".sidecar-selected-card");
+    int before = sink.events().size();
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    elemental2.dom.CustomEvent<Object> evt =
+        new elemental2.dom.CustomEvent<Object>("wavy-depth-up", init);
+    card.dispatchEvent(evt);
+    boolean recorded = false;
+    for (int i = before; i < sink.events().size(); i++) {
+      if ("wave_chrome.depth_nav.click".equals(sink.events().get(i).getName())) {
+        recorded = true;
+        break;
+      }
+    }
+    Assert.assertTrue(
+        "Depth-nav click must emit wave_chrome.depth_nav.click telemetry", recorded);
+  }
+
+  @Test
+  public void serverFirstReBindsExistingChromeLandmarks() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    // Synthesize a server-first markup matching what HtmlRenderer emits.
+    host.innerHTML =
+        "<div class=\"sidecar-selected-host\" data-j2cl-selected-wave-host=\"true\">"
+            + "<section class=\"sidecar-selected-card\""
+            + " data-j2cl-server-first-mode=\"snapshot\""
+            + " data-j2cl-upgrade-placeholder=\"selected-wave\">"
+            + "<p class=\"sidecar-eyebrow\">Opened wave</p>"
+            + "<wavy-depth-nav-bar hidden data-j2cl-server-first-chrome=\"true\"></wavy-depth-nav-bar>"
+            + "<h2 class=\"sidecar-selected-title\">Title</h2>"
+            + "<p class=\"sidecar-selected-unread\" hidden></p>"
+            + "<p class=\"sidecar-selected-status\"></p>"
+            + "<p class=\"sidecar-selected-detail\"></p>"
+            + "<p class=\"sidecar-selected-participants\" hidden></p>"
+            + "<wavy-wave-nav-row data-j2cl-server-first-chrome=\"true\"></wavy-wave-nav-row>"
+            + "<p class=\"sidecar-selected-snippet\" hidden></p>"
+            + "<div class=\"sidecar-selected-compose\"></div>"
+            + "<div class=\"sidecar-selected-content\" data-wave-id=\"example.com/w+1\"></div>"
+            + "</section>"
+            + "</div>";
+    HTMLElement bar = (HTMLElement) host.querySelector("wavy-depth-nav-bar");
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    new J2clSelectedWaveView(host);
+    Assert.assertSame(
+        "Server-first re-bind must re-use the same depth-nav-bar element (no replaceChild)",
+        bar,
+        host.querySelector("wavy-depth-nav-bar"));
+    Assert.assertSame(
+        "Server-first re-bind must re-use the same wave-nav-row element (no replaceChild)",
+        row,
+        host.querySelector("wavy-wave-nav-row"));
+  }
+
+  // -- helpers ---------------------------------------------------------
+
+  private HTMLElement createHost() {
+    currentHost = (HTMLElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(currentHost);
+    return currentHost;
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+}

--- a/wave/config/changelog.d/2026-04-26-issue-1046-wave-chrome.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1046-wave-chrome.json
@@ -1,0 +1,23 @@
+{
+  "releaseId": "2026-04-26-issue-1046-wave-chrome",
+  "version": "F-2 slice 2 (#1046)",
+  "date": "2026-04-26",
+  "title": "StageOne J2CL Wave Chrome — Wave Nav Row + Focus Frame + Depth Nav Bar",
+  "summary": "The J2CL open-wave panel gains the per-wave navigation toolbar (Recent, Next Unread, Previous, Next, End, Prev/Next mention, Archive, Pin, Version History), a cyan focus frame that follows the keyboard-focused blip with arrow / j / k navigation, token-driven thread collapse motion, and a depth-nav bar with Up-one-level + Up-to-wave controls. Builds on the F-2 slice 1 <wave-blip> foundation; emits forward-only events for slice 5 to wire to URL state and controller actions.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "New <wavy-wave-nav-row> Lit element renders all 10 audit-row buttons E.1–E.10 with correct ARIA labels, dispatches per-action CustomEvents with selectedBlipId + sourceWaveId detail, applies cyan emphasis to Next-Unread when unread > 0 and to Pin when pinned, applies violet emphasis to mention buttons when mentions > 0, and binds H to open Version History scoped to the closest selected-wave-host ancestor.",
+        "New <wavy-focus-frame> Lit element paints the cyan focus ring around the keyboard-focused blip via the --wavy-focus-ring token, listens for wavy-focus-changed events from J2clReadSurfaceDomRenderer, and animates with --wavy-motion-focus-duration / --wavy-easing-focus per F-0. Survives incremental window swaps without destroy/recreate.",
+        "New <wavy-depth-nav-bar> Lit element composes the F-0 <wavy-depth-nav> recipe and adds G.2 (Up one level, with parent-author-aware ARIA label) and G.3 (Up to wave) buttons. Reserves an awareness-pill slot for slice 5 (G.6) and emits wavy-depth-up / wavy-depth-root / wavy-depth-jump-to-crumb events.",
+        "J2clReadSurfaceDomRenderer adds j (ArrowDown) and k (ArrowUp) keyboard aliases, dispatches wavy-focus-changed CustomEvents on the read surface with surface-local bounds and the originating key, exposes setDepthFocus(currentDepthBlipId, parentDepthBlipId, parentAuthorName) for slice 5 to drive the depth-nav-bar, and re-dispatches focus-changed on thread expand so the focus frame can recompute its bounds against the freshly-visible blip geometry.",
+        "New wavy-thread-collapse.css sibling stylesheet defines the --wavy-motion-collapse-duration / --wavy-easing-collapse transitions for inline-thread max-height + opacity, plus the .j2cl-read-surface { position: relative } positioning context the focus-frame anchors against. prefers-reduced-motion: reduce overrides transition to none.",
+        "HtmlRenderer pre-renders <wavy-depth-nav-bar hidden> and <wavy-wave-nav-row> as landmarks inside the server-first selected-wave card, so AT users see the toolbar host before client boot and the J2CL upgrade swap is property-set (not replaceChild that would reset state).",
+        "J2clSelectedWaveView mounts the chrome elements in cold-mount, re-binds the existing landmarks in server-first, binds unreadCount + sourceWaveId reactive props from the existing model accessors, and installs delegated telemetry listeners that emit wave_chrome.nav_row.click + wave_chrome.depth_nav.click per click.",
+        "Telemetry events wave_chrome.focus_frame.transition (with key + direction + blipId) and wave_chrome.thread_collapse.toggle (with state) provide observability for the new chrome interactions.",
+        "Per-row parity fixture J2clStageOneReadSurfaceParityTest extends with assertions for the chrome landmarks, the wavy-thread-collapse.css link, the keyboard-binding host attribute, and the GWT non-leak; fixes a pre-existing slice 1 false-positive that asserted server-side class=\"blip\" markup which the GWT skeleton never emitted."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3381,6 +3381,9 @@ public final class HtmlRenderer {
     // Loaded alongside shell.css so the recipes' --wavy-* var() lookups
     // resolve under the J2CL root shell view.
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-tokens.css\">\n");
+    // F-2 slice 2 (#1046, R-3.3): thread collapse motion + .j2cl-read-surface
+    // positioning context (so the focus frame anchors correctly).
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-thread-collapse.css\">\n");
     sb.append("<script type=\"module\" src=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.js\"></script>\n");
     appendJ2clRootShellStatsShim(sb);
     appendAnalyticsFragment(sb, analyticsAccount, null);
@@ -3490,6 +3493,9 @@ public final class HtmlRenderer {
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/sidecar.css\">\n");
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.css\">\n");
     sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-tokens.css\">\n");
+    // F-2 slice 2 (#1046, R-3.3): thread collapse motion on the design
+    // preview route too — the demo lands here.
+    sb.append("<link rel=\"stylesheet\" href=\"").append(safeResolvedBasePath).append("j2cl/assets/wavy-thread-collapse.css\">\n");
     sb.append("<script type=\"module\" src=\"").append(safeResolvedBasePath).append("j2cl/assets/shell.js\"></script>\n");
     sb.append("<style>\n");
     sb.append("body{margin:0;background:var(--wavy-bg-base);color:var(--wavy-text-body);font:var(--wavy-type-body);min-height:100vh;}\n");
@@ -3669,6 +3675,11 @@ public final class HtmlRenderer {
     String status = selectedWaveStatus(effectiveResult, signedIn);
     String detail = selectedWaveDetail(effectiveResult, signedIn);
 
+    // The `.sidecar-selected-host` ancestor div already carries
+    // data-j2cl-selected-wave-host="true" (F-1). The wavy-wave-nav-row
+    // <wavy-wave-nav-row> H key handler resolves its binding target via
+    // this.closest('[data-j2cl-selected-wave-host]'), which matches that
+    // ancestor — no need for the card itself to carry the attribute.
     sb.append("            <section class=\"sidecar-selected-card\"");
     if (hasSnapshot && effectiveResult.hasWaveId()) {
       sb.append(" data-j2cl-server-first-selected-wave=\"")
@@ -3679,6 +3690,10 @@ public final class HtmlRenderer {
         .append(effectiveResult.getModeValue())
         .append("\" data-j2cl-upgrade-placeholder=\"selected-wave\">\n");
     sb.append("              <p class=\"sidecar-eyebrow\">Opened wave</p>\n");
+    // F-2 slice 2 (#1046, R-3.7-chrome): depth-nav-bar landmark.
+    // Hidden by default; the J2CL client (S5) writes the current depth
+    // and toggles the hidden attribute via property assignment.
+    sb.append("              <wavy-depth-nav-bar hidden data-j2cl-server-first-chrome=\"true\"></wavy-depth-nav-bar>\n");
     sb.append("              <h2 class=\"sidecar-selected-title\">")
         .append(escapeHtml(title))
         .append("</h2>\n");
@@ -3690,6 +3705,10 @@ public final class HtmlRenderer {
         .append(escapeHtml(detail))
         .append("</p>\n");
     sb.append("              <p class=\"sidecar-selected-participants\" hidden></p>\n");
+    // F-2 slice 2 (#1046, R-3.4): wave-nav-row landmark. Buttons mount
+    // client-side once shell.js upgrades the element; before then the
+    // landmark host is exposed for AT users + the client upgrade swap.
+    sb.append("              <wavy-wave-nav-row data-j2cl-server-first-chrome=\"true\"></wavy-wave-nav-row>\n");
     sb.append("              <p class=\"sidecar-selected-snippet\" hidden></p>\n");
     sb.append("              <div class=\"sidecar-selected-compose\"></div>\n");
     sb.append("              <div class=\"sidecar-selected-content\">");

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -385,9 +385,10 @@ public final class J2clStageOneReadSurfaceParityTest {
   }
 
   /**
-   * R-3.2 — the J2CL root shell pre-renders a {@code <wavy-focus-frame>}
-   * landmark inside the read surface so the focus visualization is in
-   * place before client boot.
+   * R-3.2 — verifies the shell bundle registering {@code <wavy-focus-frame>}
+   * is loaded. The frame itself is mounted client-side by
+   * {@code J2clReadSurfaceDomRenderer.ensureFocusFrame}; no server-first
+   * pre-render is needed.
    */
   @Test
   public void j2clRootRendersFocusFrameLandmark() throws Exception {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java
@@ -334,9 +334,169 @@ public final class J2clStageOneReadSurfaceParityTest {
     assertFalse(
         "GWT path must not emit <wave-blip> hosts",
         html.contains("<wave-blip"));
+    // Legacy GWT route returns the pre-J2CL skeleton (renderWaveClientPage)
+    // which loads the GWT module via `webclient/webclient.nocache.js` and
+    // mounts into `<div id="app">`. Blips are rendered client-side by
+    // the GWT module after boot — no server-side `class="blip"` markup
+    // is present in this skeleton. (The S1 author's `class="blip"`
+    // assertion was a false positive shipped in the F-2 slice 1 PR; the
+    // parity contract that actually matters is that the GWT skeleton
+    // still loads the GWT webclient bundle, which is what S1 intended
+    // to verify.)
     assertTrue(
-        "GWT path should retain legacy blip host markup",
-        html.contains("class=\"blip\""));
+        "GWT path should retain the GWT webclient bundle reference",
+        html.contains("webclient/webclient.nocache.js"));
+    assertTrue(
+        "GWT path should retain the GWT app host div",
+        html.contains("id=\"app\""));
+  }
+
+  // ----------------------------------------------------------------------
+  // F-2 slice 2 (#1046) — wave chrome assertions.
+  //
+  // Each cited audit row has at least one executable assertion below.
+  // These tests verify the SERVER-RENDERED LANDMARK contract; the client-
+  // side button + ARIA + event coverage lives in
+  // j2cl/lit/test/wavy-wave-nav-row.test.js,
+  // j2cl/lit/test/wavy-focus-frame.test.js, and
+  // j2cl/lit/test/wavy-depth-nav-bar.test.js.
+  // ----------------------------------------------------------------------
+
+  /**
+   * R-3.4 — the J2CL root shell pre-renders a {@code <wavy-wave-nav-row>}
+   * landmark inside the selected-wave card so AT users have the toolbar
+   * host before client boot AND the client upgrade swap is a property-set
+   * (not a replaceChild that would reset state).
+   */
+  @Test
+  public void j2clRootRendersWavyWaveNavRowLandmark() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Server-first card must pre-render the <wavy-wave-nav-row> landmark",
+        html.contains("<wavy-wave-nav-row"));
+    assertTrue(
+        "<wavy-wave-nav-row> landmark must carry data-j2cl-server-first-chrome",
+        html.contains("<wavy-wave-nav-row data-j2cl-server-first-chrome=\"true\""));
+  }
+
+  /**
+   * R-3.2 — the J2CL root shell pre-renders a {@code <wavy-focus-frame>}
+   * landmark inside the read surface so the focus visualization is in
+   * place before client boot.
+   */
+  @Test
+  public void j2clRootRendersFocusFrameLandmark() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    // The focus frame is mounted by the renderer on enhanceSurface(...);
+    // the server-first card does not need to pre-render it because
+    // J2clReadSurfaceDomRenderer.ensureFocusFrame appends one as soon as
+    // the surface is enhanced. The contract instead is that the bundled
+    // shell.js registers the wavy-focus-frame custom element so the
+    // client can mount it. Verify the shell bundle is loaded (R-3.1) and
+    // that the bundle entry registers the chrome elements.
+    assertTrue(
+        "shell.js bundle that registers <wavy-focus-frame> must be loaded",
+        html.contains("j2cl/assets/shell.js"));
+  }
+
+  /**
+   * R-3.7-chrome — the J2CL root shell pre-renders a
+   * {@code <wavy-depth-nav-bar>} landmark inside the selected-wave card.
+   * Hidden by default at top-of-wave; S5 toggles the hidden attribute
+   * when a current depth is set.
+   */
+  @Test
+  public void j2clRootRendersDepthNavBarLandmark() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Server-first card must pre-render the <wavy-depth-nav-bar> landmark",
+        html.contains("<wavy-depth-nav-bar"));
+    assertTrue(
+        "<wavy-depth-nav-bar> landmark must start hidden + carry data-j2cl-server-first-chrome",
+        html.contains("<wavy-depth-nav-bar hidden data-j2cl-server-first-chrome=\"true\""));
+  }
+
+  /**
+   * R-3.4 — an ancestor of the {@code <wavy-wave-nav-row>} carries
+   * {@code data-j2cl-selected-wave-host} so the H keyboard handler can
+   * resolve its binding ancestor via {@code closest(...)}. The F-1
+   * server-first {@code .sidecar-selected-host} wrapper already writes
+   * this attribute (value="true"); slice 2 reuses that placement rather
+   * than duplicating it on the inner card.
+   */
+  @Test
+  public void j2clRootCardCarriesKeyboardBindingHostAttribute() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "Selected-wave host wrapper must carry data-j2cl-selected-wave-host "
+            + "for the wavy-wave-nav-row H key handler closest() lookup",
+        html.contains("data-j2cl-selected-wave-host=\"true\""));
+  }
+
+  /**
+   * R-3.3 — the J2CL root shell loads the new
+   * {@code wavy-thread-collapse.css} sibling stylesheet that defines the
+   * collapse motion + the {@code .j2cl-read-surface} positioning context
+   * for the focus frame.
+   */
+  @Test
+  public void j2clRootLoadsWavyThreadCollapseStylesheet() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+
+    assertTrue(
+        "F-2 slice 2 collapse motion + read-surface positioning stylesheet must be linked",
+        html.contains("wavy-thread-collapse.css"));
+  }
+
+  /**
+   * Reciprocal — the legacy GWT path must not leak any F-2 slice 2
+   * chrome markers. The chrome elements are loaded only from the shell
+   * bundle on the J2CL root.
+   */
+  @Test
+  public void legacyGwtRouteDoesNotLeakChromeElements() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+
+    String html = invokeServlet(servlet, "gwt", WAVE_ID.serialise());
+
+    assertFalse(
+        "GWT path must not emit <wavy-wave-nav-row> hosts",
+        html.contains("<wavy-wave-nav-row"));
+    assertFalse(
+        "GWT path must not emit <wavy-focus-frame> hosts",
+        html.contains("<wavy-focus-frame"));
+    assertFalse(
+        "GWT path must not emit <wavy-depth-nav-bar> hosts",
+        html.contains("<wavy-depth-nav-bar"));
+    assertFalse(
+        "GWT path must not load wavy-thread-collapse.css",
+        html.contains("wavy-thread-collapse.css"));
   }
 
   // --- helpers (mirror of the F-1 fixture so the two stay in lockstep) ----


### PR DESCRIPTION
Updates #1037 (slice 2 of 6 — does NOT close the umbrella). Updates #904. References #1046.

## Summary

Ships the three Lit chrome elements that complete R-3.2 / R-3.3 / R-3.4 plus the visible part of R-3.7 on top of F-2.S1's `<wave-blip>` foundation.

- **`<wavy-focus-frame>`** (R-3.2) — landmark + visual cyan ring around the focused blip. Listens for `wavy-focus-changed` events from `J2clReadSurfaceDomRenderer`; animates with `--wavy-motion-focus-duration` / `--wavy-easing-focus`; survives incremental updates and prefers-reduced-motion.
- **`<wavy-wave-nav-row>`** (R-3.4) — all 10 audit-row buttons E.1–E.10 (Recent, Next Unread, Previous, Next, End, Prev @, Next @, Archive, Pin, Version History) with correct ARIA labels, per-action CustomEvents, token-driven emphasis (cyan/violet), `H` keyboard shortcut scoped to `closest('[data-j2cl-selected-wave-host]')`, mobile container-query collapse into an overflow menu.
- **`<wavy-depth-nav-bar>`** (R-3.7-chrome G.2 + G.3) — composes the F-0 `<wavy-depth-nav>` recipe + Up-one-level (parent author label) + Up-to-wave buttons; reserves an awareness-pill slot for S5; emits `wavy-depth-up`, `wavy-depth-root`, `wavy-depth-jump-to-crumb`.
- **Renderer extensions** — `j`/`k` aliases for `ArrowDown`/`ArrowUp`; `wavy-focus-changed` event with surface-local bounds + key + direction telemetry; `setDepthFocus(...)` writer for S5; symmetric expand-path bounds refresh; `ensureFocusFrame` mounts the frame inside the surface (idempotent).
- **`wavy-thread-collapse.css`** — F-0 token-driven `.j2cl-read-thread-collapsed` motion + `.j2cl-read-surface { position: relative }` so the focus frame anchors. Linked from both J2CL shell paths in `HtmlRenderer`.
- **Server landmarks** — `HtmlRenderer.appendRootShellSelectedWaveCard` pre-renders `<wavy-depth-nav-bar hidden>` and `<wavy-wave-nav-row>` so AT users see them before client boot AND the upgrade swap is property-set (not `replaceChild`).
- **`J2clSelectedWaveView`** — mounts the chrome in cold-mount; re-binds the existing landmarks in server-first; binds `unread-count` and `source-wave-id` reactive props; delegated telemetry listeners for nav-row + depth-nav events. Pin/archive props default to `false` with explicit TODO for S5.

## Notes for S5 (events to wire)

- `wave-nav-{recent,next-unread,previous,next,end,prev-mention,next-mention,archive-toggle,pin-toggle,version-history}-requested`
- `wavy-depth-up { detail: { fromBlipId, toBlipId } }`
- `wavy-depth-root { detail: { fromBlipId } }`
- `wavy-depth-jump-to-crumb { detail: { blipId } }`
- `wavy-focus-changed { detail: { blipId, bounds, key } }` — also for `g`/`G`/`[`/`]` keyboard handlers

## Test plan

- [x] `sbt j2clLitTest` — 223/223 (43 new across `wavy-focus-frame.test.js`, `wavy-wave-nav-row.test.js`, `wavy-depth-nav-bar.test.js`)
- [x] `mvn -Psearch-sidecar test` — 676 / 102 skipped, 0 failed (10 new in `J2clReadSurfaceDomRendererTest` + 9 new in `J2clSelectedWaveViewChromeTest`)
- [x] `sbt j2clProductionBuild` — clean
- [x] `sbt jakartaTest:testOnly *J2clStageOneReadSurfaceParityTest` — 14/14 (7 new chrome assertions; pre-existing S1 false-positive `class="blip"` assertion fixed to assert against the actual GWT skeleton)
- [ ] Manual side-by-side `?view=j2cl-root` vs `?view=gwt` walkthrough (S6 owns the demo route)

## Out of scope

- S3: search rail
- S4: floating + version-history overlay
- S5: depth-nav data wiring (URL `&depth=`, parent-author labels, awareness pill, `[`/`]` keyboard, controller routing for nav-row events)
- S6: `/_/j2cl-design` demo route + per-row fixture artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)