### PR TITLE
fix(j2cl): make wavy F-2 chrome the only rendered surface (#1060)

### DIFF
--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -19,6 +19,17 @@ export class ComposerInlineReply extends LitElement {
     :host {
       display: block;
     }
+    /* F-2 follow-up (#1060): collapse the whole reply composer until an
+     * edit session marks it as available. Pre-fix this element painted
+     * "Reply target: ..." + an empty Send-reply textarea on every
+     * selected wave even when the user had not opened a compose, which
+     * read as a permanent editor-toolbar wall in the right column. The
+     * controller flips the available property to true via setProperty
+     * before any compose interaction, so users still see the textarea
+     * the moment they Reply / Edit. */
+    :host(:not([available])) {
+      display: none;
+    }
 
     .reply {
       display: grid;

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -378,7 +378,6 @@ export class WavySearchRail extends LitElement {
         })}
       </ul>
       <p class="result-count" aria-live="polite">${this.resultCount || ""}</p>
-      <slot></slot>
     `;
   }
 }

--- a/j2cl/lit/test/visual-regression-1060.test.js
+++ b/j2cl/lit/test/visual-regression-1060.test.js
@@ -1,0 +1,104 @@
+import { fixture, expect, html } from "@open-wc/testing";
+import "../src/elements/wavy-search-rail.js";
+import "../src/elements/composer-inline-reply.js";
+
+/**
+ * F-2 follow-up (#1060) — visible-regression locks for the three gaps
+ * that survived the F-2 closeout (PR #1059, sha dc8ee6a3):
+ *
+ *   1. <wavy-search-rail> shadow DOM exposed a default <slot></slot>,
+ *      which projected the SSR'd light-DOM rail (search box + folder
+ *      list + "Saved searches" header) under the rendered shadow chrome.
+ *      Live readers saw the rail twice — dark wavy on top + light
+ *      legacy below.
+ *   2. The J2CL read renderer fell back to "Blip <id>" in the posted-at
+ *      slot when a blip had no real modified time. The user-visible
+ *      result was a flat blip card titled "Blip fN7oSXulpwB" with no
+ *      author / avatar / timestamp / per-blip toolbar.
+ *   3. <composer-inline-reply> rendered "Reply target: ..." + an empty
+ *      Send-reply textarea on every selected wave, even when no compose
+ *      was active, painting as a permanent editor-toolbar wall.
+ *
+ * These assertions FAIL on origin/main HEAD before the fix and PASS
+ * after, so the regression cannot ship a third time.
+ */
+
+describe("F-2 follow-up #1060 — no duplicate rail / no flat blip-id / no toolbar wall", () => {
+  it("Gap 1: <wavy-search-rail> shadow DOM does not expose a default <slot>", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    // Regression guard: any unnamed <slot> in the shadow DOM would
+    // project SSR light children under the rendered chrome and
+    // duplicate the rail surface.
+    const defaultSlots = Array.from(
+      el.renderRoot.querySelectorAll("slot")
+    ).filter((s) => !s.hasAttribute("name"));
+    expect(
+      defaultSlots,
+      "wavy-search-rail must not project SSR'd light DOM via a default slot"
+    ).to.have.length(0);
+  });
+
+  it("Gap 1: light-DOM SSR fallback children are not rendered after upgrade", async () => {
+    // Mount the element with the same SSR'd light-DOM shape the Jakarta
+    // HtmlRenderer emits, then assert the projected fallback chrome is
+    // absent from the visible render.
+    const el = await fixture(html`
+      <wavy-search-rail query="in:inbox" data-active-folder="inbox" result-count="">
+        <div class="search">
+          <input type="search" class="query" name="q" value="in:inbox" />
+          <button type="button" class="help-trigger">?</button>
+        </div>
+        <div class="actions">
+          <button type="button" class="new-wave">New Wave</button>
+          <button type="button" class="manage-saved">Manage saved searches</button>
+        </div>
+        <div class="folders-header">
+          <h2 id="folders-title">Saved searches</h2>
+        </div>
+        <ul class="folders" aria-labelledby="folders-title">
+          <li><button class="folder" data-folder-id="inbox">Inbox</button></li>
+        </ul>
+      </wavy-search-rail>
+    `);
+    await el.updateComplete;
+    // Light-DOM children are still in the DOM (custom element preserved
+    // them) but they should NOT render twice on screen — only the
+    // shadow-DOM render is visible. Since there is no default <slot>,
+    // light children with no slot= attribute have no place to project
+    // and are visually hidden by the shadow root.
+    const lightChildren = Array.from(el.children).filter(
+      (c) => !c.hasAttribute("slot")
+    );
+    expect(lightChildren.length, "test fixture supplies SSR light children")
+      .to.be.greaterThan(0);
+    for (const child of lightChildren) {
+      expect(
+        child.assignedSlot,
+        `light child <${child.tagName.toLowerCase()}> must not assign to any slot`
+      ).to.equal(null);
+    }
+  });
+
+  it("Gap 3: <composer-inline-reply> collapses to display:none when not available", async () => {
+    const el = await fixture(html`
+      <composer-inline-reply target-label="Root blip"></composer-inline-reply>
+    `);
+    await el.updateComplete;
+    expect(el.hasAttribute("available")).to.equal(false);
+    const computed = window.getComputedStyle(el).display;
+    expect(
+      computed,
+      "composer-inline-reply must collapse pre-compose so the reply textarea is not always visible"
+    ).to.equal("none");
+  });
+
+  it("Gap 3: <composer-inline-reply> renders normally once available is set", async () => {
+    const el = await fixture(html`
+      <composer-inline-reply available target-label="Root blip"></composer-inline-reply>
+    `);
+    await el.updateComplete;
+    expect(window.getComputedStyle(el).display).to.equal("block");
+    expect(el.renderRoot.textContent).to.include("Root blip");
+  });
+});

--- a/j2cl/lit/test/visual-regression-1060.test.js
+++ b/j2cl/lit/test/visual-regression-1060.test.js
@@ -3,24 +3,22 @@ import "../src/elements/wavy-search-rail.js";
 import "../src/elements/composer-inline-reply.js";
 
 /**
- * F-2 follow-up (#1060) — visible-regression locks for the three gaps
- * that survived the F-2 closeout (PR #1059, sha dc8ee6a3):
+ * F-2 follow-up (#1060) — visible-regression locks for the gaps covered
+ * in this file that survived the F-2 closeout (PR #1059, sha dc8ee6a3):
  *
  *   1. <wavy-search-rail> shadow DOM exposed a default <slot></slot>,
  *      which projected the SSR'd light-DOM rail (search box + folder
  *      list + "Saved searches" header) under the rendered shadow chrome.
  *      Live readers saw the rail twice — dark wavy on top + light
  *      legacy below.
- *   2. The J2CL read renderer fell back to "Blip <id>" in the posted-at
- *      slot when a blip had no real modified time. The user-visible
- *      result was a flat blip card titled "Blip fN7oSXulpwB" with no
- *      author / avatar / timestamp / per-blip toolbar.
- *   3. <composer-inline-reply> rendered "Reply target: ..." + an empty
+ *   2. <composer-inline-reply> rendered "Reply target: ..." + an empty
  *      Send-reply textarea on every selected wave, even when no compose
  *      was active, painting as a permanent editor-toolbar wall.
  *
  * These assertions FAIL on origin/main HEAD before the fix and PASS
- * after, so the regression cannot ship a third time.
+ * after, so these covered regressions cannot ship a third time.
+ * (The J2CL read-renderer fallback-to-blip-id fix is regression-locked
+ * in HtmlRendererJ2clRootShellIntegrationTest.)
  */
 
 describe("F-2 follow-up #1060 — no duplicate rail / no flat blip-id / no toolbar wall", () => {

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -184,18 +184,26 @@ describe("<wavy-search-rail>", () => {
     expect(p.textContent.trim()).to.equal("133 waves");
   });
 
-  it("default slot accepts <wavy-search-rail-card> children", async () => {
+  it("does NOT expose a default slot for SSR fallback children (#1060)", async () => {
+    // F-2 follow-up (#1060): the previous default slot projected the
+    // SSR'd light DOM under the rendered shadow chrome and painted the
+    // rail twice. The shadow-DOM render is now self-contained; light
+    // DOM children supplied for SSR fallback have no slot to project
+    // into and are visually hidden after upgrade.
     const el = await fixture(html`
       <wavy-search-rail>
         <div data-stub-card="1">card</div>
       </wavy-search-rail>
     `);
     await el.updateComplete;
-    const slot = el.renderRoot.querySelector("slot");
-    expect(slot).to.exist;
-    const assigned = slot.assignedElements();
-    expect(assigned.length).to.equal(1);
-    expect(assigned[0].dataset.stubCard).to.equal("1");
+    const defaultSlot = Array.from(
+      el.renderRoot.querySelectorAll("slot")
+    ).find((s) => !s.hasAttribute("name"));
+    expect(defaultSlot, "no default <slot> in shadow DOM").to.not.exist;
+    const stub = el.querySelector('[data-stub-card="1"]');
+    expect(stub, "light child stays in light DOM").to.exist;
+    expect(stub.assignedSlot, "light child must not project anywhere")
+      .to.equal(null);
   });
 });
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -294,9 +294,17 @@ public final class J2clReadSurfaceDomRenderer {
       element.setAttribute("posted-at", formatRelativeTimestamp(modifiedMs));
       element.setAttribute("posted-at-iso", formatIsoTimestamp(modifiedMs));
     } else {
-      // Fallback so the avatar header still renders an empty <time> with
-      // the legacy "Blip <id>" label, preserving AT discoverability.
-      element.setAttribute("posted-at", blipLabel(blip.getBlipId()));
+      // F-2 follow-up (#1060): when a blip has no real modified time
+      // (e.g. fixture / fallback paths, or first paint before metadata
+      // arrives) we used to fall back to the literal label "Blip <id>"
+      // in the posted-at slot, which painted as the entire header text
+      // on the live read surface (no author, no avatar — just the raw
+      // id). Leave posted-at empty so the visible <time> element does
+      // not show an internal token, but expose the AT-friendly label on
+      // the host's aria-label so screen readers can still announce the
+      // blip.
+      element.setAttribute("posted-at", "");
+      element.setAttribute("aria-label", blipLabel(blip.getBlipId()));
     }
     if (blip.isUnread()) {
       element.setAttribute("unread", "");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -300,11 +300,16 @@ public final class J2clReadSurfaceDomRenderer {
       // in the posted-at slot, which painted as the entire header text
       // on the live read surface (no author, no avatar — just the raw
       // id). Leave posted-at empty so the visible <time> element does
-      // not show an internal token, but expose the AT-friendly label on
-      // the host's aria-label so screen readers can still announce the
-      // blip.
+      // not show an internal token. Only set aria-label when there is no
+      // author info to announce — otherwise it would override the richer
+      // accessible name composed from author-name/author-id content.
       element.setAttribute("posted-at", "");
-      element.setAttribute("aria-label", blipLabel(blip.getBlipId()));
+      boolean hasAuthor =
+          (displayName != null && !displayName.isEmpty())
+              || (blip.getAuthorId() != null && !blip.getAuthorId().isEmpty());
+      if (!hasAuthor) {
+        element.setAttribute("aria-label", blipLabel(blip.getBlipId()));
+      }
     }
     if (blip.isUnread()) {
       element.setAttribute("unread", "");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceController.java
@@ -170,7 +170,19 @@ public final class J2clToolbarSurfaceController {
     if (viewActionsEnabled) {
       addViewActions(actions);
     }
-    addEditActions(actions);
+    // F-2 follow-up (#1060): only emit the edit-formatting toolbar
+    // (Bold / Italic / Underline / ... / attachment buttons) while an
+    // edit session is active. Previously the controller emitted the
+    // full edit-action set on every render with the buttons disabled,
+    // which painted as a permanent editor-toolbar wall on the right of
+    // the read surface even when no compose was open. The view's
+    // host.hidden = actions.isEmpty() guard then resolves the toolbar
+    // host to display:none, and the wavy-thread-collapse `:empty`
+    // collapse rule on the parent compose host removes the layout
+    // gap entirely until an edit session is opened.
+    if (editState.editable) {
+      addEditActions(actions);
+    }
     view.render(new J2clToolbarSurfaceModel(actions));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/toolbar/J2clToolbarSurfaceControllerTest.java
@@ -166,6 +166,21 @@ public class J2clToolbarSurfaceControllerTest {
   }
 
   @Test
+  public void editStateNotEditableProducesNoEditActions() {
+    FakeView view = new FakeView();
+    J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });
+
+    controller.start();
+    controller.onEditStateChanged(new J2clToolbarSurfaceController.EditState(false));
+
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.ITALIC));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.UNDERLINE));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.ATTACHMENT_INSERT));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.ATTACHMENT_UPLOAD_QUEUE));
+  }
+
+  @Test
   public void unavailableActionSurfacesExplicitErrorText() {
     FakeView view = new FakeView();
     J2clToolbarSurfaceController controller = new J2clToolbarSurfaceController(view, action -> { });

--- a/wave/config/changelog.d/2026-04-27-issue-1060-wavy-chrome-only.json
+++ b/wave/config/changelog.d/2026-04-27-issue-1060-wavy-chrome-only.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-27-issue-1060-wavy-chrome-only",
+  "version": "PR #1060",
+  "date": "2026-04-27",
+  "title": "F-2 follow-up: wavy chrome is the only rendered surface",
+  "summary": "The J2CL root view now renders only the wavy F-2 chrome — no duplicate light search rail, no flat blip-id headers, no permanent editor-toolbar wall.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the default <slot> from <wavy-search-rail> shadow DOM so the SSR'd light rail no longer projects under the rendered chrome as a duplicate \"Saved searches\" surface.",
+        "Stopped the J2CL read renderer from falling back to the literal label \"Blip <id>\" in the posted-at slot when a blip has no real modified time — the avatar / author header now owns the metadata row and the AT label moves to aria-label.",
+        "Gated the J2CL toolbar's edit-formatting actions (Bold / Italic / ... / attachments) on an active edit session and collapsed <composer-inline-reply> until the controller flips it available so the read surface no longer shows a permanent editor-toolbar wall."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -477,6 +477,17 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
                     + "addEditActions\\s*\\(")
             .matcher(source)
             .find());
+    // Also verify no unconditional addEditActions call exists outside the guard.
+    String sourceWithoutEditableGuard =
+        source.replaceFirst(
+            "if\\s*\\(\\s*editState\\.editable\\s*\\)\\s*\\{[\\s\\S]*?addEditActions\\s*\\(\\s*actions\\s*\\)\\s*;[\\s\\S]*?\\}",
+            "");
+    assertFalse(
+        "J2clToolbarSurfaceController.render must not call addEditActions "
+            + "outside the editState.editable guard (see #1060)",
+        java.util.regex.Pattern.compile("addEditActions\\s*\\([^;]*\\)\\s*;")
+            .matcher(sourceWithoutEditableGuard)
+            .find());
   }
 
   public void testComposerInlineReplyCollapsesUntilAvailable() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -381,4 +381,123 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Preview route must hide the legacy search card via the same data-marker as the root shell",
         html.contains("data-j2cl-legacy-search-card=\"hidden\""));
   }
+
+  // ---------------------------------------------------------------------
+  // F-2 follow-up (#1060) — visible-regression locks for the three gaps
+  // that survived the F-2 closeout (PR #1059, sha dc8ee6a3):
+  //
+  //   1. <wavy-search-rail> shadow DOM exposed a default <slot></slot>,
+  //      which projected the SSR'd light-DOM rail under the rendered
+  //      shadow chrome. Live readers saw the rail twice.
+  //   2. The J2CL read renderer fell back to "Blip <id>" in the
+  //      posted-at slot when a blip had no real modified time, painting
+  //      as the entire header text on the live read surface.
+  //   3. The J2CL toolbar surface controller emitted the full edit-
+  //      formatting toolbar (Bold/Italic/.../attachment buttons) on
+  //      every render, causing a permanent editor-toolbar wall on the
+  //      right of the read surface even when no compose was active.
+  //
+  // These assertions are static-source pins so the regression cannot
+  // ship by going around the Lit-side jsdom fixture in
+  // j2cl/lit/test/visual-regression-1060.test.js.
+  // ---------------------------------------------------------------------
+
+  /** Reads a source file relative to the worktree root. */
+  private static String readSourceFile(String relativePath) {
+    Path candidate = Paths.get(relativePath);
+    if (!Files.isRegularFile(candidate)) {
+      candidate = Paths.get("../" + relativePath);
+    }
+    if (!Files.isRegularFile(candidate)) {
+      throw new AssertionError(
+          "source file not found at "
+              + relativePath
+              + " — run from the repo root or stage the file");
+    }
+    try {
+      return new String(Files.readAllBytes(candidate), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new AssertionError("Could not read " + candidate + ": " + e.getMessage(), e);
+    }
+  }
+
+  public void testWavySearchRailHasNoDefaultSlotInShadowDom() {
+    // Gap 1: a default <slot></slot> in the shadow DOM render projects
+    // the SSR'd light-DOM rail under the rendered chrome and paints the
+    // rail twice. Pin the static source so the regression cannot return.
+    String source = readSourceFile("j2cl/lit/src/elements/wavy-search-rail.js");
+    // Allow named slots (e.g. <slot name="..."></slot>) — those project
+    // only explicitly-slotted children — but reject the default
+    // unnamed <slot> form.
+    assertFalse(
+        "wavy-search-rail must not expose a default <slot></slot> "
+            + "(see #1060 — projects SSR'd light DOM as a duplicate rail)",
+        java.util.regex.Pattern.compile("<slot\\s*></slot>")
+            .matcher(source)
+            .find());
+    assertFalse(
+        "wavy-search-rail must not expose a default <slot> with a "
+            + "fallback body (see #1060)",
+        java.util.regex.Pattern.compile("<slot\\s*>(?![^<]*name=)")
+            .matcher(source)
+            .find());
+  }
+
+  public void testJ2clReadRendererDoesNotFallBackToBlipIdLabel() {
+    // Gap 2: the renderer used to set posted-at="Blip <id>" when a
+    // blip had no real modified time. The wave-blip element rendered
+    // that text inside the visible <time> element so every metadata-
+    // less blip painted as a flat card titled "Blip fN7oSXulpwB". Pin
+    // the static source so the regression cannot return.
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/read/"
+                + "J2clReadSurfaceDomRenderer.java");
+    assertFalse(
+        "J2clReadSurfaceDomRenderer must not set posted-at to the "
+            + "'Blip <id>' fallback (see #1060 — renders as the entire "
+            + "header text on the live read surface)",
+        source.contains(
+            "element.setAttribute(\"posted-at\", blipLabel(blip.getBlipId()));"));
+  }
+
+  public void testJ2clToolbarOnlyEmitsEditActionsWhileEditing() {
+    // Gap 3: the toolbar controller used to call addEditActions on
+    // every render, regardless of editState.editable. The view's
+    // host.hidden = actions.isEmpty() guard then never fired and the
+    // full Bold/Italic/.../attachment toolbar painted as a permanent
+    // wall on the right of the read surface. Pin the static source.
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/toolbar/"
+                + "J2clToolbarSurfaceController.java");
+    // The fix: addEditActions must be inside an if (editState.editable)
+    // guard. We pin the regex shape so the regression cannot return by
+    // dropping the guard and re-introducing the wall.
+    assertTrue(
+        "J2clToolbarSurfaceController.render must gate addEditActions "
+            + "on editState.editable (see #1060 — otherwise the editor-"
+            + "toolbar wall paints permanently)",
+        java.util.regex.Pattern.compile(
+                "if\\s*\\(\\s*editState\\.editable\\s*\\)\\s*\\{\\s*"
+                    + "addEditActions\\s*\\(")
+            .matcher(source)
+            .find());
+  }
+
+  public void testComposerInlineReplyCollapsesUntilAvailable() {
+    // Gap 3 partner: <composer-inline-reply> rendered "Reply target: ..."
+    // + an empty Send-reply textarea on every selected wave even when
+    // no compose was active. Pin the :host(:not([available]))
+    // display:none rule in the Lit element source.
+    String source =
+        readSourceFile("j2cl/lit/src/elements/composer-inline-reply.js");
+    assertTrue(
+        "composer-inline-reply must collapse the host until the "
+            + "controller flips available=true (see #1060)",
+        java.util.regex.Pattern.compile(
+                ":host\\(:not\\(\\[available\\]\\)\\)\\s*\\{\\s*display\\s*:\\s*none\\s*;\\s*\\}")
+            .matcher(source)
+            .find());
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -427,12 +427,18 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
     // rail twice. Pin the static source so the regression cannot return.
     String source = readSourceFile("j2cl/lit/src/elements/wavy-search-rail.js");
     // Allow named slots (e.g. <slot name="..."></slot>) — those project
-    // only explicitly-slotted children — but reject the default
-    // unnamed <slot> form.
+    // only explicitly-slotted children — but reject any default
+    // unnamed <slot> form, including self-closing variants.
     assertFalse(
         "wavy-search-rail must not expose a default <slot></slot> "
             + "(see #1060 — projects SSR'd light DOM as a duplicate rail)",
         java.util.regex.Pattern.compile("<slot\\s*></slot>")
+            .matcher(source)
+            .find());
+    assertFalse(
+        "wavy-search-rail must not expose a self-closing default <slot/> "
+            + "(see #1060 — projects SSR'd light DOM as a duplicate rail)",
+        java.util.regex.Pattern.compile("<slot\\s*/>")
             .matcher(source)
             .find());
     assertFalse(

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -427,24 +427,12 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
     // rail twice. Pin the static source so the regression cannot return.
     String source = readSourceFile("j2cl/lit/src/elements/wavy-search-rail.js");
     // Allow named slots (e.g. <slot name="..."></slot>) — those project
-    // only explicitly-slotted children — but reject any default
-    // unnamed <slot> form, including self-closing variants.
+    // only explicitly-slotted children — but reject any <slot ...> that
+    // lacks a name= attribute, including self-closing and attributed forms.
     assertFalse(
-        "wavy-search-rail must not expose a default <slot></slot> "
+        "wavy-search-rail must not expose any unnamed <slot ...> "
             + "(see #1060 — projects SSR'd light DOM as a duplicate rail)",
-        java.util.regex.Pattern.compile("<slot\\s*></slot>")
-            .matcher(source)
-            .find());
-    assertFalse(
-        "wavy-search-rail must not expose a self-closing default <slot/> "
-            + "(see #1060 — projects SSR'd light DOM as a duplicate rail)",
-        java.util.regex.Pattern.compile("<slot\\s*/>")
-            .matcher(source)
-            .find());
-    assertFalse(
-        "wavy-search-rail must not expose a default <slot> with a "
-            + "fallback body (see #1060)",
-        java.util.regex.Pattern.compile("<slot\\s*>(?![^<]*name=)")
+        java.util.regex.Pattern.compile("<slot(?![^>]*\\bname\\s*=)[^>]*>")
             .matcher(source)
             .find());
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -477,17 +477,22 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
                     + "addEditActions\\s*\\(")
             .matcher(source)
             .find());
-    // Also verify no unconditional addEditActions call exists outside the guard.
-    String sourceWithoutEditableGuard =
-        source.replaceFirst(
-            "if\\s*\\(\\s*editState\\.editable\\s*\\)\\s*\\{[\\s\\S]*?addEditActions\\s*\\(\\s*actions\\s*\\)\\s*;[\\s\\S]*?\\}",
-            "");
-    assertFalse(
-        "J2clToolbarSurfaceController.render must not call addEditActions "
-            + "outside the editState.editable guard (see #1060)",
-        java.util.regex.Pattern.compile("addEditActions\\s*\\([^;]*\\)\\s*;")
-            .matcher(sourceWithoutEditableGuard)
-            .find());
+    // Also verify there is exactly one CALL to addEditActions in the
+    // file (the guarded one) — the only other occurrence should be the
+    // method declaration. If the guard is dropped and a second
+    // unconditional call is added, this count check fails.
+    java.util.regex.Matcher callMatcher =
+        java.util.regex.Pattern.compile("addEditActions\\s*\\(\\s*actions\\s*\\)\\s*;")
+            .matcher(source);
+    int callCount = 0;
+    while (callMatcher.find()) {
+      callCount++;
+    }
+    assertEquals(
+        "J2clToolbarSurfaceController must invoke addEditActions exactly "
+            + "once (inside the editState.editable guard — see #1060)",
+        1,
+        callCount);
   }
 
   public void testComposerInlineReplyCollapsesUntilAvailable() {


### PR DESCRIPTION
Closes #1060. Updates #904. Fixes the three live-page regressions left after the F-2 closeout (PR #1059, sha dc8ee6a3).

## Three gaps fixed

1. **Duplicate light search rail** — `<wavy-search-rail>` shadow DOM exposed a default `<slot></slot>`, which projected the SSR'd light-DOM rail under the rendered chrome and painted the rail twice (dark wavy on top, light legacy below). Removed the slot.
2. **Flat blip-id headers** — the J2CL read renderer fell back to the literal label `Blip <id>` in the `posted-at` slot when a blip had no real modified time. The `<wave-blip>` element rendered that text inside the visible `<time>` element, so every metadata-less blip painted as a flat card titled `Blip fN7oSXulpwB`. The fallback now leaves `posted-at` empty and moves the AT label to the host's `aria-label`.
3. **Permanent editor-toolbar wall** — the J2CL toolbar surface controller emitted the full edit-formatting toolbar (Bold / Italic / ... / attachments) on every render, regardless of `editState.editable`. With `viewActionsEnabled=false` in the root shell controller, the host stayed visible because the actions list was never empty. Gated `addEditActions` on `editState.editable` so the host collapses until an edit session is opened. Also collapsed `<composer-inline-reply>` via `:host(:not([available])) { display:none }` so the `Reply target: ...` line + empty Send-reply textarea no longer paint pre-compose.

## Why the integration tests didn't catch this

The previous `HtmlRendererJ2clRootShellIntegrationTest` asserted on the presence of new markers (`data-j2cl-legacy-search-card="hidden"`, `<wavy-search-rail>` count, etc.), but never on the absence / invisibility of the legacy markup the rail / blip / toolbar surfaces still emitted. Four new static-source pins now regression-lock each gap:

- `testWavySearchRailHasNoDefaultSlotInShadowDom`
- `testJ2clReadRendererDoesNotFallBackToBlipIdLabel`
- `testJ2clToolbarOnlyEmitsEditActionsWhileEditing`
- `testComposerInlineReplyCollapsesUntilAvailable`

The new `j2cl/lit/test/visual-regression-1060.test.js` fixture exercises the same contract end-to-end via the jsdom Lit harness so the regression cannot return by going around the static-source check.

## Test plan

- [x] `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild` — all green
- [x] `sbt -batch Test/testOnly *HtmlRendererJ2clRootShellIntegrationTest` — 23 / 23 pass (4 new + 19 existing)
- [x] `sbt -batch JakartaTest/testOnly *J2clStageOneFinalParityTest *J2clStageOneReadSurfaceParityTest *J2clSearchRailParityTest` — 25 / 25 pass (1 skipped)
- [x] `j2cl/mvnw -P search-sidecar test` — 681 / 681 pass (102 skipped)
- [x] Lit web-test-runner — 384 / 384 pass
- [ ] Hard-refresh `/?view=j2cl-root&q=in:inbox` on a deploy and confirm only the wavy chrome paints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reply composer now collapses when unavailable, preventing persistent layout/toolbar space.
  * Edit-formatting toolbar actions are shown only during active editing, reducing read-surface clutter.
  * Blip timestamp metadata no longer exposes raw internal tokens; accessible labeling improved.
  * Wavy search rail no longer projects server-rendered light DOM into the rendered rail.

* **Tests**
  * Added visual, integration, and unit tests to lock these rendering and accessibility behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->