### PR TITLE
docs: J2CL functional-UI Wavy mockups (Stitch-style)

### DIFF
--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/01-shell-inbox-with-waves.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/01-shell-inbox-with-waves.svg
@@ -1,0 +1,310 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-1 / J-UI-2 — Desktop shell with rendered Inbox digest cards</title>
+  <desc id="desc">SupaWave J2CL desktop shell. Header with logo and search. Saved-search rail (Inbox/Mentions/Tasks/Public/Archive/Pinned), filter chip strip, six rendered wavy-search-rail-card digests with avatar stack, title, snippet, msg count, unread badge, relative timestamp. Center wave-region shows the selected wave header with action toolbar and a placeholder reading frame.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+    <symbol id="avatar-cyan" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="16" fill="#22d3ee"/>
+    </symbol>
+    <symbol id="avatar-violet" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="16" fill="#7c3aed"/>
+    </symbol>
+    <symbol id="avatar-amber" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="16" fill="#fb923c"/>
+    </symbol>
+    <symbol id="avatar-slate" viewBox="0 0 32 32">
+      <circle cx="16" cy="16" r="16" fill="#475569"/>
+    </symbol>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#bg)"/>
+
+  <!-- ============ HEADER (shell-header) ============ -->
+  <g>
+    <rect x="0" y="0" width="1440" height="64" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <use href="#supawave-mark" x="20" y="14" width="36" height="36"/>
+    <text x="64" y="40" font-size="20" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+    <text x="64" y="54" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">J2CL · /?view=j2cl-root</text>
+
+    <!-- Global search -->
+    <rect x="420" y="16" width="600" height="32" rx="16" fill="#f6f7fb" stroke="rgba(11,19,32,0.10)"/>
+    <circle cx="440" cy="32" r="6" fill="none" stroke="rgba(11,19,32,0.55)" stroke-width="1.5"/>
+    <line x1="445" y1="37" x2="450" y2="42" stroke="rgba(11,19,32,0.55)" stroke-width="1.5"/>
+    <text x="460" y="36" font-size="13" fill="rgba(11,19,32,0.55)">Search waves, blips, tags…</text>
+    <text x="990" y="35" font-size="11" font-family="Geist, Inter, sans-serif" fill="rgba(11,19,32,0.55)">⌘K</text>
+
+    <!-- Right cluster -->
+    <rect x="1248" y="16" width="84" height="32" rx="16" fill="#22d3ee" />
+    <text x="1290" y="36" text-anchor="middle" font-size="13" font-weight="600" fill="#0b1320">+ New Wave</text>
+    <use href="#avatar-violet" x="1352" y="16" width="32" height="32"/>
+    <text x="1368" y="37" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">YZ</text>
+  </g>
+
+  <!-- ============ NAV RAIL (shell-nav-rail / wavy-search-rail) ============ -->
+  <g transform="translate(0,64)">
+    <rect x="0" y="0" width="296" height="836" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Saved-search folder list -->
+    <text x="20" y="32" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">SAVED SEARCHES</text>
+
+    <!-- Inbox (active) -->
+    <rect x="12" y="44" width="272" height="40" rx="12" fill="rgba(34,211,238,0.18)"/>
+    <rect x="12" y="44" width="3" height="40" rx="2" fill="#22d3ee"/>
+    <text x="32" y="69" font-size="14" font-weight="600" fill="#0b1320">Inbox</text>
+    <rect x="232" y="56" width="40" height="20" rx="10" fill="#22d3ee"/>
+    <text x="252" y="70" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">12</text>
+
+    <!-- Mentions -->
+    <text x="32" y="113" font-size="14" fill="#0b1320">Mentions</text>
+    <circle cx="262" cy="108" r="5" fill="#7c3aed"/>
+
+    <!-- Tasks -->
+    <text x="32" y="153" font-size="14" fill="#0b1320">Tasks</text>
+    <rect x="240" y="140" width="32" height="18" rx="9" fill="rgba(251,146,60,0.22)"/>
+    <text x="256" y="153" text-anchor="middle" font-size="11" font-weight="600" fill="#7a3a06">5</text>
+
+    <!-- Public -->
+    <text x="32" y="193" font-size="14" fill="#0b1320">Public</text>
+
+    <!-- Archive -->
+    <text x="32" y="233" font-size="14" fill="#0b1320">Archive</text>
+
+    <!-- Pinned -->
+    <text x="32" y="273" font-size="14" fill="#0b1320">Pinned</text>
+
+    <!-- Manage saved searches -->
+    <text x="32" y="306" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">+ Manage saved searches</text>
+
+    <!-- Filter chips strip -->
+    <line x1="20" y1="332" x2="276" y2="332" stroke="rgba(11,19,32,0.10)"/>
+    <text x="20" y="356" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">FILTERS</text>
+
+    <!-- chip: Unread only (active) -->
+    <rect x="20" y="370" width="92" height="26" rx="13" fill="#0b1320"/>
+    <text x="66" y="387" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">Unread only</text>
+    <!-- chip: Attachments -->
+    <rect x="118" y="370" width="106" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <text x="171" y="387" text-anchor="middle" font-size="11" fill="#0b1320">Attachments</text>
+    <!-- chip: From me -->
+    <rect x="20" y="404" width="78" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <text x="59" y="421" text-anchor="middle" font-size="11" fill="#0b1320">From me</text>
+    <!-- chip: With @ -->
+    <rect x="104" y="404" width="74" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <text x="141" y="421" text-anchor="middle" font-size="11" fill="#0b1320">With @</text>
+    <!-- chip: Has task -->
+    <rect x="184" y="404" width="84" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <text x="226" y="421" text-anchor="middle" font-size="11" fill="#0b1320">Has task</text>
+
+    <line x1="20" y1="450" x2="276" y2="450" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Status text -->
+    <text x="20" y="476" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Showing 12 unread waves in Inbox</text>
+  </g>
+
+  <!-- ============ SEARCH RESULT PANEL (rendered digest cards) ============ -->
+  <g transform="translate(296,64)">
+    <rect x="0" y="0" width="448" height="836" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+    <text x="24" y="36" font-size="16" font-weight="600" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Inbox</text>
+    <text x="24" y="54" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">in:inbox unread:true · 12 waves</text>
+
+    <!-- Card 1 (selected, has unread badge + pulse ring) -->
+    <g transform="translate(16,76)">
+      <rect width="416" height="120" rx="12" fill="#ffffff" stroke="#22d3ee" stroke-width="2" filter="url(#card-shadow)"/>
+      <!-- avatar stack: 3 + overflow -->
+      <g transform="translate(16,16)">
+        <use href="#avatar-cyan" x="0" y="0" width="28" height="28"/>
+        <text x="14" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">AT</text>
+        <use href="#avatar-violet" x="20" y="0" width="28" height="28"/>
+        <text x="34" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">SK</text>
+        <use href="#avatar-amber" x="40" y="0" width="28" height="28"/>
+        <text x="54" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+        <circle cx="74" cy="14" r="14" fill="rgba(11,19,32,0.10)"/>
+        <text x="74" y="18" text-anchor="middle" font-size="10" font-weight="600" fill="#0b1320">+2</text>
+      </g>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="#0b1320">Robot streaming follow-up — 4xx retries</text>
+      <text x="124" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Sasha: I bumped the retry budget but we still see backoff after</text>
+      <text x="124" y="68" font-size="12" fill="rgba(11,19,32,0.62)">five consecutive 502s on the streaming endpoint. Anyone seeing</text>
+      <text x="124" y="84" font-size="12" fill="rgba(11,19,32,0.62)">this on prod-2 today?</text>
+      <!-- meta row -->
+      <g transform="translate(124,96)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.18)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">3 new</text>
+        <text x="56" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 18 blips</text>
+        <text x="280" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 min ago</text>
+      </g>
+      <rect x="396" y="12" width="12" height="12" rx="6" fill="#22d3ee">
+        <animate attributeName="r" values="6;7;6" dur="600ms" repeatCount="indefinite"/>
+      </rect>
+    </g>
+
+    <!-- Card 2 -->
+    <g transform="translate(16,212)">
+      <rect width="416" height="100" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+      <use href="#avatar-violet" x="16" y="16" width="28" height="28"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">YZ</text>
+      <use href="#avatar-slate" x="36" y="16" width="28" height="28"/>
+      <text x="50" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">DK</text>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="#0b1320">Lucene startup reuse — design review</text>
+      <text x="124" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Dan: design memo updated with the index-stamp invariant. Ready</text>
+      <text x="124" y="68" font-size="12" fill="rgba(11,19,32,0.62)">for a second pass when you have a window today.</text>
+      <g transform="translate(124,80)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.18)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">1 new</text>
+        <text x="56" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 9 blips · @you</text>
+        <text x="280" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">14 min ago</text>
+      </g>
+    </g>
+
+    <!-- Card 3 -->
+    <g transform="translate(16,328)">
+      <rect width="416" height="100" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+      <use href="#avatar-amber" x="16" y="16" width="28" height="28"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+      <text x="60" y="32" font-size="14" font-weight="700" fill="#0b1320">Sprint 18 retro</text>
+      <text x="60" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Marina: tasks rolled forward. Two carryovers from F-3. Tagged</text>
+      <text x="60" y="68" font-size="12" fill="rgba(11,19,32,0.62)">Yuri and Sasha as owners — see the task list at the bottom.</text>
+      <g transform="translate(60,80)">
+        <rect width="44" height="20" rx="10" fill="rgba(251,146,60,0.22)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#7a3a06">2 task</text>
+        <text x="56" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 6 blips</text>
+        <text x="280" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+      </g>
+    </g>
+
+    <!-- Card 4 (read - dimmer, no badge) -->
+    <g transform="translate(16,444)" opacity="0.78">
+      <rect width="416" height="92" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <use href="#avatar-cyan" x="16" y="16" width="28" height="28"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">AT</text>
+      <text x="60" y="32" font-size="14" font-weight="600" fill="#0b1320">Onboarding flow polish</text>
+      <text x="60" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Anton: pushed the welcome-wave copy. Final review tomorrow.</text>
+      <g transform="translate(60,68)">
+        <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">4 blips · all read</text>
+        <text x="340" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hours ago</text>
+      </g>
+    </g>
+
+    <!-- Card 5 -->
+    <g transform="translate(16,552)">
+      <rect width="416" height="92" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <use href="#avatar-violet" x="16" y="16" width="28" height="28"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">YZ</text>
+      <use href="#avatar-cyan" x="36" y="16" width="28" height="28"/>
+      <text x="50" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">PK</text>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="#0b1320">J2CL parity matrix — gate review</text>
+      <text x="124" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Pavel: 4/26 gates green; we need J-UI-1..8 closed before a re-vote.</text>
+      <g transform="translate(124,68)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.18)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">5 new</text>
+        <text x="56" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 22 blips · 2 tasks</text>
+        <text x="280" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">3 hours ago</text>
+      </g>
+    </g>
+
+    <!-- Card 6 -->
+    <g transform="translate(16,660)">
+      <rect width="416" height="92" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <use href="#avatar-slate" x="16" y="16" width="28" height="28"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">DK</text>
+      <text x="60" y="32" font-size="14" font-weight="700" fill="#0b1320">Grafana perf dashboard — INP regression</text>
+      <text x="60" y="52" font-size="12" fill="rgba(11,19,32,0.62)">Dan: p75 INP up 18% on /?view=j2cl-root since Tuesday's deploy.</text>
+      <g transform="translate(60,68)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.18)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">2 new</text>
+        <text x="56" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 11 blips · @you</text>
+        <text x="280" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">5 hours ago</text>
+      </g>
+    </g>
+
+    <!-- Skeleton hint of more cards -->
+    <g transform="translate(16,768)" opacity="0.5">
+      <rect width="416" height="60" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="208" y="36" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">6 more waves below</text>
+    </g>
+  </g>
+
+  <!-- ============ WAVE PANEL (shell-main-region) ============ -->
+  <g transform="translate(744,64)">
+    <rect x="0" y="0" width="696" height="836" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Wave header -->
+    <g transform="translate(24,24)">
+      <text x="0" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · UPDATED 2 MIN AGO</text>
+      <text x="0" y="50" font-size="22" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Robot streaming follow-up — 4xx retries</text>
+
+      <!-- Participants -->
+      <g transform="translate(0,68)">
+        <use href="#avatar-cyan" x="0" y="0" width="24" height="24"/>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <use href="#avatar-violet" x="18" y="0" width="24" height="24"/>
+        <text x="30" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">SK</text>
+        <use href="#avatar-amber" x="36" y="0" width="24" height="24"/>
+        <text x="48" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+        <use href="#avatar-slate" x="54" y="0" width="24" height="24"/>
+        <text x="66" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">DK</text>
+        <use href="#avatar-violet" x="72" y="0" width="24" height="24"/>
+        <text x="84" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">YZ</text>
+        <text x="106" y="16" font-size="12" fill="rgba(11,19,32,0.62)">5 participants</text>
+      </g>
+
+      <!-- Toolbar -->
+      <g transform="translate(0,108)">
+        <rect width="92" height="32" rx="16" fill="#0b1320"/>
+        <text x="46" y="20" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">Reply</text>
+        <rect x="100" y="0" width="76" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="138" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Pin</text>
+        <rect x="184" y="0" width="92" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="230" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Archive</text>
+        <rect x="284" y="0" width="100" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="334" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Mark read</text>
+        <rect x="392" y="0" width="60" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="422" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Tags</text>
+      </g>
+    </g>
+
+    <line x1="24" y1="200" x2="672" y2="200" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Reading-frame placeholder showing first blip preview, full thread on screen 02 -->
+    <g transform="translate(24,224)">
+      <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">THREADED READING · SCREEN 02 ZOOMS IN</text>
+
+      <!-- Root blip preview -->
+      <g transform="translate(0,32)">
+        <rect width="624" height="120" rx="12" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+        <use href="#avatar-cyan" x="16" y="16" width="32" height="32"/>
+        <text x="32" y="36" text-anchor="middle" font-size="12" font-weight="700" fill="#0b1320">AT</text>
+        <text x="60" y="32" font-size="13" font-weight="700" fill="#0b1320">Anton T.</text>
+        <text x="120" y="32" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hours ago</text>
+        <text x="60" y="56" font-size="13" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry budget after the F-3 cleanup? I'm</text>
+        <text x="60" y="74" font-size="13" fill="rgba(11,19,32,0.92)">seeing logs that look like we're doubling up between the streaming</text>
+        <text x="60" y="92" font-size="13" fill="rgba(11,19,32,0.92)">handler and the outer fetch. Repro is on prod-2 only.</text>
+      </g>
+
+      <g transform="translate(0,176)">
+        <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">17 more blips · 2 collapsed sub-threads · 1 task active</text>
+      </g>
+    </g>
+
+    <!-- Floating scroll-to-new chip -->
+    <g transform="translate(484,750)">
+      <rect width="180" height="36" rx="18" fill="#22d3ee"/>
+      <text x="90" y="22" text-anchor="middle" font-size="12" font-weight="600" fill="#0b1320">↓ 3 new blips below</text>
+    </g>
+  </g>
+
+  <!-- ============ ANNOTATION OVERLAY ============ -->
+  <g transform="translate(20,860)">
+    <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">J-UI-1 · J-UI-2 · matrix R-3.5, R-4.5 · components: shell-root, wavy-search-rail, wavy-search-rail-card, shell-main-region · light theme · 1440×900</text>
+  </g>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/02-open-wave-threaded-reading.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/02-open-wave-threaded-reading.svg
@@ -1,0 +1,246 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-4 — Open wave, threaded reading view with focus frame</title>
+  <desc id="desc">Selected wave with threaded blip rendering. Author avatar+name+timestamp per blip, two indent levels of replies, collapse chevrons, per-blip toolbar, and a cyan focus frame on one blip. Right-side keyboard hint.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <filter id="focus-ring" x="-10%" y="-20%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="0" stdDeviation="6" flood-color="#22d3ee" flood-opacity="0.55"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#bg)"/>
+
+  <!-- Header (compact) -->
+  <rect x="0" y="0" width="1440" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  <use href="#supawave-mark" x="20" y="10" width="36" height="36"/>
+  <text x="64" y="34" font-size="18" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+  <text x="186" y="34" font-size="13" fill="rgba(11,19,32,0.62)">Inbox › Robot streaming follow-up — 4xx retries</text>
+  <rect x="1248" y="12" width="84" height="32" rx="16" fill="#22d3ee"/>
+  <text x="1290" y="32" text-anchor="middle" font-size="13" font-weight="600" fill="#0b1320">+ New Wave</text>
+
+  <!-- Left: collapsed nav rail strip (visual reminder) -->
+  <g transform="translate(0,56)">
+    <rect width="72" height="844" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <rect x="12" y="20" width="48" height="40" rx="12" fill="rgba(34,211,238,0.18)"/>
+    <text x="36" y="44" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">Inbox</text>
+    <text x="36" y="92" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.62)">@</text>
+    <text x="36" y="124" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.62)">✓</text>
+    <text x="36" y="156" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.62)">#</text>
+    <text x="36" y="188" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.62)">📥</text>
+    <text x="36" y="220" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.62)">📌</text>
+  </g>
+
+  <!-- Wave header -->
+  <g transform="translate(96,80)">
+    <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · 5 PARTICIPANTS</text>
+    <text x="0" y="44" font-size="24" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Robot streaming follow-up — 4xx retries</text>
+
+    <!-- Action toolbar -->
+    <g transform="translate(0,64)">
+      <rect width="80" height="32" rx="16" fill="#0b1320"/>
+      <text x="40" y="20" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">Reply</text>
+      <rect x="88" y="0" width="64" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="120" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Pin</text>
+      <rect x="160" y="0" width="80" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="200" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Archive</text>
+      <rect x="248" y="0" width="92" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="294" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Mark read</text>
+      <rect x="348" y="0" width="60" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="378" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Tags</text>
+    </g>
+  </g>
+
+  <line x1="96" y1="200" x2="1080" y2="200" stroke="rgba(11,19,32,0.10)"/>
+
+  <!-- ============ THREADED BLIPS ============ -->
+  <!-- Indent guides -->
+  <g stroke="rgba(34,211,238,0.30)" stroke-width="2" fill="none">
+    <line x1="148" y1="320" x2="148" y2="780"/>
+    <line x1="220" y1="430" x2="220" y2="640"/>
+  </g>
+
+  <!-- Blip 1: Root -->
+  <g transform="translate(96,224)">
+    <g>
+      <text x="-12" y="20" font-size="14" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">▾</text>
+      <circle cx="20" cy="20" r="20" fill="#22d3ee"/>
+      <text x="20" y="25" text-anchor="middle" font-size="13" font-weight="700" fill="#0b1320">AT</text>
+      <text x="52" y="16" font-size="13" font-weight="700" fill="#0b1320">Anton T.</text>
+      <text x="120" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hours ago · root</text>
+      <text x="52" y="38" font-size="14" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry budget after the F-3 cleanup? I'm seeing logs that look like</text>
+      <text x="52" y="56" font-size="14" fill="rgba(11,19,32,0.92)">we're doubling up between the streaming handler and the outer fetch. Repro is on prod-2 only.</text>
+
+      <!-- per-blip toolbar (wave-blip-toolbar) -->
+      <g transform="translate(52,68)">
+        <rect width="280" height="24" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="14" y="16" font-size="11" font-weight="600" fill="#0b1320">↩ Reply</text>
+        <line x1="56" y1="6" x2="56" y2="18" stroke="rgba(11,19,32,0.10)"/>
+        <text x="68" y="16" font-size="11" fill="#0b1320">✎ Edit</text>
+        <line x1="106" y1="6" x2="106" y2="18" stroke="rgba(11,19,32,0.10)"/>
+        <text x="118" y="16" font-size="11" fill="#0b1320">🗑 Delete</text>
+        <line x1="166" y1="6" x2="166" y2="18" stroke="rgba(11,19,32,0.10)"/>
+        <text x="178" y="16" font-size="11" fill="#0b1320">🔗 Link</text>
+        <line x1="216" y1="6" x2="216" y2="18" stroke="rgba(11,19,32,0.10)"/>
+        <text x="228" y="16" font-size="11" fill="#0b1320">✓ Task</text>
+      </g>
+    </g>
+  </g>
+
+  <!-- Blip 2: Reply (indent 1) -->
+  <g transform="translate(168,344)">
+    <text x="-20" y="20" font-size="14" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">▾</text>
+    <circle cx="16" cy="20" r="16" fill="#7c3aed"/>
+    <text x="16" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">SK</text>
+    <text x="44" y="16" font-size="13" font-weight="700" fill="#0b1320">Sasha K.</text>
+    <text x="104" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">1 hour ago</text>
+    <text x="44" y="38" font-size="13" fill="rgba(11,19,32,0.92)">The budget is 3 retries with 200ms / 600ms / 1.4s backoff. Outer fetch should not retry —</text>
+    <text x="44" y="54" font-size="13" fill="rgba(11,19,32,0.92)">if it does, that's the duplicate you're seeing. Can you grab a request-id from prod-2?</text>
+  </g>
+
+  <!-- Blip 3: Reply-of-reply (indent 2) WITH FOCUS FRAME -->
+  <g transform="translate(240,440)" filter="url(#focus-ring)">
+    <rect x="-12" y="-8" width="800" height="92" rx="14" fill="#ffffff" stroke="#22d3ee" stroke-width="2"/>
+    <text x="-32" y="20" font-size="14" fill="#22d3ee" font-family="Geist, Inter, sans-serif" font-weight="700">▾</text>
+    <circle cx="16" cy="20" r="16" fill="#fb923c"/>
+    <text x="16" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+    <text x="44" y="16" font-size="13" font-weight="700" fill="#0b1320">Marina R.</text>
+    <text x="116" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago · focused</text>
+    <text x="44" y="38" font-size="13" fill="rgba(11,19,32,0.92)">request-id 6f1a-7cc4: outer fetch retried twice after a 502 from upstream. The handler</text>
+    <text x="44" y="54" font-size="13" fill="rgba(11,19,32,0.92)">retried 3 more times on top. So 5 total. Filed bug as #1081.</text>
+
+    <g transform="translate(44,66)">
+      <rect width="280" height="22" rx="11" fill="rgba(34,211,238,0.18)" stroke="#22d3ee"/>
+      <text x="14" y="14" font-size="11" font-weight="600" fill="#0b1320">↩ Reply</text>
+      <text x="68" y="14" font-size="11" fill="#0b1320">✎ Edit</text>
+      <text x="118" y="14" font-size="11" fill="#0b1320">🗑 Delete</text>
+      <text x="178" y="14" font-size="11" fill="#0b1320">🔗 #1081</text>
+      <text x="232" y="14" font-size="11" font-weight="600" fill="#0b1320">✓ Task</text>
+    </g>
+  </g>
+
+  <!-- Blip 4: Reply (indent 1) -->
+  <g transform="translate(168,560)">
+    <text x="-20" y="20" font-size="14" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">▸</text>
+    <circle cx="16" cy="20" r="16" fill="#7c3aed"/>
+    <text x="16" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">SK</text>
+    <text x="44" y="16" font-size="13" font-weight="700" fill="#0b1320">Sasha K.</text>
+    <text x="104" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">38 min ago</text>
+    <text x="44" y="38" font-size="13" fill="rgba(11,19,32,0.92)">Patch open — pinning outer fetch retry to 1, will land behind feature flag…</text>
+    <text x="44" y="56" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">3 collapsed replies</text>
+  </g>
+
+  <!-- Blip 5: Reply (indent 1) - newest -->
+  <g transform="translate(168,640)">
+    <text x="-20" y="20" font-size="14" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">▾</text>
+    <circle cx="16" cy="20" r="16" fill="#475569"/>
+    <text x="16" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">DK</text>
+    <text x="44" y="16" font-size="13" font-weight="700" fill="#0b1320">Dan K.</text>
+    <text x="92" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 min ago</text>
+    <rect x="156" y="4" width="56" height="18" rx="9" fill="#22d3ee"/>
+    <text x="184" y="17" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">NEW</text>
+    <text x="44" y="38" font-size="13" fill="rgba(11,19,32,0.92)">Confirmed on staging-3 too. Bumping severity. Looping in @yuri for the deploy gate.</text>
+  </g>
+
+  <!-- Compose at bottom (collapsed reply trigger - wavy-wave-root-reply-trigger) -->
+  <g transform="translate(96,760)">
+    <rect width="900" height="48" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)" stroke-dasharray="4 4"/>
+    <text x="20" y="30" font-size="13" fill="rgba(11,19,32,0.55)">Reply to wave… (R)</text>
+    <rect x="820" y="10" width="64" height="28" rx="14" fill="rgba(34,211,238,0.18)"/>
+    <text x="852" y="28" text-anchor="middle" font-size="11" font-weight="600" fill="#0b1320">Reply</text>
+  </g>
+
+  <!-- Right rail: keyboard hint -->
+  <g transform="translate(1100,80)">
+    <rect width="320" height="780" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+    <text x="20" y="32" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Keyboard</text>
+
+    <g font-family="Geist, Inter, sans-serif" font-size="12">
+      <g transform="translate(20,56)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">j / ↓</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Move focus to next blip</text>
+      </g>
+      <g transform="translate(20,86)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">k / ↑</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Move focus to previous blip</text>
+      </g>
+      <g transform="translate(20,116)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">o / ↵</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Open / focus blip</text>
+      </g>
+      <g transform="translate(20,146)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">r</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Reply to focused blip</text>
+      </g>
+      <g transform="translate(20,176)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">e</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Edit</text>
+      </g>
+      <g transform="translate(20,206)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">t</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Toggle task</text>
+      </g>
+      <g transform="translate(20,236)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">c</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Collapse / expand thread</text>
+      </g>
+      <g transform="translate(20,266)">
+        <rect width="44" height="22" rx="6" fill="#0b1320"/>
+        <text x="22" y="16" text-anchor="middle" fill="#ffffff" font-weight="600">u</text>
+        <text x="56" y="16" fill="rgba(11,19,32,0.62)">Mark read / unread</text>
+      </g>
+    </g>
+
+    <line x1="20" y1="316" x2="300" y2="316" stroke="rgba(11,19,32,0.10)"/>
+    <text x="20" y="344" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Wave info</text>
+    <g font-size="12" font-family="Geist, Inter, sans-serif">
+      <text x="20" y="370" fill="rgba(11,19,32,0.55)">CREATED</text>
+      <text x="20" y="386" fill="rgba(11,19,32,0.92)">Apr 26 · 14:22</text>
+      <text x="20" y="412" fill="rgba(11,19,32,0.55)">PARTICIPANTS</text>
+      <text x="20" y="428" fill="rgba(11,19,32,0.92)">Anton, Sasha, Marina, Dan, Yuri</text>
+      <text x="20" y="454" fill="rgba(11,19,32,0.55)">TAGS</text>
+      <g transform="translate(20,464)">
+        <rect width="46" height="22" rx="11" fill="rgba(124,58,237,0.22)"/>
+        <text x="23" y="16" text-anchor="middle" font-weight="600" fill="#3a1280">robots</text>
+        <rect x="54" y="0" width="62" height="22" rx="11" fill="rgba(251,146,60,0.22)"/>
+        <text x="85" y="16" text-anchor="middle" font-weight="600" fill="#7a3a06">streaming</text>
+      </g>
+      <text x="20" y="514" fill="rgba(11,19,32,0.55)">TASKS</text>
+      <text x="20" y="530" fill="rgba(11,19,32,0.92)">1 active · 0 done</text>
+      <text x="20" y="556" fill="rgba(11,19,32,0.55)">REACTIONS</text>
+      <text x="20" y="572" fill="rgba(11,19,32,0.92)">👀 3 · 🚀 1</text>
+    </g>
+
+    <line x1="20" y1="600" x2="300" y2="600" stroke="rgba(11,19,32,0.10)"/>
+    <text x="20" y="628" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Live activity</text>
+    <text x="20" y="652" font-size="12" fill="rgba(11,19,32,0.62)" font-family="Geist, Inter, sans-serif">Dan is typing…</text>
+    <circle cx="40" cy="676" r="3" fill="#22d3ee">
+      <animate attributeName="opacity" values="0.3;1;0.3" dur="900ms" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="50" cy="676" r="3" fill="#22d3ee">
+      <animate attributeName="opacity" values="0.3;1;0.3" dur="900ms" begin="200ms" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="676" r="3" fill="#22d3ee">
+      <animate attributeName="opacity" values="0.3;1;0.3" dur="900ms" begin="400ms" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <text x="20" y="884" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">J-UI-4 · matrix R-3.1, R-3.2, R-3.3, R-3.6 · components: shell-main-region, wave-blip, wavy-focus-frame, wave-blip-toolbar, wavy-thread-collapse · light theme</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/03-inline-rich-text-composer.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/03-inline-rich-text-composer.svg
@@ -1,0 +1,195 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-5 — Inline rich-text composer with selection-driven format toolbar</title>
+  <desc id="desc">An inline contenteditable composer opened at a specific blip in a wave. The selection-driven format toolbar floats above the composer with bold/italic/link/list/heading/alignment buttons; bold and italic are active because the current selection is bold-italic. Send and Cancel buttons sit at the bottom-right.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <filter id="toolbar-shadow" x="-10%" y="-30%" width="120%" height="160%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#0b1320" flood-opacity="0.20"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#bg)"/>
+
+  <!-- Header -->
+  <rect x="0" y="0" width="1440" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  <use href="#supawave-mark" x="20" y="10" width="36" height="36"/>
+  <text x="64" y="34" font-size="18" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+  <text x="186" y="34" font-size="13" fill="rgba(11,19,32,0.62)">Inbox › Robot streaming follow-up — composing reply at depth 2</text>
+
+  <!-- Wave area -->
+  <rect x="0" y="56" width="280" height="844" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  <text x="20" y="84" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">SAVED SEARCHES</text>
+  <rect x="12" y="96" width="256" height="36" rx="12" fill="rgba(34,211,238,0.18)"/>
+  <rect x="12" y="96" width="3" height="36" rx="2" fill="#22d3ee"/>
+  <text x="32" y="119" font-size="13" font-weight="600" fill="#0b1320">Inbox</text>
+  <text x="32" y="158" font-size="13" fill="#0b1320">Mentions</text>
+  <text x="32" y="194" font-size="13" fill="#0b1320">Tasks</text>
+  <text x="32" y="230" font-size="13" fill="#0b1320">Public</text>
+  <text x="32" y="266" font-size="13" fill="#0b1320">Archive</text>
+  <text x="32" y="302" font-size="13" fill="#0b1320">Pinned</text>
+
+  <!-- Wave panel background -->
+  <rect x="280" y="56" width="1160" height="844" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+
+  <!-- Wave header -->
+  <text x="304" y="92" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · 5 PARTICIPANTS</text>
+  <text x="304" y="124" font-size="22" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Robot streaming follow-up — 4xx retries</text>
+
+  <line x1="304" y1="148" x2="1416" y2="148" stroke="rgba(11,19,32,0.10)"/>
+
+  <!-- Existing blip 1 -->
+  <g transform="translate(304,168)">
+    <circle cx="20" cy="20" r="20" fill="#22d3ee"/>
+    <text x="20" y="25" text-anchor="middle" font-size="13" font-weight="700" fill="#0b1320">AT</text>
+    <text x="52" y="16" font-size="13" font-weight="700" fill="#0b1320">Anton T.</text>
+    <text x="120" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hours ago · root</text>
+    <text x="52" y="38" font-size="14" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry budget after the F-3 cleanup?</text>
+  </g>
+
+  <!-- Existing blip 2 (parent of the reply being composed) -->
+  <g transform="translate(376,232)">
+    <circle cx="16" cy="20" r="16" fill="#7c3aed"/>
+    <text x="16" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">SK</text>
+    <text x="44" y="16" font-size="13" font-weight="700" fill="#0b1320">Sasha K.</text>
+    <text x="104" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">1 hour ago</text>
+    <text x="44" y="38" font-size="13" fill="rgba(11,19,32,0.92)">Budget is 3 retries with 200ms / 600ms / 1.4s backoff. Outer fetch should not retry — if it does,</text>
+    <text x="44" y="56" font-size="13" fill="rgba(11,19,32,0.92)">that's the duplicate you're seeing. Can you grab a request-id from prod-2?</text>
+  </g>
+
+  <!-- ============ INLINE COMPOSER (composer-inline-reply + wavy-composer) ============ -->
+  <g transform="translate(376,316)">
+    <!-- Connector tail showing inline anchor -->
+    <line x1="0" y1="0" x2="0" y2="48" stroke="rgba(34,211,238,0.40)" stroke-width="2"/>
+
+    <!-- Composer card -->
+    <rect x="0" y="48" width="900" height="376" rx="16" fill="#ffffff" stroke="#22d3ee" stroke-width="2" filter="url(#card-shadow)"/>
+
+    <!-- Composer header -->
+    <g transform="translate(20,68)">
+      <text x="0" y="14" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">REPLYING TO SASHA K. · DEPTH 2</text>
+    </g>
+
+    <!-- contenteditable surface -->
+    <g transform="translate(20,96)">
+      <rect width="860" height="232" rx="12" fill="#f6f7fb"/>
+      <!-- Sample rich text content with selection -->
+      <text x="20" y="32" font-size="14" fill="rgba(11,19,32,0.92)">request-id is</text>
+      <text x="118" y="32" font-size="14" font-weight="700" fill="#0b1320">6f1a-7cc4</text>
+      <text x="194" y="32" font-size="14" fill="rgba(11,19,32,0.92)">. The outer fetch retried after the 502 hit, then</text>
+      <!-- Selected fragment (bold + italic) - highlighted -->
+      <rect x="20" y="44" width="296" height="22" rx="3" fill="rgba(34,211,238,0.22)"/>
+      <text x="20" y="62" font-size="14" font-weight="700" font-style="italic" fill="#0b1320">the handler retried 3 more times on top</text>
+      <text x="318" y="62" font-size="14" fill="rgba(11,19,32,0.92)">. Net</text>
+      <text x="20" y="92" font-size="14" fill="rgba(11,19,32,0.92)">5 retries against the same upstream. I think the fix is in the outer fetch:</text>
+
+      <!-- bullet list -->
+      <text x="36" y="124" font-size="14" fill="rgba(11,19,32,0.92)">• pin its retry to 1</text>
+      <text x="36" y="146" font-size="14" fill="rgba(11,19,32,0.92)">• keep the handler budget unchanged</text>
+      <text x="36" y="168" font-size="14" fill="rgba(11,19,32,0.92)">• gate behind</text>
+      <!-- inline link -->
+      <text x="142" y="168" font-size="14" font-weight="600" fill="#0a4f82" text-decoration="underline">flag:robotStreamingRetryV2</text>
+
+      <text x="20" y="200" font-size="14" fill="rgba(11,19,32,0.92)">Filed bug as #1081. Patch will land later today.</text>
+
+      <!-- caret -->
+      <line x1="332" y1="186" x2="332" y2="208" stroke="#22d3ee" stroke-width="2">
+        <animate attributeName="opacity" values="1;0;1" dur="900ms" repeatCount="indefinite"/>
+      </line>
+    </g>
+
+    <!-- Bottom action bar -->
+    <g transform="translate(20,348)">
+      <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Markdown supported · ⌘↵ to send · Esc to cancel</text>
+      <rect x="700" y="-4" width="80" height="28" rx="14" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="740" y="15" text-anchor="middle" font-size="12" fill="#0b1320">Cancel</text>
+      <rect x="788" y="-4" width="92" height="28" rx="14" fill="#22d3ee"/>
+      <text x="834" y="15" text-anchor="middle" font-size="12" font-weight="700" fill="#0b1320">Send reply</text>
+    </g>
+  </g>
+
+  <!-- ============ FLOATING SELECTION-DRIVEN FORMAT TOOLBAR (wavy-format-toolbar) ============ -->
+  <!-- Anchored above the selected fragment -->
+  <g transform="translate(396,388)">
+    <rect width="540" height="48" rx="12" fill="#0b1320" filter="url(#toolbar-shadow)"/>
+    <!-- pointer arrow -->
+    <polygon points="60,48 72,60 84,48" fill="#0b1320"/>
+
+    <!-- Group 1: typography toggles -->
+    <!-- Bold (active) -->
+    <rect x="8" y="8" width="32" height="32" rx="8" fill="#22d3ee"/>
+    <text x="24" y="29" text-anchor="middle" font-size="14" font-weight="900" fill="#0b1320">B</text>
+    <!-- Italic (active) -->
+    <rect x="44" y="8" width="32" height="32" rx="8" fill="#22d3ee"/>
+    <text x="60" y="29" text-anchor="middle" font-size="14" font-weight="700" font-style="italic" fill="#0b1320">I</text>
+    <!-- Underline -->
+    <rect x="80" y="8" width="32" height="32" rx="8" fill="transparent"/>
+    <text x="96" y="29" text-anchor="middle" font-size="14" fill="#ffffff" text-decoration="underline">U</text>
+    <!-- Strike -->
+    <rect x="116" y="8" width="32" height="32" rx="8" fill="transparent"/>
+    <text x="132" y="29" text-anchor="middle" font-size="14" fill="#ffffff" text-decoration="line-through">S</text>
+
+    <line x1="160" y1="12" x2="160" y2="36" stroke="rgba(255,255,255,0.20)"/>
+
+    <!-- Group 2: heading + structure -->
+    <text x="184" y="29" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">H1</text>
+    <text x="220" y="29" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">H2</text>
+    <text x="256" y="29" text-anchor="middle" font-size="14" fill="#ffffff">"</text>
+
+    <line x1="276" y1="12" x2="276" y2="36" stroke="rgba(255,255,255,0.20)"/>
+
+    <!-- Group 3: lists -->
+    <g transform="translate(296,16)">
+      <circle cx="3" cy="4" r="2" fill="#ffffff"/>
+      <line x1="10" y1="4" x2="22" y2="4" stroke="#ffffff" stroke-width="1.5"/>
+      <circle cx="3" cy="12" r="2" fill="#ffffff"/>
+      <line x1="10" y1="12" x2="22" y2="12" stroke="#ffffff" stroke-width="1.5"/>
+    </g>
+    <g transform="translate(332,16)">
+      <text x="0" y="6" font-size="8" fill="#ffffff">1.</text>
+      <line x1="10" y1="4" x2="22" y2="4" stroke="#ffffff" stroke-width="1.5"/>
+      <text x="0" y="14" font-size="8" fill="#ffffff">2.</text>
+      <line x1="10" y1="12" x2="22" y2="12" stroke="#ffffff" stroke-width="1.5"/>
+    </g>
+
+    <line x1="368" y1="12" x2="368" y2="36" stroke="rgba(255,255,255,0.20)"/>
+
+    <!-- Group 4: alignment -->
+    <g transform="translate(380,18)" stroke="#ffffff" stroke-width="1.5" fill="none">
+      <line x1="0" y1="0" x2="20" y2="0"/>
+      <line x1="0" y1="6" x2="14" y2="6"/>
+      <line x1="0" y1="12" x2="20" y2="12"/>
+    </g>
+    <g transform="translate(412,18)" stroke="#ffffff" stroke-width="1.5" fill="none">
+      <line x1="3" y1="0" x2="23" y2="0"/>
+      <line x1="6" y1="6" x2="20" y2="6"/>
+      <line x1="3" y1="12" x2="23" y2="12"/>
+    </g>
+
+    <line x1="448" y1="12" x2="448" y2="36" stroke="rgba(255,255,255,0.20)"/>
+
+    <!-- Group 5: link + code -->
+    <g transform="translate(460,18)" stroke="#ffffff" stroke-width="1.5" fill="none">
+      <path d="M0 6 a4 4 0 0 1 4-4 h6 a4 4 0 0 1 4 4"/>
+      <path d="M8 6 a4 4 0 0 1 4 4 h6 a4 4 0 0 1 0 0"/>
+    </g>
+    <text x="498" y="30" font-size="13" fill="#ffffff" font-family="monospace">{ }</text>
+
+    <text x="540" y="74" text-anchor="end" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">selection: bold + italic detected — toggles reflect</text>
+  </g>
+
+  <!-- Annotation -->
+  <g transform="translate(304,820)">
+    <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">J-UI-5 · matrix R-5.1, R-5.2, R-5.7 · components: composer-inline-reply, wavy-composer, wavy-format-toolbar, toolbar-button, toolbar-group · light theme</text>
+  </g>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/04-task-toggle-and-done-state.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/04-task-toggle-and-done-state.svg
@@ -1,0 +1,220 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-6 — Per-blip task toggle: idle, active, done states</title>
+  <desc id="desc">Three side-by-side close-ups of the same blip. Left: idle — task affordance visible but not toggled. Center: task active — amber chip and metadata badge appear, due date popover anchored to the affordance. Right: done — strikethrough text, checkmark, completion timestamp, persists on reload.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="1200" height="760" fill="url(#bg)"/>
+
+  <!-- Header -->
+  <rect x="0" y="0" width="1200" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  <use href="#supawave-mark" x="20" y="10" width="36" height="36"/>
+  <text x="64" y="34" font-size="18" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+  <text x="186" y="34" font-size="13" fill="rgba(11,19,32,0.62)">Task toggle states · close-up</text>
+
+  <!-- Title -->
+  <text x="40" y="100" font-size="22" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Per-blip task toggle &amp; done state</text>
+  <text x="40" y="124" font-size="13" fill="rgba(11,19,32,0.62)">wavy-task-affordance + task-metadata-popover · DocOp-backed · persists across reload</text>
+
+  <!-- ============ STATE 1: IDLE ============ -->
+  <g transform="translate(40,164)">
+    <text x="0" y="0" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">1 · IDLE</text>
+    <rect x="0" y="16" width="360" height="180" rx="14" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+
+    <!-- avatar + author -->
+    <circle cx="28" cy="48" r="16" fill="#fb923c"/>
+    <text x="28" y="53" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+    <text x="56" y="44" font-size="13" font-weight="700" fill="#0b1320">Marina R.</text>
+    <text x="120" y="44" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+
+    <text x="56" y="64" font-size="13" fill="rgba(11,19,32,0.92)">Pin outer fetch retry to 1 and gate</text>
+    <text x="56" y="80" font-size="13" fill="rgba(11,19,32,0.92)">behind robotStreamingRetryV2.</text>
+
+    <!-- per-blip toolbar -->
+    <g transform="translate(56,108)">
+      <rect width="280" height="26" rx="13" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <text x="14" y="17" font-size="11" font-weight="600" fill="#0b1320">↩ Reply</text>
+      <text x="68" y="17" font-size="11" fill="#0b1320">✎ Edit</text>
+      <text x="118" y="17" font-size="11" fill="#0b1320">🔗 Link</text>
+      <line x1="166" y1="6" x2="166" y2="20" stroke="rgba(11,19,32,0.10)"/>
+      <!-- task affordance (idle) -->
+      <rect x="178" y="4" width="84" height="18" rx="9" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <circle cx="190" cy="13" r="5" fill="none" stroke="rgba(11,19,32,0.55)" stroke-width="1.5"/>
+      <text x="200" y="17" font-size="11" font-weight="600" fill="rgba(11,19,32,0.62)">Mark task</text>
+    </g>
+
+    <text x="0" y="160" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Click the empty circle, or press</text>
+    <rect x="208" y="148" width="20" height="16" rx="4" fill="#0b1320"/>
+    <text x="218" y="160" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">t</text>
+    <text x="232" y="160" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">on focus.</text>
+  </g>
+
+  <!-- arrow -->
+  <g stroke="#22d3ee" stroke-width="2" fill="none">
+    <line x1="412" y1="270" x2="438" y2="270"/>
+    <polygon points="436,266 446,270 436,274" fill="#22d3ee" stroke="none"/>
+  </g>
+
+  <!-- ============ STATE 2: ACTIVE TASK ============ -->
+  <g transform="translate(456,164)">
+    <text x="0" y="0" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">2 · TASK ACTIVE</text>
+    <rect x="0" y="16" width="360" height="220" rx="14" fill="#ffffff" stroke="#fb923c" stroke-width="2" filter="url(#card-shadow)"/>
+
+    <!-- amber rail -->
+    <rect x="0" y="16" width="3" height="220" rx="2" fill="#fb923c"/>
+
+    <!-- avatar + author -->
+    <circle cx="28" cy="48" r="16" fill="#fb923c"/>
+    <text x="28" y="53" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+    <text x="56" y="44" font-size="13" font-weight="700" fill="#0b1320">Marina R.</text>
+    <text x="120" y="44" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+
+    <!-- task header chip -->
+    <rect x="220" y="32" width="120" height="22" rx="11" fill="rgba(251,146,60,0.22)"/>
+    <text x="232" y="47" font-size="11" font-weight="700" fill="#7a3a06">⚑ TASK · DUE FRI</text>
+
+    <text x="56" y="68" font-size="13" fill="rgba(11,19,32,0.92)">Pin outer fetch retry to 1 and gate</text>
+    <text x="56" y="84" font-size="13" fill="rgba(11,19,32,0.92)">behind robotStreamingRetryV2.</text>
+
+    <!-- task metadata row -->
+    <g transform="translate(56,100)">
+      <rect width="66" height="20" rx="10" fill="rgba(251,146,60,0.22)"/>
+      <text x="33" y="14" text-anchor="middle" font-size="10" font-weight="700" fill="#7a3a06">@sasha</text>
+      <rect x="74" y="0" width="92" height="20" rx="10" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <text x="120" y="14" text-anchor="middle" font-size="10" fill="#0b1320">📅 Fri Apr 30</text>
+      <rect x="174" y="0" width="62" height="20" rx="10" fill="rgba(124,58,237,0.22)"/>
+      <text x="205" y="14" text-anchor="middle" font-size="10" font-weight="600" fill="#3a1280">P1</text>
+    </g>
+
+    <!-- per-blip toolbar with task active -->
+    <g transform="translate(56,140)">
+      <rect width="280" height="26" rx="13" fill="rgba(251,146,60,0.22)"/>
+      <text x="14" y="17" font-size="11" font-weight="600" fill="#7a3a06">↩ Reply</text>
+      <text x="68" y="17" font-size="11" fill="#7a3a06">✎ Edit</text>
+      <text x="118" y="17" font-size="11" fill="#7a3a06">🔗 Link</text>
+      <line x1="166" y1="6" x2="166" y2="20" stroke="rgba(122,58,6,0.25)"/>
+      <!-- task affordance (active) -->
+      <rect x="178" y="4" width="84" height="18" rx="9" fill="#fb923c"/>
+      <circle cx="190" cy="13" r="5" fill="#0b1320"/>
+      <text x="200" y="17" font-size="11" font-weight="700" fill="#0b1320">Done?</text>
+    </g>
+
+    <!-- popover hint (task-metadata-popover) -->
+    <g transform="translate(178,180)">
+      <rect width="158" height="42" rx="10" fill="#0b1320"/>
+      <polygon points="74,0 80,-6 86,0" fill="#0b1320"/>
+      <text x="12" y="18" font-size="11" font-weight="600" fill="#ffffff" font-family="Geist, Inter, sans-serif">Edit task metadata</text>
+      <text x="12" y="32" font-size="10" fill="rgba(255,255,255,0.62)" font-family="Geist, Inter, sans-serif">assignee · due · priority</text>
+    </g>
+  </g>
+
+  <!-- arrow -->
+  <g stroke="#22d3ee" stroke-width="2" fill="none">
+    <line x1="828" y1="270" x2="854" y2="270"/>
+    <polygon points="852,266 862,270 852,274" fill="#22d3ee" stroke="none"/>
+  </g>
+
+  <!-- ============ STATE 3: DONE ============ -->
+  <g transform="translate(872,164)">
+    <text x="0" y="0" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">3 · DONE · PERSISTS ACROSS RELOAD</text>
+    <rect x="0" y="16" width="288" height="200" rx="14" fill="#fafbfd" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+
+    <!-- green-ish completed rail -->
+    <rect x="0" y="16" width="3" height="200" rx="2" fill="#22d3ee"/>
+
+    <circle cx="28" cy="48" r="16" fill="#fb923c" opacity="0.65"/>
+    <text x="28" y="53" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320" opacity="0.65">MR</text>
+    <text x="56" y="44" font-size="13" font-weight="700" fill="rgba(11,19,32,0.62)">Marina R.</text>
+    <text x="120" y="44" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+
+    <!-- DONE chip -->
+    <rect x="200" y="32" width="76" height="22" rx="11" fill="#22d3ee"/>
+    <text x="212" y="47" font-size="11" font-weight="700" fill="#0b1320">✓ DONE</text>
+
+    <!-- strikethrough body -->
+    <text x="56" y="68" font-size="13" fill="rgba(11,19,32,0.55)" text-decoration="line-through">Pin outer fetch retry to 1 and gate</text>
+    <text x="56" y="84" font-size="13" fill="rgba(11,19,32,0.55)" text-decoration="line-through">behind robotStreamingRetryV2.</text>
+
+    <!-- completion meta -->
+    <g transform="translate(56,100)">
+      <text x="0" y="12" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Completed by</text>
+      <rect x="74" y="0" width="60" height="18" rx="9" fill="rgba(124,58,237,0.22)"/>
+      <text x="104" y="13" text-anchor="middle" font-size="10" font-weight="600" fill="#3a1280">@sasha</text>
+      <text x="138" y="12" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 8 min ago</text>
+    </g>
+
+    <!-- per-blip toolbar with undo -->
+    <g transform="translate(56,140)">
+      <rect width="216" height="26" rx="13" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <text x="14" y="17" font-size="11" fill="rgba(11,19,32,0.62)">↩ Reply</text>
+      <text x="68" y="17" font-size="11" fill="rgba(11,19,32,0.62)">🔗 Link</text>
+      <line x1="116" y1="6" x2="116" y2="20" stroke="rgba(11,19,32,0.10)"/>
+      <rect x="128" y="4" width="80" height="18" rx="9" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <circle cx="140" cy="13" r="5" fill="#22d3ee"/>
+      <path d="M137 13 l2 2 l4 -4" stroke="#0b1320" stroke-width="1.5" fill="none"/>
+      <text x="151" y="17" font-size="11" font-weight="600" fill="#0b1320">Reopen</text>
+    </g>
+  </g>
+
+  <!-- ============ STATE TRANSITIONS LEDGER (DocOp wire) ============ -->
+  <g transform="translate(40,408)">
+    <rect width="1120" height="320" rx="14" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+    <text x="20" y="32" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Wire-level state transitions</text>
+    <text x="20" y="50" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Task toggle is wired to the task DocOp on the wavelet — done state survives reload because it is a document annotation, not a UI flag.</text>
+
+    <g font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="11">
+      <!-- Idle -->
+      <text x="20" y="92" fill="rgba(11,19,32,0.55)">Idle</text>
+      <text x="20" y="110" fill="#0b1320">{ blipId: 'b9d4', task: null }</text>
+
+      <line x1="280" y1="100" x2="312" y2="100" stroke="#22d3ee" stroke-width="2"/>
+      <polygon points="310,96 320,100 310,104" fill="#22d3ee"/>
+      <text x="280" y="84" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">click ✓ Task</text>
+
+      <!-- Active -->
+      <text x="332" y="92" fill="rgba(11,19,32,0.55)">Active</text>
+      <text x="332" y="110" fill="#0b1320">{ blipId: 'b9d4',</text>
+      <text x="332" y="126" fill="#0b1320">  task: {</text>
+      <text x="332" y="142" fill="#0b1320">    state: 'open',</text>
+      <text x="332" y="158" fill="#0b1320">    assignee: 'sasha',</text>
+      <text x="332" y="174" fill="#0b1320">    due: '2026-04-30',</text>
+      <text x="332" y="190" fill="#0b1320">    priority: 'P1' } }</text>
+
+      <line x1="612" y1="100" x2="644" y2="100" stroke="#22d3ee" stroke-width="2"/>
+      <polygon points="642,96 652,100 642,104" fill="#22d3ee"/>
+      <text x="612" y="84" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">click Done?</text>
+
+      <!-- Done -->
+      <text x="664" y="92" fill="rgba(11,19,32,0.55)">Done</text>
+      <text x="664" y="110" fill="#0b1320">{ blipId: 'b9d4',</text>
+      <text x="664" y="126" fill="#0b1320">  task: {</text>
+      <text x="664" y="142" fill="#0b1320">    state: 'done',</text>
+      <text x="664" y="158" fill="#0b1320">    completedBy: 'sasha',</text>
+      <text x="664" y="174" fill="#0b1320">    completedAt:</text>
+      <text x="664" y="190" fill="#0b1320">      '2026-04-28T10:42Z' } }</text>
+    </g>
+
+    <line x1="20" y1="220" x2="1100" y2="220" stroke="rgba(11,19,32,0.10)"/>
+
+    <text x="20" y="248" font-size="12" font-weight="700" fill="#0b1320">Acceptance · matrix R-5.4</text>
+    <g font-family="Geist, Inter, sans-serif" font-size="12" fill="rgba(11,19,32,0.92)">
+      <text x="20" y="270">• Task toggle round-trips through the wavelet's task DocOp (not a transient client flag).</text>
+      <text x="20" y="290">• Done state renders strikethrough body + checkmark chip + completion meta.</text>
+      <text x="20" y="310">• State persists across reload, restart, and remote-client updates (live decrement of Tasks folder count).</text>
+    </g>
+  </g>
+
+  <text x="40" y="746" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">J-UI-6 · matrix R-5.4 · components: wavy-task-affordance, task-metadata-popover, wave-blip, wave-blip-toolbar · light theme</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/05-new-wave-create-flow.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/05-new-wave-create-flow.svg
@@ -1,0 +1,197 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-3 — New Wave create flow (dialog over shell)</title>
+  <desc id="desc">Modal dialog overlaying the desktop shell. Title field, participants chooser with invited and suggested chips, body composer with format toolbar, attachment row, and Send/Cancel actions. Behind the dim layer the inbox shows a pulse-ring on the just-created wave appearing at the top of the rail.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <filter id="modal-shadow" x="-10%" y="-20%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="20" stdDeviation="30" flood-color="#0b1320" flood-opacity="0.20"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#bg)"/>
+
+  <!-- ============ DIMMED SHELL BEHIND ============ -->
+  <g opacity="0.45">
+    <rect x="0" y="0" width="1440" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <use href="#supawave-mark" x="20" y="10" width="36" height="36"/>
+    <text x="64" y="34" font-size="18" font-weight="700" fill="#0b1320">SupaWave</text>
+    <rect x="280" y="56" width="1160" height="844" fill="#fafbfd"/>
+    <rect x="0" y="56" width="280" height="844" fill="#ffffff"/>
+
+    <!-- Inbox card preview -->
+    <text x="20" y="84" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" letter-spacing="0.08em">SAVED SEARCHES</text>
+    <rect x="12" y="96" width="256" height="36" rx="12" fill="rgba(34,211,238,0.18)"/>
+    <text x="32" y="119" font-size="13" font-weight="600" fill="#0b1320">Inbox</text>
+    <text x="32" y="158" font-size="13" fill="#0b1320">Mentions</text>
+    <text x="32" y="194" font-size="13" fill="#0b1320">Tasks</text>
+
+    <!-- placeholder cards -->
+    <rect x="296" y="100" width="416" height="80" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+    <rect x="296" y="196" width="416" height="80" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Wave panel placeholder -->
+    <rect x="744" y="100" width="676" height="200" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  </g>
+
+  <!-- Pulse ring on top inbox slot — the just-created wave will land here -->
+  <g transform="translate(296,100)">
+    <rect width="416" height="80" rx="12" fill="#ffffff" stroke="#22d3ee" stroke-width="2" opacity="0.85"/>
+    <rect width="416" height="80" rx="12" fill="none" stroke="#22d3ee" stroke-width="2" opacity="0.45">
+      <animate attributeName="stroke-width" values="2;6;2" dur="900ms" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.45;0;0.45" dur="900ms" repeatCount="indefinite"/>
+    </rect>
+    <text x="20" y="28" font-size="11" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">JUST CREATED · LANDING IN INBOX</text>
+    <text x="20" y="50" font-size="13" font-weight="700" fill="#0b1320" opacity="0.65">F-3 follow-up: streaming retry telemetry</text>
+    <text x="20" y="68" font-size="11" fill="rgba(11,19,32,0.55)" opacity="0.65">(rendering after server confirms)</text>
+  </g>
+
+  <rect x="0" y="0" width="1440" height="900" fill="rgba(11,19,32,0.40)"/>
+
+  <!-- ============ MODAL ============ -->
+  <g transform="translate(280,80)">
+    <rect width="880" height="740" rx="20" fill="#ffffff" filter="url(#modal-shadow)"/>
+
+    <!-- Modal header -->
+    <g transform="translate(32,28)">
+      <text x="0" y="14" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">NEW WAVE</text>
+      <text x="0" y="44" font-size="22" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Start a new wave</text>
+      <text x="0" y="66" font-size="13" fill="rgba(11,19,32,0.62)">Title and body submit a write through the J2CL conversation model. Esc cancels.</text>
+    </g>
+
+    <!-- close X -->
+    <g transform="translate(820,28)">
+      <rect width="32" height="32" rx="8" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <line x1="11" y1="11" x2="21" y2="21" stroke="#0b1320" stroke-width="1.5"/>
+      <line x1="21" y1="11" x2="11" y2="21" stroke="#0b1320" stroke-width="1.5"/>
+    </g>
+
+    <line x1="32" y1="116" x2="848" y2="116" stroke="rgba(11,19,32,0.10)"/>
+
+    <!-- Title field -->
+    <g transform="translate(32,140)">
+      <text x="0" y="14" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">TITLE</text>
+      <rect width="816" height="48" rx="12" y="22" fill="#fafbfd" stroke="#22d3ee" stroke-width="2"/>
+      <text x="20" y="52" font-size="16" font-weight="600" fill="#0b1320">F-3 follow-up: streaming retry telemetry</text>
+      <line x1="424" y1="40" x2="424" y2="60" stroke="#22d3ee" stroke-width="2">
+        <animate attributeName="opacity" values="1;0;1" dur="900ms" repeatCount="indefinite"/>
+      </line>
+      <text x="816" y="84" text-anchor="end" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 / 120</text>
+    </g>
+
+    <!-- Participants -->
+    <g transform="translate(32,256)">
+      <text x="0" y="14" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">PARTICIPANTS</text>
+      <rect width="816" height="48" rx="12" y="22" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+
+      <!-- existing chips -->
+      <g transform="translate(12,32)">
+        <rect width="92" height="28" rx="14" fill="rgba(124,58,237,0.22)"/>
+        <circle cx="14" cy="14" r="10" fill="#7c3aed"/>
+        <text x="14" y="18" text-anchor="middle" font-size="9" font-weight="700" fill="#ffffff">YZ</text>
+        <text x="30" y="18" font-size="12" font-weight="600" fill="#3a1280">@yuri</text>
+        <line x1="78" y1="10" x2="84" y2="18" stroke="#3a1280" stroke-width="1.5"/>
+        <line x1="84" y1="10" x2="78" y2="18" stroke="#3a1280" stroke-width="1.5"/>
+      </g>
+      <g transform="translate(112,32)">
+        <rect width="100" height="28" rx="14" fill="rgba(34,211,238,0.18)"/>
+        <circle cx="14" cy="14" r="10" fill="#22d3ee"/>
+        <text x="14" y="18" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">SK</text>
+        <text x="30" y="18" font-size="12" font-weight="600" fill="#0b1320">@sasha</text>
+        <line x1="86" y1="10" x2="92" y2="18" stroke="#0b1320" stroke-width="1.5"/>
+        <line x1="92" y1="10" x2="86" y2="18" stroke="#0b1320" stroke-width="1.5"/>
+      </g>
+      <g transform="translate(220,32)">
+        <rect width="106" height="28" rx="14" fill="rgba(251,146,60,0.22)"/>
+        <circle cx="14" cy="14" r="10" fill="#fb923c"/>
+        <text x="14" y="18" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">MR</text>
+        <text x="30" y="18" font-size="12" font-weight="600" fill="#7a3a06">@marina</text>
+        <line x1="92" y1="10" x2="98" y2="18" stroke="#7a3a06" stroke-width="1.5"/>
+        <line x1="98" y1="10" x2="92" y2="18" stroke="#7a3a06" stroke-width="1.5"/>
+      </g>
+      <text x="344" y="50" font-size="13" fill="rgba(11,19,32,0.55)">Add a person… (type @ to search)</text>
+
+      <!-- Suggested -->
+      <text x="0" y="94" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Suggested:</text>
+      <rect x="80" y="80" width="74" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="117" y="94" text-anchor="middle" font-size="11" fill="#0b1320">+ @dan</text>
+      <rect x="160" y="80" width="86" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="203" y="94" text-anchor="middle" font-size="11" fill="#0b1320">+ @anton</text>
+      <rect x="252" y="80" width="80" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="292" y="94" text-anchor="middle" font-size="11" fill="#0b1320">+ #robots</text>
+    </g>
+
+    <!-- Body composer -->
+    <g transform="translate(32,388)">
+      <text x="0" y="14" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">BODY</text>
+
+      <!-- mini format toolbar -->
+      <g transform="translate(0,22)">
+        <rect width="816" height="36" rx="10" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+        <text x="14" y="24" font-size="13" font-weight="900" fill="#0b1320">B</text>
+        <text x="36" y="24" font-size="13" font-weight="700" font-style="italic" fill="#0b1320">I</text>
+        <text x="58" y="24" font-size="13" fill="#0b1320" text-decoration="underline">U</text>
+        <line x1="80" y1="8" x2="80" y2="28" stroke="rgba(11,19,32,0.10)"/>
+        <text x="100" y="24" font-size="12" font-weight="700" fill="#0b1320">H1</text>
+        <text x="130" y="24" font-size="12" font-weight="700" fill="#0b1320">H2</text>
+        <line x1="156" y1="8" x2="156" y2="28" stroke="rgba(11,19,32,0.10)"/>
+        <text x="180" y="24" font-size="12" fill="#0b1320">• List</text>
+        <text x="226" y="24" font-size="12" fill="#0b1320">1. List</text>
+        <line x1="278" y1="8" x2="278" y2="28" stroke="rgba(11,19,32,0.10)"/>
+        <text x="298" y="24" font-size="12" fill="#0b1320">🔗 Link</text>
+        <text x="354" y="24" font-size="12" font-family="monospace" fill="#0b1320">{ } Code</text>
+        <line x1="424" y1="8" x2="424" y2="28" stroke="rgba(11,19,32,0.10)"/>
+        <text x="444" y="24" font-size="12" fill="#0b1320">📎 Attach</text>
+        <text x="510" y="24" font-size="12" fill="#0b1320">@ Mention</text>
+        <text x="586" y="24" font-size="12" fill="#0b1320">#️ Tag</text>
+        <text x="804" y="24" text-anchor="end" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Markdown</text>
+      </g>
+
+      <!-- Body input -->
+      <rect width="816" height="180" rx="12" y="68" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+
+      <text x="20" y="96" font-size="14" font-weight="700" fill="#0b1320">## Context</text>
+      <text x="20" y="118" font-size="14" fill="rgba(11,19,32,0.92)">After F-3 we still see duplicate retries against streaming endpoints. We need a</text>
+      <text x="20" y="136" font-size="14" fill="rgba(11,19,32,0.92)">visible per-request counter wired to the Grafana dashboard.</text>
+      <text x="20" y="160" font-size="14" font-weight="700" fill="#0b1320">## Asks</text>
+      <text x="36" y="180" font-size="14" fill="rgba(11,19,32,0.92)">• @sasha — patch outer fetch retry pin</text>
+      <text x="36" y="198" font-size="14" fill="rgba(11,19,32,0.92)">• @marina — confirm telemetry shape</text>
+      <text x="36" y="216" font-size="14" fill="rgba(11,19,32,0.92)">• @dan — wire to /grafana/api-latency board</text>
+      <line x1="278" y1="208" x2="278" y2="228" stroke="#22d3ee" stroke-width="2">
+        <animate attributeName="opacity" values="1;0;1" dur="900ms" repeatCount="indefinite"/>
+      </line>
+    </g>
+
+    <!-- Attachment row -->
+    <g transform="translate(32,654)">
+      <rect width="240" height="44" rx="10" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <rect x="6" y="6" width="32" height="32" rx="6" fill="rgba(34,211,238,0.18)"/>
+      <text x="22" y="26" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">PNG</text>
+      <text x="46" y="22" font-size="12" font-weight="600" fill="#0b1320">retry-doubling-prod-2.png</text>
+      <text x="46" y="38" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">240KB · pasted</text>
+    </g>
+
+    <!-- Footer -->
+    <line x1="32" y1="708" x2="848" y2="708" stroke="rgba(11,19,32,0.10)"/>
+    <g transform="translate(32,720)">
+      <text x="0" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Posts to Inbox · ⌘↵ to send</text>
+
+      <rect x="624" y="0" width="80" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="664" y="20" text-anchor="middle" font-size="13" fill="#0b1320">Cancel</text>
+      <rect x="712" y="0" width="104" height="32" rx="16" fill="#22d3ee"/>
+      <text x="764" y="20" text-anchor="middle" font-size="13" font-weight="700" fill="#0b1320">Create wave</text>
+    </g>
+  </g>
+
+  <text x="40" y="876" font-size="11" fill="rgba(255,255,255,0.85)" font-family="Geist, Inter, sans-serif">J-UI-3 · matrix R-5.1 · components: composer-shell, wavy-composer, wavy-format-toolbar, compose-attachment-card, mention-suggestion-popover · light theme · modal over shell</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/06-mobile-inbox-and-wave.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/06-mobile-inbox-and-wave.svg
@@ -1,0 +1,302 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="900" viewBox="0 0 900 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">Mobile shell — Inbox and open wave (390×844, side-by-side)</title>
+  <desc id="desc">Two mobile frames at 390×844 each. Left: Inbox folder list collapsed into a sticky top bar plus filter chip strip and a vertical list of digest cards. Right: open wave with back-to-inbox affordance, wave header, threaded reading, mobile compose dock at the bottom.</desc>
+  <defs>
+    <linearGradient id="page-bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="phone-shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#0b1320" flood-opacity="0.15"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="900" height="900" fill="url(#page-bg)"/>
+  <text x="450" y="32" text-anchor="middle" font-size="13" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Mobile · 390 × 844 · Inbox + open wave</text>
+
+  <!-- ============ LEFT PHONE: Inbox ============ -->
+  <g transform="translate(40,40)" filter="url(#phone-shadow)">
+    <rect width="390" height="844" rx="44" fill="#0b1320"/>
+    <rect x="8" y="8" width="374" height="828" rx="36" fill="#ffffff"/>
+
+    <!-- notch -->
+    <rect x="155" y="10" width="80" height="22" rx="11" fill="#0b1320"/>
+
+    <g transform="translate(8,40)">
+      <!-- Status bar -->
+      <text x="20" y="14" font-size="10" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif">9:41</text>
+      <text x="354" y="14" text-anchor="end" font-size="10" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif">100%</text>
+
+      <!-- App header -->
+      <g transform="translate(0,28)">
+        <rect width="374" height="56" fill="#ffffff"/>
+        <use href="#supawave-mark" x="16" y="10" width="32" height="32"/>
+        <text x="56" y="32" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+        <rect x="306" y="14" width="52" height="28" rx="14" fill="#22d3ee"/>
+        <text x="332" y="33" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">+ New</text>
+      </g>
+
+      <!-- Folder pill scroll (saved searches) -->
+      <g transform="translate(0,96)">
+        <rect x="12" y="0" width="62" height="32" rx="16" fill="#0b1320"/>
+        <text x="43" y="20" text-anchor="middle" font-size="12" font-weight="600" fill="#ffffff">Inbox</text>
+        <text x="63" y="20" text-anchor="middle" font-size="10" fill="rgba(255,255,255,0.62)" font-family="Geist, Inter, sans-serif"></text>
+        <rect x="80" y="0" width="84" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="118" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Mentions</text>
+        <circle cx="148" cy="10" r="4" fill="#7c3aed"/>
+        <rect x="170" y="0" width="68" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="200" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Tasks</text>
+        <rect x="218" y="6" width="20" height="20" rx="10" fill="rgba(251,146,60,0.22)"/>
+        <text x="228" y="20" text-anchor="middle" font-size="10" font-weight="700" fill="#7a3a06">5</text>
+        <rect x="244" y="0" width="62" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="275" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Public</text>
+        <rect x="312" y="0" width="60" height="32" rx="16" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="342" y="20" text-anchor="middle" font-size="12" fill="#0b1320">Pinned</text>
+      </g>
+
+      <!-- Filter chip row -->
+      <g transform="translate(12,140)">
+        <rect width="84" height="26" rx="13" fill="#0b1320"/>
+        <text x="42" y="17" text-anchor="middle" font-size="10" font-weight="600" fill="#ffffff">Unread only</text>
+        <rect x="92" y="0" width="92" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="138" y="17" text-anchor="middle" font-size="10" fill="#0b1320">Attachments</text>
+        <rect x="188" y="0" width="64" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="220" y="17" text-anchor="middle" font-size="10" fill="#0b1320">From me</text>
+        <rect x="256" y="0" width="62" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="287" y="17" text-anchor="middle" font-size="10" fill="#0b1320">Has task</text>
+      </g>
+
+      <line x1="12" y1="180" x2="362" y2="180" stroke="rgba(11,19,32,0.10)"/>
+
+      <text x="12" y="200" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">12 UNREAD WAVES</text>
+
+      <!-- Card 1 -->
+      <g transform="translate(12,210)">
+        <rect width="350" height="116" rx="12" fill="#ffffff" stroke="#22d3ee" stroke-width="1.5"/>
+        <circle cx="22" cy="22" r="14" fill="#22d3ee"/>
+        <text x="22" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <circle cx="38" cy="22" r="14" fill="#7c3aed"/>
+        <text x="38" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">SK</text>
+        <circle cx="54" cy="22" r="14" fill="#fb923c"/>
+        <text x="54" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+        <text x="80" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">5 participants</text>
+        <text x="280" y="20" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 min</text>
+        <text x="12" y="56" font-size="13" font-weight="700" fill="#0b1320">Robot streaming follow-up</text>
+        <text x="12" y="74" font-size="11" fill="rgba(11,19,32,0.62)">Sasha: I bumped the retry budget but we still see</text>
+        <text x="12" y="88" font-size="11" fill="rgba(11,19,32,0.62)">backoff after five consecutive 502s on prod-2.</text>
+        <rect x="12" y="98" width="40" height="18" rx="9" fill="rgba(34,211,238,0.18)"/>
+        <text x="32" y="111" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">3 new</text>
+        <text x="58" y="111" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">· 18 blips</text>
+        <circle cx="338" cy="14" r="5" fill="#22d3ee"/>
+      </g>
+
+      <!-- Card 2 -->
+      <g transform="translate(12,338)">
+        <rect width="350" height="100" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <circle cx="22" cy="22" r="14" fill="#7c3aed"/>
+        <text x="22" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">YZ</text>
+        <text x="44" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 participants</text>
+        <text x="280" y="20" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">14 min</text>
+        <text x="12" y="56" font-size="13" font-weight="700" fill="#0b1320">Lucene startup reuse — review</text>
+        <text x="12" y="74" font-size="11" fill="rgba(11,19,32,0.62)">Dan: design memo updated with the index-stamp invariant.</text>
+        <rect x="12" y="84" width="40" height="14" rx="7" fill="rgba(34,211,238,0.18)"/>
+        <text x="32" y="94" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">1 new</text>
+        <rect x="58" y="84" width="32" height="14" rx="7" fill="rgba(124,58,237,0.22)"/>
+        <text x="74" y="94" text-anchor="middle" font-size="9" font-weight="600" fill="#3a1280">@you</text>
+      </g>
+
+      <!-- Card 3 -->
+      <g transform="translate(12,450)">
+        <rect width="350" height="100" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <circle cx="22" cy="22" r="14" fill="#fb923c"/>
+        <text x="22" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+        <text x="44" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Marina R.</text>
+        <text x="280" y="20" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min</text>
+        <text x="12" y="56" font-size="13" font-weight="700" fill="#0b1320">Sprint 18 retro</text>
+        <text x="12" y="74" font-size="11" fill="rgba(11,19,32,0.62)">Tasks rolled forward. Two carryovers from F-3.</text>
+        <rect x="12" y="84" width="44" height="14" rx="7" fill="rgba(251,146,60,0.22)"/>
+        <text x="34" y="94" text-anchor="middle" font-size="9" font-weight="700" fill="#7a3a06">2 task</text>
+      </g>
+
+      <!-- Card 4 -->
+      <g transform="translate(12,562)" opacity="0.78">
+        <rect width="350" height="84" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <circle cx="22" cy="22" r="14" fill="#22d3ee"/>
+        <text x="22" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <text x="280" y="20" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hr</text>
+        <text x="44" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Anton T.</text>
+        <text x="12" y="56" font-size="13" font-weight="600" fill="#0b1320">Onboarding flow polish</text>
+        <text x="12" y="74" font-size="11" fill="rgba(11,19,32,0.62)">All read · 4 blips</text>
+      </g>
+
+      <!-- Card 5 -->
+      <g transform="translate(12,658)">
+        <rect width="350" height="84" rx="12" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <circle cx="22" cy="22" r="14" fill="#475569"/>
+        <text x="22" y="27" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">DK</text>
+        <text x="44" y="20" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Dan K.</text>
+        <text x="280" y="20" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">5 hr</text>
+        <text x="12" y="56" font-size="13" font-weight="700" fill="#0b1320">Grafana INP regression</text>
+        <text x="12" y="74" font-size="11" fill="rgba(11,19,32,0.62)">p75 INP +18% on j2cl-root since Tuesday.</text>
+      </g>
+    </g>
+
+    <!-- bottom tab bar -->
+    <g transform="translate(8,772)">
+      <rect width="374" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <g font-family="Geist, Inter, sans-serif" font-size="10" text-anchor="middle">
+        <g transform="translate(46,8)">
+          <rect width="56" height="40" rx="10" fill="rgba(34,211,238,0.18)"/>
+          <text x="28" y="18" font-size="14" fill="#0b1320">📥</text>
+          <text x="28" y="34" font-weight="700" fill="#0b1320">Inbox</text>
+        </g>
+        <g transform="translate(118,8)">
+          <text x="28" y="18" font-size="14" fill="#0b1320">@</text>
+          <text x="28" y="34" fill="rgba(11,19,32,0.62)">Mentions</text>
+        </g>
+        <g transform="translate(190,8)">
+          <text x="28" y="18" font-size="14" fill="#0b1320">✓</text>
+          <text x="28" y="34" fill="rgba(11,19,32,0.62)">Tasks</text>
+        </g>
+        <g transform="translate(262,8)">
+          <text x="28" y="18" font-size="14" fill="#0b1320">📌</text>
+          <text x="28" y="34" fill="rgba(11,19,32,0.62)">Pinned</text>
+        </g>
+      </g>
+    </g>
+  </g>
+
+  <text x="235" y="900" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Inbox · J-UI-1 / J-UI-2</text>
+
+  <!-- ============ RIGHT PHONE: Open wave ============ -->
+  <g transform="translate(470,40)" filter="url(#phone-shadow)">
+    <rect width="390" height="844" rx="44" fill="#0b1320"/>
+    <rect x="8" y="8" width="374" height="828" rx="36" fill="#ffffff"/>
+
+    <!-- notch -->
+    <rect x="155" y="10" width="80" height="22" rx="11" fill="#0b1320"/>
+
+    <g transform="translate(8,40)">
+      <text x="20" y="14" font-size="10" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif">9:41</text>
+      <text x="354" y="14" text-anchor="end" font-size="10" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif">100%</text>
+
+      <!-- back-to-inbox bar -->
+      <g transform="translate(0,28)">
+        <rect width="374" height="48" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="16" y="30" font-size="13" font-weight="700" fill="#0b1320">‹ Inbox</text>
+        <text x="187" y="30" text-anchor="middle" font-size="13" font-weight="700" fill="#0b1320">Wave</text>
+        <text x="358" y="30" text-anchor="end" font-size="14" fill="#0b1320">⋯</text>
+      </g>
+
+      <!-- wave header -->
+      <g transform="translate(16,84)">
+        <text x="0" y="14" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · 2 MIN AGO</text>
+        <text x="0" y="36" font-size="16" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Robot streaming follow-up — 4xx retries</text>
+        <g transform="translate(0,48)">
+          <circle cx="12" cy="12" r="12" fill="#22d3ee"/>
+          <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+          <circle cx="26" cy="12" r="12" fill="#7c3aed"/>
+          <text x="26" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">SK</text>
+          <circle cx="40" cy="12" r="12" fill="#fb923c"/>
+          <text x="40" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+          <circle cx="54" cy="12" r="12" fill="#475569"/>
+          <text x="54" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">DK</text>
+          <text x="76" y="16" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">+ Yuri · 5 total</text>
+        </g>
+
+        <!-- Action chips -->
+        <g transform="translate(0,86)">
+          <rect width="58" height="26" rx="13" fill="#0b1320"/>
+          <text x="29" y="17" text-anchor="middle" font-size="11" font-weight="600" fill="#ffffff">Reply</text>
+          <rect x="66" y="0" width="48" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+          <text x="90" y="17" text-anchor="middle" font-size="11" fill="#0b1320">Pin</text>
+          <rect x="122" y="0" width="62" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+          <text x="153" y="17" text-anchor="middle" font-size="11" fill="#0b1320">Archive</text>
+          <rect x="192" y="0" width="46" height="26" rx="13" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+          <text x="215" y="17" text-anchor="middle" font-size="11" fill="#0b1320">Tags</text>
+        </g>
+      </g>
+
+      <line x1="0" y1="220" x2="374" y2="220" stroke="rgba(11,19,32,0.10)"/>
+
+      <!-- Threaded blips -->
+      <g transform="translate(16,236)">
+        <!-- Root -->
+        <circle cx="14" cy="14" r="14" fill="#22d3ee"/>
+        <text x="14" y="18" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">AT</text>
+        <text x="36" y="14" font-size="12" font-weight="700" fill="#0b1320">Anton T.</text>
+        <text x="100" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hr</text>
+        <text x="36" y="32" font-size="12" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry</text>
+        <text x="36" y="48" font-size="12" fill="rgba(11,19,32,0.92)">budget after the F-3 cleanup?</text>
+
+        <!-- Reply 1 (indent) -->
+        <g transform="translate(20,72)" stroke="rgba(34,211,238,0.30)" stroke-width="2" fill="none">
+          <line x1="0" y1="-12" x2="0" y2="60"/>
+        </g>
+        <g transform="translate(28,68)">
+          <circle cx="12" cy="12" r="12" fill="#7c3aed"/>
+          <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">SK</text>
+          <text x="30" y="14" font-size="11" font-weight="700" fill="#0b1320">Sasha K.</text>
+          <text x="84" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">1 hr</text>
+          <text x="30" y="32" font-size="11" fill="rgba(11,19,32,0.92)">Budget is 3 retries. Outer fetch</text>
+          <text x="30" y="46" font-size="11" fill="rgba(11,19,32,0.92)">should not retry — ID please?</text>
+        </g>
+
+        <!-- Reply 2 (indent 2) WITH FOCUS -->
+        <g transform="translate(60,140)">
+          <rect x="-8" y="-6" width="280" height="64" rx="10" fill="#fafbfd" stroke="#22d3ee" stroke-width="2"/>
+          <circle cx="12" cy="12" r="12" fill="#fb923c"/>
+          <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+          <text x="30" y="14" font-size="11" font-weight="700" fill="#0b1320">Marina R.</text>
+          <text x="100" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min</text>
+          <text x="30" y="32" font-size="11" fill="rgba(11,19,32,0.92)">request-id 6f1a-7cc4: outer fetch</text>
+          <text x="30" y="46" font-size="11" fill="rgba(11,19,32,0.92)">retried twice + handler 3 = 5.</text>
+        </g>
+
+        <!-- Reply 3 -->
+        <g transform="translate(28,222)">
+          <text x="-22" y="14" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">▸</text>
+          <circle cx="12" cy="12" r="12" fill="#475569"/>
+          <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">DK</text>
+          <text x="30" y="14" font-size="11" font-weight="700" fill="#0b1320">Dan K.</text>
+          <rect x="78" y="2" width="38" height="14" rx="7" fill="#22d3ee"/>
+          <text x="97" y="13" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">NEW</text>
+          <text x="124" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 min</text>
+          <text x="30" y="32" font-size="11" fill="rgba(11,19,32,0.92)">Confirmed on staging-3 too. 3 collapsed.</text>
+        </g>
+
+        <!-- Task affordance summary -->
+        <g transform="translate(0,280)">
+          <rect width="342" height="44" rx="10" fill="rgba(251,146,60,0.16)" stroke="rgba(251,146,60,0.40)"/>
+          <rect x="6" y="6" width="32" height="32" rx="6" fill="rgba(251,146,60,0.22)"/>
+          <text x="22" y="27" text-anchor="middle" font-size="14" fill="#7a3a06">⚑</text>
+          <text x="46" y="20" font-size="11" font-weight="700" fill="#0b1320">1 task active in this wave</text>
+          <text x="46" y="34" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">@sasha · due Fri Apr 30</text>
+        </g>
+      </g>
+
+      <!-- floating "↓ 3 new" pill -->
+      <g transform="translate(106,648)">
+        <rect width="160" height="32" rx="16" fill="#22d3ee"/>
+        <text x="80" y="20" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">↓ 3 new blips below</text>
+      </g>
+
+      <!-- compose dock -->
+      <g transform="translate(0,704)">
+        <rect width="374" height="68" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <rect x="12" y="12" width="280" height="44" rx="22" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+        <text x="28" y="38" font-size="12" fill="rgba(11,19,32,0.55)">Reply to wave…</text>
+        <text x="270" y="38" font-size="13" fill="#0b1320">📎</text>
+        <rect x="304" y="12" width="56" height="44" rx="22" fill="#22d3ee"/>
+        <text x="332" y="40" text-anchor="middle" font-size="14" font-weight="700" fill="#0b1320">↑</text>
+      </g>
+    </g>
+  </g>
+
+  <text x="665" y="900" text-anchor="middle" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Open wave · J-UI-4 / J-UI-5 / J-UI-6</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/07-dark-mode-shell.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/07-dark-mode-shell.svg
@@ -1,0 +1,282 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">Dark mode shell — Wavy Firefly Signal default</title>
+  <desc id="desc">Same shell as #1 in the dark variant from j2cl/lit/src/design/wavy-tokens.css. Bg #0b1320, surface #11192a, hairline cyan border. Cyan, violet, amber accents preserved. Saved-search rail, filter chips, six digest cards, wave panel header.</desc>
+  <defs>
+    <filter id="dark-card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#000000" flood-opacity="0.40"/>
+    </filter>
+    <filter id="cyan-glow" x="-20%" y="-40%" width="140%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#22d3ee" flood-opacity="0.45"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#22d3ee" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <!-- bg-base -->
+  <rect width="1440" height="900" fill="#0b1320"/>
+
+  <!-- subtle aurora gradient for atmosphere -->
+  <defs>
+    <radialGradient id="aurora" cx="50%" cy="0%" r="80%">
+      <stop offset="0%" stop-color="rgba(124,58,237,0.18)"/>
+      <stop offset="60%" stop-color="rgba(11,19,32,0)"/>
+    </radialGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#aurora)"/>
+
+  <!-- Header -->
+  <g>
+    <rect x="0" y="0" width="1440" height="64" fill="#11192a" stroke="rgba(34,211,238,0.18)"/>
+    <use href="#supawave-mark" x="20" y="14" width="36" height="36"/>
+    <text x="64" y="40" font-size="20" font-weight="700" fill="rgba(232,240,255,0.92)" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+    <text x="64" y="54" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">J2CL · /?view=j2cl-root · DARK</text>
+
+    <!-- Search -->
+    <rect x="420" y="16" width="600" height="32" rx="16" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+    <circle cx="440" cy="32" r="6" fill="none" stroke="rgba(232,240,255,0.62)" stroke-width="1.5"/>
+    <line x1="445" y1="37" x2="450" y2="42" stroke="rgba(232,240,255,0.62)" stroke-width="1.5"/>
+    <text x="460" y="36" font-size="13" fill="rgba(232,240,255,0.62)">Search waves, blips, tags…</text>
+    <text x="990" y="35" font-size="11" font-family="Geist, Inter, sans-serif" fill="rgba(232,240,255,0.42)">⌘K</text>
+
+    <rect x="1248" y="16" width="84" height="32" rx="16" fill="#22d3ee" filter="url(#cyan-glow)"/>
+    <text x="1290" y="36" text-anchor="middle" font-size="13" font-weight="600" fill="#0b1320">+ New Wave</text>
+    <circle cx="1368" cy="32" r="16" fill="#7c3aed"/>
+    <text x="1368" y="37" text-anchor="middle" font-size="12" font-weight="700" fill="#ffffff">YZ</text>
+  </g>
+
+  <!-- Nav rail -->
+  <g transform="translate(0,64)">
+    <rect x="0" y="0" width="296" height="836" fill="#11192a" stroke="rgba(34,211,238,0.18)"/>
+
+    <text x="20" y="32" font-size="11" font-weight="600" fill="rgba(232,240,255,0.62)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">SAVED SEARCHES</text>
+
+    <!-- Inbox active with cyan rail -->
+    <rect x="12" y="44" width="272" height="40" rx="12" fill="rgba(34,211,238,0.22)"/>
+    <rect x="12" y="44" width="3" height="40" rx="2" fill="#22d3ee"/>
+    <text x="32" y="69" font-size="14" font-weight="600" fill="rgba(232,240,255,0.92)">Inbox</text>
+    <rect x="232" y="56" width="40" height="20" rx="10" fill="#22d3ee"/>
+    <text x="252" y="70" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">12</text>
+
+    <text x="32" y="113" font-size="14" fill="rgba(232,240,255,0.92)">Mentions</text>
+    <circle cx="262" cy="108" r="5" fill="#7c3aed">
+      <animate attributeName="r" values="4;6;4" dur="900ms" repeatCount="indefinite"/>
+    </circle>
+
+    <text x="32" y="153" font-size="14" fill="rgba(232,240,255,0.92)">Tasks</text>
+    <rect x="240" y="140" width="32" height="18" rx="9" fill="rgba(251,146,60,0.22)"/>
+    <text x="256" y="153" text-anchor="middle" font-size="11" font-weight="600" fill="#fb923c">5</text>
+
+    <text x="32" y="193" font-size="14" fill="rgba(232,240,255,0.92)">Public</text>
+    <text x="32" y="233" font-size="14" fill="rgba(232,240,255,0.92)">Archive</text>
+    <text x="32" y="273" font-size="14" fill="rgba(232,240,255,0.92)">Pinned</text>
+    <text x="32" y="306" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">+ Manage saved searches</text>
+
+    <line x1="20" y1="332" x2="276" y2="332" stroke="rgba(34,211,238,0.18)"/>
+    <text x="20" y="356" font-size="11" font-weight="600" fill="rgba(232,240,255,0.62)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">FILTERS</text>
+
+    <rect x="20" y="370" width="92" height="26" rx="13" fill="#22d3ee"/>
+    <text x="66" y="387" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">Unread only</text>
+    <rect x="118" y="370" width="106" height="26" rx="13" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+    <text x="171" y="387" text-anchor="middle" font-size="11" fill="rgba(232,240,255,0.92)">Attachments</text>
+    <rect x="20" y="404" width="78" height="26" rx="13" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+    <text x="59" y="421" text-anchor="middle" font-size="11" fill="rgba(232,240,255,0.92)">From me</text>
+    <rect x="104" y="404" width="74" height="26" rx="13" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+    <text x="141" y="421" text-anchor="middle" font-size="11" fill="rgba(232,240,255,0.92)">With @</text>
+    <rect x="184" y="404" width="84" height="26" rx="13" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+    <text x="226" y="421" text-anchor="middle" font-size="11" fill="rgba(232,240,255,0.92)">Has task</text>
+
+    <line x1="20" y1="450" x2="276" y2="450" stroke="rgba(34,211,238,0.18)"/>
+    <text x="20" y="476" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">Showing 12 unread waves in Inbox</text>
+  </g>
+
+  <!-- Search result panel -->
+  <g transform="translate(296,64)">
+    <rect x="0" y="0" width="448" height="836" fill="#11192a" stroke="rgba(34,211,238,0.18)"/>
+    <text x="24" y="36" font-size="16" font-weight="600" fill="rgba(232,240,255,0.92)" font-family="'Space Grotesk', Inter, sans-serif">Inbox</text>
+    <text x="24" y="54" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">in:inbox unread:true · 12 waves</text>
+
+    <!-- Card 1 selected with cyan glow -->
+    <g transform="translate(16,76)" filter="url(#cyan-glow)">
+      <rect width="416" height="120" rx="12" fill="rgba(34,211,238,0.08)" stroke="#22d3ee" stroke-width="2"/>
+    </g>
+    <g transform="translate(16,76)">
+      <g transform="translate(16,16)">
+        <circle cx="14" cy="14" r="14" fill="#22d3ee"/>
+        <text x="14" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">AT</text>
+        <circle cx="34" cy="14" r="14" fill="#7c3aed"/>
+        <text x="34" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">SK</text>
+        <circle cx="54" cy="14" r="14" fill="#fb923c"/>
+        <text x="54" y="19" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+        <circle cx="74" cy="14" r="14" fill="rgba(232,240,255,0.18)"/>
+        <text x="74" y="18" text-anchor="middle" font-size="10" font-weight="600" fill="rgba(232,240,255,0.92)">+2</text>
+      </g>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="rgba(232,240,255,0.92)">Robot streaming follow-up — 4xx retries</text>
+      <text x="124" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Sasha: I bumped the retry budget but we still see backoff after</text>
+      <text x="124" y="68" font-size="12" fill="rgba(232,240,255,0.62)">five consecutive 502s on the streaming endpoint. Anyone seeing</text>
+      <text x="124" y="84" font-size="12" fill="rgba(232,240,255,0.62)">this on prod-2 today?</text>
+      <g transform="translate(124,96)">
+        <rect width="44" height="20" rx="10" fill="#22d3ee"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">3 new</text>
+        <text x="56" y="14" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">· 18 blips</text>
+        <text x="280" y="14" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">2 min ago</text>
+      </g>
+      <circle cx="402" cy="20" r="6" fill="#22d3ee">
+        <animate attributeName="r" values="6;9;6" dur="900ms" repeatCount="indefinite"/>
+      </circle>
+    </g>
+
+    <!-- Card 2 -->
+    <g transform="translate(16,212)">
+      <rect width="416" height="100" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)" filter="url(#dark-card-shadow)"/>
+      <circle cx="30" cy="30" r="14" fill="#7c3aed"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">YZ</text>
+      <circle cx="50" cy="30" r="14" fill="#475569"/>
+      <text x="50" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">DK</text>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="rgba(232,240,255,0.92)">Lucene startup reuse — design review</text>
+      <text x="124" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Dan: design memo updated with the index-stamp invariant.</text>
+      <text x="124" y="68" font-size="12" fill="rgba(232,240,255,0.62)">Ready for a second pass when you have a window today.</text>
+      <g transform="translate(124,80)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.22)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#22d3ee">1 new</text>
+        <rect x="54" y="0" width="40" height="20" rx="10" fill="rgba(124,58,237,0.22)"/>
+        <text x="74" y="14" text-anchor="middle" font-size="11" font-weight="600" fill="#7c3aed">@you</text>
+        <text x="280" y="14" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">14 min ago</text>
+      </g>
+    </g>
+
+    <!-- Card 3 -->
+    <g transform="translate(16,328)">
+      <rect width="416" height="100" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)" filter="url(#dark-card-shadow)"/>
+      <circle cx="30" cy="30" r="14" fill="#fb923c"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">MR</text>
+      <text x="60" y="32" font-size="14" font-weight="700" fill="rgba(232,240,255,0.92)">Sprint 18 retro</text>
+      <text x="60" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Marina: tasks rolled forward. Two carryovers from F-3.</text>
+      <text x="60" y="68" font-size="12" fill="rgba(232,240,255,0.62)">Tagged Yuri and Sasha as owners.</text>
+      <g transform="translate(60,80)">
+        <rect width="44" height="20" rx="10" fill="rgba(251,146,60,0.22)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#fb923c">2 task</text>
+        <text x="56" y="14" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">· 6 blips</text>
+        <text x="280" y="14" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+      </g>
+    </g>
+
+    <!-- Card 4 read -->
+    <g transform="translate(16,444)" opacity="0.7">
+      <rect width="416" height="92" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <circle cx="30" cy="30" r="14" fill="#22d3ee"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">AT</text>
+      <text x="60" y="32" font-size="14" font-weight="600" fill="rgba(232,240,255,0.92)">Onboarding flow polish</text>
+      <text x="60" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Anton: pushed the welcome-wave copy. Final review tomorrow.</text>
+      <text x="60" y="80" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">4 blips · all read</text>
+      <text x="400" y="80" text-anchor="end" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">2 hours ago</text>
+    </g>
+
+    <!-- Card 5 -->
+    <g transform="translate(16,552)">
+      <rect width="416" height="92" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <circle cx="30" cy="30" r="14" fill="#7c3aed"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">YZ</text>
+      <circle cx="50" cy="30" r="14" fill="#22d3ee"/>
+      <text x="50" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">PK</text>
+      <text x="124" y="32" font-size="14" font-weight="700" fill="rgba(232,240,255,0.92)">J2CL parity matrix — gate review</text>
+      <text x="124" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Pavel: 4/26 gates green; need J-UI-1..8 closed before re-vote.</text>
+      <g transform="translate(124,68)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.22)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#22d3ee">5 new</text>
+      </g>
+    </g>
+
+    <!-- Card 6 -->
+    <g transform="translate(16,660)">
+      <rect width="416" height="92" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <circle cx="30" cy="30" r="14" fill="#475569"/>
+      <text x="30" y="35" text-anchor="middle" font-size="11" font-weight="700" fill="#ffffff">DK</text>
+      <text x="60" y="32" font-size="14" font-weight="700" fill="rgba(232,240,255,0.92)">Grafana INP regression</text>
+      <text x="60" y="52" font-size="12" fill="rgba(232,240,255,0.62)">Dan: p75 INP up 18% on /?view=j2cl-root since Tuesday's deploy.</text>
+      <g transform="translate(60,68)">
+        <rect width="44" height="20" rx="10" fill="rgba(34,211,238,0.22)"/>
+        <text x="22" y="14" text-anchor="middle" font-size="11" font-weight="700" fill="#22d3ee">2 new</text>
+      </g>
+    </g>
+
+    <!-- skeleton -->
+    <g transform="translate(16,768)" opacity="0.4">
+      <rect width="416" height="60" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <text x="208" y="36" text-anchor="middle" font-size="11" fill="rgba(232,240,255,0.62)" font-family="Geist, Inter, sans-serif">6 more waves below</text>
+    </g>
+  </g>
+
+  <!-- Wave panel -->
+  <g transform="translate(744,64)">
+    <rect x="0" y="0" width="696" height="836" fill="#11192a" stroke="rgba(34,211,238,0.18)"/>
+
+    <g transform="translate(24,24)">
+      <text x="0" y="20" font-size="11" fill="rgba(232,240,255,0.62)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · UPDATED 2 MIN AGO</text>
+      <text x="0" y="50" font-size="22" font-weight="700" fill="rgba(232,240,255,0.92)" font-family="'Space Grotesk', Inter, sans-serif">Robot streaming follow-up — 4xx retries</text>
+
+      <g transform="translate(0,68)">
+        <circle cx="12" cy="12" r="12" fill="#22d3ee"/>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <circle cx="30" cy="12" r="12" fill="#7c3aed"/>
+        <text x="30" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">SK</text>
+        <circle cx="48" cy="12" r="12" fill="#fb923c"/>
+        <text x="48" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">MR</text>
+        <circle cx="66" cy="12" r="12" fill="#475569"/>
+        <text x="66" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">DK</text>
+        <circle cx="84" cy="12" r="12" fill="#7c3aed"/>
+        <text x="84" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#ffffff">YZ</text>
+        <text x="106" y="16" font-size="12" fill="rgba(232,240,255,0.62)">5 participants</text>
+      </g>
+
+      <g transform="translate(0,108)">
+        <rect width="92" height="32" rx="16" fill="#22d3ee" filter="url(#cyan-glow)"/>
+        <text x="46" y="20" text-anchor="middle" font-size="12" font-weight="700" fill="#0b1320">Reply</text>
+        <rect x="100" y="0" width="76" height="32" rx="16" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+        <text x="138" y="20" text-anchor="middle" font-size="12" fill="rgba(232,240,255,0.92)">Pin</text>
+        <rect x="184" y="0" width="92" height="32" rx="16" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+        <text x="230" y="20" text-anchor="middle" font-size="12" fill="rgba(232,240,255,0.92)">Archive</text>
+        <rect x="284" y="0" width="100" height="32" rx="16" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+        <text x="334" y="20" text-anchor="middle" font-size="12" fill="rgba(232,240,255,0.92)">Mark read</text>
+        <rect x="392" y="0" width="60" height="32" rx="16" fill="transparent" stroke="rgba(34,211,238,0.18)"/>
+        <text x="422" y="20" text-anchor="middle" font-size="12" fill="rgba(232,240,255,0.92)">Tags</text>
+      </g>
+    </g>
+
+    <line x1="24" y1="200" x2="672" y2="200" stroke="rgba(34,211,238,0.18)"/>
+
+    <!-- Sample blip -->
+    <g transform="translate(24,224)">
+      <rect width="624" height="120" rx="12" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <circle cx="32" cy="32" r="16" fill="#22d3ee"/>
+      <text x="32" y="37" text-anchor="middle" font-size="12" font-weight="700" fill="#0b1320">AT</text>
+      <text x="60" y="32" font-size="13" font-weight="700" fill="rgba(232,240,255,0.92)">Anton T.</text>
+      <text x="120" y="32" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">2 hours ago · root</text>
+      <text x="60" y="56" font-size="13" fill="rgba(232,240,255,0.92)">Sasha — what's the actual retry budget after the F-3 cleanup? I'm</text>
+      <text x="60" y="74" font-size="13" fill="rgba(232,240,255,0.92)">seeing logs that look like we're doubling up between the streaming</text>
+      <text x="60" y="92" font-size="13" fill="rgba(232,240,255,0.92)">handler and the outer fetch. Repro is on prod-2 only.</text>
+    </g>
+
+    <text x="24" y="380" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">17 more blips · 2 collapsed sub-threads · 1 task active</text>
+
+    <!-- Reactions strip -->
+    <g transform="translate(24,420)">
+      <rect width="180" height="32" rx="16" fill="#0b1320" stroke="rgba(34,211,238,0.18)"/>
+      <text x="14" y="20" font-size="13">👀</text>
+      <text x="36" y="22" font-size="11" font-weight="700" fill="rgba(232,240,255,0.92)" font-family="Geist, Inter, sans-serif">3</text>
+      <text x="60" y="20" font-size="13">🚀</text>
+      <text x="82" y="22" font-size="11" font-weight="700" fill="rgba(232,240,255,0.92)" font-family="Geist, Inter, sans-serif">1</text>
+      <text x="106" y="20" font-size="13">+</text>
+    </g>
+
+    <!-- Floating scroll-to-new -->
+    <g transform="translate(484,750)">
+      <rect width="180" height="36" rx="18" fill="#22d3ee" filter="url(#cyan-glow)"/>
+      <text x="90" y="22" text-anchor="middle" font-size="12" font-weight="700" fill="#0b1320">↓ 3 new blips below</text>
+    </g>
+  </g>
+
+  <text x="20" y="884" font-size="11" fill="rgba(232,240,255,0.42)" font-family="Geist, Inter, sans-serif">Dark variant · matches j2cl/lit/src/design/wavy-tokens.css default · matrix R-3.5, R-4.5 · same components, theme via [data-wavy-theme="dark"]</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/08-server-first-paint.svg
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/08-server-first-paint.svg
@@ -1,0 +1,286 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc" font-family="Inter, -apple-system, 'Segoe UI', sans-serif">
+  <title id="title">J-UI-8 — Server-first paint of selected wave (before vs after JS upgrade)</title>
+  <desc id="desc">Diagram comparing two phases of /?view=j2cl-root&amp;wave=7c4a91. Left: HTML response from J2clSelectedWaveSnapshotRenderer rendered directly by the browser before any client JS boots — wave header, blip text, simple read-only DOM. Right: hydrated shell after Lit components upgrade — same DOM positions, now interactive with focus frame, toolbars, live activity. Annotation rail underneath shows network timeline and key invariants.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f7fb"/>
+      <stop offset="100%" stop-color="#eef1f7"/>
+    </linearGradient>
+    <filter id="card-shadow" x="-5%" y="-10%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="6" flood-color="#0b1320" flood-opacity="0.06"/>
+    </filter>
+    <symbol id="supawave-mark" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="24" fill="#0a4f82"/>
+      <path d="M8 28 Q14 16 20 28 Q24 36 28 28 Q34 16 40 28" stroke="#ffffff" stroke-width="4" stroke-linecap="round" fill="none"/>
+      <circle cx="24" cy="18" r="3.5" fill="#ffd166"/>
+    </symbol>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#bg)"/>
+
+  <!-- Top bar -->
+  <rect x="0" y="0" width="1440" height="56" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+  <use href="#supawave-mark" x="20" y="10" width="36" height="36"/>
+  <text x="64" y="34" font-size="18" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">SupaWave</text>
+  <text x="186" y="34" font-size="13" fill="rgba(11,19,32,0.62)">Server-first first-paint diagram · /?view=j2cl-root&amp;wave=7c4a91</text>
+
+  <!-- Section header -->
+  <text x="40" y="100" font-size="22" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Before JS boots → After upgrade</text>
+  <text x="40" y="124" font-size="13" fill="rgba(11,19,32,0.62)">J2clSelectedWaveSnapshotRenderer renders the visible region in the initial HTML; the shell upgrades in place — no "Select a wave" flash.</text>
+
+  <!-- ============ LEFT: BEFORE (server HTML) ============ -->
+  <g transform="translate(40,160)">
+    <text x="0" y="0" font-size="11" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">PHASE 1 · SERVER HTML · 0–80MS</text>
+    <rect x="0" y="16" width="640" height="500" rx="14" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+
+    <!-- Browser chrome -->
+    <g transform="translate(0,16)">
+      <rect width="640" height="32" rx="14" fill="#fafbfd"/>
+      <rect width="640" height="14" fill="#fafbfd"/>
+      <circle cx="14" cy="16" r="4" fill="#fb923c"/>
+      <circle cx="28" cy="16" r="4" fill="#22d3ee" opacity="0.6"/>
+      <circle cx="42" cy="16" r="4" fill="#7c3aed" opacity="0.6"/>
+      <rect x="60" y="6" width="560" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="74" y="20" font-size="10" font-family="ui-monospace, monospace" fill="rgba(11,19,32,0.62)">supawave.dev/?view=j2cl-root&amp;wave=7c4a91</text>
+    </g>
+
+    <!-- Server-rendered minimal shell -->
+    <g transform="translate(16,68)">
+      <!-- Static header -->
+      <rect width="608" height="40" rx="8" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <use href="#supawave-mark" x="8" y="8" width="24" height="24"/>
+      <text x="40" y="26" font-size="12" font-weight="700" fill="#0b1320">SupaWave</text>
+      <text x="120" y="26" font-size="11" fill="rgba(11,19,32,0.55)">Inbox › Robot streaming follow-up</text>
+
+      <!-- Static rail (read-only) -->
+      <rect x="0" y="52" width="160" height="408" rx="8" fill="#fafbfd" stroke="rgba(11,19,32,0.10)"/>
+      <text x="12" y="76" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">SAVED</text>
+      <rect x="6" y="84" width="148" height="28" rx="8" fill="rgba(34,211,238,0.18)"/>
+      <text x="16" y="102" font-size="11" font-weight="600" fill="#0b1320">Inbox</text>
+      <text x="16" y="130" font-size="11" fill="#0b1320">Mentions</text>
+      <text x="16" y="150" font-size="11" fill="#0b1320">Tasks</text>
+      <text x="16" y="170" font-size="11" fill="#0b1320">Public</text>
+      <text x="16" y="190" font-size="11" fill="#0b1320">Archive</text>
+      <text x="16" y="210" font-size="11" fill="#0b1320">Pinned</text>
+
+      <!-- Static wave panel (snapshot renderer output) -->
+      <rect x="172" y="52" width="436" height="408" rx="8" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="184" y="76" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · 5 PARTICIPANTS</text>
+      <text x="184" y="100" font-size="14" font-weight="700" fill="#0b1320">Robot streaming follow-up — 4xx retries</text>
+
+      <line x1="184" y1="116" x2="596" y2="116" stroke="rgba(11,19,32,0.10)"/>
+
+      <!-- snapshot blips -->
+      <g transform="translate(184,128)">
+        <circle cx="12" cy="12" r="12" fill="#22d3ee"/>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <text x="32" y="14" font-size="11" font-weight="700" fill="#0b1320">Anton T.</text>
+        <text x="92" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hr ago</text>
+        <text x="32" y="32" font-size="11" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry budget after the F-3</text>
+        <text x="32" y="46" font-size="11" fill="rgba(11,19,32,0.92)">cleanup? I'm seeing logs that look like we're doubling up.</text>
+      </g>
+
+      <g transform="translate(204,196)">
+        <circle cx="10" cy="10" r="10" fill="#7c3aed"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#ffffff">SK</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Sasha K.</text>
+        <text x="80" y="12" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">1 hr ago</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">Budget is 3 retries. Outer fetch should not retry — got an ID?</text>
+      </g>
+
+      <g transform="translate(224,250)">
+        <circle cx="10" cy="10" r="10" fill="#fb923c"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">MR</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Marina R.</text>
+        <text x="88" y="12" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">42 min ago</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">request-id 6f1a-7cc4: outer retried 2 + handler 3 = 5.</text>
+      </g>
+
+      <g transform="translate(204,304)">
+        <circle cx="10" cy="10" r="10" fill="#475569"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#ffffff">DK</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Dan K.</text>
+        <text x="76" y="12" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 min ago</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">Confirmed on staging-3 too. Bumping severity.</text>
+      </g>
+
+      <!-- noscript reply hint -->
+      <g transform="translate(184,372)">
+        <rect width="412" height="40" rx="8" fill="#fafbfd" stroke="rgba(11,19,32,0.10)" stroke-dasharray="4 4"/>
+        <text x="14" y="18" font-size="11" font-weight="600" fill="#0b1320">Reply form (noscript fallback)</text>
+        <text x="14" y="32" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Submits via POST /api/wavelet/7c4a91/blips · upgrades on JS boot</text>
+      </g>
+    </g>
+
+    <!-- callouts -->
+    <g transform="translate(0,484)">
+      <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.62)" font-family="Geist, Inter, sans-serif">Read-only DOM · no JS bundle yet · zero "Select a wave" flash</text>
+    </g>
+  </g>
+
+  <!-- arrow between -->
+  <g transform="translate(700,400)">
+    <line x1="0" y1="0" x2="40" y2="0" stroke="#22d3ee" stroke-width="3"/>
+    <polygon points="38,-6 50,0 38,6" fill="#22d3ee"/>
+    <text x="-10" y="-12" text-anchor="end" font-size="11" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif">JS boot</text>
+    <text x="-10" y="2" text-anchor="end" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">≈ 200ms</text>
+    <text x="-10" y="16" text-anchor="end" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">customElements upgrade</text>
+  </g>
+
+  <!-- ============ RIGHT: AFTER (hydrated) ============ -->
+  <g transform="translate(760,160)">
+    <text x="0" y="0" font-size="11" font-weight="600" fill="#0b1320" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">PHASE 2 · HYDRATED · 200MS+</text>
+    <rect x="0" y="16" width="640" height="500" rx="14" fill="#ffffff" stroke="#22d3ee" stroke-width="2" filter="url(#card-shadow)"/>
+
+    <!-- Browser chrome -->
+    <g transform="translate(0,16)">
+      <rect width="640" height="32" rx="14" fill="#fafbfd"/>
+      <rect width="640" height="14" fill="#fafbfd"/>
+      <circle cx="14" cy="16" r="4" fill="#fb923c"/>
+      <circle cx="28" cy="16" r="4" fill="#22d3ee" opacity="0.6"/>
+      <circle cx="42" cy="16" r="4" fill="#7c3aed" opacity="0.6"/>
+      <rect x="60" y="6" width="560" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="74" y="20" font-size="10" font-family="ui-monospace, monospace" fill="rgba(11,19,32,0.62)">supawave.dev/?view=j2cl-root&amp;wave=7c4a91</text>
+      <rect x="540" y="6" width="76" height="20" rx="10" fill="rgba(34,211,238,0.18)"/>
+      <text x="578" y="20" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320" font-family="Geist, Inter, sans-serif">UPGRADED</text>
+    </g>
+
+    <!-- Hydrated shell -->
+    <g transform="translate(16,68)">
+      <rect width="608" height="40" rx="8" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <use href="#supawave-mark" x="8" y="8" width="24" height="24"/>
+      <text x="40" y="26" font-size="12" font-weight="700" fill="#0b1320">SupaWave</text>
+      <rect x="500" y="6" width="100" height="28" rx="14" fill="#22d3ee"/>
+      <text x="550" y="25" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">+ New Wave</text>
+
+      <!-- Active rail with chips -->
+      <rect x="0" y="52" width="160" height="408" rx="8" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="12" y="76" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">SAVED</text>
+      <rect x="6" y="84" width="148" height="28" rx="8" fill="rgba(34,211,238,0.18)"/>
+      <rect x="6" y="84" width="3" height="28" rx="2" fill="#22d3ee"/>
+      <text x="16" y="102" font-size="11" font-weight="600" fill="#0b1320">Inbox</text>
+      <rect x="120" y="90" width="28" height="16" rx="8" fill="#22d3ee"/>
+      <text x="134" y="102" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">12</text>
+      <text x="16" y="130" font-size="11" fill="#0b1320">Mentions</text>
+      <circle cx="146" cy="125" r="4" fill="#7c3aed"/>
+      <text x="16" y="150" font-size="11" fill="#0b1320">Tasks</text>
+      <rect x="124" y="138" width="24" height="16" rx="8" fill="rgba(251,146,60,0.22)"/>
+      <text x="136" y="150" text-anchor="middle" font-size="9" font-weight="700" fill="#7a3a06">5</text>
+      <text x="16" y="170" font-size="11" fill="#0b1320">Public</text>
+      <text x="16" y="190" font-size="11" fill="#0b1320">Archive</text>
+      <text x="16" y="210" font-size="11" fill="#0b1320">Pinned</text>
+
+      <line x1="6" y1="232" x2="154" y2="232" stroke="rgba(11,19,32,0.10)"/>
+      <text x="12" y="252" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">FILTERS</text>
+      <rect x="6" y="262" width="68" height="20" rx="10" fill="#0b1320"/>
+      <text x="40" y="276" text-anchor="middle" font-size="10" font-weight="600" fill="#ffffff">Unread</text>
+      <rect x="80" y="262" width="74" height="20" rx="10" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="117" y="276" text-anchor="middle" font-size="10" fill="#0b1320">Has task</text>
+
+      <!-- Hydrated wave panel — same DOM positions, now interactive -->
+      <rect x="172" y="52" width="436" height="408" rx="8" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+      <text x="184" y="76" font-size="10" font-weight="600" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif" letter-spacing="0.08em">WAVE · 7c4a91 · 5 PARTICIPANTS</text>
+      <text x="184" y="100" font-size="14" font-weight="700" fill="#0b1320">Robot streaming follow-up — 4xx retries</text>
+
+      <!-- toolbar appears -->
+      <g transform="translate(184,108)">
+        <rect width="64" height="22" rx="11" fill="#0b1320"/>
+        <text x="32" y="15" text-anchor="middle" font-size="10" font-weight="600" fill="#ffffff">Reply</text>
+        <rect x="72" y="0" width="48" height="22" rx="11" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="96" y="15" text-anchor="middle" font-size="10" fill="#0b1320">Pin</text>
+        <rect x="128" y="0" width="64" height="22" rx="11" fill="#ffffff" stroke="rgba(11,19,32,0.10)"/>
+        <text x="160" y="15" text-anchor="middle" font-size="10" fill="#0b1320">Archive</text>
+      </g>
+
+      <line x1="184" y1="142" x2="596" y2="142" stroke="rgba(11,19,32,0.10)"/>
+
+      <!-- Same blips, but now interactive with focus frame on Marina -->
+      <g transform="translate(184,154)">
+        <circle cx="12" cy="12" r="12" fill="#22d3ee"/>
+        <text x="12" y="16" text-anchor="middle" font-size="10" font-weight="700" fill="#0b1320">AT</text>
+        <text x="32" y="14" font-size="11" font-weight="700" fill="#0b1320">Anton T.</text>
+        <text x="92" y="14" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">2 hr ago</text>
+        <text x="32" y="32" font-size="11" fill="rgba(11,19,32,0.92)">Sasha — what's the actual retry budget after the F-3</text>
+        <text x="32" y="46" font-size="11" fill="rgba(11,19,32,0.92)">cleanup?</text>
+      </g>
+
+      <g transform="translate(204,212)">
+        <circle cx="10" cy="10" r="10" fill="#7c3aed"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#ffffff">SK</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Sasha K.</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">Budget is 3 retries. Outer fetch should not retry.</text>
+      </g>
+
+      <!-- Focus frame -->
+      <g transform="translate(220,256)">
+        <rect x="-4" y="-6" width="380" height="44" rx="8" fill="#fafbfd" stroke="#22d3ee" stroke-width="2"/>
+        <circle cx="10" cy="10" r="10" fill="#fb923c"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">MR</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Marina R.</text>
+        <rect x="92" y="2" width="38" height="14" rx="7" fill="rgba(34,211,238,0.18)"/>
+        <text x="111" y="13" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">FOCUS</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">request-id 6f1a-7cc4: outer 2 + handler 3 = 5.</text>
+      </g>
+
+      <g transform="translate(204,310)">
+        <circle cx="10" cy="10" r="10" fill="#475569"/>
+        <text x="10" y="14" text-anchor="middle" font-size="9" font-weight="700" fill="#ffffff">DK</text>
+        <text x="28" y="12" font-size="11" font-weight="700" fill="#0b1320">Dan K.</text>
+        <rect x="74" y="2" width="36" height="14" rx="7" fill="#22d3ee"/>
+        <text x="92" y="13" text-anchor="middle" font-size="9" font-weight="700" fill="#0b1320">NEW</text>
+        <text x="28" y="28" font-size="11" fill="rgba(11,19,32,0.92)">Confirmed on staging-3 too. Bumping severity.</text>
+      </g>
+
+      <!-- Compose dock (now contenteditable) -->
+      <g transform="translate(184,372)">
+        <rect width="412" height="40" rx="8" fill="#fafbfd" stroke="#22d3ee" stroke-width="2"/>
+        <text x="14" y="18" font-size="11" font-weight="600" fill="#0b1320">Inline rich-text composer (contenteditable)</text>
+        <text x="14" y="32" font-size="10" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">Selection-driven format toolbar · ⌘↵ to send</text>
+        <rect x="356" y="8" width="48" height="24" rx="12" fill="#22d3ee"/>
+        <text x="380" y="23" text-anchor="middle" font-size="11" font-weight="700" fill="#0b1320">Send</text>
+      </g>
+    </g>
+
+    <g transform="translate(0,484)">
+      <text x="0" y="14" font-size="11" fill="rgba(11,19,32,0.62)" font-family="Geist, Inter, sans-serif">Live activity, focus frame, contenteditable composer · same DOM positions, no layout shift</text>
+    </g>
+  </g>
+
+  <!-- ============ TIMELINE / INVARIANTS RAIL ============ -->
+  <g transform="translate(40,684)">
+    <rect width="1360" height="180" rx="14" fill="#ffffff" stroke="rgba(11,19,32,0.10)" filter="url(#card-shadow)"/>
+    <text x="20" y="32" font-size="14" font-weight="700" fill="#0b1320" font-family="'Space Grotesk', Inter, sans-serif">Timeline &amp; invariants</text>
+
+    <!-- timeline -->
+    <g transform="translate(20,52)">
+      <line x1="0" y1="0" x2="1300" y2="0" stroke="rgba(11,19,32,0.10)"/>
+      <!-- ticks -->
+      <g font-family="Geist, Inter, sans-serif" font-size="10" fill="rgba(11,19,32,0.55)">
+        <line x1="0" y1="-4" x2="0" y2="4" stroke="rgba(11,19,32,0.55)"/>
+        <text x="0" y="22" text-anchor="middle">0ms</text>
+        <line x1="240" y1="-4" x2="240" y2="4" stroke="rgba(11,19,32,0.55)"/>
+        <text x="240" y="22" text-anchor="middle">80ms · server HTML reaches client</text>
+        <line x1="640" y1="-4" x2="640" y2="4" stroke="rgba(11,19,32,0.55)"/>
+        <text x="640" y="22" text-anchor="middle">160ms · J2clSelectedWaveSnapshotRenderer DOM visible</text>
+        <line x1="1000" y1="-4" x2="1000" y2="4" stroke="rgba(11,19,32,0.55)"/>
+        <text x="1000" y="22" text-anchor="middle">240ms · customElements upgrade · interactive</text>
+        <line x1="1300" y1="-4" x2="1300" y2="4" stroke="rgba(11,19,32,0.55)"/>
+        <text x="1300" y="22" text-anchor="middle">live updates online</text>
+      </g>
+
+      <!-- bands -->
+      <rect x="0" y="-10" width="640" height="6" rx="3" fill="#22d3ee" opacity="0.40"/>
+      <rect x="640" y="-10" width="660" height="6" rx="3" fill="#7c3aed" opacity="0.40"/>
+    </g>
+
+    <!-- invariants list -->
+    <g transform="translate(20,108)" font-size="12" font-family="Geist, Inter, sans-serif">
+      <text x="0" y="0" font-weight="700" fill="#0b1320">Acceptance · matrix R-6.1, R-6.3</text>
+      <text x="0" y="22" fill="rgba(11,19,32,0.92)">• Initial HTML response contains the wave snapshot · no "Select a wave" placeholder ever flashes for valid wave param</text>
+      <text x="0" y="42" fill="rgba(11,19,32,0.92)">• Hydration upgrades the same DOM nodes — no layout shift, scroll position preserved, focus state derivable from snapshot</text>
+      <text x="0" y="62" fill="rgba(11,19,32,0.92)">• &lt;noscript&gt; reply form posts to /api/wavelet/&lt;id&gt;/blips so the page is functional even with JS disabled</text>
+    </g>
+  </g>
+
+  <text x="40" y="884" font-size="11" fill="rgba(11,19,32,0.55)" font-family="Geist, Inter, sans-serif">J-UI-8 · matrix R-6.1, R-6.3 · components: J2clSelectedWaveSnapshotRenderer (server) → shell-root, shell-main-region, wave-blip (client) · SSR-then-upgrade</text>
+</svg>

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
@@ -1,0 +1,223 @@
+# J2CL Functional UI — Wavy Mockups
+
+Status: Draft, 2026-04-28
+Roadmap: [`../../specs/2026-04-28-j2cl-functional-ui-roadmap.md`](../../specs/2026-04-28-j2cl-functional-ui-roadmap.md)
+Audit basis: [`../../audits/2026-04-26-j2cl-gwt-parity-audit.md`](../../audits/2026-04-26-j2cl-gwt-parity-audit.md)
+Parity matrix: [`../../../j2cl-gwt-parity-matrix.md`](../../../j2cl-gwt-parity-matrix.md)
+
+## 1. Why these exist
+
+The 2026-04-26 audit verified that `/?view=j2cl-root` is a placeholder shell:
+4/26 matrix rows pass, the wave list does not render, blips appear as raw IDs,
+and the composer is detached from a non-rich textarea. The roadmap turns
+that into eight slice issues (J-UI-1..8). These mockups show, concretely, what
+each slice is meant to look like once it lands — using the exact terminology
+and component names already present in `j2cl/lit/src/`.
+
+The point of the set is to remove ambiguity for impl lanes: instead of
+"renders with a focus frame", the implementer sees the focus frame, the
+toolbar layout, the chip styles, and the DOM positions they have to hit.
+
+## 2. Index of surfaces
+
+| # | File | Slice | Matrix rows |
+| - | --- | --- | --- |
+| 01 | [`01-shell-inbox-with-waves.svg`](01-shell-inbox-with-waves.svg) | J-UI-1, J-UI-2 | R-3.5, R-4.5 |
+| 02 | [`02-open-wave-threaded-reading.svg`](02-open-wave-threaded-reading.svg) | J-UI-4 | R-3.1, R-3.2, R-3.3, R-3.6 |
+| 03 | [`03-inline-rich-text-composer.svg`](03-inline-rich-text-composer.svg) | J-UI-5 | R-5.1, R-5.2, R-5.7 |
+| 04 | [`04-task-toggle-and-done-state.svg`](04-task-toggle-and-done-state.svg) | J-UI-6 | R-5.4 |
+| 05 | [`05-new-wave-create-flow.svg`](05-new-wave-create-flow.svg) | J-UI-3 | R-5.1 |
+| 06 | [`06-mobile-inbox-and-wave.svg`](06-mobile-inbox-and-wave.svg) | J-UI-1, J-UI-4, J-UI-5, J-UI-6 (mobile) | R-3.5, R-4.5, R-5.1, R-5.4 |
+| 07 | [`07-dark-mode-shell.svg`](07-dark-mode-shell.svg) | J-UI-1 (dark variant) | R-3.5, R-4.5 |
+| 08 | [`08-server-first-paint.svg`](08-server-first-paint.svg) | J-UI-8 | R-6.1, R-6.3 |
+
+J-UI-7 ("mark-as-read + live unread decrement") is not its own dedicated
+mockup — it shows up in #01 as the cyan unread badge with the pulse-ring
+animation, and in #07 (dark) as the same badge against the dark surface. The
+visual contract is "badge count drops, ring pulses once on mutation, then
+the card de-emphasises" — calling that out in the slice issue is enough; a
+dedicated SVG would only repeat #01.
+
+## 3. Component mapping (what each mockup is implementable with)
+
+All component names below already exist in `j2cl/lit/src/`. The mockups
+are intentionally constrained to that set so the implementer never has to
+invent a component to ship a slice.
+
+### Shell skeleton
+- `shell-root` — top-level shell, owns route state and theme attribute
+- `shell-header` — top bar with logo, search, +New Wave, profile
+- `shell-nav-rail` / `wavy-search-rail` — left rail with saved searches and
+  filter strip
+- `shell-main-region` — the wave reading panel
+- `shell-status-strip` — bottom-of-rail status text (used in #01 dark/light)
+- `shell-skip-link` — implied by header but not visible in the mockups
+
+### Search rail
+- `wavy-search-rail` — saved-search folder list (Inbox/Mentions/Tasks/
+  Public/Archive/Pinned), filter strip, +Manage saved searches
+- `wavy-search-rail-card` — digest card: avatar stack (max 3 + overflow
+  chip), title, snippet, msg count, unread badge, relative timestamp
+- `wavy-search-help` — helper text on empty state (referenced by status
+  strip in #01)
+
+### Wave reading
+- `wave-blip` — author + timestamp + body, indented by depth
+- `wave-blip-toolbar` — per-blip toolbar (reply / edit / delete / link /
+  task)
+- `wavy-focus-frame` — cyan ring + glow shown on the focused blip in #02
+  and #06
+- `wavy-thread-collapse` (`wavy-thread-collapse.css`) — chevron + collapsed
+  count line ("3 collapsed replies")
+- `wavy-floating-scroll-to-new` — the cyan "↓ N new blips below" pill
+- `wavy-back-to-inbox` — mobile-only back button in #06
+- `wavy-depth-nav-bar` — breadcrumb under deep threads (latent, not all
+  mockups show it)
+
+### Composer
+- `composer-shell` — modal composer wrapper used by #05
+- `composer-inline-reply` — inline composer dropping into the thread at
+  the parent blip in #03
+- `wavy-composer` — shared contenteditable surface (replaces the legacy
+  textarea)
+- `wavy-format-toolbar` — selection-driven floating toolbar with bold /
+  italic / underline / strike / heading / list / alignment / link /
+  inline code
+- `composer-submit-affordance` — Send / Cancel pair in #03 and #05
+- `compose-attachment-picker` / `compose-attachment-card` — attachment row
+  in #05
+- `mention-suggestion-popover` — `@yuri` autocompletion in the participants
+  field of #05
+
+### Tasks, mentions, reactions
+- `wavy-task-affordance` — toggle button on the per-blip toolbar
+- `task-metadata-popover` — assignee / due / priority editor in #04
+- `reaction-row` / `reaction-picker-popover` / `reaction-authors-popover`
+  — reaction strip in the dark wave panel of #07
+
+### Misc
+- `wavy-confirm-dialog` — referenced by Delete in toolbar, not drawn
+- `wavy-link-modal` — referenced by 🔗 Link in toolbar, not drawn
+- `wavy-version-history` — referenced but out of scope
+- `wavy-profile-overlay` — referenced by header avatar, not drawn
+- `wavy-tags-row` — tags chips in the right info panel of #02
+
+### Server-side companion (J-UI-8)
+- `J2clSelectedWaveSnapshotRenderer` (Java, server) — produces the
+  pre-boot HTML in #08. Expected to share class names with the Lit shell
+  so customElements upgrade in place.
+
+## 4. Gap analysis
+
+Most of #01..#07 should be implementable with the components already in
+`j2cl/lit/src/elements/`. Gaps the mockups make explicit:
+
+1. **Wave list materialisation (J-UI-1)** — `wavy-search-rail-card` exists
+   but is not being instantiated for J2CL search results. Slice 1 wires
+   the search-result presenter to render the cards instead of the
+   `Showing search results for in:inbox.` text-only fallback.
+2. **Filter chip composition (J-UI-2)** — `wavy-search-rail` already owns
+   the chip strip; the gap is that the chip toggles do not affect the
+   query the search-result presenter consumes. Slice 2 closes that loop.
+3. **Threaded reading DOM (J-UI-4)** — `wave-blip` exists but in the lived
+   J2CL surface today the wave panel renders raw blip IDs. Slice 4 wires
+   the conversation-DOM walker through `shell-main-region` so each blip
+   becomes a `wave-blip` instance. The focus frame component
+   (`wavy-focus-frame`) is already there — it just needs the keyboard
+   presenter that moves it.
+4. **Inline contenteditable composer (J-UI-5)** — `wavy-composer` and
+   `wavy-format-toolbar` exist; today the composer is a `<textarea>`.
+   Slice 5 swaps to `composer-inline-reply` anchored to the focused blip,
+   wires the toolbar to selection events, and routes Send to the correct
+   parent blip.
+5. **Task DocOp round-trip (J-UI-6)** — `wavy-task-affordance` exists but
+   today the toggle is a UI flag that resets on reload. Slice 6 routes
+   the toggle through the wavelet's task DocOp so the state survives
+   reload and propagates to other clients.
+6. **Server-first first-paint (J-UI-8)** — `J2clSelectedWaveSnapshotRenderer`
+   is the named server-side seam. The mockup pins the contract:
+   pre-boot HTML must place the same DOM nodes (matching tag names and
+   IDs) that the customElements upgrade expects, so hydration is in-place
+   and there is no flash.
+7. **Dark-token coverage** — `wavy-tokens.css` already ships dark and
+   high-contrast variants. The dark mockup #07 reuses those tokens
+   verbatim and does not propose new ones. The page-level theme is
+   selected via `[data-wavy-theme="dark"]` on the shell-root scope or via
+   `prefers-color-scheme: dark`. No new design tokens are required for
+   this roadmap.
+
+## 5. Wavy aesthetic principles applied
+
+The Wavy "Firefly Signal" packet (Stitch project 15560635515125057401, asset
+6962139294633729409) is the source of truth — these mockups use it
+verbatim, never a re-interpretation:
+
+- **Colour.** Cyan `#22d3ee` is the primary signal — used for focus rings,
+  unread badges, primary action chips, +New Wave, and the cyan glow on
+  hydrated state. Violet `#7c3aed` carries identity (avatars, mention
+  dots, person chips). Amber `#fb923c` carries pending / task state.
+  Surface and text triads flip wholesale between light and dark; accents
+  do not flip.
+- **Typography.** Space Grotesk for display and headings (wave titles,
+  shell logo wordmark, section headers). Inter for body. Geist for
+  labels, meta, and keyboard-cap glyphs. Sizes follow `--wavy-type-*`:
+  display for the page-level wave title, h2/h3 for section titles, body
+  for blip text, label for chip text, meta for relative timestamps and
+  letter-spaced eyebrows.
+- **Spacing.** 4px base. Rail width 296px (= 8 × 37 ≈ tied to the 4px
+  rhythm with the saved-search row standardised to 40px). Card radius
+  `--wavy-radius-card: 12px`. Pill radius `--wavy-radius-pill` for chips.
+- **Motion.** Pulse ring on the just-mutated unread badge
+  (`--wavy-motion-pulse-duration` 600ms, `--wavy-easing-pulse`).
+  Focus-frame transitions at 180ms with `--wavy-easing-focus`. Thread
+  collapse at 240ms. Reduced-motion media query collapses all four to
+  ~0 — the SVGs use SMIL animations that the browser will skip when
+  `prefers-reduced-motion: reduce` is set.
+- **Hairline borders.** Cyan-alpha hairlines `rgba(34,211,238,0.18)` carry
+  the surface seams in dark; black-alpha `rgba(11,19,32,0.10)` in light.
+  Edges, not light, do the contrast work in the high-contrast variant.
+- **Glow vs flat.** Cyan glow filter is reserved for state-change moments
+  (just-pushed action, just-upgraded shell, just-arrived blip). Steady
+  state is flat fills + hairlines.
+
+## 6. Terminology guarantees
+
+Every visible string in the mockups uses the canonical terminology:
+
+- **Wave**, never "thread" / "conversation"
+- **Blip**, never "message" / "post"
+- **Inbox / Mentions / Tasks / Public / Archive / Pinned**, the canonical
+  six saved searches as defined in `wavy-search-rail.js`
+- **Reactions**, **Mentions**, **Tasks**, **Tags** at the wave level
+- **Mark read / Mark unread**, never "Mark seen"
+- **Pin** at the wave level (the "Pinned" folder is its destination)
+
+## 7. Out of scope
+
+- **Reactions add/remove flow** ships visible in #02 and #07 (reaction
+  strip) but the picker popover walkthrough is deferred — it lives behind
+  F-3 follow-ups #1073–#1076 and is not blocking "actually usable
+  interface" per roadmap §5.
+- **Mentions autocomplete** is shown in #05 (suggested chips below the
+  participants field) but the per-blip @-autocomplete popover is the
+  same mention-suggestion-popover and is not separately mocked.
+- **Attachments inline rendering** is shown as a single attachment card
+  in #05; the broader gallery / lightbox surface is a follow-up.
+- **Default-root cutover** (#923 / #924) is gated by the parity matrix
+  §8 vote and remains a separate decision after this roadmap closes.
+- **Visual latitude beyond the Wavy "Firefly Signal" packet** is
+  explicitly deferred — these mockups commit to the existing tokens
+  and do not introduce new design directions.
+
+## 8. Verifying the mockups locally
+
+```
+cd docs/superpowers/mockups/2026-04-28-j2cl-functional-ui
+python3 -m http.server 8080
+# open http://localhost:8080/01-shell-inbox-with-waves.svg ...
+```
+
+All eight files are pure SVG — no external assets, no JS, no fonts beyond
+the system stack listed in `wavy-tokens.css`. Browsers will fall back to
+Inter / system if Space Grotesk and Geist are not installed; the mockups
+remain readable.

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
@@ -40,7 +40,10 @@ dedicated SVG would only repeat #01.
 
 ## 3. Component mapping (what each mockup is implementable with)
 
-All component names below already exist in `j2cl/lit/src/`. The mockups
+All component names below already exist somewhere in `j2cl/` (most under
+`j2cl/lit/src/`; a couple of read-surface CSS classes live in
+`j2cl/src/main/webapp/assets/sidecar.css` and are applied by
+`j2cl/src/main/java/.../J2clReadSurfaceDomRenderer.java`). The mockups
 are intentionally constrained to that set so the implementer never has to
 invent a component to ship a slice.
 
@@ -67,9 +70,12 @@ invent a component to ship a slice.
   task)
 - `wavy-focus-frame` — cyan ring + glow shown on the focused blip in #02
   and #06
