### PR TITLE
J-UI-1: Wave list renders in the search rail

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-1-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-1-plan.md
@@ -1,0 +1,166 @@
+# J-UI-1 Plan — Wave list renders in the search rail
+
+Status: In progress
+Owner: claude/j2cl-ui-1
+Closes: #1079
+Refs umbrella #1078, parent #904
+Spec: [docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md §3.J-UI-1](../specs/2026-04-28-j2cl-functional-ui-roadmap.md)
+
+## 1. Goal
+
+When a signed-in user opens `/?view=j2cl-root&q=in:inbox`, the saved-search
+rail must populate one `<wavy-search-rail-card>` per digest in the search
+result. Clicking a card opens that wave and updates the URL such that the deep
+link round-trips across reload and browser back/forward.
+
+This satisfies J-UI-1 hard acceptance and the matrix rows it cites:
+
+- **R-3.5** (visible-region container — list level): the rail must render only
+  when result digests are present. The rail itself stays in the SSR'd light
+  DOM; per-digest cards are appended on first paint of search results.
+  Loading-state text continues to flow through the existing
+  `aria-live="polite"` result-count slot.
+- **R-4.5** (route/history integration): clicking a card updates the URL
+  (`?wave=<encoded id>` carried via the existing
+  `J2clSidecarRouteController`). Reload at the same URL re-hydrates selection
+  and focus lands on the now-selected card.
+
+## 2. Where the bug is today
+
+Audit fixture at `docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md`
+shows the rail loads the SSR chrome (folders, filters, result-count text) but
+no per-digest cards. The data path actually works:
+`J2clSearchPanelController.requestSearch` calls
+`J2clSearchResultProjector.project`, builds a list of
+`J2clSearchDigestItem`s, and hands them to `J2clSearchPanelView.render`. The
+view's `render` then walks the items into `J2clDigestView` plain-DOM buttons
+and appends them into the legacy `.sidecar-digests` div in the workflow card.
+
+The gap: the workflow card lives in the right column, not in the rail. The
+rail has no card slot wired to the controller; the rail's default slot is
+empty post-render.
+
+## 3. Approach
+
+Project search-result digest items as `<wavy-search-rail-card>` instances
+appended to the `<wavy-search-rail>` host (its default slot). Wire the rail's
+`wavy-search-rail-card-selected` event back into the controller's existing
+`onDigestSelected(waveId)` path so the URL/route work continues to flow
+through `J2clSidecarRouteController.selectWave`.
+
+Also wire the rail's emitted events into the controller so the rail's input
+box and saved-search folder buttons drive the same flow:
+
+- `wavy-search-submit` -> `controller.onQuerySubmitted`
+- `wavy-saved-search-selected` -> `controller.onQuerySubmitted` (using the
+  folder's `query` property from event detail)
+- `wavy-search-filter-toggled` -> `controller.onQuerySubmitted` (Lit element
+  already composes the query and emits `wavy-search-submit`, so this is
+  redundant — implement as a single listener for the submit event, the filter
+  emit is just a metric tap and is left for J-UI-2)
+- `wavy-search-refresh-requested` -> re-issue the current query
+
+Mirror result-count text to the rail's `result-count` attribute (which the
+rail reflects to the SSR'd `<p class="result-count">` slot pre-upgrade).
+
+### 3.1 Files to modify
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java`
+  — switch the digest projection target from the workflow card's
+  `.sidecar-digests` div to the `<wavy-search-rail>` element when the rail
+  cards path is enabled. Replace `J2clDigestView` plain-button construction
+  with a new `J2clSearchRailCardView` that creates `<wavy-search-rail-card>`
+  custom elements and exposes the same selection / live-unread API.
+  Bind to the rail's events (submit, saved-search-selected, refresh).
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchRailCardView.java`
+  — NEW. Mirrors the responsibilities of `J2clDigestView` but produces a
+  `<wavy-search-rail-card>` element with the appropriate attributes
+  (`data-wave-id`, `title`, `snippet`, `posted-at`, `posted-at-iso`,
+  `msg-count`, `unread-count`, `pinned`, `authors`). Click is dispatched via
+  the element's `wavy-search-rail-card-selected` event; selected state is
+  reflected via the existing `aria-current` pattern on the host
+  `<wavy-search-rail-card>` for now (keeps focus styling consistent with the
+  card's hover/focus selectors).
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java`
+  — emit a `data-rail-cards-enabled="true"` attribute on `<wavy-search-rail>`
+  when the new flag is enabled for the viewer. The view consults this
+  attribute on construction. NO change to the SSR chrome — it stays the same
+  six folders, filter chips, result-count slot.
+- `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java`
+  — register `j2cl-search-rail-cards` (default OFF in prod).
+- `j2cl/lit/src/elements/wavy-search-rail-card.js` — surface a relative
+  timestamp helper so the controller doesn't need to format dates in Java.
+  (Optional polish — defer if not blocked.)
+
+### 3.2 DocOp / data-path changes
+
+None. The slice is presentation-only; it consumes the existing
+`SidecarSearchResponse.Digest` projection.
+
+### 3.3 Feature flag
+
+`j2cl-search-rail-cards`
+- description: "Render J2CL search digests as <wavy-search-rail-card> elements
+  inside <wavy-search-rail> instead of the legacy plain-DOM digest list."
+- default: OFF in prod. Local-dev seed: ON for `admin@wavelylabs.com` so the
+  demo flow exercises the new path without operator action.
+
+When the flag is ON the new rendering path is the only path. Per project rule
+"no legacy fallbacks for flagged features", the new path must not silently
+degrade to the legacy `J2clDigestView` if a card construction fails — surface
+the error via `setStatus(error=true)` instead.
+
+When OFF, the legacy `J2clDigestView` path stays in place unchanged. After
+J-UI-1 ships and bakes, a follow-up issue will retire the OFF branch.
+
+### 3.4 Test plan
+
+- **Java unit**: `J2clSearchPanelViewTest` (new, in
+  `j2cl/src/test/java/.../search/`) verifies that when the SSR'd
+  `<wavy-search-rail>` carries `data-rail-cards-enabled="true"`, calling
+  `view.render(model)` appends one `<wavy-search-rail-card>` per digest as
+  children of the rail with the expected attributes; firing a
+  `wavy-search-rail-card-selected` event on a card invokes
+  `listener.onDigestSelected(waveId)`. A second test verifies the legacy path
+  remains unchanged when the attribute is absent.
+- **Lit unit**: existing `j2cl/lit/test/wavy-search-rail.test.js` already
+  pins the rail's slot rendering. Add one new `it()` covering "rail accepts
+  injected `<wavy-search-rail-card>` children and routes their click events
+  to the document".
+- **Jakarta integration**: extend `J2clSearchRailParityTest` with a fixture
+  that mounts `?view=j2cl-root&q=in:inbox` with the flag enabled and asserts
+  the SSR carries `data-rail-cards-enabled="true"` on `<wavy-search-rail>`.
+  (Card injection is client-side, so we don't assert it in SSR.)
+- **Browser harness**: add
+  `j2cl/lit/test/search-rail-card-injection.test.js` which mounts the rail,
+  injects three `<wavy-search-rail-card>` children, fires a click on the
+  middle one, and asserts the route listener receives the matching waveId.
+- **Local server**: register a fresh user, send self a wave (or seed via a
+  second account), open `/?view=j2cl-root&q=in:inbox`, confirm cards visible
+  with avatar/title/snippet/count/timestamp, click one, confirm URL updates
+  and wave region opens, reload — selection persists. GWT path under
+  `?view=gwt` unaffected.
+
+### 3.5 Roll-back path
+
+Disable `j2cl-search-rail-cards` via `scripts/feature-flag.sh disable
+j2cl-search-rail-cards`. The legacy `J2clDigestView` path resumes immediately
+on next page load. No data migration is required.
+
+## 4. Sequencing
+
+1. Plan committed and reviewed (this doc).
+2. Add the flag + SSR attribute plumbing.
+3. Add `J2clSearchRailCardView` + view-level switch in `J2clSearchPanelView`.
+4. Wire rail-emitted events into the controller listener interface.
+5. Tests (Java + Lit + Jakarta integration).
+6. Local-server QA — register fresh user, exercise slice, screenshot.
+7. Open PR. PR monitor pane opens.
+
+## 5. Out of scope
+
+- Folder / filter chip switching — that is J-UI-2.
+- New-Wave create flow — that is J-UI-3.
+- Threaded reading view inside the opened wave — that is J-UI-4.
+- Per-blip task toggle — that is J-UI-6.
+- Server-first first-paint of selected wave — that is J-UI-8.

--- a/docs/superpowers/plans/2026-04-28-j-ui-1-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-1-plan.md
@@ -157,7 +157,54 @@ on next page load. No data migration is required.
 6. Local-server QA — register fresh user, exercise slice, screenshot.
 7. Open PR. PR monitor pane opens.
 
-## 5. Out of scope
+## 5. Plan-review revisions (2026-04-28)
+
+Copilot review (claude-opus-4.7) raised twelve points; resolutions:
+
+- **Rail has no `<slot>`.** Confirmed — `wavy-search-rail.js` `render()` does
+  not include a `<slot>` element, so light-DOM children of
+  `<wavy-search-rail>` would be hidden by the shadow DOM. RESOLUTION: add a
+  `<slot name="cards"></slot>` to the rail's render output, positioned
+  between `.folders` (saved-search list) and `details.filters`. The slot
+  name is explicit so SSR can carry `slot="cards"` on injected children if
+  needed. Default-slot fallback is also acceptable, but a named slot keeps
+  the layout explicit.
+- **Card has no `selected` / `aria-current` property.** Confirmed —
+  `wavy-search-rail-card.js` declares only `waveId`, `title`, `snippet`,
+  `postedAt`, `postedAtIso`, `msgCount`, `unreadCount`, `pinned`, `authors`.
+  RESOLUTION: add a `selected: { type: Boolean, reflect: true }` property
+  and reflect `aria-current="true"` on the inner `<article>` when set.
+- **Per-viewer flag plumbing path.** Use the same pattern existing flag
+  emissions follow in `HtmlRenderer`: read via `featureFlagService.isEnabled
+  ("j2cl-search-rail-cards", viewerAddress)` and emit
+  `data-rail-cards-enabled="true"` on the `<wavy-search-rail>` opening tag.
+- **`wavy-search-submit` source.** Verified — emitted by `_onQueryKey` on
+  Enter (line 327) and by `_toggleFilter` (line 376). The new view will
+  bind a single document-level listener for the event.
+- **Idempotent re-render.** `J2clSearchPanelView.render` will clear prior
+  `<wavy-search-rail-card>` children of the rail before appending new ones,
+  matching the existing `digestList.innerHTML = ""` clear that runs for
+  the legacy path.
+- **Empty-state copy.** When the search returns zero digests, the rail
+  receives no cards; the existing `result-count` aria-live slot continues
+  to surface "No waves matched this query." via `setStatus`. Out of scope:
+  a dedicated empty-state illustration inside the rail.
+- **Keyboard nav between cards.** Out of scope for J-UI-1 — defer to a
+  future polish issue (no matrix row demands it for the list slice).
+- **`J2clSearchRailParityTest`.** Confirmed exists at
+  `wave/src/jakarta-test/java/.../J2clSearchRailParityTest.java`. Will
+  extend, not create.
+- **`setStatus(error=true)` on per-card construction failure.** Add unit
+  test covering this branch.
+- **Selection persistence on reload.** The rail card's new `selected`
+  property is set inside `J2clSearchPanelView.setSelectedWaveId` on every
+  call, including the post-render call from the controller's success path.
+- **`posted-at` / `posted-at-iso`.** Both declared (lines 47-48 of
+  `wavy-search-rail-card.js`). Confirmed.
+- **`resultCount` reflection pre-upgrade.** Drop the duplicate plumbing —
+  the rail already reflects the property to its rendered slot.
+
+## 6. Out of scope
 
 - Folder / filter chip switching — that is J-UI-2.
 - New-Wave create flow — that is J-UI-3.

--- a/docs/superpowers/screenshots/j-ui-1/local-verification.md
+++ b/docs/superpowers/screenshots/j-ui-1/local-verification.md
@@ -1,0 +1,74 @@
+# J-UI-1 local-server verification
+
+Date: 2026-04-28
+Branch: claude/j2cl-ui-1
+Server: dev mode, `sbt 'set ThisBuild / skipGwt := true' run` on `127.0.0.1:9898`
+User: fresh registration `qa1@local.net` / password `secret123` (admin by virtue of
+being the first registered account on a clean memory store).
+
+## Steps performed
+
+1. Built `j2clProductionBuild` and `j2clLitBuild`.
+2. Started server with skipGwt=true (J2CL surface only).
+3. Registered fresh user via `/auth/register` → `qa1@local.net`.
+4. Signed in via `/auth/signin`.
+5. Enabled `j2cl-search-rail-cards` flag globally via `POST /admin/flags`.
+6. Navigated to `/?view=j2cl-root&q=in:inbox`.
+7. Inspected DOM via JS console.
+8. Clicked the rendered card to verify route update.
+
+## Results
+
+### SSR carries the flag attribute (flag ON)
+
+```html
+<wavy-search-rail query="in:inbox" data-active-folder="inbox" result-count=""
+                  data-rail-cards-enabled="true">
+```
+
+Reciprocal: with the flag OFF the attribute is absent (default render path
+verified pre-flag-flip).
+
+### Cards project as wavy-search-rail-card direct children
+
+```json
+{
+  "railFound": true,
+  "railCardsAttr": "true",
+  "cardCount": 1,
+  "cardWaveIds": ["local.net/w+1f4vogi825404A"],
+  "cardTitles": ["Welcome to SupaWave"],
+  "workflowDigests": 0,
+  "statusText": "Showing 1 result(s) for in:inbox."
+}
+```
+
+`workflowDigests: 0` confirms the legacy `J2clDigestView` path does NOT also
+render — there is no double rendering. The card is the only digest surface
+when the flag is on.
+
+### R-4.5: clicking the card routes the URL
+
+After clicking the card's inner `<article>`:
+
+```
+location.href -> http://127.0.0.1:9898/?view=j2cl-root&q=in%3Ainbox&wave=local.net%2Fw%2B1f4vogi825404A
+```
+
+The `wave=` parameter was appended; reload at this URL re-hydrates the
+selection (round-trip verified).
+
+### GWT path unaffected
+
+```
+GET /?view=gwt → 200, no <wavy-search-rail or data-rail-cards-enabled markers
+in the body (grep -c returned 0).
+```
+
+### Visual reference
+
+`local-render-flag-on.png` (also saved as the screenshot in the PR body):
+shows the rail with the "Welcome to SupaWave" wavy-search-rail-card mounted
+inside it — avatar (`QA`), title, snippet, msg-count badge (6), unread badge
+(8 cyan), timestamp ("2m ago"), and the right-side "Select a wave" empty
+state since no wave is open yet.

--- a/docs/superpowers/screenshots/j-ui-1/local-verification.md
+++ b/docs/superpowers/screenshots/j-ui-1/local-verification.md
@@ -51,7 +51,7 @@ when the flag is on.
 
 After clicking the card's inner `<article>`:
 
-```
+```text
 location.href -> http://127.0.0.1:9898/?view=j2cl-root&q=in%3Ainbox&wave=local.net%2Fw%2B1f4vogi825404A
 ```
 
@@ -60,7 +60,7 @@ selection (round-trip verified).
 
 ### GWT path unaffected
 
-```
+```text
 GET /?view=gwt → 200, no <wavy-search-rail or data-rail-cards-enabled markers
 in the body (grep -c returned 0).
 ```

--- a/docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md
+++ b/docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md
@@ -1,0 +1,137 @@
+# J2CL Functional UI Roadmap (2026-04-28)
+
+Status: Active
+Owner: J2CL parity sprint
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Audit basis: [`docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md`](../audits/2026-04-26-j2cl-gwt-parity-audit.md)
+Parity matrix: [`docs/j2cl-gwt-parity-matrix.md`](../../j2cl-gwt-parity-matrix.md)
+
+## 1. Why this exists
+
+The 2026-04-26 audit verified that despite F-0..F-4 closing in GitHub, the lived
+J2CL surface at `/?view=j2cl-root` is not usable: 4/26 matrix gate rows pass,
+the wave list does not render, blips appear as raw IDs, and the composer is
+detached from a non-rich textarea. The user-visible state is a `Select a wave`
+placeholder with no clickable digest cards.
+
+This roadmap drives the J2CL UI from "shell skeleton" to "actually usable as a
+SupaWave client." It is intentionally framed in user-action terms (list waves,
+filter, open, edit, mark done) rather than architecture, because the prior
+chain over-indexed on architecture and shipped placeholders.
+
+## 2. Deliverables
+
+| Phase | Deliverable | Lane |
+| --- | --- | --- |
+| 1 | Wavy mockups for the J2CL functional UI (SVG) | docs PR |
+| 2 | Umbrella issue + 8 slice issues filed against #904 | issue-creation lane |
+| 3 | One PR per slice issue, each with local-server verification | per-slice impl lane |
+
+Mockups must use the SupaWave wordmark/logo, real terminology (Wave, Blip,
+Inbox/Mentions/Tasks/Public/Archive/Pinned), and reflect the current J2CL Lit
+shell components (`shell-root`, `wavy-search-rail`, `wavy-search-rail-card`,
+`shell-main-region`). Surfaces to mock: shell layout, threaded reading view,
+inline rich-text composer, mobile, dark mode.
+
+## 3. Issue list
+
+Each issue cites specific matrix rows as hard acceptance — no
+"practical parity" escape hatches.
+
+### J-UI-1. Wave list renders in the search rail
+- **User story**: I open `/?view=j2cl-root&q=in:inbox`; the rail shows my waves
+  as digest cards (avatar, title, snippet, count, timestamp). Clicking opens
+  the wave.
+- **Acceptance**: J2CL search digest results materialize as
+  `<wavy-search-rail-card>` instances inside `<wavy-search-rail>`; selection
+  routes URL state and opens the wave region.
+- **Matrix rows**: R-3.5 (visible-region container — list level), R-4.5 (route
+  integration).
+- **Bug evidence**: screenshot on `?view=j2cl-root&q=in:inbox` — `Showing
+  search results for in:inbox.` text rendered, zero cards visible.
+
+### J-UI-2. Folder + filter chip switching is functional
+- **User story**: I click `Mentions`, `Tasks`, `Public`, `Archive`, `Pinned`,
+  or any filter chip (`Unread only`, `With attachments`, `From me`); the rail
+  re-queries and updates.
+- **Acceptance**: Each saved-search button issues the corresponding query and
+  the rail repopulates; filter chips compose with the active folder; URL
+  reflects the active query.
+- **Matrix rows**: R-4.5.
+
+### J-UI-3. New Wave create flow
+- **User story**: I click `New Wave`, type a title and message, the wave is
+  created on the server, lands at the top of Inbox, and opens in the wave
+  panel.
+- **Acceptance**: End-to-end create flow exercising the J2CL write path; new
+  wave digest appears in the rail without page reload.
+- **Matrix rows**: R-5.1 (compose flow).
+
+### J-UI-4. Open-wave threaded reading view
+- **User story**: I open a wave; blips render with author avatar, name,
+  relative timestamp, and threaded indenting. I navigate with arrow keys / `j`
+  / `k` and a focus frame moves. Threads collapse and expand.
+- **Acceptance**: Conversation DOM (not raw blip IDs) for every blip;
+  `FocusFramePresenter`-equivalent visible focus; collapse toggle wired.
+- **Matrix rows**: R-3.1, R-3.2, R-3.3, R-3.6.
+
+### J-UI-5. Inline rich-text composer + working toolbar
+- **User story**: I click reply on a blip; an inline contenteditable composer
+  opens at that position. Toolbar buttons (bold, italic, link, list, heading,
+  alignment) toggle on selection and apply to the active range.
+- **Acceptance**: Composer is contenteditable, not `<textarea>`; toolbar is
+  selection-driven; replies submit to the correct parent blip.
+- **Matrix rows**: R-5.1, R-5.2, R-5.7.
+
+### J-UI-6. Per-blip task toggle + done state
+- **User story**: I click the task affordance on a blip; the blip becomes a
+  task. I click "done"; the task is marked complete and the visual state
+  reflects it. Reload preserves the state.
+- **Acceptance**: Task toggle is wired to the task DocOp; done state renders
+  with strikethrough/checkmark and persists across reload.
+- **Matrix rows**: R-5.4.
+
+### J-UI-7. Mark-as-read + live unread decrement
+- **User story**: I open a wave; its unread count drops to zero in the rail
+  digest. Other clients reflect the change.
+- **Acceptance**: Per-user read state mutates on open; rail digest re-renders
+  count and badge styling; live updates from other clients apply.
+- **Matrix rows**: R-4.4.
+
+### J-UI-8. Server-first first-paint of selected wave
+- **User story**: I refresh on `?wave=<id>`; the visible region is readable
+  before client JS boots.
+- **Acceptance**: `J2clSelectedWaveSnapshotRenderer` output present in the
+  initial HTML response and visible (no `Select a wave` flash); shell upgrades
+  in place.
+- **Matrix rows**: R-6.1, R-6.3.
+
+## 4. Sequencing
+
+Phases 1 and 2 run in parallel. Phase 3 sequencing inside the impl lanes:
+
+1. J-UI-1 (unblocks visible feedback for everything else)
+2. J-UI-2 (small follow-up to J-UI-1)
+3. J-UI-4 (read surface — required by J-UI-5 and J-UI-6)
+4. J-UI-5 (composer)
+5. J-UI-7 (live state — small)
+6. J-UI-6 (tasks — depends on per-blip rendering)
+7. J-UI-3 (write path) — can run in parallel with 4–6
+8. J-UI-8 (server-first paint) — last, decorator on top of everything else
+
+## 5. Out of scope
+
+- Reactions, mentions autocomplete, attachments inline rendering — these are
+  follow-ups already filed under F-3 follow-up issues (#1073–#1076). They are
+  not blockers for "actually usable interface."
+- Default-root cutover (#923/#924) — gated by the parity matrix §8 gate; this
+  roadmap brings J-UI parity to the level needed to revisit that gate, but
+  cutover itself remains a separate decision.
+- Visual latitude beyond the Wavy mockup set is deferred to future iterations.
+
+## 6. Workflow per slice
+
+Each slice issue follows the standing full-drill workflow:
+plan → review → implement → review → QA on local server → flag → changelog →
+PR. Each PR receives a `wave-pr-monitor` pane that stays alive until the PR is
+merged with all conversations resolved.

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -48,7 +48,13 @@ export class WavySearchRailCard extends LitElement {
     msgCount: { type: Number, attribute: "msg-count" },
     unreadCount: { type: Number, attribute: "unread-count" },
     pinned: { type: Boolean, reflect: true },
-    authors: { type: String }
+    authors: { type: String },
+    /**
+     * J-UI-1 (#1079, R-4.5): selected card reflects aria-current="true" on
+     * its inner <article>; the host also reflects `selected` so callers
+     * can target `wavy-search-rail-card[selected]` from CSS or queries.
+     */
+    selected: { type: Boolean, reflect: true }
   };
 
   static styles = css`
@@ -68,6 +74,10 @@ export class WavySearchRailCard extends LitElement {
     :host(:hover),
     :host(:focus-within) {
       border-color: var(--wavy-signal-cyan, #22d3ee);
+    }
+    :host([selected]) {
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+      background: rgba(34, 211, 238, 0.08);
     }
     .top {
       display: flex;
@@ -166,6 +176,7 @@ export class WavySearchRailCard extends LitElement {
     this.unreadCount = 0;
     this.pinned = false;
     this.authors = "";
+    this.selected = false;
   }
 
   firePulse() {
@@ -223,6 +234,7 @@ export class WavySearchRailCard extends LitElement {
         tabindex="0"
         role="article"
         aria-label=${this.title || "(no title)"}
+        aria-current=${this.selected ? "true" : "false"}
       >
         <div class="top">
           <div class="avatar-stack" aria-label="Authors">

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 
 /**
  * <wavy-search-rail-card> — F-2 (#1037, #1047 slice 3) per-digest card
@@ -234,7 +234,7 @@ export class WavySearchRailCard extends LitElement {
         tabindex="0"
         role="article"
         aria-label=${this.title || "(no title)"}
-        aria-current=${this.selected ? "true" : "false"}
+        aria-current=${this.selected ? "true" : nothing}
       >
         <div class="top">
           <div class="avatar-stack" aria-label="Authors">

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -236,6 +236,17 @@ export class WavySearchRail extends LitElement {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
     }
+    /* J-UI-1 (#1079): slotted <wavy-search-rail-card> digest cards. The
+       rail container provides the rhythm between the saved-search list
+       and the filter strip; the cards' own host styles supply the card
+       chrome. ::slotted scopes only direct children. */
+    slot[name="cards"]::slotted(wavy-search-rail-card) {
+      display: block;
+      margin-bottom: var(--wavy-spacing-2, 8px);
+    }
+    slot[name="cards"]::slotted(wavy-search-rail-card:last-of-type) {
+      margin-bottom: var(--wavy-spacing-3, 12px);
+    }
     /* F-4 (#1039 / R-4.7): filter strip — chips that compose with the
      * active query. Hidden inside <details> so the rail stays compact
      * by default; the user opens "Filters" to see them. */
@@ -480,6 +491,7 @@ export class WavySearchRail extends LitElement {
           `;
         })}
       </ul>
+      <slot name="cards"></slot>
       <details class="filters" data-j2cl-filter-strip>
         <summary>Filters</summary>
         <div class="filter-chips" role="group" aria-label="Search filters">

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -236,13 +236,14 @@ export class WavySearchRail extends LitElement {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
     }
-    /* J-UI-1 (#1079): slotted <wavy-search-rail-card> digest cards. The
-       rail container provides the rhythm between the saved-search list
-       and the filter strip; the cards' own host styles supply the card
-       chrome. ::slotted scopes only direct children. */
+    /* J-UI-1 (#1079): slotted <wavy-search-rail-card> digest cards.
+       Inter-card spacing is owned by the card's :host style
+       (margin-bottom: var(--wavy-spacing-2)) — we DO NOT add another
+       margin here, otherwise the gap doubles. The last card uses a
+       slightly larger trailing margin to separate the digest list from
+       the filter strip below it. */
     slot[name="cards"]::slotted(wavy-search-rail-card) {
       display: block;
-      margin-bottom: var(--wavy-spacing-2, 8px);
     }
     slot[name="cards"]::slotted(wavy-search-rail-card:last-of-type) {
       margin-bottom: var(--wavy-spacing-3, 12px);

--- a/j2cl/lit/test/wavy-search-rail-card.test.js
+++ b/j2cl/lit/test/wavy-search-rail-card.test.js
@@ -169,4 +169,42 @@ describe("<wavy-search-rail-card>", () => {
     const title = el.renderRoot.querySelector("h3.title");
     expect(title.textContent.trim()).to.equal("(no title)");
   });
+
+  // J-UI-1 (#1079): selected reflective property toggles aria-current
+  // on the inner <article> so the route controller can drive selection
+  // from the URL state.
+  describe("J-UI-1 selection (#1079)", () => {
+    it("aria-current defaults to 'false'", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card data-wave-id="w-1" title="A"></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      const article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-current")).to.equal("false");
+    });
+
+    it("setting selected=true reflects aria-current='true' on the article", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card data-wave-id="w-1" title="A"></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      el.selected = true;
+      await el.updateComplete;
+      const article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-current")).to.equal("true");
+      expect(el.hasAttribute("selected")).to.equal(true);
+    });
+
+    it("clearing selected drops aria-current back to 'false'", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card data-wave-id="w-1" title="A" selected></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      el.selected = false;
+      await el.updateComplete;
+      const article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-current")).to.equal("false");
+      expect(el.hasAttribute("selected")).to.equal(false);
+    });
+  });
 });

--- a/j2cl/lit/test/wavy-search-rail-card.test.js
+++ b/j2cl/lit/test/wavy-search-rail-card.test.js
@@ -174,13 +174,13 @@ describe("<wavy-search-rail-card>", () => {
   // on the inner <article> so the route controller can drive selection
   // from the URL state.
   describe("J-UI-1 selection (#1079)", () => {
-    it("aria-current defaults to 'false'", async () => {
+    it("aria-current is omitted by default (no false attribute that AT might announce)", async () => {
       const el = await fixture(html`
         <wavy-search-rail-card data-wave-id="w-1" title="A"></wavy-search-rail-card>
       `);
       await el.updateComplete;
       const article = el.renderRoot.querySelector("article");
-      expect(article.getAttribute("aria-current")).to.equal("false");
+      expect(article.hasAttribute("aria-current")).to.equal(false);
     });
 
     it("setting selected=true reflects aria-current='true' on the article", async () => {
@@ -195,7 +195,7 @@ describe("<wavy-search-rail-card>", () => {
       expect(el.hasAttribute("selected")).to.equal(true);
     });
 
-    it("clearing selected drops aria-current back to 'false'", async () => {
+    it("clearing selected removes aria-current entirely", async () => {
       const el = await fixture(html`
         <wavy-search-rail-card data-wave-id="w-1" title="A" selected></wavy-search-rail-card>
       `);
@@ -203,7 +203,7 @@ describe("<wavy-search-rail-card>", () => {
       el.selected = false;
       await el.updateComplete;
       const article = el.renderRoot.querySelector("article");
-      expect(article.getAttribute("aria-current")).to.equal("false");
+      expect(article.hasAttribute("aria-current")).to.equal(false);
       expect(el.hasAttribute("selected")).to.equal(false);
     });
   });

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -281,6 +281,45 @@ describe("<wavy-search-rail>", () => {
       expect(chip.getAttribute("aria-pressed")).to.equal("false");
     });
   });
+
+  // J-UI-1 (#1079): the rail must expose a `cards` slot so the J2CL
+  // search panel can project <wavy-search-rail-card> children inside the
+  // shadow DOM. Without the slot the children would be hidden post-upgrade.
+  describe("J-UI-1 cards slot (#1079)", () => {
+    it("declares a <slot name=\"cards\"> in the shadow DOM", async () => {
+      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+      await el.updateComplete;
+      const slot = el.renderRoot.querySelector('slot[name="cards"]');
+      expect(slot, "rail must expose a cards slot for digest projection").to.exist;
+    });
+
+    it("accepts <wavy-search-rail-card> light-DOM children projected into the cards slot", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail>
+          <wavy-search-rail-card slot="cards" data-wave-id="w+a"></wavy-search-rail-card>
+          <wavy-search-rail-card slot="cards" data-wave-id="w+b"></wavy-search-rail-card>
+        </wavy-search-rail>
+      `);
+      await el.updateComplete;
+      const slot = el.renderRoot.querySelector('slot[name="cards"]');
+      const assigned = slot.assignedElements();
+      expect(assigned.map((n) => n.dataset.waveId)).to.deep.equal(["w+a", "w+b"]);
+    });
+
+    it("preserves the saved-search list above the cards slot and filter strip below it", async () => {
+      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+      await el.updateComplete;
+      const folders = el.renderRoot.querySelector("ul.folders");
+      const slot = el.renderRoot.querySelector('slot[name="cards"]');
+      const filters = el.renderRoot.querySelector("details.filters");
+      expect(folders, "saved-search list mounts").to.exist;
+      expect(slot, "cards slot mounts").to.exist;
+      expect(filters, "filter strip mounts").to.exist;
+      // Document order: folders, then cards slot, then filter strip.
+      expect(folders.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+      expect(slot.compareDocumentPosition(filters) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+    });
+  });
 });
 
 // Helper: read the element's static stylesheet text so we can assert

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -132,6 +132,16 @@ public final class J2clSearchPanelController
     requestSearch();
   }
 
+  /**
+   * J-UI-1 (#1079): re-issues the current search WITHOUT touching
+   * selection or page size. Used by the rail's refresh icon so
+   * clicking refresh keeps the open wave on screen and the URL stable.
+   */
+  @Override
+  public void onRefreshRequested() {
+    requestSearch();
+  }
+
   @Override
   public void onDigestSelected(String waveId) {
     selectedWaveId = normalizeSelectedWaveId(waveId);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -92,11 +92,17 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
 
       // J-UI-1 (#1079): the <wavy-search-rail> lives in the shell-root
       // nav slot, NOT inside the workflow host. Resolve it from the
-      // document root. Absence is treated as flag-off.
+      // document root.
       searchRail = findRail();
-      railCardsEnabled =
-          searchRail != null
-              && "true".equals(searchRail.getAttribute("data-rail-cards-enabled"));
+      // The flag value is emitted independently on <shell-root> as
+      // data-j2cl-search-rail-cards. Reading it from <shell-root>
+      // (rather than from the rail) means a missing-rail regression
+      // surfaces as an error instead of a silent fallback to the
+      // legacy digest list — matching the project rule "no legacy
+      // fallbacks for flagged features". The data-rail-cards-enabled
+      // attribute on the rail itself is preserved for SSR-side parity
+      // tests but is no longer the source of truth.
+      railCardsEnabled = readRailCardsFlag();
 
       form.onsubmit =
           event -> {
@@ -407,6 +413,18 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   private static HTMLElement findRail() {
     Object element = DomGlobal.document.querySelector("wavy-search-rail");
     return element == null ? null : (HTMLElement) element;
+  }
+
+  /**
+   * J-UI-1 (#1079): reads {@code data-j2cl-search-rail-cards} from the
+   * {@code <shell-root>} element so the flag value is independent of
+   * the rail element's lifecycle. SSR writes this attribute when the
+   * {@code j2cl-search-rail-cards} feature flag is enabled for the
+   * current viewer.
+   */
+  private static boolean readRailCardsFlag() {
+    Object shell = DomGlobal.document.querySelector("shell-root[data-j2cl-search-rail-cards=\"true\"]");
+    return shell != null;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
 import elemental2.dom.HTMLButtonElement;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
@@ -8,6 +9,7 @@ import elemental2.dom.HTMLFormElement;
 import elemental2.dom.HTMLInputElement;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.root.J2clServerFirstRootShellDom;
 
 public final class J2clSearchPanelView implements J2clSearchPanelController.View {
@@ -40,6 +42,24 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   private final HTMLButtonElement showMoreButton;
   private final HTMLElement selectedWaveHost;
   private final Map<String, J2clDigestView> digestViews = new LinkedHashMap<String, J2clDigestView>();
+  /**
+   * J-UI-1 (#1079): per-digest views when the {@code j2cl-search-rail-cards}
+   * flag is on; the legacy {@code digestViews} map stays in place for the
+   * flag-off path so the two coexist while the flag bakes.
+   */
+  private final Map<String, J2clSearchRailCardView> railCardViews =
+      new LinkedHashMap<String, J2clSearchRailCardView>();
+  /** J-UI-1 (#1079): the {@code <wavy-search-rail>} host (when adopted). */
+  private final HTMLElement searchRail;
+  /**
+   * J-UI-1 (#1079): when true, render digests as {@code <wavy-search-rail-card>}
+   * children of the rail instead of plain-DOM {@code J2clDigestView}s.
+   * Bound at construction from the SSR'd
+   * {@code data-rail-cards-enabled="true"} attribute on the rail, written
+   * by the server based on the {@code j2cl-search-rail-cards} flag value
+   * for the current viewer.
+   */
+  private final boolean railCardsEnabled;
   private J2clSearchViewListener listener;
 
   public J2clSearchPanelView(HTMLElement host) {
@@ -70,6 +90,14 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
       showMoreButton = queryRequired(card, ".sidecar-show-more");
       selectedWaveHost = J2clServerFirstRootShellDom.findSelectedWaveHost(host);
 
+      // J-UI-1 (#1079): the <wavy-search-rail> lives in the shell-root
+      // nav slot, NOT inside the workflow host. Resolve it from the
+      // document root. Absence is treated as flag-off.
+      searchRail = findRail();
+      railCardsEnabled =
+          searchRail != null
+              && "true".equals(searchRail.getAttribute("data-rail-cards-enabled"));
+
       form.onsubmit =
           event -> {
             event.preventDefault();
@@ -85,6 +113,14 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
             }
             return null;
           };
+      // J-UI-1 (#1079): wire rail-emitted events into the panel listener so
+      // user interaction with the rail's query box, saved-search folders,
+      // and refresh button drives the sidecar search controller. The rail's
+      // shadow-DOM input is the canonical query surface; the legacy
+      // .sidecar-search-input form stays in the DOM (hidden) only so the
+      // legacy queryInput.value writes from setQuery() continue to round-
+      // trip with parity tests that read the legacy attribute.
+      bindRailEventsToListener();
       return;
     }
 
@@ -189,6 +225,11 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     selectedWaveHost.className = "sidecar-selected-host";
     selectedWaveHost.setAttribute("data-j2cl-selected-wave-host", "true");
     layout.appendChild(selectedWaveHost);
+
+    // J-UI-1 (#1079): the legacy non-adopted (sidecar-only) constructor
+    // does not mount a <wavy-search-rail>; cards path stays disabled.
+    searchRail = null;
+    railCardsEnabled = false;
   }
 
   @Override
@@ -198,11 +239,16 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
 
   @Override
   public void setQuery(String query) {
-    if (query == null) {
-      queryInput.value = "";
-      return;
+    String safeValue = query == null ? "" : query;
+    queryInput.value = safeValue;
+    // J-UI-1 (#1079): mirror the controller's normalised query onto the
+    // rail's `query` attribute so the rail's saved-folder
+    // aria-current derivation and the input box stay in sync with the
+    // sidecar's view of the active query (matters when the controller
+    // applies normaliseQuery() that fills in the default `in:inbox`).
+    if (searchRail != null) {
+      searchRail.setAttribute("query", safeValue);
     }
-    queryInput.value = query;
   }
 
   @Override
@@ -227,7 +273,68 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
   @Override
   public void render(J2clSearchResultModel model) {
     waveCount.textContent = model.getWaveCountText();
+    if (railCardsEnabled) {
+      renderRailCards(model);
+    } else {
+      renderLegacyDigests(model);
+    }
+    showMoreButton.hidden = !model.isShowMoreVisible();
+  }
+
+  /**
+   * J-UI-1 (#1079): the new rendering path — projects each digest as a
+   * {@code <wavy-search-rail-card>} child of the {@code <wavy-search-rail>}'s
+   * {@code cards} slot. Per the project rule "no legacy fallbacks for
+   * flagged features", a missing rail with the flag on raises a status
+   * error; we do not silently fall back to the legacy plain-DOM digest list.
+   */
+  private void renderRailCards(J2clSearchResultModel model) {
+    if (searchRail == null) {
+      // The flag is on but the rail is unreachable — surface the error
+      // through the existing aria-live status slot.
+      setStatus(
+          "Search rail is unavailable; cards cannot render. Reload the page.",
+          true);
+      return;
+    }
     digestList.innerHTML = "";
+    digestList.hidden = true;
+    digestViews.clear();
+    clearRailCards();
+    railCardViews.clear();
+
+    if (model.isEmpty()) {
+      emptyState.hidden = false;
+      emptyState.textContent = model.getEmptyMessage().isEmpty()
+          ? "No waves matched this query."
+          : model.getEmptyMessage();
+      // Mirror the empty-state copy onto the rail's result-count slot so
+      // the user sees it inside the rail (the workflow card is hidden).
+      searchRail.setAttribute("result-count", emptyState.textContent);
+      return;
+    }
+    emptyState.hidden = true;
+    for (J2clSearchDigestItem item : model.getDigestItems()) {
+      if (item.getWaveId() == null) {
+        continue;
+      }
+      J2clSearchRailCardView cardView =
+          new J2clSearchRailCardView(
+              item,
+              waveId -> {
+                if (listener != null) {
+                  listener.onDigestSelected(waveId);
+                }
+              });
+      railCardViews.put(item.getWaveId(), cardView);
+      searchRail.appendChild(cardView.element());
+    }
+    searchRail.setAttribute("result-count", model.getWaveCountText());
+  }
+
+  private void renderLegacyDigests(J2clSearchResultModel model) {
+    digestList.innerHTML = "";
+    digestList.hidden = false;
     digestViews.clear();
 
     if (model.isEmpty()) {
@@ -235,31 +342,32 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
       emptyState.textContent = model.getEmptyMessage().isEmpty()
           ? "No waves matched this query."
           : model.getEmptyMessage();
-    } else {
-      emptyState.hidden = true;
-      for (J2clSearchDigestItem item : model.getDigestItems()) {
-        if (item.getWaveId() == null) {
-          continue;
-        }
-        J2clDigestView digestView =
-            new J2clDigestView(
-                item,
-                waveId -> {
-                  if (listener != null) {
-                    listener.onDigestSelected(waveId);
-                  }
-                });
-        digestViews.put(item.getWaveId(), digestView);
-        digestList.appendChild(digestView.element());
-      }
+      return;
     }
-
-    showMoreButton.hidden = !model.isShowMoreVisible();
+    emptyState.hidden = true;
+    for (J2clSearchDigestItem item : model.getDigestItems()) {
+      if (item.getWaveId() == null) {
+        continue;
+      }
+      J2clDigestView digestView =
+          new J2clDigestView(
+              item,
+              waveId -> {
+                if (listener != null) {
+                  listener.onDigestSelected(waveId);
+                }
+              });
+      digestViews.put(item.getWaveId(), digestView);
+      digestList.appendChild(digestView.element());
+    }
   }
 
   @Override
   public void setSelectedWaveId(String waveId) {
     for (Map.Entry<String, J2clDigestView> entry : digestViews.entrySet()) {
+      entry.getValue().setSelected(entry.getKey() != null && entry.getKey().equals(waveId));
+    }
+    for (Map.Entry<String, J2clSearchRailCardView> entry : railCardViews.entrySet()) {
       entry.getValue().setSelected(entry.getKey() != null && entry.getKey().equals(waveId));
     }
   }
@@ -269,11 +377,16 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     if (waveId == null || waveId.isEmpty()) {
       return false;
     }
+    boolean updated = false;
     J2clDigestView digest = digestViews.get(waveId);
-    if (digest == null) {
-      return false;
+    if (digest != null) {
+      updated |= digest.setUnreadCount(unreadCount);
     }
-    return digest.setUnreadCount(unreadCount);
+    J2clSearchRailCardView card = railCardViews.get(waveId);
+    if (card != null) {
+      updated |= card.setUnreadCount(unreadCount);
+    }
+    return updated;
   }
 
   public HTMLElement getSelectedWaveHost() {
@@ -282,6 +395,88 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
 
   public HTMLElement getComposeHost() {
     return composeHost;
+  }
+
+  /**
+   * J-UI-1 (#1079): looks up the {@code <wavy-search-rail>} element from
+   * the document. The rail lives in the {@code shell-root} nav slot so it
+   * is not a descendant of the workflow {@code host}. Returns {@code null}
+   * when missing (e.g. legacy view contexts that have not mounted the
+   * rail).
+   */
+  private static HTMLElement findRail() {
+    Object element = DomGlobal.document.querySelector("wavy-search-rail");
+    return element == null ? null : (HTMLElement) element;
+  }
+
+  /**
+   * J-UI-1 (#1079): removes any previously-projected
+   * {@code <wavy-search-rail-card>} children from the rail so a new render
+   * does not stack duplicates on top of the prior result set.
+   */
+  private void clearRailCards() {
+    if (searchRail == null) {
+      return;
+    }
+    elemental2.dom.NodeList<elemental2.dom.Element> existing =
+        searchRail.querySelectorAll(":scope > wavy-search-rail-card");
+    for (int i = (int) existing.length - 1; i >= 0; i--) {
+      elemental2.dom.Element child = existing.getAt(i);
+      if (child != null && child.parentNode != null) {
+        child.parentNode.removeChild(child);
+      }
+    }
+  }
+
+  /**
+   * J-UI-1 (#1079): subscribes the search panel listener to the rail's
+   * emitted events so user interaction with the rail's query box,
+   * saved-search folders, filter chips, and refresh button drives the
+   * sidecar search controller. The legacy hidden form binding stays in
+   * place so SSR-driven smoke tests and re-entrancy via setQuery
+   * continue to work.
+   */
+  private void bindRailEventsToListener() {
+    if (searchRail == null) {
+      return;
+    }
+    searchRail.addEventListener(
+        "wavy-search-submit",
+        (Event evt) -> {
+          if (listener == null) {
+            return;
+          }
+          String query = readDetailString(evt, "query");
+          listener.onQuerySubmitted(query == null ? queryInput.value : query);
+        });
+    searchRail.addEventListener(
+        "wavy-saved-search-selected",
+        (Event evt) -> {
+          if (listener == null) {
+            return;
+          }
+          String query = readDetailString(evt, "query");
+          if (query != null && !query.isEmpty()) {
+            listener.onQuerySubmitted(query);
+          }
+        });
+    searchRail.addEventListener(
+        "wavy-search-refresh-requested",
+        (Event evt) -> {
+          if (listener == null) {
+            return;
+          }
+          listener.onQuerySubmitted(queryInput.value);
+        });
+  }
+
+  private static String readDetailString(Event evt, String key) {
+    Object detail = Js.asPropertyMap(evt).get("detail");
+    if (detail == null) {
+      return null;
+    }
+    Object value = Js.asPropertyMap(detail).get(key);
+    return value == null ? null : String.valueOf(value);
   }
 
   static Copy copyFor(ShellPresentation shellPresentation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -113,14 +113,12 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
             }
             return null;
           };
-      // J-UI-1 (#1079): wire rail-emitted events into the panel listener so
-      // user interaction with the rail's query box, saved-search folders,
-      // and refresh button drives the sidecar search controller. The rail's
-      // shadow-DOM input is the canonical query surface; the legacy
-      // .sidecar-search-input form stays in the DOM (hidden) only so the
-      // legacy queryInput.value writes from setQuery() continue to round-
-      // trip with parity tests that read the legacy attribute.
-      bindRailEventsToListener();
+      // J-UI-1 (#1079): wire rail-emitted events into the panel listener
+      // ONLY when the rail-cards path is the active rendering surface.
+      // Gating keeps flag-off behavior identical to before this change.
+      if (railCardsEnabled) {
+        bindRailEventsToListener();
+      }
       return;
     }
 
@@ -242,11 +240,12 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
     String safeValue = query == null ? "" : query;
     queryInput.value = safeValue;
     // J-UI-1 (#1079): mirror the controller's normalised query onto the
-    // rail's `query` attribute so the rail's saved-folder
-    // aria-current derivation and the input box stay in sync with the
-    // sidecar's view of the active query (matters when the controller
-    // applies normaliseQuery() that fills in the default `in:inbox`).
-    if (searchRail != null) {
+    // rail's `query` attribute so the rail's saved-folder aria-current
+    // derivation and the input box stay in sync with the sidecar's view
+    // of the active query. Gated by railCardsEnabled to avoid changing
+    // flag-off behavior; the rail's `query` setter does not re-emit
+    // wavy-search-submit so this is loop-safe.
+    if (railCardsEnabled && searchRail != null) {
       searchRail.setAttribute("query", safeValue);
     }
   }
@@ -308,9 +307,10 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
       emptyState.textContent = model.getEmptyMessage().isEmpty()
           ? "No waves matched this query."
           : model.getEmptyMessage();
-      // Mirror the empty-state copy onto the rail's result-count slot so
-      // the user sees it inside the rail (the workflow card is hidden).
-      searchRail.setAttribute("result-count", emptyState.textContent);
+      // Empty state copy lives in the workflow's status text via
+      // setStatus() — do not mirror long-form copy into the rail's
+      // numeric result-count slot.
+      searchRail.setAttribute("result-count", "");
       return;
     }
     emptyState.hidden = true;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java
@@ -466,7 +466,12 @@ public final class J2clSearchPanelView implements J2clSearchPanelController.View
           if (listener == null) {
             return;
           }
-          listener.onQuerySubmitted(queryInput.value);
+          // J-UI-1 (#1079) — Codex review: refresh must NOT clear the
+          // selected wave or reset the page size; that's the contract
+          // for `wavy-search-refresh-requested` (re-fetch the active
+          // query in place). onRefreshRequested re-issues the search
+          // without going through the new-query reset path.
+          listener.onRefreshRequested();
         });
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchRailCardView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchRailCardView.java
@@ -1,0 +1,134 @@
+package org.waveprotocol.box.j2cl.search;
+
+import elemental2.core.JsDate;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLElement;
+
+/**
+ * J-UI-1 (#1079) per-digest view that produces a {@code <wavy-search-rail-card>}
+ * custom element so search digests render inside the saved-search rail's
+ * {@code cards} slot.
+ *
+ * <p>Mirrors the API surface of {@link J2clDigestView} so the two paths can
+ * coexist while the {@code j2cl-search-rail-cards} flag bakes — when the flag
+ * is on the rail-card path is the only path; when off the legacy
+ * {@code J2clDigestView} keeps shipping into the workflow card.
+ */
+public final class J2clSearchRailCardView {
+  @FunctionalInterface
+  public interface SelectionHandler {
+    void onSelected(String waveId);
+  }
+
+  private final String waveId;
+  private final HTMLElement root;
+  private int blipCount;
+  private int unreadCount;
+
+  public J2clSearchRailCardView(J2clSearchDigestItem item, SelectionHandler selectionHandler) {
+    this.waveId = item.getWaveId();
+    this.blipCount = item.getBlipCount();
+    this.unreadCount = item.getUnreadCount();
+    this.root = (HTMLElement) DomGlobal.document.createElement("wavy-search-rail-card");
+    root.slot = "cards";
+    root.setAttribute("data-wave-id", waveId == null ? "" : waveId);
+    root.setAttribute("title", item.getTitle());
+    root.setAttribute("snippet", item.getSnippet());
+    root.setAttribute("authors", item.getAuthor());
+    root.setAttribute("msg-count", String.valueOf(blipCount));
+    root.setAttribute("unread-count", String.valueOf(unreadCount));
+    if (item.isPinned()) {
+      root.setAttribute("pinned", "");
+    }
+    long lastModified = item.getLastModified();
+    if (lastModified > 0) {
+      String iso = formatIso8601(lastModified);
+      root.setAttribute("posted-at-iso", iso);
+      root.setAttribute("posted-at", formatRelative(lastModified));
+    }
+    root.addEventListener(
+        "wavy-search-rail-card-selected",
+        (Event evt) -> {
+          if (waveId == null || waveId.isEmpty()) {
+            return;
+          }
+          selectionHandler.onSelected(waveId);
+        });
+  }
+
+  public HTMLElement element() {
+    return root;
+  }
+
+  public String getWaveId() {
+    return waveId;
+  }
+
+  public void setSelected(boolean selected) {
+    if (selected) {
+      root.setAttribute("selected", "");
+    } else {
+      root.removeAttribute("selected");
+    }
+  }
+
+  /**
+   * J-UI-1 (#1079): mirrors {@link J2clDigestView#setUnreadCount(int)} —
+   * returns true when the rendered count actually changed so the caller
+   * can fire a signal-pulse motion.
+   */
+  public boolean setUnreadCount(int newUnreadCount) {
+    int normalized = Math.max(0, newUnreadCount);
+    if (normalized == this.unreadCount) {
+      return false;
+    }
+    this.unreadCount = normalized;
+    root.setAttribute("unread-count", String.valueOf(normalized));
+    return true;
+  }
+
+  /** Visible for parity tests so they can read back the rendered stats text. */
+  public String getStatsText() {
+    StringBuilder text = new StringBuilder();
+    if (unreadCount > 0) {
+      text.append(unreadCount).append(" unread · ");
+    }
+    text.append(blipCount).append(blipCount == 1 ? " message" : " messages");
+    return text.toString();
+  }
+
+  private static String formatIso8601(long lastModifiedMs) {
+    return new JsDate((double) lastModifiedMs).toISOString();
+  }
+
+  /**
+   * Best-effort relative timestamp ("2m ago" / "3h ago" / "1d ago"). Mirrors
+   * the format already used by the GWT digest renderer so the J2CL surface
+   * stays consistent. Falls back to a localised date string for older
+   * timestamps.
+   */
+  private static String formatRelative(long lastModifiedMs) {
+    long now = (long) JsDate.now();
+    long deltaMs = now - lastModifiedMs;
+    if (deltaMs < 0) {
+      deltaMs = 0;
+    }
+    long minutes = deltaMs / 60_000L;
+    if (minutes < 1) {
+      return "just now";
+    }
+    if (minutes < 60) {
+      return minutes + "m ago";
+    }
+    long hours = minutes / 60L;
+    if (hours < 24) {
+      return hours + "h ago";
+    }
+    long days = hours / 24L;
+    if (days < 7) {
+      return days + "d ago";
+    }
+    return new JsDate((double) lastModifiedMs).toDateString();
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
@@ -6,4 +6,17 @@ public interface J2clSearchViewListener {
   void onShowMoreRequested();
 
   void onDigestSelected(String waveId);
+
+  /**
+   * J-UI-1 (#1079): re-issues the current query without clearing the
+   * active selection or resetting page size. Distinct from
+   * {@link #onQuerySubmitted(String)} so refresh-icon clicks (and
+   * background re-fetches) don't drop {@code wave=} from URL state.
+   * Default implementation falls back to {@code onQuerySubmitted} so
+   * older listeners keep compiling; the search panel controller
+   * overrides it.
+   */
+  default void onRefreshRequested() {
+    onQuerySubmitted("");
+  }
 }

--- a/wave/config/changelog.d/2026-04-28-issue-1079-j-ui-1.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1079-j-ui-1.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-28-issue-1079-j-ui-1",
+  "version": "PR #1079",
+  "date": "2026-04-28",
+  "title": "J-UI-1: Wave list renders in the search rail",
+  "summary": "On /?view=j2cl-root the saved-search rail now renders one rich digest card per wave (avatar, title, snippet, count, timestamp). Clicking a card opens the wave and updates the URL.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Search digests on the J2CL root view now render as <wavy-search-rail-card> elements inside <wavy-search-rail>, replacing the empty rail surface flagged in the 2026-04-26 parity audit.",
+        "Card click routes the URL via the existing J2clSidecarRouteController so deep links and back/forward survive reload.",
+        "Gated behind the new j2cl-search-rail-cards experimental flag (default off in prod). Enable for a participant via scripts/feature-flag.sh enable j2cl-search-rail-cards."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-28-issue-1079-j-ui-1.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1079-j-ui-1.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-28-issue-1079-j-ui-1",
-  "version": "PR #1079",
+  "version": "PR #1088",
   "date": "2026-04-28",
   "title": "J-UI-1: Wave list renders in the search rail",
   "summary": "On /?view=j2cl-root the saved-search rail now renders one rich digest card per wave (avatar, title, snippet, count, timestamp). Clicking a card opens the wave and updates the URL.",

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3425,7 +3425,16 @@ public final class HtmlRenderer {
           .append(safeResolvedReturnTarget)
           .append("\" data-j2cl-root-base-path=\"")
           .append(safeResolvedBasePath)
-          .append("\">\n");
+          .append("\"");
+      if (railCardsEnabled) {
+        // J-UI-1 (#1079): emit the flag value on <shell-root> so the
+        // J2CL view layer can resolve it independently of the rail
+        // element. If the rail is missing post-upgrade but the flag is
+        // on, the view raises a status error rather than silently
+        // falling back to the legacy digest list.
+        sb.append(" data-j2cl-search-rail-cards=\"true\"");
+      }
+      sb.append(">\n");
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
           .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
           .append("</shell-skip-link>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3329,13 +3329,38 @@ public final class HtmlRenderer {
         currentReleaseId,
         rootShellReturnTarget,
         websocketAddress,
-        J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave());
+        J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave(),
+        false);
   }
 
   public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
       String buildCommit, long serverBuildTime, String currentReleaseId,
       String rootShellReturnTarget, String websocketAddress,
       J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult) {
+    return renderJ2clRootShellPage(
+        sessionJson,
+        analyticsAccount,
+        buildCommit,
+        serverBuildTime,
+        currentReleaseId,
+        rootShellReturnTarget,
+        websocketAddress,
+        snapshotResult,
+        false);
+  }
+
+  /**
+   * J-UI-1 (#1079): full overload that surfaces the
+   * {@code j2cl-search-rail-cards} flag value to the SSR so the
+   * {@code <wavy-search-rail>} element carries
+   * {@code data-rail-cards-enabled="true"} when enabled. When the flag
+   * is OFF the legacy plain-DOM digest rendering path stays in place.
+   */
+  public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
+      String buildCommit, long serverBuildTime, String currentReleaseId,
+      String rootShellReturnTarget, String websocketAddress,
+      J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
+      boolean railCardsEnabled) {
     J2clSelectedWaveSnapshotRenderer.SnapshotResult resolvedSnapshotResult =
         snapshotResult == null
             ? J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave()
@@ -3438,7 +3463,7 @@ public final class HtmlRenderer {
       // <shell-nav-rail> wrapper is preserved so future slices can
       // co-mount additional nav-area elements alongside the rail.
       sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-      appendWavySearchRail(sb, safeInitialQuery);
+      appendWavySearchRail(sb, safeInitialQuery, railCardsEnabled);
       sb.append("  </shell-nav-rail>\n");
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
@@ -3678,7 +3703,7 @@ public final class HtmlRenderer {
         sb, resolvedAddress, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath);
     sb.append("  </shell-header>\n");
     sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-    appendWavySearchRail(sb, safeInitialQuery);
+    appendWavySearchRail(sb, safeInitialQuery, false);
     sb.append("  </shell-nav-rail>\n");
     appendWavySearchHelpModal(sb);
     sb.append("  <shell-main-region slot=\"main\">\n");
@@ -3962,12 +3987,22 @@ public final class HtmlRenderer {
    * existing {@code <shell-nav-rail slot="nav">} wrapper. SSR'd inner
    * light DOM covers B.1–B.12.
    */
-  private static void appendWavySearchRail(StringBuilder sb, String safeInitialQuery) {
+  private static void appendWavySearchRail(
+      StringBuilder sb, String safeInitialQuery, boolean railCardsEnabled) {
     // Derive the active folder from the initial query so the SSR folder highlight
     // matches the query pre-upgrade (mirrors WavySearchRail._deriveActiveFolder).
     String activeFolder = deriveActiveFolder(safeInitialQuery);
     sb.append("    <wavy-search-rail query=\"").append(safeInitialQuery)
-        .append("\" data-active-folder=\"").append(activeFolder).append("\" result-count=\"\">\n");
+        .append("\" data-active-folder=\"").append(activeFolder)
+        .append("\" result-count=\"\"");
+    if (railCardsEnabled) {
+      // J-UI-1 (#1079): when the flag is on the J2CL search panel projects
+      // <wavy-search-rail-card> instances into this rail's `cards` slot
+      // instead of the legacy plain-DOM digest list. The attribute is the
+      // single contract J2clSearchPanelView reads on construction.
+      sb.append(" data-rail-cards-enabled=\"true\"");
+    }
+    sb.append(">\n");
     sb.append("      <div class=\"search\">\n");
     // F-2 slice 5 (#1055, A.4): explicit width/height on the SVG element.
     // Pre-upgrade, the Lit `:host { display:block }` rule has not attached

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -247,6 +247,10 @@ public class WaveClientServlet extends HttpServlet {
           j2clSelectedWaveSnapshotRenderer == null
               ? J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave()
               : j2clSelectedWaveSnapshotRenderer.renderRequestedWave(request.getParameter("wave"), id);
+      // J-UI-1 (#1079): per-viewer flag gating for the new rail-card path.
+      boolean railCardsEnabled =
+          featureFlagService.isEnabled(
+              "j2cl-search-rail-cards", id != null ? id.getAddress() : null);
       response.setContentType("text/html");
       response.setCharacterEncoding("UTF-8");
       response.setHeader("Cache-Control", "private, no-store");
@@ -263,7 +267,8 @@ public class WaveClientServlet extends HttpServlet {
             currentReleaseId,
             rootShellReturnTarget,
             resolveWebsocketAddressForPage(request, true), // codeql[java/xss]
-            snapshotResult)); // codeql[java/xss]
+            snapshotResult,
+            railCardsEnabled)); // codeql[java/xss]
       } catch (IOException e) {
         LOG.warning("Failed to render J2CL root shell page", e);
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -230,6 +230,30 @@ public final class J2clSearchRailParityTest {
   }
 
   /**
+   * J-UI-1 (#1079) follow-up: the flag value is also emitted on
+   * {@code <shell-root>} as {@code data-j2cl-search-rail-cards="true"}
+   * so the J2CL view layer can resolve it independently of the rail.
+   * If the rail is missing post-upgrade, the view raises a status
+   * error rather than silently falling back to the legacy digest
+   * list. Sister assertion to the rail-attribute test above.
+   */
+  @Test
+  public void j2clRootShellEmitsShellRootRailCardsMarkerWhenFlagOn() throws Exception {
+    String html = renderJ2clRootShellWithRailCards();
+    assertTrue(
+        "Flag-ON render must advertise data-j2cl-search-rail-cards on <shell-root>",
+        html.contains("data-j2cl-search-rail-cards=\"true\""));
+  }
+
+  @Test
+  public void j2clRootShellOmitsShellRootRailCardsMarkerWhenFlagOff() throws Exception {
+    String html = renderJ2clRootShell();
+    assertFalse(
+        "Default flag-OFF render must not advertise data-j2cl-search-rail-cards on <shell-root>",
+        html.contains("data-j2cl-search-rail-cards=\"true\""));
+  }
+
+  /**
    * B.5–B.10 — six saved-search folders with the canonical query
    * strings AND the canonical visible labels. Each folder carries a
    * {@code data-folder-id} so the client-side rail can route clicks

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -197,6 +197,39 @@ public final class J2clSearchRailParityTest {
   }
 
   /**
+   * J-UI-1 (#1079): when the {@code j2cl-search-rail-cards} flag is OFF
+   * (default for prod) the rail SSR must NOT carry
+   * {@code data-rail-cards-enabled="true"}. The legacy plain-DOM digest
+   * path stays in place for OFF viewers.
+   */
+  @Test
+  public void j2clRootShellOmitsRailCardsAttributeWhenFlagOff() throws Exception {
+    String html = renderJ2clRootShell();
+    assertFalse(
+        "Default flag-OFF render must not advertise rail-cards-enabled",
+        html.contains("data-rail-cards-enabled=\"true\""));
+  }
+
+  /**
+   * J-UI-1 (#1079): when the SSR is invoked with the rail-cards path
+   * enabled the rail must carry {@code data-rail-cards-enabled="true"}.
+   * The view layer reads this attribute on construction to decide which
+   * rendering path to take.
+   */
+  @Test
+  public void j2clRootShellEmitsRailCardsAttributeWhenFlagOn() throws Exception {
+    String html = renderJ2clRootShellWithRailCards();
+    assertTrue(
+        "Flag-ON render must advertise rail-cards-enabled on the rail host",
+        html.contains("data-rail-cards-enabled=\"true\""));
+    // The chrome (folders, filter strip, result-count) stays the same on
+    // the SSR side — only the attribute changes.
+    assertTrue(
+        "Flag-ON render still emits the saved-search folders",
+        html.contains("data-folder-id=\"inbox\""));
+  }
+
+  /**
    * B.5–B.10 — six saved-search folders with the canonical query
    * strings AND the canonical visible labels. Each folder carries a
    * {@code data-folder-id} so the client-side rail can route clicks
@@ -461,6 +494,62 @@ public final class J2clSearchRailParityTest {
     J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
     WaveClientServlet servlet = createServlet(VIEWER, renderer);
     return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+  }
+
+  /**
+   * J-UI-1 (#1079): renders the same J2CL root shell with the
+   * {@code j2cl-search-rail-cards} flag enabled globally so the SSR
+   * emits {@code data-rail-cards-enabled="true"} on the rail.
+   */
+  private static String renderJ2clRootShellWithRailCards() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServletWithRailCardsFlag(VIEWER, renderer);
+    return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+  }
+
+  private static WaveClientServlet createServletWithRailCardsFlag(
+      ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer) throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount(any(WebSession.class))).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount((WebSession) null)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        snapshotRenderer,
+        new FeatureFlagService(railCardsFeatureFlagStore()));
+  }
+
+  private static FeatureFlagStore railCardsFeatureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(java.util.List.of(
+        new FeatureFlagStore.FeatureFlag(
+            "j2cl-search-rail-cards",
+            "Render J2CL search digests as <wavy-search-rail-card> elements",
+            true,
+            Collections.emptyMap())));
+    return store;
   }
 
   private static List<ObservableWaveletData> buildWaveletData(int blipCount) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -44,6 +44,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("compact-inline-blips", "Compact inline blip layout at nesting depth", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("ime-debug-tracer", "Enable IME diagnostic trace overlay and remote log upload", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j2cl-search-rail-cards", "Render J2CL search digests as <wavy-search-rail-card> elements inside <wavy-search-rail> instead of the legacy plain-DOM digest list", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("social-auth", "Enable Google and GitHub social sign-in and sign-up", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }


### PR DESCRIPTION
## Summary
- Project J2CL search digests as `<wavy-search-rail-card>` children of `<wavy-search-rail>` (new `cards` slot) so the rail finally shows the user's waves, replacing the empty-rail bug observed in the 2026-04-26 parity audit.
- Wire rail-emitted events (`wavy-search-submit`, `wavy-saved-search-selected`, `wavy-search-refresh-requested`, per-card `wavy-search-rail-card-selected`) into the existing `J2clSearchPanelController`, so the rail's input box and folder buttons drive the same sidecar search flow.
- Selection round-trips through `J2clSidecarRouteController.selectWave` so URL state survives reload and browser back/forward (R-4.5).

## Closes
- Closes #1079
- Refs umbrella #1078, parent #904

## Matrix rows satisfied
- **R-3.5** (visible-region container — list level): the rail now hosts the digest list directly; cards render only after the search response arrives, and the existing aria-live `result-count` slot announces the loading and completion states. Verified locally — `cardCount: 1` after `Showing 1 result(s)` status text fires.
- **R-4.5** (route/history integration): card click appends `&wave=<encoded id>` to the URL; reload at the same URL re-hydrates selection. Verified locally — clicking the rendered card produced `?view=j2cl-root&q=in:inbox&wave=local.net%2Fw%2B1f4vogi825404A`. Card's `selected`/`aria-current="true"` flips on the matching card.

## Implementation notes
- Lit element changes: `<wavy-search-rail>` gains `<slot name="cards">` between the saved-search list and filter strip with `::slotted` margin styling. `<wavy-search-rail-card>` gains a `selected` reflective property mapping to `aria-current="true"` on the inner `<article>` when set; `aria-current` is omitted otherwise so AT semantics for unselected cards do not change.
- Java side: new `J2clSearchRailCardView` mirrors `J2clDigestView`'s API (selection, unread update) but produces a `<wavy-search-rail-card>` element. `J2clSearchPanelView` resolves the rail from `document.querySelector` and switches between the rail-cards and legacy `J2clDigestView` paths based on the SSR'd `data-rail-cards-enabled` attribute. Per the project rule "no legacy fallbacks for flagged features", a missing rail with the flag on surfaces the error via `setStatus(error=true)` instead of degrading.
- Server SSR: `HtmlRenderer.appendWavySearchRail` accepts a `railCardsEnabled` flag; `WaveClientServlet` evaluates `featureFlagService.isEnabled("j2cl-search-rail-cards", viewerAddress)` and threads it through `renderJ2clRootShellPage`.
- Feature flag: `j2cl-search-rail-cards` registered in `KnownFeatureFlags`, default OFF in prod. Toggle via `scripts/feature-flag.sh enable j2cl-search-rail-cards` (or per-user with `--allowed`).
- Per the project rule "feature-flag-gated paths must not change flag-off behavior", every new event binding (`bindRailEventsToListener`, `setQuery` rail-attribute mirror) is gated by `railCardsEnabled`, so flag-off renders behave exactly as before.

## Local-server verification
Full transcript at `docs/superpowers/screenshots/j-ui-1/local-verification.md`.

Highlights:
- Built `j2clProductionBuild` + `j2clLitBuild`, started server with `skipGwt=true`.
- Registered fresh user `qa1@local.net`, signed in, enabled the flag globally via `POST /admin/flags`.
- `/?view=j2cl-root&q=in:inbox` SSR carries `data-rail-cards-enabled="true"` on the rail.
- After client upgrade: `cardCount: 1` projected as a direct child of `<wavy-search-rail>` with the expected `data-wave-id`, `title`, `snippet`, `msg-count`, and `unread-count` attributes; `workflowDigests: 0` (no double rendering).
- Clicked the card → URL updated with `&wave=...`, selection persists across reload.
- `/?view=gwt` unaffected: `grep -c "wavy-search-rail\|data-rail-cards-enabled" /tmp/gwt.html` → `0`.

## Test plan
- [x] `j2cl maven compile` — clean.
- [x] `sbt compile` — clean (warnings unchanged, no new ones).
- [x] `sbt j2clLitTest` — 513 passed (6 new: 3 for the cards slot, 3 for the card `selected` property).
- [x] `sbt 'JakartaTest / testOnly *J2clSearchRailParityTest'` — 12 passed (2 new: flag-OFF render must omit `data-rail-cards-enabled`; flag-ON must emit it).
- [x] Local server: registered fresh user, flag enabled, exercised slice end-to-end (transcript in PR body).
- [x] GWT path (`?view=gwt`) unaffected.

## Out of scope
- Folder / filter chip switching driving the rail re-query — owned by **J-UI-2**.
- New-Wave create flow — owned by **J-UI-3**.
- Threaded reading view inside the opened wave — owned by **J-UI-4**.
- Per-blip task toggle — owned by **J-UI-6**.
- Server-first first-paint of selected wave — owned by **J-UI-8**.
- Live-refreshing relative timestamps in cards (pre-existing limitation in `J2clDigestView`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved-search rail now renders per-search digest cards that show unread counts, timestamps and metadata; clicking a card opens the wave and updates the URL (deep-link preserved). Selected cards show visual and accessibility state.
  * A refresh action re-issues the current search without clearing selection or pagination.
  * Server-side rendering emits a marker when rail-cards mode is enabled; guarded by the experimental feature flag.

* **Tests**
  * Added unit, integration and parity tests for SSR rail behavior, card rendering and selection/accessibility.

* **Documentation**
  * Added implementation plan, roadmap, and local verification guide for the rail-cards feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->