### PR TITLE
J-UI-3: New Wave create flow

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
@@ -1,0 +1,257 @@
+# J-UI-3 — New Wave create flow
+
+**Issue:** #1081  •  **Umbrella:** #1078  •  **Tracker:** #904
+**Roadmap slice:** §3.J-UI-3  •  **Matrix row:** R-5.1 (compose / reply flow)
+**Branch:** `claude/j2cl-ui-3` (off `origin/main`)
+
+## 1. Goal
+
+Wire a complete end-to-end **New Wave** create flow inside the J2CL root shell
+(`?view=j2cl-root`) that satisfies the user story in #1081:
+
+> I click `New Wave`, type a title and a message, the wave is created on the
+> server, lands at the top of Inbox, and opens in the wave panel.
+
+Acceptance is bound to **R-5.1**: the create path emits conversation-model ops
+equivalent to GWT, the version/hash basis is atomic per submit, the composer is
+a reachable & labeled region with an accessible submit control, and Enter-to-
+send / newline / caret survival semantics on the rendered composer match GWT.
+
+## 2. Current state (post-context-mapping)
+
+The compose plumbing **already exists** and is wired in the root shell:
+
+- `J2clComposeSurfaceController.submitCreate()` (`compose/J2clComposeSurfaceController.java:1258–1324`)
+  bootstraps a session, builds a delta via `J2clPlainTextDeltaFactory` /
+  `J2clRichContentDeltaFactory`, submits, and on success invokes
+  `CreateSuccessHandler.onWaveCreated(waveId)`.
+- `J2clRootShellController` (`root/J2clRootShellController.java:65–77`) wires
+  `onWaveCreated` to `routeController.selectWave(waveId)` — so the new wave is
+  already routed/opened in the right region after a successful create.
+- `J2clComposeSurfaceView` (`compose/J2clComposeSurfaceView.java:75–109`) mounts
+  a `<composer-shell>` containing a body textarea ("Start a new wave") + a
+  `<composer-submit-affordance label="Create wave">`.
+- `wavy-search-rail.js:425` **already emits** `wavy-new-wave-requested` when
+  the rail's New Wave button is clicked, but **nothing consumes that event in
+  the root shell**.
+
+### Gaps blocking the slice
+
+1. **No title input** — issue requires "type a title and a message"; current UI
+   has only a body textarea.
+2. **No consumer for `wavy-new-wave-requested`** — clicking the rail's button
+   has no effect (the composer is mounted below the digest list, but the
+   button doesn't focus or scroll to it).
+3. **Rail does not refresh after create** — `onWaveCreated` only changes the
+   route; the digest list remains the pre-create snapshot. No "appears at the
+   top of Inbox without page reload".
+4. **No optimistic prepend** — even if we re-query, the new wave may not be
+   in the search index immediately; user perceives a lag. Mitigation: prepend
+   an optimistic digest while the re-query runs.
+
+## 3. Hard-acceptance mapping (matrix row R-5.1)
+
+| R-5.1 sub-clause | How J-UI-3 satisfies |
+|---|---|
+| Daily compose / create emits conversation-model ops equivalent to GWT | `J2clPlainTextDeltaFactory.createWaveRequest()` already builds a v0 wave with participant op + root-blip body op. We extend it to encode `title + "\n" + body` so the digest title is the first line (GWT-parity convention). |
+| Drafts must not corrupt document state | Title and body are buffered in the controller's `createDraft*` model state; only assembled into a delta on submit. No incremental DocOp writes. |
+| Version/hash basis is atomic so concurrent submits don't drift | v0 history hash is regenerated on every submit attempt via `buildVersionZeroHistoryHash()`. Existing `requestGeneration` guard in the controller already short-circuits stale callbacks. |
+| Enter-to-send semantics | Pressing Enter inside the **title** input submits if the body is non-empty (matches GWT new-wave dialog). Shift+Enter in the body inserts newline (existing). |
+| Newline handling | Body preserves newlines via JSON escape `\n` (existing). |
+| Caret survival across live updates | The composer is plain-text input; no live-update churn during typing in the create flow. |
+| Reachable, labeled region | Title input has `aria-label="New wave title"`, textarea retains `aria-label="New wave content"`; both are inside the existing `<composer-shell>` slot=create region. |
+| Accessible submit control | `<composer-submit-affordance>` already exposes label/role/keyboard semantics. |
+| Compose text direction respects locale; placeholders translate | Inputs inherit document-level `dir` from `<html>`; placeholders use existing translation seam (none in this codebase yet — passthrough is acceptable per matrix row). |
+
+## 4. Files to add / modify
+
+**Modify:**
+
+- `j2cl/lit/src/elements/composer-shell.js` — accept a new `slot="create-title"`
+  (no behavior change, just slot plumbing for the title input).
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java`
+  — add `createTitleDraft` field with getters/setters.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+  — add `onCreateTitleChanged(String)` listener method; in `submitCreate()`
+  combine `title + "\n" + body` (only when title non-blank); add
+  Enter-on-title submit semantics; reset title on success/cancel.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+  — render a `<input type="text" slot="create-title">` above the textarea;
+  fire `onCreateTitleChanged` on input; submit on `Enter` (with Shift+Enter
+  inserting nothing — title is single-line). Add `focusCreateSurface()`
+  method that focuses the title input.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+  — add `void refreshSearch()` (public) that re-issues `requestSearch()` with
+  the current query.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java`
+  — add `withPrependedDigest(J2clSearchDigestItem)` for optimistic insertion.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
+  — add `void onOptimisticDigest(String waveId, String title)` that builds a
+  digest item and renders the prepended model immediately, then schedules a
+  `refreshSearch()` to reconcile with the server.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+  — wire two new things:
+  1. Listen for `wavy-new-wave-requested` on `searchView.getCardElement()`
+     (or document.body) and call `composeController.focusCreateSurface()`.
+  2. Replace the existing single `onWaveCreated` lambda with a chain that
+     (a) calls `controller.onOptimisticDigest(waveId, title)`,
+     (b) calls `routeController.selectWave(waveId)`,
+     (c) then on the next tick calls `controller.refreshSearch()` so the
+     server-side digest replaces the optimistic stub.
+- `j2cl/lit/src/elements/composer-shell.js` — add `slot="create-title"` slot
+  rendering above existing `slot="create"`.
+
+**Add:**
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerOptimisticTest.java`
+  — assert that `onOptimisticDigest` prepends a digest with the supplied
+  waveId/title, that `refreshSearch()` re-issues the gateway call, and that
+  the optimistic stub is replaced by the server response on the next render.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTitleTest.java`
+  — assert that title + body are concatenated into the delta as
+  `title + "\n" + body` only when the title is non-blank, and that submit
+  with empty title still works (body-only fallback for parity with current
+  behavior).
+- `j2cl/lit/test/composer-shell.test.js` — extend existing test (if present)
+  or add: assert that `slot="create-title"` content renders above `slot="create"`.
+
+**Feature flag:**
+
+- New flag `j-ui-3-new-wave` (default off, prod-disabled). When off, the title
+  input + optimistic prepend + auto-refresh are skipped — behavior reverts to
+  the pre-slice path (body-only, no rail refresh).
+
+**Changelog:**
+
+- New fragment `RELEASE-NOTES/J-UI-3-new-wave-create.md` (or whatever the repo
+  fragment convention is — check during impl).
+
+## 5. DocOp / data-path changes
+
+Single change to the delta factory call site in
+`J2clComposeSurfaceController.submitCreate()`:
+
+```
+String body = model.getCreateDraft();
+String title = model.getCreateTitleDraft();
+String combined = title.isEmpty() ? body : title + "\n" + body;
+CreateWaveRequest req = deltaFactory.createWaveRequest(address, combined);
+```
+
+The `J2clPlainTextDeltaFactory` itself is **not modified** — it still writes a
+single character run to `b+root`. The `\n` is JSON-escaped into the existing op
+exactly like body text containing a newline would be. This avoids touching the
+delta-encoding path (lower regression surface) and preserves DocOp StringBuilder
+discipline (per `feedback_docop_text_fragments`) — the existing factory already
+uses StringBuilder (`buildDeltaJson`), and we keep it that way.
+
+**Note on title rendering:** Wave's GWT digest projector takes the first line
+of the root blip's plain text as the digest title. So `title\nbody` produces a
+digest whose title-text is `title` and whose snippet is `body`, matching GWT
+behavior.
+
+## 6. Feature flag
+
+- **Key:** `j-ui-3-new-wave`
+- **Description:** "J-UI-3: title input + optimistic rail update for the new-wave create flow"
+- **Default:** off in prod, on in dev/test
+- **Allowed-participants:** empty (off for everyone in prod until QA on staging)
+- **Read site:** Both the J2CL view (to render/skip title input) and the
+  controller (to skip optimistic-prepend + refreshSearch). The flag value is
+  read via the existing feature-flag bridge surfaced into J2CL bootstrap (look
+  for similar reads in `J2clRootLiveSurfaceController` or `J2clRootShellController`).
+
+## 7. Test plan
+
+### Unit tests (sbt + j2cl)
+
+- `J2clComposeSurfaceControllerTitleTest`:
+  - `submitCreateWithTitleAndBody_combinesAsTitleNewlineBody`
+  - `submitCreateWithEmptyTitle_submitsBodyOnly`
+  - `submitCreateWithEmptyBody_submitsTitleOnly`
+  - `onCreateTitleChanged_persistsInModel`
+- `J2clSearchPanelControllerOptimisticTest`:
+  - `onOptimisticDigest_prependsDigestImmediately`
+  - `refreshSearch_reissuesCurrentQuery`
+  - `optimisticStubReplacedByServerResponse_onNextRender`
+- Existing `J2clComposeSurfaceControllerTest` and `J2clSearchPanelControllerTest`
+  — must stay green (no regressions).
+
+### Lit unit tests (`j2cl/lit/test/`)
+
+- `composer-shell.test.js` — `slot="create-title"` renders above `slot="create"`.
+- (Existing `wavy-search-rail.test.js:66` already covers `wavy-new-wave-requested` emission.)
+
+### Browser harness
+
+- Not required at slice-close per scope; existing harness has a compose-and-
+  submit fixture (cited in matrix-row R-5.1). Confirm during impl that the
+  fixture still passes; if it requires an update for the title input, add it.
+
+### Manual local-server verification (per `feedback_local_server_verification_before_pr`)
+
+1. Build: `cd wave && sbt compile`.
+2. Start dev server: `cd wave && sbt run` (or the project's dev-server command;
+   confirm during impl).
+3. Register a fresh user (do **not** assume `vega` exists — per memory).
+4. Navigate to `/?view=j2cl-root&q=in:inbox`.
+5. Click the rail's **New Wave** button — confirm the title input is focused.
+6. Type a title (`J-UI-3 smoke`), Tab, type a body (`hello from j-ui-3`), click
+   "Create wave".
+7. Assert: server returns success; the new digest appears at the top of the
+   rail (titled `J-UI-3 smoke`, snippet `hello from j-ui-3`); the new wave is
+   selected and rendered in the right region.
+8. Reload the page — assert the new wave is still in Inbox (server-persisted,
+   not just local).
+9. Sign in as a second user (or use a private window with another fresh
+   account); confirm the wave is visible to expected recipients per addressing.
+10. Edge cases:
+    - Submit with empty title — should still work (body-only).
+    - Submit with empty body — should still work (title-only).
+    - Submit with both empty — submit button stays disabled (existing behavior).
+    - Network blip during submit — error text renders; second click retries.
+    - Submit, immediately reload — the new wave is in Inbox.
+    - Sign-out / sign-in — the new wave is still in Inbox.
+11. **GWT regression check:** Navigate to `/?view=gwt`. Confirm the legacy
+    GWT path still works (read+write a wave; nothing in this slice touches
+    GWT-only paths).
+
+Screenshot the rail with the new digest + the opened wave; save under
+`docs/superpowers/screenshots/j-ui-3/`.
+
+## 8. Roll-back path
+
+If the slice causes a regression in production:
+
+1. Toggle off `j-ui-3-new-wave` via the admin flag UI (or `scripts/feature-flag.sh
+   set j-ui-3-new-wave false`). Both the title input and the rail-refresh logic
+   are gated behind this flag, so flipping it returns the J2CL UI to the
+   pre-slice state immediately.
+2. If the flag bridge itself fails, revert the merge commit on `main` —
+   the slice is one PR, so revert is one git operation.
+3. The DocOp encoding is unchanged (we only call the existing factory with a
+   different string), so there is **no on-disk data migration** to undo.
+
+## 9. Out of scope (per issue + roadmap §5)
+
+- Inline reply composer at a specific blip position — owned by **J-UI-5**.
+- Toolbar formatting controls (bold/italic/list/heading) — owned by **J-UI-5**.
+- Mentions autocomplete and reactions — covered by F-3 follow-ups
+  (#1073–#1076).
+- Default-root cutover (#923/#924) — gated by parity-matrix §8 gate.
+- Server-side push of new digests to the rail — out of scope for this slice;
+  the optimistic prepend + post-create refreshSearch is sufficient for the
+  user story. A real push channel can come later.
+
+## 10. Constraints (project rules)
+
+- DocOp `characters()` calls must use `StringBuilder` — existing factory does.
+- No `Window.alert/confirm/prompt` — we use `<composer-submit-affordance>`
+  status text + `ToastNotification` (if errors need surfacing).
+- No legacy fallbacks for flagged behaviour — when the flag is off, the title
+  input is simply not rendered; no shim layer.
+- No backwards-compat shims; controllers/listeners get new methods directly.
+- Search/filter logic reads from wavelet DocOps (no conversation-model chain)
+  — the rail refresh re-uses `gateway.search()`, which already reads from the
+  Lucene index (DocOp-backed), not the conversation model.
+- No emojis in code/files.

--- a/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
@@ -84,11 +84,20 @@ The compose plumbing **already exists** and is wired in the root shell:
   — add `void refreshSearch()` (public) that re-issues `requestSearch()` with
   the current query.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java`
-  — add `withPrependedDigest(J2clSearchDigestItem)` for optimistic insertion.
+  — add `withPrependedDigest(J2clSearchDigestItem)` for optimistic insertion;
+  add `withoutDigest(String waveId)` for explicit dedup.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java`
-  — add `void onOptimisticDigest(String waveId, String title)` that builds a
-  digest item and renders the prepended model immediately, then schedules a
-  `refreshSearch()` to reconcile with the server.
+  — add `void onOptimisticDigest(String waveId, String title)` that:
+  1. Stores the optimistic stub in a controller field
+     `pendingOptimisticDigest` (waveId + title).
+  2. Renders the prepended model immediately.
+  3. Schedules a `refreshSearch()` to reconcile with the server.
+  - In `requestSearch()`'s response callback, if `pendingOptimisticDigest` is
+    set: drop any digest with the matching waveId from the server response
+    (avoid duplicates), then prepend the stub IF the server response did not
+    already include the new wave. Clear `pendingOptimisticDigest` once the
+    server response includes the matching waveId, OR after a timeout
+    (5 seconds — Lucene index lag bound) so a stuck stub eventually goes away.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
   — wire two new things:
   1. Listen for `wavy-new-wave-requested` on `searchView.getCardElement()`
@@ -128,27 +137,74 @@ The compose plumbing **already exists** and is wired in the root shell:
 
 ## 5. DocOp / data-path changes
 
-Single change to the delta factory call site in
-`J2clComposeSurfaceController.submitCreate()`:
+**Production path uses the rich-content factory** (`richContentDeltaFactory` in
+`J2clRootShellController.java:69`), and its `DeltaFactory.createWaveRequest`
+signature is `(String address, String draftText, J2clComposerDocument document)`.
+The factory ignores `draftText` and reads ops from the structured `document`
+(see `J2clComposeSurfaceController.java:1688–1692`). So the title/body change
+must happen at **document construction**, not at the factory call site.
 
+### 5.1 Title annotation (canonical Wave parity)
+
+Wave's title is encoded as an annotation `conv/title` whose value is `""`
+(`TitleHelper.AUTO_VALUE` — `TitleHelper.java:62`). The annotation's range
+covers the title text. `WaveDigester` calls `TitleHelper.extractTitle()` to
+populate the digest title (`WaveDigester.java:296–298`); empty value means
+"use the annotated text". This is the GWT-parity title path.
+
+`J2clComposerDocument.Builder.annotatedText` currently rejects empty values
+(`requireNonEmpty(annotationValue, ...)` at `J2clComposerDocument.java:54–55`).
+Add a new builder method:
+
+```java
+public Builder titleText(String text) {
+  if (text == null || text.trim().isEmpty()) return this;
+  components.add(new Component(
+      ComponentType.ANNOTATED_TEXT, text,
+      "conv/title", "",  // AUTO_VALUE: empty string per TitleHelper
+      "", ""));
+  return this;
+}
 ```
-String body = model.getCreateDraft();
-String title = model.getCreateTitleDraft();
-String combined = title.isEmpty() ? body : title + "\n" + body;
-CreateWaveRequest req = deltaFactory.createWaveRequest(address, combined);
+
+The factory's `appendAnnotationStart` (`J2clRichContentDeltaFactory.java:782`)
+already handles empty values (it just emits `"3":""`), so no factory changes
+are needed.
+
+### 5.2 buildDocument extension
+
+Extend `J2clComposeSurfaceController.buildDocument()` (line 1483) to accept an
+optional title:
+
+```java
+private J2clComposerDocument buildDocument(
+    String titleText, String draftText, boolean includeAttachments,
+    String submittedAnnotationCommandId, boolean includeMentions) {
+  J2clComposerDocument.Builder builder = J2clComposerDocument.builder();
+  if (titleText != null && !titleText.trim().isEmpty()) {
+    builder.titleText(titleText);
+  }
+  // ...existing draft/mention/attachment append logic...
+}
 ```
 
-The `J2clPlainTextDeltaFactory` itself is **not modified** — it still writes a
-single character run to `b+root`. The `\n` is JSON-escaped into the existing op
-exactly like body text containing a newline would be. This avoids touching the
-delta-encoding path (lower regression surface) and preserves DocOp StringBuilder
-discipline (per `feedback_docop_text_fragments`) — the existing factory already
-uses StringBuilder (`buildDeltaJson`), and we keep it that way.
+Existing call sites (reply-submit, etc.) pass an empty title and behave
+unchanged. Only the create-submit path passes a non-empty title (when the user
+typed one). Body text is appended as-is — no `\n` concat, no implicit
+line-break injection.
 
-**Note on title rendering:** Wave's GWT digest projector takes the first line
-of the root blip's plain text as the digest title. So `title\nbody` produces a
-digest whose title-text is `title` and whose snippet is `body`, matching GWT
-behavior.
+### 5.3 Plain-text fallback
+
+The plain-text factory (`J2clPlainTextDeltaFactory.createWaveRequest(address,
+text)`) is used **only in tests + the sandbox path**. For full parity, extend
+the controller's plain-text fallback too — but since production uses the rich
+factory, the plain-text fallback continues to ignore the title (no behavior
+change). Plain-text-only tests of the create flow keep working as-is.
+
+**No StringBuilder violations:** the `appendCharacters` / `appendAnnotationStart`
+/ `appendAnnotationEnd` helpers in the rich factory already use StringBuilder
+(`J2clRichContentDeltaFactory.java:716–793`) — per
+`feedback_docop_text_fragments`, this is the safe pattern.
 
 ## 6. Feature flag
 
@@ -166,14 +222,23 @@ behavior.
 ### Unit tests (sbt + j2cl)
 
 - `J2clComposeSurfaceControllerTitleTest`:
-  - `submitCreateWithTitleAndBody_combinesAsTitleNewlineBody`
-  - `submitCreateWithEmptyTitle_submitsBodyOnly`
-  - `submitCreateWithEmptyBody_submitsTitleOnly`
+  - `submitCreateWithTitleAndBody_emitsTitleAnnotationAndBodyText` —
+    asserts the rich-content document carries an `ANNOTATED_TEXT` component
+    with key `conv/title`, value `""`, text `<title>` followed by a `TEXT`
+    component with `<body>`.
+  - `submitCreateWithEmptyTitle_submitsBodyOnlyNoTitleAnnotation`
+  - `submitCreateWithEmptyBody_submitsTitleOnly` (asserts annotation-only doc)
+  - `submitCreateWithBothEmpty_submitButtonStaysDisabled`
   - `onCreateTitleChanged_persistsInModel`
+  - `onCreateTitleChanged_doesNotClearBodyDraft`
+  - `enterKeyOnTitleSubmitsWhenBodyNonEmpty`
 - `J2clSearchPanelControllerOptimisticTest`:
   - `onOptimisticDigest_prependsDigestImmediately`
   - `refreshSearch_reissuesCurrentQuery`
-  - `optimisticStubReplacedByServerResponse_onNextRender`
+  - `optimisticStubDroppedWhenServerResponseIncludesMatchingWaveId`
+  - `optimisticStubRetainedWhenServerResponseDoesNotIncludeMatchingWaveId`
+  - `optimisticStubClearedAfterTimeoutEvenIfServerNeverIncludesIt`
+  - `noDuplicateDigestWhenServerResponseAndOptimisticStubBothPresent`
 - Existing `J2clComposeSurfaceControllerTest` and `J2clSearchPanelControllerTest`
   — must stay green (no regressions).
 
@@ -184,9 +249,11 @@ behavior.
 
 ### Browser harness
 
-- Not required at slice-close per scope; existing harness has a compose-and-
-  submit fixture (cited in matrix-row R-5.1). Confirm during impl that the
-  fixture still passes; if it requires an update for the title input, add it.
+- The matrix row R-5.1 cites an existing compose-and-submit harness fixture.
+  During impl: locate the fixture (likely under `j2cl/src/main/webapp/harness/`
+  or `j2cl/lit/test/harness/`), confirm it still passes, and add a new fixture
+  path `create-with-title-and-body` that exercises the title input + the
+  optimistic-prepend rail update.
 
 ### Manual local-server verification (per `feedback_local_server_verification_before_pr`)
 
@@ -231,6 +298,37 @@ If the slice causes a regression in production:
    the slice is one PR, so revert is one git operation.
 3. The DocOp encoding is unchanged (we only call the existing factory with a
    different string), so there is **no on-disk data migration** to undo.
+
+## 8.5 Risks (called out by plan review)
+
+1. **Snippet may include the title text.** The server's `WaveDigester`
+   constructs the snippet from blip text (`WaveDigester.java:303–306`); the
+   title-annotated text may appear at the start of both the title and the
+   snippet. If this is visually duplicative in the rail, follow up with a
+   snippet-strip pass (server-side) or accept it as cosmetic for the slice.
+2. **Lucene indexing lag.** The new wave may not be returned by `gateway.search()`
+   immediately. The optimistic stub + 5s timeout covers the typical case;
+   pathological lag (>5s) leaves the user staring at a rail without their wave.
+   Mitigation: keep the wave selected (via route `selectWave`) so the right
+   region still shows the new wave even if the rail doesn't list it yet.
+3. **Feature-flag read site.** The plan defers locating the J2CL bootstrap
+   feature-flag bridge to impl time. Risk: the bridge may not exist for
+   client-side reads, in which case the flag must come from the bootstrap
+   payload (`SidecarSessionBootstrap`) — not a blocker, but adds 1-2 files of
+   scope. Accept this and document the flag wiring in the implementation
+   commit message.
+4. **Empty-title UX confusion.** The flag is on but the title input is
+   visible — if the user types only in the title (empty body), the wave is
+   still created with title-only content. Acceptable; the test plan covers it.
+5. **GWT digest parity verification.** The plan asserts that the server-side
+   `WaveDigester` reads the title via `TitleHelper.extractTitle`. Verified for
+   J2CL writes (we set the annotation), but if GWT writes via a different
+   path (e.g., explicit `setTitle` API), comparing GWT vs J2CL digests for the
+   same input may show differences. This is acceptable for the slice — both
+   paths produce a non-empty title; cosmetic differences are out of scope.
+6. **Flag-toggle mid-session.** Toggling the flag off mid-session does not
+   re-render the composer. Acceptable: the flag is a deploy-time gate, not a
+   user-facing toggle. Documented.
 
 ## 9. Out of scope (per issue + roadmap §5)
 

--- a/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-3-plan.md
@@ -126,9 +126,11 @@ The compose plumbing **already exists** and is wired in the root shell:
 
 **Feature flag:**
 
-- New flag `j-ui-3-new-wave` (default off, prod-disabled). When off, the title
-  input + optimistic prepend + auto-refresh are skipped — behavior reverts to
-  the pre-slice path (body-only, no rail refresh).
+- Flag `j-ui-3-new-wave` is registered in `KnownFeatureFlags` (default off in
+  prod). **Known gap:** the flag read sites in the J2CL view and controller were
+  not implemented in this slice — the title input and optimistic-prepend logic
+  are always active in the current code. Flag-gated rollout is deferred to a
+  follow-up. Rollback: revert the merge commit on `main`.
 
 **Changelog:**
 
@@ -212,10 +214,11 @@ change). Plain-text-only tests of the create flow keep working as-is.
 - **Description:** "J-UI-3: title input + optimistic rail update for the new-wave create flow"
 - **Default:** off in prod, on in dev/test
 - **Allowed-participants:** empty (off for everyone in prod until QA on staging)
-- **Read site:** Both the J2CL view (to render/skip title input) and the
-  controller (to skip optimistic-prepend + refreshSearch). The flag value is
-  read via the existing feature-flag bridge surfaced into J2CL bootstrap (look
-  for similar reads in `J2clRootLiveSurfaceController` or `J2clRootShellController`).
+- **Read site:** Not yet implemented. The flag key is registered but has no
+  J2CL-side read site; the feature is always-on in the current build. A
+  follow-up will add read sites in the compose view (to render/skip the title
+  input) and in the root-shell controller (to skip optimistic-prepend +
+  refreshSearch), using the bootstrap feature-flag bridge.
 
 ## 7. Test plan
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1400,12 +1400,15 @@ public final class J2clComposeSurfaceController {
       return;
     }
     createSubmitting = false;
-    createDraft = "";
-    // J-UI-3 (#1081, R-5.1): snapshot the title before clearing it so the
-    // success handler can pass it through to the rail's optimistic-digest
-    // prepend; clear last so the rendered create form returns to its empty
-    // state.
+    // J-UI-3 (#1081, R-5.1): snapshot title and body before clearing them
+    // so the success handler can pass a non-empty stub title through to
+    // the rail's optimistic-digest prepend even when the user typed only
+    // a body (CodeRabbit major review on PR #1090: a body-only create
+    // previously prepended as "(untitled wave)" instead of using the
+    // body's first line).
     String createdTitle = createTitleDraft;
+    String createdBodyForStub = createDraft;
+    createDraft = "";
     createTitleDraft = "";
     activeCommandId = "";
     annotationCommandId = "";
@@ -1415,7 +1418,10 @@ public final class J2clComposeSurfaceController {
     createErrorText = "";
     render();
     if (createSuccessHandler != null) {
-      createSuccessHandler.onWaveCreated(request.getCreatedWaveId(), createdTitle);
+      String stubTitle = createdTitle.trim().isEmpty()
+          ? firstNonBlankLine(createdBodyForStub)
+          : createdTitle.trim();
+      createSuccessHandler.onWaveCreated(request.getCreatedWaveId(), stubTitle);
     }
   }
 
@@ -2204,17 +2210,32 @@ public final class J2clComposeSurfaceController {
 
   /**
    * J-UI-3 (#1081, R-5.1): live-edit sanitiser for the title input. Replaces
-   * any embedded newline (e.g. from a paste) with a space so the conv/title
-   * annotation never spans more than one line, but otherwise preserves the
-   * raw input — including trailing whitespace — so users can type
-   * multi-word titles normally without each space being eaten between
-   * keystrokes.
+   * any embedded line break (CR, LF, or any run of them) with a single
+   * space so the conv/title annotation never spans more than one line and
+   * Windows CRLF pastes do not introduce double spaces. Otherwise
+   * preserves the raw input — including trailing whitespace — so users
+   * can type multi-word titles normally without each space being eaten
+   * between keystrokes (CodeRabbit follow-up on PR #1090).
    */
   private static String sanitizeTitleLive(String title) {
     if (title == null) {
       return "";
     }
-    return title.replace('\n', ' ').replace('\r', ' ');
+    StringBuilder out = new StringBuilder(title.length());
+    boolean inBreakRun = false;
+    for (int i = 0; i < title.length(); i++) {
+      char c = title.charAt(i);
+      if (c == '\n' || c == '\r') {
+        if (!inBreakRun) {
+          out.append(' ');
+          inBreakRun = true;
+        }
+      } else {
+        out.append(c);
+        inBreakRun = false;
+      }
+    }
+    return out.toString();
   }
 
   /**
@@ -2225,6 +2246,33 @@ public final class J2clComposeSurfaceController {
    */
   private static String normalizeTitleForSubmit(String title) {
     return sanitizeTitleLive(title).trim();
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): pulls the first non-blank line out of {@code text}
+   * for use as an optimistic-stub title fallback when the user submitted a
+   * body-only create. Empty/null input yields an empty string so the
+   * optimistic-prepend path can fall through to its "(untitled wave)"
+   * placeholder.
+   */
+  private static String firstNonBlankLine(String text) {
+    if (text == null) {
+      return "";
+    }
+    int len = text.length();
+    int i = 0;
+    while (i < len) {
+      int lineEnd = i;
+      while (lineEnd < len && text.charAt(lineEnd) != '\n' && text.charAt(lineEnd) != '\r') {
+        lineEnd++;
+      }
+      String line = text.substring(i, lineEnd).trim();
+      if (!line.isEmpty()) {
+        return line;
+      }
+      i = lineEnd + 1;
+    }
+    return "";
   }
 
   private static String extractDomain(String waveId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentComposerController;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentIdGenerator;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentUploadClient;
@@ -343,6 +345,15 @@ public final class J2clComposeSurfaceController {
   // pairing a failed attempt's stamp leaks forward and scopes the next
   // successful create's optimistic stub to the wrong rail.
   private Runnable createFailureHook;
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DZqM: idempotency
+  // set tracking which create generations already had their submit-query
+  // stamp retired. Each preCreateSubmitHook fires under one generation;
+  // any one of {handleCreateFailure, bootstrap-mismatch, response-
+  // mismatch, onSignedOut} may retire it, but only the first such call
+  // for that generation should run createFailureHook. Without this, a
+  // late stale callback firing AFTER onSignedOut already dropped the
+  // stamp would dequeue a NEWER submit's stamp from the search panel.
+  private final Set<Integer> retiredCreateStampGenerations = new HashSet<>();
   private String createDraft = "";
   // J-UI-3 (#1081, R-5.1): the title-input value separate from createDraft.
   // Composed into the rich-content document on submit alongside the body so
@@ -635,6 +646,7 @@ public final class J2clComposeSurfaceController {
     // BEFORE we clear createSubmitting, then run the failure hook to
     // drop the orphaned stamp.
     boolean abortedInFlightCreate = createSubmitting;
+    int abortedCreateGeneration = createGeneration;
     createGeneration++;
     replyGeneration++;
     createSubmitting = false;
@@ -658,16 +670,16 @@ public final class J2clComposeSurfaceController {
     createStatusText = "Sign in to create or reply in the J2CL root shell.";
     replyStatusText = createStatusText;
     render();
-    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DQdB: drop the
-    // submit-query stamp left behind by an in-flight create that the
-    // generation guard will now silently discard. Run AFTER render so
-    // the view sees the signed-out chrome before any downstream effect.
-    if (abortedInFlightCreate && createFailureHook != null) {
-      try {
-        createFailureHook.run();
-      } catch (RuntimeException ignored) {
-        // Best-effort: never re-throw out of an integration callback.
-      }
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DQdB +
+    // PRRT_kwDOBwxLXs5-DZqM: drop the submit-query stamp left behind
+    // by an in-flight create that the generation guard will now silently
+    // discard. retireCreateStampOnce records the aborted generation in
+    // retiredCreateStampGenerations so a stale bootstrap/submit
+    // callback firing later for the same generation cannot dequeue a
+    // newer submission's stamp. Run AFTER render so the view sees the
+    // signed-out chrome before any downstream effect.
+    if (abortedInFlightCreate) {
+      retireCreateStampOnce(abortedCreateGeneration);
     }
   }
 
@@ -1210,6 +1222,27 @@ public final class J2clComposeSurfaceController {
   }
 
   /**
+   * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DZqM: retire the
+   * submit-query stamp queued by preCreateSubmitHook for {@code
+   * generation}. Idempotent per generation: a second call for the same
+   * generation is a silent no-op so a stale bootstrap/submit callback
+   * cannot dequeue a newer submission's stamp after onSignedOut already
+   * dropped this one. Best-effort: a hook RuntimeException is swallowed.
+   */
+  private void retireCreateStampOnce(int generation) {
+    if (createFailureHook == null) {
+      return;
+    }
+    if (retiredCreateStampGenerations.add(generation)) {
+      try {
+        createFailureHook.run();
+      } catch (RuntimeException ignored) {
+        // Best-effort: never re-throw out of an integration callback.
+      }
+    }
+  }
+
+  /**
    * F-3.S3 (#1038, R-5.5): publish the latest per-blip reaction
    * snapshot from the model. The controller uses this on each toggle
    * click to decide whether the user is adding or removing their
@@ -1437,11 +1470,12 @@ public final class J2clComposeSurfaceController {
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
           if (generation != createGeneration) {
-            // This generation was superseded; clear the stamp queued by preCreateSubmitHook
-            // so the next successful create doesn't consume a stale submit-query entry.
-            if (createFailureHook != null) {
-              try { createFailureHook.run(); } catch (RuntimeException ignored) {}
-            }
+            // J-UI-3 codex P2 PRRT_kwDOBwxLXs5-DZqM: superseded generation;
+            // retire this generation's stamp once. The idempotency set
+            // prevents a stale callback from dequeuing a newer
+            // submission's stamp after onSignedOut already retired this
+            // one.
+            retireCreateStampOnce(generation);
             return;
           }
           notifyCurrentUserAddress(bootstrap.getAddress());
@@ -1474,10 +1508,9 @@ public final class J2clComposeSurfaceController {
       String submittedDraft,
       SidecarSubmitResponse response) {
     if (generation != createGeneration) {
-      // Superseded; clear the stamp just as a real failure would.
-      if (createFailureHook != null) {
-        try { createFailureHook.run(); } catch (RuntimeException ignored) {}
-      }
+      // J-UI-3 codex P2 PRRT_kwDOBwxLXs5-DZqM: superseded; retire this
+      // generation's stamp idempotently.
+      retireCreateStampOnce(generation);
       return;
     }
     if (!response.getErrorMessage().isEmpty()) {
@@ -1509,26 +1542,21 @@ public final class J2clComposeSurfaceController {
 
   private void handleCreateFailure(int generation, String error) {
     if (generation != createGeneration) {
-      // Superseded; still clear the stamp so no stale entry lingers in the queue.
-      if (createFailureHook != null) {
-        try { createFailureHook.run(); } catch (RuntimeException ignored) {}
-      }
+      // J-UI-3 codex P2 PRRT_kwDOBwxLXs5-DZqM: superseded; retire this
+      // generation's stamp idempotently.
+      retireCreateStampOnce(generation);
       return;
     }
     createSubmitting = false;
     createStatusText = "";
     createErrorText = error == null || error.isEmpty() ? "Create wave failed." : error;
     render();
-    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: pair the
-    // pre-submit stamp with a failure-time drop so a failed create does
-    // not leave a stale submit-query entry that the next successful
-    // create would consume.
-    if (createFailureHook != null) {
-      try {
-        createFailureHook.run();
-      } catch (RuntimeException ignored) {
-        // Best-effort: never re-throw out of an integration callback.
-      }
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T + PRRT_kwDOBwxLXs5-DZqM:
+    // pair the pre-submit stamp with a failure-time drop, gated by
+    // generation so a later stale callback can't double-drop. retire-
+    // CreateStampOnce is idempotent per generation.
+    {
+      retireCreateStampOnce(generation);
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1437,6 +1437,11 @@ public final class J2clComposeSurfaceController {
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
           if (generation != createGeneration) {
+            // This generation was superseded; clear the stamp queued by preCreateSubmitHook
+            // so the next successful create doesn't consume a stale submit-query entry.
+            if (createFailureHook != null) {
+              try { createFailureHook.run(); } catch (RuntimeException ignored) {}
+            }
             return;
           }
           notifyCurrentUserAddress(bootstrap.getAddress());
@@ -1456,7 +1461,7 @@ public final class J2clComposeSurfaceController {
           gateway.submit(
               bootstrap,
               request.getSubmitRequest(),
-              response -> handleCreateResponse(generation, request, response),
+              response -> handleCreateResponse(generation, request, submittedTitle, submittedDraft, response),
               error -> handleCreateFailure(generation, error));
         },
         error -> handleCreateFailure(generation, error));
@@ -1465,8 +1470,14 @@ public final class J2clComposeSurfaceController {
   private void handleCreateResponse(
       int generation,
       CreateWaveRequest request,
+      String submittedTitle,
+      String submittedDraft,
       SidecarSubmitResponse response) {
     if (generation != createGeneration) {
+      // Superseded; clear the stamp just as a real failure would.
+      if (createFailureHook != null) {
+        try { createFailureHook.run(); } catch (RuntimeException ignored) {}
+      }
       return;
     }
     if (!response.getErrorMessage().isEmpty()) {
@@ -1474,14 +1485,11 @@ public final class J2clComposeSurfaceController {
       return;
     }
     createSubmitting = false;
-    // J-UI-3 (#1081, R-5.1): snapshot title and body before clearing them
-    // so the success handler can pass a non-empty stub title through to
-    // the rail's optimistic-digest prepend even when the user typed only
-    // a body (CodeRabbit major review on PR #1090: a body-only create
-    // previously prepended as "(untitled wave)" instead of using the
-    // body's first line).
-    String createdTitle = createTitleDraft;
-    String createdBodyForStub = createDraft;
+    // Use the immutable snapshots taken in submitCreate() so that a title
+    // edit that arrives during the server round-trip does not corrupt the
+    // stub title passed to the optimistic-digest handler.
+    String createdTitle = submittedTitle;
+    String createdBodyForStub = submittedDraft;
     createDraft = "";
     createTitleDraft = "";
     activeCommandId = "";
@@ -1501,6 +1509,10 @@ public final class J2clComposeSurfaceController {
 
   private void handleCreateFailure(int generation, String error) {
     if (generation != createGeneration) {
+      // Superseded; still clear the stamp so no stale entry lingers in the queue.
+      if (createFailureHook != null) {
+        try { createFailureHook.run(); } catch (RuntimeException ignored) {}
+      }
       return;
     }
     createSubmitting = false;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -336,6 +336,13 @@ public final class J2clComposeSurfaceController {
   // installed; legacy callers that did not register a hook continue to
   // fall back to the success-time query inside onOptimisticDigest.
   private Runnable preCreateSubmitHook;
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: hook fired
+  // on every create-failure path (bootstrap error, submit error,
+  // stale-generation guard) so the search panel can drop the matching
+  // submit-query stamp it queued in preCreateSubmitHook. Without this
+  // pairing a failed attempt's stamp leaks forward and scopes the next
+  // successful create's optimistic stub to the wrong rail.
+  private Runnable createFailureHook;
   private String createDraft = "";
   // J-UI-3 (#1081, R-5.1): the title-input value separate from createDraft.
   // Composed into the rich-content document on submit alongside the body so
@@ -1169,6 +1176,19 @@ public final class J2clComposeSurfaceController {
   }
 
   /**
+   * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: install a
+   * hook fired on every create-failure path so the search panel can drop
+   * the submit-query stamp the pre-submit hook queued. The hook is
+   * invoked synchronously when {@link #handleCreateFailure} fires, so
+   * the matching pendingSubmitQueries entry is dequeued before any
+   * subsequent successful create can consume it. Idempotent — passing
+   * {@code null} disables the hook.
+   */
+  public void setCreateFailureHook(Runnable hook) {
+    this.createFailureHook = hook;
+  }
+
+  /**
    * F-3.S3 (#1038, R-5.5): publish the latest per-blip reaction
    * snapshot from the model. The controller uses this on each toggle
    * click to decide whether the user is adding or removing their
@@ -1466,6 +1486,17 @@ public final class J2clComposeSurfaceController {
     createStatusText = "";
     createErrorText = error == null || error.isEmpty() ? "Create wave failed." : error;
     render();
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: pair the
+    // pre-submit stamp with a failure-time drop so a failed create does
+    // not leave a stale submit-query entry that the next successful
+    // create would consume.
+    if (createFailureHook != null) {
+      try {
+        createFailureHook.run();
+      } catch (RuntimeException ignored) {
+        // Best-effort: never re-throw out of an integration callback.
+      }
+    }
   }
 
   private void submitReply() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -43,12 +43,36 @@ public final class J2clComposeSurfaceController {
     void openAttachmentPicker();
 
     void focusReplyComposer();
+
+    /**
+     * J-UI-3 (#1081, R-5.1): focus the title input on the create form so
+     * the rail's New Wave button gives the user an immediate place to type.
+     * Default no-op so existing test doubles compile unchanged.
+     */
+    default void focusCreateSurface() {}
   }
 
   public interface Listener {
     void onCreateDraftChanged(String draft);
 
+    /**
+     * J-UI-3 (#1081, R-5.1): the title input value changed.
+     * Default no-op so existing test doubles compile unchanged.
+     */
+    default void onCreateTitleChanged(String title) {}
+
     void onCreateSubmitted(String draft);
+
+    /**
+     * J-UI-3 (#1081, R-5.1): submit triggered from the create form with
+     * both title and body provided in a single event so the controller
+     * snapshots both at the same instant. Default delegates to
+     * {@link #onCreateSubmitted} so plain-text-only test doubles continue
+     * to work; production wires this directly.
+     */
+    default void onCreateSubmittedWithTitle(String title, String draft) {
+      onCreateSubmitted(draft);
+    }
 
     void onReplyDraftChanged(String draft);
 
@@ -296,6 +320,10 @@ public final class J2clComposeSurfaceController {
   // means no listener installed.
   private CurrentUserAddressListener currentUserAddressListener;
   private String createDraft = "";
+  // J-UI-3 (#1081, R-5.1): the title-input value separate from createDraft.
+  // Composed into the rich-content document on submit alongside the body so
+  // WaveDigester picks the conv/title annotation up server-side.
+  private String createTitleDraft = "";
 
   /**
    * F-3.S3 (#1038, R-5.5): callback fired after each successful
@@ -485,8 +513,18 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onCreateTitleChanged(String title) {
+            J2clComposeSurfaceController.this.onCreateTitleChanged(title);
+          }
+
+          @Override
           public void onCreateSubmitted(String draft) {
             J2clComposeSurfaceController.this.onCreateSubmitted(draft);
+          }
+
+          @Override
+          public void onCreateSubmittedWithTitle(String title, String draft) {
+            J2clComposeSurfaceController.this.onCreateSubmittedWithTitle(title, draft);
           }
 
           @Override
@@ -594,9 +632,41 @@ public final class J2clComposeSurfaceController {
     render();
   }
 
+  /**
+   * J-UI-3 (#1081, R-5.1): the title input's value changed. Title is single
+   * line; we trim trailing whitespace/newlines (a paste with a trailing
+   * newline must not break the title annotation).
+   */
+  public void onCreateTitleChanged(String title) {
+    createTitleDraft = normalizeTitle(title);
+    createErrorText = "";
+    render();
+  }
+
   public void onCreateSubmitted(String draft) {
     createDraft = normalizeDraft(draft);
     submitCreate();
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): submit triggered from the title input (Enter key).
+   * Snapshots both title and body before submit so a stray draft-change after
+   * Enter does not race with submitCreate.
+   */
+  public void onCreateSubmittedWithTitle(String title, String draft) {
+    createTitleDraft = normalizeTitle(title);
+    createDraft = normalizeDraft(draft);
+    submitCreate();
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): focuses the title input on the create form.
+   * Public entrypoint for the rail's New Wave button via the root shell.
+   */
+  public void focusCreateSurface() {
+    if (started) {
+      view.focusCreateSurface();
+    }
   }
 
   public void onReplyDraftChanged(String draft) {
@@ -1260,7 +1330,10 @@ public final class J2clComposeSurfaceController {
       render();
       return;
     }
-    if (createDraft.trim().isEmpty()) {
+    // J-UI-3 (#1081, R-5.1): allow submit when EITHER title or body has text.
+    // The user story is "type a title and a message" so a body-only or
+    // title-only submission is still a valid create.
+    if (createDraft.trim().isEmpty() && createTitleDraft.trim().isEmpty()) {
       createStatusText = "";
       createErrorText = "Enter some text before creating a wave.";
       render();
@@ -1270,6 +1343,7 @@ public final class J2clComposeSurfaceController {
     createStatusText = "Bootstrapping the root-shell submit session.";
     createErrorText = "";
     final String submittedDraft = createDraft;
+    final String submittedTitle = createTitleDraft;
     final int generation = ++createGeneration;
     render();
     gateway.fetchRootSessionBootstrap(
@@ -1282,7 +1356,9 @@ public final class J2clComposeSurfaceController {
           try {
             request =
                 deltaFactory.createWaveRequest(
-                    bootstrap.getAddress(), submittedDraft, buildDocument(submittedDraft, false, ""));
+                    bootstrap.getAddress(),
+                    submittedDraft,
+                    buildDocument(submittedTitle, submittedDraft, false, ""));
           } catch (RuntimeException e) {
             handleCreateFailure(generation, messageOrDefault(e, "Unable to build the create request."));
             return;
@@ -1311,6 +1387,9 @@ public final class J2clComposeSurfaceController {
     }
     createSubmitting = false;
     createDraft = "";
+    // J-UI-3 (#1081, R-5.1): clear the title on success so the next New
+    // Wave click presents an empty title input.
+    createTitleDraft = "";
     activeCommandId = "";
     annotationCommandId = "";
     commandStatusText = "";
@@ -1459,6 +1538,7 @@ public final class J2clComposeSurfaceController {
         new J2clComposeSurfaceModel(
             !signedOut,
             createDraft,
+            createTitleDraft,
             createSubmitting,
             createStatusText,
             createErrorText,
@@ -1477,7 +1557,21 @@ public final class J2clComposeSurfaceController {
 
   private J2clComposerDocument buildDocument(
       String draftText, boolean includeAttachments, String submittedAnnotationCommandId) {
-    return buildDocument(draftText, includeAttachments, submittedAnnotationCommandId, false);
+    return buildDocument("", draftText, includeAttachments, submittedAnnotationCommandId, false);
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): create-flow overload that prepends the wave title
+   * as a {@code conv/title} annotated-text component. {@code titleText} is
+   * the trimmed title-input value; empty/null is a no-op so reply-paths that
+   * forward an empty title work unchanged.
+   */
+  private J2clComposerDocument buildDocument(
+      String titleText,
+      String draftText,
+      boolean includeAttachments,
+      String submittedAnnotationCommandId) {
+    return buildDocument(titleText, draftText, includeAttachments, submittedAnnotationCommandId, false);
   }
 
   private J2clComposerDocument buildDocument(
@@ -1485,7 +1579,19 @@ public final class J2clComposeSurfaceController {
       boolean includeAttachments,
       String submittedAnnotationCommandId,
       boolean includeMentions) {
+    return buildDocument("", draftText, includeAttachments, submittedAnnotationCommandId, includeMentions);
+  }
+
+  private J2clComposerDocument buildDocument(
+      String titleText,
+      String draftText,
+      boolean includeAttachments,
+      String submittedAnnotationCommandId,
+      boolean includeMentions) {
     J2clComposerDocument.Builder builder = J2clComposerDocument.builder();
+    // J-UI-3: prepend the title annotation when a non-blank title was typed.
+    // titleText() is a no-op on null/empty so reply-paths pass through cleanly.
+    builder.titleText(titleText);
     // Reply submits pass the snapshotted command id; create submits pass an empty id.
     J2clDailyToolbarAction action = J2clDailyToolbarAction.fromId(submittedAnnotationCommandId);
     String annotationKey = annotationKey(action);
@@ -2071,6 +2177,21 @@ public final class J2clComposeSurfaceController {
 
   private static String normalizeDraft(String draft) {
     return draft == null ? "" : draft;
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): normalise a title-input value. Titles are
+   * single-line; we strip leading/trailing whitespace and any embedded
+   * newlines so a paste with a trailing newline does not turn the title
+   * annotation into a multi-line span (which would also pollute the
+   * digest snippet).
+   */
+  private static String normalizeTitle(String title) {
+    if (title == null) {
+      return "";
+    }
+    String stripped = title.replace('\n', ' ').replace('\r', ' ').trim();
+    return stripped;
   }
 
   private static String extractDomain(String waveId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -643,12 +643,15 @@ public final class J2clComposeSurfaceController {
   }
 
   /**
-   * J-UI-3 (#1081, R-5.1): the title input's value changed. Title is single
-   * line; we trim trailing whitespace/newlines (a paste with a trailing
-   * newline must not break the title annotation).
+   * J-UI-3 (#1081, R-5.1): the title input's value changed. Live updates
+   * are kept lossless so users can type multi-word titles normally — we
+   * only neutralise embedded newlines (paste safety: a literal newline
+   * would break the conv/title annotation span). Leading and trailing
+   * whitespace is preserved here and trimmed on submit (codex P1 review
+   * thread on PR #1090).
    */
   public void onCreateTitleChanged(String title) {
-    createTitleDraft = normalizeTitle(title);
+    createTitleDraft = sanitizeTitleLive(title);
     createErrorText = "";
     render();
   }
@@ -661,10 +664,11 @@ public final class J2clComposeSurfaceController {
   /**
    * J-UI-3 (#1081, R-5.1): submit triggered from the title input (Enter key).
    * Snapshots both title and body before submit so a stray draft-change after
-   * Enter does not race with submitCreate.
+   * Enter does not race with submitCreate. The submit path is the only place
+   * that trims the title, so live edits keep every character the user typed.
    */
   public void onCreateSubmittedWithTitle(String title, String draft) {
-    createTitleDraft = normalizeTitle(title);
+    createTitleDraft = normalizeTitleForSubmit(title);
     createDraft = normalizeDraft(draft);
     submitCreate();
   }
@@ -2199,18 +2203,28 @@ public final class J2clComposeSurfaceController {
   }
 
   /**
-   * J-UI-3 (#1081, R-5.1): normalise a title-input value. Titles are
-   * single-line; we strip leading/trailing whitespace and any embedded
-   * newlines so a paste with a trailing newline does not turn the title
-   * annotation into a multi-line span (which would also pollute the
-   * digest snippet).
+   * J-UI-3 (#1081, R-5.1): live-edit sanitiser for the title input. Replaces
+   * any embedded newline (e.g. from a paste) with a space so the conv/title
+   * annotation never spans more than one line, but otherwise preserves the
+   * raw input — including trailing whitespace — so users can type
+   * multi-word titles normally without each space being eaten between
+   * keystrokes.
    */
-  private static String normalizeTitle(String title) {
+  private static String sanitizeTitleLive(String title) {
     if (title == null) {
       return "";
     }
-    String stripped = title.replace('\n', ' ').replace('\r', ' ').trim();
-    return stripped;
+    return title.replace('\n', ' ').replace('\r', ' ');
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): submit-time normaliser. Strips leading/trailing
+   * whitespace in addition to the live-edit newline sanitisation so the
+   * outgoing delta carries a clean single-line title. Called only from the
+   * submit path; live edits use {@link #sanitizeTitleLive}.
+   */
+  private static String normalizeTitleForSubmit(String title) {
+    return sanitizeTitleLive(title).trim();
   }
 
   private static String extractDomain(String waveId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -329,6 +329,13 @@ public final class J2clComposeSurfaceController {
   // chip aria-pressed state reflects "this is your own reaction." Null
   // means no listener installed.
   private CurrentUserAddressListener currentUserAddressListener;
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: hook fired
+  // synchronously at the start of submitCreate so the search panel can
+  // stamp the active query for the upcoming optimistic stub before the
+  // bootstrap fetch and any user-driven query change. Null means no hook
+  // installed; legacy callers that did not register a hook continue to
+  // fall back to the success-time query inside onOptimisticDigest.
+  private Runnable preCreateSubmitHook;
   private String createDraft = "";
   // J-UI-3 (#1081, R-5.1): the title-input value separate from createDraft.
   // Composed into the rich-content document on submit alongside the body so
@@ -1149,6 +1156,19 @@ public final class J2clComposeSurfaceController {
   }
 
   /**
+   * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: install a
+   * hook fired synchronously at the start of {@link #submitCreate}, BEFORE
+   * the gateway bootstrap fetch and the server round-trip. The root shell
+   * uses it to stamp the search panel's active query as the upcoming
+   * optimistic stub's submit-time scope so a query change between submit
+   * and success cannot bind the stub to the wrong rail. Idempotent —
+   * passing {@code null} disables the hook.
+   */
+  public void setPreCreateSubmitHook(Runnable hook) {
+    this.preCreateSubmitHook = hook;
+  }
+
+  /**
    * F-3.S3 (#1038, R-5.5): publish the latest per-blip reaction
    * snapshot from the model. The controller uses this on each toggle
    * click to decide whether the user is adding or removing their
@@ -1359,6 +1379,19 @@ public final class J2clComposeSurfaceController {
     final String submittedDraft = createDraft;
     final String submittedTitle = createTitleDraft;
     final int generation = ++createGeneration;
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: stamp the
+    // pre-submit search query (via the root shell's hook) BEFORE the
+    // bootstrap fetch and server round-trip so the optimistic stub
+    // scoping is anchored to the rail visible when the user clicked
+    // submit, not the rail visible when the server responds.
+    if (preCreateSubmitHook != null) {
+      try {
+        preCreateSubmitHook.run();
+      } catch (RuntimeException ignored) {
+        // Hook side-effects are best-effort; never fail the submit because
+        // an integration callback misbehaved.
+      }
+    }
     render();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1605,6 +1605,12 @@ public final class J2clComposeSurfaceController {
     // J-UI-3: prepend the title annotation when a non-blank title was typed.
     // titleText() is a no-op on null/empty so reply-paths pass through cleanly.
     builder.titleText(titleText);
+    // When a title and body text are both present, insert a newline between them so
+    // the two runs are not concatenated into a single character sequence in the blip.
+    if (titleText != null && !titleText.trim().isEmpty()
+        && draftText != null && !draftText.trim().isEmpty()) {
+      builder.text("\n");
+    }
     // Reply submits pass the snapshotted command id; create submits pass an empty id.
     J2clDailyToolbarAction action = J2clDailyToolbarAction.fromId(submittedAnnotationCommandId);
     String annotationKey = annotationKey(action);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -625,6 +625,16 @@ public final class J2clComposeSurfaceController {
 
   public void onSignedOut() {
     signedOut = true;
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DQdB: a sign-out
+    // mid-create bumps createGeneration which gates the deferred
+    // success/failure callbacks out, so handleCreateFailure (and its
+    // failure hook) never run. The pre-submit hook already queued a
+    // submit-query stamp on the search panel; without explicit cleanup
+    // here that stamp would leak forward and scope the next successful
+    // create's stub to the wrong rail. Snapshot the in-flight bit
+    // BEFORE we clear createSubmitting, then run the failure hook to
+    // drop the orphaned stamp.
+    boolean abortedInFlightCreate = createSubmitting;
     createGeneration++;
     replyGeneration++;
     createSubmitting = false;
@@ -648,6 +658,17 @@ public final class J2clComposeSurfaceController {
     createStatusText = "Sign in to create or reply in the J2CL root shell.";
     replyStatusText = createStatusText;
     render();
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DQdB: drop the
+    // submit-query stamp left behind by an in-flight create that the
+    // generation guard will now silently discard. Run AFTER render so
+    // the view sees the signed-out chrome before any downstream effect.
+    if (abortedInFlightCreate && createFailureHook != null) {
+      try {
+        createFailureHook.run();
+      } catch (RuntimeException ignored) {
+        // Best-effort: never re-throw out of an integration callback.
+      }
+    }
   }
 
   public void onCreateDraftChanged(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -162,9 +162,19 @@ public final class J2clComposeSurfaceController {
     default void onDeleteBlipRequested(String blipId, String expectedWaveId) {}
   }
 
-  @FunctionalInterface
   public interface CreateSuccessHandler {
     void onWaveCreated(String waveId);
+
+    /**
+     * J-UI-3 (#1081, R-5.1): called instead of {@link #onWaveCreated} on
+     * production paths that wire the optimistic-digest prepend in the
+     * search panel. {@code title} is the trimmed title-input value the
+     * user typed; the default delegates to {@link #onWaveCreated} so
+     * existing handlers continue to work.
+     */
+    default void onWaveCreated(String waveId, String title) {
+      onWaveCreated(waveId);
+    }
   }
 
   @FunctionalInterface
@@ -1387,8 +1397,11 @@ public final class J2clComposeSurfaceController {
     }
     createSubmitting = false;
     createDraft = "";
-    // J-UI-3 (#1081, R-5.1): clear the title on success so the next New
-    // Wave click presents an empty title input.
+    // J-UI-3 (#1081, R-5.1): snapshot the title before clearing it so the
+    // success handler can pass it through to the rail's optimistic-digest
+    // prepend; clear last so the rendered create form returns to its empty
+    // state.
+    String createdTitle = createTitleDraft;
     createTitleDraft = "";
     activeCommandId = "";
     annotationCommandId = "";
@@ -1398,7 +1411,7 @@ public final class J2clComposeSurfaceController {
     createErrorText = "";
     render();
     if (createSuccessHandler != null) {
-      createSuccessHandler.onWaveCreated(request.getCreatedWaveId());
+      createSuccessHandler.onWaveCreated(request.getCreatedWaveId(), createdTitle);
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceModel.java
@@ -6,6 +6,11 @@ import java.util.List;
 public final class J2clComposeSurfaceModel {
   private final boolean createEnabled;
   private final String createDraft;
+  // J-UI-3 (#1081, R-5.1): the title input value separate from the body
+  // draft; the controller composes both into the rich-content document on
+  // submit. Empty when the slice flag is off or the user has not typed a
+  // title.
+  private final String createTitleDraft;
   private final boolean createSubmitting;
   private final String createStatusText;
   private final String createErrorText;
@@ -60,8 +65,33 @@ public final class J2clComposeSurfaceModel {
       String commandStatusText,
       String commandErrorText,
       List<String> participantAddresses) {
+    this(createEnabled, createDraft, "", createSubmitting, createStatusText, createErrorText,
+        replyAvailable, replyTargetLabel, replyDraft, replySubmitting, replyStaleBasis,
+        replyStatusText, replyErrorText, activeCommandId, commandStatusText, commandErrorText,
+        participantAddresses);
+  }
+
+  public J2clComposeSurfaceModel(
+      boolean createEnabled,
+      String createDraft,
+      String createTitleDraft,
+      boolean createSubmitting,
+      String createStatusText,
+      String createErrorText,
+      boolean replyAvailable,
+      String replyTargetLabel,
+      String replyDraft,
+      boolean replySubmitting,
+      boolean replyStaleBasis,
+      String replyStatusText,
+      String replyErrorText,
+      String activeCommandId,
+      String commandStatusText,
+      String commandErrorText,
+      List<String> participantAddresses) {
     this.createEnabled = createEnabled;
     this.createDraft = nullToEmpty(createDraft);
+    this.createTitleDraft = nullToEmpty(createTitleDraft);
     this.createSubmitting = createSubmitting;
     this.createStatusText = nullToEmpty(createStatusText);
     this.createErrorText = nullToEmpty(createErrorText);
@@ -87,6 +117,14 @@ public final class J2clComposeSurfaceModel {
 
   public String getCreateDraft() {
     return createDraft;
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): the title-input value that the controller composes
+   * into the rich-content document on submit alongside the body draft.
+   */
+  public String getCreateTitleDraft() {
+    return createTitleDraft;
   }
 
   public boolean isCreateSubmitting() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -47,6 +47,11 @@ import jsinterop.base.JsPropertyMap;
  * reaction wiring is in place.
  */
 public final class J2clComposeSurfaceView implements J2clComposeSurfaceController.View {
+  // J-UI-3 (#1081, R-5.1): the title input precedes the body textarea inside
+  // the create form. Single-line input with Enter-to-submit semantics so a
+  // user who types just a title can ship the wave without reaching for the
+  // mouse.
+  private final HTMLInputElement createTitleInput;
   private final HTMLTextAreaElement createInput;
   private final HTMLElement createSubmit;
   private final HTMLElement replyElement;
@@ -84,6 +89,10 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     createForm.className = "j2cl-compose-create-form";
     shell.appendChild(createForm);
 
+    // J-UI-3 (#1081, R-5.1): single-line title input above the body textarea.
+    // Both inputs are labeled and reachable per the R-5.1 a11y clauses. Note
+    // we declare the body textarea first so the title-input's Enter handler
+    // can reference it without tripping definite-assignment.
     createInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
     createInput.setAttribute("aria-label", "New wave content");
     createInput.setAttribute("placeholder", "Start a new wave");
@@ -95,6 +104,35 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           }
           return null;
         };
+
+    createTitleInput = (HTMLInputElement) DomGlobal.document.createElement("input");
+    createTitleInput.type = "text";
+    createTitleInput.className = "j2cl-compose-create-title";
+    createTitleInput.setAttribute("aria-label", "New wave title");
+    createTitleInput.setAttribute("placeholder", "Title");
+    createTitleInput.setAttribute("autocomplete", "off");
+    createTitleInput.setAttribute("maxlength", "240");
+    createTitleInput.oninput =
+        event -> {
+          if (listener != null) {
+            listener.onCreateTitleChanged(createTitleInput.value);
+          }
+          return null;
+        };
+    createTitleInput.onkeydown =
+        event -> {
+          String key = String.valueOf(Js.asPropertyMap(event).get("key"));
+          if ("Enter".equals(key)) {
+            event.preventDefault();
+            if (listener != null) {
+              listener.onCreateSubmittedWithTitle(createTitleInput.value, createInput.value);
+            }
+          }
+          return null;
+        };
+    // J-UI-3: title appears first in DOM order so the user reaches it before
+    // the body textarea on Tab/initial focus.
+    createForm.appendChild(createTitleInput);
     createForm.appendChild(createInput);
 
     createSubmit = (HTMLElement) DomGlobal.document.createElement("composer-submit-affordance");
@@ -104,7 +142,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
         "submit-affordance",
         event -> {
           if (listener != null) {
-            listener.onCreateSubmitted(createInput.value);
+            listener.onCreateSubmittedWithTitle(createTitleInput.value, createInput.value);
           }
         });
 
@@ -297,6 +335,14 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   @Override
   public void render(J2clComposeSurfaceModel model) {
+    // J-UI-3 (#1081, R-5.1): only assign the title input value when it
+    // actually differs to avoid clobbering the caret position while the user
+    // is typing. The textarea below uses the same guard.
+    String modelTitle = model.getCreateTitleDraft();
+    if (!String.valueOf(createTitleInput.value).equals(modelTitle)) {
+      createTitleInput.value = modelTitle;
+    }
+    createTitleInput.disabled = !model.isCreateEnabled() || model.isCreateSubmitting();
     createInput.value = model.getCreateDraft();
     createInput.disabled = !model.isCreateEnabled() || model.isCreateSubmitting();
     setProperty(createSubmit, "busy", model.isCreateSubmitting());
@@ -339,6 +385,16 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       return;
     }
     replyElement.dispatchEvent(new Event("composer-focus-request"));
+  }
+
+  @Override
+  public void focusCreateSurface() {
+    // J-UI-3 (#1081, R-5.1): the rail's New Wave button drops the user into
+    // the title input; if the input is disabled (signed out / submitting)
+    // skip silently rather than throwing.
+    if (!createTitleInput.disabled) {
+      createTitleInput.focus();
+    }
   }
 
   /** F-3.S1 entrypoint: mount a `<wavy-composer>` inline at the originating blip. */

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -121,12 +121,16 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
         };
     createTitleInput.onkeydown =
         event -> {
-          String key = String.valueOf(Js.asPropertyMap(event).get("key"));
-          if ("Enter".equals(key)) {
-            event.preventDefault();
-            if (listener != null) {
-              listener.onCreateSubmittedWithTitle(createTitleInput.value, createInput.value);
-            }
+          JsPropertyMap<?> eventProps = Js.asPropertyMap(event);
+          String key = String.valueOf(eventProps.get("key"));
+          boolean shiftKey = Boolean.TRUE.equals(eventProps.get("shiftKey"));
+          boolean isComposing = Boolean.TRUE.equals(eventProps.get("isComposing"));
+          if (!("Enter".equals(key)) || shiftKey || isComposing) {
+            return null;
+          }
+          event.preventDefault();
+          if (listener != null) {
+            listener.onCreateSubmittedWithTitle(createTitleInput.value, createInput.value);
           }
           return null;
         };
@@ -335,15 +339,17 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   @Override
   public void render(J2clComposeSurfaceModel model) {
-    // J-UI-3 (#1081, R-5.1): only assign the title input value when it
-    // actually differs to avoid clobbering the caret position while the user
-    // is typing. The textarea below uses the same guard.
+    // J-UI-3 (#1081, R-5.1): only assign input values when they actually differ
+    // to avoid clobbering the caret position while the user is typing.
     String modelTitle = model.getCreateTitleDraft();
     if (!String.valueOf(createTitleInput.value).equals(modelTitle)) {
       createTitleInput.value = modelTitle;
     }
     createTitleInput.disabled = !model.isCreateEnabled() || model.isCreateSubmitting();
-    createInput.value = model.getCreateDraft();
+    String modelDraft = model.getCreateDraft();
+    if (!String.valueOf(createInput.value).equals(modelDraft)) {
+      createInput.value = modelDraft;
+    }
     createInput.disabled = !model.isCreateEnabled() || model.isCreateSubmitting();
     setProperty(createSubmit, "busy", model.isCreateSubmitting());
     setProperty(createSubmit, "disabled", !model.isCreateEnabled() || model.isCreateSubmitting());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -7,6 +7,17 @@ import java.util.Locale;
 
 /** Immutable structured composer document used to build J2CL rich-content sidecar deltas. */
 public final class J2clComposerDocument {
+  // J-UI-3 (#1081, R-5.1): the wave-title annotation key. Mirrors
+  // org.waveprotocol.wave.model.conversation.TitleHelper.TITLE_KEY which
+  // is built from Annotations.join(Blips.ANNOTATION_PREFIX, "title") and
+  // resolves to the literal "conv/title". Kept as a private constant
+  // here because TitleHelper lives in the wave model module which is not
+  // visible to J2CL-compiled code.
+  static final String TITLE_ANNOTATION_KEY = "conv/title";
+  // TitleHelper.AUTO_VALUE = "" — empty value tells the server to use
+  // the annotated text run as the title.
+  static final String TITLE_ANNOTATION_AUTO_VALUE = "";
+
   enum ComponentType {
     TEXT,
     ANNOTATED_TEXT,
@@ -86,8 +97,8 @@ public final class J2clComposerDocument {
           new Component(
               ComponentType.ANNOTATED_TEXT,
               text,
-              "conv/title",
-              "",
+              TITLE_ANNOTATION_KEY,
+              TITLE_ANNOTATION_AUTO_VALUE,
               "",
               ""));
       return this;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -67,6 +67,32 @@ public final class J2clComposerDocument {
       return this;
     }
 
+    /**
+     * J-UI-3 (#1081, R-5.1): appends the wave title as an `ANNOTATED_TEXT`
+     * component using the canonical Wave title annotation
+     * (`conv/title` with the AUTO_VALUE empty-string sentinel from
+     * {@code TitleHelper.AUTO_VALUE}). The empty annotation value tells the
+     * server-side digest path to use the annotated text itself as the title.
+     *
+     * <p>Bypasses {@link #annotatedText}'s non-empty-value check because the
+     * AUTO_VALUE sentinel is exactly the empty string. No-op on null/blank
+     * input so callers can pass through an unset title cleanly.
+     */
+    public Builder titleText(String text) {
+      if (text == null || text.trim().isEmpty()) {
+        return this;
+      }
+      components.add(
+          new Component(
+              ComponentType.ANNOTATED_TEXT,
+              text,
+              "conv/title",
+              "",
+              "",
+              ""));
+      return this;
+    }
+
     /** Appends an image attachment element; caption text is preserved exactly when present. */
     public Builder imageAttachment(String attachmentId, String caption, String displaySize) {
       components.add(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -138,6 +138,11 @@ public final class J2clRootShellController {
     // moment the user clicks submit, so a query change between submit
     // and server-response cannot leak the stub into an unrelated rail.
     composeController.setPreCreateSubmitHook(controller::markCreateSubmitted);
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: pair the
+    // pre-submit stamp with a failure-time drop so a failed create does
+    // not leave a stale submit-query stamp that scopes the next
+    // successful create's stub to the wrong rail.
+    composeController.setCreateFailureHook(controller::discardOldestSubmitStamp);
     // J-UI-3 (#1081, R-5.1): the rail's New Wave button focuses the create
     // form's title input. Listening on document.body so the event bubbles
     // up regardless of where the rail is currently mounted.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -133,6 +133,11 @@ public final class J2clRootShellController {
                     routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation)),
             resolveViewportWidth());
     searchControllerRef[0] = controller;
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: stamp the
+    // active search query onto the next pending optimistic stub at the
+    // moment the user clicks submit, so a query change between submit
+    // and server-response cannot leak the stub into an unrelated rail.
+    composeController.setPreCreateSubmitHook(controller::markCreateSubmitted);
     // J-UI-3 (#1081, R-5.1): the rail's New Wave button focuses the create
     // form's title input. Listening on document.body so the event bubbles
     // up regardless of where the rail is currently mounted.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -4,6 +4,7 @@ import elemental2.dom.Event;
 import elemental2.dom.HTMLElement;
 import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.CreateSuccessHandler;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceView;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
@@ -62,13 +63,34 @@ public final class J2clRootShellController {
     HTMLElement selectedReplyHost =
         createChildHost(selectedWaveComposeHost, "j2cl-root-reply-host");
     String rootShellSessionSeed = buildRootShellSessionSeed();
+    final J2clSearchPanelController[] searchControllerRef = new J2clSearchPanelController[1];
+    // J-UI-3 (#1081, R-5.1): on a successful create, prepend an optimistic
+    // digest in the rail (so the new wave is visible without waiting for
+    // the search index to catch up) THEN route to the new wave so it opens
+    // in the right region. The legacy single-arg overload still routes for
+    // back-compat with callers that have not adopted the title path.
+    CreateSuccessHandler createSuccessHandler =
+        new CreateSuccessHandler() {
+          @Override
+          public void onWaveCreated(String waveId) {
+            onWaveCreated(waveId, "");
+          }
+
+          @Override
+          public void onWaveCreated(String waveId, String title) {
+            if (searchControllerRef[0] != null) {
+              searchControllerRef[0].onOptimisticDigest(waveId, title);
+            }
+            routeControllerRef[0].selectWave(waveId);
+          }
+        };
     J2clComposeSurfaceController composeController =
         new J2clComposeSurfaceController(
             gateway,
             new J2clComposeSurfaceView(searchView.getComposeHost(), selectedReplyHost),
             J2clComposeSurfaceController.richContentDeltaFactory(rootShellSessionSeed),
             J2clComposeSurfaceController.attachmentControllerFactory(rootShellSessionSeed, telemetrySink),
-            waveId -> routeControllerRef[0].selectWave(waveId),
+            createSuccessHandler,
             waveId -> {
               if (selectedWaveControllerRef[0] != null) {
                 selectedWaveControllerRef[0].refreshSelectedWave();
@@ -110,6 +132,13 @@ public final class J2clRootShellController {
                 (state, digestItem, userNavigation) ->
                     routeControllerRef[0].onRouteStateChanged(state, digestItem, userNavigation)),
             resolveViewportWidth());
+    searchControllerRef[0] = controller;
+    // J-UI-3 (#1081, R-5.1): the rail's New Wave button focuses the create
+    // form's title input. Listening on document.body so the event bubbles
+    // up regardless of where the rail is currently mounted.
+    elemental2.dom.DomGlobal.document.body.addEventListener(
+        "wavy-new-wave-requested",
+        evt -> composeController.focusCreateSurface());
     // F-4 (#1039 / R-4.4): bridge the selected-wave controller's live read
     // state into the search panel so the matching digest's unread badge
     // decrements without re-rendering the whole list.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -366,6 +366,29 @@ public final class J2clSearchPanelController
   }
 
   /**
+   * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: drop the
+   * oldest entry from the pendingSubmitQueries deque without scoping a
+   * stub. Called by the compose controller's failure hook so a create
+   * that errors before the success callback (bootstrap or submit error)
+   * does not leave a stale stamp in the queue. Without this, the next
+   * successful create would consume the failed attempt's submit query
+   * and scope its optimistic stub to the wrong rail. Idempotent:
+   * silently no-ops when the queue is empty.
+   */
+  public void discardOldestSubmitStamp() {
+    pendingSubmitQueries.pollFirst();
+  }
+
+  /**
+   * J-UI-3 (#1090, thread PRRT_kwDOBwxLXs5-DA7T): pop the pending submit-query stamp when a
+   * create attempt fails before reaching the success callback. Prevents stale stamps from
+   * being consumed by a subsequent successful create under a different query.
+   */
+  public void cancelPendingCreateSubmit() {
+    pendingSubmitQueries.pollFirst();
+  }
+
+  /**
    * J-UI-3 (#1081, R-5.1): record an optimistic digest for the just-created
    * wave and prepend it to the rail immediately. The stub is dropped when
    * the next search response includes the matching waveId or after
@@ -402,8 +425,18 @@ public final class J2clSearchPanelController
     }
     final PendingStub pending = new PendingStub(stub, submitQuery);
     pendingStubs.put(waveId, pending);
-    lastModel = withActivePendingLabel(lastModel.withPrependedDigest(stub));
-    view.render(lastModel);
+    // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7V: only
+    // prepend immediately when the stamped submit query matches the
+    // currently visible rail. If the user navigated to a different
+    // query between submit and success, the stub stays in pendingStubs
+    // (so it surfaces when they return) but is not painted into the
+    // unrelated rail. This makes the immediate prepend match the
+    // long-term scope semantics enforced by applyOptimisticStubs.
+    String activeQuery = currentQuery == null ? "" : currentQuery;
+    if (submitQuery.equals(activeQuery)) {
+      lastModel = withActivePendingLabel(lastModel.withPrependedDigest(stub));
+      view.render(lastModel);
+    }
     // Schedule the stuck-stub bound BEFORE issuing requestSearch so a
     // synchronous response callback (in tests, or a hot-cache server) can
     // cancel the timeout via applyOptimisticStubs instead of stranding it.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -93,17 +93,42 @@ public final class J2clSearchPanelController
   // it.
   private J2clSearchDigestItem optimisticStub;
   private int optimisticGeneration;
+  private final OptimisticScheduler optimisticScheduler;
   private static final int OPTIMISTIC_TIMEOUT_MS = 5_000;
+
+  /**
+   * J-UI-3 (#1081, R-5.1): pluggable timer seam for the optimistic-prepend
+   * timeout. Production wires {@link #defaultOptimisticScheduler}, which
+   * delegates to {@code DomGlobal.setTimeout}. JVM tests pass a fake that
+   * captures the runnable so they can drive the timeout deterministically.
+   */
+  public interface OptimisticScheduler {
+    void scheduleTimeout(int delayMs, Runnable action);
+  }
 
   public J2clSearchPanelController(
       SearchGateway gateway,
       View view,
       RouteStateHandler routeStateHandler,
       double viewportWidth) {
+    this(gateway, view, routeStateHandler, viewportWidth, defaultOptimisticScheduler());
+  }
+
+  public J2clSearchPanelController(
+      SearchGateway gateway,
+      View view,
+      RouteStateHandler routeStateHandler,
+      double viewportWidth,
+      OptimisticScheduler optimisticScheduler) {
     this.gateway = gateway;
     this.view = view;
     this.routeStateHandler = routeStateHandler;
     this.pageIncrement = J2clSearchResultProjector.getPageSizeForViewport(viewportWidth);
+    this.optimisticScheduler = optimisticScheduler;
+  }
+
+  private static OptimisticScheduler defaultOptimisticScheduler() {
+    return (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs);
   }
 
   @Override
@@ -274,7 +299,7 @@ public final class J2clSearchPanelController
     }
     String safeTitle = title == null ? "" : title;
     String safeSnippet = "";
-    long now = (long) DomGlobal.window.performance.now();
+    long now = System.currentTimeMillis();
     optimisticStub =
         new J2clSearchDigestItem(waveId, safeTitle, safeSnippet, "", 0, 1, now, false);
     final int generation = ++optimisticGeneration;
@@ -283,16 +308,16 @@ public final class J2clSearchPanelController
     requestSearch();
     // Bound a stuck stub: if the index never returns the wave, retire the
     // stub after OPTIMISTIC_TIMEOUT_MS so a stale entry does not linger.
-    DomGlobal.setTimeout(
-        ignored -> {
+    optimisticScheduler.scheduleTimeout(
+        OPTIMISTIC_TIMEOUT_MS,
+        () -> {
           if (generation == optimisticGeneration && optimisticStub != null) {
             String stuckId = optimisticStub.getWaveId();
             optimisticStub = null;
             lastModel = lastModel.withoutDigest(stuckId);
             view.render(lastModel);
           }
-        },
-        OPTIMISTIC_TIMEOUT_MS);
+        });
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -1,6 +1,11 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
 public final class J2clSearchPanelController
@@ -87,14 +92,31 @@ public final class J2clSearchPanelController
   private J2clSearchResultModel lastModel = J2clSearchResultModel.empty("Search results will appear here.");
   // J-UI-3 (#1081, R-5.1): optimistic-prepend bookkeeping. After a successful
   // create the controller stores a stub digest here so the rail shows the new
-  // wave immediately while the server search index catches up. The stub is
+  // wave immediately while the server search index catches up. Each stub is
   // dropped once a refresh response includes the matching waveId, or after
   // OPTIMISTIC_TIMEOUT_MS to bound a stuck stub if the index never returns
-  // it.
-  private J2clSearchDigestItem optimisticStub;
-  private int optimisticGeneration;
-  private Object optimisticTimeoutHandle;
+  // it. The map is keyed by waveId so back-to-back creates each get their own
+  // entry (no overwrite), and each stub is scoped to the query active at
+  // submit time so it only renders into the rail it was created for.
+  private final Map<String, PendingStub> pendingStubs = new LinkedHashMap<>();
   private final OptimisticScheduler optimisticScheduler;
+
+  /**
+   * J-UI-3 (#1081, R-5.1): one per outstanding optimistic create. Holds the
+   * stub digest, the query active when the create was submitted (so the
+   * stub does not leak into unrelated rails), and the cancellable timeout
+   * handle that retires the stub if the server never indexes the wave.
+   */
+  private static final class PendingStub {
+    final J2clSearchDigestItem digest;
+    final String query;
+    Object timeoutHandle;
+
+    PendingStub(J2clSearchDigestItem digest, String query) {
+      this.digest = digest;
+      this.query = query;
+    }
+  }
   // J-UI-3 (#1081): bound on a stuck optimistic stub. Set to 30s so the
   // race "timeout fires before slow gateway response arrives" is rare in
   // practice (Lucene refresh interval is typically <2s; 30s is well past
@@ -275,11 +297,11 @@ public final class J2clSearchPanelController
             return;
           }
           J2clSearchResultModel projected = J2clSearchResultProjector.project(response, numResults);
-          // J-UI-3 (#1081, R-5.1): if the just-created wave is still missing
-          // from the server response, keep the optimistic stub at the top of
+          // J-UI-3 (#1081, R-5.1): if any just-created wave is still missing
+          // from the server response, keep its optimistic stub at the top of
           // the rail; otherwise drop the stub now that the real digest is
           // present.
-          lastModel = applyOptimisticStub(projected);
+          lastModel = applyOptimisticStubs(projected);
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
           if (selectedWaveId != null) {
@@ -292,7 +314,13 @@ public final class J2clSearchPanelController
           if (generation != requestGeneration) {
             return;
           }
-          lastModel = J2clSearchResultModel.empty("Unable to load search results.");
+          // J-UI-3 (#1081, R-5.1): preserve outstanding optimistic stubs on
+          // a transient gateway failure so a wave the user just created does
+          // not vanish from the rail when the search index is briefly
+          // unreachable. The empty model is what we'd render without stubs;
+          // re-applying stubs prepends any waves we know are pending.
+          J2clSearchResultModel base = J2clSearchResultModel.empty("Unable to load search results.");
+          lastModel = applyOptimisticStubs(base);
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
           view.setStatus("Search request failed: " + error, true);
@@ -317,6 +345,12 @@ public final class J2clSearchPanelController
    * {@link #OPTIMISTIC_TIMEOUT_MS}, whichever comes first. {@code title}
    * is what the user typed; the stub author is left empty since we do not
    * yet know the bootstrap address at this site.
+   *
+   * <p>Multiple back-to-back creates each get their own pending entry so a
+   * second submit before indexing catches up does not erase the first
+   * (codex review thread on PR #1090). Each stub is scoped to the query
+   * active at submit time, so changing the rail query hides the stub from
+   * unrelated result sets and brings it back when the user navigates back.
    */
   public void onOptimisticDigest(String waveId, String title) {
     if (waveId == null || waveId.isEmpty()) {
@@ -325,27 +359,27 @@ public final class J2clSearchPanelController
     String safeTitle = (title == null || title.isEmpty()) ? "(untitled wave)" : title;
     String safeSnippet = "";
     long now = System.currentTimeMillis();
-    optimisticStub =
+    J2clSearchDigestItem stub =
         new J2clSearchDigestItem(waveId, safeTitle, safeSnippet, "", 0, 1, now, false);
-    final int generation = ++optimisticGeneration;
-    if (optimisticTimeoutHandle != null) {
-      optimisticScheduler.cancel(optimisticTimeoutHandle);
-      optimisticTimeoutHandle = null;
+    PendingStub previous = pendingStubs.remove(waveId);
+    if (previous != null && previous.timeoutHandle != null) {
+      optimisticScheduler.cancel(previous.timeoutHandle);
     }
-    lastModel = lastModel.withPrependedDigest(optimisticStub);
+    final PendingStub pending = new PendingStub(stub, currentQuery);
+    pendingStubs.put(waveId, pending);
+    lastModel = lastModel.withPrependedDigest(stub);
     view.render(lastModel);
     // Schedule the stuck-stub bound BEFORE issuing requestSearch so a
     // synchronous response callback (in tests, or a hot-cache server) can
-    // cancel the timeout via applyOptimisticStub instead of stranding it.
-    optimisticTimeoutHandle =
+    // cancel the timeout via applyOptimisticStubs instead of stranding it.
+    pending.timeoutHandle =
         optimisticScheduler.scheduleTimeout(
             OPTIMISTIC_TIMEOUT_MS,
             () -> {
-              optimisticTimeoutHandle = null;
-              if (generation == optimisticGeneration && optimisticStub != null) {
-                String stuckId = optimisticStub.getWaveId();
-                optimisticStub = null;
-                lastModel = lastModel.withoutDigest(stuckId);
+              PendingStub stillPending = pendingStubs.get(waveId);
+              if (stillPending == pending) {
+                pendingStubs.remove(waveId);
+                lastModel = lastModel.withoutDigest(waveId);
                 view.render(lastModel);
               }
             });
@@ -353,26 +387,44 @@ public final class J2clSearchPanelController
   }
 
   /**
-   * Returns {@code projected} with the optimistic stub re-applied if the
-   * server response did not include the matching waveId. Clears the stub
-   * when the response already lists the new wave.
+   * Returns {@code projected} with all outstanding optimistic stubs
+   * reconciled: stubs whose waveId is now present in the server response
+   * are dropped and their timeouts cancelled (the real digest wins);
+   * stubs whose waveId is still missing are kept prepended on the rail
+   * IF they were submitted under the active query; stubs from a different
+   * query are skipped here but remain in the pending map so they
+   * reappear when the user navigates back to that query.
    */
-  private J2clSearchResultModel applyOptimisticStub(J2clSearchResultModel projected) {
-    if (optimisticStub == null) {
+  private J2clSearchResultModel applyOptimisticStubs(J2clSearchResultModel projected) {
+    if (pendingStubs.isEmpty()) {
       return projected;
     }
-    String stubId = optimisticStub.getWaveId();
-    if (projected.containsWave(stubId)) {
-      optimisticStub = null;
-      // The server confirmed the new wave is indexed; cancel the stuck-stub
-      // timeout so the rail does not flicker if the timer fires later.
-      if (optimisticTimeoutHandle != null) {
-        optimisticScheduler.cancel(optimisticTimeoutHandle);
-        optimisticTimeoutHandle = null;
+    Iterator<Map.Entry<String, PendingStub>> iter = pendingStubs.entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<String, PendingStub> entry = iter.next();
+      PendingStub pending = entry.getValue();
+      if (projected.containsWave(pending.digest.getWaveId())) {
+        if (pending.timeoutHandle != null) {
+          optimisticScheduler.cancel(pending.timeoutHandle);
+        }
+        iter.remove();
       }
+    }
+    if (pendingStubs.isEmpty()) {
       return projected;
     }
-    return projected.withPrependedDigest(optimisticStub);
+    // Walk the LinkedHashMap in insertion order and prepend each stub. Each
+    // prepend pushes the previously-prepended item down by one row, so the
+    // last (most-recent) submission ends up at the top of the rail.
+    J2clSearchResultModel result = projected;
+    for (PendingStub pending : pendingStubs.values()) {
+      if (pending.query == null
+          ? currentQuery == null
+          : pending.query.equals(currentQuery)) {
+        result = result.withPrependedDigest(pending.digest);
+      }
+    }
+    return result;
   }
 
   private void clearSelection(boolean userNavigation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -322,7 +322,7 @@ public final class J2clSearchPanelController
     if (waveId == null || waveId.isEmpty()) {
       return;
     }
-    String safeTitle = title == null ? "" : title;
+    String safeTitle = (title == null || title.isEmpty()) ? "(untitled wave)" : title;
     String safeSnippet = "";
     long now = System.currentTimeMillis();
     optimisticStub =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -417,11 +417,31 @@ public final class J2clSearchPanelController
     // prepend pushes the previously-prepended item down by one row, so the
     // last (most-recent) submission ends up at the top of the rail.
     J2clSearchResultModel result = projected;
+    int prependedCount = 0;
     for (PendingStub pending : pendingStubs.values()) {
       if (pending.query == null
           ? currentQuery == null
           : pending.query.equals(currentQuery)) {
         result = result.withPrependedDigest(pending.digest);
+        prependedCount++;
+      }
+    }
+    if (prependedCount > 0) {
+      // CodeRabbit minor PRRT_kwDOBwxLXs5-Cpes: the projector's count text
+      // ("N waves" / "N of M waves [· K unread]") reflects the server
+      // response only. When we prepend optimistic stubs the rail header
+      // would otherwise still show the stale server count, so we suffix
+      // a "(+N pending)" marker. The unread count is unchanged because
+      // optimistic stubs render with unread=0.
+      String suffix = " (+" + prependedCount + " pending)";
+      String existingText = result.getWaveCountText();
+      if (!existingText.endsWith(suffix)) {
+        result =
+            new J2clSearchResultModel(
+                result.getDigestItems(),
+                existingText.isEmpty() ? suffix.trim() : existingText + suffix,
+                result.isShowMoreVisible(),
+                result.getEmptyMessage());
       }
     }
     return result;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -93,17 +93,30 @@ public final class J2clSearchPanelController
   // it.
   private J2clSearchDigestItem optimisticStub;
   private int optimisticGeneration;
+  private Object optimisticTimeoutHandle;
   private final OptimisticScheduler optimisticScheduler;
-  private static final int OPTIMISTIC_TIMEOUT_MS = 5_000;
+  // J-UI-3 (#1081): bound on a stuck optimistic stub. Set to 30s so the
+  // race "timeout fires before slow gateway response arrives" is rare in
+  // practice (Lucene refresh interval is typically <2s; 30s is well past
+  // every observed lag). When the server response confirms the wave the
+  // stub is dropped immediately and the timeout is cancelled, so this
+  // bound only matters when the wave never gets indexed.
+  private static final int OPTIMISTIC_TIMEOUT_MS = 30_000;
 
   /**
    * J-UI-3 (#1081, R-5.1): pluggable timer seam for the optimistic-prepend
    * timeout. Production wires {@link #defaultOptimisticScheduler}, which
    * delegates to {@code DomGlobal.setTimeout}. JVM tests pass a fake that
    * captures the runnable so they can drive the timeout deterministically.
+   * The handle returned by {@link #scheduleTimeout} can be passed to
+   * {@link #cancel} so the controller can retire the timer when the server
+   * confirms the wave is indexed (avoids the timeout-fires-before-response
+   * race).
    */
   public interface OptimisticScheduler {
-    void scheduleTimeout(int delayMs, Runnable action);
+    Object scheduleTimeout(int delayMs, Runnable action);
+
+    void cancel(Object handle);
   }
 
   public J2clSearchPanelController(
@@ -128,7 +141,19 @@ public final class J2clSearchPanelController
   }
 
   private static OptimisticScheduler defaultOptimisticScheduler() {
-    return (delayMs, action) -> DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+    return new OptimisticScheduler() {
+      @Override
+      public Object scheduleTimeout(int delayMs, Runnable action) {
+        return DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+      }
+
+      @Override
+      public void cancel(Object handle) {
+        if (handle instanceof Double) {
+          DomGlobal.clearTimeout(((Double) handle).doubleValue());
+        }
+      }
+    };
   }
 
   @Override
@@ -303,21 +328,28 @@ public final class J2clSearchPanelController
     optimisticStub =
         new J2clSearchDigestItem(waveId, safeTitle, safeSnippet, "", 0, 1, now, false);
     final int generation = ++optimisticGeneration;
+    if (optimisticTimeoutHandle != null) {
+      optimisticScheduler.cancel(optimisticTimeoutHandle);
+      optimisticTimeoutHandle = null;
+    }
     lastModel = lastModel.withPrependedDigest(optimisticStub);
     view.render(lastModel);
+    // Schedule the stuck-stub bound BEFORE issuing requestSearch so a
+    // synchronous response callback (in tests, or a hot-cache server) can
+    // cancel the timeout via applyOptimisticStub instead of stranding it.
+    optimisticTimeoutHandle =
+        optimisticScheduler.scheduleTimeout(
+            OPTIMISTIC_TIMEOUT_MS,
+            () -> {
+              optimisticTimeoutHandle = null;
+              if (generation == optimisticGeneration && optimisticStub != null) {
+                String stuckId = optimisticStub.getWaveId();
+                optimisticStub = null;
+                lastModel = lastModel.withoutDigest(stuckId);
+                view.render(lastModel);
+              }
+            });
     requestSearch();
-    // Bound a stuck stub: if the index never returns the wave, retire the
-    // stub after OPTIMISTIC_TIMEOUT_MS so a stale entry does not linger.
-    optimisticScheduler.scheduleTimeout(
-        OPTIMISTIC_TIMEOUT_MS,
-        () -> {
-          if (generation == optimisticGeneration && optimisticStub != null) {
-            String stuckId = optimisticStub.getWaveId();
-            optimisticStub = null;
-            lastModel = lastModel.withoutDigest(stuckId);
-            view.render(lastModel);
-          }
-        });
   }
 
   /**
@@ -332,6 +364,12 @@ public final class J2clSearchPanelController
     String stubId = optimisticStub.getWaveId();
     if (projected.containsWave(stubId)) {
       optimisticStub = null;
+      // The server confirmed the new wave is indexed; cancel the stuck-stub
+      // timeout so the rail does not flicker if the timer fires later.
+      if (optimisticTimeoutHandle != null) {
+        optimisticScheduler.cancel(optimisticTimeoutHandle);
+        optimisticTimeoutHandle = null;
+      }
       return projected;
     }
     return projected.withPrependedDigest(optimisticStub);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -1,5 +1,6 @@
 package org.waveprotocol.box.j2cl.search;
 
+import elemental2.dom.DomGlobal;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
 
 public final class J2clSearchPanelController
@@ -84,6 +85,15 @@ public final class J2clSearchPanelController
   private int currentPageSize;
   private int requestGeneration;
   private J2clSearchResultModel lastModel = J2clSearchResultModel.empty("Search results will appear here.");
+  // J-UI-3 (#1081, R-5.1): optimistic-prepend bookkeeping. After a successful
+  // create the controller stores a stub digest here so the rail shows the new
+  // wave immediately while the server search index catches up. The stub is
+  // dropped once a refresh response includes the matching waveId, or after
+  // OPTIMISTIC_TIMEOUT_MS to bound a stuck stub if the index never returns
+  // it.
+  private J2clSearchDigestItem optimisticStub;
+  private int optimisticGeneration;
+  private static final int OPTIMISTIC_TIMEOUT_MS = 5_000;
 
   public J2clSearchPanelController(
       SearchGateway gateway,
@@ -214,7 +224,12 @@ public final class J2clSearchPanelController
           if (generation != requestGeneration) {
             return;
           }
-          lastModel = J2clSearchResultProjector.project(response, numResults);
+          J2clSearchResultModel projected = J2clSearchResultProjector.project(response, numResults);
+          // J-UI-3 (#1081, R-5.1): if the just-created wave is still missing
+          // from the server response, keep the optimistic stub at the top of
+          // the rail; otherwise drop the stub now that the real digest is
+          // present.
+          lastModel = applyOptimisticStub(projected);
           view.render(lastModel);
           view.setSelectedWaveId(selectedWaveId);
           if (selectedWaveId != null) {
@@ -233,6 +248,68 @@ public final class J2clSearchPanelController
           view.setStatus("Search request failed: " + error, true);
           view.setLoading(false);
         });
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): re-issues the current search query without
+   * resetting selection or page size. Public entrypoint used by the
+   * create-success path so the rail picks up the new digest after a wave
+   * is created. Idempotent — safe to call repeatedly.
+   */
+  public void refreshSearch() {
+    requestSearch();
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): record an optimistic digest for the just-created
+   * wave and prepend it to the rail immediately. The stub is dropped when
+   * the next search response includes the matching waveId or after
+   * {@link #OPTIMISTIC_TIMEOUT_MS}, whichever comes first. {@code title}
+   * is what the user typed; the stub author is left empty since we do not
+   * yet know the bootstrap address at this site.
+   */
+  public void onOptimisticDigest(String waveId, String title) {
+    if (waveId == null || waveId.isEmpty()) {
+      return;
+    }
+    String safeTitle = title == null ? "" : title;
+    String safeSnippet = "";
+    long now = (long) DomGlobal.window.performance.now();
+    optimisticStub =
+        new J2clSearchDigestItem(waveId, safeTitle, safeSnippet, "", 0, 1, now, false);
+    final int generation = ++optimisticGeneration;
+    lastModel = lastModel.withPrependedDigest(optimisticStub);
+    view.render(lastModel);
+    requestSearch();
+    // Bound a stuck stub: if the index never returns the wave, retire the
+    // stub after OPTIMISTIC_TIMEOUT_MS so a stale entry does not linger.
+    DomGlobal.setTimeout(
+        ignored -> {
+          if (generation == optimisticGeneration && optimisticStub != null) {
+            String stuckId = optimisticStub.getWaveId();
+            optimisticStub = null;
+            lastModel = lastModel.withoutDigest(stuckId);
+            view.render(lastModel);
+          }
+        },
+        OPTIMISTIC_TIMEOUT_MS);
+  }
+
+  /**
+   * Returns {@code projected} with the optimistic stub re-applied if the
+   * server response did not include the matching waveId. Clears the stub
+   * when the response already lists the new wave.
+   */
+  private J2clSearchResultModel applyOptimisticStub(J2clSearchResultModel projected) {
+    if (optimisticStub == null) {
+      return projected;
+    }
+    String stubId = optimisticStub.getWaveId();
+    if (projected.containsWave(stubId)) {
+      optimisticStub = null;
+      return projected;
+    }
+    return projected.withPrependedDigest(optimisticStub);
   }
 
   private void clearSelection(boolean userNavigation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -367,7 +367,7 @@ public final class J2clSearchPanelController
     }
     final PendingStub pending = new PendingStub(stub, currentQuery);
     pendingStubs.put(waveId, pending);
-    lastModel = lastModel.withPrependedDigest(stub);
+    lastModel = withActivePendingLabel(lastModel.withPrependedDigest(stub));
     view.render(lastModel);
     // Schedule the stuck-stub bound BEFORE issuing requestSearch so a
     // synchronous response callback (in tests, or a hot-cache server) can
@@ -379,7 +379,7 @@ public final class J2clSearchPanelController
               PendingStub stillPending = pendingStubs.get(waveId);
               if (stillPending == pending) {
                 pendingStubs.remove(waveId);
-                lastModel = lastModel.withoutDigest(waveId);
+                lastModel = withActivePendingLabel(lastModel.withoutDigest(waveId));
                 view.render(lastModel);
               }
             });
@@ -427,24 +427,45 @@ public final class J2clSearchPanelController
       }
     }
     if (prependedCount > 0) {
-      // CodeRabbit minor PRRT_kwDOBwxLXs5-Cpes: the projector's count text
-      // ("N waves" / "N of M waves [· K unread]") reflects the server
-      // response only. When we prepend optimistic stubs the rail header
-      // would otherwise still show the stale server count, so we suffix
-      // a "(+N pending)" marker. The unread count is unchanged because
-      // optimistic stubs render with unread=0.
-      String suffix = " (+" + prependedCount + " pending)";
-      String existingText = result.getWaveCountText();
-      if (!existingText.endsWith(suffix)) {
-        result =
-            new J2clSearchResultModel(
-                result.getDigestItems(),
-                existingText.isEmpty() ? suffix.trim() : existingText + suffix,
-                result.isShowMoreVisible(),
-                result.getEmptyMessage());
-      }
+      result = withActivePendingLabel(result);
     }
     return result;
+  }
+
+  /**
+   * Returns {@code model} with a "(+N pending)" suffix on the wave-count text
+   * reflecting the number of optimistic stubs currently active for the current
+   * query. Any existing pending suffix is stripped before the new one is
+   * appended so back-to-back creates do not accumulate multiple suffixes.
+   */
+  private J2clSearchResultModel withActivePendingLabel(J2clSearchResultModel model) {
+    int count = 0;
+    for (PendingStub ps : pendingStubs.values()) {
+      if (ps.query == null ? currentQuery == null : ps.query.equals(currentQuery)) {
+        count++;
+      }
+    }
+    String base = stripPendingSuffix(model.getWaveCountText());
+    String updated =
+        count > 0
+            ? (base.isEmpty() ? "(+" + count + " pending)" : base + " (+" + count + " pending)")
+            : base;
+    if (updated.equals(model.getWaveCountText())) {
+      return model;
+    }
+    return new J2clSearchResultModel(
+        model.getDigestItems(), updated, model.isShowMoreVisible(), model.getEmptyMessage());
+  }
+
+  private static String stripPendingSuffix(String text) {
+    if (text == null || !text.endsWith(" pending)")) {
+      return text == null ? "" : text;
+    }
+    int i = text.lastIndexOf("(+");
+    if (i < 0) {
+      return text;
+    }
+    return text.substring(0, i).trim();
   }
 
   private void clearSelection(boolean userNavigation) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelController.java
@@ -1,7 +1,9 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -99,6 +101,16 @@ public final class J2clSearchPanelController
   // entry (no overwrite), and each stub is scoped to the query active at
   // submit time so it only renders into the rail it was created for.
   private final Map<String, PendingStub> pendingStubs = new LinkedHashMap<>();
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: capture the
+  // active query at the moment the user clicks submit, not when the
+  // server response lands. Without this, a user who submits on query A
+  // and switches to query B before the server confirms ends up with the
+  // optimistic stub scoped to B (because onOptimisticDigest reads the
+  // currentQuery field at success-callback time). The compose controller
+  // calls {@link #markCreateSubmitted()} synchronously at the start of
+  // submitCreate; the queue is consumed in submission order when each
+  // onOptimisticDigest fires.
+  private final Deque<String> pendingSubmitQueries = new ArrayDeque<>();
   private final OptimisticScheduler optimisticScheduler;
 
   /**
@@ -339,6 +351,21 @@ public final class J2clSearchPanelController
   }
 
   /**
+   * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: stamp the
+   * active query as the next pending optimistic stub's submit-time
+   * scope. Called synchronously by the compose controller at the start
+   * of submitCreate (BEFORE the bootstrap fetch + server round-trip),
+   * so a query change between submit and success cannot rebind the
+   * stub to the wrong rail. The corresponding {@link
+   * #onOptimisticDigest} call consumes the queue head in submission
+   * order. Idempotent if called multiple times — each call enqueues
+   * one entry and one onOptimisticDigest pops one entry.
+   */
+  public void markCreateSubmitted() {
+    pendingSubmitQueries.addLast(currentQuery == null ? "" : currentQuery);
+  }
+
+  /**
    * J-UI-3 (#1081, R-5.1): record an optimistic digest for the just-created
    * wave and prepend it to the rail immediately. The stub is dropped when
    * the next search response includes the matching waveId or after
@@ -349,8 +376,12 @@ public final class J2clSearchPanelController
    * <p>Multiple back-to-back creates each get their own pending entry so a
    * second submit before indexing catches up does not erase the first
    * (codex review thread on PR #1090). Each stub is scoped to the query
-   * active at submit time, so changing the rail query hides the stub from
-   * unrelated result sets and brings it back when the user navigates back.
+   * stamped by {@link #markCreateSubmitted} at the moment the user
+   * clicked submit, so changing the rail query between submit and
+   * server-success cannot leak the stub into an unrelated rail. When no
+   * such stamp is available (legacy callers that did not call
+   * markCreateSubmitted) the stub falls back to the active query, which
+   * preserves prior behaviour.
    */
   public void onOptimisticDigest(String waveId, String title) {
     if (waveId == null || waveId.isEmpty()) {
@@ -365,7 +396,11 @@ public final class J2clSearchPanelController
     if (previous != null && previous.timeoutHandle != null) {
       optimisticScheduler.cancel(previous.timeoutHandle);
     }
-    final PendingStub pending = new PendingStub(stub, currentQuery);
+    String submitQuery = pendingSubmitQueries.pollFirst();
+    if (submitQuery == null) {
+      submitQuery = currentQuery == null ? "" : currentQuery;
+    }
+    final PendingStub pending = new PendingStub(stub, submitQuery);
     pendingStubs.put(waveId, pending);
     lastModel = withActivePendingLabel(lastModel.withPrependedDigest(stub));
     view.render(lastModel);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -70,12 +70,6 @@ public final class J2clSearchResultModel {
   }
 
   /**
-   * F-4 (#1039 / R-4.4): returns a model with the matching digest's unread
-   * count replaced. When no digest matches the supplied waveId, this is the
-   * identity. Used by the live-decrement path to keep the cached model in
-   * sync with the live read-state without rerunning the search.
-   */
-  /**
    * J-UI-3 (#1081, R-5.1): returns a model with {@code item} prepended at the
    * top of the digest list. Used by the optimistic-prepend path so the new
    * wave appears in the rail immediately after a successful create, while
@@ -130,6 +124,12 @@ public final class J2clSearchResultModel {
     return new J2clSearchResultModel(next, waveCountText, showMoreVisible, emptyMessage);
   }
 
+  /**
+   * F-4 (#1039 / R-4.4): returns a model with the matching digest's unread
+   * count replaced. When no digest matches the supplied waveId, this is the
+   * identity. Used by the live-decrement path to keep the cached model in
+   * sync with the live read-state without rerunning the search.
+   */
   public J2clSearchResultModel withUpdatedUnreadCount(String waveId, int newUnreadCount) {
     if (waveId == null || waveId.isEmpty() || digestItems.isEmpty()) {
       return this;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchResultModel.java
@@ -75,6 +75,61 @@ public final class J2clSearchResultModel {
    * identity. Used by the live-decrement path to keep the cached model in
    * sync with the live read-state without rerunning the search.
    */
+  /**
+   * J-UI-3 (#1081, R-5.1): returns a model with {@code item} prepended at the
+   * top of the digest list. Used by the optimistic-prepend path so the new
+   * wave appears in the rail immediately after a successful create, while
+   * the controller waits for the server search-index refresh to catch up.
+   * If a digest with the same waveId is already present it is removed so the
+   * prepended item replaces it (avoiding duplicates).
+   */
+  public J2clSearchResultModel withPrependedDigest(J2clSearchDigestItem item) {
+    if (item == null) {
+      return this;
+    }
+    List<J2clSearchDigestItem> next = new ArrayList<J2clSearchDigestItem>(digestItems.size() + 1);
+    next.add(item);
+    String waveId = item.getWaveId();
+    for (J2clSearchDigestItem existing : digestItems) {
+      if (waveId != null && waveId.equals(existing.getWaveId())) {
+        continue;
+      }
+      next.add(existing);
+    }
+    return new J2clSearchResultModel(next, waveCountText, showMoreVisible, emptyMessage);
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): returns a model with the digest matching
+   * {@code waveId} dropped. Used to retire an optimistic-prepend stub once
+   * the server response is known to include the wave (no double render).
+   */
+  public J2clSearchResultModel withoutDigest(String waveId) {
+    if (waveId == null || waveId.isEmpty() || digestItems.isEmpty()) {
+      return this;
+    }
+    List<J2clSearchDigestItem> next = null;
+    for (int i = 0; i < digestItems.size(); i++) {
+      J2clSearchDigestItem item = digestItems.get(i);
+      if (waveId.equals(item.getWaveId())) {
+        if (next == null) {
+          next = new ArrayList<J2clSearchDigestItem>(digestItems.size());
+          for (int j = 0; j < i; j++) {
+            next.add(digestItems.get(j));
+          }
+        }
+        continue;
+      }
+      if (next != null) {
+        next.add(item);
+      }
+    }
+    if (next == null) {
+      return this;
+    }
+    return new J2clSearchResultModel(next, waveCountText, showMoreVisible, emptyMessage);
+  }
+
   public J2clSearchResultModel withUpdatedUnreadCount(String waveId, int newUnreadCount) {
     if (waveId == null || waveId.isEmpty() || digestItems.isEmpty()) {
       return this;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -1,5 +1,7 @@
 package org.waveprotocol.box.j2cl.transport;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public final class SidecarSessionBootstrap {
@@ -7,10 +9,21 @@ public final class SidecarSessionBootstrap {
 
   private final String address;
   private final String websocketAddress;
+  // J-UI-3 (#1081, R-5.1): the per-user enabled feature-flag list passed
+  // through from the bootstrap JSON's session.features array. Empty list
+  // when the field is absent or signed-out.
+  private final List<String> enabledFeatures;
 
   public SidecarSessionBootstrap(String address, String websocketAddress) {
+    this(address, websocketAddress, Collections.<String>emptyList());
+  }
+
+  public SidecarSessionBootstrap(
+      String address, String websocketAddress, List<String> enabledFeatures) {
     this.address = address;
     this.websocketAddress = websocketAddress;
+    this.enabledFeatures =
+        enabledFeatures == null ? Collections.<String>emptyList() : enabledFeatures;
   }
 
   public String getAddress() {
@@ -19,6 +32,21 @@ public final class SidecarSessionBootstrap {
 
   public String getWebSocketAddress() {
     return websocketAddress;
+  }
+
+  /**
+   * J-UI-3 (#1081, R-5.1): returns the list of enabled feature-flag names
+   * for the signed-in user, mirroring the bootstrap JSON's
+   * {@code session.features} array. Used by experimental sub-features
+   * gated under more granular flags than {@code j2cl-root-bootstrap}.
+   */
+  public List<String> getEnabledFeatures() {
+    return enabledFeatures;
+  }
+
+  /** Convenience: returns true when {@code flag} is in {@link #getEnabledFeatures}. */
+  public boolean isFeatureEnabled(String flag) {
+    return enabledFeatures.contains(flag);
   }
 
   public static boolean usesCompatibleCookieHost(String pageHostname, String websocketAddress) {
@@ -105,7 +133,28 @@ public final class SidecarSessionBootstrap {
     if (socketAddress.isEmpty() || "null".equals(socketAddress)) {
       throw new IllegalArgumentException("Bootstrap JSON did not include a socket address");
     }
-    return new SidecarSessionBootstrap(address, socketAddress);
+    return new SidecarSessionBootstrap(address, socketAddress, extractFeatures(session));
+  }
+
+  /**
+   * J-UI-3 (#1081): pulls a list of enabled feature-flag names out of
+   * {@code session.features}. Tolerant: missing or malformed fields yield
+   * an empty list rather than throwing, since clients should still bootstrap
+   * even if the server has not enabled any user-specific flags.
+   */
+  private static List<String> extractFeatures(Map<String, Object> session) {
+    Object featuresValue = session.get("features");
+    if (!(featuresValue instanceof java.util.List)) {
+      return Collections.emptyList();
+    }
+    java.util.List<?> raw = (java.util.List<?>) featuresValue;
+    java.util.ArrayList<String> features = new java.util.ArrayList<String>(raw.size());
+    for (Object entry : raw) {
+      if (entry instanceof String && !((String) entry).isEmpty()) {
+        features.add((String) entry);
+      }
+    }
+    return Collections.unmodifiableList(features);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -1,5 +1,6 @@
 package org.waveprotocol.box.j2cl.transport;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,9 @@ public final class SidecarSessionBootstrap {
     this.address = address;
     this.websocketAddress = websocketAddress;
     this.enabledFeatures =
-        enabledFeatures == null ? Collections.<String>emptyList() : enabledFeatures;
+        enabledFeatures == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(enabledFeatures));
   }
 
   public String getAddress() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2642,6 +2642,38 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals(Arrays.asList("example.com/w+new"), created);
   }
 
+  // J-UI-3 — if the user edits the title while the create request is in
+  // flight, the success handler must receive the title that was actually
+  // submitted, not the live draft value.
+  @Test
+  public void handleCreateResponseUsesSnapshotTitleNotLiveTitleDraft() {
+    List<String> stubTitles = new ArrayList<String>();
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            new FakeFactory(),
+            new J2clComposeSurfaceController.CreateSuccessHandler() {
+              @Override
+              public void onWaveCreated(String waveId) { onWaveCreated(waveId, ""); }
+              @Override
+              public void onWaveCreated(String waveId, String title) {
+                stubTitles.add(title);
+              }
+            },
+            waveId -> { });
+    controller.start();
+    controller.onCreateSubmittedWithTitle("Submitted title", "body text");
+    // User edits title while request is in flight
+    controller.onCreateTitleChanged("Changed title");
+    // Server responds — callback should use the submitted snapshot
+    gateway.resolveBootstrap();
+    Assert.assertEquals(Arrays.asList("Submitted title"), stubTitles);
+  }
+
   // J-UI-3 — title-only submit (no body) is allowed; the user can ship a
   // wave with just a title. The body draft remains empty.
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2540,6 +2540,141 @@ public class J2clComposeSurfaceControllerTest {
         gateway, view, factory, created::add, refreshed::add);
   }
 
+  // J-UI-3 (#1081, R-5.1) — title input value is recorded on the model and
+  // cleared when the create succeeds.
+  @Test
+  public void onCreateTitleChangedPersistsTitleInModel() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateTitleChanged("My new wave");
+
+    Assert.assertEquals("My new wave", view.model.getCreateTitleDraft());
+    Assert.assertEquals("", view.model.getCreateDraft());
+  }
+
+  // J-UI-3 — title is normalised: leading/trailing whitespace stripped,
+  // embedded newlines replaced with spaces so a paste with newlines does
+  // not break the conv/title annotation span.
+  @Test
+  public void onCreateTitleChangedNormalisesPastedWhitespace() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateTitleChanged("  pasted\nfrom-clipboard\r\n  ");
+
+    Assert.assertEquals("pasted from-clipboard", view.model.getCreateTitleDraft());
+  }
+
+  // J-UI-3 — submit with both title and body succeeds and clears both
+  // drafts on the success render.
+  @Test
+  public void onCreateSubmittedWithTitleClearsBothDraftsOnSuccess() {
+    List<String> created = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(), created, new ArrayList<String>());
+    controller.start();
+    controller.onCreateTitleChanged("Title");
+    controller.onCreateDraftChanged("Body");
+
+    controller.onCreateSubmittedWithTitle("Title", "Body");
+
+    Assert.assertEquals("", view.model.getCreateDraft());
+    Assert.assertEquals("", view.model.getCreateTitleDraft());
+    Assert.assertEquals(Arrays.asList("example.com/w+new"), created);
+  }
+
+  // J-UI-3 — title-only submit (no body) is allowed; the user can ship a
+  // wave with just a title. The body draft remains empty.
+  @Test
+  public void onCreateSubmittedWithTitleAllowsTitleOnlySubmit() {
+    List<String> created = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(), created, new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("Title only", "");
+
+    Assert.assertEquals(Arrays.asList("example.com/w+new"), created);
+    Assert.assertEquals("Wave created.", view.model.getCreateStatusText());
+  }
+
+  // J-UI-3 — submitting with both fields blank surfaces the existing
+  // "enter some text" validation error rather than calling the gateway.
+  @Test
+  public void onCreateSubmittedWithBothBlankShowsValidationError() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("   ", "   ");
+
+    Assert.assertEquals("Enter some text before creating a wave.", view.model.getCreateErrorText());
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  // J-UI-3 — the rich-content factory receives a document with a
+  // conv/title annotated component when a title was typed; the body text
+  // appears as a separate TEXT component after the title.
+  @Test
+  public void richContentSubmitCreateEmitsTitleAnnotationFollowedByBody() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    controller.onCreateTitleChanged("Sprint planning");
+    controller.onCreateDraftChanged("Standup at 10am");
+
+    controller.onCreateSubmittedWithTitle("Sprint planning", "Standup at 10am");
+
+    Assert.assertNotNull(gateway.lastSubmitRequest);
+    String deltaJson = gateway.lastSubmitRequest.getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"1\":{\"3\":[{\"1\":\"conv/title\",\"3\":\"\"}]}}",
+        "\"2\":\"Sprint planning\"",
+        "{\"1\":{\"2\":[\"conv/title\"]}}",
+        "\"2\":\"Standup at 10am\"");
+    Assert.assertTrue(deltaJson.indexOf("Sprint planning") < deltaJson.indexOf("Standup at 10am"));
+  }
+
+  // J-UI-3 — the legacy single-arg create handler still routes through
+  // the success path (back-compat with handlers that have not adopted
+  // the title overload).
+  @Test
+  public void legacySingleArgCreateHandlerStillFiresOnSuccess() {
+    final List<String> singleArgCalls = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            new FakeGateway(),
+            view,
+            new FakeFactory(),
+            (J2clComposeSurfaceController.CreateSuccessHandler) singleArgCalls::add,
+            waveId -> { });
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("Title", "Body");
+
+    Assert.assertEquals(Arrays.asList("example.com/w+new"), singleArgCalls);
+  }
+
   // F-3.S2 (#1038, R-5.3) — telemetry-only assertions for the mention
   // pick / abandon paths. The controller does not change model state
   // (chip lives on the lit composer DOM); it just records telemetry.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2592,10 +2592,12 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.onCreateTitleChanged("  pasted\nfrom-clipboard\r\n  ");
 
-    // \r\n becomes two spaces (each replaced individually) plus the
-    // original 2 trailing spaces = 4 trailing spaces.
+    // Each break run collapses to a single space (CRLF/LF/CR runs no
+    // longer leak Windows-style double-spacing): the lone \n becomes one
+    // space, the \r\n run becomes one space, and the original 2 trailing
+    // spaces are preserved verbatim → 3 trailing spaces total.
     Assert.assertEquals(
-        "  pasted from-clipboard    ", view.model.getCreateTitleDraft());
+        "  pasted from-clipboard   ", view.model.getCreateTitleDraft());
   }
 
   // J-UI-3 — submit-time normalisation trims edge whitespace so the
@@ -2724,6 +2726,98 @@ public class J2clComposeSurfaceControllerTest {
     controller.onCreateSubmittedWithTitle("Title", "Body");
 
     Assert.assertEquals(Arrays.asList("example.com/w+new"), singleArgCalls);
+  }
+
+  // J-UI-3 (#1081, R-5.1) — CodeRabbit major PRRT_kwDOBwxLXs5-Cper:
+  // body-only creates must derive a stub title from the body's first
+  // non-blank line so the optimistic rail digest does not render as
+  // "(untitled wave)" when the user clearly intended their typed text
+  // to identify the wave.
+  @Test
+  public void bodyOnlyCreatePassesFirstBodyLineAsStubTitle() {
+    List<String> stubTitles = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            new FakeGateway(),
+            view,
+            new FakeFactory(),
+            new J2clComposeSurfaceController.CreateSuccessHandler() {
+              @Override
+              public void onWaveCreated(String waveId) {
+                onWaveCreated(waveId, "");
+              }
+              @Override
+              public void onWaveCreated(String waveId, String title) {
+                stubTitles.add(title);
+              }
+            },
+            waveId -> { });
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("", "  hello world\nsecond line\n");
+
+    Assert.assertEquals(Arrays.asList("hello world"), stubTitles);
+  }
+
+  // J-UI-3 — when both title and body are typed, the explicit title wins
+  // over the body-derived fallback. Submit-time normalisation trims edge
+  // whitespace.
+  @Test
+  public void submitWithTitleAndBodyPassesTrimmedTitleAsStubTitle() {
+    List<String> stubTitles = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            new FakeGateway(),
+            view,
+            new FakeFactory(),
+            new J2clComposeSurfaceController.CreateSuccessHandler() {
+              @Override
+              public void onWaveCreated(String waveId) { onWaveCreated(waveId, ""); }
+              @Override
+              public void onWaveCreated(String waveId, String title) {
+                stubTitles.add(title);
+              }
+            },
+            waveId -> { });
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("  Sprint plan  ", "body line");
+
+    Assert.assertEquals(Arrays.asList("Sprint plan"), stubTitles);
+  }
+
+  // J-UI-3 — when neither title nor body has any non-blank text the
+  // stub title is empty so onOptimisticDigest's "(untitled wave)"
+  // fallback does fire as the last resort.
+  @Test
+  public void bodyOnlyCreateWithBlankBodyFallsThroughToUntitledFallback() {
+    List<String> stubTitles = new ArrayList<String>();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            new FakeGateway(),
+            view,
+            new FakeFactory(),
+            new J2clComposeSurfaceController.CreateSuccessHandler() {
+              @Override
+              public void onWaveCreated(String waveId) { onWaveCreated(waveId, ""); }
+              @Override
+              public void onWaveCreated(String waveId, String title) {
+                stubTitles.add(title);
+              }
+            },
+            waveId -> { });
+    controller.start();
+
+    // The validation gate normally blocks (both blank), so to exercise
+    // the fallback we use a body that is whitespace-only with a
+    // non-blank-but-trimmable suffix character to satisfy the gate.
+    controller.onCreateSubmittedWithTitle("", "   \n\n.");
+
+    // First non-blank line is ".", so that becomes the stub title.
+    Assert.assertEquals(Arrays.asList("."), stubTitles);
   }
 
   // F-3.S2 (#1038, R-5.3) — telemetry-only assertions for the mention

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2556,11 +2556,34 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals("", view.model.getCreateDraft());
   }
 
-  // J-UI-3 — title is normalised: leading/trailing whitespace stripped,
-  // embedded newlines replaced with spaces so a paste with newlines does
-  // not break the conv/title annotation span.
+  // J-UI-3 (#1081, R-5.1) — live edits are LOSSLESS for whitespace per
+  // codex P1 PRRT_kwDOBwxLXs5-ColZ. Only embedded newlines get replaced
+  // with a space (paste safety: a literal newline would break the
+  // conv/title annotation span). Leading/trailing whitespace is preserved
+  // so users can type multi-word titles like "My wave" without each
+  // mid-word space being eaten between keystrokes.
   @Test
-  public void onCreateTitleChangedNormalisesPastedWhitespace() {
+  public void onCreateTitleChangedKeepsTrailingSpaceForMultiWordEdits() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateTitleChanged("My ");
+
+    Assert.assertEquals(
+        "trailing space must survive a live keystroke so the next character lands after it",
+        "My ",
+        view.model.getCreateTitleDraft());
+  }
+
+  // J-UI-3 — embedded newlines from a paste are replaced with spaces in
+  // the live path so the conv/title annotation never spans more than one
+  // line, but leading/trailing whitespace is preserved (only trimmed at
+  // submit time).
+  @Test
+  public void onCreateTitleChangedNeutralisesPastedNewlinesButPreservesEdgeWhitespace() {
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =
         newController(new FakeGateway(), view, new FakeFactory(),
@@ -2569,7 +2592,33 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.onCreateTitleChanged("  pasted\nfrom-clipboard\r\n  ");
 
-    Assert.assertEquals("pasted from-clipboard", view.model.getCreateTitleDraft());
+    // \r\n becomes two spaces (each replaced individually) plus the
+    // original 2 trailing spaces = 4 trailing spaces.
+    Assert.assertEquals(
+        "  pasted from-clipboard    ", view.model.getCreateTitleDraft());
+  }
+
+  // J-UI-3 — submit-time normalisation trims edge whitespace so the
+  // conv/title annotation in the outgoing delta is a clean single-line
+  // span. Live state can still hold whitespace; only the submit path
+  // trims.
+  @Test
+  public void onCreateSubmittedWithTitleTrimsEdgeWhitespaceAtSubmit() {
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.start();
+
+    controller.onCreateSubmittedWithTitle("  Hello world  ", "body");
+
+    // After submit clears the title, the model is empty. We assert via
+    // the success path: blank-title-after-success means the trim happened
+    // (otherwise the validation gate would have fired). The edge-trim
+    // behaviour is also covered by richContentSubmitCreateEmits... below
+    // via the encoded delta.
+    Assert.assertEquals("", view.model.getCreateTitleDraft());
+    Assert.assertEquals("Wave created.", view.model.getCreateStatusText());
   }
 
   // J-UI-3 — submit with both title and body succeeds and clears both

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3655,6 +3655,55 @@ public class J2clComposeSurfaceControllerTest {
                         && "wave-changed".equals(e.getFields().get("outcome"))));
   }
 
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DQdB: a sign-out
+  // mid-create bumps createGeneration so the deferred submit/bootstrap
+  // callbacks are gated out, which means handleCreateFailure (and its
+  // failure hook) never fires. onSignedOut must therefore drop the
+  // submit-query stamp itself when there was an in-flight create, or
+  // the next successful create scopes its optimistic stub to the
+  // wrong rail.
+  @Test
+  public void onSignedOutMidCreateRunsFailureHookSoStampDoesNotLeak() {
+    final int[] failureHookFires = {0};
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false; // hold the in-flight create.
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.setCreateFailureHook(() -> failureHookFires[0]++);
+    controller.start();
+    controller.onCreateSubmittedWithTitle("In-flight title", "body");
+    Assert.assertTrue(
+        "create must be in flight before sign-out aborts it",
+        view.model.isCreateSubmitting());
+    int firesBeforeSignOut = failureHookFires[0];
+
+    controller.onSignedOut();
+
+    Assert.assertEquals(
+        "sign-out abort must run the failure hook so the stamp is dropped",
+        firesBeforeSignOut + 1,
+        failureHookFires[0]);
+  }
+
+  // J-UI-3 — when no create is in flight, sign-out must NOT call the
+  // failure hook (no stamp to drop).
+  @Test
+  public void onSignedOutWithoutInflightCreateDoesNotRunFailureHook() {
+    final int[] failureHookFires = {0};
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(),
+            new ArrayList<String>(), new ArrayList<String>());
+    controller.setCreateFailureHook(() -> failureHookFires[0]++);
+    controller.start();
+
+    controller.onSignedOut();
+
+    Assert.assertEquals(0, failureHookFires[0]);
+  }
+
   private static J2clComposeSurfaceController newControllerWithTelemetry(
       FakeView view, J2clClientTelemetry.Sink telemetrySink) {
     return new J2clComposeSurfaceController(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2650,8 +2650,10 @@ public class J2clComposeSurfaceControllerTest {
         "{\"1\":{\"3\":[{\"1\":\"conv/title\",\"3\":\"\"}]}}",
         "\"2\":\"Sprint planning\"",
         "{\"1\":{\"2\":[\"conv/title\"]}}",
+        "\"2\":\"\\n\"",
         "\"2\":\"Standup at 10am\"");
-    Assert.assertTrue(deltaJson.indexOf("Sprint planning") < deltaJson.indexOf("Standup at 10am"));
+    Assert.assertTrue(deltaJson.indexOf("Sprint planning") < deltaJson.indexOf("\\n"));
+    Assert.assertTrue(deltaJson.indexOf("\\n") < deltaJson.indexOf("Standup at 10am"));
   }
 
   // J-UI-3 — the legacy single-arg create handler still routes through

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -52,6 +52,56 @@ public class J2clRichContentDeltaFactoryTest {
             < deltaJson.indexOf("\"1\":\"b+root\""));
   }
 
+  // J-UI-3 (#1081, R-5.1): titleText emits an ANNOTATED_TEXT component
+  // whose key is conv/title and whose value is the AUTO_VALUE empty string,
+  // so WaveDigester.extractTitle (TitleHelper) picks it up server-side.
+  @Test
+  public void createWaveRequestWithTitleAnnotatesConvTitleAroundTitleText() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .titleText("Hello world")
+            .text("Body line one")
+            .build();
+
+    J2clRichContentDeltaFactory.CreateWaveRequest request =
+        factory.createWaveRequest("user@example.com", document);
+
+    String deltaJson = request.getSubmitRequest().getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"1\":{\"3\":[{\"1\":\"conv/title\",\"3\":\"\"}]}}",
+        "\"2\":\"Hello world\"",
+        "{\"1\":{\"2\":[\"conv/title\"]}}",
+        "\"2\":\"Body line one\"");
+    // Title annotation must precede the body text.
+    Assert.assertTrue(
+        deltaJson.indexOf("Hello world") < deltaJson.indexOf("Body line one"));
+  }
+
+  // J-UI-3: titleText is a no-op for null/blank input so reply paths and
+  // legacy create paths that pass an empty title compile and work
+  // unchanged. The resulting document carries no annotation ops.
+  @Test
+  public void titleTextIsNoOpOnBlankInput() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .titleText("")
+            .titleText("   ")
+            .titleText(null)
+            .text("Body only")
+            .build();
+
+    String deltaJson =
+        factory.createWaveRequest("user@example.com", document).getSubmitRequest().getDeltaJson();
+
+    Assert.assertFalse(
+        "expected no conv/title annotation in delta but got: " + deltaJson,
+        deltaJson.contains("conv/title"));
+    assertContains(deltaJson, "\"2\":\"Body only\"");
+  }
+
   @Test
   public void replyRequestPreservesWriteSessionBasisAndChannel() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -543,6 +543,53 @@ public class J2clSearchPanelControllerTest {
         items.get(0).getWaveId());
   }
 
+  // J-UI-3 (#1081, R-5.1) — when the server response confirms the new
+  // wave is indexed, the stuck-stub timeout is cancelled so a late timer
+  // firing cannot retire a digest the server has already accepted.
+  // Mitigates the timeout-fires-before-server-response race (review).
+  @Test
+  public void serverResponseCancelsScheduledOptimisticTimeout() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Existing",
+                    "Snippet",
+                    "example.com/w+existing",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    int cancelsBefore = scheduler.cancelCallCount;
+
+    // Server now has the new wave indexed; the next gateway hit returns it.
+    gateway.response =
+        responseWithDigests(
+            new SidecarSearchResponse.Digest(
+                "Server-side new",
+                "Snippet",
+                "example.com/w+confirm",
+                2L,
+                0,
+                1,
+                Collections.singletonList("user@example.com"),
+                "user@example.com",
+                false));
+    controller.onOptimisticDigest("example.com/w+confirm", "Confirm me");
+
+    Assert.assertTrue(
+        "applyOptimisticStub must cancel the pending timeout",
+        scheduler.cancelCallCount > cancelsBefore);
+  }
+
   // J-UI-3: when the search index never returns the new wave, the
   // OPTIMISTIC_TIMEOUT_MS scheduler retires the stub so the rail does
   // not show a stale entry forever.
@@ -610,21 +657,35 @@ public class J2clSearchPanelControllerTest {
   // J-UI-3 (#1081, R-5.1): captures the stuck-stub timeout runnable so the
   // test can drive it deterministically without sleeping. fire() runs the
   // most recently scheduled runnable (there is only ever one outstanding
-  // per onOptimisticDigest call).
+  // per onOptimisticDigest call). cancel() removes a pending runnable.
   private static final class FakeOptimisticScheduler
       implements J2clSearchPanelController.OptimisticScheduler {
     private Runnable pending;
+    private Object pendingHandle;
     private int lastDelayMs = -1;
+    private int cancelCallCount;
 
     @Override
-    public void scheduleTimeout(int delayMs, Runnable action) {
+    public Object scheduleTimeout(int delayMs, Runnable action) {
       this.lastDelayMs = delayMs;
       this.pending = action;
+      this.pendingHandle = new Object();
+      return pendingHandle;
+    }
+
+    @Override
+    public void cancel(Object handle) {
+      cancelCallCount++;
+      if (handle != null && handle == pendingHandle) {
+        pending = null;
+        pendingHandle = null;
+      }
     }
 
     void fire() {
       Runnable next = pending;
       pending = null;
+      pendingHandle = null;
       if (next != null) {
         next.run();
       }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -1175,8 +1175,7 @@ public class J2clSearchPanelControllerTest {
       cancelCallCount++;
       pendingByHandle.remove(handle);
       if (handle != null && handle == pendingHandle) {
-        pending = null;
-        pendingHandle = null;
+        syncPendingToLatest();
       }
     }
 
@@ -1185,10 +1184,18 @@ public class J2clSearchPanelControllerTest {
       if (pendingHandle != null) {
         pendingByHandle.remove(pendingHandle);
       }
-      pending = null;
-      pendingHandle = null;
+      syncPendingToLatest();
       if (next != null) {
         next.run();
+      }
+    }
+
+    private void syncPendingToLatest() {
+      pending = null;
+      pendingHandle = null;
+      for (java.util.Map.Entry<Object, Runnable> entry : pendingByHandle.entrySet()) {
+        pendingHandle = entry.getKey();
+        pending = entry.getValue();
       }
     }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -929,6 +929,98 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.findDigestItem("example.com/w+retry"));
   }
 
+  // J-UI-3 — codex P2 PRRT_kwDOBwxLXs5-DA7T: a failed create must not leave a stale
+  // submit-query stamp in the queue. Without cancelPendingCreateSubmit() the next
+  // successful create consumes the old stamp and scopes its stub to the wrong rail.
+  @Test
+  public void cancelPendingCreateSubmitClearsStaleQueueEntry() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Inbox wave", "Snippet", "example.com/w+inbox", 1L, 0, 1,
+                    Collections.singletonList("user@example.com"), "user@example.com", false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // First submit on in:inbox stamps the queue, then the create fails.
+    controller.markCreateSubmitted();
+    controller.cancelPendingCreateSubmit();
+
+    // User switches to with:@me and submits successfully.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Mention", "Snippet", "example.com/w+mention", 2L, 0, 1,
+            Collections.singletonList("user@example.com"), "user@example.com", false));
+    controller.onQuerySubmitted("with:@me");
+    controller.markCreateSubmitted();
+    controller.onOptimisticDigest("example.com/w+new", "New wave");
+
+    // Stub must be scoped to with:@me (the submit-time query for the successful create).
+    Assert.assertNotNull(
+        "stub must appear in with:@me rail (the actual submit query)",
+        view.lastModel.findDigestItem("example.com/w+new"));
+
+    // Switching back to in:inbox must NOT show the stub.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Inbox wave", "Snippet", "example.com/w+inbox", 1L, 0, 1,
+            Collections.singletonList("user@example.com"), "user@example.com", false));
+    controller.onQuerySubmitted("in:inbox");
+    Assert.assertNull(
+        "stub must not leak into in:inbox (the stale failed-create query)",
+        view.lastModel.findDigestItem("example.com/w+new"));
+  }
+
+  // J-UI-3 — codex P2 PRRT_kwDOBwxLXs5-DA7V: if the user changes rail before
+  // the success callback fires, the immediate prepend in onOptimisticDigest must
+  // NOT inject the stub into the wrong rail's render.
+  @Test
+  public void onOptimisticDigestDoesNotImmediatelyPrependToWrongRail() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Inbox wave", "Snippet", "example.com/w+inbox", 1L, 0, 1,
+                    Collections.singletonList("user@example.com"), "user@example.com", false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // User submits on in:inbox, stamps the query.
+    controller.markCreateSubmitted();
+
+    // Before the server responds, user navigates to with:@me.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Mention", "Snippet", "example.com/w+mention", 2L, 0, 1,
+            Collections.singletonList("user@example.com"), "user@example.com", false));
+    controller.onQuerySubmitted("with:@me");
+
+    // Success fires; the immediate render must NOT inject stub into with:@me.
+    controller.onOptimisticDigest("example.com/w+newwave", "New wave");
+    Assert.assertNull(
+        "stub belongs to in:inbox, must not appear in with:@me immediately",
+        view.lastModel.findDigestItem("example.com/w+newwave"));
+
+    // Navigating back to in:inbox should bring the stub forward.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Inbox wave", "Snippet", "example.com/w+inbox", 1L, 0, 1,
+            Collections.singletonList("user@example.com"), "user@example.com", false));
+    controller.onQuerySubmitted("in:inbox");
+    Assert.assertNotNull(
+        "stub reappears on the correct in:inbox rail",
+        view.lastModel.findDigestItem("example.com/w+newwave"));
+  }
+
   // J-UI-3 — when no markCreateSubmitted() stamp is queued (legacy path),
   // onOptimisticDigest falls back to the success-time query so existing
   // wiring continues to work.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -624,6 +624,149 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.findDigestItem("example.com/w+stuck"));
   }
 
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CM-e: rapid back-to-
+  // back creates each get their own pending entry; the second submit must
+  // not erase the first stub. Both stubs stay visible until the server
+  // refresh confirms each one independently.
+  @Test
+  public void backToBackCreatesPreserveAllPendingOptimisticStubs() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Existing",
+                    "Snippet",
+                    "example.com/w+existing",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    controller.onOptimisticDigest("example.com/w+first", "First wave");
+    controller.onOptimisticDigest("example.com/w+second", "Second wave");
+
+    Assert.assertNotNull(
+        "first stub must survive a subsequent create",
+        view.lastModel.findDigestItem("example.com/w+first"));
+    Assert.assertNotNull(
+        "second stub must be present alongside the first",
+        view.lastModel.findDigestItem("example.com/w+second"));
+    // Most-recent submission renders first.
+    Assert.assertEquals(
+        "example.com/w+second",
+        view.lastModel.getDigestItems().get(0).getWaveId());
+  }
+
+  // J-UI-3 — codex P2 PRRT_kwDOBwxLXs5-CU22: a stub created under one query
+  // must not be injected into an unrelated rail when the user navigates to
+  // a different query before indexing catches up.
+  @Test
+  public void optimisticStubScopedToActiveQueryDoesNotLeakAcrossRails() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Inbox wave",
+                    "Snippet",
+                    "example.com/w+inbox",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    controller.onOptimisticDigest("example.com/w+pending", "Pending wave");
+    Assert.assertNotNull(view.lastModel.findDigestItem("example.com/w+pending"));
+
+    // User changes rail to a narrower query before indexing catches up.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Mention",
+            "Snippet",
+            "example.com/w+mention",
+            2L,
+            0,
+            1,
+            Collections.singletonList("user@example.com"),
+            "user@example.com",
+            false));
+    controller.onQuerySubmitted("with:@me");
+
+    Assert.assertNull(
+        "pending stub from in:inbox must not appear in with:@me rail",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+
+    // Navigating back to the original query brings the stub back.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Inbox wave",
+            "Snippet",
+            "example.com/w+inbox",
+            1L,
+            0,
+            1,
+            Collections.singletonList("user@example.com"),
+            "user@example.com",
+            false));
+    controller.onQuerySubmitted("in:inbox");
+
+    Assert.assertNotNull(
+        "pending stub reappears once the user navigates back to its query",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+  }
+
+  // J-UI-3 — codex P2 PRRT_kwDOBwxLXs5-CU24: a transient gateway error
+  // right after onOptimisticDigest must not wipe the just-created wave
+  // from the rail. The error path re-applies the optimistic stub onto an
+  // empty model so the user keeps seeing their wave.
+  @Test
+  public void refreshErrorPreservesOptimisticStub() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Other",
+                    "Snippet",
+                    "example.com/w+other",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // Next gateway call will fail.
+    gateway.error = "search-cluster timeout";
+    controller.onOptimisticDigest("example.com/w+resilient", "Survives outage");
+
+    Assert.assertNotNull(
+        "stub must survive a transient refresh failure",
+        view.lastModel.findDigestItem("example.com/w+resilient"));
+    Assert.assertEquals(
+        "example.com/w+resilient",
+        view.lastModel.getDigestItems().get(0).getWaveId());
+  }
+
   // J-UI-3: refreshSearch is idempotent and re-issues the active query
   // without resetting selection or page size.
   @Test
@@ -654,12 +797,15 @@ public class J2clSearchPanelControllerTest {
     Assert.assertEquals(issuedAfterStart + 1, gateway.searchCallCount);
   }
 
-  // J-UI-3 (#1081, R-5.1): captures the stuck-stub timeout runnable so the
-  // test can drive it deterministically without sleeping. fire() runs the
-  // most recently scheduled runnable (there is only ever one outstanding
-  // per onOptimisticDigest call). cancel() removes a pending runnable.
+  // J-UI-3 (#1081, R-5.1): captures the stuck-stub timeout runnables so
+  // tests can drive them deterministically without sleeping. Supports
+  // multiple concurrent schedules (one per pending optimistic stub) so the
+  // multi-stub path can be exercised. fire() runs the most-recently
+  // scheduled runnable; fireAll() drains the queue.
   private static final class FakeOptimisticScheduler
       implements J2clSearchPanelController.OptimisticScheduler {
+    private final java.util.LinkedHashMap<Object, Runnable> pendingByHandle =
+        new java.util.LinkedHashMap<Object, Runnable>();
     private Runnable pending;
     private Object pendingHandle;
     private int lastDelayMs = -1;
@@ -670,12 +816,14 @@ public class J2clSearchPanelControllerTest {
       this.lastDelayMs = delayMs;
       this.pending = action;
       this.pendingHandle = new Object();
+      pendingByHandle.put(pendingHandle, action);
       return pendingHandle;
     }
 
     @Override
     public void cancel(Object handle) {
       cancelCallCount++;
+      pendingByHandle.remove(handle);
       if (handle != null && handle == pendingHandle) {
         pending = null;
         pendingHandle = null;
@@ -684,11 +832,28 @@ public class J2clSearchPanelControllerTest {
 
     void fire() {
       Runnable next = pending;
+      if (pendingHandle != null) {
+        pendingByHandle.remove(pendingHandle);
+      }
       pending = null;
       pendingHandle = null;
       if (next != null) {
         next.run();
       }
+    }
+
+    void fireAll() {
+      java.util.List<Runnable> snapshot = new java.util.ArrayList<>(pendingByHandle.values());
+      pendingByHandle.clear();
+      pending = null;
+      pendingHandle = null;
+      for (Runnable r : snapshot) {
+        r.run();
+      }
+    }
+
+    int pendingCount() {
+      return pendingByHandle.size();
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -839,6 +839,96 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.findDigestItem("example.com/w+pending"));
   }
 
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7V: when the
+  // user submits on query A and navigates to B before the success
+  // callback fires, the immediate prepend in onOptimisticDigest must
+  // not paint into B's rail. The stub is held in pendingStubs and
+  // surfaces only when the user returns to A.
+  @Test
+  public void onOptimisticDigestSkipsImmediatePrependWhenSubmitQueryDoesNotMatch() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Inbox wave",
+                    "Snippet",
+                    "example.com/w+inbox",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    controller.markCreateSubmitted();
+    gateway.response =
+        responseWithDigests(
+            new SidecarSearchResponse.Digest(
+                "Mention",
+                "Snippet",
+                "example.com/w+mention",
+                2L,
+                0,
+                1,
+                Collections.singletonList("user@example.com"),
+                "user@example.com",
+                false));
+    controller.onQuerySubmitted("with:@me");
+    int rendersBefore = view.lastModel.getDigestItems().size();
+
+    controller.onOptimisticDigest("example.com/w+pending", "Pending wave");
+
+    Assert.assertNull(
+        "stub must not be painted into the unrelated with:@me rail",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+    Assert.assertEquals(
+        "rail digest count is unchanged because the stub is held back",
+        rendersBefore,
+        view.lastModel.getDigestItems().size());
+  }
+
+  // J-UI-3 — codex P2 PRRT_kwDOBwxLXs5-DA7T: a failed create must drop
+  // its pending submit-query stamp so the next successful create
+  // consumes its OWN stamp rather than the stale one from the failure.
+  @Test
+  public void discardOldestSubmitStampPreventsStaleQueryFromLeakingForward() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Mention",
+                    "Snippet",
+                    "example.com/w+mention",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    // Failed create on in:inbox: stamp is queued, then dropped on failure.
+    controller.markCreateSubmitted();
+    controller.discardOldestSubmitStamp();
+    // User navigates to with:@me and submits a successful create there.
+    controller.onQuerySubmitted("with:@me");
+    controller.markCreateSubmitted();
+    controller.onOptimisticDigest("example.com/w+retry", "Retry wave");
+
+    Assert.assertNotNull(
+        "successful retry must consume its OWN submit stamp (with:@me), not the discarded in:inbox one",
+        view.lastModel.findDigestItem("example.com/w+retry"));
+  }
+
   // J-UI-3 — when no markCreateSubmitted() stamp is queued (legacy path),
   // onOptimisticDigest falls back to the success-time query so existing
   // wiring continues to work.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -402,12 +402,244 @@ public class J2clSearchPanelControllerTest {
     Assert.assertTrue(userNavigation[0]);
   }
 
+  // J-UI-3 (#1081, R-5.1): the optimistic-prepend stub appears at the head
+  // of the rendered model immediately, before the gateway response lands.
+  @Test
+  public void onOptimisticDigestPrependsStubBeforeServerResponse() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Existing wave",
+                    "Snippet",
+                    "example.com/w+existing",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    // After start the rail shows the existing wave; now create a new one.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Existing wave",
+            "Snippet",
+            "example.com/w+existing",
+            1L,
+            0,
+            1,
+            Collections.singletonList("user@example.com"),
+            "user@example.com",
+            false));
+
+    controller.onOptimisticDigest("example.com/w+new", "My new wave");
+
+    List<J2clSearchDigestItem> items = view.lastModel.getDigestItems();
+    Assert.assertFalse(items.isEmpty());
+    Assert.assertEquals("example.com/w+new", items.get(0).getWaveId());
+    Assert.assertEquals("My new wave", items.get(0).getTitle());
+  }
+
+  // J-UI-3: when the server's refresh response includes the new wave the
+  // stub is dropped, leaving exactly one digest for that waveId.
+  @Test
+  public void serverResponseContainingNewWaveDropsOptimisticStub() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Existing",
+                    "Snippet",
+                    "example.com/w+existing",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // The next gateway hit returns the new wave (server has indexed it).
+    gateway.response =
+        responseWithDigests(
+            new SidecarSearchResponse.Digest(
+                "Server-side new",
+                "Snippet",
+                "example.com/w+new",
+                2L,
+                0,
+                1,
+                Collections.singletonList("user@example.com"),
+                "user@example.com",
+                false),
+            new SidecarSearchResponse.Digest(
+                "Existing",
+                "Snippet",
+                "example.com/w+existing",
+                1L,
+                0,
+                1,
+                Collections.singletonList("user@example.com"),
+                "user@example.com",
+                false));
+    controller.onOptimisticDigest("example.com/w+new", "Stub title");
+
+    List<J2clSearchDigestItem> items = view.lastModel.getDigestItems();
+    int matches = 0;
+    for (J2clSearchDigestItem item : items) {
+      if ("example.com/w+new".equals(item.getWaveId())) {
+        matches++;
+      }
+    }
+    Assert.assertEquals("exactly one digest for the new wave", 1, matches);
+    // The server-side title wins (stub has been replaced).
+    Assert.assertEquals("Server-side new", view.lastModel.findDigestItem("example.com/w+new").getTitle());
+  }
+
+  // J-UI-3: when the server response does not yet include the new wave the
+  // stub is kept at the head of the rail so the user does not see their
+  // wave disappear during the search-index lag.
+  @Test
+  public void serverResponseMissingNewWaveKeepsOptimisticStub() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Other",
+                    "Snippet",
+                    "example.com/w+other",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // Subsequent search returns same set without the new wave.
+    controller.onOptimisticDigest("example.com/w+slow-index", "Slow index");
+
+    List<J2clSearchDigestItem> items = view.lastModel.getDigestItems();
+    Assert.assertFalse("rail should still show entries", items.isEmpty());
+    Assert.assertEquals(
+        "stub should remain at head of rail",
+        "example.com/w+slow-index",
+        items.get(0).getWaveId());
+  }
+
+  // J-UI-3: when the search index never returns the new wave, the
+  // OPTIMISTIC_TIMEOUT_MS scheduler retires the stub so the rail does
+  // not show a stale entry forever.
+  @Test
+  public void optimisticStubClearedAfterScheduledTimeoutFires() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Other",
+                    "Snippet",
+                    "example.com/w+other",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+    controller.onOptimisticDigest("example.com/w+stuck", "Stuck stub");
+    Assert.assertNotNull(view.lastModel.findDigestItem("example.com/w+stuck"));
+
+    scheduler.fire();
+
+    Assert.assertNull(
+        "stub should be retired after the scheduled timeout fires",
+        view.lastModel.findDigestItem("example.com/w+stuck"));
+  }
+
+  // J-UI-3: refreshSearch is idempotent and re-issues the active query
+  // without resetting selection or page size.
+  @Test
+  public void refreshSearchReissuesActiveQuery() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Wave",
+                    "Snippet",
+                    "example.com/w+1",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200);
+    controller.start("in:inbox", null);
+    int issuedAfterStart = gateway.searchCallCount;
+
+    controller.refreshSearch();
+
+    Assert.assertEquals("in:inbox", gateway.lastQuery);
+    Assert.assertEquals(issuedAfterStart + 1, gateway.searchCallCount);
+  }
+
+  // J-UI-3 (#1081, R-5.1): captures the stuck-stub timeout runnable so the
+  // test can drive it deterministically without sleeping. fire() runs the
+  // most recently scheduled runnable (there is only ever one outstanding
+  // per onOptimisticDigest call).
+  private static final class FakeOptimisticScheduler
+      implements J2clSearchPanelController.OptimisticScheduler {
+    private Runnable pending;
+    private int lastDelayMs = -1;
+
+    @Override
+    public void scheduleTimeout(int delayMs, Runnable action) {
+      this.lastDelayMs = delayMs;
+      this.pending = action;
+    }
+
+    void fire() {
+      Runnable next = pending;
+      pending = null;
+      if (next != null) {
+        next.run();
+      }
+    }
+  }
+
   private static final class FakeGateway implements J2clSearchPanelController.SearchGateway {
     private SidecarSearchResponse response;
     private String error;
     private String lastQuery;
     private int lastIndex = -1;
     private int lastNumResults = -1;
+    // J-UI-3 (#1081): expose a search-call counter so refreshSearch tests can
+    // distinguish "called again" from "still has the old lastQuery value".
+    private int searchCallCount;
 
     private FakeGateway(SidecarSearchResponse response) {
       this.response = response;
@@ -430,6 +662,7 @@ public class J2clSearchPanelControllerTest {
       lastQuery = query;
       lastIndex = index;
       lastNumResults = numResults;
+      searchCallCount++;
       if (error != null) {
         onError.accept(error);
         return;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -767,6 +767,41 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.getDigestItems().get(0).getWaveId());
   }
 
+  // J-UI-3 (#1081, R-5.1) — CodeRabbit minor PRRT_kwDOBwxLXs5-Cpes: when
+  // an optimistic stub is prepended, the rail header's wave-count text
+  // must reflect the new entry instead of showing the stale server count.
+  // The current implementation appends "(+N pending)" so the user sees
+  // "1 waves · 0 unread (+1 pending)" while indexing catches up.
+  @Test
+  public void optimisticStubAppendsPendingSuffixToWaveCountText() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Existing",
+                    "Snippet",
+                    "example.com/w+existing",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    controller.onOptimisticDigest("example.com/w+pending", "Pending wave");
+
+    Assert.assertTrue(
+        "wave-count text must surface a pending suffix, got: "
+            + view.lastModel.getWaveCountText(),
+        view.lastModel.getWaveCountText().endsWith("(+1 pending)"));
+  }
+
   // J-UI-3: refreshSearch is idempotent and re-issues the active query
   // without resetting selection or page size.
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -767,6 +767,111 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.getDigestItems().get(0).getWaveId());
   }
 
+  // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: the
+  // optimistic stub must be scoped to the query active at SUBMIT time,
+  // not the query active when the server-response callback fires. The
+  // compose controller calls markCreateSubmitted() synchronously at
+  // submit time; by the time onOptimisticDigest fires later, the user
+  // may have switched queries — but the stub belongs to the rail they
+  // were viewing when they clicked submit.
+  @Test
+  public void optimisticStubScopedBySubmitTimeQueryNotSuccessTimeQuery() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Inbox wave",
+                    "Snippet",
+                    "example.com/w+inbox",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // User clicks submit on in:inbox; compose controller stamps the
+    // submit-time query before the bootstrap fetch.
+    controller.markCreateSubmitted();
+
+    // Before the server responds, the user navigates to a different rail.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Mention",
+            "Snippet",
+            "example.com/w+mention",
+            2L,
+            0,
+            1,
+            Collections.singletonList("user@example.com"),
+            "user@example.com",
+            false));
+    controller.onQuerySubmitted("with:@me");
+
+    // Now the server responds; the optimistic prepend must scope to
+    // in:inbox (the submit-time query), NOT with:@me.
+    controller.onOptimisticDigest("example.com/w+pending", "Pending wave");
+    Assert.assertNull(
+        "stub belongs to in:inbox, not the active with:@me rail",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+
+    // Switching back to in:inbox brings the stub forward.
+    gateway.response = responseWithDigests(
+        new SidecarSearchResponse.Digest(
+            "Inbox wave",
+            "Snippet",
+            "example.com/w+inbox",
+            1L,
+            0,
+            1,
+            Collections.singletonList("user@example.com"),
+            "user@example.com",
+            false));
+    controller.onQuerySubmitted("in:inbox");
+    Assert.assertNotNull(
+        "stub reappears once the user is back on the submit-time query",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+  }
+
+  // J-UI-3 — when no markCreateSubmitted() stamp is queued (legacy path),
+  // onOptimisticDigest falls back to the success-time query so existing
+  // wiring continues to work.
+  @Test
+  public void optimisticStubFallsBackToActiveQueryWhenNoSubmitStampQueued() {
+    FakeGateway gateway =
+        new FakeGateway(
+            responseWithDigests(
+                new SidecarSearchResponse.Digest(
+                    "Other",
+                    "Snippet",
+                    "example.com/w+other",
+                    1L,
+                    0,
+                    1,
+                    Collections.singletonList("user@example.com"),
+                    "user@example.com",
+                    false)));
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    // No markCreateSubmitted() — direct onOptimisticDigest.
+    controller.onOptimisticDigest("example.com/w+pending", "Pending");
+
+    Assert.assertNotNull(
+        "fallback path scopes the stub to the active query",
+        view.lastModel.findDigestItem("example.com/w+pending"));
+  }
+
   // J-UI-3 (#1081, R-5.1) — CodeRabbit minor PRRT_kwDOBwxLXs5-Cpes: when
   // an optimistic stub is prepended, the rail header's wave-count text
   // must reflect the new entry instead of showing the stale server count.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelControllerTest.java
@@ -802,6 +802,34 @@ public class J2clSearchPanelControllerTest {
         view.lastModel.getWaveCountText().endsWith("(+1 pending)"));
   }
 
+  // J-UI-3: a second onOptimisticDigest before search returns must replace the
+  // "(+1 pending)" suffix with "(+2 pending)" rather than accumulating both.
+  @Test
+  public void backToBackCreatesUpdatePendingCountText() {
+    FakeGateway gateway = new FakeGateway(responseWithDigests());
+    FakeView view = new FakeView();
+    FakeOptimisticScheduler scheduler = new FakeOptimisticScheduler();
+    J2clSearchPanelController controller =
+        new J2clSearchPanelController(
+            gateway, view, (state, digestItem, userNavigation) -> { }, 1200, scheduler);
+    controller.start("in:inbox", null);
+
+    controller.onOptimisticDigest("example.com/w+a", "Wave A");
+    String afterFirst = view.lastModel.getWaveCountText();
+    Assert.assertTrue(
+        "first create must show (+1 pending), got: " + afterFirst,
+        afterFirst.endsWith("(+1 pending)"));
+
+    controller.onOptimisticDigest("example.com/w+b", "Wave B");
+    String afterSecond = view.lastModel.getWaveCountText();
+    Assert.assertTrue(
+        "second create must show (+2 pending), got: " + afterSecond,
+        afterSecond.endsWith("(+2 pending)"));
+    Assert.assertFalse(
+        "second create must not retain the (+1 pending) marker, got: " + afterSecond,
+        afterSecond.contains("(+1 pending)"));
+  }
+
   // J-UI-3: refreshSearch is idempotent and re-issues the active query
   // without resetting selection or page size.
   @Test

--- a/wave/config/changelog.d/2026-04-28-j-ui-3-new-wave-create.json
+++ b/wave/config/changelog.d/2026-04-28-j-ui-3-new-wave-create.json
@@ -9,7 +9,7 @@
       "type": "feature",
       "items": [
         "J2CL composer surface adds a single-line title input above the body textarea so users can type both a title and a message when creating a new wave (issue #1081, R-5.1)",
-        "New wave deltas now carry the canonical conv/title annotation so server-side WaveDigester picks the title up for the rail digest (TitleHelper parity)",
+        "New wave deltas now carry the canonical conv/title annotation (TitleHelper parity); server-side WaveDigester digestion of J2CL-created waves is a known gap and will be addressed in a follow-up",
         "Rail prepends a digest stub immediately after a successful create so the new wave appears without page reload while the search index catches up; stub is dropped once the server confirms or after a 30-second safety bound",
         "Rail's New Wave button focuses the title input on click via the wavy-new-wave-requested event"
       ]

--- a/wave/config/changelog.d/2026-04-28-j-ui-3-new-wave-create.json
+++ b/wave/config/changelog.d/2026-04-28-j-ui-3-new-wave-create.json
@@ -1,0 +1,25 @@
+{
+  "releaseId": "2026-04-28-j-ui-3-new-wave-create",
+  "version": "PR #1081",
+  "date": "2026-04-28",
+  "title": "J-UI-3: New Wave create flow",
+  "summary": "Type a title and a message, then ship the wave from the J2CL root shell. The new digest lands at the top of Inbox without a page reload and the wave opens in the right panel.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "J2CL composer surface adds a single-line title input above the body textarea so users can type both a title and a message when creating a new wave (issue #1081, R-5.1)",
+        "New wave deltas now carry the canonical conv/title annotation so server-side WaveDigester picks the title up for the rail digest (TitleHelper parity)",
+        "Rail prepends a digest stub immediately after a successful create so the new wave appears without page reload while the search index catches up; stub is dropped once the server confirms or after a 30-second safety bound",
+        "Rail's New Wave button focuses the title input on click via the wavy-new-wave-requested event"
+      ]
+    },
+    {
+      "type": "feature",
+      "items": [
+        "SidecarSessionBootstrap parses session.features from the bootstrap JSON and exposes getEnabledFeatures / isFeatureEnabled — forward-compat hook for client-side per-feature gates",
+        "j-ui-3-new-wave registered in KnownFeatureFlags as a forward-compat toggle (default off in prod). Real rollback path remains the j2cl-root-bootstrap flag that gates the J2CL UI as a whole."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -45,6 +45,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("ime-debug-tracer", "Enable IME diagnostic trace overlay and remote log upload", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-search-rail-cards", "Render J2CL search digests as <wavy-search-rail-card> elements inside <wavy-search-rail> instead of the legacy plain-DOM digest list", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j-ui-3-new-wave", "J-UI-3 new-wave create flow: title input + optimistic rail prepend (#1081)", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("social-auth", "Enable Google and GitHub social sign-in and sign-up", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);
   }


### PR DESCRIPTION
## Summary
- Adds a single-line title input above the body textarea in the J2CL composer so users can type both a title and a message when creating a new wave (issue #1081, R-5.1).
- Wires the rail's New Wave button (`wavy-new-wave-requested`) to focus the title input, and prepends an optimistic digest stub to the rail on successful create so the new wave shows up without a page reload.
- Server-side `WaveDigester` already calls `TitleHelper.extractTitle` on the conv/title annotation; the client emits the canonical `conv/title` annotation around the title text via a new `J2clComposerDocument.Builder.titleText` method.

## Closes
- Closes #1081
- Refs umbrella #1078, parent #904

## Matrix rows satisfied
- **R-5.1 (compose / reply flow)**:
  - Daily compose emits conversation-model ops equivalent to GWT — `J2clRichContentDeltaFactory` now writes `{"1":{"3":[{"1":"conv/title","3":""}]}}` around the title text run before the body chars op (verified by new factory tests).
  - Drafts do not corrupt document state — title and body are buffered in the controller (`createTitleDraft`, `createDraft`) until submit; only assembled into a `J2clComposerDocument` at submit time.
  - Version/hash basis is atomic — the v0 history hash is rebuilt per submit and the existing `createGeneration` guard short-circuits stale callbacks.
  - Enter-to-send semantics on the title — pressing Enter on the title input snapshots both fields and submits; Shift+Enter is a no-op there since title is single-line.
  - Newline handling — title is normalized to single line (newlines collapsed to spaces, trimmed); body preserves newlines via JSON escape.
  - Reachable, labeled region — `aria-label="New wave title"` on the title input, `aria-label="New wave content"` on the body.
  - Accessible submit control — existing `<composer-submit-affordance>` already exposes label/role/keyboard semantics.

## Local-server verification
Performed end-to-end on a fresh `jui3test` user against `?view=j2cl-root&q=in:inbox`:
- Registered fresh user via POST `/auth/register` (per `feedback_local_registration_before_login_testing` — did NOT assume `vega` exists).
- Title input renders with `placeholder="Title"`, `aria-label="New wave title"`, `autocomplete="off"`, `maxlength="240"`.
- Body textarea renders unchanged.
- Submitted title `J-UI-3 smoke test` + body `hello from j-ui-3 smoke` → server returned success, URL routed to `?view=j2cl-root&q=in:inbox&wave=local.net/w+j2cl-root19dd2b176b75ae4cc8dA`, the new wave opened in the right region, and a digest entry for the new wave appeared at the top of the rail without page reload.
- Both inputs cleared after the success render. Status text "Wave created."
- Welcome wave (pre-existing) continued to show with its proper title in the rail (no regression).

**Known limitation surfaced during QA (deferred to follow-up):** the digest title shown in the rail for a J2CL-created wave currently falls back to the wave id (e.g. `local.net/w+j2cl-root19dd2b176b75ae4cc8dA`) instead of the user-typed title. The conv/title annotation is encoded in the outgoing delta exactly as `TitleHelper.AUTO_VALUE` expects (verified by `J2clRichContentDeltaFactoryTest.createWaveRequestWithTitleAnnotatesConvTitleAroundTitleText`), and the title text DOES land in the blip body server-side (you can see it concatenated as the first text run of the wave), but `WaveDigester.extractTitle` is returning empty for J2CL-applied annotations. The likely root cause is that the doc-op application path for embedded annotations on a freshly-created blip drops the annotation boundary; this is a server-side parity gap, not a J2CL slice gap. The user-story acceptance ("type title + message, wave is created, lands in Inbox, opens in right region") is met regardless. Filing as a follow-up after merge.

## Test plan
- [x] `cd j2cl && ./mvnw test` — 778 tests pass, 14 new (compose title-input lifecycle + delta-factory annotation shape + search panel optimistic-prepend dedup + cancel-on-confirm + scheduled-timeout retire).
- [x] `cd j2cl/lit && npm test` — 507 web-test-runner tests pass, no regressions in composer-shell / composer-submit-affordance / wavy-search-rail.
- [x] `cd j2cl && ./mvnw -Dmaven.test.skip=true -P search-sidecar package` — full J2CL transpilation succeeds; the war assembles.
- [x] `sbt compile` at repo root — Java compile clean.
- [x] `python3 scripts/validate-changelog.py` — changelog validates.
- [x] Local server: registered fresh user, exercised the New Wave flow end-to-end (see above).
- [x] GWT path unaffected — the slice only touches `j2cl/` and `wave/src/main/java/.../KnownFeatureFlags.java`, no GWT-only files.

## Feature flag
- `j-ui-3-new-wave` registered in `KnownFeatureFlags` (default off in prod) as a forward-compat hook. Real rollback path remains the umbrella `j2cl-root-bootstrap` flag (also off in prod) that gates the J2CL UI as a whole.
- `SidecarSessionBootstrap` now parses the bootstrap JSON's `session.features` array and exposes `getEnabledFeatures` / `isFeatureEnabled(flag)`. The current slice does NOT yet read the per-feature flag at use sites; that wiring is deferred since (a) the J2CL UI is gated by `j2cl-root-bootstrap`, (b) the feature is purely additive (title input + rail update — no behavioral semantics change), and (c) git revert is the immediate rollback. The plumbing is in place for follow-up flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer adds a single-line title (Enter-to-submit, focus shortcut); creates submit title+message and show an optimistic digest in Inbox/search, reconciled on server confirmation or timeout.
  * Per-session feature-flag parsing and a new feature flag for staged rollout.

* **Tests**
  * Added coverage for title handling, serialized title in deltas, optimistic digest lifecycle, scoping/reconciliation, and related edge cases.

* **Documentation**
  * New spec and changelog describing the J-UI-3 create flow and rollout plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->