-- `wavy-thread-collapse.css` / `.j2cl-read-thread-toggle` /
-  `.j2cl-read-thread-collapsed` — chevron + collapsed count line
-  ("3 collapsed replies")
+- `j2cl/lit/src/design/wavy-thread-collapse.css` (Lit-side stylesheet,
+  defines the `.j2cl-read-thread-collapsed` rule) +
+  `j2cl/src/main/webapp/assets/sidecar.css` (defines
+  `.j2cl-read-thread-toggle`, applied by
+  `j2cl/src/main/java/.../J2clReadSurfaceDomRenderer.java`) — together
+  produce the chevron + collapsed count line ("3 collapsed replies")
 - `wavy-floating-scroll-to-new` — the cyan "↓ N new blips below" pill
 - `wavy-back-to-inbox` — mobile-only back button in #06
 - `wavy-depth-nav-bar` — breadcrumb under deep threads (latent, not all

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
@@ -1,7 +1,7 @@
 # J2CL Functional UI — Wavy Mockups
 
 Status: Draft, 2026-04-28
-Roadmap: `../../specs/2026-04-28-j2cl-functional-ui-roadmap.md` (document not yet added in this PR)
+Roadmap: `../../specs/2026-04-28-j2cl-functional-ui-roadmap.md` (reference-only — not included in this PR)
 Audit basis: [`../../audits/2026-04-26-j2cl-gwt-parity-audit.md`](../../audits/2026-04-26-j2cl-gwt-parity-audit.md)
 Parity matrix: [`../../../j2cl-gwt-parity-matrix.md`](../../../j2cl-gwt-parity-matrix.md)
 
@@ -172,7 +172,7 @@ verbatim, never a re-interpretation:
   (`--wavy-motion-pulse-duration` 600ms, `--wavy-easing-pulse`).
   Focus-frame transitions at 180ms with `--wavy-easing-focus`. Thread
   collapse at 240ms. In the product spec, reduced-motion handling
-  collapses all four to ~0; these mockup SVGs are illustrative and do
+  collapses all four to ~0; these mockups are illustrative and do
   not themselves guarantee that embedded SMIL animations will stop when
   `prefers-reduced-motion: reduce` is set.
 - **Hairline borders.** Cyan-alpha hairlines `rgba(34,211,238,0.18)` carry

--- a/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
+++ b/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md
@@ -1,7 +1,7 @@
 # J2CL Functional UI — Wavy Mockups
 
 Status: Draft, 2026-04-28
-Roadmap: [`../../specs/2026-04-28-j2cl-functional-ui-roadmap.md`](../../specs/2026-04-28-j2cl-functional-ui-roadmap.md)
+Roadmap: `../../specs/2026-04-28-j2cl-functional-ui-roadmap.md` (document not yet added in this PR)
 Audit basis: [`../../audits/2026-04-26-j2cl-gwt-parity-audit.md`](../../audits/2026-04-26-j2cl-gwt-parity-audit.md)
 Parity matrix: [`../../../j2cl-gwt-parity-matrix.md`](../../../j2cl-gwt-parity-matrix.md)
 
@@ -67,8 +67,9 @@ invent a component to ship a slice.
   task)
 - `wavy-focus-frame` — cyan ring + glow shown on the focused blip in #02
   and #06
