### PR TITLE
J-UI-7: Live unread cue + read-state hooks for the J2CL rail

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-7-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-7-plan.md
@@ -1,0 +1,250 @@
+# J-UI-7 — Mark-as-read + live unread decrement (issue #1085)
+
+Branch: `claude/j2cl-ui-7`
+Umbrella: #1078 · Tracker: #904 · Audit row: R-4.4
+
+## 1. Goal
+
+Restore parity with GWT for **R-4.4 (read/unread state live updates)** in the
+J2CL surface:
+
+- Per-user read state mutates as the viewer reads a wave, with no page reload.
+- The saved-search rail digest re-renders the count when the selected-wave
+  read state changes (decrement on open, increment when a peer posts a new
+  reply, etc.).
+- The rail card surfaces a visible "the count just changed" cue so the live
+  decrement is noticeable, not a silent attribute swap.
+- Counts remain exposed to assistive technology and continue to localize.
+- The persisted server state survives a reload (the next `/search` returns
+  the post-mutation count).
+
+The 2026-04-26 audit recorded R-4.4 as **FAIL**; the F-4 plumbing had landed
+piecemeal across #931, #1056, and #1079 but had not been verified end to end
+against the rail digest. This slice closes the verification gap and adds the
+last few wires that make the live decrement visible to the user.
+
+## 2. Existing state (read carefully — do not duplicate)
+
+The data path is mostly in place from earlier slices:
+
+- `SidecarSelectedWaveReadState` (transport DTO).
+- `J2clSelectedWaveController` already debounces a `/read-state` fetch on
+  every selected-wave update (`scheduleReadStateFetch`), exposes a
+  `ReadStateListener` interface (`onReadStateChanged(waveId, unreadCount,
+  stale)`), drives `MarkBlipReadHandler` from a viewport-dwell signal, and
+  re-fetches on `visibilitychange`.
+- `J2clSearchPanelController.onReadStateChanged` mutates the cached
+  `J2clSearchResultModel` via `withUpdatedUnreadCount(...)` and calls
+  `view.updateDigestUnread(...)` to patch the live DOM.
+- `J2clSearchPanelView.updateDigestUnread` updates *both* the legacy
+  `J2clDigestView` and the new `J2clSearchRailCardView` via `setUnreadCount`.
+- `J2clRootShellController` and `SandboxEntryPoint` already wire
+  `selectedWaveController.setReadStateListener(controller::onReadStateChanged)`.
+- Server seams: `SelectedWaveReadStateHelper` (read endpoint) and
+  `MarkBlipReadHelper` (write endpoint), plus the Jakarta servlets
+  `SelectedWaveReadStateServlet` and `MarkBlipReadServlet`.
+- Feature flag `j2cl-search-rail-cards` (#1079) gates the rail-card path.
+
+So this slice is **wiring + feedback + verification**, not new infrastructure.
+
+## 3. Gaps this slice closes
+
+1. **No visible cue when the count changes.** `J2clSearchRailCardView.setUnreadCount`
+   updates `unread-count` on the Lit element, which re-renders the badge but
+   does not pulse. The Lit element already has a `firePulse()` method (used
+   for blip cards); it just is not invoked when the unread attribute changes
+   on the rail card. Result: the live decrement happens but is easy to miss.
+
+2. **`J2clDigestView` (legacy DOM digest) badge styling does not change with
+   read state.** When unread drops to zero, the stats line just loses the
+   "N unread · " prefix; there is no `data-read="true"` / `aria-label` cue
+   that AT or styling can hook into.
+
+3. **No regression test for the live-decrement Lit reactivity.** The Lit
+   `wavy-search-rail-card.test.js` covers initial attribute → render but does
+   not cover the live update path: setAttribute('unread-count', '0') →
+   badge disappears + pulse fires.
+
+4. **No JVM assertion for the pulse signal from the Java side.** A test for
+   `J2clSearchRailCardView.setUnreadCount` should pin down that the element
+   gets the `unread-count` attribute updated *and* receives the pulse trigger
+   when the value actually changed (not on a no-op).
+
+5. **No documented end-to-end QA recipe** showing the matrix-row evidence.
+
+The `K`-shaped "live update from another client" path is already exercised
+by `J2clSelectedWaveControllerTest` (it hits `applyReadStateToModel` and
+`onReadStateChanged` after a `dispatchReadStateFetch`); we will lean on that
+and add a thin glue test rather than re-prove the controller wiring.
+
+## 4. Files to change
+
+### Lit elements (`j2cl/lit/src/elements/`)
+
+- `wavy-search-rail-card.js` — fire `firePulse()` when the `unread-count`
+  attribute changes to a non-zero value (a true visible change, not just an
+  initial render). Use Lit's `updated(changed)` hook so we can compare
+  previous and next values, including the 0→0 no-op case. Keep `firePulse()`
+  callable from external code (the J2CL Java view never invokes it
+  explicitly; the Lit element decides when to pulse based on attribute
+  changes).
+- `wavy-search-rail-card.js` — also reflect a `data-read="true"` attribute on
+  the host when `unreadCount === 0` (and remove it when > 0) so styling and
+  parity tests can hook the badge-styling state without scraping DOM.
+
+### Java view (`j2cl/src/main/java/org/waveprotocol/box/j2cl/search/`)
+
+- `J2clDigestView` — when `setUnreadCount(0)` lands, set
+  `data-read="true"` on the digest button so legacy CSS / parity probes can
+  detect the read state. Remove the attribute when > 0. Keep the existing
+  stats text path; surface the count to AT via an `aria-label` on the stats
+  row that includes "N unread" (when > 0) or "All read" (when = 0).
+- `J2clSearchRailCardView` — when the count changes, also set `data-read`
+  on the host so JVM-side parity probes do not need to guess what Lit will
+  render.
+
+### Java glue (already present, no change required)
+
+- `J2clSelectedWaveController`, `J2clSearchPanelController`,
+  `J2clSearchPanelView`, `J2clRootShellController`, `SandboxEntryPoint`.
+
+### Tests (`j2cl/lit/test/`, `j2cl/src/test/java/.../search/`)
+
+- `wavy-search-rail-card.test.js` — add cases:
+  - setting `unread-count` from `2` to `1` fires a pulse
+    (`data-pulse="ring"` appears).
+  - setting `unread-count` from `1` to `0` removes the unread badge AND
+    sets `data-read="true"` on the host AND clears the pulse marker.
+  - setting `unread-count` from `0` to `2` clears `data-read`, fires a
+    pulse, and re-renders the badge.
+- `J2clSearchPanelControllerTest` — add a case that runs
+  `onReadStateChanged(...)` for a wave that the controller is currently
+  showing and asserts the cached model picks up the new count
+  (`withUpdatedUnreadCount` round-trip is already covered, but assert the
+  view's `updateDigestUnread` propagation count and the `data-read` attr
+  on the rail-card view).
+- New `J2clSearchRailCardViewTest` (JVM Robolectric / pure Elemental2 mock
+  is already used in this package) — assert:
+  - `setUnreadCount(0)` sets `unread-count="0"` AND `data-read="true"`.
+  - `setUnreadCount(2)` clears `data-read`.
+  - `setUnreadCount(currentCount)` returns `false` (no churn).
+
+### Browser harness fixture (lit dev)
+
+- Add a small `j2cl/lit/test/wavy-search-rail-card-live-decrement.test.js`
+  that wires a rail with a card and simulates the J2CL update path:
+  `card.setAttribute('unread-count', '0')` and verifies pulse + badge swap.
+  This *is* the per-Lit-element regression for the audit's failing row.
+
+### Docs
+
+- `docs/j2cl-gwt-parity-matrix.md` — flip the `R-4.4` row's evidence note to
+  point at the new fixture / harness coverage; do **not** declare R-4.4
+  PASS unilaterally — that decision belongs to the audit refresh, not this
+  slice.
+- `docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md` — leave
+  unchanged. The audit is a snapshot in time; the next refresh will report
+  the new state.
+- `docs/superpowers/screenshots/j-ui-7/` — local-server verification log
+  + screenshots (before/after rail digest).
+
+### Feature flag
+
+Reuse the existing `j2cl-search-rail-cards` flag. The live-decrement code
+runs on both the legacy `J2clDigestView` path and the rail-card path, so
+this slice does not introduce a new flag. The flag-off path (legacy DOM
+digest) keeps the same listener wiring it has today; the new contribution
+is the `data-read` attribute and the AT label, both of which are
+backwards-compatible.
+
+If, during implementation, we discover any user-visible behavior that
+should be opt-in (e.g. the pulse motion on the rail card), we will gate it
+behind a new flag `j2cl-live-unread-pulse` (default off) rather than
+shipping it always-on.
+
+## 5. DocOp / data-path changes
+
+None. The read-state path uses the existing `/read-state` JSON endpoint
+(no DocOp). The mark-as-read write path uses
+`MarkBlipReadHelper.markBlipRead`, which already submits a supplement op
+through the normal `OpBasedWavelet` pipeline. No `characters()` calls are
+added or moved.
+
+## 6. Test plan
+
+### Java unit (`sbt j2cl/test`)
+
+- `J2clSelectedWaveControllerTest` — already covers debounced read-state
+  fetch and listener invocation. No changes; verify the suite still passes.
+- `J2clSearchPanelControllerTest` — add `onReadStateChangedReflectsDataReadAttribute`
+  that drives the controller end to end with a fake view and asserts the
+  updated unread count + the `data-read` swap.
+- `J2clSearchRailCardViewTest` (new) — pure Elemental2 mock test for the
+  view; asserts attribute round-trip.
+
+### Lit unit (`j2cl/lit` test runner — `npm test` or the build alias used
+by the existing tests)
+
+- `wavy-search-rail-card.test.js` — three new cases (decrement,
+  zero-out, increment).
+- New `wavy-search-rail-card-live-decrement.test.js` — single-element
+  fixture verifying pulse + badge swap on attribute change.
+
+### Browser harness
+
+- The existing parity harness fixture covers the rail card render. Extend
+  one fixture that mounts the rail with a card and triggers the
+  `unread-count` mutation, then asserts pulse + badge.
+
+### Local-server verification (issue's required steps 1–8)
+
+Recorded under `docs/superpowers/screenshots/j-ui-7/local-verification.md`:
+
+1. Build: `cd wave && sbt 'j2clProductionBuild;j2clLitBuild' && sbt 'j2cl/test'`.
+2. Run server: `cd wave && sbt 'jakartaServer/run'` (or the project's
+   standard server run command — discovered during QA).
+3. Register a fresh user (do **not** assume `vega`). Use a second account
+   to seed unread blips.
+4. Navigate to `?view=j2cl-root&q=in:inbox`. Confirm the rail card shows
+   non-zero unread + cyan badge.
+5. Click the card. Confirm the unread count drops to zero live
+   (with pulse motion) and `data-read="true"` is set.
+6. Reload the page. Confirm the count remains zero (server-persisted).
+7. Open a third browser session as the same user. Have the second account
+   reply to the wave. Confirm both sessions tick up live.
+8. Reopen the wave in one session; confirm the other session ticks back
+   to zero live.
+9. Confirm GWT path (`?view=gwt`) is unaffected: digest still renders;
+   no `data-read` attribute is required there because GWT keeps its own
+   read-state surface.
+
+Screenshots captured in `docs/superpowers/screenshots/j-ui-7/`.
+
+### Telemetry / observability
+
+`J2clSelectedWaveController` already emits the
+`j2cl.read.mark_blip_read` event with outcome + latency. No new
+telemetry in this slice. The pulse hook is purely visual.
+
+## 7. Roll-back path
+
+- If the `data-read` attribute or the auto-pulse breaks rail-card layout
+  in production, revert just the Lit element commit
+  (`wavy-search-rail-card.js`); the Java view still works because Lit
+  silently ignores unknown attributes. The
+  `j2cl-search-rail-cards` flag stays on by default-off in prod, so
+  rolling the flag back is also still available.
+- If the JVM-side `data-read` toggle in `J2clDigestView` somehow breaks
+  the legacy DOM digest path, revert that commit; the listener wiring
+  still works.
+
+## 8. Out of scope
+
+- Threaded blip rendering (J-UI-4).
+- Folder/chip switching (J-UI-2).
+- Initial digest render (J-UI-1).
+- Persistent unread badge on the *non-selected* search results across a
+  long-running session (currently only the selected wave receives live
+  decrement; non-selected unread changes appear after the next search
+  refresh). The audit row R-4.4 only requires the selected wave to be
+  live; cross-wave unread propagation is outside this slice.

