### PR TITLE
fix(j2cl/compose): plug F-3.S2 task-write race + popover re-render gap

### DIFF
--- a/docs/superpowers/plans/2026-04-27-issue-1068-f3s2-followup.md
+++ b/docs/superpowers/plans/2026-04-27-issue-1068-f3s2-followup.md
@@ -1,0 +1,81 @@
+# 2026-04-27 — Issue #1068 F-3.S2 follow-up
+
+## Goal
+
+Two real bugs landed in F-3.S2 (#1066) but the auto-merge fired before
+chatgpt-codex-connector posted them. This is a focused follow-up that
+plugs both holes with regression tests.
+
+## Bugs
+
+### Bug 1 (P1) — `J2clComposeSurfaceController` task-write silent discard
+
+`onTaskToggled` and `onTaskMetadataChanged` capture
+`writeSession` into `submitSession`, then re-check
+`writeSession != submitSession` after the bootstrap callback fires.
+Reference equality breaks if the same wave re-publishes its session
+(e.g. a no-op refresh after a tag-set update). The writes are silently
+dropped.
+
+**Fix**: replace the reference-identity check with a logical-session
+check that compares `getSelectedWaveId()` of the captured session and
+the current `writeSession`. A no-op refresh produces a new object with
+the same wave id, so the submit goes through. A genuine wave switch or
+sign-out still drops the write (the `signedOut` check + null-session
+check already guard those).
+
+The fix lives entirely inside the two callbacks at
+`J2clComposeSurfaceController.java:700` and `:744`.
+
+### Bug 2 (P2) — `wavy-task-affordance` popover stuck open after submit
+
+`_onMetadataSubmit` mutates `_popoverOpen = false` and toggles the
+`data-popover-open` attribute, but never calls `requestUpdate()`. If
+both `assigneeAddress` and `dueDate` are unchanged, no reactive
+property mutates and Lit never re-renders, so the
+`task-metadata-popover` stays in the DOM. (`_openDetails` and
+`_onPopoverClose` already call `requestUpdate()` — the omission is a
+local oversight.)
+
+**Fix**: add `this.requestUpdate()` after the close mutation in
+`_onMetadataSubmit`.
+
+## Test plan
+
+### Java side (jakartaTest + j2clSearchTest)
+
+Add a regression test in
+`J2clComposeSurfaceControllerTest`:
+
+1. `onTaskToggledSurvivesNoOpSessionRefresh` — uses
+   `autoResolveBootstrap = false`, captures the pending bootstrap, then
+   pushes a new `J2clSidecarWriteSession` instance with the same
+   `selectedWaveId` (no-op refresh), then resolves the bootstrap and
+   asserts `submitCalls` incremented.
+2. `onTaskMetadataChangedSurvivesNoOpSessionRefresh` — same pattern for
+   `onTaskMetadataChanged`.
+3. (Defensive) `onTaskToggledDropsWriteOnWaveSwitch` — same pattern but
+   the refreshed session has a different wave id; asserts no submit.
+
+### Lit side (j2clLitTest)
+
+Add a test in `wavy-task-affordance.test.js`:
+
+- Open the popover, dispatch `task-metadata-submit` with the same
+  assignee + due date that's already set, then await
+  `el.updateComplete` and assert the popover is gone from the
+  renderRoot and `data-popover-open` is false.
+
+## Verification
+
+- `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild`
+- `sbt -batch jakartaTest:testOnly *J2clStageThreeComposeS2ParityTest *J2clComposeSurfaceControllerTest`
+
+## Out of scope
+
+Anything beyond the two bug locations + their regression tests. Don't
+re-touch other F-3.S2 code, parity test, or umbrella docs.
+
+## Branch
+
+`codex/issue-1068-f3s2-followup` from latest `origin/main`.

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -163,6 +163,12 @@ export class WavyTaskAffordance extends LitElement {
     this.dueDate = due;
     this._popoverOpen = false;
     this.toggleAttribute("data-popover-open", false);
+    // F-3.S2 (#1068): _popoverOpen is internal state, not a Lit
+    // reactive property. When assignee/dueDate are unchanged, no
+    // observed property mutates and Lit otherwise skips the re-render
+    // that would tear down the inner <task-metadata-popover>. Force
+    // an update so the dialog actually closes on submit.
+    this.requestUpdate();
     this.dispatchEvent(
       new CustomEvent("wave-blip-task-metadata-changed", {
         bubbles: true,

--- a/j2cl/lit/test/wavy-task-affordance.test.js
+++ b/j2cl/lit/test/wavy-task-affordance.test.js
@@ -153,6 +153,44 @@ describe("<wavy-task-affordance>", () => {
     expect(el.hasAttribute("data-popover-open")).to.equal(false);
   });
 
+  // F-3.S2 (#1068): regression — the popover must close even when the
+  // submit doesn't change assignee or due date. Without a manual
+  // requestUpdate() call, _popoverOpen mutates but Lit skips the
+  // re-render that tears the popover down, leaving it visually open.
+  it("closes the popover on submit when fields are unchanged", async () => {
+    const el = await fixture(html`
+      <wavy-task-affordance
+        data-blip-id="b1"
+        data-task-assignee="alice@example.com"
+        data-task-due-date="2026-05-01"
+      ></wavy-task-affordance>
+    `);
+    const details = el.renderRoot.querySelector('[data-task-details-trigger="true"]');
+    details.click();
+    await el.updateComplete;
+    const popover = el.renderRoot.querySelector("task-metadata-popover");
+    expect(popover).to.exist;
+
+    // Submit with the same assignee + due date that's already set.
+    popover.dispatchEvent(
+      new CustomEvent("task-metadata-submit", {
+        bubbles: true,
+        composed: true,
+        detail: {
+          taskId: "b1",
+          assigneeAddress: "alice@example.com",
+          dueDate: "2026-05-01"
+        }
+      })
+    );
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector("task-metadata-popover")).to.equal(null);
+    expect(el.hasAttribute("data-popover-open")).to.equal(false);
+    const detailsAfter = el.renderRoot.querySelector('[data-task-details-trigger="true"]');
+    expect(detailsAfter.getAttribute("aria-expanded")).to.equal("false");
+  });
+
   it("does not bubble overlay-close past the affordance host", async () => {
     const el = await fixture(html`
       <wavy-task-affordance data-blip-id="b1"></wavy-task-affordance>

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -697,7 +697,11 @@ public final class J2clComposeSurfaceController {
     final String trimmedBlipId = blipId.trim();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
-          if (signedOut || writeSession != submitSession) {
+          // F-3.S2 (#1068): a no-op session refresh on the same wave
+          // produces a new J2clSidecarWriteSession instance. We must not
+          // drop the write in that case — only bail when the user has
+          // signed out or actually switched waves.
+          if (signedOut || !sameLogicalSession(submitSession, writeSession)) {
             return;
           }
           SidecarSubmitRequest request;
@@ -741,7 +745,10 @@ public final class J2clComposeSurfaceController {
     final String normalizedDue = dueDate == null ? "" : dueDate.trim();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
-          if (signedOut || writeSession != submitSession) {
+          // F-3.S2 (#1068): tolerate no-op session refreshes on the same
+          // wave; only drop the write when sign-out or a real wave
+          // switch happens between click and bootstrap completion.
+          if (signedOut || !sameLogicalSession(submitSession, writeSession)) {
             return;
           }
           SidecarSubmitRequest request;
@@ -1620,6 +1627,21 @@ public final class J2clComposeSurfaceController {
 
   private static boolean hasSelectedWave(J2clSidecarWriteSession session) {
     return session != null && !isEmpty(session.getSelectedWaveId());
+  }
+
+  /**
+   * F-3.S2 (#1068): two write sessions describe the same logical wave
+   * when both are non-null and share the same selected wave id. This is
+   * looser than reference equality so that no-op session refreshes
+   * (same wave, new session object) do not silently drop deferred task
+   * writes that captured the prior session reference.
+   */
+  private static boolean sameLogicalSession(
+      J2clSidecarWriteSession captured, J2clSidecarWriteSession current) {
+    if (captured == null || current == null) {
+      return false;
+    }
+    return safeEquals(captured.getSelectedWaveId(), current.getSelectedWaveId());
   }
 
   private static String normalizeDraft(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -708,7 +708,7 @@ public final class J2clComposeSurfaceController {
           try {
             request =
                 deltaFactory.createTaskToggleRequest(
-                    bootstrap.getAddress(), submitSession, trimmedBlipId, completed);
+                    bootstrap.getAddress(), writeSession, trimmedBlipId, completed);
           } catch (RuntimeException e) {
             // Toggling a task is best-effort; log telemetry and return.
             recordTaskToggleTelemetry(completed, "failure-build");
@@ -756,7 +756,7 @@ public final class J2clComposeSurfaceController {
             request =
                 deltaFactory.createTaskMetadataRequest(
                     bootstrap.getAddress(),
-                    submitSession,
+                    writeSession,
                     trimmedBlipId,
                     normalizedAssignee,
                     normalizedDue);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2875,6 +2875,90 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals(beforeSubmits + 1, gateway.submitCalls);
   }
 
+  // F-3.S2 (#1068): regression — a no-op session refresh (same wave id,
+  // new J2clSidecarWriteSession instance) used to break the deferred
+  // task-toggle write because the post-bootstrap guard compared
+  // sessions by reference. The fix compares by selected wave id, so
+  // the submit must still go through.
+  @Test
+  public void onTaskToggledSurvivesNoOpSessionRefresh() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+    int beforeSubmits = gateway.submitCalls;
+    controller.onTaskToggled("b+root", true);
+    // Bootstrap is still pending — simulate a no-op session refresh on
+    // the same wave between the click and the bootstrap response.
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 45L, "EFGH", "b+root"));
+    gateway.resolveBootstrap();
+    Assert.assertEquals(
+        "task-toggle write must survive a no-op session refresh on the same wave",
+        beforeSubmits + 1,
+        gateway.submitCalls);
+  }
+
+  @Test
+  public void onTaskMetadataChangedSurvivesNoOpSessionRefresh() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+    int beforeSubmits = gateway.submitCalls;
+    controller.onTaskMetadataChanged("b+root", "alice@example.com", "2026-05-15");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 45L, "EFGH", "b+root"));
+    gateway.resolveBootstrap();
+    Assert.assertEquals(
+        "task-metadata write must survive a no-op session refresh on the same wave",
+        beforeSubmits + 1,
+        gateway.submitCalls);
+  }
+
+  @Test
+  public void onTaskToggledDropsWriteOnWaveSwitch() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+    int beforeSubmits = gateway.submitCalls;
+    controller.onTaskToggled("b+root", true);
+    // Genuine wave switch — the captured session no longer matches the
+    // current selected wave; the write must be dropped.
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 1L, "ZZZZ", "b+root"));
+    gateway.resolveBootstrap();
+    Assert.assertEquals(
+        "task-toggle write must NOT submit after a real wave switch",
+        beforeSubmits,
+        gateway.submitCalls);
+  }
+
   private static J2clComposeSurfaceController newControllerWithTelemetry(
       FakeView view, J2clClientTelemetry.Sink telemetrySink) {
     return new J2clComposeSurfaceController(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2905,6 +2905,8 @@ public class J2clComposeSurfaceControllerTest {
         "task-toggle write must survive a no-op session refresh on the same wave",
         beforeSubmits + 1,
         gateway.submitCalls);
+    Assert.assertEquals("chan-1", gateway.lastSubmitRequest.getChannelId());
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "\"1\":45", "\"2\":\"EFGH\"");
   }
 
   @Test
@@ -2930,6 +2932,8 @@ public class J2clComposeSurfaceControllerTest {
         "task-metadata write must survive a no-op session refresh on the same wave",
         beforeSubmits + 1,
         gateway.submitCalls);
+    Assert.assertEquals("chan-1", gateway.lastSubmitRequest.getChannelId());
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "\"1\":45", "\"2\":\"EFGH\"");
   }
 
   @Test

--- a/wave/config/changelog.d/2026-04-27-issue-1068-f3s2-followup.json
+++ b/wave/config/changelog.d/2026-04-27-issue-1068-f3s2-followup.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-27-issue-1068-f3s2-followup",
+  "version": "PR #1069",
+  "date": "2026-04-27",
+  "title": "F-3.S2 follow-up: stop dropping task writes on no-op session refresh; force popover re-render on submit",
+  "summary": "Plugs two bugs that landed in F-3.S2 (#1066) but were posted by the post-merge bot review after auto-merge fired: a same-wave session refresh used to silently drop the deferred task-toggle / metadata write, and the metadata popover stayed visually open after submitting unchanged fields.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2clComposeSurfaceController#onTaskToggled and #onTaskMetadataChanged now compare write sessions by selectedWaveId rather than by reference. A no-op session refresh on the same wave (tag set update, participant churn) replaces the J2clSidecarWriteSession instance with one that has the same wave id; the previous reference-equality guard treated this as a wave switch and silently discarded the user's write. The new logical-session check accepts the refreshed session, while signed-out and null-session guards still drop writes on real wave switches.",
+        "wavy-task-affordance#_onMetadataSubmit now calls requestUpdate() after closing the popover. _popoverOpen is internal state, not a Lit reactive property, so submitting the popover with unchanged assignee + due date used to skip the re-render that tears the inner <task-metadata-popover> down — leaving the dialog visually open until the next reactive change. The forced update mirrors how _openDetails and _onPopoverClose already behave.",
+        "Regression coverage: J2clComposeSurfaceControllerTest gains onTaskToggledSurvivesNoOpSessionRefresh, onTaskMetadataChangedSurvivesNoOpSessionRefresh, and onTaskToggledDropsWriteOnWaveSwitch (each defers bootstrap resolution, then either replays the same wave id or switches waves); wavy-task-affordance.test.js gains a case that opens the popover, submits with the existing assignee + due date, and asserts the dialog actually leaves the renderRoot."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Two real bugs that landed in F-3.S2 (#1066) — chatgpt-codex-connector
posted them after auto-merge fired, so they slipped through.

- **Bug 1 (P1)** — `J2clComposeSurfaceController#onTaskToggled` and
  `#onTaskMetadataChanged` post-bootstrap rejected writes whenever the
  current `writeSession` no longer matched the captured reference. A
  no-op session refresh on the same wave produces a new
  `J2clSidecarWriteSession` instance with the same `selectedWaveId`,
  so the reference check failed and the user's task write was silently
  dropped. Replaced reference equality with a logical-session compare
  on `selectedWaveId`; the existing `signedOut` and null-session
  guards still drop writes on real wave switches.
- **Bug 2 (P2)** — `wavy-task-affordance#_onMetadataSubmit` mutates
  the internal `_popoverOpen` flag and toggles the
  `data-popover-open` attribute but never calls `requestUpdate()`.
  When the submitted assignee and due date match the current values,
  no observed Lit property changes and the framework skips the
  re-render that would tear the popover down — so the dialog stayed
  visually open. Added the missing `requestUpdate()`.

## Tests

- `J2clComposeSurfaceControllerTest` — three new regressions:
  `onTaskToggledSurvivesNoOpSessionRefresh`,
  `onTaskMetadataChangedSurvivesNoOpSessionRefresh`,
  `onTaskToggledDropsWriteOnWaveSwitch`.
- `wavy-task-affordance.test.js` — one new test that submits the
  popover with unchanged fields and asserts the dialog actually
  closes.

## SBT verification

```
sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild
  -> success (lit: 480 passed; search: 111 passed in
              J2clComposeSurfaceControllerTest; production: success)

sbt -batch "jakartaTest:testOnly *J2clStageThreeComposeS2ParityTest \
                                 *J2clComposeSurfaceControllerTest"
  -> success (18 parity tests passed)
```

## Test plan

- [x] `sbt -batch j2clLitTest j2clSearchTest j2clProductionBuild`
- [x] `sbt -batch jakartaTest:testOnly *J2clStageThreeComposeS2ParityTest *J2clComposeSurfaceControllerTest`

Closes #1068. Updates #1038. Updates #904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Popover reliably closes after metadata submission even when fields are unchanged.
  * Deferred task writes are preserved across benign session refreshes that don’t change the active wave; real wave switches still suppress writes.

* **Documentation**
  * Added a runbook detailing the regressions, verification steps, scope constraints, and target branch.

* **Tests**
  * Added regression and unit tests covering metadata submit behavior and session-refresh scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->