-- `wavy-thread-collapse` (`wavy-thread-collapse.css`) — chevron + collapsed
-  count line ("3 collapsed replies")
+- `wavy-thread-collapse.css` / `.j2cl-read-thread-toggle` /
+  `.j2cl-read-thread-collapsed` — chevron + collapsed count line
+  ("3 collapsed replies")
 - `wavy-floating-scroll-to-new` — the cyan "↓ N new blips below" pill
 - `wavy-back-to-inbox` — mobile-only back button in #06
 - `wavy-depth-nav-bar` — breadcrumb under deep threads (latent, not all
@@ -170,8 +171,9 @@ verbatim, never a re-interpretation:
 - **Motion.** Pulse ring on the just-mutated unread badge
   (`--wavy-motion-pulse-duration` 600ms, `--wavy-easing-pulse`).
   Focus-frame transitions at 180ms with `--wavy-easing-focus`. Thread
-  collapse at 240ms. Reduced-motion media query collapses all four to
-  ~0 — the SVGs use SMIL animations that the browser will skip when
+  collapse at 240ms. In the product spec, reduced-motion handling
+  collapses all four to ~0; these mockup SVGs are illustrative and do
+  not themselves guarantee that embedded SMIL animations will stop when
   `prefers-reduced-motion: reduce` is set.
 - **Hairline borders.** Cyan-alpha hairlines `rgba(34,211,238,0.18)` carry
   the surface seams in dark; black-alpha `rgba(11,19,32,0.10)` in light.
@@ -211,7 +213,7 @@ Every visible string in the mockups uses the canonical terminology:
 
 ## 8. Verifying the mockups locally
 
-```
+```bash
 cd docs/superpowers/mockups/2026-04-28-j2cl-functional-ui
 python3 -m http.server 8080
 # open http://localhost:8080/01-shell-inbox-with-waves.svg ...

--- a/wave/config/changelog.d/2026-04-28-j2cl-functional-ui-mockups.json
+++ b/wave/config/changelog.d/2026-04-28-j2cl-functional-ui-mockups.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-28-j2cl-functional-ui-mockups",
+  "version": "PR #1087",
+  "date": "2026-04-28",
+  "title": "J2CL functional-UI Wavy mockups",
+  "summary": "Added eight Wavy-aesthetic SVG mockups plus a design memo grounding every slice of the J2CL functional-UI roadmap (J-UI-1..8) to the existing Lit components and Wavy Firefly Signal tokens.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/ with eight SVG surfaces covering shell+inbox, threaded reading, inline composer, task toggle states, new-wave flow, mobile, dark mode, and server-first paint",
+        "Added a design memo mapping each surface to its J-UI slice, parity-matrix rows, and existing Lit components in j2cl/lit/src/elements/ and j2cl/lit/src/design/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Eight Wavy-aesthetic SVG mockups + a design memo grounding every slice
of the J2CL functional-UI roadmap (parent tracker
[#904](https://github.com/vega113/supawave/issues/904), roadmap doc on
[`claude/sharp-williams-4f7a26`](https://github.com/vega113/supawave/blob/claude/sharp-williams-4f7a26/docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md)).

Each mockup uses:

- the Wavy "Firefly Signal" tokens already defined in
  [`j2cl/lit/src/design/wavy-tokens.css`](../blob/claude/j2cl-functional-ui-mockups/j2cl/lit/src/design/wavy-tokens.css)
  — no new colours / spacing / motion tokens are introduced
- canonical terminology (Wave, Blip, Inbox, Mentions, Tasks, Public,
  Archive, Pinned, Reactions) — never "thread", "message", "folder"
- the existing Lit component names from
  [`j2cl/lit/src/elements/`](../tree/claude/j2cl-functional-ui-mockups/j2cl/lit/src/elements)
  so each surface is implementable with what is already in the tree

## Surfaces

| # | File | Slice | Matrix rows |
| - | --- | --- | --- |
| 01 | [`01-shell-inbox-with-waves.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/01-shell-inbox-with-waves.svg) | J-UI-1, J-UI-2 | R-3.5, R-4.5 |
| 02 | [`02-open-wave-threaded-reading.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/02-open-wave-threaded-reading.svg) | J-UI-4 | R-3.1, R-3.2, R-3.3, R-3.6 |
| 03 | [`03-inline-rich-text-composer.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/03-inline-rich-text-composer.svg) | J-UI-5 | R-5.1, R-5.2, R-5.7 |
| 04 | [`04-task-toggle-and-done-state.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/04-task-toggle-and-done-state.svg) | J-UI-6 | R-5.4 |
| 05 | [`05-new-wave-create-flow.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/05-new-wave-create-flow.svg) | J-UI-3 | R-5.1 |
| 06 | [`06-mobile-inbox-and-wave.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/06-mobile-inbox-and-wave.svg) | J-UI-1/4/5/6 (mobile) | R-3.5, R-4.5, R-5.1, R-5.4 |
| 07 | [`07-dark-mode-shell.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/07-dark-mode-shell.svg) | J-UI-1 dark variant | R-3.5, R-4.5 |
| 08 | [`08-server-first-paint.svg`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/08-server-first-paint.svg) | J-UI-8 | R-6.1, R-6.3 |

J-UI-7 (mark-as-read / live unread decrement) is captured as the cyan
unread badge with pulse-ring animation in #01 and #07; the visual
contract is small enough not to warrant a dedicated SVG.

The design memo
([`README.md`](../blob/claude/j2cl-functional-ui-mockups/docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/README.md))
covers:

- per-mockup matrix-row + Lit-component mapping
- gap analysis (what each slice actually has to add vs. what already
  exists in `j2cl/lit/src/`)
- Wavy aesthetic principles (palette, type, spacing, motion) and
  terminology guarantees
- explicit out-of-scope: reactions picker walkthrough, mention
  autocomplete popover, attachment gallery, default-root cutover

## Why this PR

The 2026-04-26 parity audit verified that `/?view=j2cl-root` is a
shell skeleton: 4/26 matrix rows pass, the wave list does not render,
blips appear as raw IDs, and the composer is detached from a non-rich
textarea. Roadmap §2 calls for Wavy mockups in parallel with the
issue-creation lane so impl lanes do not have to translate prose into
pixels themselves.

## Test plan

- [x] `python3 -c "import xml.etree.ElementTree as ET; ET.parse(...)"` over each SVG (XML-valid)
- [x] `qlmanage -t -s 1000 -o ...` over each SVG renders correctly with no broken refs
- [x] Spot-checked rendered PNGs of #01, #02, #03, #04, #05, #06, #07, #08 — palette, terminology, focus frame, threaded indenting, format toolbar, task chip states all readable
- [x] All visible strings use canonical terminology (Wave / Blip / Inbox / Mentions / Tasks / Public / Archive / Pinned / Reactions)
- [x] No new design tokens introduced; everything maps to `wavy-tokens.css`
- [x] Component names in the memo all resolve to files under `j2cl/lit/src/elements/` or `j2cl/lit/src/design/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a draft README for the J2CL Functional UI “Wavy Mockups” SVG pack: links to roadmap/audit, indexes eight UI surfaces, maps mockups to J-UI slices (J-UI-1..8), provides per-slice gap analysis, defines Wavy visual principles and canonical terminology, lists out-of-scope flows, and includes local preview instructions.
* **Chores**
  * Added a release changelog entry documenting the new Wavy SVG mockups and their mapping to UI slices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->