--- a/docs/superpowers/plans/2026-04-28-j-ui-7-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-7-plan.md
@@ -13,8 +13,12 @@ J2CL surface:
   read state changes (decrement on open, increment when a peer posts a new
   reply, etc.).
 - The rail card surfaces a visible "the count just changed" cue so the live
-  decrement is noticeable, not a silent attribute swap.
-- Counts remain exposed to assistive technology and continue to localize.
+  decrement is noticeable, not a silent attribute swap. Crucially this
+  includes the `1 → 0` zero-out case (open a wave, badge disappears) — not
+  just `n → m > 0`.
+- Counts remain exposed to assistive technology via the rail-card root's
+  accessible name (the existing `aria-label` on `<article>`), not via a
+  detached stats-row label.
 - The persisted server state survives a reload (the next `/search` returns
   the post-mutation count).
 
@@ -25,14 +29,17 @@ last few wires that make the live decrement visible to the user.
 
 ## 2. Existing state (read carefully — do not duplicate)
 
-The data path is mostly in place from earlier slices:
+The data path is already in place from earlier slices:
 
 - `SidecarSelectedWaveReadState` (transport DTO).
-- `J2clSelectedWaveController` already debounces a `/read-state` fetch on
-  every selected-wave update (`scheduleReadStateFetch`), exposes a
+- `J2clSelectedWaveController` debounces a `/read-state` fetch on every
+  selected-wave update (`scheduleReadStateFetch`), exposes a
   `ReadStateListener` interface (`onReadStateChanged(waveId, unreadCount,
   stale)`), drives `MarkBlipReadHandler` from a viewport-dwell signal, and
   re-fetches on `visibilitychange`.
+- `J2clSelectedWaveControllerTest` already covers debounced `/read-state`,
+  visibility-triggered refetch, mark-as-read dispatch, and post-success
+  refetch.
 - `J2clSearchPanelController.onReadStateChanged` mutates the cached
   `J2clSearchResultModel` via `withUpdatedUnreadCount(...)` and calls
   `view.updateDigestUnread(...)` to patch the live DOM.
@@ -49,120 +56,168 @@ So this slice is **wiring + feedback + verification**, not new infrastructure.
 
 ## 3. Gaps this slice closes
 
-1. **No visible cue when the count changes.** `J2clSearchRailCardView.setUnreadCount`
-   updates `unread-count` on the Lit element, which re-renders the badge but
-   does not pulse. The Lit element already has a `firePulse()` method (used
-   for blip cards); it just is not invoked when the unread attribute changes
-   on the rail card. Result: the live decrement happens but is easy to miss.
-
-2. **`J2clDigestView` (legacy DOM digest) badge styling does not change with
-   read state.** When unread drops to zero, the stats line just loses the
-   "N unread · " prefix; there is no `data-read="true"` / `aria-label` cue
-   that AT or styling can hook into.
-
-3. **No regression test for the live-decrement Lit reactivity.** The Lit
-   `wavy-search-rail-card.test.js` covers initial attribute → render but does
-   not cover the live update path: setAttribute('unread-count', '0') →
-   badge disappears + pulse fires.
-
-4. **No JVM assertion for the pulse signal from the Java side.** A test for
-   `J2clSearchRailCardView.setUnreadCount` should pin down that the element
-   gets the `unread-count` attribute updated *and* receives the pulse trigger
-   when the value actually changed (not on a no-op).
-
+1. **No visible cue when the rail-card unread count changes.** The `Lit`
+   element exposes `firePulse()` but nothing fires it when `unread-count`
+   mutates after the initial render. The pulse box-shadow today is also
+   scoped to `.badge.unread`, which means the most important case — `1 →
+   0` (open the wave, badge disappears) — has nothing left to pulse.
+2. **Legacy `J2clDigestView` has no read-state styling hook.** When unread
+   drops to zero, the stats line just loses the "N unread · " prefix; there
+   is no attribute that styling, AT, or parity probes can hook to detect
+   the read state.
+3. **No regression test for live unread-count mutation on the rail card.**
+   The Lit `wavy-search-rail-card.test.js` covers initial-attribute →
+   render but not the live update path (`setAttribute('unread-count',
+   '0')` → badge disappears + pulse fires).
+4. **No direct view tests.** `J2clSearchRailCardViewTest` and
+   `J2clDigestViewTest` do not exist, so the JVM side has no coverage of
+   the read-state styling toggle.
 5. **No documented end-to-end QA recipe** showing the matrix-row evidence.
 
-The `K`-shaped "live update from another client" path is already exercised
-by `J2clSelectedWaveControllerTest` (it hits `applyReadStateToModel` and
-`onReadStateChanged` after a `dispatchReadStateFetch`); we will lean on that
-and add a thin glue test rather than re-prove the controller wiring.
+The "live update from another client" path is already exercised by
+`J2clSelectedWaveControllerTest`; we lean on it rather than re-prove the
+controller wiring.
 
 ## 4. Files to change
 
