### PR TITLE
F-2 (slice 5): View wiring + URL state + read state + integration cleanup

### DIFF
--- a/docs/superpowers/plans/2026-04-26-issue-1055-view-wiring.md
+++ b/docs/superpowers/plans/2026-04-26-issue-1055-view-wiring.md
@@ -1,0 +1,186 @@
+# F-2 (slice 5) — view wiring + integration cleanup (issue #1055)
+
+Date: 2026-04-26
+Branch: claude/hungry-albattani-103e9a
+
+This plan executes F-2 slice 5 in two parts. Part A is the user-visible
+duplicate-removal pass. Part B is URL state, depth-nav wiring, keyboard
+plumbing, focus-trap, and pin/archive prop binding.
+
+## Part A — Integration cleanup (blocking, non-deferrable)
+
+### A.1 Remove the legacy "Hosted workflow" intro card content
+
+`HtmlRenderer.appendRootShellWorkflowMarkup` currently emits a centered
+`<div class="sidecar-search-card">` that contains:
+- a `<p class="sidecar-eyebrow">J2CL root shell</p>` eyebrow
+- `<h1 class="sidecar-title">Hosted workflow</h1>` headline
+- a `<p class="sidecar-detail">` with the long workflow description
+- `<form class="sidecar-search-toolbar">` with `<input class="sidecar-search-input">` + `<button class="sidecar-search-submit">`
+
+`J2clSearchPanelView` adopts this card via `queryRequired(card, ".sidecar-search-toolbar")`
++ several other selectors, so we can NOT delete the wrapper without breaking
+the search panel adoption path. Plan:
+
+- Drop the eyebrow, title, and detail entirely from the SSR emit (they were
+  pure decoration; no client code reads them).
+- Keep the `<div class="sidecar-search-card">` wrapper itself.
+- Keep the `<form class="sidecar-search-toolbar">` AND inputs but flag the
+  whole legacy form/eyebrow as `data-j2cl-legacy-search-form="true"` and
+  apply CSS `display:none` so the visible chrome is gone — `<wavy-search-rail>`
+  is the canonical surface. `J2clSearchPanelView` still finds the elements
+  via querySelector and binds `onsubmit`; the search query is fed via the
+  rail and forwarded to `setQuery()` so callers see the same outcome.
+- Hide the legacy `<p class="sidecar-search-session">` and `<p class="sidecar-search-status">`
+  text bodies (kept in DOM, hidden by CSS on the wrapper so element queries
+  still resolve). The status surface migrates to inline messages on the rail
+  in a future slice; today the status updates are observational.
+
+### A.2 Replace "Select a wave" placeholder with wavy empty-state
+
+`appendRootShellSelectedWaveCard` currently emits a `<div class="sidecar-empty-state">`
+with the text "Select a wave to open it here." plus the eyebrow "Opened wave"
+and an `<h2>Select a wave</h2>` placeholder.
+
+Plan:
+- Wrap the empty-state content in a wavy empty-state recipe: centered ghost
+  waveform mark (re-use the SVG glyph from the search rail at 64px), an
+  `<h3 class="wavy-empty-state-headline">Open a wave to read</h3>` headline,
+  and the placeholder text moves into a `<p class="wavy-empty-state-subhead">`.
+- Quick-pick chips are a stretch goal — defer to a follow-up if budget runs
+  out.
+- Keep `<div class="sidecar-empty-state">` as the outer wrapper so existing
+  view code (`emptyState.hidden = ...`) continues to work; only restructure
+  the inside.
+- The headline text and CSS class names must round-trip through
+  `J2clSelectedWaveViewChromeTest`.
+
+### A.3 Suppress legacy editor-toolbar wall when no compose active
+
+`J2clToolbarSurfaceController.render()` always calls `addViewActions` and
+emits Recent / Next-unread / Previous / Next / Last / Previous-mention /
+Next-mention / Archive|Inbox / Pin|Unpin / History — these duplicate the
+brand-new `<wavy-wave-nav-row>` (E.1–E.10). When `editState.editable=false`,
+no edit actions render but the view actions still wall the bottom of the
+shell.
+
+Plan: introduce an `enableViewActions` flag on `J2clToolbarSurfaceController`
+(default `true` to preserve sidecar-mode behaviour). The root shell turns it
+off via the controller wiring in `J2clRootShellController` so view actions
+are drained from the legacy toolbar wall — `<wavy-wave-nav-row>` is the
+canonical view chrome.
+
+The host stays mounted (and visible) ONLY when there are edit actions to
+render (i.e. `editState.editable=true` AND `selectedWaveState.selectedWavePresent=true`).
+That collapses the wall entirely until the user is composing.
+
+### A.4 Fix `<wavy-search-rail>` waveform glyph sizing
+
+Pre-upgrade, `<wavy-search-rail>` is a slot-less custom element. The Lit
+`:host { display: block }` rule lives in the shadow DOM, which does not
+attach until `customElements.define` runs. The SSR-emitted SVG inside the
+slot is `<svg viewBox="0 0 14 14" ...>` without explicit `width`/`height`
+attributes; SVG defaults to `300 × 150` per CSS-SVG spec, so it overflows.
+
+Plan:
+- Add explicit `width="14" height="14"` attributes to the SVG element in
+  `appendWavySearchRail` (HtmlRenderer line 3740).
+- Add the same explicit width/height to the Lit element render to belt-and-
+  suspenders post-upgrade.
+- Add a defensive global CSS rule (in `wavy-thread-collapse.css` since it
+  already loads) clamping any svg directly inside `wavy-search-rail .waveform`
+  to `width:14px; height:14px`. Pre-upgrade clamp.
+
+### A.5 Mount the new chrome as canonical surface in `J2clSelectedWaveView`
+
+S2 already wires `<wavy-depth-nav-bar>` and `<wavy-wave-nav-row>` into the
+selected-wave card. S5 makes them load-bearing by:
+- driving `currentDepthBlipId` / `parentDepthBlipId` / `parentAuthorName`
+  from the read surface's `data-current-depth-blip-id` attributes (already
+  written by `setDepthFocus`).
+- toggling the `hidden` attribute on `<wavy-depth-nav-bar>` based on
+  whether `currentDepthBlipId` is non-empty.
+
+### A.6 New parity test `J2clRootShellIntegrationTest`
+
+Asserts (signed-in route):
+- exactly one `<wavy-search-rail>` element in the rendered HTML
+- exactly one `<wavy-wave-nav-row>` element
+- exactly one `<wavy-depth-nav-bar>` element
+- no `Hosted workflow` literal in the body
+- no `<h1 class="sidecar-title">` literal anywhere
+- no `<p class="sidecar-eyebrow">J2CL root shell</p>`
+- the legacy form is marked `data-j2cl-legacy-search-form="true"`
+- the SVG inside `<wavy-search-rail>` has explicit width="14" height="14"
+- the wavy empty-state recipe markup is present:
+  `class="wavy-empty-state-mark"` + `class="wavy-empty-state-headline"`
+- `j2cl-root-toolbar-host` carries `hidden` initially OR is wrapped in a
+  `display:none` container
+
+## Part B — View wiring
+
+### B.1 URL `&depth=<blip-id>`
+
+Extend `J2clSidecarRouteState` with a third field `depthBlipId`. Update
+`J2clSidecarRouteCodec.parse`/`toUrl` to round-trip it. `J2clSelectedWaveView`
+exposes a `setDepthBlipId(...)` setter that calls `setDepthFocus` on the
+read surface. The route controller pushes the depth on user drill events
+(see B.3 below).
+
+### B.2 Pin/archive nav-row props (S2 deferral)
+
+`J2clSelectedWaveController` already receives `J2clSearchDigestItem` on
+`onWaveSelected(waveId, digestItem)`. Plumb `digestItem.isPinned()` through
+to the nav-row's `pinned` attribute. The `archived` attribute defaults to
+the search query containing `in:archive` until F-4 wires the live folder
+state.
+
+### B.3 Keyboard `[` / `]` drill-out / drill-in
+
+The read surface already owns the keymap. Extend
+`J2clReadSurfaceDomRenderer.handleKeyDown` to dispatch:
+- `[` -> `wavy-depth-up` event (G.2 — drill out)
+- `]` -> drill into the focused blip's reply subthread (emit a custom
+  `wavy-depth-drill-in` event with `{ blipId: focusedBlip.dataset.blipId }`)
+
+The view listens for both events on the card and updates the URL state +
+`<wavy-depth-nav-bar>` props.
+
+### B.4 R-3.7 G.6 awareness pill
+
+When a reply lands inside the currently-focused subthread's ancestor chain,
+surface a "↑ N new replies above" pill. Implementation: J2clSelectedWaveView
+adds an `<output class="wavy-awareness-pill" hidden>` element to the
+card, and the view's `render(...)` updates its text from
+`model.getViewportState().getReadWindowEntries()` deltas. Defer the live
+pulse animation to `--wavy-pulse-ring` token usage.
+
+### B.5 Focus-trap + `inert` for `<wavy-version-history>` and `<wavy-profile-overlay>`
+
+S4 ships these floating overlays already. S5 closes the focus-trap deferral:
+each overlay must:
+- on open, set `inert` on every sibling under `<body>`
+- on open, focus the first focusable child
+- on close, restore focus to the previously-focused element and remove
+  `inert` from siblings
+
+### B.6 `markBlipRead` Gateway extension — DEFERRED
+
+R-4.4 (mark-blip-read debounce + supplement op gateway) is the heaviest
+piece. Per token-budget guidance, file a follow-up issue and explicitly
+defer R-4.4 carrying `j2cl.read.mark_blip_read` telemetry counter. The
+deferred pieces:
+- Server: `MarkBlipReadServlet` (POST /j2cl/mark-blip-read) that emits
+  the supplement op via `SelectedWaveReadStateHelper`.
+- Client: IntersectionObserver-equivalent in `J2clReadSurfaceDomRenderer`.
+- Decrement of unread badge via supplement subscription.
+
+Follow-up issue link will be added to the PR body.
+
+## Verification gate
+
+```
+sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild \
+  jakartaTest:testOnly *J2clRootShellIntegrationTest *J2clStageOneReadSurfaceParityTest
+```
+must exit 0.

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -119,7 +119,6 @@ wavy-search-rail .waveform > svg {
   color: var(--wavy-signal-cyan, #22d3ee);
   font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
   font-weight: 600;
-  cursor: pointer;
   box-shadow: var(--wavy-pulse-ring, 0 0 0 0 rgba(34, 211, 238, 0));
 }
 

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -39,3 +39,90 @@
     transition: none;
   }
 }
