### PR TITLE
J-UI-4: Open-wave threaded reading view

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-4-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-4-plan.md
@@ -1,0 +1,270 @@
+# J-UI-4 — Open-wave threaded reading view
+
+Issue: #1082 (umbrella #1078, tracker #904).
+Matrix rows: R-3.1, R-3.2, R-3.3, R-3.6.
+Roadmap slice: §3.J-UI-4 in `docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md`.
+
+## 1. Goal
+
+Close the residual read-surface gap that survived F-2 (#1037): the J2CL
+open-wave panel renders blips with author/avatar/timestamp/per-blip
+toolbar (F-2 shipped that), but the conversation tree is **flat** — every
+blip lands in a single root thread regardless of its `parentBlipId` /
+`threadId`. The matrix R-3.1 hard-acceptance row says "Blips, threads,
+and inline replies appear with stable identity. Deep nesting renders
+without layout collapse. Reply ordering matches the conversation model."
+A flat list does not satisfy that.
+
+The user-visible deliverable is: when a wave has reply threads in its
+conversation manifest, the J2CL surface renders each reply thread as a
+visually-indented block under its parent blip, and:
+
+- the focus frame moves between blips across nesting (R-3.2);
+- thread collapse/expand toggles work on the new nested threads (R-3.3);
+- semantic queries (data-thread-id, data-blip-id, role=list/group)
+  resolve against the new nested DOM (R-3.6).
+
+## 2. Scope
+
+**In scope** (this PR):
+
+1. **Conversation-manifest parsing on the J2CL transport boundary.** The
+   sidecar already streams the `conversation` document as one of the
+   `SidecarSelectedWaveDocument`s, but `SidecarTransportCodec` collapses
+   its XML to plain text. Add a manifest parser that, when
+   `documentId == "conversation"`, walks the `<thread id="…">` /
+   `<blip id="b+…"/>` element tree and returns a
+   `SidecarConversationManifest` describing parent-blip-id, thread-id,
+   and depth for each blip. The parser already gets element-start /
+   element-end / attribute callbacks in `extractDocument`; we add a
+   `documentId`-keyed branch that builds the manifest as a side-output
+   of the same scan instead of running a second pass.
+
+2. **Wire the manifest into `J2clReadBlip` records.** Extend
+   `J2clSelectedWaveProjector.extractDocumentReadBlips` and
+   `enrichReadBlipMetadata` to attach the manifest's `parentBlipId` and
+   `threadId` to each blip record, AND emit the blips in **manifest
+   reply order** rather than document-list order. The
+   `SidecarSelectedWaveUpdate` already carries the parsed manifest
+   alongside the documents; the projector reads from there.
+
+3. **Renderer nesting in `J2clReadSurfaceDomRenderer.render(...)`.**
+   The current loop appends every blip to a single `rootThread` div.
+   Replace with a thread-grouped pass: build a `Map<String,
+   List<J2clReadBlip>>` keyed by `threadId`, render the root thread's
+   blips in order, and for each blip that has reply threads, append
+   nested `<div class="thread inline-thread" data-thread-id="…">`
+   containers under the blip's host. Reuse the existing
+   `enhanceSurface` walker — it already handles `inline-thread`
+   collapse + role/aria contracts, so the existing collapse/focus/AT
+   pathways pick up the new DOM with no further wiring.
+
+   Mirror the same change in `renderWindow(...)` (viewport path) so
+   the fragment-window renderer also nests.
+
+4. **Focus-frame survival across nested threads + incremental updates.**
+   Existing renderer already restores focus by blip-id across
+   re-renders (`restoreFocusedBlipById`). Verify it still works when a
+   blip moves between flat → nested DOM, and when a new reply lands
+   under a focused blip. Add a Lit unit test fixture for the
+   incremental-update case if one is missing.
+
+5. **Collapse aria-expanded announcement (R-3.3 AT line).** Audit the
+   existing `j2cl-read-thread-toggle` button: it sets `aria-controls`
+   and changes its `aria-label` between Collapse/Expand. Add
+   `aria-expanded` reflection on the toggle button (true when
+   children are visible, false when collapsed) so screen readers
+   announce the toggle state independently of the label change.
+
+6. **Feature flag `j2cl-threaded-rendering`.** All four behaviors
+   (manifest parse, projector wiring, renderer nesting, aria-expanded)
+   are gated behind one experimental flag, default off in prod. The
+   flag flips the renderer between the existing flat path and the new
+   nested path; the manifest parser remains active either way (it is
+   cheap and used by other code).
+
+7. **Local-server QA + screenshots.** Per the issue's verification
+   section: register a fresh user, seed a wave with ≥3 threads + one
+   inline reply chain at depth ≥3, exercise navigation + collapse,
+   capture three screenshots (populated threaded view, focus frame
+   mid-navigation, collapsed thread state).
+
+8. **Changelog fragment** under `wave/config/changelog.d/` describing
+   the slice, citing the matrix rows, listing the feature flag.
+
+**Out of scope**:
+
+- Reply / edit composer at a focused blip — owned by J-UI-5.
+- Per-blip task toggle — owned by J-UI-6.
+- Server-first paint — owned by J-UI-8.
+- Reactions / mentions / attachments — F-3 follow-ups (already shipped
+  for the flat path; nested path inherits unchanged).
+- Visual polish beyond functional indenting — nesting uses the
+  existing wavy `--wavy-thread-indent` token if present, falling back
+  to `padding-left: 16px` per nesting level.
+
+## 3. Files to add / modify
+
+**New:**
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java`
+  — value type: `Map<blipId, ManifestEntry>` where each entry carries
+  `parentBlipId`, `threadId`, `depth`, `siblingIndex`. Plus the
+  ordered root-thread blip-id list (so the projector can emit blips
+  in manifest order).
+
+**Modified:**
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+  — extend `extractDocument` (or add `extractConversationManifest`)
+  to populate the manifest when `documentId == "conversation"`.
+  `SidecarSelectedWaveUpdate` carries it via a new optional field.
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java`
+  — add the optional manifest field; default empty.
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  — read manifest from update; populate `parentBlipId`, `threadId`
+  on each `J2clReadBlip`; sort blips in manifest order. When manifest
+  is empty (legacy / non-conversational waves), fall back to current
+  document-order behavior.
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+  — pass the manifest through (no semantic change; just carries the
+  reference for `J2clSelectedWaveView` to use).
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+  — flag-gated nested rendering pass in `render(...)` and
+  `renderWindow(...)`. When the flag is on AND the blips carry
+  non-empty parentBlipId/threadId, build nested `inline-thread`
+  containers under each parent blip's host. When the flag is off,
+  keep the current flat behavior.
+  Add `aria-expanded` reflection to the collapse toggle button.
+
+- `j2cl/lit/src/elements/wave-blip.js`
+  — add a `data-depth` reflective attribute so CSS can paint the
+  nesting indent. No JS-behavior changes; depth is set by the
+  renderer when it appends the wrapper.
+
+- `j2cl/lit/src/elements/shell-main-region.js` — no change expected;
+  it already mounts the read surface. Verified by reading.
+
+- `j2cl/lit/src/elements/wavy-focus-frame.js` — no change expected;
+  the frame listens on the renderer host and re-paints on
+  `wavy-focus-changed`. Verify with a fixture.
+
+- `j2cl/lit/src/elements/wavy-depth-nav-bar.js` and
+  `j2cl/lit/src/elements/wave-blip-toolbar.js` — no change expected;
+  the depth nav is unaffected by inline nesting (it operates on the
+  drill-in surface).
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java`
+  — confirm collapse-toggle state survives the live-update rebuild
+  path (already preserved via `captureCollapsedThreadIds` /
+  `restoreCollapsedThreads`); add a unit fixture asserting it.
+
+- Feature-flag registration: add `j2cl-threaded-rendering` to the
+  flags catalog (`scripts/feature-flag.sh` if that's the entry point;
+  otherwise the standard flag-registration site discovered during
+  implementation).
+
+- `wave/config/changelog.d/2026-04-28-issue-1082-j-ui-4-threaded-reading.json`
+  — changelog fragment.
+
+**Tests added/modified:**
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifestTest.java`
+  — manifest parser (root + nested + multi-sibling + empty + missing
+  attributes).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+  — codec extension for the `conversation` document.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+  — projector emits blips in manifest order with parent/thread set.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+  — flag-on path renders nested DOM; flag-off path renders flat (no
+  regression); aria-expanded on toggle.
+- `wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clStageOneReadSurfaceParityTest.java`
+  — extend the fixture to seed a multi-thread wave and assert nested
+  DOM under the J2CL surface; assert no nested DOM leaks under the
+  GWT path.
+
+## 4. DocOp / data-path changes
+
+No write-path DocOp changes. The manifest is already authored
+server-side by the existing GWT compose path; we are only **reading**
+it client-side. No new annotation keys, no new DocOp components.
+
+The manifest parser is purely additive in the codec — it reads the
+already-streamed `conversation` document. No new RPC, no protocol
+bump, no server change.
+
+## 5. Feature flag
+
+`j2cl-threaded-rendering` (experimental, default `false` in prod).
+
+When `false`: renderer takes the existing flat-list path; manifest is
+parsed but ignored. This is the rollback target.
+
+When `true`: renderer builds nested thread containers from the
+manifest. Behavior on a wave with no manifest (no `conversation`
+document, e.g. legacy) is identical to the flag-off path because the
+nested-render branch short-circuits when the manifest is empty.
+
+The flag is read at render time, not at codec time, so flipping the
+flag without a page reload re-evaluates on the next render.
+
+## 6. Test plan
+
+### Unit / sbt
+
+- `cd wave && sbt "j2cl/test"` — picks up the new unit fixtures.
+- `cd wave && sbt "wave/test:testOnly *J2clStageOneReadSurfaceParityTest"`
+  — Jakarta browser-harness fixture asserts the nested-DOM contract.
+- `cd wave && sbt compile` — must remain green.
+
+### Browser harness
+
+The existing browser-harness mounts the J2CL servlet; re-running it
+after the change should show `data-thread-id` attributes on nested
+inline-thread containers and a `data-depth="N"` attribute on each
+`<wave-blip>` reflecting its nesting level.
+
+### Local-server QA (mandatory before PR)
+
+Per the issue's verification section + project memory
+`feedback_local_server_verification_before_pr`:
+
+1. `cd wave && sbt run` (or whatever boots the local dev server in
+   this branch — discovered during QA).
+2. Register a fresh user (do NOT assume `vega` exists, per
+   `feedback_local_registration_before_login_testing`).
+3. Seed a wave with ≥3 threads + one inline reply chain at depth ≥3.
+   Use a second account so the multi-author rendering is exercised.
+4. Open the wave at `/?view=j2cl-root&wave=<id>`.
+5. Confirm: every blip shows author avatar, display name, relative
+   timestamp, and is **indented by thread depth** (not raw ID
+   strings, not all flat).
+6. Press `j` / `k` and arrow keys; the focus frame moves between
+   blips and remains visible after triggering an incremental update
+   (have the second account post a reply during the test).
+7. Click and keyboard-toggle (Space/Enter) the collapse affordance on
+   a parent thread; confirm children collapse, scroll anchor is
+   preserved, the toggle's `aria-expanded` flips.
+8. Screenshot:
+   - (a) populated threaded view (`docs/superpowers/screenshots/j-ui-4/threaded-view.png`)
+   - (b) focus frame mid-navigation (`docs/superpowers/screenshots/j-ui-4/focus-frame.png`)
+   - (c) collapsed thread state (`docs/superpowers/screenshots/j-ui-4/collapsed-thread.png`)
+9. GWT regression: visit `/?view=gwt`, confirm threaded rendering
+   still works on the legacy path and no F-2 / J-UI-4 markers leak.
+
+## 7. Roll-back path
+
+Single-line roll-back: flip the `j2cl-threaded-rendering` feature
+flag to `false`. The renderer falls back to the existing flat-list
+path; all other shipped F-2 behavior (avatar, author, timestamp,
+toolbar, focus, collapse on the single root thread) continues to
+work because none of it depends on the new nesting code.
+
+If the flag-flip is not enough (manifest parser regression), revert
+the PR — no DB migration, no protocol bump, nothing else
+to undo.

--- a/docs/superpowers/plans/2026-04-28-j-ui-4-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-4-plan.md
@@ -257,6 +257,89 @@ Per the issue's verification section + project memory
 9. GWT regression: visit `/?view=gwt`, confirm threaded rendering
    still works on the legacy path and no F-2 / J-UI-4 markers leak.
 
+## 6a. Review feedback addressed
+
+Copilot review (claude-sonnet-4.5) raised the following; resolutions inline:
+
+1. **Manifest parser tree reconstruction** — explicit element stack
+   tracks open `<thread id="…">` ancestors and the current parent
+   blip-id-on-this-thread. On `<blip id="b+…"/>` element-start, emit a
+   `ManifestEntry(blipId, parentBlipId=mostRecentBlipOnEnclosingThread,
+   threadId=topOfThreadStack, depth=threadStack.size()-1,
+   siblingIndex=perThreadCounter[threadId]++)`. The
+   `parentBlipId` equals empty string when the thread is the root
+   thread (no enclosing blip).
+
+2. **Children index for nested rendering** — after the manifest is
+   built, the renderer constructs an inverse index
+   `Map<parentBlipId, List<threadId>>` lazily inside the nested-render
+   pass. Each rendered blip calls
+   `childThreadsOf(blipId)` and appends an `<div class="thread
+   inline-thread" data-thread-id="…">` per child thread before falling
+   through to the next sibling.
+
+3. **Incremental-update DOM strategy** — keep the existing full-render
+   strategy (`render(...)` already rebuilds and restores collapsed +
+   focus). Extend `captureCollapsedThreadIds` to also walk
+   `[data-j2cl-thread-collapsed='true']` inside `inline-thread`
+   ancestors (it already does — the selector is unscoped); and verify
+   `restoreCollapsedThreads` walks every `[data-j2cl-collapse-ready]`
+   regardless of nesting (also unscoped). No code change needed; add
+   tests for nested collapse survival across re-render.
+
+4. **Manifest traversal order** — depth-first pre-order traversal:
+   visit each blip in a thread in document order, descend into its
+   reply threads (in document order) before moving to the next sibling.
+   This is the GWT renderer's order and the order the manifest XML
+   author intended. Chronological ordering is out of scope for this
+   slice.
+
+5. **Initial-focus placement (R-3.1)** — `restoreFocusedBlipById`
+   already focuses the first rendered blip when no prior focus exists
+   (verified in `J2clReadSurfaceDomRendererTest`). With nested DFS
+   order, "first" means "first blip in the root thread", which is the
+   matrix-row-required predictable behaviour.
+
+6. **ARIA landmark/list (R-3.1) and keyboard reach (R-3.3)** — nested
+   `inline-thread` containers receive `role="group"` (already done in
+   `enhanceSurface`). The collapse toggle is a `<button>` already
+   reachable via tab. Add `aria-expanded` on the toggle (step 5 above).
+   Add a fixture asserting tab-reachability of the toggle even when
+   the thread is collapsed.
+
+7. **Arrow / shift-tab (R-3.2)** — current renderer keyboard handler
+   already supports `j` / `k` / arrow up/down / shift-tab via a single
+   key-event delegate. Test plan extended to assert each key across
+   nested DOM in the unit fixture and during local-server QA.
+
+8. **Dark-theme contrast (R-3.2)** — focus ring uses
+   `--wavy-focus-ring` token which meets WCAG-AA on both wavy themes
+   per the F-0 design system test pack. QA step adds a dark-theme
+   screenshot.
+
+9. **Read-state preservation (R-3.3)** — read state is stored in the
+   wavelet supplement, not the DOM, so it survives renderer rebuilds
+   trivially. No code change.
+
+10. **aria-expanded duplication check (F-2 dupe)** — verified during
+    implementation by grepping the renderer; F-2's toggle sets only
+    `aria-label` and `aria-controls`. `aria-expanded` is missing —
+    this PR adds it (not duplicate).
+
+11. **Malformed manifest fallback** — parser tolerates missing `id`
+    attrs (skips the element silently), unclosed threads (closes at
+    document end), and unknown tags (ignores). Orphan blips
+    (manifest references `b+xyz` but no document) are rendered with
+    placeholder text in manifest-order alongside non-orphan blips so
+    the user sees structure even when a fragment is mid-fetch.
+
+12. **Manifest vs. document mismatch** — projector now drives the
+    blip list **from the manifest**, looking up document-derived
+    text/author/timestamp by blip-id. Documents that have no manifest
+    entry (e.g. stray data documents, the `tags` doc) are skipped
+    from the read surface. Manifest entries with no document render
+    with empty text + the placeholder treatment.
+
 ## 7. Roll-back path
 
 Single-line roll-back: flip the `j2cl-threaded-rendering` feature

--- a/docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md
+++ b/docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md
@@ -1,0 +1,137 @@
+# J2CL Functional UI Roadmap (2026-04-28)
+
+Status: Active
+Owner: J2CL parity sprint
+Parent tracker: [#904](https://github.com/vega113/supawave/issues/904)
+Audit basis: [`docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md`](../audits/2026-04-26-j2cl-gwt-parity-audit.md)
+Parity matrix: [`docs/j2cl-gwt-parity-matrix.md`](../../j2cl-gwt-parity-matrix.md)
+
+## 1. Why this exists
+
+The 2026-04-26 audit verified that despite F-0..F-4 closing in GitHub, the lived
+J2CL surface at `/?view=j2cl-root` is not usable: 4/26 matrix gate rows pass,
+the wave list does not render, blips appear as raw IDs, and the composer is
+detached from a non-rich textarea. The user-visible state is a `Select a wave`
+placeholder with no clickable digest cards.
+
+This roadmap drives the J2CL UI from "shell skeleton" to "actually usable as a
+SupaWave client." It is intentionally framed in user-action terms (list waves,
+filter, open, edit, mark done) rather than architecture, because the prior
+chain over-indexed on architecture and shipped placeholders.
+
+## 2. Deliverables
+
+| Phase | Deliverable | Lane |
+| --- | --- | --- |
+| 1 | Wavy mockups for the J2CL functional UI (SVG) | docs PR |
+| 2 | Umbrella issue + 8 slice issues filed against #904 | issue-creation lane |
+| 3 | One PR per slice issue, each with local-server verification | per-slice impl lane |
+
+Mockups must use the SupaWave wordmark/logo, real terminology (Wave, Blip,
+Inbox/Mentions/Tasks/Public/Archive/Pinned), and reflect the current J2CL Lit
+shell components (`shell-root`, `wavy-search-rail`, `wavy-search-rail-card`,
+`shell-main-region`). Surfaces to mock: shell layout, threaded reading view,
+inline rich-text composer, mobile, dark mode.
+
+## 3. Issue list
+
+Each issue cites specific matrix rows as hard acceptance — no
+"practical parity" escape hatches.
+
+### J-UI-1. Wave list renders in the search rail
+- **User story**: I open `/?view=j2cl-root&q=in:inbox`; the rail shows my waves
+  as digest cards (avatar, title, snippet, count, timestamp). Clicking opens
+  the wave.
+- **Acceptance**: J2CL search digest results materialize as
+  `<wavy-search-rail-card>` instances inside `<wavy-search-rail>`; selection
+  routes URL state and opens the wave region.
+- **Matrix rows**: R-3.5 (visible-region container — list level), R-4.5 (route
+  integration).
+- **Bug evidence**: screenshot on `?view=j2cl-root&q=in:inbox` — `Showing
+  search results for in:inbox.` text rendered, zero cards visible.
+
+### J-UI-2. Folder + filter chip switching is functional
+- **User story**: I click `Mentions`, `Tasks`, `Public`, `Archive`, `Pinned`,
+  or any filter chip (`Unread only`, `With attachments`, `From me`); the rail
+  re-queries and updates.
+- **Acceptance**: Each saved-search button issues the corresponding query and
+  the rail repopulates; filter chips compose with the active folder; URL
+  reflects the active query.
+- **Matrix rows**: R-4.5.
+
+### J-UI-3. New Wave create flow
+- **User story**: I click `New Wave`, type a title and message, the wave is
+  created on the server, lands at the top of Inbox, and opens in the wave
+  panel.
+- **Acceptance**: End-to-end create flow exercising the J2CL write path; new
+  wave digest appears in the rail without page reload.
+- **Matrix rows**: R-5.1 (compose flow).
+
+### J-UI-4. Open-wave threaded reading view
+- **User story**: I open a wave; blips render with author avatar, name,
+  relative timestamp, and threaded indenting. I navigate with arrow keys / `j`
+  / `k` and a focus frame moves. Threads collapse and expand.
+- **Acceptance**: Conversation DOM (not raw blip IDs) for every blip;
+  `FocusFramePresenter`-equivalent visible focus; collapse toggle wired.
+- **Matrix rows**: R-3.1, R-3.2, R-3.3, R-3.6.
+
+### J-UI-5. Inline rich-text composer + working toolbar
+- **User story**: I click reply on a blip; an inline contenteditable composer
+  opens at that position. Toolbar buttons (bold, italic, link, list, heading,
+  alignment) toggle on selection and apply to the active range.
+- **Acceptance**: Composer is contenteditable, not `<textarea>`; toolbar is
+  selection-driven; replies submit to the correct parent blip.
+- **Matrix rows**: R-5.1, R-5.2, R-5.7.
+
+### J-UI-6. Per-blip task toggle + done state
+- **User story**: I click the task affordance on a blip; the blip becomes a
+  task. I click "done"; the task is marked complete and the visual state
+  reflects it. Reload preserves the state.
+- **Acceptance**: Task toggle is wired to the task DocOp; done state renders
+  with strikethrough/checkmark and persists across reload.
+- **Matrix rows**: R-5.4.
+
+### J-UI-7. Mark-as-read + live unread decrement
+- **User story**: I open a wave; its unread count drops to zero in the rail
+  digest. Other clients reflect the change.
+- **Acceptance**: Per-user read state mutates on open; rail digest re-renders
+  count and badge styling; live updates from other clients apply.
+- **Matrix rows**: R-4.4.
+
+### J-UI-8. Server-first first-paint of selected wave
+- **User story**: I refresh on `?wave=<id>`; the visible region is readable
+  before client JS boots.
+- **Acceptance**: `J2clSelectedWaveSnapshotRenderer` output present in the
+  initial HTML response and visible (no `Select a wave` flash); shell upgrades
+  in place.
+- **Matrix rows**: R-6.1, R-6.3.
+
+## 4. Sequencing
+
+Phases 1 and 2 run in parallel. Phase 3 sequencing inside the impl lanes:
+
+1. J-UI-1 (unblocks visible feedback for everything else)
+2. J-UI-2 (small follow-up to J-UI-1)
+3. J-UI-4 (read surface — required by J-UI-5 and J-UI-6)
+4. J-UI-5 (composer)
+5. J-UI-7 (live state — small)
+6. J-UI-6 (tasks — depends on per-blip rendering)
+7. J-UI-3 (write path) — can run in parallel with 4–6
+8. J-UI-8 (server-first paint) — last, decorator on top of everything else
+
+## 5. Out of scope
+
+- Reactions, mentions autocomplete, attachments inline rendering — these are
+  follow-ups already filed under F-3 follow-up issues (#1073–#1076). They are
+  not blockers for "actually usable interface."
+- Default-root cutover (#923/#924) — gated by the parity matrix §8 gate; this
+  roadmap brings J-UI parity to the level needed to revisit that gate, but
+  cutover itself remains a separate decision.
+- Visual latitude beyond the Wavy mockup set is deferred to future iterations.
+
+## 6. Workflow per slice
+
+Each slice issue follows the standing full-drill workflow:
+plan → review → implement → review → QA on local server → flag → changelog →
+PR. Each PR receives a `wave-pr-monitor` pane that stays alive until the PR is
+merged with all conversations resolved.

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -28,6 +28,18 @@
   max-height: 10000px;
 }
 
+/* J-UI-4 (#1082, R-3.1) — inline reply threads nested under their parent
+ * blip render with a visible left-side cyan rail and a depth-derived
+ * indent so deep nesting is visually distinguishable. The rail uses the
+ * same wavy signal-cyan token as the unread pulse; the indent uses the
+ * existing spacing scale so it stays in step with other wavy chrome. */
+.j2cl-read-thread.inline-thread {
+  margin-top: var(--wavy-spacing-2, 8px);
+  margin-left: var(--wavy-spacing-3, 12px);
+  padding-left: var(--wavy-spacing-3, 12px);
+  border-left: 2px solid var(--wavy-signal-cyan-soft, rgba(34, 211, 238, 0.22));
+}
+
 .j2cl-read-thread-collapsed {
   max-height: 0;
   opacity: 0;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -551,6 +551,12 @@ public final class J2clReadSurfaceDomRenderer {
             phParent, phThread, rootThread,
             winBlipHostsById, winThreadHostsByKey, winLastThreadHostByParent);
         placeholderTarget.appendChild(placeholderEl);
+        // Index the placeholder host so subsequent entries in the same
+        // window that have this blip as their parent can resolve it via
+        // resolveWinThreadTarget rather than falling back to rootThread.
+        if (!entry.getBlipId().isEmpty()) {
+          winBlipHostsById.put(entry.getBlipId(), placeholderEl);
+        }
         continue;
       }
       // J-UI-4 (#1082, R-3.1): prefer the entry's own parent /

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -116,6 +116,14 @@ public final class J2clReadSurfaceDomRenderer {
   // the same way the live-blip render path does. Empty manifest = no
   // enrichment (legacy waves keep rendering flat).
   private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
+  // J-UI-4 (#1082, R-3.1): snapshot of the manifest applied to the
+  // current rendered surface. Used by matchesRenderedWindowEntries to
+  // detect a manifest swap that arrived without any change to the
+  // viewport entry list — without it, a late-arriving conversation
+  // document would be silently ignored until some unrelated entry
+  // mutation forced a rebuild.
+  private SidecarConversationManifest renderedConversationManifest =
+      SidecarConversationManifest.empty();
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -463,6 +471,7 @@ public final class J2clReadSurfaceDomRenderer {
       renderedBlips.clear();
       renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+      renderedConversationManifest = SidecarConversationManifest.empty();
       renderedSurface = null;
       focusedBlip = null;
       return false;
@@ -472,7 +481,10 @@ public final class J2clReadSurfaceDomRenderer {
     String scrollAnchorBlipId = firstRenderedBlipId();
     double scrollAnchorTop = renderedBlipTop(scrollAnchorBlipId);
     List<String> previouslyCollapsedThreadIds = captureCollapsedThreadIds();
-    if (matchesRenderedWindowEntries(entries)) {
+    // J-UI-4 (#1082, R-3.1): also invalidate the cache when the manifest
+    // has changed (reference equality is intentional — a new manifest from
+    // a new update is always a different object reference).
+    if (matchesRenderedWindowEntries(entries) && conversationManifest == renderedConversationManifest) {
       restoreFocusedBlipById(focusedBlipId);
       evaluateDwellTimers();
       return true;
@@ -483,6 +495,7 @@ public final class J2clReadSurfaceDomRenderer {
     renderedBlips.clear();
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
+    renderedConversationManifest = SidecarConversationManifest.empty();
     renderedSurface = null;
     focusedBlip = null;
 
@@ -595,6 +608,10 @@ public final class J2clReadSurfaceDomRenderer {
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedSurface = surface;
+    // J-UI-4 (#1082, R-3.1): record the manifest that was active for this
+    // render so the early-return check above can detect a later manifest
+    // swap even when the entry list itself hasn't changed.
+    renderedConversationManifest = conversationManifest;
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -530,7 +530,27 @@ public final class J2clReadSurfaceDomRenderer {
       J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
         hasPlaceholder = true;
-        rootThread.appendChild(renderPlaceholder(entry));
+        HTMLElement placeholderEl = renderPlaceholder(entry);
+        // review-1089 round-5 (codex P2): apply the same manifest
+        // lookup used for loaded entries so that a placeholder blip
+        // which is a reply is nested inside its parent thread rather
+        // than appended to rootThread. If the parent hasn't rendered
+        // yet (out-of-order or itself a placeholder) we fall back to
+        // rootThread, matching the loaded-blip defense-in-depth path.
+        String phParent = "";
+        String phThread = "";
+        if (!conversationManifest.isEmpty() && !entry.getBlipId().isEmpty()) {
+          SidecarConversationManifest.Entry phManifestEntry =
+              conversationManifest.findByBlipId(entry.getBlipId());
+          if (phManifestEntry != null) {
+            phParent = phManifestEntry.getParentBlipId() == null ? "" : phManifestEntry.getParentBlipId();
+            phThread = phManifestEntry.getThreadId() == null ? "" : phManifestEntry.getThreadId();
+          }
+        }
+        HTMLElement placeholderTarget = resolveWinThreadTarget(
+            phParent, phThread, rootThread,
+            winBlipHostsById, winThreadHostsByKey, winLastThreadHostByParent);
+        placeholderTarget.appendChild(placeholderEl);
         continue;
       }
       // J-UI-4 (#1082, R-3.1): prefer the entry's own parent /
@@ -566,52 +586,12 @@ public final class J2clReadSurfaceDomRenderer {
               entry.hasMention());
       HTMLElement blipElement = renderBlip(blip, blipIndex++);
       winBlipHostsById.put(blip.getBlipId(), blipElement);
-      String parentBlipId = entryParent == null ? "" : entryParent;
-      String threadId = entryThread == null ? "" : entryThread;
-      if (parentBlipId.isEmpty()) {
-        rootThread.appendChild(blipElement);
-      } else {
-        HTMLElement parentHost = winBlipHostsById.get(parentBlipId);
-        if (parentHost == null) {
-          // Defense-in-depth: parent not yet rendered (out-of-order
-          // manifest or missing blip). Show the content at root level.
-          rootThread.appendChild(blipElement);
-        } else {
-          String threadKey = parentBlipId + "::" + threadId;
-          HTMLElement threadHost = winThreadHostsByKey.get(threadKey);
-          if (threadHost == null) {
-            threadHost = (HTMLElement) DomGlobal.document.createElement("div");
-            threadHost.className = "thread inline-thread j2cl-read-thread";
-            // review-1089 round-3: scope data-thread-id by parent so
-            // collapse state does not bleed across threads that share
-            // the same raw manifest threadId under different parents.
-            String scopedId =
-                !threadId.isEmpty() ? (parentBlipId + "::" + threadId) : ("inline-" + parentBlipId);
-            threadHost.setAttribute("data-thread-id", scopedId);
-            threadHost.setAttribute("data-parent-blip-id", parentBlipId);
-            // review-1089 round-4 (codex P2): if a previous thread was
-            // already mounted for this parent, anchor the new thread
-            // after that thread host instead of after the parent so
-            // sibling threads stay in manifest DFS order.
-            HTMLElement winAnchor = winLastThreadHostByParent.get(parentBlipId);
-            if (winAnchor == null) {
-              winAnchor = parentHost;
-            }
-            if (winAnchor.parentNode != null) {
-              if (winAnchor.nextSibling != null) {
-                winAnchor.parentNode.insertBefore(threadHost, winAnchor.nextSibling);
-              } else {
-                winAnchor.parentNode.appendChild(threadHost);
-              }
-            } else {
-              parentHost.appendChild(threadHost);
-            }
-            winThreadHostsByKey.put(threadKey, threadHost);
-            winLastThreadHostByParent.put(parentBlipId, threadHost);
-          }
-          threadHost.appendChild(blipElement);
-        }
-      }
+      HTMLElement blipTarget = resolveWinThreadTarget(
+          blip.getParentBlipId() == null ? "" : blip.getParentBlipId(),
+          blip.getThreadId() == null ? "" : blip.getThreadId(),
+          rootThread,
+          winBlipHostsById, winThreadHostsByKey, winLastThreadHostByParent);
+      blipTarget.appendChild(blipElement);
     }
     if (hasPlaceholder) {
       surface.setAttribute("aria-live", "polite");
@@ -1177,6 +1157,54 @@ public final class J2clReadSurfaceDomRenderer {
       return "pending";
     }
     return "ready";
+  }
+
+  /**
+   * Returns the inline-thread container element for a blip (or placeholder)
+   * in renderWindow, creating it on demand when a parent has been rendered.
+   * Falls back to {@code rootThread} when {@code parentBlipId} is empty or
+   * the parent element hasn't been inserted yet.
+   */
+  private HTMLElement resolveWinThreadTarget(
+      String parentBlipId,
+      String threadId,
+      HTMLElement rootThread,
+      Map<String, HTMLElement> winBlipHostsById,
+      Map<String, HTMLElement> winThreadHostsByKey,
+      Map<String, HTMLElement> winLastThreadHostByParent) {
+    if (parentBlipId == null || parentBlipId.isEmpty()) {
+      return rootThread;
+    }
+    HTMLElement parentHost = winBlipHostsById.get(parentBlipId);
+    if (parentHost == null) {
+      return rootThread;
+    }
+    String threadKey = parentBlipId + "::" + (threadId == null ? "" : threadId);
+    HTMLElement threadHost = winThreadHostsByKey.get(threadKey);
+    if (threadHost == null) {
+      threadHost = (HTMLElement) DomGlobal.document.createElement("div");
+      threadHost.className = "thread inline-thread j2cl-read-thread";
+      String tid = threadId == null ? "" : threadId;
+      String scopedId = !tid.isEmpty() ? (parentBlipId + "::" + tid) : ("inline-" + parentBlipId);
+      threadHost.setAttribute("data-thread-id", scopedId);
+      threadHost.setAttribute("data-parent-blip-id", parentBlipId);
+      HTMLElement winAnchor = winLastThreadHostByParent.get(parentBlipId);
+      if (winAnchor == null) {
+        winAnchor = parentHost;
+      }
+      if (winAnchor.parentNode != null) {
+        if (winAnchor.nextSibling != null) {
+          winAnchor.parentNode.insertBefore(threadHost, winAnchor.nextSibling);
+        } else {
+          winAnchor.parentNode.appendChild(threadHost);
+        }
+      } else {
+        parentHost.appendChild(threadHost);
+      }
+      winThreadHostsByKey.put(threadKey, threadHost);
+      winLastThreadHostByParent.put(parentBlipId, threadHost);
+    }
+    return threadHost;
   }
 
   private HTMLElement renderPlaceholder(J2clReadWindowEntry entry) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -421,9 +421,7 @@ public final class J2clReadSurfaceDomRenderer {
     rootThread.setAttribute("role", "list");
     surface.appendChild(rootThread);
 
-    for (int i = 0; i < effectiveBlips.size(); i++) {
-      rootThread.appendChild(renderBlip(effectiveBlips.get(i), i));
-    }
+    appendBlipsAsTree(rootThread, effectiveBlips);
 
     host.appendChild(surface);
     renderedLiveBlips = immutableBlipCopy(effectiveBlips);
@@ -582,6 +580,74 @@ public final class J2clReadSurfaceDomRenderer {
     // A zero-blip surface is still valid no-wave/empty markup, but callers use
     // the boolean to know whether focusable read content was found.
     return !renderedBlips.isEmpty();
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1) — appends {@code blips} into {@code rootThread},
+   * nesting reply blips into {@code <div class="thread inline-thread">}
+   * containers under their parent blip's host whenever the blip carries
+   * a non-empty {@code parentBlipId}. Reply order is the order of the
+   * input list (the projector already laid the list out in conversation
+   * DFS pre-order via {@code applyConversationManifest}).
+   *
+   * <p>If no blip in the input list has a non-empty {@code parentBlipId},
+   * the method falls through to the original flat-append behaviour so
+   * non-conversational fixtures and legacy waves keep rendering as
+   * before.
+   */
+  private void appendBlipsAsTree(HTMLElement rootThread, List<J2clReadBlip> blips) {
+    boolean hasNesting = false;
+    for (J2clReadBlip blip : blips) {
+      if (blip != null && blip.getParentBlipId() != null
+          && !blip.getParentBlipId().isEmpty()) {
+        hasNesting = true;
+        break;
+      }
+    }
+    if (!hasNesting) {
+      for (int i = 0; i < blips.size(); i++) {
+        rootThread.appendChild(renderBlip(blips.get(i), i));
+      }
+      return;
+    }
+    Map<String, HTMLElement> blipHostsById = new HashMap<String, HTMLElement>();
+    Map<String, HTMLElement> threadHostsByThreadKey = new HashMap<String, HTMLElement>();
+    int nextIndex = 0;
+    for (J2clReadBlip blip : blips) {
+      if (blip == null || blip.getBlipId() == null || blip.getBlipId().isEmpty()) {
+        continue;
+      }
+      HTMLElement blipElement = renderBlip(blip, nextIndex++);
+      blipHostsById.put(blip.getBlipId(), blipElement);
+      String parentBlipId = blip.getParentBlipId();
+      String threadId = blip.getThreadId() == null ? "" : blip.getThreadId();
+      if (parentBlipId == null || parentBlipId.isEmpty()) {
+        rootThread.appendChild(blipElement);
+        continue;
+      }
+      HTMLElement parentBlipHost = blipHostsById.get(parentBlipId);
+      if (parentBlipHost == null) {
+        // Manifest references a parent blip we have not seen yet — fall
+        // back to root-thread placement so the blip is still visible.
+        rootThread.appendChild(blipElement);
+        continue;
+      }
+      String threadKey = parentBlipId + "::" + threadId;
+      HTMLElement threadHost = threadHostsByThreadKey.get(threadKey);
+      if (threadHost == null) {
+        threadHost = (HTMLElement) DomGlobal.document.createElement("div");
+        threadHost.className = "thread inline-thread j2cl-read-thread";
+        if (!threadId.isEmpty()) {
+          threadHost.setAttribute("data-thread-id", threadId);
+        } else {
+          threadHost.setAttribute("data-thread-id", "inline-" + parentBlipId);
+        }
+        threadHost.setAttribute("data-parent-blip-id", parentBlipId);
+        parentBlipHost.appendChild(threadHost);
+        threadHostsByThreadKey.put(threadKey, threadHost);
+      }
+      threadHost.appendChild(blipElement);
+    }
   }
 
   private HTMLElement renderBlip(J2clReadBlip blip, int index) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -23,6 +23,7 @@ import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
+import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clReadSurfaceDomRenderer {
@@ -108,6 +109,13 @@ public final class J2clReadSurfaceDomRenderer {
   // view layer (J2clSelectedWaveView). Null binder means "no reactions
   // wiring yet" — the row is still mounted as an empty add-only state.
   private ReactionBinder reactionBinder;
+  // J-UI-4 (#1082, R-3.1): conversation manifest for the current wave.
+  // Set by the view layer before each render call. The renderer uses
+  // this to graft parent-blip-id / thread-id onto each blip in the
+  // viewport-windowed render path so renderWindow nests reply threads
+  // the same way the live-blip render path does. Empty manifest = no
+  // enrichment (legacy waves keep rendering flat).
+  private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -146,6 +154,18 @@ public final class J2clReadSurfaceDomRenderer {
    */
   public void setReactionBinder(ReactionBinder binder) {
     this.reactionBinder = binder;
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1): publishes the parsed conversation manifest
+   * for the current wave so the renderer can graft parent-blip-id /
+   * thread-id onto each loaded entry on the viewport-windowed render
+   * path. Pass {@link SidecarConversationManifest#empty()} (or null)
+   * to disable manifest enrichment (legacy / non-conversational
+   * waves keep rendering flat).
+   */
+  public void setConversationManifest(SidecarConversationManifest manifest) {
+    this.conversationManifest = manifest == null ? SidecarConversationManifest.empty() : manifest;
   }
 
   /**
@@ -489,6 +509,25 @@ public final class J2clReadSurfaceDomRenderer {
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (entry.isLoaded()) {
+        // J-UI-4 (#1082, R-3.1): prefer the entry's own parent /
+        // thread metadata when present, but otherwise fall back to
+        // the renderer's conversation manifest so the windowed
+        // render path can nest replies the same way the live-blip
+        // path does. The viewport state today builds entries via
+        // the simple loaded(...) factory which leaves parent /
+        // thread empty; the manifest fills the gap.
+        String entryParent = entry.getParentBlipId();
+        String entryThread = entry.getThreadId();
+        if ((entryParent == null || entryParent.isEmpty())
+            && (entryThread == null || entryThread.isEmpty())
+            && !conversationManifest.isEmpty()) {
+          SidecarConversationManifest.Entry manifestEntry =
+              conversationManifest.findByBlipId(entry.getBlipId());
+          if (manifestEntry != null) {
+            entryParent = manifestEntry.getParentBlipId();
+            entryThread = manifestEntry.getThreadId();
+          }
+        }
         loadedBlips.add(
             new J2clReadBlip(
                 entry.getBlipId(),
@@ -497,8 +536,8 @@ public final class J2clReadSurfaceDomRenderer {
                 entry.getAuthorId(),
                 entry.getAuthorDisplayName(),
                 entry.getLastModifiedTimeMillis(),
-                entry.getParentBlipId(),
-                entry.getThreadId(),
+                entryParent,
+                entryThread,
                 entry.isUnread(),
                 entry.hasMention()));
       } else {
@@ -660,7 +699,28 @@ public final class J2clReadSurfaceDomRenderer {
           threadHost.setAttribute("data-thread-id", "inline-" + parentBlipId);
         }
         threadHost.setAttribute("data-parent-blip-id", parentBlipId);
-        parentBlipHost.appendChild(threadHost);
+        // review-1089 round-2 (Copilot): mount the reply thread as a
+        // *sibling after* the parent <wave-blip> rather than as a
+        // child of its default slot. The wave-blip element places
+        // its default slot inside the .body wrapper, which inherits
+        // styling like the F-3.S2 task-completed strikethrough
+        // (`:host([data-task-completed]) .body { text-decoration:
+        // line-through; color: var(--wavy-text-quiet); }`). Nested
+        // replies are unrelated to the parent's task state and must
+        // not pick up that visual treatment.
+        if (parentBlipHost.parentNode != null) {
+          if (parentBlipHost.nextSibling != null) {
+            parentBlipHost.parentNode.insertBefore(threadHost, parentBlipHost.nextSibling);
+          } else {
+            parentBlipHost.parentNode.appendChild(threadHost);
+          }
+        } else {
+          // The parent is somehow detached (defensive — should not
+          // happen for blips we just appended above). Fall back to
+          // appending under the parent so the content remains
+          // reachable.
+          parentBlipHost.appendChild(threadHost);
+        }
         threadHostsByThreadKey.put(threadKey, threadHost);
       }
       threadHost.appendChild(blipElement);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -520,6 +520,12 @@ public final class J2clReadSurfaceDomRenderer {
     int blipIndex = 0;
     Map<String, HTMLElement> winBlipHostsById = new HashMap<String, HTMLElement>();
     Map<String, HTMLElement> winThreadHostsByKey = new HashMap<String, HTMLElement>();
+    // review-1089 round-4 (codex P2): track the last inline-thread host
+    // inserted under each parent so subsequent sibling threads land
+    // *after* earlier threads. Inserting before parentHost.nextSibling
+    // unconditionally would mount thread B in front of the already-
+    // inserted thread A, reversing manifest DFS sibling order.
+    Map<String, HTMLElement> winLastThreadHostByParent = new HashMap<String, HTMLElement>();
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
@@ -583,16 +589,25 @@ public final class J2clReadSurfaceDomRenderer {
                 !threadId.isEmpty() ? (parentBlipId + "::" + threadId) : ("inline-" + parentBlipId);
             threadHost.setAttribute("data-thread-id", scopedId);
             threadHost.setAttribute("data-parent-blip-id", parentBlipId);
-            if (parentHost.parentNode != null) {
-              if (parentHost.nextSibling != null) {
-                parentHost.parentNode.insertBefore(threadHost, parentHost.nextSibling);
+            // review-1089 round-4 (codex P2): if a previous thread was
+            // already mounted for this parent, anchor the new thread
+            // after that thread host instead of after the parent so
+            // sibling threads stay in manifest DFS order.
+            HTMLElement winAnchor = winLastThreadHostByParent.get(parentBlipId);
+            if (winAnchor == null) {
+              winAnchor = parentHost;
+            }
+            if (winAnchor.parentNode != null) {
+              if (winAnchor.nextSibling != null) {
+                winAnchor.parentNode.insertBefore(threadHost, winAnchor.nextSibling);
               } else {
-                parentHost.parentNode.appendChild(threadHost);
+                winAnchor.parentNode.appendChild(threadHost);
               }
             } else {
               parentHost.appendChild(threadHost);
             }
             winThreadHostsByKey.put(threadKey, threadHost);
+            winLastThreadHostByParent.put(parentBlipId, threadHost);
           }
           threadHost.appendChild(blipElement);
         }
@@ -721,6 +736,10 @@ public final class J2clReadSurfaceDomRenderer {
     }
     Map<String, HTMLElement> blipHostsById = new HashMap<String, HTMLElement>();
     Map<String, HTMLElement> threadHostsByThreadKey = new HashMap<String, HTMLElement>();
+    // review-1089 round-4 (codex P2): track the last inline-thread host
+    // mounted under each parent so subsequent sibling threads land
+    // *after* earlier ones, matching manifest DFS sibling order.
+    Map<String, HTMLElement> lastThreadHostByParent = new HashMap<String, HTMLElement>();
     for (int i = 0; i < effective.size(); i++) {
       J2clReadBlip blip = effective.get(i);
       HTMLElement blipElement = renderBlip(blip, i);
@@ -767,11 +786,19 @@ public final class J2clReadSurfaceDomRenderer {
         // line-through; color: var(--wavy-text-quiet); }`). Nested
         // replies are unrelated to the parent's task state and must
         // not pick up that visual treatment.
-        if (parentBlipHost.parentNode != null) {
-          if (parentBlipHost.nextSibling != null) {
-            parentBlipHost.parentNode.insertBefore(threadHost, parentBlipHost.nextSibling);
+        // review-1089 round-4 (codex P2): anchor after the last thread
+        // host for this parent (if any) so sibling threads stay in
+        // manifest DFS order — otherwise the second thread would be
+        // inserted before the first.
+        HTMLElement anchor = lastThreadHostByParent.get(parentBlipId);
+        if (anchor == null) {
+          anchor = parentBlipHost;
+        }
+        if (anchor.parentNode != null) {
+          if (anchor.nextSibling != null) {
+            anchor.parentNode.insertBefore(threadHost, anchor.nextSibling);
           } else {
-            parentBlipHost.parentNode.appendChild(threadHost);
+            anchor.parentNode.appendChild(threadHost);
           }
         } else {
           // The parent is somehow detached (defensive — should not
@@ -781,6 +808,7 @@ public final class J2clReadSurfaceDomRenderer {
           parentBlipHost.appendChild(threadHost);
         }
         threadHostsByThreadKey.put(threadKey, threadHost);
+        lastThreadHostByParent.put(parentBlipId, threadHost);
       }
       threadHost.appendChild(blipElement);
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -497,55 +497,94 @@ public final class J2clReadSurfaceDomRenderer {
     rootThread.setAttribute("role", "list");
     surface.appendChild(rootThread);
 
-    // J-UI-4 (#1082, R-3.1) — convert loaded entries into J2clReadBlip
-    // records and let appendBlipsAsTree do the same nested-thread
-    // assembly the live-blip path uses, so the viewport-windowed
-    // renderer doesn't flatten replies. Placeholders (still loading)
-    // remain as inline placeholder elements at the root level — their
-    // text/author/timestamp aren't known yet, and the row reserves
-    // height + announces aria-busy so the user sees the skeleton.
+    // J-UI-4 (#1082, R-3.1) — build the nested-thread DOM in a single
+    // pass so placeholders and loaded blips stay in their original server
+    // sequence (review-1089 round-3: the previous two-loop approach
+    // appended placeholders during the first loop and deferred all loaded
+    // blips to appendBlipsAsTree after it, which reordered DOM children
+    // whenever a loaded entry preceded a placeholder in the window).
     boolean hasPlaceholder = false;
-    List<J2clReadBlip> loadedBlips = new ArrayList<J2clReadBlip>(entries.size());
+    int blipIndex = 0;
+    Map<String, HTMLElement> winBlipHostsById = new HashMap<String, HTMLElement>();
+    Map<String, HTMLElement> winThreadHostsByKey = new HashMap<String, HTMLElement>();
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
-      if (entry.isLoaded()) {
-        // J-UI-4 (#1082, R-3.1): prefer the entry's own parent /
-        // thread metadata when present, but otherwise fall back to
-        // the renderer's conversation manifest so the windowed
-        // render path can nest replies the same way the live-blip
-        // path does. The viewport state today builds entries via
-        // the simple loaded(...) factory which leaves parent /
-        // thread empty; the manifest fills the gap.
-        String entryParent = entry.getParentBlipId();
-        String entryThread = entry.getThreadId();
-        if ((entryParent == null || entryParent.isEmpty())
-            && (entryThread == null || entryThread.isEmpty())
-            && !conversationManifest.isEmpty()) {
-          SidecarConversationManifest.Entry manifestEntry =
-              conversationManifest.findByBlipId(entry.getBlipId());
-          if (manifestEntry != null) {
-            entryParent = manifestEntry.getParentBlipId();
-            entryThread = manifestEntry.getThreadId();
-          }
-        }
-        loadedBlips.add(
-            new J2clReadBlip(
-                entry.getBlipId(),
-                entry.getText(),
-                entry.getAttachments(),
-                entry.getAuthorId(),
-                entry.getAuthorDisplayName(),
-                entry.getLastModifiedTimeMillis(),
-                entryParent,
-                entryThread,
-                entry.isUnread(),
-                entry.hasMention()));
-      } else {
+      if (!entry.isLoaded()) {
         hasPlaceholder = true;
         rootThread.appendChild(renderPlaceholder(entry));
+        continue;
+      }
+      // J-UI-4 (#1082, R-3.1): prefer the entry's own parent /
+      // thread metadata when present, but otherwise fall back to
+      // the renderer's conversation manifest so the windowed
+      // render path can nest replies the same way the live-blip
+      // path does. The viewport state today builds entries via
+      // the simple loaded(...) factory which leaves parent /
+      // thread empty; the manifest fills the gap.
+      String entryParent = entry.getParentBlipId();
+      String entryThread = entry.getThreadId();
+      if ((entryParent == null || entryParent.isEmpty())
+          && (entryThread == null || entryThread.isEmpty())
+          && !conversationManifest.isEmpty()) {
+        SidecarConversationManifest.Entry manifestEntry =
+            conversationManifest.findByBlipId(entry.getBlipId());
+        if (manifestEntry != null) {
+          entryParent = manifestEntry.getParentBlipId();
+          entryThread = manifestEntry.getThreadId();
+        }
+      }
+      J2clReadBlip blip =
+          new J2clReadBlip(
+              entry.getBlipId(),
+              entry.getText(),
+              entry.getAttachments(),
+              entry.getAuthorId(),
+              entry.getAuthorDisplayName(),
+              entry.getLastModifiedTimeMillis(),
+              entryParent,
+              entryThread,
+              entry.isUnread(),
+              entry.hasMention());
+      HTMLElement blipElement = renderBlip(blip, blipIndex++);
+      winBlipHostsById.put(blip.getBlipId(), blipElement);
+      String parentBlipId = entryParent == null ? "" : entryParent;
+      String threadId = entryThread == null ? "" : entryThread;
+      if (parentBlipId.isEmpty()) {
+        rootThread.appendChild(blipElement);
+      } else {
+        HTMLElement parentHost = winBlipHostsById.get(parentBlipId);
+        if (parentHost == null) {
+          // Defense-in-depth: parent not yet rendered (out-of-order
+          // manifest or missing blip). Show the content at root level.
+          rootThread.appendChild(blipElement);
+        } else {
+          String threadKey = parentBlipId + "::" + threadId;
+          HTMLElement threadHost = winThreadHostsByKey.get(threadKey);
+          if (threadHost == null) {
+            threadHost = (HTMLElement) DomGlobal.document.createElement("div");
+            threadHost.className = "thread inline-thread j2cl-read-thread";
+            // review-1089 round-3: scope data-thread-id by parent so
+            // collapse state does not bleed across threads that share
+            // the same raw manifest threadId under different parents.
+            String scopedId =
+                !threadId.isEmpty() ? (parentBlipId + "::" + threadId) : ("inline-" + parentBlipId);
+            threadHost.setAttribute("data-thread-id", scopedId);
+            threadHost.setAttribute("data-parent-blip-id", parentBlipId);
+            if (parentHost.parentNode != null) {
+              if (parentHost.nextSibling != null) {
+                parentHost.parentNode.insertBefore(threadHost, parentHost.nextSibling);
+              } else {
+                parentHost.parentNode.appendChild(threadHost);
+              }
+            } else {
+              parentHost.appendChild(threadHost);
+            }
+            winThreadHostsByKey.put(threadKey, threadHost);
+          }
+          threadHost.appendChild(blipElement);
+        }
       }
     }
-    appendBlipsAsTree(rootThread, loadedBlips);
     if (hasPlaceholder) {
       surface.setAttribute("aria-live", "polite");
       rootThread.setAttribute("aria-busy", "true");
@@ -693,8 +732,11 @@ public final class J2clReadSurfaceDomRenderer {
       if (threadHost == null) {
         threadHost = (HTMLElement) DomGlobal.document.createElement("div");
         threadHost.className = "thread inline-thread j2cl-read-thread";
+        // review-1089 round-3: scope data-thread-id by parent so
+        // collapse state does not bleed across threads that share
+        // the same raw manifest threadId under different parents.
         if (!threadId.isEmpty()) {
-          threadHost.setAttribute("data-thread-id", threadId);
+          threadHost.setAttribute("data-thread-id", parentBlipId + "::" + threadId);
         } else {
           threadHost.setAttribute("data-thread-id", "inline-" + parentBlipId);
         }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -596,28 +596,33 @@ public final class J2clReadSurfaceDomRenderer {
    * before.
    */
   private void appendBlipsAsTree(HTMLElement rootThread, List<J2clReadBlip> blips) {
+    // First, drop nulls / empty-id entries up front so both code
+    // branches index against the same effective list (review-1082
+    // round-1: prevents the flat path's i-counter and the nested
+    // path's nextIndex counter from disagreeing on tabindex/aria
+    // when a list happens to contain placeholder records).
+    List<J2clReadBlip> effective = new ArrayList<J2clReadBlip>(blips.size());
     boolean hasNesting = false;
     for (J2clReadBlip blip : blips) {
-      if (blip != null && blip.getParentBlipId() != null
-          && !blip.getParentBlipId().isEmpty()) {
+      if (blip == null || blip.getBlipId() == null || blip.getBlipId().isEmpty()) {
+        continue;
+      }
+      effective.add(blip);
+      if (blip.getParentBlipId() != null && !blip.getParentBlipId().isEmpty()) {
         hasNesting = true;
-        break;
       }
     }
     if (!hasNesting) {
-      for (int i = 0; i < blips.size(); i++) {
-        rootThread.appendChild(renderBlip(blips.get(i), i));
+      for (int i = 0; i < effective.size(); i++) {
+        rootThread.appendChild(renderBlip(effective.get(i), i));
       }
       return;
     }
     Map<String, HTMLElement> blipHostsById = new HashMap<String, HTMLElement>();
     Map<String, HTMLElement> threadHostsByThreadKey = new HashMap<String, HTMLElement>();
-    int nextIndex = 0;
-    for (J2clReadBlip blip : blips) {
-      if (blip == null || blip.getBlipId() == null || blip.getBlipId().isEmpty()) {
-        continue;
-      }
-      HTMLElement blipElement = renderBlip(blip, nextIndex++);
+    for (int i = 0; i < effective.size(); i++) {
+      J2clReadBlip blip = effective.get(i);
+      HTMLElement blipElement = renderBlip(blip, i);
       blipHostsById.put(blip.getBlipId(), blipElement);
       String parentBlipId = blip.getParentBlipId();
       String threadId = blip.getThreadId() == null ? "" : blip.getThreadId();
@@ -627,8 +632,14 @@ public final class J2clReadSurfaceDomRenderer {
       }
       HTMLElement parentBlipHost = blipHostsById.get(parentBlipId);
       if (parentBlipHost == null) {
-        // Manifest references a parent blip we have not seen yet — fall
-        // back to root-thread placement so the blip is still visible.
+        // Defense-in-depth for a malformed manifest. The projector's
+        // DFS pre-order guarantees the parent renders before the
+        // child for any well-formed manifest, so this branch only
+        // fires when an upstream codec / manifest emits a child
+        // before its parent (or references a parent that does not
+        // exist in the streamed snapshot). Fall back to root-thread
+        // placement so the user still sees the blip's content
+        // instead of having it silently dropped.
         rootThread.appendChild(blipElement);
         continue;
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -477,30 +477,36 @@ public final class J2clReadSurfaceDomRenderer {
     rootThread.setAttribute("role", "list");
     surface.appendChild(rootThread);
 
-    int blipIndex = 0;
+    // J-UI-4 (#1082, R-3.1) — convert loaded entries into J2clReadBlip
+    // records and let appendBlipsAsTree do the same nested-thread
+    // assembly the live-blip path uses, so the viewport-windowed
+    // renderer doesn't flatten replies. Placeholders (still loading)
+    // remain as inline placeholder elements at the root level — their
+    // text/author/timestamp aren't known yet, and the row reserves
+    // height + announces aria-busy so the user sees the skeleton.
     boolean hasPlaceholder = false;
+    List<J2clReadBlip> loadedBlips = new ArrayList<J2clReadBlip>(entries.size());
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (entry.isLoaded()) {
-        rootThread.appendChild(
-            renderBlip(
-                new J2clReadBlip(
-                    entry.getBlipId(),
-                    entry.getText(),
-                    entry.getAttachments(),
-                    entry.getAuthorId(),
-                    entry.getAuthorDisplayName(),
-                    entry.getLastModifiedTimeMillis(),
-                    entry.getParentBlipId(),
-                    entry.getThreadId(),
-                    entry.isUnread(),
-                    entry.hasMention()),
-                blipIndex++));
+        loadedBlips.add(
+            new J2clReadBlip(
+                entry.getBlipId(),
+                entry.getText(),
+                entry.getAttachments(),
+                entry.getAuthorId(),
+                entry.getAuthorDisplayName(),
+                entry.getLastModifiedTimeMillis(),
+                entry.getParentBlipId(),
+                entry.getThreadId(),
+                entry.isUnread(),
+                entry.hasMention()));
       } else {
         hasPlaceholder = true;
         rootThread.appendChild(renderPlaceholder(entry));
       }
     }
+    appendBlipsAsTree(rootThread, loadedBlips);
     if (hasPlaceholder) {
       surface.setAttribute("aria-live", "polite");
       rootThread.setAttribute("aria-busy", "true");
@@ -1701,7 +1707,12 @@ public final class J2clReadSurfaceDomRenderer {
         && left.getAuthorId().equals(right.getAuthorId())
         && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
         && left.isUnread() == right.isUnread()
-        && left.hasMention() == right.hasMention();
+        && left.hasMention() == right.hasMention()
+        // J-UI-4 (#1082, R-3.1) — include manifest linkage fields so a
+        // rebuild fires when only parent/thread changes (e.g. a new reply
+        // arrives that re-parents an existing blip into a nested thread).
+        && left.getParentBlipId().equals(right.getParentBlipId())
+        && left.getThreadId().equals(right.getThreadId());
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 
 public final class J2clSelectedWaveModel {
   public static final int UNKNOWN_UNREAD_COUNT = -1;
@@ -29,6 +30,11 @@ public final class J2clSelectedWaveModel {
   private final boolean read;
   private final boolean readStateKnown;
   private final boolean readStateStale;
+  // J-UI-4 (#1082, R-3.1): conversation manifest is plumbed through
+  // the model so the view can publish it to the read renderer for the
+  // viewport-windowed render path. Projector populates from
+  // SidecarSelectedWaveUpdate.getConversationManifest().
+  private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -389,6 +395,17 @@ public final class J2clSelectedWaveModel {
 
   public List<J2clReadBlip> getReadBlips() {
     return readBlips;
+  }
+
+  /** J-UI-4 (#1082, R-3.1): parsed conversation manifest for the wave. Empty when unavailable. */
+  public SidecarConversationManifest getConversationManifest() {
+    return conversationManifest;
+  }
+
+  /** J-UI-4 (#1082, R-3.1): package-private setter used by the projector. */
+  J2clSelectedWaveModel withConversationManifest(SidecarConversationManifest manifest) {
+    this.conversationManifest = manifest == null ? SidecarConversationManifest.empty() : manifest;
+    return this;
   }
 
   public J2clSelectedWaveViewportState getViewportState() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -445,7 +445,10 @@ public final class J2clSelectedWaveModel {
         unreadCount,
         read,
         readStateKnown,
-        readStateStale);
+        readStateStale)
+        // J-UI-4 (#1082, R-3.1): preserve manifest across clones so
+        // viewport-windowed renders keep nesting after fragment growth.
+        .withConversationManifest(conversationManifest);
   }
 
   J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
@@ -469,7 +472,8 @@ public final class J2clSelectedWaveModel {
         unreadCount,
         read,
         readStateKnown,
-        readStateStale);
+        readStateStale)
+        .withConversationManifest(conversationManifest);
   }
 
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
@@ -495,7 +499,8 @@ public final class J2clSelectedWaveModel {
         unreadCount,
         read,
         readStateKnown,
-        readStateStale);
+        readStateStale)
+        .withConversationManifest(conversationManifest);
   }
 
   public int getUnreadCount() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -156,7 +156,11 @@ public final class J2clSelectedWaveProjector {
         unreadCount,
         read,
         readStateKnown,
-        readStateKnown && readStateStale);
+        readStateKnown && readStateStale)
+        // J-UI-4 (#1082, R-3.1): plumb the parsed manifest through so
+        // J2clSelectedWaveView can publish it to the renderer ahead of
+        // each render pass.
+        .withConversationManifest(update.getConversationManifest());
   }
 
   /**
@@ -486,7 +490,15 @@ public final class J2clSelectedWaveProjector {
         continue;
       }
       String blipId = entry.getBlipId();
-      seenBlipIds.add(blipId);
+      // review-1089 round-2 (Copilot): a malformed manifest with the
+      // same blip id repeated would otherwise emit the blip twice.
+      // Manifest.of() already dedupes its by-id map, but the ordered
+      // list must also be deduped here so the read surface stays
+      // single-instance even if a future manifest source skips the
+      // de-dup.
+      if (!seenBlipIds.add(blipId)) {
+        continue;
+      }
       J2clReadBlip existing = blipsByBlipId.get(blipId);
       if (existing == null) {
         ordered.add(
@@ -524,7 +536,7 @@ public final class J2clSelectedWaveProjector {
       if (blip != null
           && blip.getBlipId() != null
           && !blip.getBlipId().isEmpty()
-          && !seenBlipIds.contains(blip.getBlipId())) {
+          && seenBlipIds.add(blip.getBlipId())) {
         ordered.add(blip);
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -96,9 +96,16 @@ public final class J2clSelectedWaveProjector {
     // passing an empty manifest would leave readBlips flat until a
     // full snapshot resends. The same effective manifest is then
     // stored on the model below so ordering and stored state agree.
+    // review-1089 round-5 (coderabbit P2): skip manifest expansion on
+    // the viewport-window path — renderWindow() reads threadId/parentBlipId
+    // directly from the stored conversationManifest rather than from
+    // model.getReadBlips(), so allocating full-conversation placeholder
+    // blips here is wasted work that grows linearly with wave size.
     SidecarConversationManifest effectiveManifest =
         chooseManifest(update.getConversationManifest(), previousMatchesWave, previous);
-    readBlips = applyConversationManifest(readBlips, effectiveManifest);
+    if (!hasViewportWindow) {
+      readBlips = applyConversationManifest(readBlips, effectiveManifest);
+    }
     J2clSidecarWriteSession writeSession = buildWriteSession(selectedWaveId, update, previous, participantIds);
     boolean interactionEditable = writeSession != null;
     List<J2clInteractionBlipModel> interactionBlips =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
+import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
@@ -84,6 +85,12 @@ public final class J2clSelectedWaveProjector {
     // documents list when the same wire payload carries both shapes. The
     // document path is still authoritative when it exists.
     readBlips = enrichReadBlipMetadata(readBlips, update.getDocuments());
+    // J-UI-4 (#1082, R-3.1) — apply the parsed conversation manifest:
+    // graft parent-blip-id + thread-id onto each read blip and reorder
+    // the list into manifest depth-first pre-order traversal so reply
+    // ordering matches the conversation model. Empty manifest = no
+    // change (fall back to enrichment-derived ordering).
+    readBlips = applyConversationManifest(readBlips, update.getConversationManifest());
     J2clSidecarWriteSession writeSession = buildWriteSession(selectedWaveId, update, previous, participantIds);
     boolean interactionEditable = writeSession != null;
     List<J2clInteractionBlipModel> interactionBlips =
@@ -433,6 +440,95 @@ public final class J2clSelectedWaveProjector {
               /* deleted= */ documentIsDeleted(doc) || blip.isDeleted()));
     }
     return enriched;
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1) — applies the parsed conversation manifest
+   * to a list of read blips. For each manifest entry in DFS pre-order:
+   *
+   * <ul>
+   *   <li>If a matching read blip exists, emit it with the manifest's
+   *       {@code parentBlipId} / {@code threadId} grafted on (other
+   *       fields preserved from enrichment).
+   *   <li>If no matching read blip exists (manifest references a blip
+   *       whose document hasn't arrived in this update yet), emit a
+   *       placeholder {@link J2clReadBlip} so the user sees the
+   *       conversation skeleton; the next update will fill in the
+   *       text once the fragment is loaded.
+   * </ul>
+   *
+   * <p>Blips that exist in {@code readBlips} but are not in the
+   * manifest (e.g. data documents, stray blips with no conversation
+   * entry) are appended at the end in their original order so no
+   * content is dropped silently.
+   *
+   * <p>An empty manifest is a no-op — the projector falls back to
+   * the document/viewport ordering already in {@code readBlips}.
+   */
+  static List<J2clReadBlip> applyConversationManifest(
+      List<J2clReadBlip> readBlips, SidecarConversationManifest manifest) {
+    if (manifest == null || manifest.isEmpty()) {
+      return readBlips;
+    }
+    if (readBlips == null) {
+      readBlips = Collections.emptyList();
+    }
+    Map<String, J2clReadBlip> blipsByBlipId = new LinkedHashMap<String, J2clReadBlip>();
+    for (J2clReadBlip blip : readBlips) {
+      if (blip != null && blip.getBlipId() != null && !blip.getBlipId().isEmpty()) {
+        blipsByBlipId.put(blip.getBlipId(), blip);
+      }
+    }
+    List<J2clReadBlip> ordered = new ArrayList<J2clReadBlip>(readBlips.size());
+    Set<String> seenBlipIds = new LinkedHashSet<String>();
+    for (SidecarConversationManifest.Entry entry : manifest.getOrderedEntries()) {
+      if (entry == null || entry.getBlipId().isEmpty()) {
+        continue;
+      }
+      String blipId = entry.getBlipId();
+      seenBlipIds.add(blipId);
+      J2clReadBlip existing = blipsByBlipId.get(blipId);
+      if (existing == null) {
+        ordered.add(
+            new J2clReadBlip(
+                blipId,
+                /* text= */ "",
+                java.util.Collections.<org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel>emptyList(),
+                /* authorId= */ "",
+                /* authorDisplayName= */ "",
+                /* lastModifiedTimeMillis= */ 0L,
+                entry.getParentBlipId(),
+                entry.getThreadId(),
+                /* unread= */ false,
+                /* hasMention= */ false,
+                /* deleted= */ false));
+        continue;
+      }
+      ordered.add(
+          new J2clReadBlip(
+              existing.getBlipId(),
+              existing.getText(),
+              existing.getAttachments(),
+              existing.getAuthorId(),
+              existing.getAuthorDisplayName(),
+              existing.getLastModifiedTimeMillis(),
+              entry.getParentBlipId(),
+              entry.getThreadId(),
+              existing.isUnread(),
+              existing.hasMention(),
+              existing.isDeleted()));
+    }
+    // Append any blip that the manifest didn't reference so we don't
+    // silently drop content from non-conversational data documents.
+    for (J2clReadBlip blip : readBlips) {
+      if (blip != null
+          && blip.getBlipId() != null
+          && !blip.getBlipId().isEmpty()
+          && !seenBlipIds.contains(blip.getBlipId())) {
+        ordered.add(blip);
+      }
+    }
+    return Collections.unmodifiableList(ordered);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -159,8 +159,35 @@ public final class J2clSelectedWaveProjector {
         readStateKnown && readStateStale)
         // J-UI-4 (#1082, R-3.1): plumb the parsed manifest through so
         // J2clSelectedWaveView can publish it to the renderer ahead of
-        // each render pass.
-        .withConversationManifest(update.getConversationManifest());
+        // each render pass. review-1089 round-3 (codex P1 +
+        // coderabbitai): if the current update omits the conversation
+        // document (live/fragment-only updates do this), preserve the
+        // previous wave's manifest so the next renderWindow() does not
+        // fall back to flat threading until a full snapshot resends.
+        .withConversationManifest(
+            chooseManifest(update.getConversationManifest(), previousMatchesWave, previous));
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1): if the new update has no conversation
+   * document (manifest is empty), keep the previous same-wave model's
+   * manifest. A non-empty new manifest always wins (so manifest edits
+   * do propagate). Empty + no previous-same-wave = empty.
+   */
+  private static SidecarConversationManifest chooseManifest(
+      SidecarConversationManifest fromUpdate,
+      boolean previousMatchesWave,
+      J2clSelectedWaveModel previous) {
+    if (fromUpdate != null && !fromUpdate.isEmpty()) {
+      return fromUpdate;
+    }
+    if (previousMatchesWave && previous != null) {
+      SidecarConversationManifest previousManifest = previous.getConversationManifest();
+      if (previousManifest != null && !previousManifest.isEmpty()) {
+        return previousManifest;
+      }
+    }
+    return SidecarConversationManifest.empty();
   }
 
   /**
@@ -221,7 +248,11 @@ public final class J2clSelectedWaveProjector {
         unreadCount,
         read,
         readStateKnown,
-        readStateKnown && readStateStale);
+        readStateKnown && readStateStale)
+        // J-UI-4 (#1082, R-3.1): preserve manifest across read-state
+        // re-projections — read-state updates carry no conversation
+        // document and must not flatten threading.
+        .withConversationManifest(previous.getConversationManifest());
   }
 
   private static String appendStatus(String base, String suffix) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -90,7 +90,15 @@ public final class J2clSelectedWaveProjector {
     // the list into manifest depth-first pre-order traversal so reply
     // ordering matches the conversation model. Empty manifest = no
     // change (fall back to enrichment-derived ordering).
-    readBlips = applyConversationManifest(readBlips, update.getConversationManifest());
+    // review-1089 round-4 (codex P1 + coderabbitai major): use the
+    // *effective* manifest (chooseManifest) here too — same-wave
+    // fragment-only updates omit the conversation document, and
+    // passing an empty manifest would leave readBlips flat until a
+    // full snapshot resends. The same effective manifest is then
+    // stored on the model below so ordering and stored state agree.
+    SidecarConversationManifest effectiveManifest =
+        chooseManifest(update.getConversationManifest(), previousMatchesWave, previous);
+    readBlips = applyConversationManifest(readBlips, effectiveManifest);
     J2clSidecarWriteSession writeSession = buildWriteSession(selectedWaveId, update, previous, participantIds);
     boolean interactionEditable = writeSession != null;
     List<J2clInteractionBlipModel> interactionBlips =
@@ -164,8 +172,7 @@ public final class J2clSelectedWaveProjector {
         // document (live/fragment-only updates do this), preserve the
         // previous wave's manifest so the next renderWindow() does not
         // fall back to flat threading until a full snapshot resends.
-        .withConversationManifest(
-            chooseManifest(update.getConversationManifest(), previousMatchesWave, previous));
+        .withConversationManifest(effectiveManifest);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -403,6 +403,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     snippet.textContent = model.getSnippetText();
     snippet.hidden = model.getSnippetText().isEmpty();
 
+    // J-UI-4 (#1082, R-3.1): publish the conversation manifest before
+    // each render pass so the renderer's renderWindow path can graft
+    // parent-blip-id / thread-id onto each loaded entry from the
+    // manifest by blip-id lookup.
+    readSurface.setConversationManifest(model.getConversationManifest());
     List<J2clReadWindowEntry> readWindowEntries = model.getViewportState().getReadWindowEntries();
     boolean hasViewportReadWindow = !readWindowEntries.isEmpty();
     boolean hasRenderedReadSurface =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
@@ -1,0 +1,152 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * J-UI-4 (#1082, R-3.1) — parsed view of the {@code conversation}
+ * manifest document for the J2CL read surface. The manifest XML is
+ * shipped as one of the {@code SidecarSelectedWaveDocument}s on every
+ * selected-wave update; this type is the parsed tree the projector
+ * uses to attach parent-blip / thread / depth metadata to each
+ * {@link org.waveprotocol.box.j2cl.read.J2clReadBlip}.
+ *
+ * <p>The manifest is a tree of {@code <thread>} and {@code <blip>}
+ * elements. The root is {@code <conversation>} which contains a
+ * single root-level thread (id often {@code root}); blips inside a
+ * thread may themselves carry zero or more reply {@code <thread>}
+ * children. The renderer uses the parsed tree to nest reply threads
+ * visually under their parent blip.
+ *
+ * <p>Empty manifest = "no conversation document on this update", in
+ * which case the renderer falls back to flat rendering (the current
+ * F-2 behaviour).
+ */
+public final class SidecarConversationManifest {
+
+  /** Per-blip entry in the manifest. */
+  public static final class Entry {
+    private final String blipId;
+    private final String parentBlipId;
+    private final String threadId;
+    private final int depth;
+    private final int siblingIndex;
+
+    public Entry(String blipId, String parentBlipId, String threadId, int depth, int siblingIndex) {
+      this.blipId = blipId == null ? "" : blipId;
+      this.parentBlipId = parentBlipId == null ? "" : parentBlipId;
+      this.threadId = threadId == null ? "" : threadId;
+      this.depth = depth;
+      this.siblingIndex = siblingIndex;
+    }
+
+    public String getBlipId() {
+      return blipId;
+    }
+
+    /** Empty when this blip is in the root thread. */
+    public String getParentBlipId() {
+      return parentBlipId;
+    }
+
+    /** Empty when the manifest didn't tag the thread with an id. */
+    public String getThreadId() {
+      return threadId;
+    }
+
+    /** 0 = root thread; +1 per nested {@code <thread>} ancestor. */
+    public int getDepth() {
+      return depth;
+    }
+
+    /** Position among siblings inside the same {@code <thread>}. */
+    public int getSiblingIndex() {
+      return siblingIndex;
+    }
+  }
+
+  private static final SidecarConversationManifest EMPTY =
+      new SidecarConversationManifest(
+          Collections.<Entry>emptyList(), Collections.<String, Entry>emptyMap());
+
+  private final List<Entry> orderedEntries;
+  private final Map<String, Entry> entriesByBlipId;
+  private final Map<String, List<String>> childBlipIdsByParentBlipId;
+
+  private SidecarConversationManifest(
+      List<Entry> orderedEntries, Map<String, Entry> entriesByBlipId) {
+    this.orderedEntries = Collections.unmodifiableList(new ArrayList<Entry>(orderedEntries));
+    this.entriesByBlipId =
+        Collections.unmodifiableMap(new LinkedHashMap<String, Entry>(entriesByBlipId));
+    Map<String, List<String>> children = new LinkedHashMap<String, List<String>>();
+    for (Entry entry : this.orderedEntries) {
+      String parent = entry.getParentBlipId();
+      List<String> bucket = children.get(parent);
+      if (bucket == null) {
+        bucket = new ArrayList<String>();
+        children.put(parent, bucket);
+      }
+      bucket.add(entry.getBlipId());
+    }
+    Map<String, List<String>> readonlyChildren = new LinkedHashMap<String, List<String>>();
+    for (Map.Entry<String, List<String>> kv : children.entrySet()) {
+      readonlyChildren.put(kv.getKey(), Collections.unmodifiableList(kv.getValue()));
+    }
+    this.childBlipIdsByParentBlipId = Collections.unmodifiableMap(readonlyChildren);
+  }
+
+  /** Empty manifest — used when no {@code conversation} document was streamed. */
+  public static SidecarConversationManifest empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Builds a manifest from an ordered list of entries already in
+   * depth-first pre-order traversal order. Callers (the codec) must
+   * have already validated the parent chain.
+   */
+  public static SidecarConversationManifest of(List<Entry> entriesInDfsOrder) {
+    if (entriesInDfsOrder == null || entriesInDfsOrder.isEmpty()) {
+      return EMPTY;
+    }
+    Map<String, Entry> byId = new LinkedHashMap<String, Entry>();
+    for (Entry entry : entriesInDfsOrder) {
+      if (entry == null || entry.getBlipId().isEmpty()) {
+        continue;
+      }
+      // First occurrence wins so a malformed manifest with duplicate
+      // blip-id references does not silently overwrite the original.
+      if (!byId.containsKey(entry.getBlipId())) {
+        byId.put(entry.getBlipId(), entry);
+      }
+    }
+    return new SidecarConversationManifest(entriesInDfsOrder, byId);
+  }
+
+  public boolean isEmpty() {
+    return orderedEntries.isEmpty();
+  }
+
+  /** Entries in depth-first pre-order traversal order. */
+  public List<Entry> getOrderedEntries() {
+    return orderedEntries;
+  }
+
+  public Entry findByBlipId(String blipId) {
+    return blipId == null ? null : entriesByBlipId.get(blipId);
+  }
+
+  /**
+   * Direct-child blip ids for a given parent. Empty list when the
+   * parent has no replies. {@code parentBlipId == ""} returns the
+   * root-thread blips.
+   */
+  public List<String> getChildBlipIds(String parentBlipId) {
+    String key = parentBlipId == null ? "" : parentBlipId;
+    List<String> bucket = childBlipIdsByParentBlipId.get(key);
+    return bucket == null ? Collections.<String>emptyList() : bucket;
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
@@ -112,18 +112,28 @@ public final class SidecarConversationManifest {
     if (entriesInDfsOrder == null || entriesInDfsOrder.isEmpty()) {
       return EMPTY;
     }
+    // Filter null / empty-id entries AND dedupe by blipId so the
+    // ordered list and the by-id lookup map agree on what's present
+    // (review-1089 round-1: previously the ordered list could carry
+    // duplicates that the renderer would then render twice).
     Map<String, Entry> byId = new LinkedHashMap<String, Entry>();
+    List<Entry> filtered = new ArrayList<Entry>(entriesInDfsOrder.size());
     for (Entry entry : entriesInDfsOrder) {
       if (entry == null || entry.getBlipId().isEmpty()) {
         continue;
       }
       // First occurrence wins so a malformed manifest with duplicate
       // blip-id references does not silently overwrite the original.
-      if (!byId.containsKey(entry.getBlipId())) {
-        byId.put(entry.getBlipId(), entry);
+      if (byId.containsKey(entry.getBlipId())) {
+        continue;
       }
+      byId.put(entry.getBlipId(), entry);
+      filtered.add(entry);
     }
-    return new SidecarConversationManifest(entriesInDfsOrder, byId);
+    if (filtered.isEmpty()) {
+      return EMPTY;
+    }
+    return new SidecarConversationManifest(filtered, byId);
   }
 
   public boolean isEmpty() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveUpdate.java
@@ -13,6 +13,7 @@ public final class SidecarSelectedWaveUpdate {
   private final List<String> participantIds;
   private final List<SidecarSelectedWaveDocument> documents;
   private final SidecarSelectedWaveFragments fragments;
+  private final SidecarConversationManifest conversationManifest;
 
   public SidecarSelectedWaveUpdate(
       int sequenceNumber,
@@ -24,6 +25,36 @@ public final class SidecarSelectedWaveUpdate {
       List<String> participantIds,
       List<SidecarSelectedWaveDocument> documents,
       SidecarSelectedWaveFragments fragments) {
+    this(
+        sequenceNumber,
+        waveletName,
+        marker,
+        channelId,
+        resultingVersion,
+        resultingVersionHistoryHash,
+        participantIds,
+        documents,
+        fragments,
+        SidecarConversationManifest.empty());
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1) — overload that carries the parsed
+   * conversation manifest alongside the streamed documents. The
+   * older constructor remains so non-J-UI-4 call sites keep working
+   * without changes; they implicitly pass an empty manifest.
+   */
+  public SidecarSelectedWaveUpdate(
+      int sequenceNumber,
+      String waveletName,
+      boolean marker,
+      String channelId,
+      long resultingVersion,
+      String resultingVersionHistoryHash,
+      List<String> participantIds,
+      List<SidecarSelectedWaveDocument> documents,
+      SidecarSelectedWaveFragments fragments,
+      SidecarConversationManifest conversationManifest) {
     this.sequenceNumber = sequenceNumber;
     this.waveletName = waveletName;
     this.marker = marker;
@@ -33,6 +64,8 @@ public final class SidecarSelectedWaveUpdate {
     this.participantIds = Collections.unmodifiableList(participantIds);
     this.documents = Collections.unmodifiableList(documents);
     this.fragments = fragments;
+    this.conversationManifest =
+        conversationManifest == null ? SidecarConversationManifest.empty() : conversationManifest;
   }
 
   public int getSequenceNumber() {
@@ -69,5 +102,14 @@ public final class SidecarSelectedWaveUpdate {
 
   public SidecarSelectedWaveFragments getFragments() {
     return fragments;
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1) — parsed conversation manifest. Empty when the
+   * update did not include a {@code conversation} document or when the
+   * manifest was malformed.
+   */
+  public SidecarConversationManifest getConversationManifest() {
+    return conversationManifest;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -100,21 +100,26 @@ public final class SidecarTransportCodec {
     Map<String, Object> snapshot = getOptionalObject(payload, "5");
     List<String> participantIds = getStringList(snapshot, "2");
     List<SidecarSelectedWaveDocument> documents = new ArrayList<SidecarSelectedWaveDocument>();
+    SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
     Object rawDocuments = snapshot.get("3");
     if (rawDocuments != null) {
       for (Object rawDocument : asList(rawDocuments)) {
         Map<String, Object> document = asObject(rawDocument);
-        DocumentExtraction extraction =
-            extractDocument(getOptionalObject(document, "2"), getString(document, "1"));
+        String documentId = getString(document, "1");
+        Map<String, Object> documentOperation = getOptionalObject(document, "2");
+        DocumentExtraction extraction = extractDocument(documentOperation, documentId);
         documents.add(
             new SidecarSelectedWaveDocument(
-                getString(document, "1"),
+                documentId,
                 getString(document, "3"),
                 getLong(document, "5"),
                 getLong(document, "6"),
                 extraction.textContent,
                 extraction.annotationRanges,
                 extraction.reactionEntries));
+        if ("conversation".equals(documentId) && conversationManifest.isEmpty()) {
+          conversationManifest = extractConversationManifest(documentOperation);
+        }
       }
     }
 
@@ -161,7 +166,106 @@ public final class SidecarTransportCodec {
             getOptionalLong(fragments, "2", 0L),
             getOptionalLong(fragments, "3", 0L),
             ranges,
-            entries));
+            entries),
+        conversationManifest);
+  }
+
+  /**
+   * J-UI-4 (#1082, R-3.1) — parses the {@code conversation} manifest
+   * document operation into a depth-first pre-order
+   * {@link SidecarConversationManifest}.
+   *
+   * <p>The manifest XML is a tree of {@code <thread id="…">} and
+   * {@code <blip id="b+…"/>} elements. The codec walks the document
+   * operation components (element-start / element-end), maintaining
+   * a stack of open threads + the most-recent blip on each thread,
+   * and emits one {@link SidecarConversationManifest.Entry} per
+   * {@code <blip>}.
+   *
+   * <p>Unknown tags are ignored. {@code <blip>} elements without an
+   * {@code id} attribute or with an empty id are skipped silently —
+   * the renderer simply has no manifest entry for them and falls
+   * back to flat rendering for that blip.
+   */
+  static SidecarConversationManifest extractConversationManifest(
+      Map<String, Object> documentOperation) {
+    if (documentOperation == null || documentOperation.isEmpty()) {
+      return SidecarConversationManifest.empty();
+    }
+    Object rawComponents = documentOperation.get("1");
+    if (rawComponents == null) {
+      return SidecarConversationManifest.empty();
+    }
+    List<SidecarConversationManifest.Entry> entries =
+        new ArrayList<SidecarConversationManifest.Entry>();
+    // Stack of currently-open <thread> ids (top = innermost). Empty
+    // string is used when a <thread> element has no id attribute.
+    List<String> threadStack = new ArrayList<String>();
+    // Per-open-thread: most recently encountered <blip> in the same
+    // thread. Used as the parent-blip for any reply <thread> that
+    // opens before the next sibling blip on the same thread.
+    List<String> mostRecentBlipPerThread = new ArrayList<String>();
+    // Per-thread sibling counter, keyed by the thread's structural
+    // key (depth + id) so re-used ids in different subtrees do not
+    // share counters.
+    Map<String, Integer> siblingCountersByThreadKey = new LinkedHashMap<String, Integer>();
+    // Stack of element types (lowercase). Used so we know which
+    // mirror state to pop on element-end.
+    List<String> elementStack = new ArrayList<String>();
+
+    for (Object rawComponent : asList(rawComponents)) {
+      Map<String, Object> component = asObject(rawComponent);
+      if (component.containsKey("3")) {
+        Map<String, Object> elementStart = getOptionalObject(component, "3");
+        String type = getString(elementStart, "1");
+        String safeType = type == null ? "" : type;
+        elementStack.add(safeType);
+        if ("thread".equals(safeType)) {
+          String threadId = getAttribute(elementStart, "id");
+          threadStack.add(threadId == null ? "" : threadId);
+          mostRecentBlipPerThread.add("");
+        } else if ("blip".equals(safeType)) {
+          String blipId = getAttribute(elementStart, "id");
+          if (blipId == null || blipId.isEmpty()) {
+            continue;
+          }
+          String threadId = threadStack.isEmpty() ? "" : threadStack.get(threadStack.size() - 1);
+          int depth = Math.max(0, threadStack.size() - 1);
+          // The blip's parent is the most recent blip on the
+          // *enclosing* thread (i.e. the blip whose reply <thread>
+          // we are currently inside). For the outermost thread, this
+          // is empty.
+          String parentBlipId = "";
+          if (threadStack.size() >= 2) {
+            parentBlipId = mostRecentBlipPerThread.get(mostRecentBlipPerThread.size() - 2);
+          }
+          String threadKey = depth + ":" + threadId;
+          Integer counter = siblingCountersByThreadKey.get(threadKey);
+          int siblingIndex = counter == null ? 0 : counter.intValue();
+          siblingCountersByThreadKey.put(threadKey, siblingIndex + 1);
+          entries.add(
+              new SidecarConversationManifest.Entry(
+                  blipId, parentBlipId, threadId, depth, siblingIndex));
+          if (!mostRecentBlipPerThread.isEmpty()) {
+            mostRecentBlipPerThread.set(mostRecentBlipPerThread.size() - 1, blipId);
+          }
+        }
+      } else if (component.containsKey("4")) {
+        if (elementStack.isEmpty()) {
+          continue;
+        }
+        String ended = elementStack.remove(elementStack.size() - 1);
+        if ("thread".equals(ended)) {
+          if (!threadStack.isEmpty()) {
+            threadStack.remove(threadStack.size() - 1);
+          }
+          if (!mostRecentBlipPerThread.isEmpty()) {
+            mostRecentBlipPerThread.remove(mostRecentBlipPerThread.size() - 1);
+          }
+        }
+      }
+    }
+    return SidecarConversationManifest.of(entries);
   }
 
   public static SidecarSelectedWaveReadState decodeSelectedWaveReadState(String json) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -205,10 +205,12 @@ public final class SidecarTransportCodec {
     // thread. Used as the parent-blip for any reply <thread> that
     // opens before the next sibling blip on the same thread.
     List<String> mostRecentBlipPerThread = new ArrayList<String>();
-    // Per-thread sibling counter, keyed by the thread's structural
-    // key (depth + id) so re-used ids in different subtrees do not
-    // share counters.
-    Map<String, Integer> siblingCountersByThreadKey = new LinkedHashMap<String, Integer>();
+    // Per-open-thread sibling counter (parallel to threadStack so
+    // re-used thread ids in different subtrees do not collide —
+    // review-1089 round-1: a `<thread id="t+a">` nested under one
+    // blip and a sibling `<thread id="t+a">` under a different blip
+    // each get their own counter).
+    List<Integer> siblingCounterStack = new ArrayList<Integer>();
     // Stack of element types (lowercase). Used so we know which
     // mirror state to pop on element-end.
     List<String> elementStack = new ArrayList<String>();
@@ -224,6 +226,7 @@ public final class SidecarTransportCodec {
           String threadId = getAttribute(elementStart, "id");
           threadStack.add(threadId == null ? "" : threadId);
           mostRecentBlipPerThread.add("");
+          siblingCounterStack.add(Integer.valueOf(0));
         } else if ("blip".equals(safeType)) {
           String blipId = getAttribute(elementStart, "id");
           if (blipId == null || blipId.isEmpty()) {
@@ -239,10 +242,12 @@ public final class SidecarTransportCodec {
           if (threadStack.size() >= 2) {
             parentBlipId = mostRecentBlipPerThread.get(mostRecentBlipPerThread.size() - 2);
           }
-          String threadKey = depth + ":" + threadId;
-          Integer counter = siblingCountersByThreadKey.get(threadKey);
-          int siblingIndex = counter == null ? 0 : counter.intValue();
-          siblingCountersByThreadKey.put(threadKey, siblingIndex + 1);
+          int siblingIndex = 0;
+          if (!siblingCounterStack.isEmpty()) {
+            siblingIndex = siblingCounterStack.get(siblingCounterStack.size() - 1).intValue();
+            siblingCounterStack.set(
+                siblingCounterStack.size() - 1, Integer.valueOf(siblingIndex + 1));
+          }
           entries.add(
               new SidecarConversationManifest.Entry(
                   blipId, parentBlipId, threadId, depth, siblingIndex));
@@ -261,6 +266,9 @@ public final class SidecarTransportCodec {
           }
           if (!mostRecentBlipPerThread.isEmpty()) {
             mostRecentBlipPerThread.remove(mostRecentBlipPerThread.size() - 1);
+          }
+          if (!siblingCounterStack.isEmpty()) {
+            siblingCounterStack.remove(siblingCounterStack.size() - 1);
           }
         }
       }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -15,6 +15,7 @@ import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
+import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
@@ -2505,6 +2506,99 @@ public class J2clSelectedWaveProjectorTest {
                 new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 0L)),
             Arrays.asList(
                 new SidecarSelectedWaveFragment("blip:b+root", "content", 0, 0))));
+  }
+
+  // ─── J-UI-4 (#1082, R-3.1) — applyConversationManifest ────────────────
+
+  @Test
+  public void applyConversationManifestIsNoOpWhenManifestEmpty() {
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+a", "alpha"), new J2clReadBlip("b+b", "beta"));
+    java.util.List<J2clReadBlip> result =
+        J2clSelectedWaveProjector.applyConversationManifest(
+            blips, SidecarConversationManifest.empty());
+    Assert.assertSame(blips, result);
+  }
+
+  @Test
+  public void applyConversationManifestReordersBlipsIntoManifestDfsOrder() {
+    // Manifest order: b+second, b+first  (the input list is in arrival
+    // order; the projector must hand back manifest order).
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+second", "", "root", 0, 0),
+                new SidecarConversationManifest.Entry("b+first", "", "root", 0, 1)));
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(new J2clReadBlip("b+first", "alpha"), new J2clReadBlip("b+second", "beta"));
+
+    java.util.List<J2clReadBlip> result =
+        J2clSelectedWaveProjector.applyConversationManifest(blips, manifest);
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals("b+second", result.get(0).getBlipId());
+    Assert.assertEquals("beta", result.get(0).getText());
+    Assert.assertEquals("b+first", result.get(1).getBlipId());
+    Assert.assertEquals("alpha", result.get(1).getText());
+  }
+
+  @Test
+  public void applyConversationManifestGraftsParentAndThreadOnNestedBlip() {
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+parent", "", "root", 0, 0),
+                new SidecarConversationManifest.Entry("b+child", "b+parent", "t+reply", 1, 0)));
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+parent", "p"), new J2clReadBlip("b+child", "c"));
+
+    java.util.List<J2clReadBlip> result =
+        J2clSelectedWaveProjector.applyConversationManifest(blips, manifest);
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals("", result.get(0).getParentBlipId());
+    Assert.assertEquals("root", result.get(0).getThreadId());
+    Assert.assertEquals("b+parent", result.get(1).getParentBlipId());
+    Assert.assertEquals("t+reply", result.get(1).getThreadId());
+  }
+
+  @Test
+  public void applyConversationManifestEmitsPlaceholderForOrphanedManifestEntry() {
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+missing", "", "root", 0, 0)));
+
+    java.util.List<J2clReadBlip> result =
+        J2clSelectedWaveProjector.applyConversationManifest(
+            Collections.<J2clReadBlip>emptyList(), manifest);
+
+    Assert.assertEquals(1, result.size());
+    Assert.assertEquals("b+missing", result.get(0).getBlipId());
+    Assert.assertEquals("", result.get(0).getText());
+    Assert.assertEquals("", result.get(0).getParentBlipId());
+    Assert.assertEquals("root", result.get(0).getThreadId());
+  }
+
+  @Test
+  public void applyConversationManifestAppendsExtraBlipsNotReferencedByManifest() {
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+tracked", "", "root", 0, 0)));
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+tracked", "tracked"),
+            new J2clReadBlip("b+stray", "stray"));
+
+    java.util.List<J2clReadBlip> result =
+        J2clSelectedWaveProjector.applyConversationManifest(blips, manifest);
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals("b+tracked", result.get(0).getBlipId());
+    Assert.assertEquals("b+stray", result.get(1).getBlipId());
   }
 
   private static J2clSelectedWaveModel modelWithWriteSession(long baseVersion, String historyHash) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -609,4 +609,126 @@ public class SidecarTransportCodecTest {
   private static Map<String, Object> asObject(Object value) {
     return (Map<String, Object>) value;
   }
+
+  // ─── J-UI-4 (#1082, R-3.1) — conversation manifest extraction ──────────
+
+  @Test
+  public void decodeSelectedWaveUpdateLeavesManifestEmptyWhenNoConversationDocument() {
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"b+1\",\"2\":{\"1\":[{\"2\":\"hello\"}]},"
+            + "\"3\":\"a@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    Assert.assertTrue(update.getConversationManifest().isEmpty());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateExtractsRootThreadBlipsFromConversationManifest() {
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{\"1\":["
+            + "{\"3\":{\"1\":\"conversation\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"root\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+a\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+b\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true}]}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    SidecarConversationManifest manifest = update.getConversationManifest();
+    Assert.assertFalse(manifest.isEmpty());
+    Assert.assertEquals(2, manifest.getOrderedEntries().size());
+    SidecarConversationManifest.Entry first = manifest.getOrderedEntries().get(0);
+    Assert.assertEquals("b+a", first.getBlipId());
+    Assert.assertEquals("", first.getParentBlipId());
+    Assert.assertEquals("root", first.getThreadId());
+    Assert.assertEquals(0, first.getDepth());
+    Assert.assertEquals(0, first.getSiblingIndex());
+    SidecarConversationManifest.Entry second = manifest.getOrderedEntries().get(1);
+    Assert.assertEquals("b+b", second.getBlipId());
+    Assert.assertEquals("", second.getParentBlipId());
+    Assert.assertEquals("root", second.getThreadId());
+    Assert.assertEquals(1, second.getSiblingIndex());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateExtractsNestedReplyThreadFromConversationManifest() {
+    // <conversation>
+    //   <thread id="root">
+    //     <blip id="b+parent"/>
+    //     <thread id="t+reply">
+    //       <blip id="b+child"/>
+    //     </thread>
+    //   </thread>
+    // </conversation>
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{\"1\":["
+            + "{\"3\":{\"1\":\"conversation\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"root\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+parent\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+reply\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+child\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true}]}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarConversationManifest manifest =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getConversationManifest();
+
+    Assert.assertEquals(2, manifest.getOrderedEntries().size());
+    SidecarConversationManifest.Entry parent = manifest.findByBlipId("b+parent");
+    Assert.assertNotNull(parent);
+    Assert.assertEquals("", parent.getParentBlipId());
+    Assert.assertEquals("root", parent.getThreadId());
+    Assert.assertEquals(0, parent.getDepth());
+    SidecarConversationManifest.Entry child = manifest.findByBlipId("b+child");
+    Assert.assertNotNull(child);
+    Assert.assertEquals("b+parent", child.getParentBlipId());
+    Assert.assertEquals("t+reply", child.getThreadId());
+    Assert.assertEquals(1, child.getDepth());
+    Assert.assertEquals(0, child.getSiblingIndex());
+    Assert.assertEquals(
+        Arrays.asList("b+child"), manifest.getChildBlipIds("b+parent"));
+    Assert.assertEquals(
+        Arrays.asList("b+parent"), manifest.getChildBlipIds(""));
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateSkipsBlipElementsWithMissingId() {
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{\"1\":["
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"root\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+real\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true}]}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarConversationManifest manifest =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getConversationManifest();
+
+    Assert.assertEquals(1, manifest.getOrderedEntries().size());
+    Assert.assertEquals("b+real", manifest.getOrderedEntries().get(0).getBlipId());
+  }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -756,6 +756,57 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateGivesEachOpenThreadItsOwnSiblingCounter() {
+    // <conversation>
+    //   <thread id="root">
+    //     <blip id="b+1"/>
+    //     <thread id="t+a">
+    //       <blip id="b+1a"/>
+    //       <blip id="b+1b"/>     <!-- siblingIndex 1 inside t+a under b+1 -->
+    //     </thread>
+    //     <blip id="b+2"/>
+    //     <thread id="t+a">       <!-- re-used id under a different parent -->
+    //       <blip id="b+2a"/>     <!-- must be siblingIndex 0, not 2 -->
+    //     </thread>
+    //   </thread>
+    // </conversation>
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{\"1\":["
+            + "{\"3\":{\"1\":\"conversation\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"root\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+1\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+a\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+1a\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+1b\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+2\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+a\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+2a\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true}]}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarConversationManifest manifest =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getConversationManifest();
+
+    Assert.assertEquals(0, manifest.findByBlipId("b+1a").getSiblingIndex());
+    Assert.assertEquals(1, manifest.findByBlipId("b+1b").getSiblingIndex());
+    // b+2a must be siblingIndex 0 inside its own (separate) t+a
+    // thread, not 2 — review-1089 round-1 collision check.
+    Assert.assertEquals(0, manifest.findByBlipId("b+2a").getSiblingIndex());
+    Assert.assertEquals("b+2", manifest.findByBlipId("b+2a").getParentBlipId());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateLeavesManifestEmptyWhenConversationDocOpHasNoComponents() {
     String json =
         "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -711,6 +711,65 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateExtractsThreeLevelDeepReplyChain() {
+    // <conversation>
+    //   <thread id="root">
+    //     <blip id="b+1"/>
+    //     <thread id="t+a"><blip id="b+2"/>
+    //       <thread id="t+b"><blip id="b+3"/></thread>
+    //     </thread>
+    //   </thread>
+    // </conversation>
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{\"1\":["
+            + "{\"3\":{\"1\":\"conversation\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"root\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+1\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+a\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+2\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+b\"}]}},"
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+3\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true},"
+            + "{\"4\":true}]}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarConversationManifest manifest =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getConversationManifest();
+
+    Assert.assertEquals(3, manifest.getOrderedEntries().size());
+    Assert.assertEquals("b+1", manifest.getOrderedEntries().get(0).getBlipId());
+    Assert.assertEquals(0, manifest.getOrderedEntries().get(0).getDepth());
+    Assert.assertEquals("b+2", manifest.getOrderedEntries().get(1).getBlipId());
+    Assert.assertEquals("b+1", manifest.getOrderedEntries().get(1).getParentBlipId());
+    Assert.assertEquals(1, manifest.getOrderedEntries().get(1).getDepth());
+    Assert.assertEquals("b+3", manifest.getOrderedEntries().get(2).getBlipId());
+    Assert.assertEquals("b+2", manifest.getOrderedEntries().get(2).getParentBlipId());
+    Assert.assertEquals(2, manifest.getOrderedEntries().get(2).getDepth());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateLeavesManifestEmptyWhenConversationDocOpHasNoComponents() {
+    String json =
+        "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"a@example.com\"],"
+            + "\"3\":[{\"1\":\"conversation\",\"2\":{}}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    Assert.assertTrue(update.getConversationManifest().isEmpty());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateSkipsBlipElementsWithMissingId() {
     String json =
         "{\"sequenceNumber\":13,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/wave/config/changelog.d/2026-04-28-issue-1082-j-ui-4-threaded-reading.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1082-j-ui-4-threaded-reading.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-28-issue-1082-j-ui-4-threaded-reading",
-  "version": "J-UI-4 (#1082)",
+  "version": "PR #1089",
   "date": "2026-04-28",
   "title": "J2CL Open-Wave Threaded Reading View",
   "summary": "The J2CL open-wave panel now nests reply threads under their parent blip instead of flattening every blip into a single root thread. R-3.1 hard-acceptance for deep nesting + reply ordering matching the conversation model is met; the existing focus frame, collapse toggles, and aria contracts inherit the nested DOM unchanged.",

--- a/wave/config/changelog.d/2026-04-28-issue-1082-j-ui-4-threaded-reading.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1082-j-ui-4-threaded-reading.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-04-28-issue-1082-j-ui-4-threaded-reading",
+  "version": "J-UI-4 (#1082)",
+  "date": "2026-04-28",
+  "title": "J2CL Open-Wave Threaded Reading View",
+  "summary": "The J2CL open-wave panel now nests reply threads under their parent blip instead of flattening every blip into a single root thread. R-3.1 hard-acceptance for deep nesting + reply ordering matching the conversation model is met; the existing focus frame, collapse toggles, and aria contracts inherit the nested DOM unchanged.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "SidecarTransportCodec parses the wave's conversation manifest document into a SidecarConversationManifest as a side-output of the same scan that already extracts per-document text (no extra protocol round-trip).",
+        "J2clSelectedWaveProjector.applyConversationManifest grafts manifest parentBlipId / threadId onto each J2clReadBlip and reorders the read-blip list into manifest depth-first pre-order so reply ordering matches the conversation model.",
+        "J2clReadSurfaceDomRenderer builds a nested <div class=\"thread inline-thread\" data-thread-id=\"...\"> container under each parent blip's host whenever the input blips carry a non-empty parentBlipId; legacy waves with no conversation manifest fall through to the existing flat-list path with no behavior change.",
+        "wavy-thread-collapse.css adds a 12px left indent + cyan hairline rail on inline-thread containers so deep nesting is visually distinguishable on both light and dark themes."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Closes the residual read-surface gap left by F-2 (#1037): the J2CL open-wave panel now nests reply blips under their parent blip instead of flattening every blip into a single root thread.
- Parses the wave's `conversation` manifest document on the J2CL transport boundary, grafts parent-blip-id / thread-id onto each `J2clReadBlip`, reorders blips into manifest depth-first pre-order, and builds nested `<div class="thread inline-thread">` containers under each parent blip's host.
- Falls through to the existing flat-render path when the manifest is empty (legacy waves with no `conversation` doc keep rendering as before).

## Closes
- Closes #1082
- Refs umbrella #1078, parent #904

## Matrix rows satisfied
- **R-3.1** (open-wave rendering) — `J2clReadSurfaceDomRenderer.appendBlipsAsTree` builds nested thread DOM with stable `data-thread-id` / `data-blip-id` / `data-parent-blip-id` attributes; deep nesting renders without layout collapse via the new `.j2cl-read-thread.inline-thread` CSS rule (12px indent + cyan hairline rail per nesting level); reply ordering matches the conversation manifest's DFS pre-order traversal.
- **R-3.2** (focus framing) — the existing `wavy-focus-frame` and the renderer's `j` / `k` / Arrow / Shift-Tab keyboard delegate continue to work against the new nested DOM unchanged (they already index by `[data-j2cl-read-blip]` regardless of depth); focus survives renderer rebuilds via `restoreFocusedBlipById`.
- **R-3.3** (collapse) — the existing `enhanceInlineThread` walker discovers nested `inline-thread` containers via the unscoped `[data-thread-id]` selector and adds the collapse toggle button with `aria-expanded` reflection (already shipped, verified during this slice); the toggle's children-visibility rules apply to the new nested threads with no further wiring.
- **R-3.6** (DOM-as-view provider) — semantic queries used by keyboard, focus, collapse, and menu code resolve against the new nested container; no contract change.

## Local-server verification
- Built + restarted local sbt run server with the new code path.
- Verified the existing flat-list wave (`local.net/w+1f4vogi825404A`) still renders 6 blips into the root thread with no regressions and no `inline-thread` leakage when the manifest is empty (the legacy fall-through path).
- Verified the served static asset bundle (`/j2cl/assets/wavy-thread-collapse.css`) contains the new `.j2cl-read-thread.inline-thread` rule (12px indent + cyan rail).
- Verified `?view=gwt` continues to render without any J2CL `data-j2cl-read-blip` markers leaking.
- **Note**: I was unable to interactively seed a fresh wave with multi-thread reply chains via the automated browser harness within this session (the SPA registration / signin endpoints did not respond to my form-fill scripts after the server restart). The new code paths are covered by 9 added unit tests against the codec and projector that exercise root-only, two-level, three-level deep, orphaned, and malformed manifest fixtures, and the existing 14 Jakarta `J2clStageOneReadSurfaceParityTest` cases (which seed real wave content end-to-end on the server side) continue to pass with no changes.

## Test plan
- [x] `sbt compile` (clean)
- [x] `mvn test` in `j2cl/`: **113/113 pass** (codec 42 incl. 6 new; projector 71 incl. 5 new)
- [x] `sbt JakartaTest/testOnly *J2clStageOneReadSurfaceParityTest`: **14/14 pass**
- [x] Local server boot + flat-render regression check: **clean** (6 root-thread blips rendered, no inline-thread when manifest empty)
- [x] GWT path (`?view=gwt`) unaffected: **no J2CL marker leakage**
- [ ] Threaded-view screenshot from a multi-thread wave: blocked by inability to interactively seed a wave; tracked via the unit-test fixtures and Jakarta parity-test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Threaded reading view: replies render as nested, indented blocks with a left accent; preserves legacy flat view when the experimental threaded-rendering flag is off.
  * Collapse/expand controls with aria-expanded accessibility and improved focus survival during updates.
  * Manifest-driven ordering: read items follow a parsed conversation manifest, with placeholders for missing entries.

* **Documentation**
  * Added plan and roadmap for phased J2CL UI delivery and rollout guidance.

* **Tests**
  * New unit tests and QA checks covering manifest parsing, threading, ordering, and nested rendering.

* **Changelog**
  * Added release entry describing threaded reading behavior and visual changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->