-### Lit elements (`j2cl/lit/src/elements/`)
+### Lit element (`j2cl/lit/src/elements/wavy-search-rail-card.js`)
 
-- `wavy-search-rail-card.js` — fire `firePulse()` when the `unread-count`
-  attribute changes to a non-zero value (a true visible change, not just an
-  initial render). Use Lit's `updated(changed)` hook so we can compare
-  previous and next values, including the 0→0 no-op case. Keep `firePulse()`
-  callable from external code (the J2CL Java view never invokes it
-  explicitly; the Lit element decides when to pulse based on attribute
-  changes).
-- `wavy-search-rail-card.js` — also reflect a `data-read="true"` attribute on
-  the host when `unreadCount === 0` (and remove it when > 0) so styling and
-  parity tests can hook the badge-styling state without scraping DOM.
+- Make `unreadCount` reflect to the `unread-count` attribute
+  (`{ type: Number, attribute: "unread-count", reflect: true }`) so the
+  attribute is the single source of truth and CSS can match
+  `:host([unread-count="0"])`.
+- Add a Lit `updated(changed)` hook that:
+  - Skips the very first render (initial attribute → no pulse).
+  - On subsequent transitions (any change, including `1 → 0`), calls
+    `firePulse()`.
+- Move the pulse visual from `.badge.unread` to the host (`:host([data-pulse="ring"])`)
+  with the existing `box-shadow: var(--wavy-pulse-ring, …)`. Keep the
+  badge's `.unread` class so when the badge is visible it still gets the
+  cyan styling, but the pulse motion is independent of badge visibility.
+  This is the only way the `1 → 0` zero-out case can show a cue.
+- Lit owns rail-card read styling. **Do not** also stamp `data-read` from
+  `J2clSearchRailCardView` — duplicating state invites drift. CSS for
+  rail-card read-state styling keys off `:host([unread-count="0"])`.
 
 ### Java view (`j2cl/src/main/java/org/waveprotocol/box/j2cl/search/`)
 
-- `J2clDigestView` — when `setUnreadCount(0)` lands, set
-  `data-read="true"` on the digest button so legacy CSS / parity probes can
-  detect the read state. Remove the attribute when > 0. Keep the existing
-  stats text path; surface the count to AT via an `aria-label` on the stats
-  row that includes "N unread" (when > 0) or "All read" (when = 0).
-- `J2clSearchRailCardView` — when the count changes, also set `data-read`
-  on the host so JVM-side parity probes do not need to guess what Lit will
-  render.
+- `J2clDigestView` (legacy DOM digest, no Lit host) — when the count
+  toggles, set `data-read="true"` on the `<button>` root when the
+  normalized count is `0`, remove the attribute when `> 0`. The legacy
+  path has no Lit element to derive from, so it owns its own attribute.
+  Keep the existing stats-text path. Improve the AT name by labelling the
+  root `<button>` with an `aria-label` that includes the unread phrase,
+  e.g. `aria-label="Wave: <title>. <N> unread."` or `… Read."` — and
+  refresh it inside `setUnreadCount`. The stats element itself does not
+  need an `aria-label`; the parent button is the focusable surface and
+  carries the accessible name.
+- `J2clSearchRailCardView` — **no `data-read` writes**. The Java view
+  continues to call `setAttribute("unread-count", …)`; Lit reflects.
+  Optional: refresh the `aria-label` attribute on the rail-card's
+  `<wavy-search-rail-card>` host so the inner `<article>` still
+  announces the post-change unread state. Implementation is at the Java
+  view layer because the Lit element does not own the title text.
 
 ### Java glue (already present, no change required)
 
 - `J2clSelectedWaveController`, `J2clSearchPanelController`,
   `J2clSearchPanelView`, `J2clRootShellController`, `SandboxEntryPoint`.
 
-### Tests (`j2cl/lit/test/`, `j2cl/src/test/java/.../search/`)
+### Tests
 
-- `wavy-search-rail-card.test.js` — add cases:
-  - setting `unread-count` from `2` to `1` fires a pulse
-    (`data-pulse="ring"` appears).
-  - setting `unread-count` from `1` to `0` removes the unread badge AND
-    sets `data-read="true"` on the host AND clears the pulse marker.
-  - setting `unread-count` from `0` to `2` clears `data-read`, fires a
-    pulse, and re-renders the badge.
-- `J2clSearchPanelControllerTest` — add a case that runs
-  `onReadStateChanged(...)` for a wave that the controller is currently
-  showing and asserts the cached model picks up the new count
-  (`withUpdatedUnreadCount` round-trip is already covered, but assert the
-  view's `updateDigestUnread` propagation count and the `data-read` attr
-  on the rail-card view).
-- New `J2clSearchRailCardViewTest` (JVM Robolectric / pure Elemental2 mock
-  is already used in this package) — assert:
-  - `setUnreadCount(0)` sets `unread-count="0"` AND `data-read="true"`.
-  - `setUnreadCount(2)` clears `data-read`.
-  - `setUnreadCount(currentCount)` returns `false` (no churn).
+`j2cl/lit/test/wavy-search-rail-card.test.js` — add cases:
 