+
+/* F-2 slice 5 (#1055, A.4) — defensive pre-upgrade clamp. The
+ * <wavy-search-rail>'s :host { display:block } rule lives in shadow DOM
+ * and only attaches after customElements.define runs; before then the
+ * SSR-emitted <svg> inside .waveform overflows to its 300x150 default.
+ * This global rule clamps every direct SVG child of .waveform inside
+ * <wavy-search-rail>'s light DOM to the icon size used by the rail. */
+wavy-search-rail .waveform svg,
+wavy-search-rail .waveform > svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* F-2 slice 5 (#1055, A.1) — hide the legacy "Hosted workflow" search
+ * card (now superseded by <wavy-search-rail> in the nav slot). The card
+ * wrapper stays in the DOM so J2clSearchPanelView can adopt the inputs
+ * + digest list, but its visible chrome collapses. The nested digests
+ * + empty-state list opt back in below. */
+.sidecar-search-card[data-j2cl-legacy-search-card="hidden"] {
+  display: contents;
+}
+
+.sidecar-search-card[data-j2cl-legacy-search-card="hidden"]
+  > [data-j2cl-legacy-search-form="true"] {
+  display: none;
+}
+
+/* F-2 slice 5 (#1055, A.2) — wavy empty-state recipe styling. Matches
+ * the design-tokens used by the rest of the F-2 chrome. */
+.wavy-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--wavy-spacing-3, 12px);
+  padding: var(--wavy-spacing-6, 24px);
+  text-align: center;
+  color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+}
+
+.wavy-empty-state-mark {
+  display: inline-flex;
+  width: 64px;
+  height: 64px;
+  color: var(--wavy-text-muted, rgba(232, 240, 255, 0.4));
+}
+
+.wavy-empty-state-mark svg {
+  width: 100%;
+  height: 100%;
+}
+
+.wavy-empty-state-headline {
+  margin: 0;
+  font: var(--wavy-type-h3, 1rem / 1.4 sans-serif);
+  font-weight: 600;
+  color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+}
+
+.wavy-empty-state-subhead {
+  margin: 0;
+  max-width: 36ch;
+  font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+}
+
+/* F-2 slice 5 (#1055, R-3.7 G.6) — live-update awareness pill. Shown
+ * when ancestor-thread replies arrive while the user is focused below.
+ * Animates the F-0 --wavy-pulse-ring token. */
+.wavy-awareness-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--wavy-spacing-2, 8px);
+  margin: var(--wavy-spacing-2, 8px) 0 0;
+  padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-3, 12px);
+  border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+  border-radius: var(--wavy-radius-pill, 9999px);
+  background: var(--wavy-bg-surface, rgba(34, 211, 238, 0.08));
+  color: var(--wavy-signal-cyan, #22d3ee);
+  font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--wavy-pulse-ring, 0 0 0 0 rgba(34, 211, 238, 0));
+}
+
+.wavy-awareness-pill[hidden] {
+  display: none;
+}

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -208,6 +208,26 @@ export class WavyProfileOverlay extends LitElement {
       // host's keydown handler. tabindex=-1 keeps it out of the tab
       // sequence — focus is moved here explicitly on open.
       this.setAttribute("tabindex", "-1");
+      // F-2 slice 5 (#1055, S4 deferral): focus-trap + inert on
+      // siblings — modal semantics. Save the previously focused element
+      // and inert every <body> direct child except this host.
+      this._previouslyFocusedElement =
+        (this.ownerDocument && this.ownerDocument.activeElement) || null;
+      this._inertedSiblings = [];
+      try {
+        const body = this.ownerDocument && this.ownerDocument.body;
+        if (body) {
+          for (const child of Array.from(body.children)) {
+            if (child === this) continue;
+            if (child.hasAttribute && !child.hasAttribute("inert")) {
+              child.setAttribute("inert", "");
+              this._inertedSiblings.push(child);
+            }
+          }
+        }
+      } catch (_e) {
+        // inert support is observational; never block open.
+      }
       // Move focus to the host on the next microtask so the browser
       // has finished reflecting the hidden→visible flip.
       Promise.resolve().then(() => {
@@ -220,6 +240,20 @@ export class WavyProfileOverlay extends LitElement {
       this.setAttribute("aria-hidden", "true");
       this.removeAttribute("tabindex");
       this.removeAttribute("aria-label");
+      // F-2 slice 5 (#1055, S4 deferral): restore focus + un-inert siblings.
+      if (Array.isArray(this._inertedSiblings)) {
+        for (const sibling of this._inertedSiblings) {
+          try { sibling.removeAttribute("inert"); } catch (_e) {}
+        }
+        this._inertedSiblings = [];
+      }
+      const previouslyFocused = this._previouslyFocusedElement;
+      this._previouslyFocusedElement = null;
+      if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+        try { previouslyFocused.focus({ preventScroll: true }); } catch (_e) {
+          try { previouslyFocused.focus(); } catch (_err) {}
+        }
+      }
     }
   }
 

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -285,7 +285,10 @@ export class WavySearchRail extends LitElement {
     return html`
       <div class="search">
         <span class="waveform" aria-hidden="true">
-          <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6">
+          <!-- F-2 slice 5 (#1055): explicit width/height on the SVG so
+               the glyph never overflows even if shadow DOM has not yet
+               attached (e.g. server-rendered light-DOM fallback). -->
+          <svg viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6">
             <path d="M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </span>

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -241,6 +241,26 @@ export class WavyVersionHistory extends LitElement {
       // tabindex=-1 keeps it out of the tab sequence — focus is moved
       // here explicitly on open.
       this.setAttribute("tabindex", "-1");
+      // F-2 slice 5 (#1055, S4 deferral): focus-trap + inert on siblings
+      // so the overlay reads as a true modal. Save the previously
+      // focused element and inert every <body> child except this host.
+      this._previouslyFocusedElement =
+        (this.ownerDocument && this.ownerDocument.activeElement) || null;
+      this._inertedSiblings = [];
+      try {
+        const body = this.ownerDocument && this.ownerDocument.body;
+        if (body) {
+          for (const child of Array.from(body.children)) {
+            if (child === this) continue;
+            if (child.hasAttribute && !child.hasAttribute("inert")) {
+              child.setAttribute("inert", "");
+              this._inertedSiblings.push(child);
+            }
+          }
+        }
+      } catch (_e) {
+        // inert support is observational; never block open.
+      }
       Promise.resolve().then(() => {
         if (this.open && typeof this.focus === "function") {
           try { this.focus({ preventScroll: true }); } catch (_e) { this.focus(); }
@@ -250,6 +270,21 @@ export class WavyVersionHistory extends LitElement {
       this.setAttribute("hidden", "");
       this.setAttribute("aria-hidden", "true");
       this.removeAttribute("tabindex");
+      // F-2 slice 5 (#1055, S4 deferral): restore focus + un-inert
+      // siblings on close.
+      if (Array.isArray(this._inertedSiblings)) {
+        for (const sibling of this._inertedSiblings) {
+          try { sibling.removeAttribute("inert"); } catch (_e) {}
+        }
+        this._inertedSiblings = [];
+      }
+      const previouslyFocused = this._previouslyFocusedElement;
+      this._previouslyFocusedElement = null;
+      if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+        try { previouslyFocused.focus({ preventScroll: true }); } catch (_e) {
+          try { previouslyFocused.focus(); } catch (_err) {}
+        }
+      }
       // If the inline confirm <dialog> was left open (e.g. user clicked
       // Restore then closed the overlay via Exit/backdrop), close it
       // alongside the overlay so reopening does not show a stale modal.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -757,21 +757,99 @@ public final class J2clReadSurfaceDomRenderer {
     }
     String key = keyEvent.key;
     // F-2 slice 2 (#1046, R-3.2): j/k aliases for ArrowDown/ArrowUp.
+    // F-2 slice 5 (#1055, R-3.7 G.5): [ / ] drill out / drill in,
+    //                                  g / G jump to first / last blip.
     // Documented as Wavy-specific aliases; intentionally NOT announced via
-    // aria-keyshortcuts to avoid screen-reader collisions with global
-    // shortcuts (g/G, [/] are deferred to slice 5).
+    // aria-keyshortcuts to avoid screen-reader collisions with the
+    // browser's built-in shortcuts.
     if ("ArrowDown".equals(key) || "j".equals(key)) {
       focusByOffset(1, key);
       keyEvent.preventDefault();
     } else if ("ArrowUp".equals(key) || "k".equals(key)) {
       focusByOffset(-1, key);
       keyEvent.preventDefault();
-    } else if ("Home".equals(key)) {
+    } else if ("Home".equals(key) || "g".equals(key)) {
       focusByIndex(0, key);
       keyEvent.preventDefault();
-    } else if ("End".equals(key)) {
+    } else if ("End".equals(key) || "G".equals(key)) {
       focusByIndex(renderedBlips.size() - 1, key);
       keyEvent.preventDefault();
+    } else if ("[".equals(key)) {
+      // Drill out one depth level (G.2). The depth-nav-bar listens for
+      // wavy-depth-up on the card and pushes the URL change.
+      dispatchDepthEvent("wavy-depth-up");
+      keyEvent.preventDefault();
+    } else if ("]".equals(key)) {
+      // Drill into the focused blip's subthread (G.1). Emits a custom
+      // wavy-depth-drill-in event with the focused blip id.
+      String focusedBlipId = focusedBlip == null ? null : focusedBlip.getAttribute("data-blip-id");
+      if (focusedBlipId != null && !focusedBlipId.isEmpty()) {
+        dispatchDepthDrillInEvent(focusedBlipId);
+      }
+      keyEvent.preventDefault();
+    }
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.5): dispatch a depth-nav event on the
+   * read surface host so the selected-wave card listener (registered in
+   * J2clSelectedWaveView) can update the URL state and toggle the
+   * {@code <wavy-depth-nav-bar>} hidden attribute.
+   */
+  private void dispatchDepthEvent(String eventName) {
+    HTMLElement target = renderedSurface != null ? renderedSurface : host;
+    if (target == null || eventName == null || eventName.isEmpty()) {
+      return;
+    }
+    try {
+      CustomEventInit<Object> init = CustomEventInit.create();
+      init.setBubbles(true);
+      init.setComposed(true);
+      target.dispatchEvent(new CustomEvent<Object>(eventName, init));
+    } catch (Throwable ignored) {
+      // Event dispatch is observational.
+    }
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("j2cl.depth.drill_in")
+              .field("direction", "out")
+              .field("source", "keyboard")
+              .build());
+    } catch (Throwable ignored) {
+      // Telemetry is observational.
+    }
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.1): dispatch a drill-in event with the
+   * focused blip id so the view can push the depth state into the URL
+   * and update the depth-nav-bar.
+   */
+  private void dispatchDepthDrillInEvent(String blipId) {
+    HTMLElement target = renderedSurface != null ? renderedSurface : host;
+    if (target == null || blipId == null || blipId.isEmpty()) {
+      return;
+    }
+    try {
+      JsPropertyMap<Object> detail = JsPropertyMap.of();
+      detail.set("blipId", blipId);
+      CustomEventInit<Object> init = CustomEventInit.create();
+      init.setBubbles(true);
+      init.setComposed(true);
+      init.setDetail(Js.cast(detail));
+      target.dispatchEvent(new CustomEvent<Object>("wavy-depth-drill-in", init));
+    } catch (Throwable ignored) {
+      // Event dispatch is observational.
+    }
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("j2cl.depth.drill_in")
+              .field("direction", "in")
+              .field("source", "keyboard")
+              .field("blipId", blipId)
+              .build());
+    } catch (Throwable ignored) {
+      // Telemetry is observational.
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -775,9 +775,9 @@ public final class J2clReadSurfaceDomRenderer {
       focusByIndex(renderedBlips.size() - 1, key);
       keyEvent.preventDefault();
     } else if ("[".equals(key)) {
-      // Drill out one depth level (G.2). The depth-nav-bar listens for
-      // wavy-depth-up on the card and pushes the URL change.
-      dispatchDepthEvent("wavy-depth-up");
+      // Drill out one depth level (G.2). Include toBlipId from the host
+      // data attribute so the root shell can navigate to parent, not root.
+      dispatchDepthUpEvent();
       keyEvent.preventDefault();
     } else if ("]".equals(key)) {
       // Drill into the focused blip's subthread (G.1). Emits a custom
@@ -806,6 +806,39 @@ public final class J2clReadSurfaceDomRenderer {
       init.setBubbles(true);
       init.setComposed(true);
       target.dispatchEvent(new CustomEvent<Object>(eventName, init));
+    } catch (Throwable ignored) {
+      // Event dispatch is observational.
+    }
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("j2cl.depth.drill_in")
+              .field("direction", "out")
+              .field("source", "keyboard")
+              .build());
+    } catch (Throwable ignored) {
+      // Telemetry is observational.
+    }
+  }
+
+  /**
+   * Dispatches wavy-depth-up with detail.toBlipId read from the host's
+   * data-parent-depth-blip-id attribute so the root-shell handler can
+   * navigate up one level instead of collapsing all the way to root.
+   */
+  private void dispatchDepthUpEvent() {
+    HTMLElement target = renderedSurface != null ? renderedSurface : host;
+    if (target == null) {
+      return;
+    }
+    String parentId = host != null ? host.getAttribute("data-parent-depth-blip-id") : null;
+    try {
+      JsPropertyMap<Object> detail = JsPropertyMap.of();
+      detail.set("toBlipId", parentId != null ? parentId : "");
+      CustomEventInit<Object> init = CustomEventInit.create();
+      init.setBubbles(true);
+      init.setComposed(true);
+      init.setDetail(Js.cast(detail));
+      target.dispatchEvent(new CustomEvent<Object>("wavy-depth-up", init));
     } catch (Throwable ignored) {
       // Event dispatch is observational.
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -1,6 +1,8 @@
 package org.waveprotocol.box.j2cl.root;
 
+import elemental2.dom.Event;
 import elemental2.dom.HTMLElement;
+import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceView;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
@@ -9,6 +11,7 @@ import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveController;
 import org.waveprotocol.box.j2cl.search.J2clSelectedWaveView;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceController;
 import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceView;
@@ -34,14 +37,25 @@ public final class J2clRootShellController {
         new J2clSelectedWaveController[1];
     final J2clToolbarSurfaceController[] toolbarControllerRef =
         new J2clToolbarSurfaceController[1];
+    final J2clSelectedWaveView[] selectedWaveViewRef = new J2clSelectedWaveView[1];
     // The route controller is wired below; the starter runs only after that assignment.
+    // F-2 slice 5 (#1055, R-3.7 G.4): the starter ALSO re-hydrates the
+    // depth-nav-bar from the URL state so a deep-linked &depth=<blip-id>
+    // survives reload.
     J2clRootLiveSurfaceController liveSurfaceController =
-        new J2clRootLiveSurfaceController(shellView, () -> routeControllerRef[0].start());
+        new J2clRootLiveSurfaceController(
+            shellView,
+            () -> {
+              routeControllerRef[0].start();
+              rehydrateDepthFromRoute(
+                  selectedWaveViewRef[0], routeControllerRef[0]);
+            });
     J2clSearchPanelView searchView =
         new J2clSearchPanelView(
             shellView.getWorkflowHost(), J2clSearchPanelView.ShellPresentation.ROOT_SHELL);
     J2clSelectedWaveView selectedWaveView =
         new J2clSelectedWaveView(searchView.getSelectedWaveHost(), telemetrySink);
+    selectedWaveViewRef[0] = selectedWaveView;
     HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
     HTMLElement selectedToolbarHost =
         createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
@@ -70,6 +84,11 @@ public final class J2clRootShellController {
                     action, "This toolbar action is not wired in the J2CL root shell yet.");
               }
             });
+    // F-2 slice 5 (#1055, A.3): the wavy <wavy-wave-nav-row> already
+    // mounts the canonical view-action chrome (E.1–E.10), so disable the
+    // legacy view actions here. Edit actions still render when a
+    // composer is active.
+    toolbarController.setViewActionsEnabled(false);
     toolbarControllerRef[0] = toolbarController;
     J2clSelectedWaveController selectedWaveController =
         new J2clSelectedWaveController(
@@ -111,7 +130,107 @@ public final class J2clRootShellController {
     composeController.start();
     toolbarController.start();
     toolbarController.onEditStateChanged(new J2clToolbarSurfaceController.EditState(false));
+    // F-2 slice 5 (#1055, R-3.7 G.4 + G.5): wire depth-nav events to the
+    // route controller so URL state survives reload + back/forward.
+    // The rehydration runs inside the live-surface starter so the URL
+    // depth value is applied right after route.start().
+    bindDepthEventsToRoute(selectedWaveView, routeController);
     liveSurfaceController.start();
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.5): listen for depth-nav events emitted
+   * by the {@code J2clReadSurfaceDomRenderer} (drill-in / drill-out /
+   * root) on the selected-wave card and forward the resolved depth blip
+   * id to the route controller.
+   *
+   * <p>The events bubble up to the card via the read-surface dispatch.
+   * For drill-in we use the event detail's {@code blipId}; for
+   * {@code wavy-depth-up} we resolve to the parent depth blip id from
+   * the read-surface attribute (kept in sync by setDepthFocus); and for
+   * {@code wavy-depth-root} we clear the depth.
+   */
+  private static void bindDepthEventsToRoute(
+      J2clSelectedWaveView view, J2clSidecarRouteController routeController) {
+    HTMLElement card = view.getCardElement();
+    if (card == null || routeController == null) {
+      return;
+    }
+    card.addEventListener(
+        "wavy-depth-drill-in",
+        evt -> {
+          Object detail = Js.asPropertyMap(evt).get("detail");
+          if (detail == null) {
+            return;
+          }
+          Object blipId = Js.asPropertyMap(detail).get("blipId");
+          if (blipId == null) {
+            return;
+          }
+          String resolved = String.valueOf(blipId);
+          if (!resolved.isEmpty()) {
+            routeController.onDepthChanged(resolved);
+            view.setDepthFocus(resolved, "", "");
+          }
+        });
+    card.addEventListener(
+        "wavy-depth-up",
+        evt -> {
+          Object detail = Js.asPropertyMap(evt).get("detail");
+          String parentId = "";
+          if (detail != null) {
+            Object resolved = Js.asPropertyMap(detail).get("toBlipId");
+            if (resolved != null) {
+              parentId = String.valueOf(resolved);
+            }
+          }
+          // toBlipId may be empty when the parent is the wave root —
+          // collapsing to empty clears the URL depth parameter.
+          routeController.onDepthChanged(parentId.isEmpty() ? null : parentId);
+          view.setDepthFocus(parentId.isEmpty() ? "" : parentId, "", "");
+        });
+    card.addEventListener(
+        "wavy-depth-root",
+        (Event evt) -> {
+          routeController.onDepthChanged(null);
+          view.setDepthFocus("", "", "");
+        });
+    card.addEventListener(
+        "wavy-depth-jump-to-crumb",
+        evt -> {
+          Object detail = Js.asPropertyMap(evt).get("detail");
+          String blipId = "";
+          if (detail != null) {
+            Object resolved = Js.asPropertyMap(detail).get("blipId");
+            if (resolved != null) {
+              blipId = String.valueOf(resolved);
+            }
+          }
+          routeController.onDepthChanged(blipId.isEmpty() ? null : blipId);
+          view.setDepthFocus(blipId, "", "");
+        });
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.4): re-hydrate the depth-nav-bar from
+   * the parsed URL state. Called after {@code routeController.start()}
+   * has populated currentState.
+   */
+  private static void rehydrateDepthFromRoute(
+      J2clSelectedWaveView view, J2clSidecarRouteController routeController) {
+    if (view == null || routeController == null) {
+      return;
+    }
+    J2clSidecarRouteState state = routeController.getCurrentState();
+    if (state == null) {
+      return;
+    }
+    String depthBlipId = state.getDepthBlipId();
+    if (depthBlipId == null || depthBlipId.isEmpty()) {
+      view.setDepthFocus("", "", "");
+      return;
+    }
+    view.setDepthFocus(depthBlipId, "", "");
   }
 
   private static HTMLElement createChildHost(HTMLElement parent, String className) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -124,7 +124,10 @@ public final class J2clRootShellController {
                   selectedWaveController.onWaveSelected(waveId, digestItem);
                 }),
             "view=j2cl-root",
-            liveSurfaceController::onRouteUrlChanged);
+            url -> {
+              liveSurfaceController.onRouteUrlChanged(url);
+              rehydrateDepthFromRoute(selectedWaveViewRef[0], routeControllerRef[0]);
+            });
     routeControllerRef[0] = routeController;
     searchView.setSessionSummary("Mounted inside the J2CL root shell.");
     composeController.start();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -81,6 +81,31 @@ public final class J2clSelectedWaveController
 
     default void setViewportEdgeHandler(ViewportEdgeHandler handler) {
     }
+
+    /**
+     * F-2 slice 5 (#1055, S2 deferral): publish pin / archive folder
+     * state for the {@code <wavy-wave-nav-row>} chrome (E.7 / E.8 toggle
+     * buttons). Defaults to a no-op for legacy presentations.
+     */
+    default void setNavRowFolderState(boolean pinned, boolean archived) {
+    }
+
+    /**
+     * F-2 slice 5 (#1055, R-3.7 G.4): publish the depth focus to the
+     * {@code <wavy-depth-nav-bar>} chrome. Empty string clears the depth
+     * focus and toggles the bar's hidden attribute.
+     */
+    default void setDepthFocus(
+        String currentDepthBlipId, String parentDepthBlipId, String parentAuthorName) {
+    }
+
+    /**
+     * F-2 slice 5 (#1055, R-3.7 G.6): publish the live-update awareness
+     * pill text + hidden state. {@code pendingCount &lt;= 0} hides the
+     * pill.
+     */
+    default void setAwarenessPill(int pendingCount) {
+    }
   }
 
   @FunctionalInterface
@@ -294,6 +319,9 @@ public final class J2clSelectedWaveController
         && currentSubscription != null
         && requestGeneration > 0) {
       selectedDigestItem = digestItem;
+      // F-2 slice 5 (#1055, S2 deferral): publish pin folder state so
+      // the wavy-wave-nav-row can render its E.7 pin toggle correctly.
+      publishNavRowFolderState();
       if (lastUpdate != null) {
         currentModel =
             J2clSelectedWaveProjector.project(
@@ -328,6 +356,9 @@ public final class J2clSelectedWaveController
       currentModel = J2clSelectedWaveModel.clearedSelection();
       view.render(currentModel);
       publishWriteSession();
+      // F-2 slice 5 (#1055): clear nav-row folder state when the
+      // selection drops so the chrome reverts to the default pin/inbox.
+      publishNavRowFolderState();
       return;
     }
 
@@ -337,7 +368,18 @@ public final class J2clSelectedWaveController
     reconnectCount = 0;
     currentReadState = null;
     readStateStale = false;
+    publishNavRowFolderState();
     fetchBootstrapAndOpenSelectedWave(generation, 0, false);
+  }
+
+  /**
+   * F-2 slice 5 (#1055, S2 deferral): forward pin folder state from the
+   * selected digest to the {@code <wavy-wave-nav-row>} chrome. Archived
+   * state stays {@code false} until F-4 wires the live folder feed.
+   */
+  private void publishNavRowFolderState() {
+    boolean pinned = selectedDigestItem != null && selectedDigestItem.isPinned();
+    view.setNavRowFolderState(pinned, false);
   }
 
   private void fetchBootstrapAndOpenSelectedWave(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -30,6 +30,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private final HTMLElement card;
   private final HTMLElement depthNavBar;
   private final HTMLElement waveNavRow;
+  // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.
+  // Hidden by default; setAwarenessPill toggles visibility + text.
+  private final HTMLElement awarenessPill;
   private boolean serverFirstActive;
   private boolean serverFirstSwapRecorded;
   private boolean coldMountSwapRecorded;
@@ -68,6 +71,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       this.card = existingCard;
       this.depthNavBar = ensureDepthNavBar(existingCard);
       this.waveNavRow = ensureWaveNavRow(existingCard);
+      this.awarenessPill = ensureAwarenessPill(existingCard);
       bindChromeEvents(existingCard, effectiveTelemetrySink);
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
@@ -110,6 +114,14 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     detail = (HTMLElement) DomGlobal.document.createElement("p");
     detail.className = "sidecar-selected-detail";
     coldCard.appendChild(detail);
+
+    // F-2 slice 5 (#1055, R-3.7 G.6): awareness pill — hidden by default
+    // until setAwarenessPill is called with a positive count.
+    awarenessPill = (HTMLElement) DomGlobal.document.createElement("output");
+    awarenessPill.className = "wavy-awareness-pill";
+    awarenessPill.setAttribute("data-j2cl-awareness-pill", "true");
+    awarenessPill.setAttribute("hidden", "");
+    coldCard.appendChild(awarenessPill);
 
     participantSummary = (HTMLElement) DomGlobal.document.createElement("p");
     participantSummary.className = "sidecar-selected-participants";
@@ -172,6 +184,31 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       card.insertBefore(bar, card.firstChild);
     }
     return bar;
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.6): locate the server-first awareness
+   * pill if present, otherwise create it client-side and insert just
+   * after the detail line so the pill reads as a context affordance.
+   */
+  private static HTMLElement ensureAwarenessPill(HTMLElement card) {
+    HTMLElement existing = (HTMLElement) card.querySelector(".wavy-awareness-pill");
+    if (existing != null) {
+      return existing;
+    }
+    HTMLElement pill = (HTMLElement) DomGlobal.document.createElement("output");
+    pill.className = "wavy-awareness-pill";
+    pill.setAttribute("data-j2cl-awareness-pill", "true");
+    pill.setAttribute("hidden", "");
+    HTMLElement detail = (HTMLElement) card.querySelector(".sidecar-selected-detail");
+    if (detail != null && detail.nextSibling != null) {
+      card.insertBefore(pill, detail.nextSibling);
+    } else if (detail != null) {
+      card.appendChild(pill);
+    } else {
+      card.appendChild(pill);
+    }
+    return pill;
   }
 
   /**
@@ -373,6 +410,100 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   public SidecarViewportHints initialViewportHints(String selectedWaveId) {
     return resolveInitialViewportHints(
         serverFirstActive, serverFirstWaveId, selectedWaveId, serverFirstBlipAnchor());
+  }
+
+  /**
+   * F-2 slice 5 (#1055, S2 deferral): publish pin / archive folder
+   * state on the {@code <wavy-wave-nav-row>} chrome. Uses attribute
+   * reflection so the SSR'd pre-upgrade light DOM and the post-upgrade
+   * shadow DOM agree on the rendered button state.
+   */
+  @Override
+  public void setNavRowFolderState(boolean pinned, boolean archived) {
+    if (waveNavRow == null) {
+      return;
+    }
+    if (pinned) {
+      waveNavRow.setAttribute("pinned", "");
+    } else {
+      waveNavRow.removeAttribute("pinned");
+    }
+    if (archived) {
+      waveNavRow.setAttribute("archived", "");
+    } else {
+      waveNavRow.removeAttribute("archived");
+    }
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.4): publish the depth focus to the
+   * {@code <wavy-depth-nav-bar>} chrome and to the read-surface host's
+   * data-attributes (read by other chrome). Empty current id collapses
+   * the bar via the {@code hidden} attribute.
+   */
+  @Override
+  public void setDepthFocus(
+      String currentDepthBlipId, String parentDepthBlipId, String parentAuthorName) {
+    readSurface.setDepthFocus(currentDepthBlipId, parentDepthBlipId, parentAuthorName);
+    if (depthNavBar == null) {
+      return;
+    }
+    String safeCurrent = currentDepthBlipId == null ? "" : currentDepthBlipId;
+    String safeParent = parentDepthBlipId == null ? "" : parentDepthBlipId;
+    String safeName = parentAuthorName == null ? "" : parentAuthorName;
+    depthNavBar.setAttribute("current-depth-blip-id", safeCurrent);
+    depthNavBar.setAttribute("parent-depth-blip-id", safeParent);
+    depthNavBar.setAttribute("parent-author-name", safeName);
+    if (safeCurrent.isEmpty()) {
+      depthNavBar.setAttribute("hidden", "");
+    } else {
+      depthNavBar.removeAttribute("hidden");
+    }
+    try {
+      Js.asPropertyMap(depthNavBar).set("currentDepthBlipId", safeCurrent);
+      Js.asPropertyMap(depthNavBar).set("parentDepthBlipId", safeParent);
+      Js.asPropertyMap(depthNavBar).set("parentAuthorName", safeName);
+    } catch (Throwable ignored) {
+      // Property write is best-effort; the attribute reflection above
+      // already covers the SSR + post-upgrade state.
+    }
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.6): publish the awareness pill text +
+   * visibility. Counts &lt;= 0 hide the pill; positive counts surface
+   * "↑ N new replies above" with the cyan pulse ring.
+   */
+  @Override
+  public void setAwarenessPill(int pendingCount) {
+    if (awarenessPill == null) {
+      return;
+    }
+    if (pendingCount <= 0) {
+      awarenessPill.setAttribute("hidden", "");
+      awarenessPill.textContent = "";
+      return;
+    }
+    awarenessPill.removeAttribute("hidden");
+    awarenessPill.textContent =
+        "↑ " + pendingCount + " new repl" + (pendingCount == 1 ? "y" : "ies") + " above";
+  }
+
+  /**
+   * F-2 slice 5 (#1055): expose the depth-nav-bar handle so route
+   * controllers can attach their URL writer once on shell start.
+   */
+  public HTMLElement getDepthNavBar() {
+    return depthNavBar;
+  }
+
+  /**
+   * F-2 slice 5 (#1055): expose the card root for route controllers
+   * that need to listen for {@code wavy-depth-up} / {@code wavy-depth-root}
+   * / {@code wavy-depth-drill-in} events.
+   */
+  public HTMLElement getCardElement() {
+    return card;
   }
 
   public static boolean shouldPreserveServerSnapshot(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -18,6 +18,7 @@ public final class J2clSidecarRouteCodec {
   public static J2clSidecarRouteState parse(String search, String hash) {
     String query = null;
     String selectedWaveId = null;
+    String depthBlipId = null;
     if (search != null && !search.isEmpty()) {
       String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
       if (!trimmed.isEmpty()) {
@@ -30,6 +31,8 @@ public final class J2clSidecarRouteCodec {
             query = decodeQueryValue(value);
           } else if ("wave".equals(key)) {
             selectedWaveId = decodeWaveValue(value);
+          } else if ("depth".equals(key)) {
+            depthBlipId = decodeDepthValue(value);
           }
         }
       }
@@ -37,7 +40,7 @@ public final class J2clSidecarRouteCodec {
     if (selectedWaveId == null) {
       selectedWaveId = decodeLegacyHashWaveValue(hash);
     }
-    return new J2clSidecarRouteState(query, selectedWaveId);
+    return new J2clSidecarRouteState(query, selectedWaveId, depthBlipId);
   }
 
   public static String toUrl(J2clSidecarRouteState state) {
@@ -55,6 +58,11 @@ public final class J2clSidecarRouteCodec {
     if (state.getSelectedWaveId() != null) {
       url.append("&wave=").append(encodeUriComponentSafe(state.getSelectedWaveId()));
     }
+    // F-2 slice 5 (#1055, R-3.7 G.4): emit &depth=<blip-id> only when a
+    // depth focus is active so the URL stays clean for top-of-wave reads.
+    if (state.getDepthBlipId() != null) {
+      url.append("&depth=").append(encodeUriComponentSafe(state.getDepthBlipId()));
+    }
     return url.toString();
   }
 
@@ -67,6 +75,31 @@ public final class J2clSidecarRouteCodec {
       return J2clSearchResultProjector.normalizeQuery(decoded);
     } catch (RuntimeException e) {
       return J2clSearchResultProjector.DEFAULT_QUERY;
+    }
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.4): decode the {@code depth} URL
+   * parameter. Empty values clear the depth focus; whitespace is
+   * trimmed conservatively. Invalid UTF-8 collapses to an unset depth
+   * — the depth-nav-bar will then revert to "no focus" rather than
+   * stranding the URL state on a corrupt blip id.
+   */
+  private static String decodeDepthValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    try {
+      String decoded = decodeUriComponentSafe(value);
+      if (decoded == null) {
+        return null;
+      }
+      String trimmed = decoded.trim();
+      // Reject whitespace-bearing or zero-length payloads; depth blip
+      // ids are always opaque tokens with no internal spaces.
+      return trimmed.isEmpty() || trimmed.indexOf(' ') >= 0 ? null : trimmed;
+    } catch (RuntimeException e) {
+      return null;
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteController.java
@@ -130,6 +130,36 @@ public final class J2clSidecarRouteController {
     onRouteStateChanged(new J2clSidecarRouteState(query, waveId), null, true);
   }
 
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.4): push a new depth focus into the URL
+   * state. Empty / null clears the depth parameter. Other state fields
+   * (query, selectedWaveId) are preserved.
+   */
+  public void onDepthChanged(String depthBlipId) {
+    if (currentState == null) {
+      return;
+    }
+    String normalized =
+        depthBlipId == null || depthBlipId.isEmpty() ? null : depthBlipId;
+    J2clSidecarRouteState nextState = currentState.withDepthBlipId(normalized);
+    if (nextState.equals(currentState)) {
+      return;
+    }
+    String nextUrl = J2clSidecarRouteCodec.toUrl(nextState, fixedQueryString);
+    history.pushUrl(nextUrl);
+    emitUrlChanged(nextUrl);
+    currentState = nextState;
+  }
+
+  /**
+   * F-2 slice 5 (#1055): expose the current route state so route
+   * observers (e.g. the selected-wave view's depth re-hydration on
+   * mount) can read the parsed URL state.
+   */
+  public J2clSidecarRouteState getCurrentState() {
+    return currentState;
+  }
+
   private void handlePopState() {
     currentState = J2clSidecarRouteCodec.parse(history.getSearch(), history.getHash());
     emitUrlChanged(J2clSidecarRouteCodec.toUrl(currentState, fixedQueryString));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteState.java
@@ -3,11 +3,22 @@ package org.waveprotocol.box.j2cl.search;
 public final class J2clSidecarRouteState {
   private final String query;
   private final String selectedWaveId;
+  private final String depthBlipId;
 
   public J2clSidecarRouteState(String query, String selectedWaveId) {
+    this(query, selectedWaveId, null);
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 G.4): include the depth-focus blip id in
+   * the route state so it round-trips through reload + back/forward.
+   */
+  public J2clSidecarRouteState(String query, String selectedWaveId, String depthBlipId) {
     this.query = J2clSearchResultProjector.normalizeQuery(query);
     this.selectedWaveId =
         selectedWaveId == null || selectedWaveId.isEmpty() ? null : selectedWaveId;
+    this.depthBlipId =
+        depthBlipId == null || depthBlipId.isEmpty() ? null : depthBlipId;
   }
 
   public String getQuery() {
@@ -18,19 +29,35 @@ public final class J2clSidecarRouteState {
     return selectedWaveId;
   }
 
+  public String getDepthBlipId() {
+    return depthBlipId;
+  }
+
+  /**
+   * F-2 slice 5 (#1055): produce a copy of this state with the supplied
+   * depth blip id (null/empty clears the depth focus). Existing query
+   * and selected-wave fields are preserved.
+   */
+  public J2clSidecarRouteState withDepthBlipId(String nextDepthBlipId) {
+    return new J2clSidecarRouteState(query, selectedWaveId, nextDepthBlipId);
+  }
+
   @Override
   public boolean equals(Object other) {
     if (!(other instanceof J2clSidecarRouteState)) {
       return false;
     }
     J2clSidecarRouteState that = (J2clSidecarRouteState) other;
-    return safeEquals(query, that.query) && safeEquals(selectedWaveId, that.selectedWaveId);
+    return safeEquals(query, that.query)
+        && safeEquals(selectedWaveId, that.selectedWaveId)
+        && safeEquals(depthBlipId, that.depthBlipId);
   }
 
   @Override
   public int hashCode() {
     int result = query == null ? 0 : query.hashCode();
     result = 31 * result + (selectedWaveId == null ? 0 : selectedWaveId.hashCode());
+    result = 31 * result + (depthBlipId == null ? 0 : depthBlipId.hashCode());
     return result;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
@@ -78,10 +78,30 @@ public final class J2clToolbarSurfaceController {
   private J2clDailyToolbarAction errorAction;
   private String errorText = "";
   private boolean started;
+  // F-2 slice 5 (#1055, A.3): suppress legacy view actions in callers
+  // where <wavy-wave-nav-row> already provides the same affordances. The
+  // sidecar (legacy) presentation keeps the default `true`.
+  private boolean viewActionsEnabled = true;
 
   public J2clToolbarSurfaceController(View view, ActionDispatcher dispatcher) {
     this.view = view;
     this.dispatcher = dispatcher;
+  }
+
+  /**
+   * F-2 slice 5 (#1055, A.3) — opt out of view actions when the caller's
+   * presentation already mounts the canonical view-nav chrome (i.e. the
+   * J2CL root shell mounts {@code <wavy-wave-nav-row>}). Defaults to
+   * {@code true} so the sidecar presentation is unchanged.
+   */
+  public void setViewActionsEnabled(boolean enabled) {
+    if (this.viewActionsEnabled == enabled) {
+      return;
+    }
+    this.viewActionsEnabled = enabled;
+    if (started) {
+      render();
+    }
   }
 
   public void start() {
@@ -147,7 +167,9 @@ public final class J2clToolbarSurfaceController {
     }
     List<J2clToolbarSurfaceModel.ActionModel> actions =
         new ArrayList<J2clToolbarSurfaceModel.ActionModel>();
-    addViewActions(actions);
+    if (viewActionsEnabled) {
+      addViewActions(actions);
+    }
     addEditActions(actions);
     view.render(new J2clToolbarSurfaceModel(actions));
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceView.java
@@ -28,6 +28,10 @@ public final class J2clToolbarSurfaceView implements J2clToolbarSurfaceControlle
 
   @Override
   public void render(J2clToolbarSurfaceModel model) {
+    // F-2 slice 5 (#1055, A.3): collapse the toolbar host when there are
+    // no actions to render so the legacy editor-toolbar wall does not
+    // duplicate the wavy chrome before composition starts.
+    host.hidden = model.getActions().isEmpty();
     Set<String> seenGroups = new HashSet<String>();
     Set<String> seenActions = new HashSet<String>();
     String currentGroup = "";

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
@@ -105,4 +105,59 @@ public class J2clSidecarRouteCodecTest {
     Assert.assertNull(J2clSidecarRouteCodec.parse("", "").getSelectedWaveId());
     Assert.assertNull(J2clSidecarRouteCodec.parse("", "#not-a-wave").getSelectedWaveId());
   }
+
+  // --- F-2 slice 5 (#1055, R-3.7 G.4): depth URL parameter -----------
+
+  @Test
+  public void depthBlipIdParsesFromUrl() {
+    J2clSidecarRouteState state =
+        J2clSidecarRouteCodec.parse(
+            "?q=with%3A%40&wave=example.com%2Fw%2B1&depth=b%2Bdrillin");
+    Assert.assertEquals("with:@", state.getQuery());
+    Assert.assertEquals("example.com/w+1", state.getSelectedWaveId());
+    Assert.assertEquals("b+drillin", state.getDepthBlipId());
+  }
+
+  @Test
+  public void depthBlipIdRoundTripsThroughToUrl() {
+    J2clSidecarRouteState state =
+        new J2clSidecarRouteState("with:@", "example.com/w+abc123", "b+leaf-blip");
+    String url = J2clSidecarRouteCodec.toUrl(state);
+    Assert.assertEquals(
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123&depth=b%2Bleaf-blip", url);
+  }
+
+  @Test
+  public void depthBlipIdEmptyOrMissingStaysNull() {
+    Assert.assertNull(
+        J2clSidecarRouteCodec.parse("?wave=example.com%2Fw%2B1").getDepthBlipId());
+    Assert.assertNull(
+        J2clSidecarRouteCodec.parse("?wave=example.com%2Fw%2B1&depth=").getDepthBlipId());
+    Assert.assertNull(
+        J2clSidecarRouteCodec.parse("?wave=example.com%2Fw%2B1&depth=%20")
+            .getDepthBlipId());
+  }
+
+  @Test
+  public void depthIsOmittedFromUrlWhenAbsent() {
+    // Absence of depth means a clean ?q=&wave=... URL, no trailing &depth=.
+    J2clSidecarRouteState state =
+        new J2clSidecarRouteState("with:@", "example.com/w+abc123");
+    String url = J2clSidecarRouteCodec.toUrl(state);
+    Assert.assertEquals(
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123", url);
+  }
+
+  @Test
+  public void withDepthBlipIdProducesMatchingState() {
+    J2clSidecarRouteState base =
+        new J2clSidecarRouteState("with:@", "example.com/w+abc");
+    J2clSidecarRouteState withDepth = base.withDepthBlipId("b+anchor");
+    Assert.assertEquals("b+anchor", withDepth.getDepthBlipId());
+    Assert.assertEquals(base.getQuery(), withDepth.getQuery());
+    Assert.assertEquals(base.getSelectedWaveId(), withDepth.getSelectedWaveId());
+    // Clearing the depth produces an equal-to-base state.
+    Assert.assertEquals(base, withDepth.withDepthBlipId(null));
+    Assert.assertEquals(base, withDepth.withDepthBlipId(""));
+  }
 }

--- a/wave/config/changelog.d/2026-04-26-issue-1055-view-wiring.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1055-view-wiring.json
@@ -1,0 +1,29 @@
+{
+  "releaseId": "2026-04-26-issue-1055-view-wiring",
+  "version": "F-2.S5 (#1055)",
+  "date": "2026-04-26",
+  "title": "F-2 Slice 5 — View wiring + URL state + integration cleanup",
+  "summary": "F-2 view-wiring slice. Removes the legacy 'Hosted workflow' intro card + duplicate search toolbar from the J2CL root shell now that <wavy-search-rail> is the canonical surface; replaces the 'Select a wave' placeholder with the wavy empty-state recipe (centered ghost waveform mark + headline); fixes the SSR <wavy-search-rail> waveform glyph overflow with explicit width=14 height=14; suppresses the legacy editor-toolbar wall when no compose session is active by gating view actions on the toolbar surface. Adds &depth=<blip-id> URL state (round-trips through reload + back/forward), [ / ] keyboard drill-out / drill-in, g / G first-blip / last-blip jump, and the R-3.7 G.6 awareness pill landmark. Wires pin folder state from J2clSearchDigestItem.isPinned() onto the <wavy-wave-nav-row> chrome (S2 deferral closeout). Closes the S4 focus-trap deferral on <wavy-version-history> and <wavy-profile-overlay> via inert-on-siblings + previous-focus restore. R-4.4 mark-blip-read Gateway is deferred to a follow-up so this slice can land cleanly.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Integration cleanup: removed the visible 'Hosted workflow' eyebrow + h1.sidecar-title + sidecar-detail copy from the J2CL root shell. The structural <div class=\"sidecar-search-card\"> wrapper stays so J2clSearchPanelView can still adopt the form / digests / empty-state DOM, but the wrapper now carries data-j2cl-legacy-search-card=\"hidden\" and the form carries data-j2cl-legacy-search-form=\"true\" + the hidden attribute. <wavy-search-rail> in the nav slot is the canonical query surface.",
+        "Wavy empty-state recipe: replaced the 'Select a wave to open it here.' placeholder with a centered ghost waveform mark, a wavy-empty-state-headline ('Select a wave' / mode-specific title), and a wavy-empty-state-subhead. Class names are pinned by the new HtmlRendererJ2clRootShellIntegrationTest.",
+        "Search-rail waveform glyph fix: <wavy-search-rail> SSR'd <svg> now carries explicit width=\"14\" height=\"14\" so the glyph does not overflow to the SVG default 300x150 before customElements.define attaches the shadow DOM (reproduces the giant waveform reported in issue #1055). The Lit element's render also pins the dimensions, and a defensive global rule in wavy-thread-collapse.css clamps any direct svg child of .waveform inside <wavy-search-rail>'s light DOM.",
+        "Editor-toolbar wall suppression: J2clToolbarSurfaceController grew a setViewActionsEnabled(boolean) opt-out, defaulting to true to preserve the sidecar presentation. The J2CL root shell sets it to false because <wavy-wave-nav-row> already mounts the canonical view-action chrome (E.1-E.10). The toolbar host now hides itself when the action model is empty so the legacy Bold/Italic wall no longer renders before composition starts.",
+        "URL state (R-3.7 G.4): J2clSidecarRouteState carries an optional depthBlipId; J2clSidecarRouteCodec round-trips &depth=<blip-id> through parse/toUrl with explicit width on the new param so it stays out of the URL when no depth focus is set. The route controller exposes onDepthChanged(blipId) + getCurrentState() so the root shell can push depth changes into history.",
+        "Keyboard wiring (R-3.7 G.5): the read surface's blip keydown handler now dispatches wavy-depth-up on '[' (drill out one level) and wavy-depth-drill-in on ']' (drill into focused blip). Aliases 'g' = first blip and 'G' = last blip layer over the existing Home / End. j2cl.depth.drill_in telemetry counter records direction (in/out) + source (keyboard).",
+        "Awareness pill (R-3.7 G.6): the selected-wave card now mounts an <output class=\"wavy-awareness-pill\" data-j2cl-awareness-pill=\"true\"> landmark. View.setAwarenessPill(int pendingCount) toggles hidden + textContent ('↑ N new replies above'). The CSS reuses --wavy-pulse-ring + signal-cyan tokens for the cyan border-pill.",
+        "Pin/archive nav-row (S2 deferral closed): J2clSelectedWaveController publishes pin folder state via View.setNavRowFolderState(boolean pinned, boolean archived) on every selection change. Pinned reflects from J2clSearchDigestItem.isPinned(); archived stays false until F-4 wires the live folder feed.",
+        "Focus-trap on overlays (S4 deferral closed): wavy-version-history and wavy-profile-overlay now save document.activeElement on open, set inert on every <body> direct child except the overlay host, and restore focus + remove inert on close. The host's tabindex=-1 + microtask focus call from S4 stays unchanged."
+      ]
+    },
+    {
+      "type": "deferral",
+      "items": [
+        "R-4.4 mark-blip-read Gateway extension is intentionally deferred from this slice. The IntersectionObserver-equivalent debounce wiring on J2clReadSurfaceDomRenderer + the supplement-op POST /j2cl/mark-blip-read endpoint will land in a follow-up so this slice can ship the user-visible duplicate-removal cleanup without growing past one merge window."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-26-issue-1055-view-wiring.json
+++ b/wave/config/changelog.d/2026-04-26-issue-1055-view-wiring.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "type": "deferral",
+      "type": "feature",
       "items": [
         "R-4.4 mark-blip-read Gateway extension is intentionally deferred from this slice. The IntersectionObserver-equivalent debounce wiring on J2clReadSurfaceDomRenderer + the supplement-op POST /j2cl/mark-blip-read endpoint will land in a follow-up so this slice can ship the user-visible duplicate-removal cleanup without growing past one merge window."
       ]

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3737,7 +3737,13 @@ public final class HtmlRenderer {
     sb.append("    <wavy-search-rail query=\"").append(safeInitialQuery)
         .append("\" data-active-folder=\"").append(activeFolder).append("\" result-count=\"\">\n");
     sb.append("      <div class=\"search\">\n");
-    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"><svg viewBox=\"0 0 14 14\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.6\" aria-hidden=\"true\"><path d=\"M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></span>\n");
+    // F-2 slice 5 (#1055, A.4): explicit width/height on the SVG element.
+    // Pre-upgrade, the Lit `:host { display:block }` rule has not attached
+    // (shadow DOM is not yet rendered), so the SVG defaults to its CSS
+    // intrinsic 300x150 size. Pinning width/height prevents the giant
+    // waveform glyph from blowing out the rail before the J2CL bundle
+    // upgrades the element.
+    sb.append("        <span class=\"waveform\" aria-hidden=\"true\"><svg viewBox=\"0 0 14 14\" width=\"14\" height=\"14\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.6\" aria-hidden=\"true\"><path d=\"M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></span>\n");
     sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"").append(safeInitialQuery).append("\">\n");
     sb.append("        <button type=\"button\" class=\"help-trigger\" aria-label=\"Search help\" aria-haspopup=\"dialog\" aria-controls=\"wavy-search-help\">?</button>\n");
     sb.append("      </div>\n");
@@ -3943,9 +3949,14 @@ public final class HtmlRenderer {
       StringBuilder sb,
       J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
       boolean signedIn) {
-    String workflowDetail = signedIn
-        ? "The signed-in root shell hosts the search, compose, and selected-wave surfaces inline."
-        : "Sign in to search, read, and compose inside the root shell.";
+    // F-2 slice 5 (#1055): the legacy "Hosted workflow" intro card and its
+    // inline search toolbar are replaced by <wavy-search-rail> in the nav
+    // slot. The sidecar-search-card wrapper + the elements
+    // J2clSearchPanelView adopts (form, input, submit, status, digests,
+    // empty-state, show-more) stay in the DOM so the search panel can still
+    // bind, but the visible eyebrow / "Hosted workflow" title / detail
+    // copy is gone. The form itself is hidden via data-j2cl-legacy-search-form
+    // — the rail is the canonical query surface.
     String sessionSummary = signedIn
         ? "Inspecting the active root session."
         : "Sign in to inspect the active root session.";
@@ -3958,16 +3969,11 @@ public final class HtmlRenderer {
 
     sb.append("      <section class=\"sidecar-search-shell\" data-j2cl-server-first-workflow=\"true\">\n");
     sb.append("        <div class=\"sidecar-split-layout\">\n");
-    sb.append("          <div class=\"sidecar-search-card\">\n");
-    sb.append("            <p class=\"sidecar-eyebrow\">J2CL root shell</p>\n");
-    sb.append("            <h1 class=\"sidecar-title\">Hosted workflow</h1>\n");
-    sb.append("            <p class=\"sidecar-detail\">")
-        .append(escapeHtml(workflowDetail))
-        .append("</p>\n");
-    sb.append("            <p class=\"sidecar-search-session\">")
-        .append(escapeHtml(sessionSummary))
-        .append("</p>\n");
-    sb.append("            <form class=\"sidecar-search-toolbar\" action=\"#\" onsubmit=\"return false;\">\n");
+    sb.append("          <div class=\"sidecar-search-card\" data-j2cl-legacy-search-card=\"hidden\">\n");
+    // Legacy form retained for J2clSearchPanelView's queryRequired bindings;
+    // the wavy-search-rail in the nav slot is the canonical query surface,
+    // so the form is hidden from view but kept in the DOM.
+    sb.append("            <form class=\"sidecar-search-toolbar\" data-j2cl-legacy-search-form=\"true\" action=\"#\" onsubmit=\"return false;\" hidden>\n");
     sb.append("              <input class=\"sidecar-search-input\" type=\"search\" placeholder=\"Search waves\" aria-label=\"Search waves\" autocomplete=\"off\"");
     if (!signedIn) {
       sb.append(" disabled");
@@ -3979,11 +3985,17 @@ public final class HtmlRenderer {
     }
     sb.append(">Search</button>\n");
     sb.append("            </form>\n");
+    // Session summary + search status retained for the search panel's
+    // setSessionSummary / setStatus calls; hidden so they don't render
+    // duplicate copy alongside the rail.
+    sb.append("            <p class=\"sidecar-search-session\" hidden>")
+        .append(escapeHtml(sessionSummary))
+        .append("</p>\n");
     sb.append("            <div class=\"sidecar-search-compose\"></div>\n");
-    sb.append("            <p class=\"sidecar-search-status\">")
+    sb.append("            <p class=\"sidecar-search-status\" hidden>")
         .append(escapeHtml(searchStatus))
         .append("</p>\n");
-    sb.append("            <p class=\"sidecar-wave-count\"></p>\n");
+    sb.append("            <p class=\"sidecar-wave-count\" hidden></p>\n");
     sb.append("            <div class=\"sidecar-digests\"></div>\n");
     sb.append("            <div class=\"sidecar-empty-state\">")
         .append(escapeHtml(emptyState))
@@ -4043,26 +4055,67 @@ public final class HtmlRenderer {
     sb.append("              <p class=\"sidecar-selected-detail\">")
         .append(escapeHtml(detail))
         .append("</p>\n");
+    // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.
+    // Hidden by default; the view's render() unhides + writes count text
+    // when ancestor replies arrive.
+    sb.append("              <output class=\"wavy-awareness-pill\" data-j2cl-awareness-pill=\"true\" hidden></output>\n");
     sb.append("              <p class=\"sidecar-selected-participants\" hidden></p>\n");
     // F-2 slice 2 (#1046, R-3.4): wave-nav-row landmark. Buttons mount
     // client-side once shell.js upgrades the element; before then the
     // landmark host is exposed for AT users + the client upgrade swap.
     sb.append("              <wavy-wave-nav-row data-j2cl-server-first-chrome=\"true\"></wavy-wave-nav-row>\n");
     sb.append("              <p class=\"sidecar-selected-snippet\" hidden></p>\n");
-    sb.append("              <div class=\"sidecar-selected-compose\"></div>\n");
+    // F-2 slice 5 (#1055): toolbar host hidden by default; the
+    // controller un-hides it only when an edit session is active so the
+    // legacy editor-toolbar wall does not duplicate <wavy-wave-nav-row>.
+    sb.append("              <div class=\"sidecar-selected-compose\" data-j2cl-compose-host=\"true\"></div>\n");
     sb.append("              <div class=\"sidecar-selected-content\">");
     if (hasSnapshot) {
       sb.append(snapshotResult.getSnapshotHtml());
     }
     sb.append("</div>\n");
+    // F-2 slice 5 (#1055): the empty-state slot now hosts the wavy
+    // empty-state recipe (centered ghost waveform mark + headline) when
+    // no snapshot is rendered. The headline + class names round-trip
+    // through J2clRootShellIntegrationTest.
     sb.append("              <div class=\"sidecar-empty-state\"");
     if (hasSnapshot) {
       sb.append(" hidden");
     }
-    sb.append(">")
-        .append(escapeHtml(detail))
-        .append("</div>\n");
+    sb.append(">\n");
+    appendWavyEmptyStateRecipe(sb, title, detail);
+    sb.append("              </div>\n");
     sb.append("            </section>\n");
+  }
+
+  /**
+   * F-2 slice 5 (#1055, R-3.7 integration cleanup): emit the wavy
+   * empty-state recipe — a centered ghost waveform mark, the configured
+   * headline, and a sub-headline for the longer detail copy.
+   *
+   * <p>The waveform glyph reuses the same SVG path the search rail
+   * emits, scaled up to 64px and dimmed to {@code --wavy-text-muted}.
+   * Test {@code J2clRootShellIntegrationTest} pins the marker class
+   * names so future visual tweaks do not accidentally regress the
+   * empty-state shape.
+   */
+  private static void appendWavyEmptyStateRecipe(
+      StringBuilder sb, String headline, String detail) {
+    sb.append("                <div class=\"wavy-empty-state\" data-j2cl-empty-state-recipe=\"true\">\n");
+    sb.append("                  <span class=\"wavy-empty-state-mark\" aria-hidden=\"true\">")
+        .append(
+            "<svg viewBox=\"0 0 14 14\" width=\"64\" height=\"64\" fill=\"none\""
+                + " stroke=\"currentColor\" stroke-width=\"1.6\" aria-hidden=\"true\">"
+                + "<path d=\"M1 7h2l1-3 1 6 1-4 1 5 1-6 1 4 1-2h2\""
+                + " stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>")
+        .append("</span>\n");
+    sb.append("                  <h3 class=\"wavy-empty-state-headline\">")
+        .append(escapeHtml(headline))
+        .append("</h3>\n");
+    sb.append("                  <p class=\"wavy-empty-state-subhead\">")
+        .append(escapeHtml(detail))
+        .append("</p>\n");
+    sb.append("                </div>\n");
   }
 
   private static String selectedWaveTitle(

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4074,16 +4074,20 @@ public final class HtmlRenderer {
       sb.append(snapshotResult.getSnapshotHtml());
     }
     sb.append("</div>\n");
-    // F-2 slice 5 (#1055): the empty-state slot now hosts the wavy
-    // empty-state recipe (centered ghost waveform mark + headline) when
-    // no snapshot is rendered. The headline + class names round-trip
-    // through J2clRootShellIntegrationTest.
+    // F-2 slice 5 (#1055): the empty-state slot hosts the wavy recipe only
+    // for the true no-wave state; DENIED/RENDER_ERROR already render status
+    // copy above and should not also show the waveform illustration.
+    boolean showEmptyStateRecipe =
+        !hasSnapshot
+            && effectiveResult.getMode() == J2clSelectedWaveSnapshotRenderer.Mode.NO_WAVE;
     sb.append("              <div class=\"sidecar-empty-state\"");
-    if (hasSnapshot) {
+    if (!showEmptyStateRecipe) {
       sb.append(" hidden");
     }
     sb.append(">\n");
-    appendWavyEmptyStateRecipe(sb, title, detail);
+    if (showEmptyStateRecipe) {
+      appendWavyEmptyStateRecipe(sb, title, detail);
+    }
     sb.append("              </div>\n");
     sb.append("            </section>\n");
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -77,7 +77,7 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
     assertEquals(
         "Signed-in root shell must mount exactly one <wavy-search-rail>",
         1,
-        countOccurrences(html, "<wavy-search-rail "));
+        countOccurrences(html, "<wavy-search-rail"));
   }
 
   public void testExactlyOneWavyWaveNavRow() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import junit.framework.TestCase;
+import org.json.JSONObject;
+
+/**
+ * F-2 slice 5 (#1055) integration test. Asserts on the no-duplicate
+ * contract that the full F-2 chrome bundle establishes:
+ *
+ * <ul>
+ *   <li>exactly one {@code <wavy-search-rail>} (in nav slot),
+ *   <li>exactly one {@code <wavy-wave-nav-row>},
+ *   <li>exactly one {@code <wavy-depth-nav-bar>},
+ *   <li>no legacy "Hosted workflow" intro card content (eyebrow,
+ *       h1.sidecar-title, sidecar-detail copy),
+ *   <li>the legacy search-card wrapper carries
+ *       {@code data-j2cl-legacy-search-card="hidden"} and the form is
+ *       marked {@code data-j2cl-legacy-search-form="true"} + hidden,
+ *   <li>the search-rail SVG glyph carries explicit width/height attrs,
+ *   <li>the wavy empty-state recipe markup is present, and
+ *   <li>no orphaned empty-state placeholder text appears alongside the
+ *       wavy chrome.
+ * </ul>
+ */
+public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
+
+  private static String renderSignedInPage() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "user");
+    return HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/", "ws.example:443");
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    int idx = 0;
+    while (true) {
+      int next = haystack.indexOf(needle, idx);
+      if (next < 0) {
+        break;
+      }
+      count++;
+      idx = next + needle.length();
+    }
+    return count;
+  }
+
+  // ---------------------------------------------------------------------
+  // No-duplicate assertions
+  // ---------------------------------------------------------------------
+
+  public void testExactlyOneWavySearchRail() {
+    String html = renderSignedInPage();
+    assertEquals(
+        "Signed-in root shell must mount exactly one <wavy-search-rail>",
+        1,
+        countOccurrences(html, "<wavy-search-rail "));
+  }
+
+  public void testExactlyOneWavyWaveNavRow() {
+    String html = renderSignedInPage();
+    assertEquals(
+        "Signed-in root shell must mount exactly one <wavy-wave-nav-row>",
+        1,
+        countOccurrences(html, "<wavy-wave-nav-row"));
+  }
+
+  public void testExactlyOneWavyDepthNavBar() {
+    String html = renderSignedInPage();
+    assertEquals(
+        "Signed-in root shell must mount exactly one <wavy-depth-nav-bar>",
+        1,
+        countOccurrences(html, "<wavy-depth-nav-bar"));
+  }
+
+  // ---------------------------------------------------------------------
+  // Legacy "Hosted workflow" intro card removed
+  // ---------------------------------------------------------------------
+
+  public void testLegacyHostedWorkflowTitleIsAbsent() {
+    String html = renderSignedInPage();
+    assertFalse(
+        "The legacy 'Hosted workflow' h1 must not render alongside the wavy chrome",
+        html.contains("Hosted workflow"));
+    assertFalse(
+        "The legacy <h1 class=\"sidecar-title\"> must not render — chrome is the surface",
+        html.contains("class=\"sidecar-title\""));
+  }
+
+  public void testLegacyEyebrowIsAbsent() {
+    String html = renderSignedInPage();
+    assertFalse(
+        "The legacy 'J2CL root shell' eyebrow must not render with the wavy chrome",
+        html.contains("<p class=\"sidecar-eyebrow\">J2CL root shell</p>"));
+  }
+
+  public void testLegacyDetailCopyIsAbsent() {
+    String html = renderSignedInPage();
+    assertFalse(
+        "The legacy <p class=\"sidecar-detail\"> body must not render alongside the wavy chrome",
+        html.contains("<p class=\"sidecar-detail\">"));
+  }
+
+  // ---------------------------------------------------------------------
+  // Legacy search-card wrapper retained (J2clSearchPanelView adoption),
+  // but flagged + hidden
+  // ---------------------------------------------------------------------
+
+  public void testLegacySearchCardWrapperIsFlaggedHidden() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Legacy <div class=\"sidecar-search-card\"> must carry data-j2cl-legacy-search-card",
+        html.contains("data-j2cl-legacy-search-card=\"hidden\""));
+  }
+
+  public void testLegacySearchFormIsFlaggedHidden() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Legacy <form class=\"sidecar-search-toolbar\"> must carry data-j2cl-legacy-search-form",
+        html.contains("data-j2cl-legacy-search-form=\"true\""));
+    assertTrue(
+        "Legacy search form must carry the hidden attribute so it does not duplicate the rail",
+        html.contains(
+            "<form class=\"sidecar-search-toolbar\" data-j2cl-legacy-search-form=\"true\""
+                + " action=\"#\" onsubmit=\"return false;\" hidden>"));
+  }
+
+  // ---------------------------------------------------------------------
+  // Search-rail waveform glyph sizing fix
+  // ---------------------------------------------------------------------
+
+  public void testSearchRailWaveformSvgPinsExplicitDimensions() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Search-rail SVG must carry explicit width=\"14\" so it does not overflow before"
+            + " the Lit upgrade attaches the shadow DOM",
+        html.contains(
+            "<svg viewBox=\"0 0 14 14\" width=\"14\" height=\"14\" fill=\"none\""));
+  }
+
+  // ---------------------------------------------------------------------
+  // Wavy empty-state recipe is present
+  // ---------------------------------------------------------------------
+
+  public void testWavyEmptyStateRecipeIsMounted() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Empty-state slot must mount the wavy empty-state recipe",
+        html.contains("data-j2cl-empty-state-recipe=\"true\""));
+    assertTrue(
+        "Wavy empty-state must include the ghost waveform mark",
+        html.contains("class=\"wavy-empty-state-mark\""));
+    assertTrue(
+        "Wavy empty-state must include the headline",
+        html.contains("class=\"wavy-empty-state-headline\""));
+    assertTrue(
+        "Wavy empty-state must include the subhead",
+        html.contains("class=\"wavy-empty-state-subhead\""));
+  }
+
+  // ---------------------------------------------------------------------
+  // Awareness pill is present (default hidden)
+  // ---------------------------------------------------------------------
+
+  public void testAwarenessPillIsMountedHidden() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Selected-wave card must mount the awareness pill landmark",
+        html.contains("data-j2cl-awareness-pill=\"true\""));
+    assertTrue(
+        "Awareness pill must default to hidden so the cyan ring does not flash on cold mount",
+        html.contains(
+            "<output class=\"wavy-awareness-pill\""
+                + " data-j2cl-awareness-pill=\"true\" hidden></output>"));
+  }
+
+  // ---------------------------------------------------------------------
+  // Compose host carries the F-2 slice 5 marker so the toolbar can be
+  // co-located without confusing automation
+  // ---------------------------------------------------------------------
+
+  public void testComposeHostCarriesSliceFiveMarker() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Compose host must carry data-j2cl-compose-host so view-wiring can target it",
+        html.contains("data-j2cl-compose-host=\"true\""));
+  }
+}


### PR DESCRIPTION
Updates #1037 (slice 5 of 6 — does NOT close the umbrella). Updates #904. References #1055.

## Summary

This is the F-2 view-wiring slice. It reconciles the additive S1+S2+S3+S4 chrome by removing the legacy "Hosted workflow" intro card + duplicate search toolbar from the J2CL root shell now that `<wavy-search-rail>` is the canonical surface, then wires the new chrome to URL state, depth navigation, keyboard, focus-trap, and pin folder state.

### Part A — Integration cleanup (the user-visible win)

- **Removed the legacy "Hosted workflow" intro card content** from `HtmlRenderer.appendRootShellWorkflowMarkup` — the eyebrow ("J2CL root shell"), the `<h1 class="sidecar-title">Hosted workflow</h1>`, and the `<p class="sidecar-detail">` body copy are gone. The `<div class="sidecar-search-card">` wrapper stays in the DOM (the `J2clSearchPanelView` still adopts the form / digests / empty-state nodes via `querySelector`), but the wrapper now carries `data-j2cl-legacy-search-card="hidden"` and the form is flagged `data-j2cl-legacy-search-form="true"` + `hidden`. The wavy search rail in the nav slot is the only visible query surface.

- **Replaced the "Select a wave" placeholder** with the wavy empty-state recipe — centered ghost waveform mark, `wavy-empty-state-headline`, `wavy-empty-state-subhead`. Class names round-trip through the new `HtmlRendererJ2clRootShellIntegrationTest`.

- **Fixed the `<wavy-search-rail>` waveform glyph overflow** that was rendering the SVG at the SVG default 300×150 before the Lit upgrade attached the shadow DOM. SSR + Lit render now both pin `width="14" height="14"` on the SVG element, and `wavy-thread-collapse.css` adds a defensive `wavy-search-rail .waveform svg { width: 14px; height: 14px }` clamp.

- **Suppressed the legacy editor-toolbar wall** when no compose session is active: `J2clToolbarSurfaceController` grew `setViewActionsEnabled(boolean)` (default `true` to keep the sidecar presentation unchanged); the J2CL root shell sets it `false` because `<wavy-wave-nav-row>` mounts the canonical view-action chrome (E.1–E.10). `J2clToolbarSurfaceView.render` now also auto-hides the host when the action model is empty so the legacy Bold/Italic wall no longer renders before composition starts.

### Part B — View wiring

- **URL state `&depth=<blip-id>` (R-3.7 G.4)**: `J2clSidecarRouteState.depthBlipId` + codec round-trip + `J2clSidecarRouteController.onDepthChanged(...)` push. Five new tests in `J2clSidecarRouteCodecTest` pin the round-trip + the absence-clean URL.
- **Keyboard (R-3.7 G.5)**: `[` drill out / `]` drill in / `g` first / `G` last on the read surface. The events bubble to the selected-wave card; `J2clRootShellController.bindDepthEventsToRoute` translates `wavy-depth-drill-in` / `wavy-depth-up` / `wavy-depth-root` / `wavy-depth-jump-to-crumb` into route pushes. `j2cl.depth.drill_in` counter records direction + source.
- **R-3.7 G.6 awareness pill**: `<output class="wavy-awareness-pill">` landmark on the selected-wave card, toggled via `View.setAwarenessPill(int pendingCount)`.
- **Pin/archive nav-row (S2 deferral closeout)**: `J2clSelectedWaveController.publishNavRowFolderState()` wires `J2clSearchDigestItem.isPinned()` onto `<wavy-wave-nav-row>` via `View.setNavRowFolderState`. Archived stays `false` until F-4 wires the live folder feed.
- **Focus-trap + `inert` on overlays (S4 deferral closeout)**: `<wavy-version-history>` and `<wavy-profile-overlay>` now save `document.activeElement` on open, set `inert` on every `<body>` direct child except the overlay host, and restore focus + remove `inert` on close.

## Deferred

- **R-4.4 mark-blip-read Gateway extension** is intentionally deferred to **follow-up #1056**. The integration cleanup + URL state were prioritised so the user-visible duplicate-removal landed in this slice without exceeding the gate-window. The follow-up tracks the server endpoint + IntersectionObserver-equivalent debounce + live unread decrement.

## Test plan

- [x] `JakartaTest/testOnly *HtmlRendererJ2clRootShellIntegrationTest` — 12 new no-duplicate / no-legacy / waveform-fix / wavy-empty-state assertions pass.
- [x] `JakartaTest/testOnly *J2clStageOneReadSurfaceParityTest` — 14 pass.
- [x] `JakartaTest/testOnly *J2clSearchRailParityTest *J2clStageOneFloatingOverlaysParityTest *J2clViewportFirstPaintParityTest` — 21 pass.
- [x] `wave/Test/testOnly *HtmlRendererJ2clRootShellTest` — 10 pass (no regression).
- [x] `mvn -Psearch-sidecar test` — 681/681 pass (the existing 676 + 5 new codec tests).
- [x] `mvn -Pproduction package` — j2cl-sidecar war builds clean.
- [ ] Local boot at `?view=j2cl-root` to confirm visually no-duplicate state, depth-nav drill-in via URL, focus-trap on overlays, `[` / `]` keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard depth navigation (`[` / `]`) and first/last blip jumps; depth focus persisted via `&depth=` URL
  * Awareness pill showing new replies; pin/archive state surfaced in nav chrome

* **Bug Fixes**
  * Fixed waveform SVG sizing overflow; legacy toolbar view actions suppressed when inactive

* **Style**
  * New centered wavy empty-state design; legacy intro copy removed from UI

* **Tests**
  * Added integration and unit tests validating root-shell markup, depth URL handling, and empty-state/awareness behavior

* **Documentation**
  * Added implementation plan and changelog entry for these view/integration updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->