### PR TITLE
F-4 (slice 1 of 2): J2CL markBlipRead supplement op + live unread decrement (R-4.4)

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -12,8 +12,12 @@ import elemental2.dom.KeyboardEvent;
 import elemental2.dom.NodeList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
@@ -25,9 +29,48 @@ public final class J2clReadSurfaceDomRenderer {
   private static final double EDGE_SCROLL_THRESHOLD_PX = 64;
   private static final String ATTACHMENT_TELEMETRY_BOUND = "data-attachment-telemetry-bound";
 
+  /**
+   * F-4 (#1039 / R-4.4 / subsumes #1056): how long an unread blip must dwell
+   * inside the viewport before we treat it as "the user actually read it".
+   * 1.5 s (the spec from #1056) is short enough to feel responsive when
+   * users genuinely linger and long enough that scroll-through traffic
+   * doesn't fire mark-as-read.
+   */
+  public static final int VIEWPORT_DWELL_DEBOUNCE_MS = 1500;
+
+  /**
+   * F-4 (#1039 / R-4.4 / subsumes #1056): an unread blip is considered "in
+   * the viewport" when at least this fraction of its area is visible OR the
+   * intersection rect fills at least this fraction of the viewport (the
+   * second clause covers blips taller than the viewport, which can never
+   * reach the first threshold).
+   */
+  public static final double VIEWPORT_INTERSECTION_THRESHOLD = 0.5;
+
   @FunctionalInterface
   public interface ViewportEdgeListener {
     void onViewportEdge(String anchorBlipId, String direction);
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4 / subsumes #1056): listener invoked when an unread
+   * blip has been in the viewport for {@link #VIEWPORT_DWELL_DEBOUNCE_MS}.
+   */
+  @FunctionalInterface
+  public interface MarkBlipReadListener {
+    void markBlipRead(String blipId);
+  }
+
+  /** Test seam for the dwell-timer scheduler so unit tests can swap a fake clock. */
+  public interface DwellTimerScheduler {
+    /**
+     * Schedules {@code action} to run after {@code delayMs}. Returns a handle
+     * that {@link #cancel(Object)} accepts.
+     */
+    Object schedule(int delayMs, Runnable action);
+
+    /** Cancels a previously scheduled action; idempotent for unknown handles. */
+    void cancel(Object handle);
   }
 
   private final HTMLDivElement host;
@@ -42,6 +85,11 @@ public final class J2clReadSurfaceDomRenderer {
   private ViewportEdgeListener viewportEdgeListener;
   private boolean scrollListenerBound;
   private String lastScrollDirection;
+  // F-4 (#1039 / R-4.4): mark-as-read state — listener, dwell timers, in-flight set.
+  private MarkBlipReadListener markBlipReadListener;
+  private DwellTimerScheduler dwellTimerScheduler = defaultDwellTimerScheduler();
+  private final Map<String, Object> dwellTimers = new HashMap<String, Object>();
+  private final Set<String> markBlipReadInFlight = new HashSet<String>();
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -72,10 +120,209 @@ public final class J2clReadSurfaceDomRenderer {
     lastScrollDirection = null;
   }
 
+  /**
+   * F-4 (#1039 / R-4.4): registers the mark-blip-read listener that fires when
+   * an unread blip has dwelt in the viewport for at least
+   * {@link #VIEWPORT_DWELL_DEBOUNCE_MS}. Idempotent — passing null disables
+   * the listener but leaves the scroll wiring intact.
+   */
+  public void setMarkBlipReadListener(MarkBlipReadListener listener) {
+    this.markBlipReadListener = listener;
+    if (!scrollListenerBound) {
+      host.addEventListener("scroll", this::onHostScroll);
+      scrollListenerBound = true;
+    }
+  }
+
+  /**
+   * Test seam — replaces the dwell-timer scheduler with a fake. Must be set
+   * before the first render so any timers scheduled use the supplied scheduler.
+   */
+  public void setDwellTimerSchedulerForTesting(DwellTimerScheduler scheduler) {
+    this.dwellTimerScheduler = scheduler == null ? defaultDwellTimerScheduler() : scheduler;
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4): walks rendered blips and arms / cancels per-blip
+   * dwell timers based on viewport intersection. Called on every scroll and
+   * every render rebuild. Already-fired blips (in {@link #markBlipReadInFlight})
+   * and read blips (no {@code unread} attribute) are skipped.
+   */
+  void evaluateDwellTimers() {
+    if (markBlipReadListener == null) {
+      return;
+    }
+    if (renderedBlips.isEmpty()) {
+      cancelAllDwellTimers();
+      return;
+    }
+    DOMRect hostRect = host.getBoundingClientRect();
+    double viewportHeight = hostRect.height;
+    if (viewportHeight <= 0) {
+      // Off-screen / detached host — no point scheduling.
+      cancelAllDwellTimers();
+      return;
+    }
+    Set<String> visibleUnreadIds = new HashSet<String>();
+    for (HTMLElement blip : renderedBlips) {
+      if (blip == null) {
+        continue;
+      }
+      if (!blip.hasAttribute("unread")) {
+        continue;
+      }
+      String blipId = blip.getAttribute("data-blip-id");
+      if (blipId == null || blipId.isEmpty()) {
+        continue;
+      }
+      if (markBlipReadInFlight.contains(blipId)) {
+        continue;
+      }
+      if (!isBlipInViewport(blip, hostRect)) {
+        continue;
+      }
+      visibleUnreadIds.add(blipId);
+      if (!dwellTimers.containsKey(blipId)) {
+        // Snapshot the blip id; the timer fires only if the listener is
+        // still installed and the in-flight gate hasn't already taken it.
+        final String pendingBlipId = blipId;
+        Object handle =
+            dwellTimerScheduler.schedule(
+                VIEWPORT_DWELL_DEBOUNCE_MS, () -> fireDwellTimer(pendingBlipId));
+        dwellTimers.put(blipId, handle);
+      }
+    }
+    // Cancel timers for blips that left the viewport (or were cleared).
+    if (dwellTimers.size() > visibleUnreadIds.size()) {
+      List<String> stale = new ArrayList<String>(dwellTimers.keySet());
+      for (String pendingId : stale) {
+        if (!visibleUnreadIds.contains(pendingId)) {
+          Object handle = dwellTimers.remove(pendingId);
+          if (handle != null) {
+            dwellTimerScheduler.cancel(handle);
+          }
+        }
+      }
+    }
+  }
+
+  private void fireDwellTimer(String blipId) {
+    dwellTimers.remove(blipId);
+    if (markBlipReadListener == null) {
+      return;
+    }
+    if (blipId == null || blipId.isEmpty()) {
+      return;
+    }
+    if (!markBlipReadInFlight.add(blipId)) {
+      // Already in flight — defence-in-depth.
+      return;
+    }
+    try {
+      markBlipReadListener.markBlipRead(blipId);
+    } catch (Throwable t) {
+      // Listener errors must not break the renderer; clear the in-flight
+      // gate so a later re-arm can retry.
+      markBlipReadInFlight.remove(blipId);
+    }
+  }
+
+  /**
+   * Visibility predicate used by {@link #evaluateDwellTimers}. A blip is
+   * considered visible when the intersection rectangle covers ≥ 50 % of the
+   * blip OR (for blips taller than the viewport) ≥ 50 % of the viewport.
+   */
+  private static boolean isBlipInViewport(HTMLElement blip, DOMRect hostRect) {
+    DOMRect blipRect = blip.getBoundingClientRect();
+    double blipHeight = blipRect.height;
+    double blipWidth = blipRect.width;
+    if (blipHeight <= 0 || blipWidth <= 0) {
+      return false;
+    }
+    double intersectTop = Math.max(blipRect.top, hostRect.top);
+    double intersectBottom = Math.min(blipRect.bottom, hostRect.bottom);
+    double intersectHeight = intersectBottom - intersectTop;
+    if (intersectHeight <= 0) {
+      return false;
+    }
+    double intersectLeft = Math.max(blipRect.left, hostRect.left);
+    double intersectRight = Math.min(blipRect.right, hostRect.right);
+    double intersectWidth = intersectRight - intersectLeft;
+    if (intersectWidth <= 0) {
+      return false;
+    }
+    double intersectArea = intersectHeight * intersectWidth;
+    double blipArea = blipHeight * blipWidth;
+    double hostHeight = hostRect.height;
+    if (intersectArea / blipArea >= VIEWPORT_INTERSECTION_THRESHOLD) {
+      return true;
+    }
+    // Tall-blip exception: a blip taller than the viewport can never reach
+    // the area-ratio threshold. Treat "the visible slice fills ≥ 50% of the
+    // viewport" as visible too.
+    if (hostHeight > 0 && intersectHeight / hostHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
+      return true;
+    }
+    return false;
+  }
+
+  private void cancelAllDwellTimers() {
+    if (dwellTimers.isEmpty()) {
+      return;
+    }
+    for (Object handle : dwellTimers.values()) {
+      if (handle != null) {
+        dwellTimerScheduler.cancel(handle);
+      }
+    }
+    dwellTimers.clear();
+  }
+
+  /** Drops in-flight ids for blips that are no longer rendered. */
+  private void pruneStaleInFlightOnRebuild() {
+    if (markBlipReadInFlight.isEmpty()) {
+      return;
+    }
+    Set<String> renderedIds = new HashSet<String>();
+    for (HTMLElement blip : renderedBlips) {
+      if (blip == null) {
+        continue;
+      }
+      String id = blip.getAttribute("data-blip-id");
+      if (id != null && !id.isEmpty()) {
+        renderedIds.add(id);
+      }
+    }
+    markBlipReadInFlight.retainAll(renderedIds);
+  }
+
+  private static DwellTimerScheduler defaultDwellTimerScheduler() {
+    return new DwellTimerScheduler() {
+      @Override
+      public Object schedule(int delayMs, Runnable action) {
+        return DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+      }
+
+      @Override
+      public void cancel(Object handle) {
+        if (handle == null) {
+          return;
+        }
+        try {
+          DomGlobal.clearTimeout(((Number) handle).doubleValue());
+        } catch (Throwable ignored) {
+          // The handle may be opaque in test fakes; cancellation is best-effort.
+        }
+      }
+    };
+  }
+
   public boolean render(List<J2clReadBlip> blips, List<String> fallbackEntries) {
     List<J2clReadBlip> effectiveBlips = normalizeBlips(blips, fallbackEntries);
     if (effectiveBlips.isEmpty()) {
       clearViewportScrollMemory();
+      cancelAllDwellTimers();
+      markBlipReadInFlight.clear();
       host.innerHTML = "";
       renderedBlips.clear();
       renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
@@ -89,10 +336,15 @@ public final class J2clReadSurfaceDomRenderer {
     List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
     if (matchesRenderedBlips(effectiveBlips)) {
       restoreFocusedBlipById(focusedBlipId);
+      // F-4 (#1039 / R-4.4): even on a no-op match, viewport dwell may
+      // have changed since last evaluation (e.g. focus restoration moved
+      // scroll position).
+      evaluateDwellTimers();
       return true;
     }
 
     clearViewportScrollMemory();
+    cancelAllDwellTimers();
     host.innerHTML = "";
     renderedBlips.clear();
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
@@ -121,12 +373,16 @@ public final class J2clReadSurfaceDomRenderer {
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
+    pruneStaleInFlightOnRebuild();
+    evaluateDwellTimers();
     return true;
   }
 
   public boolean renderWindow(List<J2clReadWindowEntry> entries) {
     if (entries == null || entries.isEmpty()) {
       clearViewportScrollMemory();
+      cancelAllDwellTimers();
+      markBlipReadInFlight.clear();
       host.innerHTML = "";
       renderedBlips.clear();
       renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
@@ -142,9 +398,11 @@ public final class J2clReadSurfaceDomRenderer {
     List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
     if (matchesRenderedWindowEntries(entries)) {
       restoreFocusedBlipById(focusedBlipId);
+      evaluateDwellTimers();
       return true;
     }
 
+    cancelAllDwellTimers();
     host.innerHTML = "";
     renderedBlips.clear();
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
@@ -202,6 +460,8 @@ public final class J2clReadSurfaceDomRenderer {
     restoreFocusedBlipById(focusedBlipId);
     restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
     requestReachablePlaceholderAfterRender();
+    pruneStaleInFlightOnRebuild();
+    evaluateDwellTimers();
     return true;
   }
 
@@ -256,8 +516,11 @@ public final class J2clReadSurfaceDomRenderer {
     renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
     renderedSurface = surface;
     focusedBlip = null;
+    cancelAllDwellTimers();
     enhanceSurface(surface);
     restoreFocusedBlip(previousFocusedBlip);
+    pruneStaleInFlightOnRebuild();
+    evaluateDwellTimers();
     // A zero-blip surface is still valid no-wave/empty markup, but callers use
     // the boolean to know whether focusable read content was found.
     return !renderedBlips.isEmpty();
@@ -900,6 +1163,12 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void onHostScroll(Event event) {
+    // F-4 (#1039 / R-4.4): every scroll event rearms / cancels per-blip
+    // dwell timers so the user actually has to dwell on a blip rather than
+    // scroll through it. Cheap because getBoundingClientRect is O(1) per
+    // node and the rendered list is small (viewport-scoped).
+    evaluateDwellTimers();
+
     if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
       return;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -58,7 +58,7 @@ public final class J2clReadSurfaceDomRenderer {
    */
   @FunctionalInterface
   public interface MarkBlipReadListener {
-    void markBlipRead(String blipId);
+    void markBlipRead(String blipId, Runnable onError);
   }
 
   /** Test seam for the dwell-timer scheduler so unit tests can swap a fake clock. */
@@ -128,6 +128,10 @@ public final class J2clReadSurfaceDomRenderer {
    */
   public void setMarkBlipReadListener(MarkBlipReadListener listener) {
     this.markBlipReadListener = listener;
+    if (listener == null) {
+      cancelAllDwellTimers();
+      markBlipReadInFlight.clear();
+    }
     if (!scrollListenerBound) {
       host.addEventListener("scroll", this::onHostScroll);
       scrollListenerBound = true;
@@ -218,12 +222,13 @@ public final class J2clReadSurfaceDomRenderer {
       // Already in flight — defence-in-depth.
       return;
     }
+    Runnable releaseGate = () -> markBlipReadInFlight.remove(blipId);
     try {
-      markBlipReadListener.markBlipRead(blipId);
+      markBlipReadListener.markBlipRead(blipId, releaseGate);
     } catch (Throwable t) {
       // Listener errors must not break the renderer; clear the in-flight
       // gate so a later re-arm can retry.
-      markBlipReadInFlight.remove(blipId);
+      releaseGate.run();
     }
   }
 
@@ -259,8 +264,12 @@ public final class J2clReadSurfaceDomRenderer {
     }
     // Tall-blip exception: a blip taller than the viewport can never reach
     // the area-ratio threshold. Treat "the visible slice fills ≥ 50% of the
-    // viewport" as visible too.
-    if (hostHeight > 0 && intersectHeight / hostHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
+    // viewport area" as visible too.
+    double hostWidth = hostRect.width;
+    double hostArea = hostHeight * hostWidth;
+    if (blipHeight > hostHeight
+        && hostArea > 0
+        && intersectArea / hostArea >= VIEWPORT_INTERSECTION_THRESHOLD) {
       return true;
     }
     return false;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -172,6 +172,9 @@ public final class J2clReadSurfaceDomRenderer {
       if (blip == null) {
         continue;
       }
+      if (isHiddenByCollapsedThread(blip)) {
+        continue;
+      }
       if (!blip.hasAttribute("unread")) {
         continue;
       }
@@ -1025,6 +1028,7 @@ public final class J2clReadSurfaceDomRenderer {
     } catch (Throwable ignored) {
       // Telemetry is observational.
     }
+    evaluateDwellTimers();
   }
 
   private void onBlipFocus(Event event) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -303,22 +303,27 @@ public final class J2clReadSurfaceDomRenderer {
     dwellTimers.clear();
   }
 
-  /** Drops in-flight ids for blips that are no longer rendered. */
+  /**
+   * Drops the renderer's in-flight gate entries whenever the surface is
+   * rebuilt with a different blip set. The gate is keyed by blipId only
+   * (the renderer has no wave concept), so retaining entries by blipId
+   * across rebuilds is unsafe: when the user switches waves and the new
+   * wave happens to contain the same blipId — a case the controller
+   * already documents as legitimate — the stale entry would suppress
+   * dwell-timer scheduling forever and prevent mark-read for the new wave.
+   *
+   * <p>By the time a full rebuild happens the surface is rendering content
+   * for a new context (different wave / different digest selection /
+   * different fragment window), so any still-pending dispatch from the
+   * previous context is already "for the old surface" — its outcome
+   * (success or failure) cannot meaningfully credit the new surface.
+   * Clearing the set unconditionally on rebuild keeps dwell-timer
+   * scheduling responsive for the new surface and lets the controller's
+   * own composite (waveId, blipId) gate be the source of truth for
+   * cross-wave de-dup.
+   */
   private void pruneStaleInFlightOnRebuild() {
-    if (markBlipReadInFlight.isEmpty()) {
-      return;
-    }
-    Set<String> renderedIds = new HashSet<String>();
-    for (HTMLElement blip : renderedBlips) {
-      if (blip == null) {
-        continue;
-      }
-      String id = blip.getAttribute("data-blip-id");
-      if (id != null && !id.isEmpty()) {
-        renderedIds.add(id);
-      }
-    }
-    markBlipReadInFlight.retainAll(renderedIds);
+    markBlipReadInFlight.clear();
   }
 
   private static DwellTimerScheduler defaultDwellTimerScheduler() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -131,6 +131,10 @@ public final class J2clReadSurfaceDomRenderer {
     if (listener == null) {
       cancelAllDwellTimers();
       markBlipReadInFlight.clear();
+    } else {
+      // Re-enabling: arm dwell timers for any unread blips already in the
+      // viewport so callers don't need to trigger a scroll event first.
+      evaluateDwellTimers();
     }
     if (!scrollListenerBound) {
       host.addEventListener("scroll", this::onHostScroll);
@@ -226,6 +230,16 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
     Runnable releaseGate = () -> markBlipReadInFlight.remove(blipId);
+    // Re-validate before firing: the blip may have been read, scrolled out of
+    // view, or removed while the dwell timer was pending.
+    HTMLElement blipEl = renderedBlipById(blipId);
+    if (blipEl == null
+        || !blipEl.hasAttribute("unread")
+        || isHiddenByCollapsedThread(blipEl)
+        || !isBlipInViewport(blipEl, host.getBoundingClientRect())) {
+      releaseGate.run();
+      return;
+    }
     try {
       markBlipReadListener.markBlipRead(blipId, releaseGate);
     } catch (Throwable t) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -235,7 +235,7 @@ public final class J2clReadSurfaceDomRenderer {
   /**
    * Visibility predicate used by {@link #evaluateDwellTimers}. A blip is
    * considered visible when the intersection rectangle covers ≥ 50 % of the
-   * blip OR (for blips taller than the viewport) ≥ 50 % of the viewport.
+   * blip OR (for blips taller than the viewport) ≥ 50 % of the viewport height.
    */
   private static boolean isBlipInViewport(HTMLElement blip, DOMRect hostRect) {
     DOMRect blipRect = blip.getBoundingClientRect();
@@ -263,13 +263,12 @@ public final class J2clReadSurfaceDomRenderer {
       return true;
     }
     // Tall-blip exception: a blip taller than the viewport can never reach
-    // the area-ratio threshold. Treat "the visible slice fills ≥ 50% of the
-    // viewport area" as visible too.
-    double hostWidth = hostRect.width;
-    double hostArea = hostHeight * hostWidth;
+    // the area-ratio threshold. Use vertical coverage so narrow blips (e.g.
+    // deeply indented threads) can still qualify when the visible slice fills
+    // ≥ 50% of the viewport height.
     if (blipHeight > hostHeight
-        && hostArea > 0
-        && intersectArea / hostArea >= VIEWPORT_INTERSECTION_THRESHOLD) {
+        && hostHeight > 0
+        && intersectHeight / hostHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
       return true;
     }
     return false;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -110,6 +110,10 @@ public final class J2clRootShellController {
                 (state, digestItem, userNavigation) ->
                     routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation)),
             resolveViewportWidth());
+    // F-4 (#1039 / R-4.4): bridge the selected-wave controller's live read
+    // state into the search panel so the matching digest's unread badge
+    // decrements without re-rendering the whole list.
+    selectedWaveController.setReadStateListener(controller::onReadStateChanged);
     J2clSidecarRouteController routeController =
         new J2clSidecarRouteController(
             new J2clSidecarRouteController.BrowserHistoryAdapter(),

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/sandbox/SandboxEntryPoint.java
@@ -86,6 +86,9 @@ public final class SandboxEntryPoint {
               (state, digestItem, userNavigation) ->
                   routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation),
               resolveViewportWidth());
+      // F-4 (#1039 / R-4.4): bridge live read-state changes into the
+      // search panel so digest unread badges update without full re-render.
+      selectedWaveController.setReadStateListener(controller::onReadStateChanged);
       J2clSidecarRouteController routeController =
           new J2clSidecarRouteController(
               new J2clSidecarRouteController.BrowserHistoryAdapter(),

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
@@ -12,9 +12,14 @@ public final class J2clDigestView {
 
   private final String waveId;
   private final HTMLButtonElement root;
+  private final HTMLElement stats;
+  private int blipCount;
+  private int unreadCount;
 
   public J2clDigestView(J2clSearchDigestItem item, SelectionHandler selectionHandler) {
     this.waveId = item.getWaveId();
+    this.blipCount = item.getBlipCount();
+    this.unreadCount = item.getUnreadCount();
     this.root = (HTMLButtonElement) DomGlobal.document.createElement("button");
     root.type = "button";
     root.className = "sidecar-digest";
@@ -45,9 +50,9 @@ public final class J2clDigestView {
     snippet.textContent = item.getSnippet().isEmpty() ? "No snippet available." : item.getSnippet();
     root.appendChild(snippet);
 
-    HTMLElement stats = (HTMLElement) DomGlobal.document.createElement("div");
+    this.stats = (HTMLElement) DomGlobal.document.createElement("div");
     stats.className = "sidecar-digest-stats";
-    stats.textContent = buildStatsText(item);
+    stats.textContent = buildStatsText(item.getUnreadCount(), item.getBlipCount());
     root.appendChild(stats);
 
     root.onclick =
@@ -69,12 +74,32 @@ public final class J2clDigestView {
     root.className = selected ? "sidecar-digest sidecar-digest-selected" : "sidecar-digest";
   }
 
-  private static String buildStatsText(J2clSearchDigestItem item) {
-    StringBuilder text = new StringBuilder();
-    if (item.getUnreadCount() > 0) {
-      text.append(item.getUnreadCount()).append(" unread \u00b7 ");
+  /**
+   * F-4 (#1039 / R-4.4): updates the unread badge / stats text live without
+   * re-rendering the digest list. Returns true when the count actually
+   * changed (so callers can fire signal-pulse motion only on change).
+   */
+  public boolean setUnreadCount(int newUnreadCount) {
+    int normalized = Math.max(0, newUnreadCount);
+    if (normalized == this.unreadCount) {
+      return false;
     }
-    text.append(item.getBlipCount()).append(item.getBlipCount() == 1 ? " message" : " messages");
+    this.unreadCount = normalized;
+    stats.textContent = buildStatsText(unreadCount, blipCount);
+    return true;
+  }
+
+  /** Visible for parity tests so they can read back the rendered stats text. */
+  public String getStatsText() {
+    return stats == null || stats.textContent == null ? "" : stats.textContent;
+  }
+
+  private static String buildStatsText(int unreadCount, int blipCount) {
+    StringBuilder text = new StringBuilder();
+    if (unreadCount > 0) {
+      text.append(unreadCount).append(" unread \u00b7 ");
+    }
+    text.append(blipCount).append(blipCount == 1 ? " message" : " messages");
     return text.toString();
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchDigestItem.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchDigestItem.java
@@ -60,4 +60,19 @@ public final class J2clSearchDigestItem {
   public boolean isPinned() {
     return pinned;
   }
+
+  /**
+   * F-4 (#1039 / R-4.4): returns a copy with the unread count replaced.
+   * Used by the live-decrement path so the cached search result model
+   * stays in sync with the read-state controller without re-running the
+   * search.
+   */
+  public J2clSearchDigestItem withUnreadCount(int newUnreadCount) {
+    int normalized = Math.max(0, newUnreadCount);
+    if (normalized == this.unreadCount) {
+      return this;
+    }
+    return new J2clSearchDigestItem(
+        waveId, title, snippet, author, normalized, blipCount, lastModified, pinned);
+  }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -156,6 +156,105 @@ public final class J2clSearchGateway
   }
 
   @Override
+  public void markBlipRead(
+      String waveId,
+      String blipId,
+      J2clSearchPanelController.SuccessCallback<Integer> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    // F-4 (#1039 / R-4.4 / subsumes #1056): POST to the new
+    // /j2cl/mark-blip-read endpoint, parse the unreadCount field from the
+    // JSON response and dispatch to the success callback.
+    if (waveId == null || waveId.isEmpty() || blipId == null || blipId.isEmpty()) {
+      onError.accept("Wave id and blip id are required for markBlipRead.");
+      return;
+    }
+    String body = buildMarkBlipReadBody(waveId, blipId);
+    XMLHttpRequest request = new XMLHttpRequest();
+    request.open("POST", "/j2cl/mark-blip-read");
+    request.setRequestHeader("Content-Type", "application/json");
+    request.onload =
+        event -> {
+          if (request.status >= 200 && request.status < 300) {
+            try {
+              Map<String, Object> json = SidecarTransportCodec.parseJsonObject(request.responseText);
+              Object rawCount = json == null ? null : json.get("unreadCount");
+              int unreadCount = -1;
+              if (rawCount instanceof Number) {
+                unreadCount = ((Number) rawCount).intValue();
+              } else if (rawCount instanceof String) {
+                try {
+                  unreadCount = Integer.parseInt((String) rawCount);
+                } catch (NumberFormatException ignored) {
+                  unreadCount = -1;
+                }
+              }
+              // The "alreadyRead" flag from the helper is informational —
+              // currently routed only through the success Integer because
+              // the controller doesn't need to distinguish "OK" from
+              // "ALREADY_READ" for live-decrement purposes (both converge
+              // on the same unreadCount). Expose it as an extra signal in
+              // a follow-up if telemetry buckets demand finer breakdown.
+              onSuccess.accept(Integer.valueOf(unreadCount));
+            } catch (RuntimeException e) {
+              onError.accept(messageOrDefault(e, "Unable to decode the markBlipRead response."));
+            }
+          } else {
+            onError.accept("HTTP " + request.status + " for /j2cl/mark-blip-read");
+          }
+        };
+    request.onerror =
+        event -> {
+          onError.accept("Network failure for /j2cl/mark-blip-read");
+          return null;
+        };
+    request.send(body);
+  }
+
+  static String buildMarkBlipReadBody(String waveId, String blipId) {
+    StringBuilder out = new StringBuilder(64);
+    out.append("{\"waveId\":\"")
+        .append(jsonEscape(waveId))
+        .append("\",\"blipId\":\"")
+        .append(jsonEscape(blipId))
+        .append("\"}");
+    return out.toString();
+  }
+
+  private static String jsonEscape(String value) {
+    if (value == null) {
+      return "";
+    }
+    StringBuilder out = new StringBuilder(value.length() + 4);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"': out.append("\\\""); break;
+        case '\\': out.append("\\\\"); break;
+        case '\n': out.append("\\n"); break;
+        case '\r': out.append("\\r"); break;
+        case '\t': out.append("\\t"); break;
+        default:
+          if (c < 0x20) {
+            // Hex-escape control chars.
+            out.append("\\u").append(zeroPad(Integer.toHexString(c), 4));
+          } else {
+            out.append(c);
+          }
+      }
+    }
+    return out.toString();
+  }
+
+  private static String zeroPad(String value, int width) {
+    StringBuilder padded = new StringBuilder(width);
+    for (int i = value.length(); i < width; i++) {
+      padded.append('0');
+    }
+    padded.append(value);
+    return padded.toString();
+  }
+
+  @Override
   public void fetchFragments(
       String waveId,
       String startBlipId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -178,15 +178,19 @@ public final class J2clSearchGateway
             try {
               Map<String, Object> json = SidecarTransportCodec.parseJsonObject(request.responseText);
               Object rawCount = json == null ? null : json.get("unreadCount");
-              int unreadCount = -1;
+              Integer unreadCount = null;
               if (rawCount instanceof Number) {
-                unreadCount = ((Number) rawCount).intValue();
+                unreadCount = Integer.valueOf(((Number) rawCount).intValue());
               } else if (rawCount instanceof String) {
                 try {
-                  unreadCount = Integer.parseInt((String) rawCount);
+                  unreadCount = Integer.valueOf(Integer.parseInt((String) rawCount));
                 } catch (NumberFormatException ignored) {
-                  unreadCount = -1;
+                  // fall through to null check
                 }
+              }
+              if (unreadCount == null) {
+                onError.accept("Invalid markBlipRead response: missing or non-numeric unreadCount.");
+                return;
               }
               // The "alreadyRead" flag from the helper is informational —
               // currently routed only through the success Integer because
@@ -194,7 +198,7 @@ public final class J2clSearchGateway
               // "ALREADY_READ" for live-decrement purposes (both converge
               // on the same unreadCount). Expose it as an extra signal in
               // a follow-up if telemetry buckets demand finer breakdown.
-              onSuccess.accept(Integer.valueOf(unreadCount));
+              onSuccess.accept(unreadCount);
             } catch (RuntimeException e) {
               onError.accept(messageOrDefault(e, "Unable to decode the markBlipRead response."));
             }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -40,6 +40,16 @@ public final class J2clSearchPanelController
     void render(J2clSearchResultModel model);
 
     void setSelectedWaveId(String waveId);
+
+    /**
+     * F-4 (#1039 / R-4.4): updates the unread badge / stats text on the digest
+     * card matching {@code waveId} without re-rendering the whole list.
+     * Returns {@code true} when a matching card was found and updated.
+     * Default no-op for legacy presentations that do not surface live unread.
+     */
+    default boolean updateDigestUnread(String waveId, int unreadCount) {
+      return false;
+    }
   }
 
   public interface RouteStateHandler {
@@ -180,6 +190,31 @@ public final class J2clSearchPanelController
 
   public J2clSearchDigestItem findDigestItem(String waveId) {
     return lastModel.findDigestItem(waveId);
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4): bridges the
+   * {@link J2clSelectedWaveController.ReadStateListener} signal into the
+   * search panel so the matching digest card decrements its unread badge
+   * live without a full re-render. Idempotent — repeated calls with the
+   * same count are a cheap no-op at the view layer.
+   *
+   * <p>The {@code stale} flag is passed through to the model in case the
+   * view wants to dim the badge while the count is provisional; the
+   * default view ignores it for now.
+   */
+  public void onReadStateChanged(String waveId, int unreadCount, boolean stale) {
+    if (waveId == null || waveId.isEmpty()) {
+      return;
+    }
+    int safeUnread = Math.max(0, unreadCount);
+    boolean updated = view.updateDigestUnread(waveId, safeUnread);
+    if (!updated) {
+      return;
+    }
+    // Also patch the cached model so a re-render (e.g. on the next search
+    // refresh) starts from the live count rather than the stale snapshot.
+    lastModel = lastModel.withUpdatedUnreadCount(waveId, safeUnread);
   }
 
   private void publishRouteState(boolean userNavigation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -264,6 +264,18 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     }
   }
 
+  @Override
+  public boolean updateDigestUnread(String waveId, int unreadCount) {
+    if (waveId == null || waveId.isEmpty()) {
+      return false;
+    }
+    J2clDigestView digest = digestViews.get(waveId);
+    if (digest == null) {
+      return false;
+    }
+    return digest.setUnreadCount(unreadCount);
+  }
+
   public HTMLElement getSelectedWaveHost() {
     return selectedWaveHost;
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -68,4 +68,33 @@ public final class J2clSearchResultModel {
     }
     return null;
   }
+
+  /**
+   * F-4 (#1039 / R-4.4): returns a model with the matching digest's unread
+   * count replaced. When no digest matches the supplied waveId, this is the
+   * identity. Used by the live-decrement path to keep the cached model in
+   * sync with the live read-state without rerunning the search.
+   */
+  public J2clSearchResultModel withUpdatedUnreadCount(String waveId, int newUnreadCount) {
+    if (waveId == null || waveId.isEmpty() || digestItems.isEmpty()) {
+      return this;
+    }
+    List<J2clSearchDigestItem> next = new ArrayList<J2clSearchDigestItem>(digestItems.size());
+    boolean changed = false;
+    for (J2clSearchDigestItem item : digestItems) {
+      if (waveId.equals(item.getWaveId())) {
+        J2clSearchDigestItem updated = item.withUnreadCount(newUnreadCount);
+        next.add(updated);
+        if (updated != item) {
+          changed = true;
+        }
+      } else {
+        next.add(item);
+      }
+    }
+    if (!changed) {
+      return this;
+    }
+    return new J2clSearchResultModel(next, waveCountText, showMoreVisible, emptyMessage);
+  }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -79,20 +79,24 @@ public final class J2clSearchResultModel {
     if (waveId == null || waveId.isEmpty() || digestItems.isEmpty()) {
       return this;
     }
-    List<J2clSearchDigestItem> next = new ArrayList<J2clSearchDigestItem>(digestItems.size());
-    boolean changed = false;
-    for (J2clSearchDigestItem item : digestItems) {
+    List<J2clSearchDigestItem> next = null;
+    for (int i = 0; i < digestItems.size(); i++) {
+      J2clSearchDigestItem item = digestItems.get(i);
+      J2clSearchDigestItem result = item;
       if (waveId.equals(item.getWaveId())) {
-        J2clSearchDigestItem updated = item.withUnreadCount(newUnreadCount);
-        next.add(updated);
-        if (updated != item) {
-          changed = true;
+        result = item.withUnreadCount(newUnreadCount);
+      }
+      if (next != null) {
+        next.add(result);
+      } else if (result != item) {
+        next = new ArrayList<J2clSearchDigestItem>(digestItems.size());
+        for (int j = 0; j < i; j++) {
+          next.add(digestItems.get(j));
         }
-      } else {
-        next.add(item);
+        next.add(result);
       }
     }
-    if (!changed) {
+    if (next == null) {
       return this;
     }
     return new J2clSearchResultModel(next, waveCountText, showMoreVisible, emptyMessage);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -70,6 +70,26 @@ public final class J2clSelectedWaveController
     void fetchAttachmentMetadata(
         List<String> attachmentIds,
         J2clAttachmentMetadataClient.MetadataCallback callback);
+
+    /**
+     * Marks a single blip as read for the authenticated user (F-4 / R-4.4 /
+     * subsumes #1056). On success, {@code onSuccess.accept(unreadCountAfter)}
+     * delivers the post-op unread count. Errors must not terminate the
+     * selected-wave subscription — the caller is expected to back off or
+     * retry via the next IntersectionObserver dwell.
+     *
+     * <p>Idempotent at the supplement layer; the gateway should also drop
+     * duplicate in-flight requests for the same {@code (waveId, blipId)}
+     * pair as a defence-in-depth measure.
+     */
+    default void markBlipRead(
+        String waveId,
+        String blipId,
+        J2clSearchPanelController.SuccessCallback<Integer> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      // Default no-op so existing test gateways compile without changes.
+      onError.accept("markBlipRead is not wired in this gateway.");
+    }
   }
 
   public interface View {
@@ -80,6 +100,14 @@ public final class J2clSelectedWaveController
     }
 
     default void setViewportEdgeHandler(ViewportEdgeHandler handler) {
+    }
+
+    /**
+     * F-4 (#1039 / R-4.4): registers the per-blip mark-as-read handler so the
+     * read surface can fire the listener when an unread blip dwells in the
+     * viewport. Default is a no-op for legacy presentations.
+     */
+    default void setMarkBlipReadHandler(MarkBlipReadHandler handler) {
     }
 
     /**
@@ -113,6 +141,15 @@ public final class J2clSelectedWaveController
     void onViewportEdge(String anchorBlipId, String direction);
   }
 
+  /**
+   * F-4 (#1039 / R-4.4): handler invoked by the view when a blip has dwelt
+   * inside the viewport long enough to count as "read".
+   */
+  @FunctionalInterface
+  public interface MarkBlipReadHandler {
+    void markBlipRead(String blipId);
+  }
+
   public interface RetryScheduler {
     void scheduleRetry(int delayMs, Runnable action);
   }
@@ -140,6 +177,17 @@ public final class J2clSelectedWaveController
     void onWriteSessionChanged(J2clSidecarWriteSession writeSession);
   }
 
+  /**
+   * F-4 (#1039 / R-4.4): listener invoked whenever the controller applies a
+   * fresh read state to the current model, so the search-panel surface can
+   * decrement the matching digest's unread badge live without a full re-render
+   * of the digest list.
+   */
+  @FunctionalInterface
+  public interface ReadStateListener {
+    void onReadStateChanged(String waveId, int unreadCount, boolean stale);
+  }
+
   private final Gateway gateway;
   private final View view;
   private final RetryScheduler retryScheduler;
@@ -161,6 +209,11 @@ public final class J2clSelectedWaveController
   private int pendingDebounceToken;
   private final Set<String> fragmentFetchesInFlight = new HashSet<String>();
   private final Set<String> attachmentMetadataFetchesInFlight = new HashSet<String>();
+  // F-4 (#1039 / R-4.4): blip ids the IntersectionObserver-equivalent has
+  // already submitted to the server; gates re-entry from re-rendering the
+  // surface or scrolling away and back.
+  private final Set<String> markBlipReadInFlight = new HashSet<String>();
+  private ReadStateListener readStateListener;
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
     this(
@@ -288,6 +341,7 @@ public final class J2clSelectedWaveController
     this.currentModel = J2clSelectedWaveModel.empty();
     this.view.render(currentModel);
     this.view.setViewportEdgeHandler(this::onViewportEdge);
+    this.view.setMarkBlipReadHandler(this::onMarkBlipRead);
     publishWriteSession();
     if (visibilitySource != null) {
       visibilitySource.addVisibilityListener(this::onVisible);
@@ -1035,6 +1089,28 @@ public final class J2clSelectedWaveController
             currentModel, selectedDigestItem, currentReadState, readStateStale);
     view.render(currentModel);
     publishWriteSession();
+    notifyReadStateListener();
+  }
+
+  /**
+   * Notifies the read-state listener (typically the search-panel controller)
+   * about the new unread count for the current wave so any matching digest
+   * card can decrement live without re-rendering the whole list. Idempotent —
+   * the listener is responsible for filtering trivial no-op updates if
+   * needed.
+   */
+  private void notifyReadStateListener() {
+    if (readStateListener == null) {
+      return;
+    }
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return;
+    }
+    if (currentReadState == null) {
+      return;
+    }
+    int unread = Math.max(0, currentReadState.getUnreadCount());
+    readStateListener.onReadStateChanged(selectedWaveId, unread, readStateStale);
   }
 
   private void resetReadStateFetchTracking() {
@@ -1051,6 +1127,101 @@ public final class J2clSelectedWaveController
     // UDW but never emits a conv+root update for this socket, so the per-update
     // refetch would never fire. Visibility-driven refresh catches it cheaply.
     scheduleReadStateFetch(requestGeneration);
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4): registers the read-state listener so the search panel
+   * can decrement digest unread badges live when the user opens a wave and
+   * dwells on its blips. Called once during shell wiring.
+   */
+  public void setReadStateListener(ReadStateListener listener) {
+    this.readStateListener = listener;
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4): invoked by the read-surface's
+   * IntersectionObserver-equivalent when an unread blip has been in the
+   * viewport for ≥1500 ms. Submits a markBlipRead to the gateway and, on
+   * success, schedules a read-state fetch through the existing debounced
+   * scheduler so concurrent supplement-bus updates coalesce instead of
+   * racing.
+   *
+   * <p>De-duplication is best-effort: a second call for the same blipId
+   * while the first is in flight is dropped. The renderer also tracks an
+   * `unread` attribute so already-read blips never reach this method, but
+   * we keep the in-flight set as defence-in-depth.
+   */
+  public void onMarkBlipRead(String blipId) {
+    if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      return;
+    }
+    if (blipId == null || blipId.isEmpty()) {
+      return;
+    }
+    if (!markBlipReadInFlight.add(blipId)) {
+      // Already in flight for this id; drop the duplicate.
+      emit(
+          J2clClientTelemetry.event("j2cl.read.mark_blip_read")
+              .field("outcome", "skipped-in-flight")
+              .field("blipId", blipId)
+              .build());
+      return;
+    }
+    final String waveIdAtDispatch = selectedWaveId;
+    final int generation = requestGeneration;
+    final double startMs = currentTimeMs();
+    gateway.markBlipRead(
+        waveIdAtDispatch,
+        blipId,
+        unreadCountAfter -> {
+          markBlipReadInFlight.remove(blipId);
+          if (!isCurrentGeneration(generation)) {
+            return;
+          }
+          if (selectedWaveId == null || !selectedWaveId.equals(waveIdAtDispatch)) {
+            return;
+          }
+          // Route through the debounced fetch scheduler so concurrent
+          // supplement-bus updates coalesce; bypassing it would race the
+          // server-pushed update from the open subscription.
+          scheduleReadStateFetch(generation);
+          emit(
+              J2clClientTelemetry.event("j2cl.read.mark_blip_read")
+                  .field("outcome", "success")
+                  .field("blipId", blipId)
+                  .field(
+                      "unreadCountAfter",
+                      unreadCountAfter == null ? "" : Integer.toString(unreadCountAfter))
+                  .field("latency_ms", Long.toString((long) (currentTimeMs() - startMs)))
+                  .build());
+        },
+        error -> {
+          markBlipReadInFlight.remove(blipId);
+          if (!isCurrentGeneration(generation)) {
+            return;
+          }
+          emit(
+              J2clClientTelemetry.event("j2cl.read.mark_blip_read")
+                  .field("outcome", "error")
+                  .field("blipId", blipId)
+                  .field("error", error == null ? "" : error)
+                  .field("latency_ms", Long.toString((long) (currentTimeMs() - startMs)))
+                  .build());
+        });
+  }
+
+  private static double currentTimeMs() {
+    // Telemetry-only timestamp source. We deliberately route through
+    // {@link System#currentTimeMillis()} rather than
+    // {@code performance.timeOrigin + performance.now()} or
+    // {@code new JsDate().getTime()} because:
+    // 1. Both alternatives are native, breaking JVM unit tests (the bytecode
+    //    has @JsType bindings with no Java implementation).
+    // 2. We use the value only for a coarse latency_ms histogram bucket;
+    //    monotonic precision is not required.
+    // 3. {@link System#currentTimeMillis()} compiles to {@code Date.now()}
+    //    in J2CL output, which is well-defined in browsers.
+    return (double) System.currentTimeMillis();
   }
 
   private static RetryScheduler defaultRetryScheduler() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -147,7 +147,7 @@ public final class J2clSelectedWaveController
    */
   @FunctionalInterface
   public interface MarkBlipReadHandler {
-    void markBlipRead(String blipId);
+    void markBlipRead(String blipId, Runnable onError);
   }
 
   public interface RetryScheduler {
@@ -1151,7 +1151,7 @@ public final class J2clSelectedWaveController
    * `unread` attribute so already-read blips never reach this method, but
    * we keep the in-flight set as defence-in-depth.
    */
-  public void onMarkBlipRead(String blipId) {
+  public void onMarkBlipRead(String blipId, Runnable rendererOnError) {
     if (selectedWaveId == null || selectedWaveId.isEmpty()) {
       return;
     }
@@ -1197,6 +1197,9 @@ public final class J2clSelectedWaveController
         },
         error -> {
           markBlipReadInFlight.remove(blipId);
+          if (rendererOnError != null) {
+            rendererOnError.run();
+          }
           if (!isCurrentGeneration(generation)) {
             return;
           }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -360,6 +360,7 @@ public final class J2clSelectedWaveController
     closeSubscription();
     resetFragmentFetchTracking();
     resetAttachmentMetadataFetchTracking();
+    resetMarkBlipReadTracking();
     reconnectCount = 0;
     // A refresh happens after the reply already committed on the server, so transient bootstrap or
     // open failures should recover like a reconnect instead of strand the panel on stale content.
@@ -398,6 +399,7 @@ public final class J2clSelectedWaveController
     resetReadStateFetchTracking();
     resetFragmentFetchTracking();
     resetAttachmentMetadataFetchTracking();
+    resetMarkBlipReadTracking();
 
     if (waveId == null || waveId.isEmpty()) {
       selectedWaveId = null;
@@ -1158,23 +1160,31 @@ public final class J2clSelectedWaveController
     if (blipId == null || blipId.isEmpty()) {
       return;
     }
-    if (!markBlipReadInFlight.add(blipId)) {
-      // Already in flight for this id; drop the duplicate.
+    final String waveIdAtDispatch = selectedWaveId;
+    // F-4 (#1039 / R-4.4): in-flight de-dup is keyed by the (waveId, blipId)
+    // pair, not blipId alone. Two waves can legitimately share a blipId; the
+    // 0x00 separator keeps composite keys unambiguous (waveIds cannot contain
+    // a NUL byte by construction).
+    final String inFlightKey = markBlipReadInFlightKey(waveIdAtDispatch, blipId);
+    final double startMs = currentTimeMs();
+    if (!markBlipReadInFlight.add(inFlightKey)) {
+      // Already in flight for this (waveId, blipId); drop the duplicate.
+      // latency_ms=0 keeps the schema aligned with the success/error
+      // outcomes so downstream consumers don't need a special case.
       emit(
           J2clClientTelemetry.event("j2cl.read.mark_blip_read")
               .field("outcome", "skipped-in-flight")
               .field("blipId", blipId)
+              .field("latency_ms", "0")
               .build());
       return;
     }
-    final String waveIdAtDispatch = selectedWaveId;
     final int generation = requestGeneration;
-    final double startMs = currentTimeMs();
     gateway.markBlipRead(
         waveIdAtDispatch,
         blipId,
         unreadCountAfter -> {
-          markBlipReadInFlight.remove(blipId);
+          markBlipReadInFlight.remove(inFlightKey);
           if (!isCurrentGeneration(generation)) {
             return;
           }
@@ -1196,7 +1206,7 @@ public final class J2clSelectedWaveController
                   .build());
         },
         error -> {
-          markBlipReadInFlight.remove(blipId);
+          markBlipReadInFlight.remove(inFlightKey);
           if (rendererOnError != null) {
             rendererOnError.run();
           }
@@ -1211,6 +1221,28 @@ public final class J2clSelectedWaveController
                   .field("latency_ms", Long.toString((long) (currentTimeMs() - startMs)))
                   .build());
         });
+  }
+
+  /**
+   * Composite in-flight key for {@link #markBlipReadInFlight}. The 0x00
+   * separator is safe because participant-derived waveIds never contain a NUL
+   * byte; using a printable separator like ":" would risk false collisions
+   * when a waveId itself contains the chosen separator.
+   */
+  private static String markBlipReadInFlightKey(String waveId, String blipId) {
+    return nullToEmpty(waveId) + ' ' + nullToEmpty(blipId);
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4): drops any in-flight markBlipRead bookkeeping. Called
+   * whenever the selection changes so a still-pending request from the
+   * previous wave cannot suppress a legitimate dispatch in the next selection.
+   * The composite (waveId, blipId) key already prevents cross-wave collisions
+   * for the contains-check; clearing here keeps the set bounded across long
+   * sessions.
+   */
+  private void resetMarkBlipReadTracking() {
+    markBlipReadInFlight.clear();
   }
 
   private static double currentTimeMs() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1154,10 +1154,16 @@ public final class J2clSelectedWaveController
    * we keep the in-flight set as defence-in-depth.
    */
   public void onMarkBlipRead(String blipId, Runnable rendererOnError) {
+    // The renderer adds the blip to its own in-flight gate before calling
+    // this method, so EVERY early-return path must release that gate via
+    // `rendererOnError` — otherwise the renderer keeps treating the blip
+    // as in-flight and never re-arms the dwell timer for it.
     if (selectedWaveId == null || selectedWaveId.isEmpty()) {
+      releaseRendererGate(rendererOnError);
       return;
     }
     if (blipId == null || blipId.isEmpty()) {
+      releaseRendererGate(rendererOnError);
       return;
     }
     final String waveIdAtDispatch = selectedWaveId;
@@ -1171,6 +1177,11 @@ public final class J2clSelectedWaveController
       // Already in flight for this (waveId, blipId); drop the duplicate.
       // latency_ms=0 keeps the schema aligned with the success/error
       // outcomes so downstream consumers don't need a special case.
+      // The renderer's gate is released so it can re-arm a dwell timer
+      // later — this controller-side de-dup means the original dispatch
+      // is already on its way; we do not want the renderer to lose its
+      // ability to retry if that original dispatch fails.
+      releaseRendererGate(rendererOnError);
       emit(
           J2clClientTelemetry.event("j2cl.read.mark_blip_read")
               .field("outcome", "skipped-in-flight")
@@ -1231,6 +1242,24 @@ public final class J2clSelectedWaveController
    */
   private static String markBlipReadInFlightKey(String waveId, String blipId) {
     return nullToEmpty(waveId) + ' ' + nullToEmpty(blipId);
+  }
+
+  /**
+   * Releases the renderer's per-blip in-flight gate (its
+   * {@code markBlipReadInFlight} entry) when {@link #onMarkBlipRead} bails
+   * before the gateway dispatch succeeds. Renderer hooks must not propagate
+   * out of this controller — the renderer is observational here, so we
+   * swallow any throw to keep the mark-read pipeline robust.
+   */
+  private static void releaseRendererGate(Runnable rendererOnError) {
+    if (rendererOnError == null) {
+      return;
+    }
+    try {
+      rendererOnError.run();
+    } catch (Throwable ignored) {
+      // Renderer hooks must not break the controller's mark-read pipeline.
+    }
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -407,6 +407,15 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   }
 
   @Override
+  public void setMarkBlipReadHandler(J2clSelectedWaveController.MarkBlipReadHandler handler) {
+    // F-4 (#1039 / R-4.4): forward through to the renderer's per-blip dwell
+    // tracker. Passing null disables the listener but leaves the scroll
+    // hook in place so re-installation on visibility change works.
+    readSurface.setMarkBlipReadListener(
+        handler == null ? null : handler::markBlipRead);
+  }
+
+  @Override
   public SidecarViewportHints initialViewportHints(String selectedWaveId) {
     return resolveInitialViewportHints(
         serverFirstActive, serverFirstWaveId, selectedWaveId, serverFirstBlipAnchor());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -412,7 +412,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // tracker. Passing null disables the listener but leaves the scroll
     // hook in place so re-installation on visibility change works.
     readSurface.setMarkBlipReadListener(
-        handler == null ? null : handler::markBlipRead);
+        handler == null ? null : (blipId, onError) -> handler.markBlipRead(blipId, onError));
   }
 
   @Override

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -178,16 +178,16 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
 
     // Only the first ~2 blips fully fit in the 100px host. b+4 is fully
     // below the host's clipped bottom and should NOT have a timer.
-    boolean fourthIsScheduled = false;
+    int dwellTimersScheduled = 0;
     for (Scheduled s : scheduler.scheduled) {
-      if (s.delayMs == J2clReadSurfaceDomRenderer.VIEWPORT_DWELL_DEBOUNCE_MS
-          && (s.label != null && s.label.contains("b+4"))) {
-        fourthIsScheduled = true;
+      if (s.delayMs == J2clReadSurfaceDomRenderer.VIEWPORT_DWELL_DEBOUNCE_MS) {
+        dwellTimersScheduled++;
       }
     }
-    Assert.assertFalse(
-        "blip rendered fully below host viewport must not arm a timer",
-        fourthIsScheduled);
+    Assert.assertEquals(
+        "only visible blips must arm dwell timers (b+4 is fully off-screen)",
+        3,
+        dwellTimersScheduled);
   }
 
   @Test
@@ -361,7 +361,7 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
     final List<String> fired = new ArrayList<String>();
 
     @Override
-    public void markBlipRead(String blipId) {
+    public void markBlipRead(String blipId, Runnable onError) {
       fired.add(blipId);
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -1,0 +1,368 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.j2cl.read;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * F-4 (#1039 / R-4.4 / subsumes #1056) tests for the IntersectionObserver-
+ * equivalent dwell-timer mark-as-read behaviour on
+ * {@link J2clReadSurfaceDomRenderer}.
+ *
+ * <p>These tests use a fake {@link J2clReadSurfaceDomRenderer.DwellTimerScheduler}
+ * so the test deterministically controls when the 1500 ms dwell window
+ * "elapses" — no flaky real-clock waiting.
+ */
+@J2clTestInput(J2clReadSurfaceDomRendererMarkReadTest.class)
+public class J2clReadSurfaceDomRendererMarkReadTest {
+
+  private HTMLDivElement currentHost;
+  private HTMLElement currentStyle;
+
+  @Before
+  public void setUp() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+
+  @After
+  public void tearDown() {
+    if (currentHost != null && currentHost.parentElement != null) {
+      currentHost.parentElement.removeChild(currentHost);
+    }
+    if (currentStyle != null && currentStyle.parentElement != null) {
+      currentStyle.parentElement.removeChild(currentStyle);
+    }
+    currentHost = null;
+    currentStyle = null;
+  }
+
+  @Test
+  public void unreadBlipDwellingForFullDelayFiresListenerOnce() {
+    HTMLDivElement host = createHost();
+    installViewport(host, /* heightPx= */ 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+1", "first"));
+    Assert.assertTrue(renderer.render(blips, java.util.Collections.<String>emptyList()));
+
+    Assert.assertEquals(
+        "render must arm one dwell timer for the unread blip", 1, scheduler.scheduled.size());
+    Object handle = scheduler.scheduled.get(0).handle;
+    Assert.assertEquals(
+        J2clReadSurfaceDomRenderer.VIEWPORT_DWELL_DEBOUNCE_MS,
+        scheduler.scheduled.get(0).delayMs);
+
+    // Fire the timer synchronously.
+    scheduler.fire(handle);
+
+    Assert.assertEquals(java.util.Arrays.asList("b+1"), listener.fired);
+  }
+
+  @Test
+  public void readBlipNeverArmsADwellTimer() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(readBlip("b+read"));
+    Assert.assertTrue(renderer.render(blips, java.util.Collections.<String>emptyList()));
+
+    Assert.assertTrue(scheduler.scheduled.isEmpty());
+    Assert.assertTrue(listener.fired.isEmpty());
+  }
+
+  @Test
+  public void blipFiringTwiceForSameIdIsBlockedByInFlightSet() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+1", "first"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+
+    // Fire the dwell timer.
+    Assert.assertEquals(1, scheduler.scheduled.size());
+    scheduler.fire(scheduler.scheduled.get(0).handle);
+    Assert.assertEquals(1, listener.fired.size());
+
+    // The renderer's evaluateDwellTimers can be triggered again (e.g. via a
+    // synthetic scroll event). We invoke it directly through the package-
+    // private hook by calling render with a matching blip set, which
+    // exercises the `matchesRenderedBlips` fast-path that re-evaluates
+    // dwell timers without rebuilding the DOM.
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+
+    // The in-flight set blocks a second arm.
+    Assert.assertEquals(
+        "second pass must not schedule a new timer for an in-flight blip",
+        1,
+        scheduler.scheduled.size());
+    Assert.assertEquals(
+        "listener must not have fired again", 1, listener.fired.size());
+  }
+
+  @Test
+  public void blipOutsideViewportDoesNotArmTimer() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 100);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    // Three blips at 40px each → 120px total. Host is 100px tall, so the
+    // third blip at offsetY 80–120 is partly off-screen; with a 50%-area
+    // threshold and 40px height, it needs ≥20px visible. The host is
+    // 100px tall so y-range visible is [0, 100]; blip rect [80, 120] is
+    // visible 80→100 → 20px → exactly at threshold.
+    // Make sure the FOURTH blip (rect [120, 160]) is fully off-screen.
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+1", "first"));
+    blips.add(unreadBlip("b+2", "second"));
+    blips.add(unreadBlip("b+3", "third"));
+    blips.add(unreadBlip("b+4", "fourth"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+
+    // Only the first ~2 blips fully fit in the 100px host. b+4 is fully
+    // below the host's clipped bottom and should NOT have a timer.
+    boolean fourthIsScheduled = false;
+    for (Scheduled s : scheduler.scheduled) {
+      if (s.delayMs == J2clReadSurfaceDomRenderer.VIEWPORT_DWELL_DEBOUNCE_MS
+          && (s.label != null && s.label.contains("b+4"))) {
+        fourthIsScheduled = true;
+      }
+    }
+    Assert.assertFalse(
+        "blip rendered fully below host viewport must not arm a timer",
+        fourthIsScheduled);
+  }
+
+  @Test
+  public void rebuildingSurfaceCancelsExistingDwellTimers() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> firstSet = new ArrayList<J2clReadBlip>();
+    firstSet.add(unreadBlip("b+old", "old"));
+    renderer.render(firstSet, java.util.Collections.<String>emptyList());
+
+    Assert.assertEquals(1, scheduler.scheduled.size());
+    Object firstHandle = scheduler.scheduled.get(0).handle;
+
+    // New, totally different set → render rebuilds the DOM, must cancel the
+    // old timer.
+    List<J2clReadBlip> secondSet = new ArrayList<J2clReadBlip>();
+    secondSet.add(unreadBlip("b+new", "new"));
+    renderer.render(secondSet, java.util.Collections.<String>emptyList());
+
+    Assert.assertTrue(
+        "render must cancel the timer for the previous blip set",
+        scheduler.cancelled.contains(firstHandle));
+  }
+
+  @Test
+  public void emptyRenderClearsInFlightAndScheduledTimers() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+a", "first"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+    scheduler.fire(scheduler.scheduled.get(0).handle);
+
+    // Empty render → all timers cancelled, in-flight set drained.
+    Assert.assertFalse(
+        renderer.render(java.util.Collections.<J2clReadBlip>emptyList(),
+                        java.util.Collections.<String>emptyList()));
+
+    // Now render the same blip again — it has no `unread` attribute server-
+    // side anymore (the data path will re-project), but for this test we
+    // simulate the still-unread case to prove the in-flight set was
+    // drained. A second listener fire is allowed because the blip just
+    // finished a full lifecycle.
+    listener.fired.clear();
+    blips.clear();
+    blips.add(unreadBlip("b+a", "first"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+    Assert.assertEquals(
+        "after empty-render the in-flight set should be drained",
+        1,
+        scheduler.scheduled.size() - 1 /* the previous fired entry */);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+
+  private HTMLDivElement createHost() {
+    currentHost = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(currentHost);
+    return currentHost;
+  }
+
+  private void installViewport(HTMLDivElement host, int heightPx) {
+    host.style.setProperty("display", "block");
+    host.style.setProperty("position", "relative");
+    host.style.setProperty("overflow", "auto");
+    host.style.setProperty("height", heightPx + "px");
+    host.style.setProperty("width", "300px");
+  }
+
+  private void installBlipLayout() {
+    currentStyle = (HTMLElement) DomGlobal.document.createElement("style");
+    currentStyle.textContent =
+        "[data-j2cl-read-blip='true']{display:block;height:40px;width:280px;}";
+    DomGlobal.document.head.appendChild(currentStyle);
+  }
+
+  private static J2clReadBlip unreadBlip(String id, String text) {
+    return new J2clReadBlip(
+        id,
+        text,
+        java.util.Collections.<org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel>emptyList(),
+        /* authorId= */ "",
+        /* authorDisplayName= */ "",
+        /* lastModifiedTimeMillis= */ 0L,
+        /* parentBlipId= */ "",
+        /* threadId= */ "",
+        /* unread= */ true,
+        /* hasMention= */ false);
+  }
+
+  private static J2clReadBlip readBlip(String id) {
+    return new J2clReadBlip(
+        id,
+        id,
+        java.util.Collections.<org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel>emptyList(),
+        "",
+        "",
+        0L,
+        "",
+        "",
+        /* unread= */ false,
+        /* hasMention= */ false);
+  }
+
+  private static final class FakeScheduler
+      implements J2clReadSurfaceDomRenderer.DwellTimerScheduler {
+    final List<Scheduled> scheduled = new ArrayList<Scheduled>();
+    final java.util.Set<Object> cancelled = new java.util.HashSet<Object>();
+    private final Map<Object, Runnable> handleToRunnable = new HashMap<Object, Runnable>();
+    private int handleCounter;
+
+    @Override
+    public Object schedule(int delayMs, Runnable action) {
+      Object handle = new HandleToken(++handleCounter);
+      handleToRunnable.put(handle, action);
+      scheduled.add(new Scheduled(handle, delayMs, "h" + handleCounter));
+      return handle;
+    }
+
+    @Override
+    public void cancel(Object handle) {
+      cancelled.add(handle);
+      handleToRunnable.remove(handle);
+    }
+
+    void fire(Object handle) {
+      Runnable r = handleToRunnable.remove(handle);
+      if (r != null) {
+        r.run();
+      }
+    }
+  }
+
+  private static final class HandleToken {
+    final int id;
+    HandleToken(int id) {
+      this.id = id;
+    }
+  }
+
+  private static final class Scheduled {
+    final Object handle;
+    final int delayMs;
+    final String label;
+    Scheduled(Object handle, int delayMs, String label) {
+      this.handle = handle;
+      this.delayMs = delayMs;
+      this.label = label;
+    }
+  }
+
+  private static final class RecordingListener
+      implements J2clReadSurfaceDomRenderer.MarkBlipReadListener {
+    final List<String> fired = new ArrayList<String>();
+
+    @Override
+    public void markBlipRead(String blipId) {
+      fired.add(blipId);
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -303,6 +303,58 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
   }
 
   /**
+   * F-4 (#1039 / R-4.4) review-fix: the renderer's in-flight gate
+   * ({@code markBlipReadInFlight}) is keyed by blipId only because the
+   * renderer has no wave concept — so it must be cleared on every full
+   * surface rebuild. Otherwise, when the user switches waves and the new
+   * wave happens to contain the same blipId, the stale in-flight entry
+   * suppresses dwell-timer scheduling forever and the new wave's blip is
+   * never marked read.
+   */
+  @Test
+  public void surfaceRebuildClearsRendererInFlightGate() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    // First "wave": render an unread blip and let the dwell timer fire so
+    // the renderer adds the blipId to its own in-flight gate. The listener
+    // never calls back (simulating a still-pending controller dispatch),
+    // so the gate stays set.
+    List<J2clReadBlip> firstWave = new ArrayList<J2clReadBlip>();
+    firstWave.add(unreadBlip("b+shared", "first wave"));
+    renderer.render(firstWave, java.util.Collections.<String>emptyList());
+    Assert.assertEquals(1, scheduler.scheduled.size());
+    scheduler.fire(scheduler.scheduled.get(0).handle);
+    Assert.assertEquals(java.util.Arrays.asList("b+shared"), listener.fired);
+
+    // Second "wave": fully different content, but happens to share the
+    // same blipId. The full rebuild must drop the renderer's in-flight
+    // entry so a new dwell timer can arm for the new context.
+    List<J2clReadBlip> secondWave = new ArrayList<J2clReadBlip>();
+    secondWave.add(unreadBlip("b+shared", "second wave"));
+    secondWave.add(unreadBlip("b+other", "second wave other"));
+    renderer.render(secondWave, java.util.Collections.<String>emptyList());
+
+    int dwellTimers = 0;
+    for (Scheduled s : scheduler.scheduled) {
+      if (s.delayMs == J2clReadSurfaceDomRenderer.VIEWPORT_DWELL_DEBOUNCE_MS) {
+        dwellTimers++;
+      }
+    }
+    Assert.assertTrue(
+        "after rebuild for new wave, b+shared must be re-armed (gate cleared); "
+            + "expected at least 2 dwell timers across the lifecycle but found " + dwellTimers,
+        dwellTimers >= 2);
+  }
+
+  /**
    * F-4 (#1039 / R-4.4) review-fix: re-installing a non-null mark-read
    * listener (e.g. after a transient teardown) must arm dwell timers
    * immediately for any unread blips already in the viewport — without

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -257,6 +257,90 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
         scheduler.scheduled.size() - 1 /* the previous fired entry */);
   }
 
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: the dwell-timer callback runs 1500 ms
+   * after it was armed, but {@code clearTimeout} cannot prevent a callback
+   * that is already queued. {@link J2clReadSurfaceDomRenderer#fireDwellTimer}
+   * must therefore re-validate the blip's qualification right before
+   * dispatching the listener. If the surface has been re-rendered without
+   * the blip in the meantime, the listener must NOT fire.
+   */
+  @Test
+  public void dwellTimerRevalidatesBlipBeforeFiring() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+armed", "armed"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+
+    Assert.assertEquals(1, scheduler.scheduled.size());
+    Object handle = scheduler.scheduled.get(0).handle;
+
+    // Replace the surface entirely; the previously-armed blip is no longer
+    // rendered. The dwell timer's callback is still queued — when it fires
+    // it must observe the missing blip and bail without invoking the
+    // listener.
+    List<J2clReadBlip> nextSet = new ArrayList<J2clReadBlip>();
+    nextSet.add(unreadBlip("b+other", "other"));
+    renderer.render(nextSet, java.util.Collections.<String>emptyList());
+
+    // The renderer cancels timers on rebuild, but to make the assertion
+    // robust against future scheduler-replacement strategies we still fire
+    // the original handle — the callback's revalidation must catch it.
+    scheduler.fire(handle);
+
+    Assert.assertTrue(
+        "listener must not fire for a blip that is no longer rendered",
+        !listener.fired.contains("b+armed"));
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: re-installing a non-null mark-read
+   * listener (e.g. after a transient teardown) must arm dwell timers
+   * immediately for any unread blips already in the viewport — without
+   * waiting for the next scroll or DOM rebuild. Without this, a user who
+   * stays still after the listener is reattached would never get their
+   * read state credited.
+   */
+  @Test
+  public void reinstallingListenerImmediatelyArmsDwellTimersForVisibleUnread() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+
+    // Render an unread blip BEFORE the listener is wired in — no timer
+    // should be armed yet because there is no listener to deliver to.
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+visible", "visible"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+    Assert.assertTrue(
+        "no listener installed → no timer should be armed yet",
+        scheduler.scheduled.isEmpty());
+
+    // Now install the listener. The blip is already in the viewport, so
+    // the renderer must arm a dwell timer immediately rather than waiting
+    // for a scroll / re-render.
+    RecordingListener listener = new RecordingListener();
+    renderer.setMarkBlipReadListener(listener);
+
+    Assert.assertEquals(
+        "re-installing the listener must arm dwell timers for visible unread blips",
+        1,
+        scheduler.scheduled.size());
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -206,6 +206,95 @@ public class J2clSearchPanelControllerTest {
   }
 
   @Test
+  public void onReadStateChangedUpdatesMatchingDigestUnreadCount() {
+    // F-4 (#1039 / R-4.4): a live read-state change for the selected wave
+    // must decrement the matching digest's unread badge in place — without
+    // re-running the search.
+    FakeGateway gateway =
+        new FakeGateway(
+            new SidecarSearchResponse(
+                "in:inbox",
+                1,
+                Collections.singletonList(
+                    new SidecarSearchResponse.Digest(
+                        "Live wave",
+                        "Snippet",
+                        "example.com/w+1",
+                        12345L,
+                        /* unread= */ 5,
+                        /* msg= */ 5,
+                        Collections.singletonList("teammate@example.com"),
+                        "user@example.com",
+                        false))));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, (state, digestItem, userNavigation) -> {}, 1200);
+    controller.start("in:inbox", null);
+
+    // Sanity check: model carries 5 unread for the wave.
+    Assert.assertEquals(5, controller.findDigestItem("example.com/w+1").getUnreadCount());
+
+    // Drive the read-state listener with a decremented count.
+    controller.onReadStateChanged("example.com/w+1", 3, /* stale= */ false);
+
+    Assert.assertEquals(
+        "live decrement must patch the cached model",
+        3,
+        controller.findDigestItem("example.com/w+1").getUnreadCount());
+    Assert.assertEquals(
+        "view's updateDigestUnread must have been called for the matching id",
+        Arrays.asList("example.com/w+1=3"),
+        view.updateDigestUnreadInvocations);
+  }
+
+  @Test
+  public void onReadStateChangedIgnoresMissingWaveId() {
+    FakeGateway gateway = new FakeGateway(new SidecarSearchResponse("in:inbox", 0, null));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, (state, digestItem, userNavigation) -> {}, 1200);
+    controller.start("in:inbox", null);
+
+    controller.onReadStateChanged("", 3, false);
+    controller.onReadStateChanged(null, 3, false);
+    controller.onReadStateChanged("example.com/w+absent", 0, false);
+
+    Assert.assertTrue(
+        "no view update for empty / null / unknown wave ids",
+        view.updateDigestUnreadInvocations.isEmpty());
+  }
+
+  @Test
+  public void onReadStateChangedClampsNegativeCountsToZero() {
+    FakeGateway gateway =
+        new FakeGateway(
+            new SidecarSearchResponse(
+                "in:inbox",
+                1,
+                Collections.singletonList(
+                    new SidecarSearchResponse.Digest(
+                        "Live wave",
+                        "Snippet",
+                        "example.com/w+1",
+                        12345L,
+                        /* unread= */ 4,
+                        /* msg= */ 4,
+                        Collections.singletonList("teammate@example.com"),
+                        "user@example.com",
+                        false))));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(gateway, view, (state, digestItem, userNavigation) -> {}, 1200);
+    controller.start("in:inbox", null);
+
+    controller.onReadStateChanged("example.com/w+1", -1, false);
+
+    Assert.assertEquals(0, controller.findDigestItem("example.com/w+1").getUnreadCount());
+    Assert.assertEquals(
+        Arrays.asList("example.com/w+1=0"), view.updateDigestUnreadInvocations);
+  }
+
+  @Test
   public void digestSelectionPublishesRouteStateAsUserNavigation() {
     FakeGateway gateway = new FakeGateway(new SidecarSearchResponse("in:inbox", 0, null));
     FakeView view = new FakeView();
@@ -273,6 +362,7 @@ public class J2clSearchPanelControllerTest {
     private boolean error;
     private J2clSearchResultModel lastModel = J2clSearchResultModel.empty("");
     private String selectedWaveId;
+    private final List<String> updateDigestUnreadInvocations = new ArrayList<String>();
 
     @Override
     public void bind(J2clSearchViewListener listener) {
@@ -308,6 +398,17 @@ public class J2clSearchPanelControllerTest {
     @Override
     public void setSelectedWaveId(String waveId) {
       this.selectedWaveId = waveId;
+    }
+
+    @Override
+    public boolean updateDigestUnread(String waveId, int unreadCount) {
+      // F-4 (#1039 / R-4.4) — emulate the production view's contract:
+      // return true only when the wave id is known to the model.
+      if (lastModel.findDigestItem(waveId) == null) {
+        return false;
+      }
+      updateDigestUnreadInvocations.add(waveId + "=" + unreadCount);
+      return true;
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1354,6 +1354,146 @@ public class J2clSelectedWaveControllerTest {
         statusCode);
   }
 
+  // F-4 (#1039 / R-4.4 / subsumes #1056) — mark-blip-read tests.
+
+  @Test
+  public void onMarkBlipReadDispatchesGatewayCall() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    int beforeAttempts = harness.markBlipReadAttempts.size();
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+
+    Assert.assertEquals(beforeAttempts + 1, harness.markBlipReadAttempts.size());
+    MarkBlipReadAttempt attempt =
+        harness.markBlipReadAttempts.get(harness.markBlipReadAttempts.size() - 1);
+    Assert.assertEquals("example.com/w+1", attempt.waveId);
+    Assert.assertEquals("b+abc", attempt.blipId);
+  }
+
+  @Test
+  public void onMarkBlipReadIgnoresEmptyBlipId() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    int beforeAttempts = harness.markBlipReadAttempts.size();
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "");
+    onMarkBlipRead.invoke(controller, (String) null);
+
+    Assert.assertEquals(
+        "empty / null blip ids must not dispatch",
+        beforeAttempts,
+        harness.markBlipReadAttempts.size());
+  }
+
+  @Test
+  public void onMarkBlipReadDeduplicatesInFlightDispatch() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+    onMarkBlipRead.invoke(controller, "b+abc");
+
+    Assert.assertEquals(
+        "second markBlipRead for same blipId must be dropped while first is in flight",
+        1,
+        harness.markBlipReadAttempts.size());
+  }
+
+  @Test
+  public void onMarkBlipReadSuccessReleasesInFlightSlotForLaterRetry() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+    Assert.assertEquals(1, harness.markBlipReadAttempts.size());
+    harness.markBlipReadAttempts.get(0).success.accept(Integer.valueOf(2));
+
+    onMarkBlipRead.invoke(controller, "b+abc");
+    Assert.assertEquals(
+        "after success, the same blipId may be dispatched again",
+        2,
+        harness.markBlipReadAttempts.size());
+  }
+
+  @Test
+  public void onMarkBlipReadErrorReleasesInFlightSlotForLaterRetry() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+    Assert.assertEquals(1, harness.markBlipReadAttempts.size());
+    harness.markBlipReadAttempts.get(0).error.accept("transient");
+
+    onMarkBlipRead.invoke(controller, "b+abc");
+    Assert.assertEquals(
+        "after error, the same blipId may be dispatched again",
+        2,
+        harness.markBlipReadAttempts.size());
+  }
+
+  @Test
+  public void onMarkBlipReadSuccessTriggersDebouncedReadStateFetch() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    int beforePending = harness.pendingReadStateDispatches.size();
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+    harness.markBlipReadAttempts.get(0).success.accept(Integer.valueOf(0));
+
+    Assert.assertTrue(
+        "success path must schedule a read-state fetch through the debounce scheduler",
+        harness.pendingReadStateDispatches.size() > beforePending);
+  }
+
+  @Test
+  public void onMarkBlipReadIgnoredWhenNoWaveSelected() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
+    onMarkBlipRead.invoke(controller, "b+abc");
+
+    Assert.assertTrue(harness.markBlipReadAttempts.isEmpty());
+  }
+
   private static final class Harness {
     private int openCount;
     private int closedCount;
@@ -1368,6 +1508,10 @@ public class J2clSelectedWaveControllerTest {
         new ArrayList<AttachmentMetadataAttempt>();
     private final List<Runnable> pendingReadStateDispatches = new ArrayList<Runnable>();
     private final List<Runnable> visibilityListeners = new ArrayList<Runnable>();
+    // F-4 (#1039 / R-4.4): captures markBlipRead dispatches issued through the
+    // controller's onMarkBlipRead path.
+    private final List<MarkBlipReadAttempt> markBlipReadAttempts =
+        new ArrayList<MarkBlipReadAttempt>();
     private SidecarViewportHints initialViewportHints;
     private Object lastModel;
     private Runnable onNextRender;
@@ -1482,6 +1626,19 @@ public class J2clSelectedWaveControllerTest {
                       (J2clAttachmentMetadataClient.MetadataCallback) args[1];
                   attachmentMetadataAttempts.add(
                       new AttachmentMetadataAttempt(attachmentIds, callback));
+                  return null;
+                }
+                if ("markBlipRead".equals(method.getName())) {
+                  // F-4 (#1039 / R-4.4): capture the dispatch so the test
+                  // controls success/error timing.
+                  @SuppressWarnings("unchecked")
+                  J2clSearchPanelController.SuccessCallback<Integer> success =
+                      (J2clSearchPanelController.SuccessCallback<Integer>) args[2];
+                  J2clSearchPanelController.ErrorCallback error =
+                      (J2clSearchPanelController.ErrorCallback) args[3];
+                  markBlipReadAttempts.add(
+                      new MarkBlipReadAttempt(
+                          (String) args[0], (String) args[1], success, error));
                   return null;
                 }
                 return null;
@@ -1884,6 +2041,25 @@ public class J2clSelectedWaveControllerTest {
         J2clSearchPanelController.SuccessCallback<SidecarSelectedWaveReadState> success,
         J2clSearchPanelController.ErrorCallback error) {
       this.waveId = waveId;
+      this.success = success;
+      this.error = error;
+    }
+  }
+
+  /** F-4 (#1039 / R-4.4): captured markBlipRead dispatch in the test harness. */
+  private static final class MarkBlipReadAttempt {
+    private final String waveId;
+    private final String blipId;
+    private final J2clSearchPanelController.SuccessCallback<Integer> success;
+    private final J2clSearchPanelController.ErrorCallback error;
+
+    private MarkBlipReadAttempt(
+        String waveId,
+        String blipId,
+        J2clSearchPanelController.SuccessCallback<Integer> success,
+        J2clSearchPanelController.ErrorCallback error) {
+      this.waveId = waveId;
+      this.blipId = blipId;
       this.success = success;
       this.error = error;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1367,8 +1367,8 @@ public class J2clSelectedWaveControllerTest {
 
     int beforeAttempts = harness.markBlipReadAttempts.size();
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
 
     Assert.assertEquals(beforeAttempts + 1, harness.markBlipReadAttempts.size());
     MarkBlipReadAttempt attempt =
@@ -1388,9 +1388,9 @@ public class J2clSelectedWaveControllerTest {
 
     int beforeAttempts = harness.markBlipReadAttempts.size();
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "");
-    onMarkBlipRead.invoke(controller, (String) null);
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "", (Runnable) () -> {});
+    onMarkBlipRead.invoke(controller, (String) null, (Runnable) () -> {});
 
     Assert.assertEquals(
         "empty / null blip ids must not dispatch",
@@ -1408,9 +1408,9 @@ public class J2clSelectedWaveControllerTest {
     harness.deliverUpdate(0, "Hello");
 
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
 
     Assert.assertEquals(
         "second markBlipRead for same blipId must be dropped while first is in flight",
@@ -1428,12 +1428,12 @@ public class J2clSelectedWaveControllerTest {
     harness.deliverUpdate(0, "Hello");
 
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
     Assert.assertEquals(1, harness.markBlipReadAttempts.size());
     harness.markBlipReadAttempts.get(0).success.accept(Integer.valueOf(2));
 
-    onMarkBlipRead.invoke(controller, "b+abc");
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
     Assert.assertEquals(
         "after success, the same blipId may be dispatched again",
         2,
@@ -1450,12 +1450,12 @@ public class J2clSelectedWaveControllerTest {
     harness.deliverUpdate(0, "Hello");
 
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
     Assert.assertEquals(1, harness.markBlipReadAttempts.size());
     harness.markBlipReadAttempts.get(0).error.accept("transient");
 
-    onMarkBlipRead.invoke(controller, "b+abc");
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
     Assert.assertEquals(
         "after error, the same blipId may be dispatched again",
         2,
@@ -1473,8 +1473,8 @@ public class J2clSelectedWaveControllerTest {
 
     int beforePending = harness.pendingReadStateDispatches.size();
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
     harness.markBlipReadAttempts.get(0).success.accept(Integer.valueOf(0));
 
     Assert.assertTrue(
@@ -1488,8 +1488,8 @@ public class J2clSelectedWaveControllerTest {
     Object controller = harness.createController(false);
 
     Method onMarkBlipRead =
-        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class);
-    onMarkBlipRead.invoke(controller, "b+abc");
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
 
     Assert.assertTrue(harness.markBlipReadAttempts.isEmpty());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1568,6 +1568,79 @@ public class J2clSelectedWaveControllerTest {
         skipped.getFields().get("latency_ms"));
   }
 
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: when {@link #onMarkBlipRead} bails before
+   * the gateway dispatch (no wave selected, empty blipId, or skipped-as-
+   * already-in-flight), the renderer's per-blip in-flight gate must still be
+   * released — the renderer added the blip to its own
+   * {@code markBlipReadInFlight} set BEFORE invoking the controller, and
+   * skipping {@code rendererOnError} would leave that gate stuck so the
+   * dwell timer can never re-arm for that blip.
+   */
+  @Test
+  public void onMarkBlipReadReleasesRendererGateWhenNoWaveSelected() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    final boolean[] released = new boolean[] {false};
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> released[0] = true);
+
+    Assert.assertTrue(
+        "rendererOnError must run when no wave is selected so the renderer gate is released",
+        released[0]);
+    Assert.assertTrue(harness.markBlipReadAttempts.isEmpty());
+  }
+
+  @Test
+  public void onMarkBlipReadReleasesRendererGateForEmptyBlipId() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    final int[] releaseCount = new int[] {0};
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "", (Runnable) () -> releaseCount[0]++);
+    onMarkBlipRead.invoke(controller, (String) null, (Runnable) () -> releaseCount[0]++);
+
+    Assert.assertEquals(
+        "rendererOnError must run on every empty/null-blipId early return",
+        2,
+        releaseCount[0]);
+  }
+
+  @Test
+  public void onMarkBlipReadReleasesRendererGateOnSkippedInFlight() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    // First dispatch: succeeds at the gateway level, no skip — gate
+    // release happens in the success/error continuations, not in the
+    // synchronous early-return.
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
+
+    // Second dispatch for the same (waveId, blipId) is the skipped-in-flight
+    // path. The renderer gate MUST still be released here, otherwise the
+    // renderer keeps treating the blip as in-flight forever.
+    final boolean[] released = new boolean[] {false};
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> released[0] = true);
+
+    Assert.assertTrue(
+        "skipped-in-flight early return must still release the renderer gate",
+        released[0]);
+  }
+
   private static final class Harness {
     private int openCount;
     private int closedCount;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -1494,6 +1494,80 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertTrue(harness.markBlipReadAttempts.isEmpty());
   }
 
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: the in-flight de-dup must be keyed by the
+   * {@code (waveId, blipId)} pair, not the blipId alone. Two waves can
+   * legitimately share a blipId — without composite keying, a still-pending
+   * request from the previous wave would suppress a legitimate dispatch in
+   * the next selection.
+   */
+  @Test
+  public void onMarkBlipReadDoesNotCollideAcrossWavesWithSameBlipId() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello A");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+shared", (Runnable) () -> {});
+    Assert.assertEquals(1, harness.markBlipReadAttempts.size());
+    // Do NOT resolve the first attempt; switch waves while it is still in flight.
+
+    harness.selectWave(controller, "example.com/w+2", null);
+    harness.resolveBootstrap(harness.bootstrapAttempts.size() - 1);
+    harness.deliverUpdate(harness.openAttempts.size() - 1, "Hello B");
+
+    onMarkBlipRead.invoke(controller, "b+shared", (Runnable) () -> {});
+
+    Assert.assertEquals(
+        "second wave's dispatch for the same blipId must not be suppressed by "
+            + "the previous wave's in-flight entry",
+        2,
+        harness.markBlipReadAttempts.size());
+    Assert.assertEquals(
+        "second dispatch must target the new wave",
+        "example.com/w+2",
+        harness.markBlipReadAttempts.get(1).waveId);
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: the {@code skipped-in-flight} telemetry
+   * outcome must include {@code latency_ms} so downstream consumers see a
+   * uniform schema across success/error/skipped paths.
+   */
+  @Test
+  public void onMarkBlipReadSkippedInFlightEventCarriesLatencyField() throws Exception {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    Harness harness = new Harness(telemetry);
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello");
+
+    Method onMarkBlipRead =
+        controller.getClass().getDeclaredMethod("onMarkBlipRead", String.class, Runnable.class);
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
+    onMarkBlipRead.invoke(controller, "b+abc", (Runnable) () -> {});
+
+    J2clClientTelemetry.Event skipped = null;
+    for (J2clClientTelemetry.Event event : telemetry.events()) {
+      if ("j2cl.read.mark_blip_read".equals(event.getName())
+          && "skipped-in-flight".equals(event.getFields().get("outcome"))) {
+        skipped = event;
+        break;
+      }
+    }
+    Assert.assertNotNull("expected a skipped-in-flight outcome event", skipped);
+    Assert.assertEquals(
+        "skipped-in-flight outcome must include latency_ms=0 for schema parity",
+        "0",
+        skipped.getFields().get("latency_ms"));
+  }
+
   private static final class Harness {
     private int openCount;
     private int closedCount;

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/ServerMain.java
@@ -388,6 +388,7 @@ public class ServerMain {
     server.addServlet("/fetch/version/*", VersionedFetchServlet.class);
     server.addServlet("/search/*", SearchServlet.class);
     server.addServlet("/read-state/*", SelectedWaveReadStateServlet.class);
+    server.addServlet("/j2cl/mark-blip-read", MarkBlipReadServlet.class);
     server.addServlet("/dev/client-applier-stats", ClientApplierStatsJakartaServlet.class);
     server.addServlet("/healthz", HealthServlet.class);
     server.addServlet("/readyz", HealthServlet.class);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/MarkBlipReadServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/MarkBlipReadServlet.java
@@ -28,8 +28,9 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
@@ -115,11 +116,11 @@ public final class MarkBlipReadServlet extends HttpServlet {
       return;
     }
     String body;
-    try (BufferedReader reader = req.getReader()) {
-      char[] buf = new char[MAX_BODY_BYTES + 1];
+    try (InputStream in = req.getInputStream()) {
+      byte[] buf = new byte[MAX_BODY_BYTES + 1];
       int total = 0;
       while (total <= MAX_BODY_BYTES) {
-        int read = reader.read(buf, total, buf.length - total);
+        int read = in.read(buf, total, buf.length - total);
         if (read < 0) {
           break;
         }
@@ -129,7 +130,7 @@ public final class MarkBlipReadServlet extends HttpServlet {
         resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         return;
       }
-      body = new String(buf, 0, total);
+      body = new String(buf, 0, total, StandardCharsets.UTF_8);
     } catch (IOException e) {
       LOG.info("mark-blip-read: failed to read body");
       resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/MarkBlipReadServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/MarkBlipReadServlet.java
@@ -1,0 +1,270 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.rpc;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSessions;
+import org.waveprotocol.box.server.waveserver.MarkBlipReadHelper;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.InvalidIdException;
+import org.waveprotocol.wave.model.id.ModernIdSerialiser;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Marks a single blip as read for the authenticated user. Implements the J2CL
+ * server seam called by {@code J2clSearchGateway.markBlipRead}; closes #1056
+ * (R-4.4 supplement-op write path deferred from F-2.S5).
+ *
+ * <p>Request: {@code POST /j2cl/mark-blip-read} with JSON body
+ * {@code {"waveId":"<id>","blipId":"<id>"[,"waveletId":"<id>"]}}. {@code waveletId}
+ * defaults to the canonical conversation root for the given wave id when
+ * omitted.
+ *
+ * <p>Response (200 OK): {@code {"ok":true,"unreadCount":N,"alreadyRead":B}}
+ * where {@code alreadyRead} reflects whether the supplement was already in the
+ * read state for that blip (no UDW delta submitted) — informational, not
+ * load-bearing for the client (the new {@code unreadCount} converges
+ * regardless).
+ *
+ * <p>Status codes:
+ * <ul>
+ *   <li>403 — unauthenticated session.</li>
+ *   <li>400 — malformed JSON body, missing/empty fields, invalid wave/wavelet id.</li>
+ *   <li>404 — unknown wave/wavelet/blip OR access denied (collapsed). Mirrors the
+ *       semantic of {@link SelectedWaveReadStateServlet} so existence cannot be
+ *       probed by non-participants.</li>
+ *   <li>500 — backend wavelet load / submit failure.</li>
+ * </ul>
+ *
+ * <p>Idempotent at the supplement layer
+ * ({@link org.waveprotocol.wave.model.supplement.SupplementedWaveImpl#markAsRead}
+ * is a no-op when the blip is already read), so client-side de-dupe is
+ * defence-in-depth not load-bearing.
+ *
+ * <p><b>CSRF posture:</b> the session cookie carries {@code SameSite=Lax}
+ * (configured in {@code ServerModule#sessionHandler}), so a cross-site
+ * form POST cannot ride the cookie. The endpoint trusts the session +
+ * SameSite default; no explicit XSRF token is required, matching the
+ * stance of the read-state, fragments, and submit endpoints.
+ */
+@SuppressWarnings("serial")
+public final class MarkBlipReadServlet extends HttpServlet {
+  private static final Log LOG = Log.get(MarkBlipReadServlet.class);
+
+  private static final int MAX_BODY_BYTES = 4 * 1024;
+
+  private final SessionManager sessionManager;
+  private final MarkBlipReadHelper helper;
+
+  @Inject
+  public MarkBlipReadServlet(SessionManager sessionManager, MarkBlipReadHelper helper) {
+    this.sessionManager = sessionManager;
+    this.helper = helper;
+  }
+
+  @Override
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    // Per-user mutation: never cache.
+    resp.setHeader("Cache-Control", "no-store");
+
+    ParticipantId user = sessionManager.getLoggedInUser(WebSessions.from(req, false));
+    if (user == null) {
+      resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    // Cap the JSON body so a misbehaving client can't OOM us with multi-MB
+    // inputs. The expected body is ~200 bytes of strings; 4 KB is generous.
+    // Read up to MAX_BODY_BYTES + 1 chars to detect oversize before parsing —
+    // a single hostile line without newlines must NOT buffer unbounded.
+    int contentLength = req.getContentLength();
+    if (contentLength > MAX_BODY_BYTES) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+    String body;
+    try (BufferedReader reader = req.getReader()) {
+      char[] buf = new char[MAX_BODY_BYTES + 1];
+      int total = 0;
+      while (total <= MAX_BODY_BYTES) {
+        int read = reader.read(buf, total, buf.length - total);
+        if (read < 0) {
+          break;
+        }
+        total += read;
+      }
+      if (total > MAX_BODY_BYTES) {
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+      body = new String(buf, 0, total);
+    } catch (IOException e) {
+      LOG.info("mark-blip-read: failed to read body");
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+    if (body == null || body.isEmpty()) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    JsonObject root;
+    try {
+      JsonElement parsed = JsonParser.parseString(body);
+      if (parsed == null || !parsed.isJsonObject()) {
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+      root = parsed.getAsJsonObject();
+    } catch (JsonSyntaxException e) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    String rawWaveId = readString(root, "waveId");
+    String rawBlipId = readString(root, "blipId");
+    String rawWaveletId = readString(root, "waveletId");
+    if (rawWaveId == null || rawWaveId.isEmpty()
+        || rawBlipId == null || rawBlipId.isEmpty()) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    WaveId waveId;
+    try {
+      waveId = ModernIdSerialiser.INSTANCE.deserialiseWaveId(rawWaveId);
+    } catch (InvalidIdException e) {
+      resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
+
+    WaveletId waveletId;
+    if (rawWaveletId == null || rawWaveletId.isEmpty()) {
+      // Default to the canonical conv+root wavelet on the same domain as the
+      // wave id. Mirrors the J2CL read surface contract documented in
+      // J2clSearchGateway#defaultWaveletId.
+      waveletId = WaveletId.of(waveId.getDomain(), IdUtil.CONVERSATION_ROOT_WAVELET);
+    } else {
+      try {
+        waveletId = ModernIdSerialiser.INSTANCE.deserialiseWaveletId(rawWaveletId);
+      } catch (InvalidIdException e) {
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+    }
+
+    MarkBlipReadHelper.Result result;
+    try {
+      result = helper.markBlipRead(user, waveId, waveletId, rawBlipId);
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: unexpected failure for wave " + rawWaveId, e);
+      resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      return;
+    }
+
+    switch (result.getOutcome()) {
+      case OK:
+        writeOk(resp, rawWaveId, result.getUnreadCountAfter(), false);
+        return;
+      case ALREADY_READ:
+        writeOk(resp, rawWaveId, result.getUnreadCountAfter(), true);
+        return;
+      case BAD_REQUEST:
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      case NOT_FOUND:
+        resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        return;
+      case INTERNAL_ERROR:
+      default:
+        resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        return;
+    }
+  }
+
+  private static String readString(JsonObject obj, String key) {
+    if (obj == null || !obj.has(key)) {
+      return null;
+    }
+    JsonElement value = obj.get(key);
+    if (value == null || value.isJsonNull() || !value.isJsonPrimitive()
+        || !value.getAsJsonPrimitive().isString()) {
+      return null;
+    }
+    return value.getAsString();
+  }
+
+  private static void writeOk(
+      HttpServletResponse resp, String waveId, int unreadCount, boolean alreadyRead)
+      throws IOException {
+    resp.setStatus(HttpServletResponse.SC_OK);
+    resp.setContentType("application/json; charset=utf-8");
+    StringBuilder body = new StringBuilder(96);
+    body.append("{\"ok\":true,\"waveId\":\"")
+        .append(escapeJson(waveId))
+        .append("\",\"unreadCount\":")
+        .append(Math.max(0, unreadCount))
+        .append(",\"alreadyRead\":")
+        .append(alreadyRead)
+        .append('}');
+    try (var w = resp.getWriter()) {
+      w.append(body.toString());
+      w.flush();
+    }
+  }
+
+  private static String escapeJson(String value) {
+    StringBuilder out = new StringBuilder(value.length() + 8);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"': out.append("\\\""); break;
+        case '\\': out.append("\\\\"); break;
+        case '\b': out.append("\\b"); break;
+        case '\f': out.append("\\f"); break;
+        case '\n': out.append("\\n"); break;
+        case '\r': out.append("\\r"); break;
+        case '\t': out.append("\\t"); break;
+        default:
+          if (c < 0x20) {
+            out.append(String.format("\\u%04x", (int) c));
+          } else {
+            out.append(c);
+          }
+      }
+    }
+    return out.toString();
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -211,9 +211,13 @@ public class MarkBlipReadHelper {
       return Result.internalError();
     }
     if (conv == null) {
-      LOG.warning("mark-blip-read: conversational wavelet unavailable "
-          + WaveletName.of(waveId, waveletId));
-      return Result.internalError();
+      // openWaveletViaContext returns null specifically when openWavelet
+      // throws InvalidRequestException — i.e. the wavelet is missing or the
+      // user lacks access. Both collapse to NOT_FOUND per the helper
+      // contract so non-participants cannot probe wavelet existence (the
+      // access probe at the top of this method already approved the wave;
+      // this guards against a racy disappearance or a stale cache).
+      return Result.notFound();
     }
 
     ObservableConversationView view = conversationUtil.buildConversation(conv);

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -1,0 +1,298 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.wave.api.InvalidRequestException;
+import com.google.wave.api.ProtocolVersion;
+import com.google.wave.api.data.converter.EventDataConverterManager;
+
+import org.waveprotocol.box.server.robots.OperationContextImpl;
+import org.waveprotocol.box.server.robots.RobotWaveletData;
+import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.box.server.robots.util.LoggingRequestListener;
+import org.waveprotocol.box.server.robots.util.OperationUtil;
+import org.waveprotocol.wave.model.conversation.Conversation;
+import org.waveprotocol.wave.model.conversation.ConversationBlip;
+import org.waveprotocol.wave.model.conversation.ObservableConversationView;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.supplement.PrimitiveSupplement;
+import org.waveprotocol.wave.model.supplement.SupplementedWave;
+import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl;
+import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl.DefaultFollow;
+import org.waveprotocol.wave.model.supplement.WaveletBasedSupplement;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
+import org.waveprotocol.wave.util.logging.Log;
+
+/**
+ * Server seam for the J2CL {@code markBlipRead} write path. Mutates the
+ * authenticated user's user-data wavelet via the same supplement op pipeline
+ * the GWT client and the robot {@code FolderActionService} use today; the J2CL
+ * surface gets behavioural parity with no new write code path.
+ *
+ * <p>This helper is structurally adjacent to
+ * {@link SelectedWaveReadStateHelper} (which serves the read counterpart), but
+ * takes a different dependency set ({@link WaveletProvider},
+ * {@link EventDataConverterManager}, {@link ConversationUtil}) so it can drive
+ * an {@link OperationContextImpl} for the write. The two helpers share the
+ * "collapse missing-wave + access-denied to {@code NOT_FOUND}" semantic so
+ * non-participants cannot probe wave existence.
+ *
+ * <p>Outcome contract:
+ * <ul>
+ *   <li>{@link Outcome#OK} — supplement op submitted; {@code unreadCountAfter}
+ *       reflects the post-op count.</li>
+ *   <li>{@link Outcome#ALREADY_READ} — blip was already read for this user;
+ *       no UDW delta was submitted (the op is idempotent at the
+ *       {@link SupplementedWave#markAsRead(ConversationBlip)} layer); the
+ *       count is reported back to the caller for live UI consistency.</li>
+ *   <li>{@link Outcome#NOT_FOUND} — wave/wavelet/blip absent OR access denied;
+ *       collapsed into a single response so existence cannot be probed.</li>
+ *   <li>{@link Outcome#BAD_REQUEST} — null arguments. Servlet maps to 400.</li>
+ *   <li>{@link Outcome#INTERNAL_ERROR} — backend wavelet load failure.</li>
+ * </ul>
+ *
+ * <p>Introduced for issue #1039 (F-4) / closes #1056.
+ */
+public class MarkBlipReadHelper {
+
+  private static final Log LOG = Log.get(MarkBlipReadHelper.class);
+
+  private static final WaveletProvider.SubmitRequestListener LOGGING_REQUEST_LISTENER =
+      new LoggingRequestListener(LOG);
+
+  /** Outcome of a {@link #markBlipRead} call. */
+  public enum Outcome {
+    /** Supplement op submitted. */
+    OK,
+    /** Blip was already read; no delta submitted. */
+    ALREADY_READ,
+    /** Wave/wavelet/blip not found OR access denied (collapsed). */
+    NOT_FOUND,
+    /** Required arguments missing or malformed. */
+    BAD_REQUEST,
+    /** Wavelet load failure. */
+    INTERNAL_ERROR;
+  }
+
+  /** Result of a {@link #markBlipRead} call. */
+  public static final class Result {
+    private final Outcome outcome;
+    private final int unreadCountAfter;
+
+    private Result(Outcome outcome, int unreadCountAfter) {
+      this.outcome = outcome;
+      this.unreadCountAfter = unreadCountAfter;
+    }
+
+    public Outcome getOutcome() {
+      return outcome;
+    }
+
+    /** -1 when unknown (not-found / bad-request / internal-error). */
+    public int getUnreadCountAfter() {
+      return unreadCountAfter;
+    }
+
+    public static Result ok(int unreadCountAfter) {
+      return new Result(Outcome.OK, Math.max(0, unreadCountAfter));
+    }
+
+    public static Result alreadyRead(int unreadCountAfter) {
+      return new Result(Outcome.ALREADY_READ, Math.max(0, unreadCountAfter));
+    }
+
+    public static Result notFound() {
+      return new Result(Outcome.NOT_FOUND, -1);
+    }
+
+    public static Result badRequest() {
+      return new Result(Outcome.BAD_REQUEST, -1);
+    }
+
+    public static Result internalError() {
+      return new Result(Outcome.INTERNAL_ERROR, -1);
+    }
+  }
+
+  private final WaveletProvider waveletProvider;
+  private final EventDataConverterManager converterManager;
+  private final ConversationUtil conversationUtil;
+  private final SelectedWaveReadStateHelper readStateHelper;
+
+  @Inject
+  public MarkBlipReadHelper(
+      WaveletProvider waveletProvider,
+      EventDataConverterManager converterManager,
+      ConversationUtil conversationUtil,
+      SelectedWaveReadStateHelper readStateHelper) {
+    this.waveletProvider = waveletProvider;
+    this.converterManager = converterManager;
+    this.conversationUtil = conversationUtil;
+    this.readStateHelper = readStateHelper;
+  }
+
+  /**
+   * Marks the given blip as read for the given user. Returns a {@link Result}
+   * carrying the outcome plus the post-op unread count for the wave (read back
+   * via {@link SelectedWaveReadStateHelper#computeReadState} so the read and
+   * write paths agree on the value the client sees).
+   */
+  public Result markBlipRead(
+      ParticipantId user, WaveId waveId, WaveletId waveletId, String blipId) {
+    if (user == null || waveId == null || waveletId == null || blipId == null
+        || blipId.isEmpty()) {
+      return Result.badRequest();
+    }
+
+    if (!IdUtil.isConversationalId(waveletId)) {
+      // The mark-read pipeline only mutates the UDW; the blip lives on a
+      // conversational wavelet. Refuse to even try other shapes.
+      return Result.badRequest();
+    }
+
+    // Existence + access guard mirroring SelectedWaveReadStateHelper:
+    // collapse missing wave / wavelet load failure / access-denied into 404
+    // so non-participants cannot probe existence.
+    SelectedWaveReadStateHelper.Result accessProbe;
+    try {
+      accessProbe = readStateHelper.computeReadState(user, waveId);
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: access probe failed for " + waveId, e);
+      return Result.internalError();
+    }
+    if (!accessProbe.exists() || !accessProbe.accessAllowed()) {
+      return Result.notFound();
+    }
+
+    // Drive the supplement op via OperationContextImpl, the same pipeline
+    // FolderActionService uses for the robot 'markAsRead' op. Implementation
+    // note: OperationContextImpl implements OperationResults
+    // (see OperationContextImpl.java:74), so it plugs straight into
+    // OperationUtil.submitDeltas without a cast.
+    OperationContextImpl context =
+        new OperationContextImpl(
+            waveletProvider,
+            converterManager.getEventDataConverter(ProtocolVersion.DEFAULT),
+            conversationUtil);
+
+    OpBasedWavelet conv;
+    try {
+      conv = openWaveletViaContext(context, waveId, waveletId, user);
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: failed to open conversational wavelet "
+          + WaveletName.of(waveId, waveletId), e);
+      return Result.notFound();
+    }
+    if (conv == null) {
+      return Result.notFound();
+    }
+
+    ObservableConversationView view = conversationUtil.buildConversation(conv);
+    Conversation root = view.getRoot();
+    if (root == null) {
+      return Result.notFound();
+    }
+
+    ConversationBlip blip = root.getBlip(blipId);
+    if (blip == null) {
+      // Unknown blip id: 404 (do NOT 400, the id may be valid syntactically
+      // but absent — same shape as wave-not-found).
+      return Result.notFound();
+    }
+
+    // Open the user-data wavelet on the same context so the supplement
+    // mutations land in a single delta. UDW is auto-created by openWavelet
+    // when missing (see OperationContextImpl#openWavelet).
+    WaveletId udwId = IdUtil.buildUserDataWaveletId(user);
+    OpBasedWavelet udw;
+    try {
+      udw = openWaveletViaContext(context, waveId, udwId, user);
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: failed to open user-data wavelet "
+          + WaveletName.of(waveId, udwId), e);
+      return Result.internalError();
+    }
+
+    PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
+    SupplementedWave supplement =
+        SupplementedWaveImpl.create(udwState, view, user, DefaultFollow.ALWAYS);
+
+    boolean wasUnread = supplement.isUnread(blip);
+    if (!wasUnread) {
+      // Supplement is already read; markAsRead is a no-op at the
+      // SupplementedWaveImpl layer (see SupplementedWaveImpl.java:306). We
+      // skip the submit entirely and report the current count for live UI.
+      return Result.alreadyRead(currentUnreadCount(user, waveId));
+    }
+
+    supplement.markAsRead(blip);
+
+    // Defence-in-depth: only the UDW delta should be present. The conv
+    // wavelet was opened only to materialize the ConversationView; if a
+    // delta accumulated there we have a bug and would silently mutate the
+    // wave. Refuse to submit and signal an error instead.
+    WaveletName convWaveletName = WaveletName.of(waveId, waveletId);
+    RobotWaveletData convData = context.getOpenWavelets().get(convWaveletName);
+    if (convData != null && !convData.getDeltas().isEmpty()) {
+      LOG.warning("mark-blip-read: unexpected conv-wavelet deltas, refusing submit "
+          + convWaveletName);
+      return Result.internalError();
+    }
+
+    OperationUtil.submitDeltas(context, waveletProvider, LOGGING_REQUEST_LISTENER);
+
+    return Result.ok(currentUnreadCount(user, waveId));
+  }
+
+  /**
+   * Reads back the current unread count via the existing read helper so the
+   * write and read paths agree on the value the client sees.
+   */
+  private int currentUnreadCount(ParticipantId user, WaveId waveId) {
+    try {
+      SelectedWaveReadStateHelper.Result post = readStateHelper.computeReadState(user, waveId);
+      if (!post.exists() || !post.accessAllowed()) {
+        return 0;
+      }
+      return post.getUnreadCount();
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: failed to recompute unread count for " + waveId, e);
+      return 0;
+    }
+  }
+
+  @VisibleForTesting
+  OpBasedWavelet openWaveletViaContext(
+      OperationContextImpl context, WaveId waveId, WaveletId waveletId, ParticipantId user) {
+    try {
+      return context.openWavelet(waveId, waveletId, user);
+    } catch (InvalidRequestException e) {
+      // openWavelet wraps load failures and missing wavelets in
+      // InvalidRequestException; collapse to null so the caller can map to 404.
+      return null;
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -235,6 +235,11 @@ public class MarkBlipReadHelper {
           + WaveletName.of(waveId, udwId), e);
       return Result.internalError();
     }
+    if (udw == null) {
+      LOG.warning("mark-blip-read: user-data wavelet unavailable "
+          + WaveletName.of(waveId, udwId));
+      return Result.internalError();
+    }
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
     SupplementedWave supplement =

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -204,10 +204,12 @@ public class MarkBlipReadHelper {
     } catch (RuntimeException e) {
       LOG.warning("mark-blip-read: failed to open conversational wavelet "
           + WaveletName.of(waveId, waveletId), e);
-      return Result.notFound();
+      return Result.internalError();
     }
     if (conv == null) {
-      return Result.notFound();
+      LOG.warning("mark-blip-read: conversational wavelet unavailable "
+          + WaveletName.of(waveId, waveletId));
+      return Result.internalError();
     }
 
     ObservableConversationView view = conversationUtil.buildConversation(conv);

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -28,8 +28,8 @@ import com.google.wave.api.data.converter.EventDataConverterManager;
 import org.waveprotocol.box.server.robots.OperationContextImpl;
 import org.waveprotocol.box.server.robots.RobotWaveletData;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
-import org.waveprotocol.box.server.robots.util.LoggingRequestListener;
 import org.waveprotocol.box.server.robots.util.OperationUtil;
+import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
 import org.waveprotocol.wave.model.conversation.Conversation;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
 import org.waveprotocol.wave.model.conversation.ObservableConversationView;
@@ -42,6 +42,7 @@ import org.waveprotocol.wave.model.supplement.SupplementedWave;
 import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl;
 import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl.DefaultFollow;
 import org.waveprotocol.wave.model.supplement.WaveletBasedSupplement;
+import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 import org.waveprotocol.wave.util.logging.Log;
@@ -79,9 +80,6 @@ import org.waveprotocol.wave.util.logging.Log;
 public class MarkBlipReadHelper {
 
   private static final Log LOG = Log.get(MarkBlipReadHelper.class);
-
-  private static final WaveletProvider.SubmitRequestListener LOGGING_REQUEST_LISTENER =
-      new LoggingRequestListener(LOG);
 
   /** Outcome of a {@link #markBlipRead} call. */
   public enum Outcome {
@@ -202,6 +200,12 @@ public class MarkBlipReadHelper {
     try {
       conv = openWaveletViaContext(context, waveId, waveletId, user);
     } catch (RuntimeException e) {
+      // openWaveletViaContext already collapses the not-found / access-denied
+      // path into a null return (via its catch of InvalidRequestException).
+      // Anything that escapes here is a genuine backend fault — mapping it
+      // to NOT_FOUND would hide a server-side error behind a false 404, so
+      // we surface it as INTERNAL_ERROR to match the helper's documented
+      // outcome contract (and to align with the udwId open path below).
       LOG.warning("mark-blip-read: failed to open conversational wavelet "
           + WaveletName.of(waveId, waveletId), e);
       return Result.internalError();
@@ -269,9 +273,64 @@ public class MarkBlipReadHelper {
       return Result.internalError();
     }
 
-    OperationUtil.submitDeltas(context, waveletProvider, LOGGING_REQUEST_LISTENER);
+    // We deliberately do NOT use the fire-and-forget LoggingRequestListener
+    // here. The servlet immediately reports the resulting outcome to the
+    // J2CL client (which decrements badges live based on it), so an OK
+    // response after a rejected submit would make the UI show a phantom
+    // decrement. The current WaveletProvider implementations
+    // (WaveServerImpl in particular) invoke SubmitRequestListener
+    // synchronously from within submitRequest(...), so capturing the
+    // outcome on the calling thread is sufficient — no waiting required.
+    CapturingRequestListener captured = new CapturingRequestListener();
+    OperationUtil.submitDeltas(context, waveletProvider, captured);
+
+    if (!captured.completed) {
+      // Defence-in-depth: every existing WaveletProvider in this codebase
+      // resolves submitRequest synchronously, but if a future provider
+      // implementation buffers the call we must not silently report OK
+      // for an unconfirmed write.
+      LOG.warning("mark-blip-read: submitDeltas returned without invoking the listener for "
+          + WaveletName.of(waveId, IdUtil.buildUserDataWaveletId(user)));
+      return Result.internalError();
+    }
+    if (captured.failureMessage != null) {
+      LOG.warning("mark-blip-read: UDW delta rejected for "
+          + WaveletName.of(waveId, IdUtil.buildUserDataWaveletId(user))
+          + " — " + captured.failureMessage);
+      return Result.internalError();
+    }
 
     return Result.ok(currentUnreadCount(user, waveId));
+  }
+
+  /**
+   * Synchronous {@link SubmitRequestListener} that captures the submit
+   * outcome on the calling thread so {@link #markBlipRead} can reject
+   * {@link Result#ok} when the provider returned a failure rather than
+   * throwing. The current {@link WaveletProvider} implementations in this
+   * server (e.g. {@code WaveServerImpl}) invoke the listener synchronously
+   * from {@code submitRequest(...)}; the {@link #completed} flag guards
+   * against a future provider that buffers the call.
+   */
+  private static final class CapturingRequestListener implements SubmitRequestListener {
+    boolean completed;
+    String failureMessage;
+
+    @Override
+    public void onSuccess(int operationsApplied, HashedVersion hashedVersionAfterApplication,
+        long applicationTimestamp) {
+      completed = true;
+      if (LOG.isFineLoggable()) {
+        LOG.fine("mark-blip-read: " + operationsApplied + " op(s) applied @"
+            + hashedVersionAfterApplication);
+      }
+    }
+
+    @Override
+    public void onFailure(String errorMessage) {
+      completed = true;
+      failureMessage = errorMessage == null ? "unknown" : errorMessage;
+    }
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/MarkBlipReadServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/MarkBlipReadServletTest.java
@@ -1,0 +1,309 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.rpc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import junit.framework.TestCase;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.waveserver.MarkBlipReadHelper;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+/** HTTP-contract tests for {@link MarkBlipReadServlet}. */
+public final class MarkBlipReadServletTest extends TestCase {
+
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@example.com");
+  private static final String VALID_WAVE_ID = "example.com/w+abc";
+  private static final String VALID_WAVELET_ID = "example.com/conv+root";
+  private static final String VALID_BLIP_ID = "b+abc";
+
+  public void testReturnsForbiddenWhenNoSession() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(null);
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+
+    MarkBlipReadServlet servlet = new MarkBlipReadServlet(sessionManager, helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_FORBIDDEN);
+  }
+
+  public void testReturnsBadRequestForEmptyBody() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody("");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestForMalformedJson() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody("{not json");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestForJsonArray() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody("[1,2,3]");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestWhenWaveIdMissing() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody(
+        "{\"blipId\":\"" + VALID_BLIP_ID + "\"}");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestWhenBlipIdMissing() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody(
+        "{\"waveId\":\"" + VALID_WAVE_ID + "\"}");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestWhenWaveIdMalformed() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody(
+        "{\"waveId\":\"not a wave id\",\"blipId\":\"" + VALID_BLIP_ID + "\"}");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsBadRequestWhenWaveletIdMalformed() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    HttpServletRequest request = requestWithBody(
+        "{\"waveId\":\"" + VALID_WAVE_ID + "\",\"blipId\":\"" + VALID_BLIP_ID
+            + "\",\"waveletId\":\"junk junk\"}");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  public void testReturnsNotFoundWhenHelperReportsMissing() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenReturn(MarkBlipReadHelper.Result.notFound());
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  public void testReturnsInternalErrorWhenHelperRaises() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenThrow(new RuntimeException("transient failure"));
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  public void testReturnsInternalErrorWhenHelperOutcomeIsInternalError() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenReturn(MarkBlipReadHelper.Result.internalError());
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  public void testReturnsOkWithBodyOnSuccess() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenReturn(MarkBlipReadHelper.Result.ok(2));
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    verify(response).setContentType("application/json; charset=utf-8");
+    verify(response).setHeader("Cache-Control", "no-store");
+    String json = body.toString();
+    assertTrue("body missing ok:true: " + json, json.contains("\"ok\":true"));
+    assertTrue("body missing unreadCount:2: " + json, json.contains("\"unreadCount\":2"));
+    assertTrue("body missing alreadyRead:false: " + json, json.contains("\"alreadyRead\":false"));
+    assertTrue("body missing waveId: " + json, json.contains("\"waveId\":\"" + VALID_WAVE_ID + "\""));
+  }
+
+  public void testReturnsOkWithAlreadyReadFlagWhenSupplementSkipped() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenReturn(MarkBlipReadHelper.Result.alreadyRead(0));
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    String json = body.toString();
+    assertTrue("body missing alreadyRead:true: " + json, json.contains("\"alreadyRead\":true"));
+    assertTrue("body missing unreadCount:0: " + json, json.contains("\"unreadCount\":0"));
+  }
+
+  public void testNoStoreCacheHeaderSetOnEveryResponsePath() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(null);
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+
+    MarkBlipReadServlet servlet = new MarkBlipReadServlet(sessionManager, helper);
+    HttpServletRequest request = requestWithBody(validBody());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setHeader("Cache-Control", "no-store");
+  }
+
+  public void testWaveletIdDefaultsToConvRootWhenOmitted() throws Exception {
+    MarkBlipReadHelper helper = mock(MarkBlipReadHelper.class);
+    when(helper.markBlipRead(any(ParticipantId.class), any(WaveId.class),
+                             any(WaveletId.class), any(String.class)))
+        .thenReturn(MarkBlipReadHelper.Result.ok(0));
+    MarkBlipReadServlet servlet = servletWithUser(helper);
+    HttpServletRequest request = requestWithBody(
+        "{\"waveId\":\"" + VALID_WAVE_ID + "\",\"blipId\":\"" + VALID_BLIP_ID + "\"}");
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    // The default conv+root wavelet on the same domain as the wave id must be
+    // forwarded to the helper when waveletId is omitted.
+    WaveletId expectedWaveletId = WaveletId.of("example.com", "conv+root");
+    verify(helper).markBlipRead(eq(USER), any(WaveId.class), eq(expectedWaveletId),
+                                eq(VALID_BLIP_ID));
+  }
+
+  public void testRejectsOversizedBody() throws Exception {
+    MarkBlipReadServlet servlet = servletWithUser();
+    StringBuilder bigBody = new StringBuilder("{\"waveId\":\"")
+        .append(VALID_WAVE_ID)
+        .append("\",\"blipId\":\"")
+        .append(VALID_BLIP_ID)
+        .append("\",\"junk\":\"");
+    for (int i = 0; i < 5000; i++) {
+      bigBody.append('A');
+    }
+    bigBody.append("\"}");
+    HttpServletRequest request = requestWithBody(bigBody.toString());
+    HttpServletResponse response = responseWithWriter();
+
+    servlet.doPost(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private static String validBody() {
+    return "{\"waveId\":\"" + VALID_WAVE_ID
+        + "\",\"waveletId\":\"" + VALID_WAVELET_ID
+        + "\",\"blipId\":\"" + VALID_BLIP_ID + "\"}";
+  }
+
+  private MarkBlipReadServlet servletWithUser() throws Exception {
+    return servletWithUser(mock(MarkBlipReadHelper.class));
+  }
+
+  private MarkBlipReadServlet servletWithUser(MarkBlipReadHelper helper) throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    return new MarkBlipReadServlet(sessionManager, helper);
+  }
+
+  private static HttpServletRequest requestWithBody(String body) throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    BufferedReader reader = new BufferedReader(new StringReader(body));
+    when(request.getReader()).thenReturn(reader);
+    when(request.getContentLength()).thenReturn(body == null ? 0 : body.length());
+    return request;
+  }
+
+  private static HttpServletResponse responseWithWriter() throws Exception {
+    return responseWithWriter(new StringWriter());
+  }
+
+  private static HttpServletResponse responseWithWriter(StringWriter backing) throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    when(response.getWriter()).thenReturn(new PrintWriter(backing));
+    return response;
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/MarkBlipReadServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/MarkBlipReadServletTest.java
@@ -25,13 +25,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
-import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 
 import junit.framework.TestCase;
 import org.waveprotocol.box.server.authentication.SessionManager;
@@ -291,10 +295,43 @@ public final class MarkBlipReadServletTest extends TestCase {
 
   private static HttpServletRequest requestWithBody(String body) throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);
-    BufferedReader reader = new BufferedReader(new StringReader(body));
-    when(request.getReader()).thenReturn(reader);
-    when(request.getContentLength()).thenReturn(body == null ? 0 : body.length());
+    byte[] bytes = body == null ? new byte[0] : body.getBytes(StandardCharsets.UTF_8);
+    when(request.getInputStream()).thenReturn(servletStreamOf(bytes));
+    when(request.getContentLength()).thenReturn(bytes.length);
     return request;
+  }
+
+  private static ServletInputStream servletStreamOf(byte[] bytes) {
+    final InputStream backing = new ByteArrayInputStream(bytes);
+    return new ServletInputStream() {
+      @Override
+      public boolean isFinished() {
+        try {
+          return backing.available() == 0;
+        } catch (IOException e) {
+          return true;
+        }
+      }
+
+      @Override
+      public boolean isReady() {
+        return true;
+      }
+
+      @Override
+      public void setReadListener(ReadListener readListener) {
+      }
+
+      @Override
+      public int read() throws IOException {
+        return backing.read();
+      }
+
+      @Override
+      public int read(byte[] b, int off, int len) throws IOException {
+        return backing.read(b, off, len);
+      }
+    };
   }
 
   private static HttpServletResponse responseWithWriter() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.wave.api.data.converter.EventDataConverterManager;
+
+import junit.framework.TestCase;
+import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+/**
+ * Unit tests for {@link MarkBlipReadHelper}. The deep supplement-op write path
+ * is covered end-to-end by
+ * {@code wave/src/jakarta-test/.../J2clMarkBlipReadParityTest} (which boots a
+ * real Wave server fixture); this unit test pins the outcome-mapping
+ * (BAD_REQUEST, NOT_FOUND, INTERNAL_ERROR) and the access-guard contract.
+ */
+public final class MarkBlipReadHelperTest extends TestCase {
+
+  private static final String DOMAIN = "example.com";
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@example.com");
+  private static final WaveId WAVE_ID = WaveId.of(DOMAIN, "w+abc");
+  private static final WaveletId CONV_ROOT = WaveletId.of(DOMAIN, "conv+root");
+  private static final WaveletId NOT_CONVERSATIONAL =
+      IdUtil.buildUserDataWaveletId(USER);
+  private static final String BLIP_ID = "b+abc";
+
+  private SelectedWaveReadStateHelper readStateHelper;
+  private MarkBlipReadHelper helper;
+
+  @Override
+  protected void setUp() {
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    EventDataConverterManager converterManager = mock(EventDataConverterManager.class);
+    ConversationUtil conversationUtil = mock(ConversationUtil.class);
+    readStateHelper = mock(SelectedWaveReadStateHelper.class);
+    helper = new MarkBlipReadHelper(
+        waveletProvider, converterManager, conversationUtil, readStateHelper);
+  }
+
+  public void testMarkBlipReadReturnsBadRequestWhenUserIsNull() {
+    MarkBlipReadHelper.Result result = helper.markBlipRead(null, WAVE_ID, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST, result.getOutcome());
+    assertEquals(-1, result.getUnreadCountAfter());
+  }
+
+  public void testMarkBlipReadReturnsBadRequestWhenWaveIdIsNull() {
+    MarkBlipReadHelper.Result result = helper.markBlipRead(USER, null, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST, result.getOutcome());
+  }
+
+  public void testMarkBlipReadReturnsBadRequestWhenWaveletIdIsNull() {
+    MarkBlipReadHelper.Result result = helper.markBlipRead(USER, WAVE_ID, null, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST, result.getOutcome());
+  }
+
+  public void testMarkBlipReadReturnsBadRequestWhenBlipIdIsEmpty() {
+    MarkBlipReadHelper.Result result = helper.markBlipRead(USER, WAVE_ID, CONV_ROOT, "");
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST, result.getOutcome());
+  }
+
+  public void testMarkBlipReadReturnsBadRequestWhenWaveletIsNotConversational() {
+    // The mark-blip-read pipeline only mutates the UDW. Refuse non-conversational
+    // wavelet ids before any backend call so we never accidentally probe
+    // unrelated wavelets.
+    MarkBlipReadHelper.Result result =
+        helper.markBlipRead(USER, WAVE_ID, NOT_CONVERSATIONAL, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST, result.getOutcome());
+  }
+
+  public void testMarkBlipReadReturnsNotFoundWhenAccessProbeReportsMissingWave() {
+    when(readStateHelper.computeReadState(USER, WAVE_ID))
+        .thenReturn(SelectedWaveReadStateHelper.Result.notFound());
+
+    MarkBlipReadHelper.Result result = helper.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.NOT_FOUND, result.getOutcome());
+    assertEquals(-1, result.getUnreadCountAfter());
+  }
+
+  public void testMarkBlipReadReturnsInternalErrorWhenAccessProbeRaises() {
+    when(readStateHelper.computeReadState(USER, WAVE_ID))
+        .thenThrow(new RuntimeException("transient backend failure"));
+
+    MarkBlipReadHelper.Result result = helper.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.INTERNAL_ERROR, result.getOutcome());
+  }
+
+  public void testResultFactories() {
+    MarkBlipReadHelper.Result ok = MarkBlipReadHelper.Result.ok(7);
+    assertEquals(MarkBlipReadHelper.Outcome.OK, ok.getOutcome());
+    assertEquals(7, ok.getUnreadCountAfter());
+
+    MarkBlipReadHelper.Result already = MarkBlipReadHelper.Result.alreadyRead(0);
+    assertEquals(MarkBlipReadHelper.Outcome.ALREADY_READ, already.getOutcome());
+    assertEquals(0, already.getUnreadCountAfter());
+
+    // Negative counts are clamped to 0 to keep the wire response well-formed.
+    MarkBlipReadHelper.Result clamped = MarkBlipReadHelper.Result.ok(-3);
+    assertEquals(0, clamped.getUnreadCountAfter());
+
+    assertEquals(MarkBlipReadHelper.Outcome.NOT_FOUND,
+        MarkBlipReadHelper.Result.notFound().getOutcome());
+    assertEquals(MarkBlipReadHelper.Outcome.BAD_REQUEST,
+        MarkBlipReadHelper.Result.badRequest().getOutcome());
+    assertEquals(MarkBlipReadHelper.Outcome.INTERNAL_ERROR,
+        MarkBlipReadHelper.Result.internalError().getOutcome());
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
@@ -148,6 +148,46 @@ public final class MarkBlipReadHelperTest extends TestCase {
     assertEquals(-1, result.getUnreadCountAfter());
   }
 
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: a {@code null} return from
+   * {@link MarkBlipReadHelper#openWaveletViaContext} represents the
+   * not-found / access-denied path (the helper's
+   * {@code InvalidRequestException} catch collapses both into {@code null}),
+   * so the outcome must be {@link Outcome#NOT_FOUND} — not
+   * {@link Outcome#INTERNAL_ERROR}. Otherwise a missing conversational
+   * wavelet (or a racy disappearance after the access probe) would be
+   * reported as a 500 and encourage incorrect retry behaviour on the
+   * client.
+   */
+  public void testMarkBlipReadReturnsNotFoundWhenConvWaveletOpenReturnsNull() {
+    when(readStateHelper.computeReadState(USER, WAVE_ID))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(/* unreadCount= */ 1));
+
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    EventDataConverterManager converterManager = mock(EventDataConverterManager.class);
+    ConversationUtil conversationUtil = mock(ConversationUtil.class);
+    MarkBlipReadHelper helperWithMissingConv =
+        new MarkBlipReadHelper(
+            waveletProvider, converterManager, conversationUtil, readStateHelper) {
+          @Override
+          OpBasedWavelet openWaveletViaContext(
+              OperationContextImpl context,
+              WaveId waveId,
+              WaveletId waveletId,
+              ParticipantId user) {
+            // Production openWaveletViaContext returns null when the
+            // underlying openWavelet throws InvalidRequestException —
+            // i.e. the wavelet is missing or inaccessible.
+            return null;
+          }
+        };
+
+    MarkBlipReadHelper.Result result =
+        helperWithMissingConv.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.NOT_FOUND, result.getOutcome());
+    assertEquals(-1, result.getUnreadCountAfter());
+  }
+
   public void testResultFactories() {
     MarkBlipReadHelper.Result ok = MarkBlipReadHelper.Result.ok(7);
     assertEquals(MarkBlipReadHelper.Outcome.OK, ok.getOutcome());

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
@@ -25,11 +25,13 @@ import static org.mockito.Mockito.when;
 import com.google.wave.api.data.converter.EventDataConverterManager;
 
 import junit.framework.TestCase;
+import org.waveprotocol.box.server.robots.OperationContextImpl;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 
 /**
  * Unit tests for {@link MarkBlipReadHelper}. The deep supplement-op write path
@@ -106,6 +108,44 @@ public final class MarkBlipReadHelperTest extends TestCase {
 
     MarkBlipReadHelper.Result result = helper.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
     assertEquals(MarkBlipReadHelper.Outcome.INTERNAL_ERROR, result.getOutcome());
+  }
+
+  /**
+   * F-4 (#1039 / R-4.4) review-fix: a {@link RuntimeException} escaping
+   * {@link MarkBlipReadHelper#openWaveletViaContext} after the access probe
+   * has already succeeded must surface as {@link Outcome#INTERNAL_ERROR}, not
+   * {@link Outcome#NOT_FOUND}. The not-found / access-denied paths are
+   * already collapsed into {@code null} by {@code openWaveletViaContext}'s
+   * {@code InvalidRequestException} catch — anything reaching the
+   * {@code RuntimeException} catch is a genuine backend fault and must not
+   * be reported as a 404.
+   */
+  public void testMarkBlipReadReturnsInternalErrorWhenConvWaveletOpenRaises() {
+    when(readStateHelper.computeReadState(USER, WAVE_ID))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(/* unreadCount= */ 1));
+
+    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    EventDataConverterManager converterManager = mock(EventDataConverterManager.class);
+    ConversationUtil conversationUtil = mock(ConversationUtil.class);
+    MarkBlipReadHelper helperWithFailingOpen =
+        new MarkBlipReadHelper(
+            waveletProvider, converterManager, conversationUtil, readStateHelper) {
+          @Override
+          OpBasedWavelet openWaveletViaContext(
+              OperationContextImpl context,
+              WaveId waveId,
+              WaveletId waveletId,
+              ParticipantId user) {
+            // Mimic a backend fault — e.g. a NPE bubbling out of the
+            // wavelet provider — escaping through openWavelet.
+            throw new RuntimeException("simulated backend fault");
+          }
+        };
+
+    MarkBlipReadHelper.Result result =
+        helperWithFailingOpen.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
+    assertEquals(MarkBlipReadHelper.Outcome.INTERNAL_ERROR, result.getOutcome());
+    assertEquals(-1, result.getUnreadCountAfter());
   }
 
   public void testResultFactories() {


### PR DESCRIPTION
## Summary

Closes #1056. Updates #1039 (slice 1 of 2 — R-4.4).

This slice ships the **R-4.4 write path** (mark-blip-read supplement op + IntersectionObserver-equivalent debounce + live wave-list decrement) deferred from F-2.S5. F-4.S2 will follow with R-4.7 (search filters/scopes, supplement-driven affordances, diff/reader toggles, plus the production `<slot name="rail-extension">`).

### Server seam
- `MarkBlipReadHelper` reuses the existing supplement-op pipeline (`SupplementedWave.markAsRead(blip)` → `OperationUtil.submitDeltas`) — the same path `FolderActionService` already takes for the robot `markAsRead` op. No new write code path.
- `MarkBlipReadServlet` (POST `/j2cl/mark-blip-read`) — auth via `SessionManager`; 403/400/404/500 mapping; collapses unknown-wave + access-denied into 404 so existence cannot be probed; 4 KB body cap with bounded buffer; `Cache-Control: no-store`. CSRF via SameSite=Lax cookie default.
- Defence-in-depth: refuses to submit if the conv wavelet accumulated unintended deltas; only the UDW delta is allowed.

### Client seam
- `J2clReadSurfaceDomRenderer.evaluateDwellTimers` arms a per-blip 1500 ms dwell timer when an unread blip occupies ≥ 50 % of the viewport (or fills ≥ 50 % of the viewport for tall blips). Cancelled on viewport exit / surface rebuild. In-flight de-dupe gates re-fire.
- `J2clSearchGateway.markBlipRead` POSTs JSON `{waveId, blipId}` and surfaces the post-op `unreadCount` to the controller.
- `J2clSelectedWaveController.onMarkBlipRead` routes success through the existing `scheduleReadStateFetch(...)` debouncer — coalesces with supplement-bus updates instead of racing.
- `ReadStateListener` bridges the live unread count to `J2clSearchPanelController.onReadStateChanged`, which patches the matching `J2clDigestView` in place. No full re-render of the digest list.
- Telemetry: `j2cl.read.mark_blip_read` with `outcome` (success / error / skipped-in-flight) and `latency_ms`.

### Plan deviation: scroll-polling for now, IntersectionObserver later
`elemental2-dom` 1.3.2 has no `IntersectionObserver` Java type. F-4.S1 implements equivalent semantics via the existing host scroll listener plus `getBoundingClientRect()` over the viewport-scoped rendered list (typically ≤ 30 blips). Test seam preserved via `DwellTimerScheduler`. Documented in the plan; a future elemental2 binding can swap the implementation without touching observable behaviour.

## Test plan

- [x] `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild` — exit 0
- [x] `sbt -batch Test/testOnly *MarkBlipReadHelperTest *MarkBlipReadServletTest` — 24 pass
- [x] `J2clSelectedWaveControllerTest` — 66 pass (7 new for markBlipRead path)
- [x] `J2clSearchPanelControllerTest` — 9 pass (3 new for live decrement)
- [x] `J2clReadSurfaceDomRendererMarkReadTest` — 6 cases for the dwell-timer state machine (skipped on JVM, exercised via headless Chrome in production build)
- [ ] Manual smoke: open a wave with multiple unread blips, dwell on each for 1.5 s, confirm the wave-list digest unread count decrements live without a page reload.

## Closeout for this slice

```
ROW DEMONSTRATED: R-4.4 ✓
SUBSUMED: #1056 (markBlipRead Gateway closed by this PR)
SUPPLEMENT OP REUSE: Option A success — `SupplementedWave.markAsRead(blip)` via OperationContextImpl, submitted via OperationUtil.submitDeltas.
DEFERRALS:
 - True IntersectionObserver: deferred until elemental2-dom exposes the Java type (tracked as part of F-4.S2 follow-up; observable behaviour unchanged)
 - F-4.S2: R-4.7 (search filters/scopes, supplement-driven affordances, diff controller, reader mode, rail-extension slot)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Blips are now automatically marked as read when users dwell in the viewport for a configurable duration.
  * Unread badges in search results and digest items now update in real-time as read state changes, without requiring page refresh.

* **Bug Fixes**
  * Search results now reflect the current read state of waves, ensuring badges stay synchronized with actual unread counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->