-### Browser harness fixture (lit dev)
+- setting `unread-count` from `2` to `1` after the initial render fires
+  a pulse (`data-pulse="ring"` on the host, asserted before the timeout
+  clears it).
+- setting `unread-count` from `1` to `0` removes the unread badge **and**
+  still fires the pulse (the host carries the pulse, not the badge).
+- setting `unread-count` from `0` to `2` re-renders the badge **and**
+  fires a pulse.
+- the very first render (initial attribute) does **not** fire a pulse
+  (avoid noisy rendering when the search list first paints).
+- `:host([unread-count="0"])` selector applies (computed style hook —
+  asserted via a dedicated CSS rule in the element so the test can read
+  back the rule's effect, e.g. an `--wavy-rail-card-read` custom prop).
 
-- Add a small `j2cl/lit/test/wavy-search-rail-card-live-decrement.test.js`
-  that wires a rail with a card and simulates the J2CL update path:
-  `card.setAttribute('unread-count', '0')` and verifies pulse + badge swap.
-  This *is* the per-Lit-element regression for the audit's failing row.
+`j2cl/src/test/java/org/waveprotocol/box/j2cl/search/`:
+
+- New `J2clDigestViewTest` — `setUnreadCount(0)` adds `data-read="true"`
+  to the button root; `setUnreadCount(2)` removes it; `setUnreadCount`
+  refreshes the root `aria-label` to include the unread phrase or
+  "Read." for zero. Assert the no-op return when the count is unchanged.
+- New `J2clSearchRailCardViewTest` — `setUnreadCount(2)` writes
+  `unread-count="2"`, `setUnreadCount(0)` writes `unread-count="0"`,
+  `setUnreadCount(currentCount)` returns `false` and writes nothing
+  extra (no churn). Optionally assert the host `aria-label` (or whatever
+  attribute the Java side uses for AT) tracks the count.
+
+`J2clSearchPanelControllerTest` — keep existing assertions on model
+mutation + `updateDigestUnread(...)`. **Do not** push DOM/host attribute
+assertions into this layer; the fake view never produces real DOM, and
+asserting them here would couple the controller test to view internals.
+
+### Browser harness fixture
+
+The existing parity fixture covers initial render. The new live-decrement
+case is covered inside `wavy-search-rail-card.test.js`; no separate
+fixture file needed.
+
+### Server SSR
+
+No change required. The SSR-emitted `unread-count` attribute is already
+correct; the new behaviour is purely client-side reactivity. Note: SSR's
+contract with the rail card today guarantees the *initial* attributes
+(`unread-count`, `data-wave-id`, etc.) — we do not introduce a new SSR
+guarantee in this slice. If `data-read` ever becomes part of the SSR
+contract for the legacy digest, that would be a follow-up and would land
+with its own server-side test.
 
 ### Docs
 
-- `docs/j2cl-gwt-parity-matrix.md` — flip the `R-4.4` row's evidence note to
-  point at the new fixture / harness coverage; do **not** declare R-4.4
-  PASS unilaterally — that decision belongs to the audit refresh, not this
-  slice.
-- `docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md` — leave
-  unchanged. The audit is a snapshot in time; the next refresh will report
-  the new state.
 - `docs/superpowers/screenshots/j-ui-7/` — local-server verification log
-  + screenshots (before/after rail digest).
+  + before/after rail-digest screenshots.
+- `docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md` —
+  unchanged. The audit is a snapshot in time; a future refresh will
+  report the new state.
+- `docs/j2cl-gwt-parity-matrix.md` — **not** modified by this slice. The
+  matrix document does not have an evidence-note column we can edit
+  cleanly, and the row's PASS/FAIL determination belongs to the audit
+  refresh, not to this slice.
 
 ### Feature flag
 
-Reuse the existing `j2cl-search-rail-cards` flag. The live-decrement code
-runs on both the legacy `J2clDigestView` path and the rail-card path, so
-this slice does not introduce a new flag. The flag-off path (legacy DOM
-digest) keeps the same listener wiring it has today; the new contribution
-is the `data-read` attribute and the AT label, both of which are
-backwards-compatible.
+Reuse the existing `j2cl-search-rail-cards` flag. The live-decrement
+code runs on both the legacy `J2clDigestView` path and the rail-card
+path. The flag-off path keeps the same listener wiring it has today;
+the new contributions (`data-read` on the legacy digest, host-level
+pulse on the rail card) are backwards-compatible.
 
-If, during implementation, we discover any user-visible behavior that
-should be opt-in (e.g. the pulse motion on the rail card), we will gate it
-behind a new flag `j2cl-live-unread-pulse` (default off) rather than
-shipping it always-on.
+If the host-level pulse motion turns out to be too aggressive on the
+production palette during local QA, we will gate it behind a new flag
+`j2cl-live-unread-pulse` (default off) rather than shipping it
+always-on.
 
-## 5. DocOp / data-path changes
+### Observability
+
+`J2clSelectedWaveController` already emits the
+`j2cl.read.mark_blip_read` event with outcome + latency. There is no
+"digest unread changed" event today, and this slice does not add one.
+Calling out the gap explicitly so a future telemetry slice can cover
+it without confusion.
+
+## 5. Localization caveat
+
+Strings such as "N unread", "Read.", "All read.", and the legacy digest's
+`X messages` are still hardcoded English in `J2clDigestView`,
+`J2clSearchRailCardView`, and `J2clSelectedWaveModel`. Localizing these is
+a separate slice (the parity matrix calls out i18n parity in a different
+column). This slice keeps using the existing English strings; the
+"counts localize correctly" line in the issue acceptance is interpreted
+as "the count is exposed as a number and is not concatenated mid-string
+in a locale-incompatible way" — which is already true today.
+
+## 6. DocOp / data-path changes
 
 None. The read-state path uses the existing `/read-state` JSON endpoint
 (no DocOp). The mark-as-read write path uses
@@ -170,79 +225,71 @@ None. The read-state path uses the existing `/read-state` JSON endpoint
 through the normal `OpBasedWavelet` pipeline. No `characters()` calls are
 added or moved.
 
-## 6. Test plan
+## 7. Test plan
 
 ### Java unit (`sbt j2cl/test`)
 
 - `J2clSelectedWaveControllerTest` — already covers debounced read-state
-  fetch and listener invocation. No changes; verify the suite still passes.
-- `J2clSearchPanelControllerTest` — add `onReadStateChangedReflectsDataReadAttribute`
-  that drives the controller end to end with a fake view and asserts the
-  updated unread count + the `data-read` swap.
-- `J2clSearchRailCardViewTest` (new) — pure Elemental2 mock test for the
-  view; asserts attribute round-trip.
+  fetch and listener invocation; no changes; verify the suite still
+  passes.
+- `J2clSearchPanelControllerTest` — no DOM-attribute assertions added at
+  this layer; existing assertions on `withUpdatedUnreadCount` /
+  `updateDigestUnread` invocation are sufficient.
+- `J2clDigestViewTest` (new) — read-state attribute toggle and
+  `aria-label` refresh.
+- `J2clSearchRailCardViewTest` (new) — attribute round-trip + no-op
+  return contract.
 
-### Lit unit (`j2cl/lit` test runner — `npm test` or the build alias used
-by the existing tests)
+### Lit unit (`j2cl/lit` test runner)
 
-- `wavy-search-rail-card.test.js` — three new cases (decrement,
-  zero-out, increment).
-- New `wavy-search-rail-card-live-decrement.test.js` — single-element
-  fixture verifying pulse + badge swap on attribute change.
-
-### Browser harness
-
-- The existing parity harness fixture covers the rail card render. Extend
-  one fixture that mounts the rail with a card and triggers the
-  `unread-count` mutation, then asserts pulse + badge.
+- `wavy-search-rail-card.test.js` — five new cases (initial render no
+  pulse, decrement pulse, zero-out pulse + no badge, increment pulse,
+  read-state CSS hook).
 
 ### Local-server verification (issue's required steps 1–8)
 
 Recorded under `docs/superpowers/screenshots/j-ui-7/local-verification.md`:
 
 1. Build: `cd wave && sbt 'j2clProductionBuild;j2clLitBuild' && sbt 'j2cl/test'`.
-2. Run server: `cd wave && sbt 'jakartaServer/run'` (or the project's
-   standard server run command — discovered during QA).
+2. Run server (use the project's standard server entry point — the
+   actual command is discovered during QA and noted in the log).
 3. Register a fresh user (do **not** assume `vega`). Use a second account
    to seed unread blips.
 4. Navigate to `?view=j2cl-root&q=in:inbox`. Confirm the rail card shows
    non-zero unread + cyan badge.
-5. Click the card. Confirm the unread count drops to zero live
-   (with pulse motion) and `data-read="true"` is set.
+5. Click the card. Confirm the unread count drops to zero live, the host
+   pulse fires, and the badge disappears. The rail card now matches
+   `:host([unread-count="0"])`.
 6. Reload the page. Confirm the count remains zero (server-persisted).
-7. Open a third browser session as the same user. Have the second account
-   reply to the wave. Confirm both sessions tick up live.
+7. Open a third browser session as the same user. Have the second
+   account reply to the wave. Confirm both sessions tick up live.
 8. Reopen the wave in one session; confirm the other session ticks back
    to zero live.
 9. Confirm GWT path (`?view=gwt`) is unaffected: digest still renders;
-   no `data-read` attribute is required there because GWT keeps its own
+   no new attributes are required there because GWT keeps its own
    read-state surface.
 
 Screenshots captured in `docs/superpowers/screenshots/j-ui-7/`.
 
-### Telemetry / observability
+## 8. Roll-back path
 
-`J2clSelectedWaveController` already emits the
-`j2cl.read.mark_blip_read` event with outcome + latency. No new
-telemetry in this slice. The pulse hook is purely visual.
-
-## 7. Roll-back path
-
-- If the `data-read` attribute or the auto-pulse breaks rail-card layout
-  in production, revert just the Lit element commit
-  (`wavy-search-rail-card.js`); the Java view still works because Lit
-  silently ignores unknown attributes. The
-  `j2cl-search-rail-cards` flag stays on by default-off in prod, so
-  rolling the flag back is also still available.
+- If the host-level pulse motion or the `:host([unread-count="0"])`
+  styling breaks rail-card layout in production, revert just the Lit
+  element commit (`wavy-search-rail-card.js`); the Java view still
+  works because Lit silently ignores unknown attributes. The
+  `j2cl-search-rail-cards` flag stays default-off in prod, so rolling
+  the flag back is also still available.
 - If the JVM-side `data-read` toggle in `J2clDigestView` somehow breaks
   the legacy DOM digest path, revert that commit; the listener wiring
   still works.
 
-## 8. Out of scope
+## 9. Out of scope
 
 - Threaded blip rendering (J-UI-4).
 - Folder/chip switching (J-UI-2).
 - Initial digest render (J-UI-1).
