### PR TITLE
fix(auth): signed-out visitors land on marketing page; surface social-auth misconfig

### DIFF
--- a/wave/config/changelog.d/2026-04-27-signed-out-landing-redirect.json
+++ b/wave/config/changelog.d/2026-04-27-signed-out-landing-redirect.json
@@ -1,0 +1,22 @@
+{
+  "releaseId": "2026-04-27-signed-out-landing-redirect",
+  "version": "PR TBD",
+  "date": "2026-04-27",
+  "title": "Sign-out routes through the public landing page; clearer social-auth misconfig log",
+  "summary": "Signing out (or any signed-out hit on /) now lands on the marketing page instead of an empty Wave shell, and admins get a one-time log when the social-auth flag is on but no provider has both a client_id and a client_secret configured.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "WaveClientServlet now serves the public landing page for signed-out visitors hitting bare \"/\" (no view, no query string), regardless of the j2cl-root-bootstrap flag, so the marketing surface is the first thing a logged-out user sees.",
+        "SignOutServlet's no-redirect fallback now returns 302 \"/\" instead of a static \"Logged out.\" HTML page, so users who reach /auth/signout without an ?r= target also land on the public site instead of a blank page."
+      ]
+    },
+    {
+      "type": "feature",
+      "items": [
+        "AuthenticationServlet emits a one-time WARNING when the 'social-auth' feature flag is globally enabled but no provider has both core.social_auth.<provider>.client_id and core.social_auth.<provider>.client_secret set, surfacing the missing OAuth configuration that silently hides the social sign-in buttons."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-27-signed-out-landing-redirect.json
+++ b/wave/config/changelog.d/2026-04-27-signed-out-landing-redirect.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-27-signed-out-landing-redirect",
-  "version": "PR TBD",
+  "version": "PR #1067",
   "date": "2026-04-27",
   "title": "Sign-out routes through the public landing page; clearer social-auth misconfig log",
   "summary": "Signing out (or any signed-out hit on /) now lands on the marketing page instead of an empty Wave shell, and admins get a one-time log when the social-auth flag is on but no provider has both a client_id and a client_secret configured.",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -501,7 +501,6 @@ public class AuthenticationServlet extends HttpServlet {
 
   private List<HtmlRenderer.SocialProviderLink> socialProviderLinks() {
     if (featureFlagService == null || socialAuthConfig == null
-        || isLoginPageDisabled
         || !featureFlagService.isGloballyEnabled(SocialAuthServlet.SOCIAL_AUTH_FLAG)) {
       return java.util.Collections.emptyList();
     }
@@ -512,6 +511,9 @@ public class AuthenticationServlet extends HttpServlet {
             provider.label(), "/auth/social/" + provider.id()));
       }
     }
+    // Warn once if flag is on but no provider is configured — runs before the
+    // isLoginPageDisabled gate so deployments that hide the login page still
+    // surface this misconfiguration in the logs.
     if (links.isEmpty() && socialAuthMisconfigurationLogged.compareAndSet(false, true)) {
       LOG.warning(
           "Feature flag '" + SocialAuthServlet.SOCIAL_AUTH_FLAG
@@ -520,7 +522,7 @@ public class AuthenticationServlet extends HttpServlet {
               + " 'core.social_auth.<provider>.client_secret' (e.g. provider='google') to surface"
               + " sign-in buttons.");
     }
-    return links;
+    return isLoginPageDisabled ? java.util.Collections.emptyList() : links;
   }
 
   private void rememberSocialReturnTarget(HttpServletRequest req) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java
@@ -118,6 +118,8 @@ public class AuthenticationServlet extends HttpServlet {
   private final boolean emailConfirmationEnabled;
   private final FeatureFlagService featureFlagService;
   private final SocialAuthConfig socialAuthConfig;
+  private final java.util.concurrent.atomic.AtomicBoolean
+      socialAuthMisconfigurationLogged = new java.util.concurrent.atomic.AtomicBoolean(false);
 
   @Inject
   public AuthenticationServlet(AccountStore accountStore,
@@ -509,6 +511,14 @@ public class AuthenticationServlet extends HttpServlet {
         links.add(new HtmlRenderer.SocialProviderLink(
             provider.label(), "/auth/social/" + provider.id()));
       }
+    }
+    if (links.isEmpty() && socialAuthMisconfigurationLogged.compareAndSet(false, true)) {
+      LOG.warning(
+          "Feature flag '" + SocialAuthServlet.SOCIAL_AUTH_FLAG
+              + "' is enabled but no social provider has both a client_id and a client_secret"
+              + " configured. Set 'core.social_auth.<provider>.client_id' and"
+              + " 'core.social_auth.<provider>.client_secret' (e.g. provider='google') to surface"
+              + " sign-in buttons.");
     }
     return links;
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
@@ -83,8 +83,10 @@ public class SignOutServlet extends HttpServlet {
 
     // No safe redirect target supplied: send the user to the site root so the
     // public landing page handles them, instead of stranding them on a blank
-    // "Logged out." page.
-    resp.sendRedirect("/");
+    // "Logged out." page.  Use the context path so deployments under a
+    // non-root context (e.g. /wave) redirect within the right base path.
+    String contextPath = req.getContextPath();
+    resp.sendRedirect(contextPath == null || contextPath.isEmpty() ? "/" : contextPath + "/");
   }
 
   private static boolean isSafeLocalRedirect(String r) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java
@@ -81,9 +81,10 @@ public class SignOutServlet extends HttpServlet {
       }
     }
 
-    resp.setStatus(HttpServletResponse.SC_OK);
-    resp.setContentType("text/html");
-    try (var w = resp.getWriter()) { w.print("<html><body>Logged out.</body></html>"); w.flush(); }
+    // No safe redirect target supplied: send the user to the site root so the
+    // public landing page handles them, instead of stranding them on a blank
+    // "Logged out." page.
+    resp.sendRedirect("/");
   }
 
   private static boolean isSafeLocalRedirect(String r) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -156,7 +156,13 @@ public class WaveClientServlet extends HttpServlet {
     boolean j2clRootBootstrapEnabled =
         featureFlagService.isEnabled("j2cl-root-bootstrap", id != null ? id.getAddress() : null);
 
-    if (VIEW_LANDING.equals(requestedView)) {
+    if (VIEW_LANDING.equals(requestedView)
+        || (id == null
+            && StringUtils.isEmpty(requestedView)
+            && StringUtils.isEmpty(request.getQueryString()))) {
+      // Signed-out visitors hitting "/" with no view/query land on the public
+      // marketing page rather than an empty Wave shell. Explicit ?view=landing
+      // continues to render the landing page for any user.
       response.setContentType("text/html");
       response.setCharacterEncoding("UTF-8");
       response.setStatus(HttpServletResponse.SC_OK);

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -156,10 +156,17 @@ public class WaveClientServlet extends HttpServlet {
     boolean j2clRootBootstrapEnabled =
         featureFlagService.isEnabled("j2cl-root-bootstrap", id != null ? id.getAddress() : null);
 
+    String contextRoot = request.getContextPath();
+    String requestUri = request.getRequestURI();
+    boolean isContextRoot = requestUri != null
+        && (requestUri.equals(contextRoot)
+            || requestUri.equals(contextRoot + "/")
+            || requestUri.equals("/"));
     if (VIEW_LANDING.equals(requestedView)
         || (id == null
             && StringUtils.isEmpty(requestedView)
-            && StringUtils.isEmpty(request.getQueryString()))) {
+            && StringUtils.isEmpty(request.getQueryString())
+            && isContextRoot)) {
       // Signed-out visitors hitting "/" with no view/query land on the public
       // marketing page rather than an empty Wave shell. Explicit ?view=landing
       // continues to render the landing page for any user.

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SignOutServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SignOutServletTest.java
@@ -20,7 +20,6 @@
 package org.waveprotocol.box.server.rpc;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,9 +61,9 @@ public class SignOutServletTest extends TestCase {
 
   public void testUserSignedOut() throws Exception {
     servlet.doGet(req, resp);
-    
+
     verify(sessionManager).logout(any(WebSession.class));
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+    verify(resp).sendRedirect("/");
   }
 
   public void testServletRedirects() throws Exception {
@@ -76,20 +75,21 @@ public class SignOutServletTest extends TestCase {
     verify(resp).sendRedirect(redirect_location);
   }
 
-  public void testServletDoesNotRedirectToRemoteUrl() throws Exception {
+  public void testServletRedirectsToRootWhenRemoteUrlSupplied() throws Exception {
     String redirect_location = "http://example.com/";
     when(req.getParameter("r")).thenReturn(redirect_location);
 
     servlet.doGet(req, resp);
 
-    verify(resp, never()).sendRedirect(anyString());
+    verify(resp, never()).sendRedirect(redirect_location);
+    verify(resp).sendRedirect("/");
   }
 
   public void testServletWorksWhenSessionIsMissing() throws Exception {
     when(req.getSession(false)).thenReturn(null);
-    
+
     servlet.doGet(req, resp);
-    
-    verify(resp).setStatus(HttpServletResponse.SC_OK);
+
+    verify(resp).sendRedirect("/");
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -103,6 +103,7 @@ public final class WaveClientServletJ2clBootstrapTest {
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/");
     when(request.getSession(false)).thenReturn(null);
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(response.getWriter()).thenReturn(new PrintWriter(body));
@@ -124,6 +125,7 @@ public final class WaveClientServletJ2clBootstrapTest {
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getContextPath()).thenReturn("");
+    when(request.getRequestURI()).thenReturn("/");
     when(request.getSession(false)).thenReturn(null);
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(response.getWriter()).thenReturn(new PrintWriter(body));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -96,7 +96,7 @@ public final class WaveClientServletJ2clBootstrapTest {
   }
 
   @Test
-  public void signedOutPlainRootFallsBackToLegacyBootstrapWhenBootstrapFlagIsOff()
+  public void signedOutPlainRootShowsLandingPageWhenBootstrapFlagIsOff()
       throws Exception {
     WaveClientServlet servlet = createServlet(null, false);
     HttpServletRequest request = mock(HttpServletRequest.class);
@@ -111,12 +111,15 @@ public final class WaveClientServletJ2clBootstrapTest {
 
     String html = body.toString();
     assertFalse(html.contains("data-j2cl-root-shell"));
-    assertTrue(html.contains("webclient/webclient.nocache.js"));
+    assertFalse(html.contains("webclient/webclient.nocache.js"));
+    assertTrue(html.contains("SupaWave - Real-time Collaborative Communication"));
+    assertTrue(html.contains("nav-link-signin"));
+    assertTrue(html.contains("nav-link-register"));
   }
 
   @Test
-  public void signedOutLegacyRootStillRendersTopbarShell() throws Exception {
-    WaveClientServlet servlet = createServlet(null, false);
+  public void signedOutPlainRootShowsLandingPageWhenBootstrapFlagIsOn() throws Exception {
+    WaveClientServlet servlet = createServlet(null, true);
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
@@ -128,22 +131,24 @@ public final class WaveClientServletJ2clBootstrapTest {
     servlet.doGet(request, response);
 
     String html = body.toString();
-    assertTrue(html.contains("<div class=\"topbar\">"));
-    assertTrue(html.contains("id=\"banner\""));
-    assertTrue(html.contains("href=\"/auth/register\""));
-    assertTrue(html.contains("href=\"/auth/signin?r=/\""));
-    assertFalse(html.contains("id=\"lang\""));
-    assertFalse(html.contains("id=\"signout\""));
+    assertFalse(html.contains("data-j2cl-root-shell"));
+    assertFalse(html.contains("webclient/webclient.nocache.js"));
+    assertTrue(html.contains("SupaWave - Real-time Collaborative Communication"));
   }
 
   @Test
-  public void signedOutPlainRootBootsIntoJ2clShellWhenBootstrapFlagIsOn() throws Exception {
+  public void signedOutPlainRootWithQueryStringStillBootsIntoJ2clShellWhenBootstrapFlagIsOn()
+      throws Exception {
+    // Preserve the existing j2cl-root behaviour for non-bare URLs (e.g. deep
+    // links carrying ?wave=… or tracking parameters); only the vanilla "/" hit
+    // gets redirected to the marketing landing page for signed-out users.
     WaveClientServlet servlet = createServlet(null, true);
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getContextPath()).thenReturn("");
     when(request.getSession(false)).thenReturn(null);
+    when(request.getQueryString()).thenReturn("utm_source=email");
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(response.getWriter()).thenReturn(new PrintWriter(body));
 
@@ -152,17 +157,20 @@ public final class WaveClientServletJ2clBootstrapTest {
     String html = body.toString();
     assertTrue(html.contains("data-j2cl-root-shell"));
     assertTrue(html.contains("data-j2cl-root-signin=\"true\""));
-    assertFalse(html.contains("webclient/webclient.nocache.js"));
+    assertFalse(html.contains("SupaWave - Real-time Collaborative Communication"));
   }
 
   @Test
   public void bootstrapedPlainRootUsesPresentedHostForWebsocketAddress()
       throws Exception {
-    WaveClientServlet servlet = createServlet(null, true);
+    // Signed-in callers retain the j2cl shell render, so this still exercises
+    // the websocket-address fallback in the bootstrap branch.
+    WaveClientServlet servlet =
+        createServlet(ParticipantId.ofUnsafe("alice@example.com"), true);
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
-    when(request.getSession(false)).thenReturn(null);
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getHeader("Host")).thenReturn("example.com:7777");
     when(response.getWriter()).thenReturn(new PrintWriter(body));


### PR DESCRIPTION
## Summary
- Signed-out visitors hitting bare `/` now get the marketing landing page instead of an empty Wave shell, so signing out actually returns users to the public site.
- `SignOutServlet`'s no-redirect fallback now returns `302 /` instead of writing a static `Logged out.` HTML page, so the unsafe-redirect rejection path also lands on the marketing site.
- `AuthenticationServlet` logs a one-time WARNING when the `social-auth` feature flag is on but no provider has both `client_id` and `client_secret` configured — naming the exact config keys.

## Why
Reported issues:
1. *"i still don't see social sign in wave even when enabled in feature flag (i still didn't configure secrets though - maybe this is the issue?)"* — yes, that is the issue. The feature flag enables the surface; `SocialAuthConfig.isConfigured()` requires both `core.social_auth.<provider>.client_id` and `core.social_auth.<provider>.client_secret` before any button renders. There was no admin-visible signal explaining the silence; this PR adds a one-time WARN log naming the exact keys.
2. *"when i sign out of wave - i should be redirected to the landing page instead of staying on the wave page and showing nothing"* — fixed. After signout, users land on `renderLandingPage()` instead of the empty j2cl-root shell.

## Files
- [wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java](wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java) — branch the landing render for signed-out + bare `/`.
- [wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java](wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SignOutServlet.java) — fallback redirects to `/`.
- [wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java](wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AuthenticationServlet.java) — one-time misconfig warning.
- [wave/src/test/java/org/waveprotocol/box/server/rpc/SignOutServletTest.java](wave/src/test/java/org/waveprotocol/box/server/rpc/SignOutServletTest.java) — verify new redirect.
- [wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java](wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java) — signed-out tests now expect landing page; new test pins the j2cl-root-shell behaviour for non-bare URLs.

## Test plan
- [x] `sbt wave/Test/compile` — clean.
- [x] Targeted unit tests pass (16/16): `SignOutServletTest`, `WaveClientServletJ2clBootstrapTest`, `WaveClientServletTest`.
- [x] Pre-existing `jakartaTest` failures in `WaveClientServletJ2clRootShellTest` (`signedInJ2clRootShellUsesExplicitReturnTargets`, `j2clRootViewPreservesCurrentRouteStateInSignedOutChrome`) reproduce on `main` without these changes — they are not introduced here.
- [x] Local server smoke (`sbt wave/prepareServerConfig run`, port 9898) on this branch:
  - `curl /` → renders `<title>SupaWave - Real-time Collaborative Communication</title>`
  - `curl /auth/signout` → `302 /`
  - `curl '/auth/signout?r=/'` → `302 /`
  - `curl '/auth/signout?r=http://evil.example.com/'` → `302 /` (no open redirect)
  - `curl /` with logged-in cookie → Wave shell (`webclient.nocache.js`, `topbar`)
- [ ] Reviewer: verify in the deploy preview that clicking "Sign Out" from the user-menu lands on the marketing page (not an empty inbox).
- [ ] Operator: confirm `WARNING ... 'social-auth' is enabled but no social provider has both a client_id and a client_secret configured` appears at most once in logs when the flag is on but secrets are unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits a one-time warning in logs when social authentication is enabled but provider credentials are missing.

* **Bug Fixes**
  * Signed-out visitors to the site root now see the public marketing/landing page instead of an empty shell.
  * Signing out with no redirect target now issues an HTTP redirect to the site root.

* **Tests**
  * Updated tests to assert the new landing-page and redirect behaviors.

* **Chores**
  * Added a changelog entry for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->