+- A "digest unread changed" telemetry event.
+- Localization of the unread strings.
 - Persistent unread badge on the *non-selected* search results across a
   long-running session (currently only the selected wave receives live
   decrement; non-selected unread changes appear after the next search

--- a/docs/superpowers/screenshots/j-ui-7/local-verification.md
+++ b/docs/superpowers/screenshots/j-ui-7/local-verification.md
@@ -1,0 +1,118 @@
+# J-UI-7 local-server verification
+
+Date: 2026-04-28
+Branch: `claude/j2cl-ui-7`
+Server: dev mode on `127.0.0.1:9899` via `bash scripts/worktree-boot.sh --port 9899` + `bash scripts/wave-smoke.sh start`.
+User: fresh registration `qajui71777358186@local.net` (admin by virtue of being the first registered account on a clean memory store).
+
+## Steps performed
+
+1. Built `j2clProductionBuild`, `j2clLitBuild`, and the GWT shell via the
+   worktree-boot helper.
+2. Started the server with the staged build.
+3. Registered fresh user via the `/auth/register` page (the user is not
+   `vega` — per the `feedback_local_registration_before_login_testing`
+   memory).
+4. Signed in via `/auth/signin` (browser flow — curl gets caught by the
+   redirect chain auth check).
+5. Enabled the `j2cl-search-rail-cards` flag globally via `POST
+   /admin/flags`.
+6. Navigated to `/?view=j2cl-root&q=in:inbox`. Confirmed the welcome wave
+   renders as a `<wavy-search-rail-card>` with the expected attributes.
+7. Verified the live unread mutation path end-to-end by driving the same
+   attribute mutations the Java side performs in
+   `J2clSearchRailCardView.setUnreadCount(...)` and observing the
+   element's reactive behaviour.
+
+## Live-server evidence
+
+Every transition below was driven by `card.setAttribute('unread-count',
+N)` — the exact call `J2clSearchRailCardView.setUnreadCount(N)` issues
+from the Java side when `J2clSearchPanelController.onReadStateChanged`
+fires.
+
+| Stage     | unread-count | data-pulse | badge        | aria-label                           | --wavy-rail-card-read |
+|-----------|--------------|------------|--------------|--------------------------------------|-----------------------|
+| Initial   | `"6"`        | `null`     | `"6"`        | `Welcome to SupaWave. 6 unread.`     | (unset)               |
+| 6 → 3     | `"3"`        | `"ring"`   | `"3"`        | `Welcome to SupaWave. 3 unread.`     | (unset)               |
+| 3 → 0     | `"0"`        | `"ring"`   | (hidden)     | `Welcome to SupaWave. Read.`         | `"1"`                 |
+
+Highlights:
+
+- The pulse fires on **every** post-initial transition, including the
+  `1 → 0` zero-out where the badge disappears entirely (this was the
+  case the v1 plan missed; the pulse box-shadow is now on the host, not
+  on `.badge.unread`).
+- Initial render did **not** fire a pulse — verified via the `before`
+  snapshot above and via the dedicated unit case in
+  `wavy-search-rail-card.test.js`.
+- `:host([unread-count="0"])` exposes a CSS read-state hook
+  (`--wavy-rail-card-read: 1`) so styling and parity probes can hook
+  the read state without scraping the badge DOM.
+- The `<article>` `aria-label` tracks the count live: 6 unread → 3
+  unread → "Read." — exactly the text AT consumers will hear when they
+  navigate back to the card.
+
+## SSR contract (flag on)
+
+```html
+<shell-root data-j2cl-root-shell="true" ... data-j2cl-search-rail-cards="true">
+  <wavy-search-rail query="in:inbox" data-active-folder="inbox"
+                    result-count="" data-rail-cards-enabled="true">
+  </wavy-search-rail>
+</shell-root>
+```
+
+The `data-j2cl-search-rail-cards="true"` SSR attribute and the
+`data-rail-cards-enabled="true"` rail mirror are both unchanged from
+J-UI-1 (#1079); J-UI-7 does not introduce new SSR attributes.
+
+## GWT path unaffected
+
+`/?view=gwt` was not touched by this slice. The legacy DOM digest path
+(used when the `j2cl-search-rail-cards` flag is off) keeps the same
+listener wiring; the new contributions there (`data-read` on the
+focusable button, `aria-label` refresh in `setUnreadCount`) are
+backwards-compatible — the existing search-panel controller already
+calls `setUnreadCount` whenever the listener fires.
+
+## Out-of-scope gap surfaced during QA
+
+While exercising the issue's local-server step 5 ("click the wave to
+open it; confirm the rail digest's unread count immediately drops to
+zero"), the per-blip read state was found to never decrement
+end-to-end on the local-server config. Investigation showed:
+
+- The `/read-state` endpoint correctly returns `unreadCount=6` for the
+  fresh user's welcome wave.
+- The J2CL read renderer does not stamp the `unread` attribute on
+  per-blip elements because per-blip unread is not on the wire
+  (`SidecarSelectedWaveDocument` carries no unread bit).
+- The viewport-dwell `markBlipRead` path therefore never fires.
+- The existing `/j2cl/mark-blip-read` endpoint (#1056) hits a separate
+  "user-data wavelet unavailable" failure under
+  `OperationContextImpl#openWavelet`, because the UDW-owner is not a
+  participant on their own UDW and the standard
+  `checkAccessPermission` denies the open.
+
+These are **pre-existing F-4 gaps**, not introduced by J-UI-7. They
+will be filed as follow-up issues. This slice ships the visible-cue
+plumbing so the moment those upstream paths converge, the rail card's
+live decrement is already pixel-correct and announceable.
+
+## Files touched (summary)
+
+- `j2cl/lit/src/elements/wavy-search-rail-card.js` — reflect
+  unread-count, host-level pulse, `:host([unread-count="0"])` hook,
+  composed `aria-label`, debounced pulse-clear timer.
+- `j2cl/lit/test/wavy-search-rail-card.test.js` — 8 new cases.
+- `j2cl/src/main/java/.../search/J2clDigestView.java` — `data-read`
+  toggle and `aria-label` refresh on the focusable button root.
+- `j2cl/src/test/java/.../search/J2clDigestViewTest.java` (new) — DOM
+  attribute round-trip.
+- `j2cl/src/test/java/.../search/J2clSearchRailCardViewTest.java`
+  (new) — DOM attribute round-trip.
+- `wave/config/changelog.d/2026-04-28-issue-1085-j-ui-7.json` (new) —
+  release-note fragment.
+- `docs/superpowers/plans/2026-04-28-j-ui-7-plan.md` (new) — slice
+  plan + copilot revision.

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -46,7 +46,14 @@ export class WavySearchRailCard extends LitElement {
     postedAt: { type: String, attribute: "posted-at" },
     postedAtIso: { type: String, attribute: "posted-at-iso" },
     msgCount: { type: Number, attribute: "msg-count" },
-    unreadCount: { type: Number, attribute: "unread-count" },
+    /**
+     * J-UI-7 (#1085, R-4.4): reflect to the `unread-count` attribute so
+     * the attribute is the single source of truth and CSS can style the
+     * read state via `:host([unread-count="0"])`. The J2CL Java view
+     * mutates the attribute live; reflection keeps the property and the
+     * attribute in sync without a second `data-read` flag.
+     */
+    unreadCount: { type: Number, attribute: "unread-count", reflect: true },
     pinned: { type: Boolean, reflect: true },
     authors: { type: String },
     /**
@@ -153,11 +160,28 @@ export class WavySearchRailCard extends LitElement {
       background: var(--wavy-signal-cyan, #22d3ee);
       color: var(--wavy-bg-base, #0b1120);
       font-weight: 600;
+    }
+    /*
+     * J-UI-7 (#1085, R-4.4): pulse lives on the host, not on the badge.
+     * The most important transition is 1 -> 0 (open the wave, badge
+     * disappears) — at that point .badge.unread no longer renders, so
+     * scoping the pulse to it would mean no visible cue. Putting the
+     * pulse on the host means a zero-out still announces the change.
+     */
+    :host {
       transition: box-shadow var(--wavy-motion-pulse-duration, 600ms)
         var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
     }
-    :host([data-pulse="ring"]) .badge.unread {
+    :host([data-pulse="ring"]) {
       box-shadow: var(--wavy-pulse-ring, 0 0 0 4px rgba(34, 211, 238, 0.22));
+    }
+    /*
+     * J-UI-7 (#1085, R-4.4): expose a CSS hook for the read state so
+     * downstream styling (and parity tests) can detect a fully-read
+     * card without scraping the badge DOM.
+     */
+    :host([unread-count="0"]) {
+      --wavy-rail-card-read: 1;
     }
     time.ts {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
@@ -194,6 +218,26 @@ export class WavySearchRailCard extends LitElement {
     }, dur);
   }
 
+  /**
+   * J-UI-7 (#1085, R-4.4): auto-pulse on every unreadCount transition
+   * after the initial render. The first render does not pulse — that
+   * would noisily flash every card on the search list whenever the
+   * page loads. Subsequent transitions (decrement on open, increment
+   * from a peer's reply) all fire the host-level pulse so the live
+   * decrement is visible regardless of whether the badge ends up
+   * visible afterwards.
+   */
+  updated(changed) {
+    if (!changed.has("unreadCount")) {
+      return;
+    }
+    if (!this._unreadCountInitialized) {
+      this._unreadCountInitialized = true;
+      return;
+    }
+    this.firePulse();
+  }
+
   _emitSelected() {
     this.dispatchEvent(
       new CustomEvent("wavy-search-rail-card-selected", {
@@ -202,6 +246,23 @@ export class WavySearchRailCard extends LitElement {
         detail: { waveId: this.waveId }
       })
     );
+  }
+
+  /**
+   * J-UI-7 (#1085, R-4.4): the focusable `<article>` exposes both the
+   * title and the live unread state to assistive technology, so users
+   * hear the count change when they navigate back to a card whose
+   * unread count just decremented (or incremented). When unreadCount
+   * is 0 the announcement collapses to "<title>. Read." rather than
+   * shouting "0 unread.".
+   */
+  _composeAriaLabel() {
+    const title = this.title || "(no title)";
+    const count = Math.max(0, this.unreadCount || 0);
+    if (count <= 0) {
+      return title + ". Read.";
+    }
+    return title + ". " + count + " unread.";
   }
 
   _initials(name) {
@@ -233,7 +294,7 @@ export class WavySearchRailCard extends LitElement {
         }}
         tabindex="0"
         role="article"
-        aria-label=${this.title || "(no title)"}
+        aria-label=${this._composeAriaLabel()}
         aria-current=${this.selected ? "true" : nothing}
       >
         <div class="top">

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -75,8 +75,11 @@ export class WavySearchRailCard extends LitElement {
       border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
       border-radius: var(--wavy-radius-card, 12px);
       cursor: pointer;
-      transition: border-color var(--wavy-motion-focus-duration, 180ms)
-        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+      transition:
+        border-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        box-shadow var(--wavy-motion-pulse-duration, 600ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
     }
     :host(:hover),
     :host(:focus-within) {
@@ -160,17 +163,6 @@ export class WavySearchRailCard extends LitElement {
       background: var(--wavy-signal-cyan, #22d3ee);
       color: var(--wavy-bg-base, #0b1120);
       font-weight: 600;
-    }
-    /*
-     * J-UI-7 (#1085, R-4.4): pulse lives on the host, not on the badge.
-     * The most important transition is 1 -> 0 (open the wave, badge
-     * disappears) — at that point .badge.unread no longer renders, so
-     * scoping the pulse to it would mean no visible cue. Putting the
-     * pulse on the host means a zero-out still announces the change.
-     */
-    :host {
-      transition: box-shadow var(--wavy-motion-pulse-duration, 600ms)
-        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
     }
     :host([data-pulse="ring"]) {
       box-shadow: var(--wavy-pulse-ring, 0 0 0 4px rgba(34, 211, 238, 0.22));

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -213,8 +213,14 @@ export class WavySearchRailCard extends LitElement {
         getComputedStyle(this).getPropertyValue("--wavy-motion-pulse-duration") || "600",
         10
       ) || 600;
-    setTimeout(() => {
+    // Cancel any in-flight clear-timer so a rapid second pulse does not
+    // get truncated by the first pulse's timer firing mid-second-pulse.
+    if (this._pulseClearHandle) {
+      clearTimeout(this._pulseClearHandle);
+    }
+    this._pulseClearHandle = setTimeout(() => {
       delete this.dataset.pulse;
+      this._pulseClearHandle = 0;
     }, dur);
   }
 

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -226,16 +226,22 @@ export class WavySearchRailCard extends LitElement {
    * from a peer's reply) all fire the host-level pulse so the live
    * decrement is visible regardless of whether the badge ends up
    * visible afterwards.
+   *
+   * <p>The initialized flag flips on the first {@code updated()} call
+   * regardless of which properties changed. This way a card whose
+   * upgrade does not touch unreadCount (e.g. attribute and default
+   * both 0) still classifies its first user-driven mutation as a
+   * post-initial change and pulses accordingly.
    */
   updated(changed) {
-    if (!changed.has("unreadCount")) {
+    const wasInitialized = this._initialUpdateComplete;
+    this._initialUpdateComplete = true;
+    if (!wasInitialized) {
       return;
     }
-    if (!this._unreadCountInitialized) {
-      this._unreadCountInitialized = true;
-      return;
+    if (changed.has("unreadCount")) {
+      this.firePulse();
     }
-    this.firePulse();
   }
 
   _emitSelected() {

--- a/j2cl/lit/test/wavy-search-rail-card.test.js
+++ b/j2cl/lit/test/wavy-search-rail-card.test.js
@@ -207,4 +207,131 @@ describe("<wavy-search-rail-card>", () => {
       expect(el.hasAttribute("selected")).to.equal(false);
     });
   });
+
+  // J-UI-7 (#1085, R-4.4): live mark-as-read decrement + the matching
+  // increment when a peer posts a new reply. The Java view mutates the
+  // `unread-count` attribute on the host; the element re-renders the
+  // badge, fires a host-level pulse, and exposes a CSS read-state hook
+  // so the cue is visible regardless of badge visibility.
+  describe("J-UI-7 live unread mutation (#1085)", () => {
+    it("does NOT pulse on the initial render (avoids paint-time noise)", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="2"
+          style="--wavy-motion-pulse-duration: 60;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.be.undefined;
+    });
+
+    it("pulses on a 2 -> 1 decrement and keeps the badge", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="2"
+          style="--wavy-motion-pulse-duration: 60;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      el.setAttribute("unread-count", "1");
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.equal("ring");
+      const badge = el.renderRoot.querySelector(".badge.unread");
+      expect(badge).to.exist;
+      expect(badge.textContent.trim()).to.equal("1");
+      await aTimeout(120);
+      expect(el.dataset.pulse).to.be.undefined;
+    });
+
+    it("pulses on a 1 -> 0 zero-out and removes the badge (host owns the cue)", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="1"
+          style="--wavy-motion-pulse-duration: 60;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      el.setAttribute("unread-count", "0");
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.equal("ring");
+      // Badge is gone — but the host still pulses, which is the whole
+      // point of moving the box-shadow from .badge.unread to :host.
+      expect(el.renderRoot.querySelector(".badge.unread")).to.be.null;
+      // Reflected attribute survives.
+      expect(el.getAttribute("unread-count")).to.equal("0");
+    });
+
+    it("pulses on a 0 -> 2 increment and re-renders the badge", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="0"
+          style="--wavy-motion-pulse-duration: 60;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".badge.unread")).to.be.null;
+      el.setAttribute("unread-count", "2");
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.equal("ring");
+      const badge = el.renderRoot.querySelector(".badge.unread");
+      expect(badge).to.exist;
+      expect(badge.textContent.trim()).to.equal("2");
+    });
+
+    it("setting the same unread-count value does not fire a pulse (no churn)", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="2"
+          style="--wavy-motion-pulse-duration: 60;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      // No-op set: same numeric value.
+      el.setAttribute("unread-count", "2");
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.be.undefined;
+    });
+
+    it("exposes :host([unread-count='0']) as a CSS read-state hook", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card unread-count="0"></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      const cs = getComputedStyle(el);
+      expect(cs.getPropertyValue("--wavy-rail-card-read").trim()).to.equal("1");
+      el.setAttribute("unread-count", "3");
+      await el.updateComplete;
+      const cs2 = getComputedStyle(el);
+      // CSS variable falls back to undefined ("") when the
+      // :host([unread-count="0"]) rule no longer matches.
+      expect(cs2.getPropertyValue("--wavy-rail-card-read").trim()).to.equal("");
+    });
+
+    it("article aria-label tracks the live unread count for AT", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card title="Sprint review" unread-count="2"></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      let article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-label")).to.equal("Sprint review. 2 unread.");
+      el.setAttribute("unread-count", "0");
+      await el.updateComplete;
+      article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-label")).to.equal("Sprint review. Read.");
+    });
+
+    it("zero-titled card still produces a sensible aria-label", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card unread-count="0"></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      const article = el.renderRoot.querySelector("article");
+      expect(article.getAttribute("aria-label")).to.equal("(no title). Read.");
+    });
+  });
 });

--- a/j2cl/lit/test/wavy-search-rail-card.test.js
+++ b/j2cl/lit/test/wavy-search-rail-card.test.js
@@ -325,6 +325,34 @@ describe("<wavy-search-rail-card>", () => {
       expect(article.getAttribute("aria-label")).to.equal("Sprint review. Read.");
     });
 
+    it("rapid back-to-back unread changes keep the pulse marker until the last clear", async () => {
+      const el = await fixture(html`
+        <wavy-search-rail-card
+          msg-count="3"
+          unread-count="2"
+          style="--wavy-motion-pulse-duration: 80;"
+        ></wavy-search-rail-card>
+      `);
+      await el.updateComplete;
+      el.setAttribute("unread-count", "1");
+      await el.updateComplete;
+      // First pulse is in flight.
+      expect(el.dataset.pulse).to.equal("ring");
+      // Second pulse arrives well before the first 80ms timer would fire.
+      await aTimeout(20);
+      el.setAttribute("unread-count", "0");
+      await el.updateComplete;
+      expect(el.dataset.pulse).to.equal("ring");
+      // First pulse's original timer would have fired by now if it had not
+      // been cancelled. The marker must still be present because the second
+      // pulse rearmed the timer.
+      await aTimeout(70);
+      expect(el.dataset.pulse).to.equal("ring");
+      // Second pulse's full duration has now elapsed; marker clears.
+      await aTimeout(40);
+      expect(el.dataset.pulse).to.be.undefined;
+    });
+
     it("zero-titled card still produces a sensible aria-label", async () => {
       const el = await fixture(html`
         <wavy-search-rail-card unread-count="0"></wavy-search-rail-card>

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clDigestView.java
@@ -11,6 +11,7 @@ public final class J2clDigestView {
   }
 
   private final String waveId;
+  private final String titleText;
   private final HTMLButtonElement root;
   private final HTMLElement stats;
   private int blipCount;
@@ -18,6 +19,7 @@ public final class J2clDigestView {
 
   public J2clDigestView(J2clSearchDigestItem item, SelectionHandler selectionHandler) {
     this.waveId = item.getWaveId();
+    this.titleText = item.getTitle() == null ? "" : item.getTitle();
     this.blipCount = item.getBlipCount();
     this.unreadCount = item.getUnreadCount();
     this.root = (HTMLButtonElement) DomGlobal.document.createElement("button");
@@ -55,6 +57,8 @@ public final class J2clDigestView {
     stats.textContent = buildStatsText(item.getUnreadCount(), item.getBlipCount());
     root.appendChild(stats);
 
+    refreshReadStateAttributes();
+
     root.onclick =
         event -> {
           selectionHandler.onSelected(item.getWaveId());
@@ -86,7 +90,28 @@ public final class J2clDigestView {
     }
     this.unreadCount = normalized;
     stats.textContent = buildStatsText(unreadCount, blipCount);
+    refreshReadStateAttributes();
     return true;
+  }
+
+  /**
+   * J-UI-7 (#1085, R-4.4): keep the {@code data-read} attribute and the
+   * accessible name on the digest button in sync with the current
+   * unread count. The legacy DOM digest path has no Lit host to derive
+   * styling from, so it owns its own attribute. The accessible name
+   * lives on the focusable {@code <button>} root rather than a stats
+   * subnode so AT consumers announce the read state when the button
+   * receives focus.
+   */
+  private void refreshReadStateAttributes() {
+    if (unreadCount <= 0) {
+      root.setAttribute("data-read", "true");
+    } else {
+      root.removeAttribute("data-read");
+    }
+    String unreadPhrase = unreadCount <= 0 ? "Read." : (unreadCount + " unread.");
+    String namePrefix = titleText.isEmpty() ? "Wave" : ("Wave: " + titleText);
+    root.setAttribute("aria-label", namePrefix + ". " + unreadPhrase);
   }
 
   /** Visible for parity tests so they can read back the rendered stats text. */

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clDigestViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clDigestViewTest.java
@@ -1,0 +1,114 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * J-UI-7 (#1085, R-4.4) — coverage for the legacy DOM digest view's
+ * read-state attribute toggle and accessible-name refresh. The view has
+ * no Lit host to derive styling from, so it owns its own
+ * {@code data-read} attribute and refreshes the root {@code aria-label}
+ * inside {@link J2clDigestView#setUnreadCount(int)}.
+ */
+@J2clTestInput(J2clDigestViewTest.class)
+public class J2clDigestViewTest {
+  @Test
+  public void initialUnreadCountStampsAriaLabelAndOmitsDataRead() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    HTMLElement root = view.element();
+    Assert.assertFalse(
+        "Initial unread > 0 must not stamp data-read", root.hasAttribute("data-read"));
+    Assert.assertEquals(
+        "Wave: Sprint review. 3 unread.", root.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void initialZeroUnreadStampsDataReadAndAllReadAriaLabel() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 0, 12), waveId -> {});
+    HTMLElement root = view.element();
+    Assert.assertEquals("true", root.getAttribute("data-read"));
+    Assert.assertEquals(
+        "Wave: Sprint review. Read.", root.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void setUnreadCountToZeroAddsDataReadAndRefreshesAriaLabel() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    boolean changed = view.setUnreadCount(0);
+    Assert.assertTrue("Transition 3 -> 0 must report changed", changed);
+    HTMLElement root = view.element();
+    Assert.assertEquals("true", root.getAttribute("data-read"));
+    Assert.assertEquals("Wave: Sprint review. Read.", root.getAttribute("aria-label"));
+    Assert.assertEquals("12 messages", view.getStatsText());
+  }
+
+  @Test
+  public void setUnreadCountToNonZeroRemovesDataReadAndRefreshesAriaLabel() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 0, 12), waveId -> {});
+    boolean changed = view.setUnreadCount(2);
+    Assert.assertTrue("Transition 0 -> 2 must report changed", changed);
+    HTMLElement root = view.element();
+    Assert.assertFalse(root.hasAttribute("data-read"));
+    Assert.assertEquals(
+        "Wave: Sprint review. 2 unread.", root.getAttribute("aria-label"));
+    Assert.assertEquals("2 unread · 12 messages", view.getStatsText());
+  }
+
+  @Test
+  public void setUnreadCountToCurrentValueIsNoOpAndKeepsAttributesStable() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 2, 12), waveId -> {});
+    HTMLElement root = view.element();
+    String labelBefore = root.getAttribute("aria-label");
+    boolean changed = view.setUnreadCount(2);
+    Assert.assertFalse("Same-value set must not report changed", changed);
+    Assert.assertEquals(labelBefore, root.getAttribute("aria-label"));
+    Assert.assertFalse(root.hasAttribute("data-read"));
+  }
+
+  @Test
+  public void emptyTitleStillProducesSensibleAriaLabel() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "", 0, 1), waveId -> {});
+    HTMLElement root = view.element();
+    Assert.assertEquals("Wave. Read.", root.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void negativeUnreadCountClampsToReadState() {
+    assumeBrowserDom();
+    J2clDigestView view = new J2clDigestView(item("w-1", "Sprint review", 4, 5), waveId -> {});
+    boolean changed = view.setUnreadCount(-1);
+    Assert.assertTrue(changed);
+    HTMLElement root = view.element();
+    Assert.assertEquals("true", root.getAttribute("data-read"));
+    Assert.assertEquals(
+        "Wave: Sprint review. Read.", root.getAttribute("aria-label"));
+  }
+
+  private static J2clSearchDigestItem item(
+      String waveId, String title, int unread, int blipCount) {
+    return new J2clSearchDigestItem(
+        waveId,
+        title,
+        /* snippet= */ "snippet",
+        /* author= */ "alice@example.com",
+        unread,
+        blipCount,
+        /* lastModified= */ 1_700_000_000_000L,
+        /* pinned= */ false);
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(
+        "DOM-only test; skipped on JVM runs", DomGlobal.document != null);
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchRailCardViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSearchRailCardViewTest.java
@@ -1,0 +1,83 @@
+package org.waveprotocol.box.j2cl.search;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * J-UI-7 (#1085, R-4.4) — coverage for the rail-card view's
+ * unread-count attribute round-trip and no-op contract.
+ *
+ * <p>The Lit element ({@code <wavy-search-rail-card>}) owns rail-card
+ * read-state styling and the article aria-label, so this test only
+ * asserts the Java view's narrow responsibility: write the attribute,
+ * report whether the count actually changed, and never churn on a
+ * same-value update.
+ */
+@J2clTestInput(J2clSearchRailCardViewTest.class)
+public class J2clSearchRailCardViewTest {
+  @Test
+  public void initialAttributeStampsUnreadCount() {
+    assumeBrowserDom();
+    J2clSearchRailCardView view =
+        new J2clSearchRailCardView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    HTMLElement el = view.element();
+    Assert.assertEquals("3", el.getAttribute("unread-count"));
+    Assert.assertEquals("12", el.getAttribute("msg-count"));
+    Assert.assertEquals("w-1", el.getAttribute("data-wave-id"));
+    Assert.assertEquals("3 unread · 12 messages", view.getStatsText());
+  }
+
+  @Test
+  public void setUnreadCountWritesAttributeAndReportsChange() {
+    assumeBrowserDom();
+    J2clSearchRailCardView view =
+        new J2clSearchRailCardView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    boolean changed = view.setUnreadCount(0);
+    Assert.assertTrue(changed);
+    Assert.assertEquals("0", view.element().getAttribute("unread-count"));
+  }
+
+  @Test
+  public void setUnreadCountToCurrentValueIsNoOp() {
+    assumeBrowserDom();
+    J2clSearchRailCardView view =
+        new J2clSearchRailCardView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    HTMLElement el = view.element();
+    String before = el.getAttribute("unread-count");
+    boolean changed = view.setUnreadCount(3);
+    Assert.assertFalse(changed);
+    Assert.assertEquals(before, el.getAttribute("unread-count"));
+  }
+
+  @Test
+  public void negativeUnreadCountClampsToZero() {
+    assumeBrowserDom();
+    J2clSearchRailCardView view =
+        new J2clSearchRailCardView(item("w-1", "Sprint review", 3, 12), waveId -> {});
+    boolean changed = view.setUnreadCount(-1);
+    Assert.assertTrue(changed);
+    Assert.assertEquals("0", view.element().getAttribute("unread-count"));
+  }
+
+  private static J2clSearchDigestItem item(
+      String waveId, String title, int unread, int blipCount) {
+    return new J2clSearchDigestItem(
+        waveId,
+        title,
+        /* snippet= */ "snippet",
+        /* author= */ "alice@example.com",
+        unread,
+        blipCount,
+        /* lastModified= */ 1_700_000_000_000L,
+        /* pinned= */ false);
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(
+        "DOM-only test; skipped on JVM runs", DomGlobal.document != null);
+  }
+}

--- a/wave/config/changelog.d/2026-04-28-issue-1085-j-ui-7.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1085-j-ui-7.json
@@ -1,0 +1,23 @@
+{
+  "releaseId": "2026-04-28-issue-1085-j-ui-7",
+  "version": "PR #TBD",
+  "date": "2026-04-28",
+  "title": "J-UI-7: Live unread cue + read-state hooks for the J2CL search rail",
+  "summary": "When the J2CL search rail's per-user unread count changes (decrement on open, increment on a peer reply), the matching <wavy-search-rail-card> now fires a host-level cyan signal-pulse and refreshes its accessible name so the live update is visible and announceable. Read state is exposed to CSS via :host([unread-count=\"0\"]); the legacy DOM digest gains a matching data-read attribute and aria-label refresh.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "<wavy-search-rail-card> reflects unreadCount to the unread-count attribute, fires a host-level pulse on every post-initial change (the pulse box-shadow lives on the host, so the 1->0 zero-out case still has a visible cue after the badge disappears), and refreshes the article aria-label so AT consumers hear 'Sprint review. 2 unread.' or 'Sprint review. Read.'.",
+        "Rapid back-to-back unread mutations (e.g. a server push landing while the previous pulse is still ringing) keep the ring visible for the full duration after the latest pulse instead of being truncated by an earlier timer.",
+        "Legacy J2clDigestView toggles a data-read attribute on the focusable button root and refreshes its aria-label to match the live count."
+      ]
+    },
+    {
+      "type": "fix",
+      "items": [
+        "Closes the visible-cue gap recorded as R-4.4 FAIL in the 2026-04-26 J2CL/GWT parity audit. The data path (read-state fetch, search-panel listener, model mutation) was already wired across #931, #1056, and #1079; this slice attaches the cue and the assistive-technology surface so the live decrement is actually noticeable when it does fire."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `<wavy-search-rail-card>` now reflects `unreadCount` to the `unread-count` attribute, fires a host-level cyan signal-pulse on every post-initial transition (decrement on open, increment on a peer reply, zero-out on full read), and refreshes the inner `<article>` `aria-label` so AT consumers hear "Welcome to SupaWave. 6 unread." or "… Read." live as the count changes.
- Pulse box-shadow lives on `:host`, not on `.badge.unread`, so the `1 → 0` zero-out case still has a visible cue after the badge disappears. `:host([unread-count="0"])` exposes a CSS read-state hook (`--wavy-rail-card-read: 1`).
- Legacy `J2clDigestView` (no Lit host) toggles `data-read="true"` on its focusable button root and refreshes the root `aria-label` to match the live count, so the legacy DOM-digest path also surfaces the read state.

## Closes

- Closes #1085
- Refs umbrella #1078, parent #904

## Matrix rows satisfied

- **R-4.4 (read/unread state live updates) — visible-cue + AT surface only.** Per-user read state was already wired across #931 / #1056 / #1079; this slice attaches the cue and the assistive-technology surface so the live decrement is actually noticeable when it does fire. End-to-end live-decrement on wave open is **still gated** on a pre-existing F-4 gap (per-blip unread is not on the wire and the existing `/j2cl/mark-blip-read` endpoint hits a "user-data wavelet unavailable" failure under `OperationContextImpl` because the UDW owner is not a participant on their own UDW). Both gaps are documented in `docs/superpowers/screenshots/j-ui-7/local-verification.md` and will be filed as follow-up issues.

## Implementation notes

Lit element changes (`j2cl/lit/src/elements/wavy-search-rail-card.js`):

- `unreadCount: { type: Number, attribute: "unread-count", reflect: true }` — single source of truth for read state.
- Pulse moved from `.badge.unread` to `:host` (the only fix that lets the `1 → 0` case still pulse).
- `updated(changed)` flips `_initialUpdateComplete` on the first `updated()` call regardless of which property changed, so a card whose upgrade does not touch `unreadCount` (attribute and default both 0) still classifies its first user-driven mutation as a post-initial change.
- `firePulse()` clears any in-flight pulse-clear timer before arming a fresh one, so rapid back-to-back unread mutations keep the ring visible for the full duration after the latest pulse.
- New `_composeAriaLabel()` builds the article accessible name from title + unread state ("(no title). Read." / "Sprint review. 2 unread.").

Java view changes (`j2cl/src/main/java/.../search/J2clDigestView.java`):

- `setUnreadCount` toggles `data-read="true"` on the button root when the normalized count is 0; removed when > 0.
- `aria-label` on the focusable `<button>` is refreshed inside `setUnreadCount` to include the live unread phrase.
- `J2clSearchRailCardView` is unchanged: the Lit element owns rail-card read styling and AT, so the Java view stays a thin attribute mutator and avoids dual ownership.

## Local-server verification

Full transcript at `docs/superpowers/screenshots/j-ui-7/local-verification.md`.

| Stage     | unread-count | data-pulse | badge        | aria-label                           | --wavy-rail-card-read |
|-----------|--------------|------------|--------------|--------------------------------------|-----------------------|
| Initial   | `"6"`        | `null`     | `"6"`        | `Welcome to SupaWave. 6 unread.`     | (unset)               |
| 6 → 3     | `"3"`        | `"ring"`   | `"3"`        | `Welcome to SupaWave. 3 unread.`     | (unset)               |
| 3 → 0     | `"0"`        | `"ring"`   | (hidden)     | `Welcome to SupaWave. Read.`         | `"1"`                 |

Each transition was driven by `card.setAttribute('unread-count', N)` — the exact call `J2clSearchRailCardView.setUnreadCount(N)` issues from the Java side. Initial render did not pulse (verified). The `1 → 0` zero-out fires the pulse on the host even though the badge is hidden. SSR contract (`data-j2cl-search-rail-cards="true"` on `<shell-root>`, `data-rail-cards-enabled="true"` on `<wavy-search-rail>`) is unchanged from #1079; this slice does not introduce new SSR attributes.

## Test plan

- [x] `sbt compile`
- [x] `./j2cl/mvnw -f j2cl/pom.xml test` — 774 tests pass, 0 failures, 123 skipped (DOM-gated tests skip on JVM).
- [x] `cd j2cl/lit && npm test -- --files test/wavy-search-rail-card.test.js` — 25 tests pass (existing 17 + 8 new).
- [x] Local server: registered fresh user `qajui71777358186@local.net`, enabled `j2cl-search-rail-cards` flag, exercised the live mutation path on `?view=j2cl-root`.
- [x] GWT path (`?view=gwt`) unaffected — no files in the legacy GWT client tree were touched.

## Out of scope (filed as follow-ups)

- Plumbing per-blip `unread` bit through `SidecarSelectedWaveDocument` so the dwell-based `markBlipRead` path can fire.
- UDW owner-access bypass in the existing `/j2cl/mark-blip-read` write path so opening a wave actually decrements the per-user count server-side.
- Localization of the unread strings and the legacy digest's `N messages` copy.
- A `j2cl.read.digest_unread_changed` telemetry event (today's `j2cl.read.mark_blip_read` covers only the per-blip write path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search rail now displays live unread count updates with host-level visual pulse feedback
  * Unread count reflects as an attribute for enhanced styling flexibility
  * Added accessible announcements that declare read/unread state changes to assistive technology
  * New CSS styling hook available for zero unread state presentation
  * Rapid successive unread mutations maintain visible pulse feedback throughout changes

* **Tests**
  * Added comprehensive test coverage for live unread mutations, visual feedback, and state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->