### PR TITLE
J-UI-5: Inline rich-text composer + working toolbar

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-5-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-5-plan.md
@@ -41,10 +41,12 @@ The Java view already mounts `<wavy-composer>` at `<wave-blip data-blip-id=…>`
 
 **Real gaps** (verified by reading sources, not just the audit):
 
-1. **No DOM-mutation handler** for toolbar action ids except `insert-task`. Bold / Italic / Underline / Strikethrough / Heading / Unordered / Ordered / Link / Unlink / Clear-Formatting clicks bubble up but never modify the composer body, so the user sees no formatting and pressed state never lights up because the wrapping tags never appear.
+1. **No DOM-mutation handler** for toolbar action ids except `insert-task`. Bold / Italic / Underline / Strikethrough / Unordered / Ordered / Link / Unlink / Clear-Formatting clicks bubble up but never modify the composer body, so the user sees no formatting and pressed state never lights up because the wrapping tags never appear.
 2. **No `<wavy-link-modal>` integration** — the modal element exists but no JS wires `wavy-format-toolbar-action[actionId=link]` to open it and consume `wavy-link-modal-submit`.
 3. **Submit path drops formatting**: the JS composer fires `reply-submit` carrying only the plain-text `draft`. The Java controller's `buildReplyDocument` builds an `annotatedText` with a single annotation across the whole draft based on the latest toolbar click — not per-fragment. So a selection-bold within a 100-char draft submits the whole 100 chars as bold.
-4. **Active-annotation map omits non-toggle tags**: `<a>`, `<ul>`, `<ol>`, `<h1>..<h3>` are missing from `ACTIVE_ANNOTATION_MAP` so even when DOM mutations land, the toolbar's pressed state will not fire for them.
+4. **Submit-side serializer covers lists / link / mention / blockquote, but not bold / italic / underline / strikethrough**: `serializeRichComponents` (`wavy-composer.js`) already emits `{type, text, annotationKey, annotationValue}` records for `<a>`, `<ul>`, `<ol>`, `<blockquote>`, mention chips. It does **not** recognise `<strong>`/`<b>`, `<em>`/`<i>`, `<u>`, `<s>` so even if the DOM mutation lands those wraps, the submit walker emits a plain-text component for the bold-italic run.
+
+(Gap originally listed as "ACTIVE_ANNOTATION_MAP omits link/list/heading" was retracted on copilot review — `wavy-format-toolbar.js` already maps `link → ["a"]`, `unordered-list → ["ul"]`, `ordered-list → ["ol"]`, `heading → ["h1","h2","h3","h4"]`, `unlink → ["a"]`. No edit there is required.)
 
 ## 4. Implementation slices
 
@@ -65,43 +67,32 @@ In `j2cl/lit/src/elements/wavy-composer.js`, extend `_handleToolbarAction(event)
 | `italic` | toggle wrap selection in `<em>` |
 | `underline` | toggle wrap selection in `<u>` |
 | `strikethrough` | toggle wrap selection in `<s>` |
-| `heading` | wrap each selected line in `<h2>` (round-trip to text on toggle off) |
 | `unordered-list` | wrap selected lines in `<ul><li>…</li></ul>` (toggle off unwraps) |
 | `ordered-list` | wrap selected lines in `<ol><li>…</li></ol>` (toggle off unwraps) |
 | `align-left`/`-center`/`-right` | set `text-align` on the nearest block ancestor inside the composer body |
 | `rtl` | set `dir="rtl"` on the nearest block ancestor |
 | `link` | open `<wavy-link-modal>`, on submit wrap selection in `<a href=…>`; on cancel restore selection |
 | `unlink` | unwrap any `<a>` ancestor of the selection |
-| `clear-formatting` | flatten formatting tags inside the selection (strip `<strong>`, `<em>`, `<u>`, `<s>`, `<a>`, headings, list wrappers) |
+| `clear-formatting` | flatten formatting tags inside the selection (strip `<strong>`, `<em>`, `<u>`, `<s>`, `<a>`, list wrappers) |
 | `attachment-insert` | already routed through the view path; unchanged |
 | `insert-task` | unchanged |
+| `heading` | **out of scope for this slice** — see §9. Wrap-as-bold round-trips lossily (re-reads as bold inline rather than a heading) and a proper element-type round-trip needs schema work the matrix does not require. |
 
-**Toggle semantics**: the wrap helper checks whether the selection is already inside the matching tag; if so, unwrap; otherwise wrap. This is what makes pressed state honest (the tag walk in `_collectActiveAnnotations` lights the button only when the selection is already inside the corresponding tag).
+**Toggle semantics**: the wrap helper checks whether the selection is already inside the matching tag; if so, unwrap; otherwise wrap. This is what makes pressed state honest (the tag walk in `_collectActiveAnnotations` lights the button only when the selection is already inside the corresponding tag). `ACTIVE_ANNOTATION_MAP` already covers all the tags we will introduce — no edit there.
 
-**Selection preservation**: each handler captures the live `Range` before any DOM mutation, performs the wrap/unwrap, then restores selection to the new content boundary so subsequent toolbar clicks chain correctly. The existing `<wavy-composer>` already declines to overwrite the body's `textContent` when it owns selection (see `_bodyOwnsSelection`), so the mutations are not clobbered by Lit re-renders.
+**Selection preservation**: each handler captures the live `Range` before any DOM mutation, performs the wrap/unwrap, then restores selection to the new content boundary so subsequent toolbar clicks chain correctly.
 
-**Active-annotation map extension** in `wavy-format-toolbar.js`:
+**Cached-range fallback (cross-browser)**: `document.getSelection()` does not pierce shadow roots reliably in Firefox / WebKit (Chromium pierces). To stay portable we stash the live `Range` from the composer body's `selectionchange` listener (`_onSelectionChange`, already invoked) into `_lastSelectionRange` whenever `_bodyOwnsSelection()` is true. Toolbar handlers reach for this stashed range first, fall back to `document.getSelection()` for the Chromium happy path. The shadow-DOM caveat goes into the risks table.
 
-```js
-const ACTIVE_ANNOTATION_MAP = {
-  bold: ["strong", "b"],
-  italic: ["em", "i"],
-  underline: ["u"],
-  strikethrough: ["s", "strike", "del"],
-  "unordered-list": ["ul"],
-  "ordered-list": ["ol"],
-  link: ["a"],
-  unlink: [],          // non-toggle but lights when selection sits in <a>
-  heading: ["h1", "h2", "h3", "h4"],
-  // … unchanged for align / rtl / clear / insert-task / attachment-insert
-};
-```
+**Event propagation**: each handler that consumes an action calls `event.stopPropagation()` so a future Java listener on `wavy-format-toolbar-action` (e.g. for telemetry / unavailable-state) does not double-fire. The existing `insert-task` branch already lets non-handled ids bubble; we keep that behaviour for any id we explicitly do not handle (currently only `attachment-insert`, which the existing view-side body listener already routes).
 
-`unlink` flips to "lights when selection is in `<a>`" — not toggleable, but `_isActionActive` short-circuits when `toggle=false`, so the visual contract here is that link/unlink share the same lit indication that the selection is inside an `<a>`.
+**Lit re-render guard**: `<wavy-composer>` mirrors the `draft` property to `body.textContent` only when (a) the body does not own selection AND (b) the body either has no rich content OR the controller-driven reset case applies (see `_isControllerReset`). Manual `<strong>`/`<em>`/etc. wraps register as rich content (the body's child node tree contains element nodes), so the existing `_bodyHasRichContent()` predicate must be extended to include the new wrap tags. We add `strong, em, u, s, a, ul[class~='wavy-task-list']` (already there), and the existing list/quote/link selectors. Concretely: change `_bodyHasRichContent` from `querySelector(".wavy-mention-chip, .wavy-task-list")` to also match `strong, em, u, s, a, ul, ol, blockquote, h1, h2, h3, h4`. That keeps the textContent overwrite from wiping the wrap tags on the next Lit update cycle.
 
 ### 4.C. JS→Java reply-submit boundary carries rich components (R-5.1, R-5.7)
 
 **Why**: today `event.detail.value` is plain text only. Without per-fragment formatting on the wire, the Java controller cannot build the right `J2clComposerDocument` and bold-on-selection collapses to bold-everything (or no-bold) at submit.
+
+**Reuse existing schema**: `serializeRichComponents` already emits `{type, text, annotationKey, annotationValue}` for `<a>`, `<ul>`, `<ol>`, `<blockquote>`, mention chips. We extend it with new tag branches rather than designing a new shape — the Java boundary parses the existing schema.
 
 **Change in `wavy-composer.js`**:
 
@@ -110,7 +101,7 @@ _submit() {
   this.dispatchEvent(new CustomEvent("reply-submit", {
     detail: {
       value: this.draft,
-      components: this.serializeRichComponents(),  // already exists
+      components: this.serializeRichComponents(),  // existing fn, extended
       replyTargetBlipId: this.replyTargetBlipId,
       mode: this.mode,
     },
@@ -120,7 +111,9 @@ _submit() {
 }
 ```
 
-**Extend `serializeRichComponents`** to recognise the new wrap tags:
+The `draft` property remains the source of truth for plain-text consumers (Lit re-render mirror, status displays). The Java view reads `event.detail` for components and falls back to `propertyString(composer, "draft")` when components are absent — keeps the legacy `<composer-inline-reply>` textarea path working unchanged.
+
+**Extend `serializeRichComponents`** with new tag branches (annotation keys match the existing `J2clComposeSurfaceController.annotationKey`/`annotationValue` static helpers at lines 2002–2030 — no Java-side mapping changes needed):
 
 | Tag | Emitted component |
 | --- | --- |
@@ -128,36 +121,67 @@ _submit() {
 | `<em>` / `<i>` | `{type: "annotated", annotationKey: "fontStyle", annotationValue: "italic", text}` |
 | `<u>` | `{type: "annotated", annotationKey: "textDecoration", annotationValue: "underline", text}` |
 | `<s>` / `<strike>` / `<del>` | `{type: "annotated", annotationKey: "textDecoration", annotationValue: "line-through", text}` |
-| `<h1>..<h3>` | `{type: "annotated", annotationKey: "fontWeight", annotationValue: "bold", text}` followed by a TEXT newline (heading visual stays in the composer; the model carries a bold run) — keeps R-5.7 limited to lists+links round-trip without inventing a heading element-type the GWT reader doesn't know |
 | `<a href=…>` | already emits `link/manual` (existing) |
 | `<ul>`/`<ol>` | already emits `list/unordered` / `list/ordered` (existing) |
-| nested combinations | walk children recursively (existing pattern in S4 list helpers) |
+| nested combinations | walk children recursively (existing pattern in the S4 list / blockquote helpers) — when an `<a>` lives inside a `<strong>`, we emit two annotated components covering the same range so the read codec applies both annotations. The existing `walk()` recursion already produces this for `<a>` inside `<blockquote>`; we extend the same recursion for `<strong>`/`<em>`/`<u>`/`<s>`. |
 
 **Java side** in `J2clComposeSurfaceView.java`:
 
 ```java
 composer.addEventListener("reply-submit", event -> {
   if (listener == null) return;
-  List<J2clComposeSurfaceController.SubmittedComponent> components =
-      readComponents(event); // null/empty when the event came from the legacy textarea
-  if (components == null || components.isEmpty()) {
+  JsArray<?> rawComponents = readComponentsArray(event); // detail.components or null
+  if (rawComponents == null || rawComponents.length == 0) {
     listener.onReplySubmitted(propertyString(composer, "draft"));
-  } else {
-    listener.onReplySubmittedWithComponents(components);
+    return;
   }
+  List<J2clComposeSurfaceController.SubmittedComponent> components =
+      decodeSubmittedComponents(rawComponents);
+  listener.onReplySubmittedWithComponents(components);
 });
 ```
 
+**SPI extension** — the `J2clComposeSurfaceController.Listener` interface (controller line 55) currently declares only `void onReplySubmitted(String draft)`. We add a new method:
+
+```java
+public interface Listener {
+  // existing methods unchanged
+  void onReplySubmitted(String draft);
+  default void onReplySubmittedWithComponents(
+      List<SubmittedComponent> components) {
+    // default to plain-text fallback so test fakes keep compiling
+    StringBuilder sb = new StringBuilder();
+    for (SubmittedComponent c : components) sb.append(c.getText());
+    onReplySubmitted(sb.toString());
+  }
+}
+```
+
+The `default` keeps existing test fakes compiling without a forced rewrite, and the controller (the real listener) overrides it. Per project rule `feedback_no_legacy_fallbacks_for_flagged_features` we are NOT keeping a fallback for **flagged** behaviour — the default exists only so non-flagged callers (e.g. unit-tested fake views) keep working. The controller implementation does the real per-fragment build.
+
 **New controller method** in `J2clComposeSurfaceController.java`:
 
-- `void onReplySubmittedWithComponents(List<SubmittedComponent>)` — builds a `J2clComposerDocument` straight from the supplied components (text vs annotated), calls `submitReplyDocument(document)`. The existing single-annotation path stays as the fallback for the legacy textarea.
+- `void onReplySubmittedWithComponents(List<SubmittedComponent>)` — builds a `J2clComposerDocument` straight from the supplied components (text vs annotated), calls a new private `submitReplyDocument(document)`. The existing `submitReply` is refactored to use `submitReplyDocument` so both call sites share the success/failure plumbing; no behaviour change for the non-rich path.
 - `J2clComposerDocument.Builder` already supports annotated text, image attachments, plain text — the new method walks the supplied components and dispatches to the right builder method.
+
+**`SubmittedComponent` value type** lives next to the controller (or in `org.waveprotocol.box.j2cl.compose`):
+
+```java
+public static final class SubmittedComponent {
+  public enum Kind { TEXT, ANNOTATED }
+  private final Kind kind;
+  private final String text;
+  private final String annotationKey;
+  private final String annotationValue;
+  // … standard ctor + getters
+}
+```
 
 ### 4.D. DocOp shape (R-5.1, R-5.7)
 
 **No new schema, no new annotation keys.** The slice reuses the existing `fontWeight`/`fontStyle`/`textDecoration`/`link/manual`/`list/unordered`/`list/ordered` annotations the GWT path and `J2clRichContentDeltaFactory` already understand.
 
-The delta builder's `appendCharacters(StringBuilder builder, String text)` (line 778 of `J2clRichContentDeltaFactory`) **already uses StringBuilder** rather than fragmenting characters — this is the project-memory invariant about DocOp `characters()` calls splitting across `annotationBoundary`. We append a single `characters` op per text fragment (matching the existing path) and bracket each annotated fragment with one `annotation start` + one `annotation end`. No code-path here splits `characters()`.
+The delta builder's `appendCharacters(StringBuilder builder, String text)` **already uses StringBuilder** rather than fragmenting characters — this is the project-memory invariant about DocOp `characters()` calls splitting across `annotationBoundary`. We append a single `characters` op per text fragment (matching the existing path) and bracket each annotated fragment with one `annotation start` + one `annotation end`. No code-path here splits `characters()`.
 
 **Read path** is unchanged: `J2clRichContentRenderer` already renders `<strong>`/`<em>` etc. from these annotations on read. (Verified by inspecting the existing F-3.S2 test fixtures.)
 
@@ -167,7 +191,7 @@ New experimental flag: **`j2cl-inline-rich-composer`**, default off in prod.
 
 - Server-side: register in `KnownFeatureFlags.java` with description "Enable inline rich-text composer + selection-driven format toolbar on `/?view=j2cl-root`. When off, the legacy textarea-shaped `<composer-inline-reply>` remains the sole composer."
 - Wire in `HtmlRenderer`: emit `data-j2cl-inline-rich-composer="true"` on `<shell-root>` when the flag is enabled for the current participant (mirrors the J-UI-1 pattern).
-- Read in `J2clComposeSurfaceView`: when the attribute is absent, do not register `wave-blip-reply-requested` listeners so the legacy textarea remains the entry point. (No legacy fallback once the flag is on — per project memory `feedback_no_legacy_fallbacks_for_flagged_features`, the inline composer is the **sole** path when the flag is on; we do not keep the textarea visible alongside.)
+- Read in `J2clComposeSurfaceView` constructor (synchronously, at view construction time — not lazily — so a session that toggles the flag at runtime does not leave the listener un-bound): when the attribute is absent, do not register `wave-blip-reply-requested` listeners so the legacy textarea remains the entry point. (No legacy fallback once the flag is on — per project memory `feedback_no_legacy_fallbacks_for_flagged_features`, the inline composer is the **sole** path when the flag is on; we do not keep the textarea visible alongside.)
 
 ## 5. Files to add / modify
 
@@ -220,11 +244,14 @@ New experimental flag: **`j2cl-inline-rich-composer`**, default off in prod.
 | --- | --- |
 | `document.execCommand` is deprecated and inconsistent across browsers | Implement wrap/unwrap by hand-rolling Range manipulation rather than `execCommand`; small surface area, deterministic. |
 | Caret loss when the modal opens for the link action | Save `range = selection.getRangeAt(0).cloneRange()` before opening the modal; restore via `selection.removeAllRanges(); selection.addRange(range)` in the modal-submit handler. |
-| Flag-off path still renders the inline composer due to ordering of HTML attribute read vs view init | Read the attribute synchronously in `J2clComposeSurfaceView.<init>`; gate the body-level event listeners behind it. |
+| Flag-off path still renders the inline composer due to ordering of HTML attribute read vs view init | Read the attribute synchronously in `J2clComposeSurfaceView.<init>`; gate the body-level event listeners behind it. Listener registration is at construction time, not lazily — sessions that toggle the flag at runtime require a page reload to switch surfaces. |
 | DocOp `characters()` split across `annotationBoundary` | Already enforced by the existing `J2clRichContentDeltaFactory.appendCharacters` StringBuilder path. New annotated components reuse it without re-fragmenting. |
 | Window.alert/confirm/prompt slip in via the link modal | The modal is a Lit `<wavy-link-modal>` element with explicit Cancel/Submit buttons; no `window.*` dialogs anywhere. Verified by inspection. |
-| Selection lookup in shadow DOM differs across browsers | The composer body lives in shadow DOM; `document.getSelection()` may return collapsed selection. Use the existing `_bodyOwnsSelection` predicate which already handles this. |
+| Selection lookup in shadow DOM differs across browsers — `document.getSelection()` does not pierce shadow roots in WebKit / Firefox | Cache the live `Range` from the composer body's `selectionchange` listener (`_lastSelectionRange` set when `_bodyOwnsSelection()` is true). Toolbar handlers reach for the cached range first; fall back to `document.getSelection()` only on the Chromium happy path. Manual browser smoke on Firefox + Safari is part of QA. |
 | Race between mention-popover Enter and toolbar Enter | Existing handler already short-circuits Enter when the popover is open. Toolbar actions never bind Enter. |
+| Lit re-render clobbers the wrap tags when external `draft` writes flow through | Extend `_bodyHasRichContent()` to also match `<strong>`, `<em>`, `<u>`, `<s>`, `<a>`, `<ul>`, `<ol>`, `<blockquote>`, `<h*>`. With these tags counted as rich content, the existing guard in `_ensureBody` and `updated()` skips the textContent overwrite and the wraps survive. The controller-driven reset case (empty `draft` after submit/cancel) still clears via `_isControllerReset`. |
+| Double-fire of `wavy-format-toolbar-action` once the Java view starts listening | Each handler that consumes an action calls `event.stopPropagation()`. Actions we explicitly do not handle bubble unchanged for the existing `attachment-insert` body-level path. |
+| New `Listener.onReplySubmittedWithComponents` SPI breaks existing test fakes | The new method has a `default` implementation that delegates to `onReplySubmitted(plainText)` so existing fakes compile unchanged. The real `J2clComposeSurfaceController` overrides it. |
 
 ## 8. Roll-back path
 
@@ -245,3 +272,4 @@ No data is migrated by this slice, so revert is plain-revert with no schema undo
 - New-wave create at the wave root (J-UI-3).
 - Server-first first-paint (J-UI-8).
 - Block quote, code, font family, color — not in the matrix daily-path subset for R-5.7.
+- **Heading button (`<h*>` round-trip)** — wrap-as-bold loses the heading semantic on reload (re-reads as bold inline text, the toolbar lights Bold instead of Heading). A proper element-type round-trip needs schema work the matrix does not require for R-5.7. The toolbar still surfaces the Heading button for visual parity but the click is a no-op until a follow-up issue defines the round-trip. Filed as a TODO in the JS handler with a link back to this plan section.

--- a/docs/superpowers/plans/2026-04-28-j-ui-5-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-5-plan.md
@@ -1,0 +1,247 @@
+# J-UI-5 Plan — Inline rich-text composer + working toolbar
+
+Status: Draft, 2026-04-28
+Issue: #1083 (umbrella #1078, parent #904)
+Roadmap: docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md §3 J-UI-5
+Audit basis: docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md (R-5.1, R-5.2, R-5.7)
+Mockup: docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/03-inline-rich-text-composer.svg
+
+## 1. Goal
+
+On `?view=j2cl-root`, clicking Reply on a rendered blip opens an
+**inline contenteditable composer at that blip position**. The floating
+**selection-driven format toolbar** (bold / italic / underline / strikethrough
+/ heading / unordered-list / ordered-list / link / unlink / clear-formatting)
+applies formatting to the **active range** and reflects the current
+selection's pressed state. Submitting the reply writes a delta against
+the correct parent blip, with the formatting **round-tripped through the
+DocOp model** so that on reload the rich content reads back intact.
+
+## 2. Acceptance mapping
+
+| Issue acceptance | Matrix row | Plan slice |
+| --- | --- | --- |
+| Composer is contenteditable, not `<textarea>` | R-5.1 | §4.A — inline mount path is canonical entry point; legacy textarea-only `composer-inline-reply` becomes inert when the inline composer is open |
+| Inline composer opens at the chosen blip position | R-5.1 | §4.A — `wave-blip-reply-requested` mounts `<wavy-composer>` inside the host blip's slot, with caret survival across live updates |
+| Toolbar buttons toggle on selection and apply to the active range | R-5.2, R-5.7 | §4.B — wire `wavy-format-toolbar-action` events to a JS DOM-mutation handler on `<wavy-composer>` |
+| Reply submits to the correct parent blip and emits conversation-model ops | R-5.1 | §4.C — extend the JS→Java reply-submit boundary to forward serialized rich components |
+| State toggles mirror current selection | R-5.2 | already partially in place via `_collectActiveAnnotations`; we extend the active-annotation map for `<a>`, `<ul>`, `<ol>`, `<h1..3>` |
+| Daily-path rich-edit (lists + inline links) preserved | R-5.7 | §4.D — round-trip `list/unordered`, `list/ordered`, `link/manual` annotations through the existing `J2clComposerDocument` shape |
+| Composer is reachable, labeled, keyboard-reachable; toolbar carries roles/labels and respects pressed state | R-5.1, R-5.2 | already in place via existing aria-label / role / pressed bindings; we add `aria-pressed` honesty for non-toggle actions and a labelled `<wavy-link-modal>` for the link flow |
+
+## 3. Current state (so the slice does not duplicate)
+
+The Lit elements already exist:
+
+- `j2cl/lit/src/elements/wavy-composer.js` — contenteditable body, draft serializer, mention/task/attachment plumbing, selection descriptor emit, caret-survival contract.
+- `j2cl/lit/src/elements/wavy-format-toolbar.js` — floating toolbar; pressed state derived from `selectionDescriptor.activeAnnotations`; emits `wavy-format-toolbar-action` `{actionId, selectionDescriptor}`.
+- `j2cl/lit/src/elements/wavy-link-modal.js` — modal for the link action; emits `wavy-link-modal-submit` / `wavy-link-modal-cancel`.
+
+The Java view already mounts `<wavy-composer>` at `<wave-blip data-blip-id=…>` on `wave-blip-reply-requested` and slots a `<wavy-format-toolbar>` into it. The selection descriptor flows from composer → toolbar.
+
+**Real gaps** (verified by reading sources, not just the audit):
+
+1. **No DOM-mutation handler** for toolbar action ids except `insert-task`. Bold / Italic / Underline / Strikethrough / Heading / Unordered / Ordered / Link / Unlink / Clear-Formatting clicks bubble up but never modify the composer body, so the user sees no formatting and pressed state never lights up because the wrapping tags never appear.
+2. **No `<wavy-link-modal>` integration** — the modal element exists but no JS wires `wavy-format-toolbar-action[actionId=link]` to open it and consume `wavy-link-modal-submit`.
+3. **Submit path drops formatting**: the JS composer fires `reply-submit` carrying only the plain-text `draft`. The Java controller's `buildReplyDocument` builds an `annotatedText` with a single annotation across the whole draft based on the latest toolbar click — not per-fragment. So a selection-bold within a 100-char draft submits the whole 100 chars as bold.
+4. **Active-annotation map omits non-toggle tags**: `<a>`, `<ul>`, `<ol>`, `<h1>..<h3>` are missing from `ACTIVE_ANNOTATION_MAP` so even when DOM mutations land, the toolbar's pressed state will not fire for them.
+
+## 4. Implementation slices
+
+### 4.A. Inline composer is the canonical reply entry point (R-5.1)
+
+No code change in this slice — the existing `J2clComposeSurfaceView.openInlineComposer` already mounts `<wavy-composer>` at the originating blip when `wave-blip-reply-requested` fires, with the legacy `composer-inline-reply` left as the fallback when no inline mount target exists. Verify:
+
+- Click Reply on a rendered blip ⇒ inline composer mounts inside the `<wave-blip>` slot, caret lands inside the contenteditable body (already covered by `composer-focus-request`).
+- Reply submit ⇒ `J2clComposeSurfaceController.onReplySubmitted` ⇒ delta targets the active blip's parent. (Already wired through `submitReply`.)
+
+### 4.B. Wire toolbar actions to apply formatting to the active range (R-5.2, R-5.7)
+
+In `j2cl/lit/src/elements/wavy-composer.js`, extend `_handleToolbarAction(event)`:
+
+| actionId | DOM mutation |
+| --- | --- |
+| `bold` | toggle wrap selection in `<strong>` |
+| `italic` | toggle wrap selection in `<em>` |
+| `underline` | toggle wrap selection in `<u>` |
+| `strikethrough` | toggle wrap selection in `<s>` |
+| `heading` | wrap each selected line in `<h2>` (round-trip to text on toggle off) |
+| `unordered-list` | wrap selected lines in `<ul><li>…</li></ul>` (toggle off unwraps) |
+| `ordered-list` | wrap selected lines in `<ol><li>…</li></ol>` (toggle off unwraps) |
+| `align-left`/`-center`/`-right` | set `text-align` on the nearest block ancestor inside the composer body |
+| `rtl` | set `dir="rtl"` on the nearest block ancestor |
+| `link` | open `<wavy-link-modal>`, on submit wrap selection in `<a href=…>`; on cancel restore selection |
+| `unlink` | unwrap any `<a>` ancestor of the selection |
+| `clear-formatting` | flatten formatting tags inside the selection (strip `<strong>`, `<em>`, `<u>`, `<s>`, `<a>`, headings, list wrappers) |
+| `attachment-insert` | already routed through the view path; unchanged |
+| `insert-task` | unchanged |
+
+**Toggle semantics**: the wrap helper checks whether the selection is already inside the matching tag; if so, unwrap; otherwise wrap. This is what makes pressed state honest (the tag walk in `_collectActiveAnnotations` lights the button only when the selection is already inside the corresponding tag).
+
+**Selection preservation**: each handler captures the live `Range` before any DOM mutation, performs the wrap/unwrap, then restores selection to the new content boundary so subsequent toolbar clicks chain correctly. The existing `<wavy-composer>` already declines to overwrite the body's `textContent` when it owns selection (see `_bodyOwnsSelection`), so the mutations are not clobbered by Lit re-renders.
+
+**Active-annotation map extension** in `wavy-format-toolbar.js`:
+
+```js
+const ACTIVE_ANNOTATION_MAP = {
+  bold: ["strong", "b"],
+  italic: ["em", "i"],
+  underline: ["u"],
+  strikethrough: ["s", "strike", "del"],
+  "unordered-list": ["ul"],
+  "ordered-list": ["ol"],
+  link: ["a"],
+  unlink: [],          // non-toggle but lights when selection sits in <a>
+  heading: ["h1", "h2", "h3", "h4"],
+  // … unchanged for align / rtl / clear / insert-task / attachment-insert
+};
+```
+
+`unlink` flips to "lights when selection is in `<a>`" — not toggleable, but `_isActionActive` short-circuits when `toggle=false`, so the visual contract here is that link/unlink share the same lit indication that the selection is inside an `<a>`.
+
+### 4.C. JS→Java reply-submit boundary carries rich components (R-5.1, R-5.7)
+
+**Why**: today `event.detail.value` is plain text only. Without per-fragment formatting on the wire, the Java controller cannot build the right `J2clComposerDocument` and bold-on-selection collapses to bold-everything (or no-bold) at submit.
+
+**Change in `wavy-composer.js`**:
+
+```js
+_submit() {
+  this.dispatchEvent(new CustomEvent("reply-submit", {
+    detail: {
+      value: this.draft,
+      components: this.serializeRichComponents(),  // already exists
+      replyTargetBlipId: this.replyTargetBlipId,
+      mode: this.mode,
+    },
+    bubbles: true,
+    composed: true,
+  }));
+}
+```
+
+**Extend `serializeRichComponents`** to recognise the new wrap tags:
+
+| Tag | Emitted component |
+| --- | --- |
+| `<strong>` / `<b>` | `{type: "annotated", annotationKey: "fontWeight", annotationValue: "bold", text}` |
+| `<em>` / `<i>` | `{type: "annotated", annotationKey: "fontStyle", annotationValue: "italic", text}` |
+| `<u>` | `{type: "annotated", annotationKey: "textDecoration", annotationValue: "underline", text}` |
+| `<s>` / `<strike>` / `<del>` | `{type: "annotated", annotationKey: "textDecoration", annotationValue: "line-through", text}` |
+| `<h1>..<h3>` | `{type: "annotated", annotationKey: "fontWeight", annotationValue: "bold", text}` followed by a TEXT newline (heading visual stays in the composer; the model carries a bold run) — keeps R-5.7 limited to lists+links round-trip without inventing a heading element-type the GWT reader doesn't know |
+| `<a href=…>` | already emits `link/manual` (existing) |
+| `<ul>`/`<ol>` | already emits `list/unordered` / `list/ordered` (existing) |
+| nested combinations | walk children recursively (existing pattern in S4 list helpers) |
+
+**Java side** in `J2clComposeSurfaceView.java`:
+
+```java
+composer.addEventListener("reply-submit", event -> {
+  if (listener == null) return;
+  List<J2clComposeSurfaceController.SubmittedComponent> components =
+      readComponents(event); // null/empty when the event came from the legacy textarea
+  if (components == null || components.isEmpty()) {
+    listener.onReplySubmitted(propertyString(composer, "draft"));
+  } else {
+    listener.onReplySubmittedWithComponents(components);
+  }
+});
+```
+
+**New controller method** in `J2clComposeSurfaceController.java`:
+
+- `void onReplySubmittedWithComponents(List<SubmittedComponent>)` — builds a `J2clComposerDocument` straight from the supplied components (text vs annotated), calls `submitReplyDocument(document)`. The existing single-annotation path stays as the fallback for the legacy textarea.
+- `J2clComposerDocument.Builder` already supports annotated text, image attachments, plain text — the new method walks the supplied components and dispatches to the right builder method.
+
+### 4.D. DocOp shape (R-5.1, R-5.7)
+
+**No new schema, no new annotation keys.** The slice reuses the existing `fontWeight`/`fontStyle`/`textDecoration`/`link/manual`/`list/unordered`/`list/ordered` annotations the GWT path and `J2clRichContentDeltaFactory` already understand.
+
+The delta builder's `appendCharacters(StringBuilder builder, String text)` (line 778 of `J2clRichContentDeltaFactory`) **already uses StringBuilder** rather than fragmenting characters — this is the project-memory invariant about DocOp `characters()` calls splitting across `annotationBoundary`. We append a single `characters` op per text fragment (matching the existing path) and bracket each annotated fragment with one `annotation start` + one `annotation end`. No code-path here splits `characters()`.
+
+**Read path** is unchanged: `J2clRichContentRenderer` already renders `<strong>`/`<em>` etc. from these annotations on read. (Verified by inspecting the existing F-3.S2 test fixtures.)
+
+### 4.E. Feature flag
+
+New experimental flag: **`j2cl-inline-rich-composer`**, default off in prod.
+
+- Server-side: register in `KnownFeatureFlags.java` with description "Enable inline rich-text composer + selection-driven format toolbar on `/?view=j2cl-root`. When off, the legacy textarea-shaped `<composer-inline-reply>` remains the sole composer."
+- Wire in `HtmlRenderer`: emit `data-j2cl-inline-rich-composer="true"` on `<shell-root>` when the flag is enabled for the current participant (mirrors the J-UI-1 pattern).
+- Read in `J2clComposeSurfaceView`: when the attribute is absent, do not register `wave-blip-reply-requested` listeners so the legacy textarea remains the entry point. (No legacy fallback once the flag is on — per project memory `feedback_no_legacy_fallbacks_for_flagged_features`, the inline composer is the **sole** path when the flag is on; we do not keep the textarea visible alongside.)
+
+## 5. Files to add / modify
+
+### Modify
+
+- `j2cl/lit/src/elements/wavy-composer.js` — extend `_handleToolbarAction`, extend `serializeRichComponents`, extend `_submit` to carry `components`.
+- `j2cl/lit/src/elements/wavy-format-toolbar.js` — extend `ACTIVE_ANNOTATION_MAP` with `link`, `heading`, list keys (some already present).
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java` — read `event.detail.components` from the composer's `reply-submit`; invoke the new controller method when present; gate the inline-composer mount on the flag attribute.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java` — add `onReplySubmittedWithComponents(List<SubmittedComponent>)` and a small `SubmittedComponent` value type; refactor `submitReply` to call into a new `submitReplyDocument(document)` so both call sites share the success/failure plumbing.
+- `wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java` — register `j2cl-inline-rich-composer`.
+- `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java` — emit `data-j2cl-inline-rich-composer` attribute on `<shell-root>`.
+- `wave/config/changelog.d/2026-04-28-issue-1083-j-ui-5.json` — changelog fragment.
+
+### Add
+
+- `j2cl/lit/test/wavy-composer-toolbar-actions.test.js` — new file. Per-action unit tests: applies wrap, toggles off, link modal flow, clear-formatting, list wrap, pressed state lights from selection.
+- `j2cl/lit/test/wavy-composer-rich-submit.test.js` — new file. `reply-submit` carries `components` array reflecting the body's annotated runs (parametrised over the listed actions).
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerRichSubmitTest.java` — new file. Verifies `onReplySubmittedWithComponents` builds the right `J2clComposerDocument` and the produced delta carries the expected annotation start/end markers (uses the existing `J2clRichContentDeltaFactoryTest` style).
+- `j2cl/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clInlineRichComposerParityTest.java` — new file. Hits `/?view=j2cl-root` with the flag on/off and asserts the SSR emits `data-j2cl-inline-rich-composer` only when on.
+
+## 6. Test plan
+
+### Unit
+- `cd wave && sbt compile` — must pass.
+- `cd wave && sbt test` (Jakarta path) — must pass.
+- `j2cl/lit` tests via the existing wtr / vitest harness — new files added, all existing files green.
+
+### Browser harness fixture
+- Extend the existing parity fixture (the one wired in PR #1066/#1077) with a J-UI-5 case: open the inline composer, exercise bold/list/link, assert the rendered DOM has the wrap tags AND the `wavy-composer` `serializeRichComponents()` output matches expectation.
+
+### Local-server verification (mandatory per project rule `feedback_local_server_verification_before_pr`)
+1. `cd wave && sbt compile`.
+2. `cd wave && sbt run` (or whatever the dev-run command is for this repo — confirm at execution).
+3. Register a fresh user (do **not** assume `vega` exists, per `feedback_local_registration_before_login_testing`).
+4. Enable the flag for that participant: `scripts/feature-flag.sh enable j2cl-inline-rich-composer --user <addr>` (uses the local URL).
+5. Seed a wave with a second account so a reply target blip exists.
+6. Sign back in as the test user; navigate to `?view=j2cl-root`; open the wave; click Reply on a blip.
+7. Confirm: inline composer mounts at the blip (not at the bottom). Type some text. Select a word; click Bold. Body wraps in `<strong>`; toolbar Bold lights up.
+8. Add a list; insert a heading; insert a link via the link modal. Confirm visual rendering and toolbar pressed-state mirror.
+9. Submit the reply. Confirm it appears as a child blip of the correct parent (not a sibling at wave root).
+10. Reload the page. Confirm the formatting round-tripped (bold/italic/list/link survive).
+11. Test edge cases: empty draft on submit (Send disabled); selection lost mid-modal cancel restores caret; Esc closes modal without writing.
+12. Sign-out / sign-in cycle preserves the flag.
+13. **GWT path unaffected**: open `?view=gwt`, exercise reply, verify nothing about this slice has bled into the GWT compose surface.
+14. Take screenshots: (a) inline composer open at a blip with toolbar visible, (b) toolbar pressed-state mirroring a selection, (c) submitted formatted reply rendered post-reload. Save to `docs/superpowers/screenshots/j-ui-5/`.
+
+## 7. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `document.execCommand` is deprecated and inconsistent across browsers | Implement wrap/unwrap by hand-rolling Range manipulation rather than `execCommand`; small surface area, deterministic. |
+| Caret loss when the modal opens for the link action | Save `range = selection.getRangeAt(0).cloneRange()` before opening the modal; restore via `selection.removeAllRanges(); selection.addRange(range)` in the modal-submit handler. |
+| Flag-off path still renders the inline composer due to ordering of HTML attribute read vs view init | Read the attribute synchronously in `J2clComposeSurfaceView.<init>`; gate the body-level event listeners behind it. |
+| DocOp `characters()` split across `annotationBoundary` | Already enforced by the existing `J2clRichContentDeltaFactory.appendCharacters` StringBuilder path. New annotated components reuse it without re-fragmenting. |
+| Window.alert/confirm/prompt slip in via the link modal | The modal is a Lit `<wavy-link-modal>` element with explicit Cancel/Submit buttons; no `window.*` dialogs anywhere. Verified by inspection. |
+| Selection lookup in shadow DOM differs across browsers | The composer body lives in shadow DOM; `document.getSelection()` may return collapsed selection. Use the existing `_bodyOwnsSelection` predicate which already handles this. |
+| Race between mention-popover Enter and toolbar Enter | Existing handler already short-circuits Enter when the popover is open. Toolbar actions never bind Enter. |
+
+## 8. Roll-back path
+
+The flag-off path leaves the legacy textarea-only `<composer-inline-reply>` as the sole composer (mounted in the reply host) — the existing fallback the controller uses today. Disabling `j2cl-inline-rich-composer` reverts behaviour to the pre-slice state without code revert. If a code revert is required, reverting the slice's PR drops:
+
+- the new toolbar action handlers (no-op on revert; toolbar buttons go back to no-op clicks)
+- the reply-submit `components` payload (the Java view falls through to the plain-text path)
+- the controller's `onReplySubmittedWithComponents` method
+- the flag entry
+
+No data is migrated by this slice, so revert is plain-revert with no schema undo.
+
+## 9. Out of scope for this slice
+
+- Mentions autocomplete (F-3 follow-up, already shipped).
+- Reactions, attachments inline rendering (F-3 closeouts, already shipped).
+- Per-blip task toggle (J-UI-6).
+- New-wave create at the wave root (J-UI-3).
+- Server-first first-paint (J-UI-8).
+- Block quote, code, font family, color — not in the matrix daily-path subset for R-5.7.

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -13,6 +13,22 @@ import "./wavy-link-modal.js";
  * `J2clComposeSurfaceController.java` so the JS submit emits exactly
  * what the Java side maps from a toolbar-action click today.
  */
+/**
+ * J-UI-5 (#1083): defense-in-depth href scheme validator. Allows the
+ * same scheme set the `<wavy-link-modal>` validates against
+ * (http/https/mailto) plus relative URLs (no scheme). Rejects any
+ * scheme that can carry script (javascript:, data:, vbscript:, file:).
+ */
+function isSafeLinkHref(url) {
+  if (!url || typeof url !== "string") return false;
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  // Relative URL — no scheme prefix.
+  if (!/^[a-zA-Z][a-zA-Z0-9+.\-]*:/.test(trimmed)) return true;
+  const scheme = trimmed.slice(0, trimmed.indexOf(":")).toLowerCase();
+  return scheme === "http" || scheme === "https" || scheme === "mailto";
+}
+
 function inlineFormatAnnotation(tag) {
   switch (tag) {
     case "strong":
@@ -327,6 +343,12 @@ export class WavyComposer extends LitElement {
     this.removeEventListener("composer-focus-request", this._handleFocusRequest);
     document.removeEventListener("selectionchange", this._handleSelectionChange);
     this.removeEventListener("wavy-format-toolbar-action", this._handleToolbarAction);
+    // J-UI-5 (#1083): drop our per-composer link modal so it does not
+    // outlive the composer host (avoids a body-level orphan node).
+    if (this._linkModalElement && this._linkModalElement.isConnected) {
+      this._linkModalElement.parentNode.removeChild(this._linkModalElement);
+    }
+    this._linkModalElement = null;
     super.disconnectedCallback();
   }
 
@@ -364,12 +386,16 @@ export class WavyComposer extends LitElement {
       actionId === "align-right"
     ) {
       const align = actionId === "align-left" ? "left" : actionId === "align-center" ? "center" : "right";
-      this._setBlockAttributeAtSelection("style", `text-align: ${align};`);
+      this._applyBlockStyleAtSelection((block) => {
+        block.style.textAlign = align;
+      });
       event.stopPropagation();
       return;
     }
     if (actionId === "rtl") {
-      this._setBlockAttributeAtSelection("dir", "rtl");
+      this._applyBlockStyleAtSelection((block) => {
+        block.dir = "rtl";
+      });
       event.stopPropagation();
       return;
     }
@@ -513,15 +539,18 @@ export class WavyComposer extends LitElement {
     this._afterBodyMutation();
   }
 
-  _setBlockAttributeAtSelection(attrName, attrValue) {
+  /**
+   * J-UI-5 (#1083, R-5.7): apply a style mutation to the block-level
+   * ancestor of the active range without clobbering pre-existing inline
+   * style. Wraps in a fresh `<div>` when no block ancestor exists.
+   */
+  _applyBlockStyleAtSelection(applyFn) {
     if (!this._bodyElement) return;
     const range = this._activeRange();
     if (!range) return;
     if (!this._bodyElement.contains(range.startContainer)) return;
     let block = this._findAncestorTag(range.startContainer, ["div", "p", "li", "blockquote"]);
     if (!block) {
-      // Wrap the active range's containing line in a <div> so the
-      // alignment/dir attribute has somewhere to land.
       block = document.createElement("div");
       try {
         block.appendChild(range.extractContents());
@@ -530,7 +559,11 @@ export class WavyComposer extends LitElement {
         return;
       }
     }
-    block.setAttribute(attrName, attrValue);
+    try {
+      applyFn(block);
+    } catch (_e) {
+      return;
+    }
     this._afterBodyMutation();
   }
 
@@ -551,11 +584,16 @@ export class WavyComposer extends LitElement {
     } catch (_e) {
       preselectedDisplay = "";
     }
-    let modal = document.querySelector("wavy-link-modal[data-j2cl-link-modal=\"true\"]");
-    if (!modal) {
+    // J-UI-5 (#1083): each composer owns its own link modal so that
+    // two composers (wave-root + inline reply) opened simultaneously
+    // never share a modal node — sharing would mean their independent
+    // submit / cancel listeners fire against each other.
+    let modal = this._linkModalElement;
+    if (!modal || !modal.isConnected) {
       modal = document.createElement("wavy-link-modal");
       modal.setAttribute("data-j2cl-link-modal", "true");
       document.body.appendChild(modal);
+      this._linkModalElement = modal;
     }
     modal.urlValue = "";
     modal.displayValue = preselectedDisplay;
@@ -583,8 +621,19 @@ export class WavyComposer extends LitElement {
   _wrapRangeInLink(range, url, displayText) {
     if (!this._bodyElement) return;
     if (!this._bodyElement.contains(range.startContainer)) return;
+    // J-UI-5 (#1083): defense in depth. The wavy-link-modal already
+    // validates the URL scheme, but the wrap helper is also reachable
+    // by any consumer dispatching `wavy-link-modal-submit` directly,
+    // so re-check here. Reject `javascript:` / `data:` / `vbscript:`
+    // URLs so a misbehaving caller cannot inject script-bearing hrefs.
+    if (!isSafeLinkHref(url)) return;
     const anchor = document.createElement("a");
     anchor.setAttribute("href", url);
+    // External-link safety defaults: open in same tab, drop the
+    // referrer/window-opener handle when the user clicks. Composer
+    // anchors do not need a target attribute, but rel hardens the
+    // default behaviour for any future caller that adds one.
+    anchor.setAttribute("rel", "noopener noreferrer");
     if (displayText && range.collapsed) {
       anchor.textContent = displayText;
     } else {
@@ -620,8 +669,13 @@ export class WavyComposer extends LitElement {
    * J-UI-5 (#1083, R-5.7): flatten formatting tags inside the active
    * range so the user can recover plain text. Strips the formatting
    * wraps we know about (`<strong>`, `<em>`, `<u>`, `<s>`, `<a>`,
-   * `<ul>`, `<ol>`, `<li>`, `<blockquote>`). Mention chips are left
-   * intact — they are semantic, not visual formatting.
+   * `<ul>`, `<ol>`, `<li>`, `<blockquote>`) **only inside the selected
+   * range**. Mention chips are left intact — they are semantic, not
+   * visual formatting.
+   *
+   * Scoping the strip to the range matters: a user clicking
+   * "Clear formatting" with one bold word selected must not erase
+   * every other formatted run elsewhere in the body.
    */
   _clearFormattingAtSelection() {
     if (!this._bodyElement) return;
@@ -647,27 +701,15 @@ export class WavyComposer extends LitElement {
       "h3",
       "h4"
     ]);
-    let container = range.commonAncestorContainer;
-    if (container.nodeType === Node.TEXT_NODE) {
-      container = container.parentNode;
-    }
-    while (container && container !== this._bodyElement) {
-      const tag = container.tagName ? container.tagName.toLowerCase() : "";
-      if (tagsToFlatten.has(tag)) {
-        // Pull container's text out and replace the container.
-        const parent = container.parentNode;
-        if (!parent) break;
-        const text = document.createTextNode(container.textContent || "");
-        parent.replaceChild(text, container);
-        container = text.parentNode;
-        continue;
-      }
-      container = container.parentNode;
-    }
-    // Now walk descendants of the common ancestor and flatten any
-    // remaining wraps inside the original range. Use a fresh tree
-    // walker over the body and strip any matching tag whose entire
-    // contents lie inside the original range bounds.
+    // Walk descendants of the body and unwrap matching tags whose
+    // tree intersects the active range. `Range.intersectsNode` returns
+    // true when any part of the candidate's subtree overlaps the
+    // selection, which matches the user expectation that selecting one
+    // bold word and clearing scopes the strip to that word's wrap +
+    // any wrap entirely inside the selection. Wraps that strictly
+    // contain the selection (e.g. a list whose items wholly enclose
+    // the range) are also unwrapped so the user can drop list
+    // membership for the selected lines.
     const walker = document.createTreeWalker(this._bodyElement, NodeFilter.SHOW_ELEMENT, null);
     const stripCandidates = [];
     let node = walker.currentNode;
@@ -675,8 +717,18 @@ export class WavyComposer extends LitElement {
       const tag = node.tagName ? node.tagName.toLowerCase() : "";
       if (!tagsToFlatten.has(tag)) continue;
       if (node.classList && node.classList.contains("wavy-mention-chip")) continue;
+      let intersects = false;
+      try {
+        intersects = range.intersectsNode(node);
+      } catch (_e) {
+        intersects = false;
+      }
+      if (!intersects) continue;
       stripCandidates.push(node);
     }
+    // Unwrap children-first so an outer wrap's children migrate cleanly
+    // (otherwise the outer unwrap orphans inner candidates).
+    stripCandidates.reverse();
     for (const candidate of stripCandidates) {
       this._unwrapElement(candidate);
     }

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -682,7 +682,13 @@ export class WavyComposer extends LitElement {
     } catch (_e) {
       return;
     }
-    const insertSiblingsBefore = (target, frag, wrapTagName) => {
+    // Codex review #1095 thread PRRT_kwDOBwxLXs5-NWWt: prefix/suffix
+    // wrappers must clone the original ancestor's attributes (most
+    // importantly `href` on `<a>`) so unlinking inside a longer link
+    // keeps the surrounding text linked. `cloneNode(false)` clones
+    // the element + its attributes WITHOUT children; we then move
+    // the prefix/suffix fragment children into the clone.
+    const insertSiblingsBefore = (target, frag, wrapTemplate) => {
       // Skip empty fragments — happens when the selection starts at
       // offset 0 (no prefix) or covers the ancestor's last char (no
       // suffix). cloneContents can also produce a fragment that holds
@@ -692,8 +698,8 @@ export class WavyComposer extends LitElement {
       const text = frag.textContent || "";
       const hasElementChild = Boolean(frag.querySelector && frag.querySelector("*"));
       if (text.length === 0 && !hasElementChild) return null;
-      if (wrapTagName) {
-        const wrapper = document.createElement(wrapTagName);
+      if (wrapTemplate) {
+        const wrapper = wrapTemplate.cloneNode(false);
         wrapper.appendChild(frag);
         parent.insertBefore(wrapper, target);
         return wrapper;
@@ -703,16 +709,11 @@ export class WavyComposer extends LitElement {
       while (frag.firstChild) parent.insertBefore(frag.firstChild, target);
       return null;
     };
-    insertSiblingsBefore(ancestor, prefixFragment, ancestor.tagName.toLowerCase());
+    insertSiblingsBefore(ancestor, prefixFragment, ancestor);
     const middleAnchor = ancestor;
     insertSiblingsBefore(middleAnchor, middleFragment, null);
-    insertSiblingsBefore(ancestor, suffixFragment, ancestor.tagName.toLowerCase());
+    insertSiblingsBefore(ancestor, suffixFragment, ancestor);
     parent.removeChild(ancestor);
-    // `spec` is currently unused but kept on the call site for
-    // future tag-specific behaviour (e.g. retaining link href on
-    // `<a>` partial unwrap should preserve href on the prefix +
-    // suffix clones, which `cloneNode` handles via createElement
-    // matching the original tagName).
     void spec;
   }
 
@@ -915,7 +916,18 @@ export class WavyComposer extends LitElement {
     if (!this._bodyElement.contains(range.startContainer)) return;
     const anchor = this._findAncestorTag(range.startContainer, ["a"]);
     if (!anchor) return;
-    this._unwrapElement(anchor);
+    // Codex review #1095 thread PRRT_kwDOBwxLXs5-NWWt: partial-range
+    // unlink must SPLIT the `<a>` so text outside the selection
+    // keeps its link. The split helper clones the ancestor's
+    // attributes (href included) onto the prefix + suffix clones,
+    // so the surrounding linked text survives intact. When the
+    // selection covers the whole anchor, fall back to a plain
+    // unwrap (cheaper, identical DOM result).
+    if (rangeFullyContainsNode(range, anchor)) {
+      this._unwrapElement(anchor);
+    } else {
+      this._unwrapAncestorWithinRange(anchor, range, null);
+    }
     this._afterBodyMutation();
   }
 

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -19,6 +19,30 @@ import "./wavy-link-modal.js";
  * (http/https/mailto) plus relative URLs (no scheme). Rejects any
  * scheme that can carry script (javascript:, data:, vbscript:, file:).
  */
+/**
+ * J-UI-5 (#1083, codex review thread PRRT_kwDOBwxLXs5-C84T):
+ * returns true when the supplied DOM node sits entirely within the
+ * range (range.start ≤ node.start AND range.end ≥ node.end). Used by
+ * `_clearFormattingAtSelection` to decide whether a container tag
+ * (`<ul>`, `<ol>`, `<li>`, `<blockquote>`) should be unwrapped — only
+ * when the user's selection covers the whole container, never when
+ * one sibling item is selected and the rest would lose formatting.
+ */
+function rangeFullyContainsNode(range, node) {
+  if (!range || !node) return false;
+  try {
+    const nodeRange = document.createRange();
+    nodeRange.selectNode(node);
+    const startsBefore =
+        range.compareBoundaryPoints(Range.START_TO_START, nodeRange) <= 0;
+    const endsAfter =
+        range.compareBoundaryPoints(Range.END_TO_END, nodeRange) >= 0;
+    return startsBefore && endsAfter;
+  } catch (_e) {
+    return false;
+  }
+}
+
 function isSafeLinkHref(url) {
   if (!url || typeof url !== "string") return false;
   const trimmed = url.trim();
@@ -380,23 +404,20 @@ export class WavyComposer extends LitElement {
       event.stopPropagation();
       return;
     }
+    // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84X):
+    // align-* and rtl have no submit-pipeline serialization in this
+    // slice — applying the DOM mutation locally would make the
+    // alignment / direction *appear* to take effect but get silently
+    // dropped on submit/reload. Leave the click as a no-op (no DOM
+    // mutation, no stopPropagation) so the action bubbles to a
+    // listener that can surface "unavailable" status. Filed alongside
+    // the heading button as an out-of-scope follow-up in plan §9.
     if (
       actionId === "align-left" ||
       actionId === "align-center" ||
-      actionId === "align-right"
+      actionId === "align-right" ||
+      actionId === "rtl"
     ) {
-      const align = actionId === "align-left" ? "left" : actionId === "align-center" ? "center" : "right";
-      this._applyBlockStyleAtSelection((block) => {
-        block.style.textAlign = align;
-      });
-      event.stopPropagation();
-      return;
-    }
-    if (actionId === "rtl") {
-      this._applyBlockStyleAtSelection((block) => {
-        block.dir = "rtl";
-      });
-      event.stopPropagation();
       return;
     }
     if (actionId === "link") {
@@ -540,34 +561,6 @@ export class WavyComposer extends LitElement {
   }
 
   /**
-   * J-UI-5 (#1083, R-5.7): apply a style mutation to the block-level
-   * ancestor of the active range without clobbering pre-existing inline
-   * style. Wraps in a fresh `<div>` when no block ancestor exists.
-   */
-  _applyBlockStyleAtSelection(applyFn) {
-    if (!this._bodyElement) return;
-    const range = this._activeRange();
-    if (!range) return;
-    if (!this._bodyElement.contains(range.startContainer)) return;
-    let block = this._findAncestorTag(range.startContainer, ["div", "p", "li", "blockquote"]);
-    if (!block) {
-      block = document.createElement("div");
-      try {
-        block.appendChild(range.extractContents());
-        range.insertNode(block);
-      } catch (_e) {
-        return;
-      }
-    }
-    try {
-      applyFn(block);
-    } catch (_e) {
-      return;
-    }
-    this._afterBodyMutation();
-  }
-
-  /**
    * J-UI-5 (#1083, R-5.7): open the existing `<wavy-link-modal>` to
    * collect a URL, then wrap the active range in `<a href=…>`. The
    * range is captured before the modal opens so caret/selection
@@ -682,7 +675,19 @@ export class WavyComposer extends LitElement {
     const range = this._activeRange();
     if (!range) return;
     if (!this._bodyElement.contains(range.startContainer)) return;
-    const tagsToFlatten = new Set([
+    // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84T):
+    // inline wraps (bold/italic/underline/strike/link/headings) are
+    // unwrapped when they intersect the selection — selecting the
+    // middle of a bold word and clearing should drop bold from the
+    // whole wrap, matching the intuitive "remove formatting from this
+    // text" expectation.
+    //
+    // Container wraps (`ul`, `ol`, `li`, `blockquote`) are different:
+    // unwrapping a `<ul>` because the user selected ONE `<li>`
+    // strips list membership from sibling items the user did not
+    // touch. Only unwrap a container when the entire container's
+    // tree is inside the selection.
+    const inlineTags = new Set([
       "strong",
       "b",
       "em",
@@ -692,38 +697,32 @@ export class WavyComposer extends LitElement {
       "strike",
       "del",
       "a",
-      "ul",
-      "ol",
-      "li",
-      "blockquote",
       "h1",
       "h2",
       "h3",
       "h4"
     ]);
-    // Walk descendants of the body and unwrap matching tags whose
-    // tree intersects the active range. `Range.intersectsNode` returns
-    // true when any part of the candidate's subtree overlaps the
-    // selection, which matches the user expectation that selecting one
-    // bold word and clearing scopes the strip to that word's wrap +
-    // any wrap entirely inside the selection. Wraps that strictly
-    // contain the selection (e.g. a list whose items wholly enclose
-    // the range) are also unwrapped so the user can drop list
-    // membership for the selected lines.
+    const containerTags = new Set(["ul", "ol", "li", "blockquote"]);
     const walker = document.createTreeWalker(this._bodyElement, NodeFilter.SHOW_ELEMENT, null);
     const stripCandidates = [];
     let node = walker.currentNode;
     while ((node = walker.nextNode())) {
       const tag = node.tagName ? node.tagName.toLowerCase() : "";
-      if (!tagsToFlatten.has(tag)) continue;
+      const isInline = inlineTags.has(tag);
+      const isContainer = containerTags.has(tag);
+      if (!isInline && !isContainer) continue;
       if (node.classList && node.classList.contains("wavy-mention-chip")) continue;
-      let intersects = false;
       try {
-        intersects = range.intersectsNode(node);
+        if (!range.intersectsNode(node)) continue;
       } catch (_e) {
-        intersects = false;
+        continue;
       }
-      if (!intersects) continue;
+      if (isContainer && !rangeFullyContainsNode(range, node)) {
+        // Container only partially covered — sibling items would lose
+        // formatting if we unwrap. Skip and let the user clear
+        // per-item by widening the selection.
+        continue;
+      }
       stripCandidates.push(node);
     }
     // Unwrap children-first so an outer wrap's children migrate cleanly
@@ -1204,8 +1203,10 @@ export class WavyComposer extends LitElement {
         // recursively so that nested formatting (e.g. <strong><em>...
         // </em></strong>) and chips inside formatted text survive
         // round-trip. Plain text inside the wrap is promoted to the
-        // matching annotation; rich components inside the wrap flow
-        // through unchanged.
+        // matching annotation; pre-annotated children carry the inner
+        // annotation in their `annotations` list and we *append* the
+        // outer annotation to that list so the combined run round-trips
+        // (codex review #1095 thread PRRT_kwDOBwxLXs5-C84a).
         const inlineAnnotation = inlineFormatAnnotation(tag);
         if (inlineAnnotation) {
           flushText();
@@ -1222,7 +1223,30 @@ export class WavyComposer extends LitElement {
                 type: "annotated",
                 text: c.text,
                 annotationKey: inlineAnnotation.key,
-                annotationValue: inlineAnnotation.value
+                annotationValue: inlineAnnotation.value,
+                annotations: [
+                  { key: inlineAnnotation.key, value: inlineAnnotation.value }
+                ]
+              });
+            } else if (c.type === "annotated") {
+              // Compose the outer annotation with whatever the inner
+              // walk already attached (italic / link / list / etc.).
+              const inner = Array.isArray(c.annotations) && c.annotations.length > 0
+                ? c.annotations.slice()
+                : [{ key: c.annotationKey, value: c.annotationValue }];
+              const merged = inner.concat([
+                { key: inlineAnnotation.key, value: inlineAnnotation.value }
+              ]);
+              components.push({
+                type: "annotated",
+                text: c.text,
+                // Singular `annotationKey`/`annotationValue` mirror the
+                // first annotation for backward-compatible consumers
+                // that read the legacy fields. Multi-annotation aware
+                // consumers walk the `annotations` array.
+                annotationKey: merged[0].key,
+                annotationValue: merged[0].value,
+                annotations: merged
               });
             } else {
               components.push(c);

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -1244,29 +1244,73 @@ export class WavyComposer extends LitElement {
     if (!this._bodyElement) return "";
     // Walk immediate child nodes to capture newlines that contenteditable
     // adds as <div> wrappers per-line (Enter key) or <br> nodes.
-    let text = "";
-    for (const node of this._bodyElement.childNodes) {
-      if (node.nodeType === Node.TEXT_NODE) {
-        text += node.textContent;
-      } else if (node.nodeType === Node.ELEMENT_NODE) {
+    //
+    // Coderabbit review #1095 thread PRRT_kwDOBwxLXs5-NWWy: list and
+    // blockquote containers must emit explicit `\n` separators between
+    // their block children. Without this, `<ul><li>a</li><li>b</li></ul>`
+    // serialised as `ab` in the draft preview while the DocOp submit
+    // path sees them as separate runs — the preview no longer matched
+    // the submitted content. Mirror the structure DocOp serialization
+    // uses by handling `<ul>` / `<ol>` (newline-separated `<li>`s)
+    // and `<blockquote>` (newline-separated block children) inline.
+    const out = { text: "" };
+    const ensureLineBreak = () => {
+      if (out.text.length > 0 && !out.text.endsWith("\n")) {
+        out.text += "\n";
+      }
+    };
+    const walk = (parent) => {
+      for (const node of parent.childNodes) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          out.text += node.textContent;
+          continue;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) continue;
         const tag = node.tagName.toLowerCase();
         if (tag === "br") {
-          text += "\n";
-        } else if (tag === "div" || tag === "p") {
-          if (text.length > 0 && !text.endsWith("\n")) text += "\n";
-          text += node.textContent;
-        } else {
-          // F-3.S2 (#1038, R-5.3 step 4): mention chip spans are
-          // contenteditable=false; their textContent is "@<displayName>"
-          // which we want in the textual draft view so consumers see
-          // the right preview. The rich serializer below
-          // (_serializeBodyComponents) emits a separate annotation
-          // component for the same chip on submit.
-          text += node.textContent;
+          out.text += "\n";
+          continue;
         }
+        if (tag === "div" || tag === "p" || tag === "h1" || tag === "h2" || tag === "h3" || tag === "h4") {
+          ensureLineBreak();
+          walk(node);
+          continue;
+        }
+        if (tag === "ul" || tag === "ol") {
+          ensureLineBreak();
+          let firstItem = true;
+          for (const child of node.childNodes) {
+            if (
+              child.nodeType === Node.ELEMENT_NODE &&
+              child.tagName.toLowerCase() === "li"
+            ) {
+              if (!firstItem) ensureLineBreak();
+              walk(child);
+              firstItem = false;
+            }
+          }
+          ensureLineBreak();
+          continue;
+        }
+        if (tag === "blockquote") {
+          ensureLineBreak();
+          // Walk children; nested block boundaries inside the quote
+          // emit their own separators via the cases above.
+          walk(node);
+          ensureLineBreak();
+          continue;
+        }
+        // F-3.S2 (#1038, R-5.3 step 4): mention chip spans are
+        // contenteditable=false; their textContent is "@<displayName>"
+        // which we want in the textual draft view so consumers see
+        // the right preview. The rich serializer below
+        // (_serializeBodyComponents) emits a separate annotation
+        // component for the same chip on submit.
+        out.text += node.textContent;
       }
-    }
-    return text;
+    };
+    walk(this._bodyElement);
+    return out.text;
   }
 
   /**

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -3,6 +3,34 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import "../design/wavy-compose-card.js";
 import "./composer-submit-affordance.js";
 import "./mention-suggestion-popover.js";
+import "./wavy-link-modal.js";
+
+/**
+ * J-UI-5 (#1083, R-5.7): map inline-format wrap tags to the
+ * `J2clComposeSurfaceController.annotationKey/annotationValue` pairs
+ * the GWT/J2CL read codec already understands. The keys here mirror
+ * the static helpers at lines 2002–2030 of
+ * `J2clComposeSurfaceController.java` so the JS submit emits exactly
+ * what the Java side maps from a toolbar-action click today.
+ */
+function inlineFormatAnnotation(tag) {
+  switch (tag) {
+    case "strong":
+    case "b":
+      return { key: "fontWeight", value: "bold" };
+    case "em":
+    case "i":
+      return { key: "fontStyle", value: "italic" };
+    case "u":
+      return { key: "textDecoration", value: "underline" };
+    case "s":
+    case "strike":
+    case "del":
+      return { key: "textDecoration", value: "line-through" };
+    default:
+      return null;
+  }
+}
 
 /**
  * <wavy-composer> — F-3.S1 (#1038, R-5.1 + R-5.2) inline rich-text
@@ -255,6 +283,11 @@ export class WavyComposer extends LitElement {
     this._pendingDraftSync = undefined;
     this._composerState = Object.freeze({});
     this._activeSelection = Object.freeze({});
+    // J-UI-5 (#1083, R-5.2): cached live Range from the most recent
+    // selection inside the composer body. Used by toolbar handlers
+    // because `document.getSelection()` does not reliably pierce the
+    // shadow root in WebKit / Firefox.
+    this._lastSelectionRange = null;
     this._handleFocusRequest = () => this.focusComposer();
     this._handleSelectionChange = () => this._onSelectionChange();
   }
@@ -299,12 +332,399 @@ export class WavyComposer extends LitElement {
 
   _handleToolbarAction = (event) => {
     const actionId = event && event.detail && event.detail.actionId;
+    if (!actionId) return;
     if (actionId === "insert-task") {
       this._insertTaskListAtCaret();
+      event.stopPropagation();
+      return;
     }
-    // Other action ids continue to bubble up to the controller; do not
-    // stop propagation here.
+    // J-UI-5 (#1083, R-5.2 + R-5.7): selection-driven format actions.
+    // The handler claims responsibility for the action ids it
+    // implements; un-handled ids continue to bubble for the existing
+    // body-level routes (e.g. `attachment-insert` ⇒ view.openAttachmentPicker).
+    const inlineWraps = {
+      bold: { tag: "strong", siblings: ["b"] },
+      italic: { tag: "em", siblings: ["i"] },
+      underline: { tag: "u", siblings: [] },
+      strikethrough: { tag: "s", siblings: ["strike", "del"] }
+    };
+    if (inlineWraps[actionId]) {
+      this._toggleInlineWrapAtSelection(inlineWraps[actionId]);
+      event.stopPropagation();
+      return;
+    }
+    if (actionId === "unordered-list" || actionId === "ordered-list") {
+      this._toggleListAtSelection(actionId === "ordered-list" ? "ol" : "ul");
+      event.stopPropagation();
+      return;
+    }
+    if (
+      actionId === "align-left" ||
+      actionId === "align-center" ||
+      actionId === "align-right"
+    ) {
+      const align = actionId === "align-left" ? "left" : actionId === "align-center" ? "center" : "right";
+      this._setBlockAttributeAtSelection("style", `text-align: ${align};`);
+      event.stopPropagation();
+      return;
+    }
+    if (actionId === "rtl") {
+      this._setBlockAttributeAtSelection("dir", "rtl");
+      event.stopPropagation();
+      return;
+    }
+    if (actionId === "link") {
+      this._openLinkModalForSelection();
+      event.stopPropagation();
+      return;
+    }
+    if (actionId === "unlink") {
+      this._unwrapLinkAtSelection();
+      event.stopPropagation();
+      return;
+    }
+    if (actionId === "clear-formatting") {
+      this._clearFormattingAtSelection();
+      event.stopPropagation();
+      return;
+    }
+    // J-UI-5 (#1083, §9 out-of-scope): heading round-trip is deferred —
+    // wrap-as-bold loses the heading semantic on reload. The toolbar
+    // surfaces the button for visual parity; click is a no-op until a
+    // follow-up issue defines the element-type round-trip. Falls
+    // through (no stopPropagation) so a future listener can act on it.
   };
+
+  /**
+   * J-UI-5 (#1083, R-5.2): cached live Range for the most-recent
+   * composer-body selection. Used by toolbar handlers because
+   * `document.getSelection()` does not pierce shadow roots in
+   * Firefox / WebKit. Updated on every `selectionchange` while the
+   * body owns selection (see `_onSelectionChange`).
+   */
+  _captureSelectionRange() {
+    const selection = typeof document !== "undefined" ? document.getSelection() : null;
+    if (!selection || selection.rangeCount === 0) return null;
+    const range = selection.getRangeAt(0);
+    if (!this._bodyElement || !this._bodyElement.contains(range.startContainer)) {
+      return null;
+    }
+    return range.cloneRange();
+  }
+
+  _activeRange() {
+    const live = this._captureSelectionRange();
+    if (live) return live;
+    return this._lastSelectionRange ? this._lastSelectionRange.cloneRange() : null;
+  }
+
+  _restoreSelectionRange(range) {
+    if (!range) return;
+    const selection = typeof document !== "undefined" ? document.getSelection() : null;
+    if (!selection) return;
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.2): toggle wrap the active range with the named
+   * inline tag. When the selection is already inside the tag (or one
+   * of its synonyms), unwrap. Selection must be non-collapsed; a
+   * collapsed caret is treated as no-op so accidental clicks do not
+   * insert empty wraps.
+   */
+  _toggleInlineWrapAtSelection(spec) {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range || range.collapsed) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    const allTags = [spec.tag, ...(spec.siblings || [])];
+    const ancestor = this._findAncestorTag(range.startContainer, allTags);
+    if (ancestor) {
+      this._unwrapElement(ancestor);
+      this._afterBodyMutation();
+      return;
+    }
+    const wrapper = document.createElement(spec.tag);
+    try {
+      wrapper.appendChild(range.extractContents());
+      range.insertNode(wrapper);
+      const restored = document.createRange();
+      restored.selectNodeContents(wrapper);
+      this._restoreSelectionRange(restored);
+    } catch (_e) {
+      // Range manipulation can throw for malformed selections; bail
+      // without wrapping rather than corrupting the body.
+      return;
+    }
+    this._afterBodyMutation();
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.7): toggle wrap the lines covered by the
+   * selection in `<ul>`/`<ol>`. Each line becomes one `<li>`. When
+   * the selection is already inside a list of the same tag, unwrap
+   * the items back to plain text.
+   */
+  _toggleListAtSelection(listTag) {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    const existing = this._findAncestorTag(range.startContainer, [listTag]);
+    if (existing) {
+      // Unwrap each <li>'s text into the parent and remove the list.
+      const parent = existing.parentNode;
+      if (!parent) return;
+      const items = Array.from(existing.querySelectorAll("li"));
+      const fragments = items.map((li) => {
+        const div = document.createElement("div");
+        while (li.firstChild) div.appendChild(li.firstChild);
+        return div;
+      });
+      for (const frag of fragments) parent.insertBefore(frag, existing);
+      parent.removeChild(existing);
+      this._afterBodyMutation();
+      return;
+    }
+    let text;
+    try {
+      text = range.toString();
+    } catch (_e) {
+      return;
+    }
+    const lines = text.split("\n").filter((line) => line.length > 0);
+    if (lines.length === 0) return;
+    const list = document.createElement(listTag);
+    for (const line of lines) {
+      const li = document.createElement("li");
+      li.textContent = line;
+      list.appendChild(li);
+    }
+    try {
+      range.deleteContents();
+      range.insertNode(list);
+      const restored = document.createRange();
+      restored.selectNodeContents(list);
+      this._restoreSelectionRange(restored);
+    } catch (_e) {
+      return;
+    }
+    this._afterBodyMutation();
+  }
+
+  _setBlockAttributeAtSelection(attrName, attrValue) {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    let block = this._findAncestorTag(range.startContainer, ["div", "p", "li", "blockquote"]);
+    if (!block) {
+      // Wrap the active range's containing line in a <div> so the
+      // alignment/dir attribute has somewhere to land.
+      block = document.createElement("div");
+      try {
+        block.appendChild(range.extractContents());
+        range.insertNode(block);
+      } catch (_e) {
+        return;
+      }
+    }
+    block.setAttribute(attrName, attrValue);
+    this._afterBodyMutation();
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.7): open the existing `<wavy-link-modal>` to
+   * collect a URL, then wrap the active range in `<a href=…>`. The
+   * range is captured before the modal opens so caret/selection
+   * survive across modal interactions.
+   */
+  _openLinkModalForSelection() {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    let preselectedDisplay = "";
+    try {
+      preselectedDisplay = range.toString();
+    } catch (_e) {
+      preselectedDisplay = "";
+    }
+    let modal = document.querySelector("wavy-link-modal[data-j2cl-link-modal=\"true\"]");
+    if (!modal) {
+      modal = document.createElement("wavy-link-modal");
+      modal.setAttribute("data-j2cl-link-modal", "true");
+      document.body.appendChild(modal);
+    }
+    modal.urlValue = "";
+    modal.displayValue = preselectedDisplay;
+    modal.open = true;
+    const onSubmit = (event) => {
+      const detail = event && event.detail;
+      modal.removeEventListener("wavy-link-modal-submit", onSubmit);
+      modal.removeEventListener("wavy-link-modal-cancel", onCancel);
+      modal.open = false;
+      if (!detail || !detail.url) return;
+      this._wrapRangeInLink(range, detail.url, detail.display || preselectedDisplay);
+    };
+    const onCancel = () => {
+      modal.removeEventListener("wavy-link-modal-submit", onSubmit);
+      modal.removeEventListener("wavy-link-modal-cancel", onCancel);
+      modal.open = false;
+      // Restore caret to the captured range so the user is back where
+      // they were before the modal stole focus.
+      this._restoreSelectionRange(range.cloneRange());
+    };
+    modal.addEventListener("wavy-link-modal-submit", onSubmit);
+    modal.addEventListener("wavy-link-modal-cancel", onCancel);
+  }
+
+  _wrapRangeInLink(range, url, displayText) {
+    if (!this._bodyElement) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", url);
+    if (displayText && range.collapsed) {
+      anchor.textContent = displayText;
+    } else {
+      try {
+        anchor.appendChild(range.extractContents());
+      } catch (_e) {
+        return;
+      }
+    }
+    try {
+      range.insertNode(anchor);
+    } catch (_e) {
+      return;
+    }
+    const restored = document.createRange();
+    restored.selectNodeContents(anchor);
+    this._restoreSelectionRange(restored);
+    this._afterBodyMutation();
+  }
+
+  _unwrapLinkAtSelection() {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    const anchor = this._findAncestorTag(range.startContainer, ["a"]);
+    if (!anchor) return;
+    this._unwrapElement(anchor);
+    this._afterBodyMutation();
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.7): flatten formatting tags inside the active
+   * range so the user can recover plain text. Strips the formatting
+   * wraps we know about (`<strong>`, `<em>`, `<u>`, `<s>`, `<a>`,
+   * `<ul>`, `<ol>`, `<li>`, `<blockquote>`). Mention chips are left
+   * intact — they are semantic, not visual formatting.
+   */
+  _clearFormattingAtSelection() {
+    if (!this._bodyElement) return;
+    const range = this._activeRange();
+    if (!range) return;
+    if (!this._bodyElement.contains(range.startContainer)) return;
+    const tagsToFlatten = new Set([
+      "strong",
+      "b",
+      "em",
+      "i",
+      "u",
+      "s",
+      "strike",
+      "del",
+      "a",
+      "ul",
+      "ol",
+      "li",
+      "blockquote",
+      "h1",
+      "h2",
+      "h3",
+      "h4"
+    ]);
+    let container = range.commonAncestorContainer;
+    if (container.nodeType === Node.TEXT_NODE) {
+      container = container.parentNode;
+    }
+    while (container && container !== this._bodyElement) {
+      const tag = container.tagName ? container.tagName.toLowerCase() : "";
+      if (tagsToFlatten.has(tag)) {
+        // Pull container's text out and replace the container.
+        const parent = container.parentNode;
+        if (!parent) break;
+        const text = document.createTextNode(container.textContent || "");
+        parent.replaceChild(text, container);
+        container = text.parentNode;
+        continue;
+      }
+      container = container.parentNode;
+    }
+    // Now walk descendants of the common ancestor and flatten any
+    // remaining wraps inside the original range. Use a fresh tree
+    // walker over the body and strip any matching tag whose entire
+    // contents lie inside the original range bounds.
+    const walker = document.createTreeWalker(this._bodyElement, NodeFilter.SHOW_ELEMENT, null);
+    const stripCandidates = [];
+    let node = walker.currentNode;
+    while ((node = walker.nextNode())) {
+      const tag = node.tagName ? node.tagName.toLowerCase() : "";
+      if (!tagsToFlatten.has(tag)) continue;
+      if (node.classList && node.classList.contains("wavy-mention-chip")) continue;
+      stripCandidates.push(node);
+    }
+    for (const candidate of stripCandidates) {
+      this._unwrapElement(candidate);
+    }
+    this._afterBodyMutation();
+  }
+
+  _findAncestorTag(node, tagNames) {
+    if (!node || !this._bodyElement) return null;
+    const lowered = tagNames.map((t) => t.toLowerCase());
+    let current = node.nodeType === Node.ELEMENT_NODE ? node : node.parentNode;
+    while (current && current !== this._bodyElement) {
+      if (current.nodeType === Node.ELEMENT_NODE) {
+        const tag = current.tagName ? current.tagName.toLowerCase() : "";
+        if (lowered.includes(tag)) return current;
+      }
+      current = current.parentNode;
+    }
+    return null;
+  }
+
+  _unwrapElement(element) {
+    if (!element) return;
+    const parent = element.parentNode;
+    if (!parent) return;
+    while (element.firstChild) parent.insertBefore(element.firstChild, element);
+    parent.removeChild(element);
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.2): re-emit `draft-change` and refresh the
+   * cached selection descriptor after a toolbar mutation so
+   * downstream consumers (toolbar pressed state, save indicator,
+   * the controller's draft cache) see the edit.
+   */
+  _afterBodyMutation() {
+    const value = this._serializeBodyText();
+    this.draft = value;
+    this.dispatchEvent(
+      new CustomEvent("draft-change", {
+        detail: { value, replyTargetBlipId: this.replyTargetBlipId, mode: this.mode },
+        bubbles: true,
+        composed: true
+      })
+    );
+    // Re-emit selection-change so the floating toolbar's pressed
+    // state mirrors the new annotation set immediately.
+    this._onSelectionChange();
+  }
 
   /**
    * F-3.S2 (#1038, R-5.4 step 6): insert a `<ul class="wavy-task-list">`
@@ -439,8 +859,15 @@ export class WavyComposer extends LitElement {
    */
   _bodyHasRichContent() {
     if (!this._bodyElement) return false;
+    // J-UI-5 (#1083): inline format wraps (bold/italic/underline/strike/
+    // link) and block wraps (lists, blockquote, headings) are also rich
+    // content the plain-text `draft` cannot round-trip. Counting them
+    // here keeps the next Lit re-render from clobbering the wraps via
+    // a textContent overwrite.
     return Boolean(
-      this._bodyElement.querySelector(".wavy-mention-chip, .wavy-task-list")
+      this._bodyElement.querySelector(
+        ".wavy-mention-chip, .wavy-task-list, strong, b, em, i, u, s, strike, del, a, ul, ol, blockquote, h1, h2, h3, h4"
+      )
     );
   }
 
@@ -719,6 +1146,36 @@ export class WavyComposer extends LitElement {
             flushText();
           }
           walk(node.childNodes);
+          continue;
+        }
+        // J-UI-5 (#1083, R-5.7): inline format wraps. Walk children
+        // recursively so that nested formatting (e.g. <strong><em>...
+        // </em></strong>) and chips inside formatted text survive
+        // round-trip. Plain text inside the wrap is promoted to the
+        // matching annotation; rich components inside the wrap flow
+        // through unchanged.
+        const inlineAnnotation = inlineFormatAnnotation(tag);
+        if (inlineAnnotation) {
+          flushText();
+          const snapLen = components.length;
+          const snapPending = pending;
+          pending = "";
+          walk(node.childNodes);
+          flushText();
+          const innerComps = components.splice(snapLen);
+          pending = snapPending;
+          for (const c of innerComps) {
+            if (c.type === "text") {
+              components.push({
+                type: "annotated",
+                text: c.text,
+                annotationKey: inlineAnnotation.key,
+                annotationValue: inlineAnnotation.value
+              });
+            } else {
+              components.push(c);
+            }
+          }
           continue;
         }
         pending += node.textContent;
@@ -1208,10 +1665,24 @@ export class WavyComposer extends LitElement {
 
   _submit() {
     if (this.submitting || this.staleBasis) return;
+    // J-UI-5 (#1083, R-5.7): forward the per-fragment annotated
+    // component list so the Java controller can build a
+    // `J2clComposerDocument` that carries the user's formatting
+    // through the DocOp model. Plain-text consumers continue to
+    // read `value`; the legacy `<composer-inline-reply>` textarea
+    // path leaves `components` empty / absent and the view falls
+    // back to plain text on submit.
+    let components = [];
+    try {
+      components = this.serializeRichComponents();
+    } catch (_e) {
+      components = [];
+    }
     this.dispatchEvent(
       new CustomEvent("reply-submit", {
         detail: {
           value: this.draft,
+          components,
           replyTargetBlipId: this.replyTargetBlipId,
           mode: this.mode
         },
@@ -1262,6 +1733,7 @@ export class WavyComposer extends LitElement {
     if (!selection || selection.rangeCount === 0) {
       this._flushPendingDraftSync();
       this.activeSelection = {};
+      this._lastSelectionRange = null;
       this._dispatchSelectionEvent({});
       // F-3.S2: caret left the document; collapse the popover.
       if (this._mentionOpen) this._dismissMentionPopover("blur");
@@ -1273,6 +1745,7 @@ export class WavyComposer extends LitElement {
       // the floating toolbar collapses.
       this._flushPendingDraftSync();
       this.activeSelection = {};
+      this._lastSelectionRange = null;
       this._dispatchSelectionEvent({});
       if (this._mentionOpen) this._dismissMentionPopover("blur");
       return;
@@ -1291,6 +1764,11 @@ export class WavyComposer extends LitElement {
       activeAnnotations: this._collectActiveAnnotations(range)
     };
     this.activeSelection = descriptor;
+    // J-UI-5 (#1083, R-5.2): cache a clone of the live range so toolbar
+    // handlers have a stable selection to act on even when
+    // `document.getSelection()` cannot pierce the shadow root (Firefox /
+    // WebKit). Cleared by the no-selection / out-of-body branches above.
+    this._lastSelectionRange = range.cloneRange();
     this._dispatchSelectionEvent(descriptor);
     // F-3.S2 (#1038, R-5.3): re-evaluate the mention trigger from the
     // live caret. This catches cases where the user clicks elsewhere

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -737,27 +737,49 @@ export class WavyComposer extends LitElement {
       const parent = existing.parentNode;
       if (!parent) return;
       const items = Array.from(existing.querySelectorAll("li"));
-      const selectedItems = items.filter((li) => {
+      const selectedSet = new Set();
+      for (const li of items) {
         try {
-          return range.intersectsNode(li);
+          if (range.intersectsNode(li)) selectedSet.add(li);
         } catch (_e) {
-          return false;
+          // ignore — leaves li unselected
         }
-      });
-      const targetItems = selectedItems.length > 0 ? selectedItems : items;
-      // Each unwrapped <li> becomes a <div> so block-level
-      // separation between adjacent former list items survives.
-      for (const li of targetItems) {
-        const div = document.createElement("div");
-        while (li.firstChild) div.appendChild(li.firstChild);
-        existing.parentNode.insertBefore(div, existing);
-        li.parentNode.removeChild(li);
       }
-      // Drop the empty list wrapper; otherwise leave it in place
-      // with the remaining items as a residual list.
-      if (existing.querySelector("li") == null && existing.parentNode) {
-        existing.parentNode.removeChild(existing);
+      const targetSet = selectedSet.size > 0 ? selectedSet : new Set(items);
+      // Codex review #1095 thread PRRT_kwDOBwxLXs5-NGAY: walk the
+      // list's children in DOM order and replace selected `<li>`s
+      // with sibling `<div>` blocks at the SAME ordinal position,
+      // so item order survives even when selected and unselected
+      // items interleave (e.g. items=[a, b, c] with [a, c] selected
+      // must serialise as div_a, ul[b], div_c — not a, c, b).
+      // Unselected runs collapse into a residual `<ul>`/`<ol>` of
+      // the original tag so list semantics persist where needed.
+      const childItems = Array.from(existing.children).filter(
+        (child) => child.tagName && child.tagName.toLowerCase() === "li"
+      );
+      const parentList = existing.parentNode;
+      const segments = [];
+      let currentResidual = null;
+      for (const li of childItems) {
+        if (targetSet.has(li)) {
+          const div = document.createElement("div");
+          while (li.firstChild) div.appendChild(li.firstChild);
+          segments.push(div);
+          currentResidual = null;
+        } else {
+          if (!currentResidual) {
+            currentResidual = document.createElement(listTag);
+            segments.push(currentResidual);
+          }
+          // Move the `<li>` into the residual list, preserving its
+          // own children (and any rich content inside).
+          currentResidual.appendChild(li);
+        }
       }
+      for (const segment of segments) {
+        parentList.insertBefore(segment, existing);
+      }
+      parentList.removeChild(existing);
       this._afterBodyMutation();
       return;
     }

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -671,13 +671,35 @@ export class WavyComposer extends LitElement {
     try {
       prefixFragment = prefixRange.cloneContents();
       suffixFragment = suffixRange.cloneContents();
-      // Range slice intersected with ancestor contents is the
-      // active selection's interior. cloneContents preserves nested
-      // formatting (e.g. `<strong><em>x</em>y</strong>` ⇒ inner
-      // `<em>x</em>` keeps italics on the un-bolded fragment).
+      // Codex review #1095 thread PRRT_kwDOBwxLXs5-N9fu: clamp the
+      // middle slice to the ancestor's bounds. If the user's
+      // selection ends OUTSIDE the formatted ancestor (e.g.
+      // `<strong>hello</strong> world` with a range from `lo` into
+      // ` wor`), the raw selection endpoints would pull text from
+      // outside the ancestor into `cloneContents()`. That cloned
+      // outside text would then be inserted before the ancestor,
+      // and the ancestor itself removed — duplicating ` wor` in the
+      // body. Use `selectNodeContents(ancestor)` as the natural
+      // baseline and only narrow start/end when the corresponding
+      // selection endpoint is actually inside the ancestor.
       const innerRange = document.createRange();
-      innerRange.setStart(range.startContainer, range.startOffset);
-      innerRange.setEnd(range.endContainer, range.endOffset);
+      innerRange.selectNodeContents(ancestor);
+      const startInside =
+          ancestor === range.startContainer || ancestor.contains(range.startContainer);
+      const endInside =
+          ancestor === range.endContainer || ancestor.contains(range.endContainer);
+      if (startInside) {
+        innerRange.setStart(range.startContainer, range.startOffset);
+      }
+      if (endInside) {
+        innerRange.setEnd(range.endContainer, range.endOffset);
+      }
+      // If neither endpoint is inside the ancestor we cannot trust
+      // the selection to describe a meaningful slice — bail rather
+      // than corrupting the body.
+      if (!startInside && !endInside) {
+        return;
+      }
       middleFragment = innerRange.cloneContents();
     } catch (_e) {
       return;

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -609,7 +609,17 @@ export class WavyComposer extends LitElement {
     const allTags = [spec.tag, ...(spec.siblings || [])];
     const ancestor = this._findAncestorTag(range.startContainer, allTags);
     if (ancestor) {
-      this._unwrapElement(ancestor);
+      // Codex review #1095 threads PRRT_kwDOBwxLXs5-Gunw / -F-8i:
+      // partial-range toggle-off must SPLIT the ancestor at the
+      // selection boundaries — otherwise unwrapping the whole
+      // wrapper drops formatting from text outside the active
+      // range. When the selection covers the entire ancestor, fall
+      // back to a plain unwrap (cheaper and produces identical DOM).
+      if (rangeFullyContainsNode(range, ancestor)) {
+        this._unwrapElement(ancestor);
+      } else {
+        this._unwrapAncestorWithinRange(ancestor, range, spec);
+      }
       this._afterBodyMutation();
       return;
     }
@@ -629,6 +639,84 @@ export class WavyComposer extends LitElement {
   }
 
   /**
+   * J-UI-5 (#1083, codex review #1095 threads PRRT_kwDOBwxLXs5-Gunw +
+   * PRRT_kwDOBwxLXs5-F-8i): split an existing inline wrapper around
+   * the active selection so toggle-off only removes formatting from
+   * the selected fragment, not the whole wrap. The wrapper is
+   * cloned for the prefix (text before the selection) and the
+   * suffix (text after); the selected slice is extracted out and
+   * inserted as a sibling between the two clones, then the
+   * original wrapper is removed.
+   */
+  _unwrapAncestorWithinRange(ancestor, range, spec) {
+    const parent = ancestor.parentNode;
+    if (!parent) return;
+    let prefixRange;
+    let suffixRange;
+    try {
+      prefixRange = document.createRange();
+      prefixRange.selectNodeContents(ancestor);
+      prefixRange.setEnd(range.startContainer, range.startOffset);
+      suffixRange = document.createRange();
+      suffixRange.selectNodeContents(ancestor);
+      suffixRange.setStart(range.endContainer, range.endOffset);
+    } catch (_e) {
+      // Selection may sit outside the ancestor on weird boundaries;
+      // bail rather than corrupting the body.
+      return;
+    }
+    let prefixFragment;
+    let suffixFragment;
+    let middleFragment;
+    try {
+      prefixFragment = prefixRange.cloneContents();
+      suffixFragment = suffixRange.cloneContents();
+      // Range slice intersected with ancestor contents is the
+      // active selection's interior. cloneContents preserves nested
+      // formatting (e.g. `<strong><em>x</em>y</strong>` ⇒ inner
+      // `<em>x</em>` keeps italics on the un-bolded fragment).
+      const innerRange = document.createRange();
+      innerRange.setStart(range.startContainer, range.startOffset);
+      innerRange.setEnd(range.endContainer, range.endOffset);
+      middleFragment = innerRange.cloneContents();
+    } catch (_e) {
+      return;
+    }
+    const insertSiblingsBefore = (target, frag, wrapTagName) => {
+      // Skip empty fragments — happens when the selection starts at
+      // offset 0 (no prefix) or covers the ancestor's last char (no
+      // suffix). cloneContents can also produce a fragment that holds
+      // an empty text node (length 0), which would still leave behind
+      // an empty `<strong></strong>` if we naively re-wrapped it.
+      if (!frag || !frag.hasChildNodes()) return null;
+      const text = frag.textContent || "";
+      const hasElementChild = Boolean(frag.querySelector && frag.querySelector("*"));
+      if (text.length === 0 && !hasElementChild) return null;
+      if (wrapTagName) {
+        const wrapper = document.createElement(wrapTagName);
+        wrapper.appendChild(frag);
+        parent.insertBefore(wrapper, target);
+        return wrapper;
+      }
+      // Inline insert without wrapping (toggle-off drops the
+      // ancestor for the slice).
+      while (frag.firstChild) parent.insertBefore(frag.firstChild, target);
+      return null;
+    };
+    insertSiblingsBefore(ancestor, prefixFragment, ancestor.tagName.toLowerCase());
+    const middleAnchor = ancestor;
+    insertSiblingsBefore(middleAnchor, middleFragment, null);
+    insertSiblingsBefore(ancestor, suffixFragment, ancestor.tagName.toLowerCase());
+    parent.removeChild(ancestor);
+    // `spec` is currently unused but kept on the call site for
+    // future tag-specific behaviour (e.g. retaining link href on
+    // `<a>` partial unwrap should preserve href on the prefix +
+    // suffix clones, which `cloneNode` handles via createElement
+    // matching the original tagName).
+    void spec;
+  }
+
+  /**
    * J-UI-5 (#1083, R-5.7): toggle wrap the lines covered by the
    * selection in `<ul>`/`<ol>`. Each line becomes one `<li>`. When
    * the selection is already inside a list of the same tag, unwrap
@@ -641,17 +729,35 @@ export class WavyComposer extends LitElement {
     if (!this._bodyElement.contains(range.startContainer)) return;
     const existing = this._findAncestorTag(range.startContainer, [listTag]);
     if (existing) {
-      // Unwrap each <li>'s text into the parent and remove the list.
+      // Codex review #1095 threads PRRT_kwDOBwxLXs5-Gun0 / -GulD:
+      // toggle-off must only unwrap the `<li>`s that the selection
+      // intersects, leaving sibling items intact. Only when the user
+      // covers every item (or the whole list) do we drop the list
+      // wrapper entirely.
       const parent = existing.parentNode;
       if (!parent) return;
       const items = Array.from(existing.querySelectorAll("li"));
-      const fragments = items.map((li) => {
+      const selectedItems = items.filter((li) => {
+        try {
+          return range.intersectsNode(li);
+        } catch (_e) {
+          return false;
+        }
+      });
+      const targetItems = selectedItems.length > 0 ? selectedItems : items;
+      // Each unwrapped <li> becomes a <div> so block-level
+      // separation between adjacent former list items survives.
+      for (const li of targetItems) {
         const div = document.createElement("div");
         while (li.firstChild) div.appendChild(li.firstChild);
-        return div;
-      });
-      for (const frag of fragments) parent.insertBefore(frag, existing);
-      parent.removeChild(existing);
+        existing.parentNode.insertBefore(div, existing);
+        li.parentNode.removeChild(li);
+      }
+      // Drop the empty list wrapper; otherwise leave it in place
+      // with the remaining items as a residual list.
+      if (existing.querySelector("li") == null && existing.parentNode) {
+        existing.parentNode.removeChild(existing);
+      }
       this._afterBodyMutation();
       return;
     }
@@ -835,7 +941,12 @@ export class WavyComposer extends LitElement {
       "h3",
       "h4"
     ]);
-    const containerTags = new Set(["ul", "ol", "li", "blockquote"]);
+    // `<li>` is intentionally NOT a container candidate: stripping it
+    // separately would pull the item's text into its parent list and
+    // collapse adjacent items together. We rely on the `<ul>`/`<ol>`
+    // unwrap (which expands each `<li>` into its own `<div>` block,
+    // see `_unwrapElement`) to handle list teardown.
+    const containerTags = new Set(["ul", "ol", "blockquote"]);
     const walker = document.createTreeWalker(this._bodyElement, NodeFilter.SHOW_ELEMENT, null);
     const stripCandidates = [];
     let node = walker.currentNode;
@@ -885,6 +996,27 @@ export class WavyComposer extends LitElement {
     if (!element) return;
     const parent = element.parentNode;
     if (!parent) return;
+    // Codex review #1095 thread PRRT_kwDOBwxLXs5-F-d2: container
+    // unwraps (`<ul>`, `<ol>`) must preserve item boundaries so
+    // `<ul><li>a</li><li>b</li></ul>` does not collapse to `ab`.
+    // Wrap each `<li>`'s contents in a `<div>` block so the post-
+    // unwrap DOM keeps one block per former item; the body's text
+    // serializer treats a `<div>` boundary as a newline.
+    const tag = element.tagName ? element.tagName.toLowerCase() : "";
+    if (tag === "ul" || tag === "ol") {
+      const itemElements = Array.from(element.children).filter(
+        (child) => child.tagName && child.tagName.toLowerCase() === "li"
+      );
+      if (itemElements.length > 0) {
+        for (const li of itemElements) {
+          const div = document.createElement("div");
+          while (li.firstChild) div.appendChild(li.firstChild);
+          parent.insertBefore(div, element);
+        }
+        parent.removeChild(element);
+        return;
+      }
+    }
     while (element.firstChild) parent.insertBefore(element.firstChild, element);
     parent.removeChild(element);
   }
@@ -921,9 +1053,14 @@ export class WavyComposer extends LitElement {
    */
   _insertTaskListAtCaret() {
     if (!this._bodyElement) return;
-    const selection = document.getSelection();
-    if (!selection || selection.rangeCount === 0) return;
-    const range = selection.getRangeAt(0);
+    // Codex review #1095 thread PRRT_kwDOBwxLXs5-F-ds: read the
+    // active range via `_activeRange()` (cached at the body's
+    // `selectionchange` listener) instead of `document.getSelection()`
+    // directly, so the action still works after the toolbar steals
+    // focus in Firefox / WebKit (where `document.getSelection()` does
+    // not pierce shadow roots).
+    const range = this._activeRange();
+    if (!range) return;
     if (!this._bodyElement.contains(range.startContainer)) return;
     const ul = document.createElement("ul");
     ul.className = "wavy-task-list";
@@ -948,8 +1085,7 @@ export class WavyComposer extends LitElement {
     const caretRange = document.createRange();
     caretRange.selectNodeContents(li);
     caretRange.collapse(false);
-    selection.removeAllRanges();
-    selection.addRange(caretRange);
+    this._restoreSelectionRange(caretRange);
     // Re-emit draft-change so consumers see the new line.
     const value = this._serializeBodyText();
     this.draft = value;

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -53,6 +53,127 @@ function isSafeLinkHref(url) {
   return scheme === "http" || scheme === "https" || scheme === "mailto";
 }
 
+/**
+ * J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-DSyb):
+ * split a DocumentFragment cloned from a Range into ordered groups
+ * of nodes that each represent ONE line, while preserving inline
+ * markup (`<strong>`, `<em>`, `<a>`, mention chips, ...). Block-level
+ * children (`<div>`, `<p>`, `<br>`) act as line separators; pre-
+ * existing `<li>` and `<ul>`/`<ol>` children are flattened into their
+ * contents so toggling a list ON over partial list-content does not
+ * nest lists. The caller wraps each group in a fresh `<li>` to build
+ * the new list.
+ */
+function splitFragmentIntoLineGroups(fragment) {
+  const groups = [];
+  let current = [];
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+  };
+  const flatChildren = [];
+  const collect = (parent) => {
+    for (const child of Array.from(parent.childNodes)) {
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        const t = child.tagName.toLowerCase();
+        if (t === "ul" || t === "ol") {
+          collect(child);
+          continue;
+        }
+        if (t === "li") {
+          collect(child);
+          flatChildren.push(document.createElement("__line_break"));
+          continue;
+        }
+      }
+      flatChildren.push(child);
+    }
+  };
+  collect(fragment);
+  for (const node of flatChildren) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const tag = node.tagName.toLowerCase();
+      if (tag === "br" || tag === "__line_break") {
+        pushCurrent();
+        continue;
+      }
+      if (tag === "div" || tag === "p") {
+        // Block boundary: flush any pending inline content from the
+        // previous block, then walk this block's children inline so
+        // marks inside the block survive (`<div><strong>x</strong></div>`
+        // becomes one `<li>` containing `<strong>x</strong>`).
+        pushCurrent();
+        for (const inner of Array.from(node.childNodes)) {
+          current.push(inner);
+        }
+        pushCurrent();
+        continue;
+      }
+    }
+    // Text nodes carrying a literal `\n` (e.g. body.textContent
+    // `"first\nsecond"`) split into multiple lines too — otherwise
+    // newline-delimited drafts produce a single `<li>` containing the
+    // whole text.
+    if (node.nodeType === Node.TEXT_NODE && node.textContent.indexOf("\n") >= 0) {
+      const parts = node.textContent.split("\n");
+      for (let i = 0; i < parts.length; i++) {
+        if (parts[i].length > 0) current.push(document.createTextNode(parts[i]));
+        if (i < parts.length - 1) pushCurrent();
+      }
+      continue;
+    }
+    current.push(node);
+  }
+  pushCurrent();
+  return groups;
+}
+
+/**
+ * J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-DSyW):
+ * fold an outer annotation onto a list of inner components produced
+ * by recursing into a wrap's children. Text components become
+ * annotated; pre-annotated components have the outer annotation
+ * appended to their `annotations` list so combined runs (e.g.
+ * `<li><strong>x</strong></li>`, `<a><em>x</em></a>`,
+ * `<blockquote><strong>x</strong></blockquote>`) round-trip both the
+ * outer annotation AND the inner formatting. Non-annotatable
+ * components (e.g. image attachments) flow through untouched.
+ */
+function mergeOuterAnnotation(innerComps, outerKey, outerValue) {
+  const out = [];
+  for (const c of innerComps) {
+    if (c.type === "text") {
+      out.push({
+        type: "annotated",
+        text: c.text,
+        annotationKey: outerKey,
+        annotationValue: outerValue,
+        annotations: [{ key: outerKey, value: outerValue }]
+      });
+      continue;
+    }
+    if (c.type === "annotated") {
+      const inner =
+        Array.isArray(c.annotations) && c.annotations.length > 0
+          ? c.annotations.slice()
+          : [{ key: c.annotationKey, value: c.annotationValue }];
+      const merged = inner.concat([{ key: outerKey, value: outerValue }]);
+      out.push({
+        type: "annotated",
+        text: c.text,
+        annotationKey: merged[0].key,
+        annotationValue: merged[0].value,
+        annotations: merged
+      });
+      continue;
+    }
+    out.push(c);
+  }
+  return out;
+}
+
 function inlineFormatAnnotation(tag) {
   switch (tag) {
     case "strong":
@@ -534,20 +655,32 @@ export class WavyComposer extends LitElement {
       this._afterBodyMutation();
       return;
     }
-    let text;
+    // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-DSyb):
+    // preserve inline markup when toggling list formatting. Extract
+    // the live DocumentFragment from the range (carrying any
+    // `<strong>`, `<em>`, `<a>`, mention chips, etc.), split it into
+    // line groups, and inject each group into a fresh `<li>` so
+    // formatting + chips survive the wrap.
+    let fragment;
     try {
-      text = range.toString();
+      fragment = range.cloneContents();
     } catch (_e) {
       return;
     }
-    const lines = text.split("\n").filter((line) => line.length > 0);
-    if (lines.length === 0) return;
+    if (!fragment || !fragment.hasChildNodes()) return;
+    const lineGroups = splitFragmentIntoLineGroups(fragment);
+    if (lineGroups.length === 0) return;
     const list = document.createElement(listTag);
-    for (const line of lines) {
+    for (const group of lineGroups) {
       const li = document.createElement("li");
-      li.textContent = line;
+      for (const node of group) li.appendChild(node);
+      // Skip <li> elements whose contents serialise to nothing — these
+      // come from blank lines in the source and would otherwise paint
+      // empty bullets.
+      if (li.textContent.length === 0 && !li.querySelector("*")) continue;
       list.appendChild(li);
     }
+    if (!list.firstChild) return;
     try {
       range.deleteContents();
       range.insertNode(list);
@@ -1101,17 +1234,16 @@ export class WavyComposer extends LitElement {
               flushText();
               const itemComps = components.splice(snapLen);
               pending = snapPending;
-              for (const c of itemComps) {
-                if (c.type === "text") {
-                  components.push({
-                    type: "annotated",
-                    text: c.text,
-                    annotationKey,
-                    annotationValue: "true"
-                  });
-                } else {
-                  components.push(c);
-                }
+              // Codex review #1095 thread PRRT_kwDOBwxLXs5-DSyW:
+              // merge the list annotation onto every child run so
+              // `<li><strong>x</strong></li>` keeps both list/* AND
+              // fontWeight=bold on the same span.
+              for (const merged of mergeOuterAnnotation(
+                itemComps,
+                annotationKey,
+                "true"
+              )) {
+                components.push(merged);
               }
             }
           }
@@ -1139,17 +1271,12 @@ export class WavyComposer extends LitElement {
           flushText();
           const bqComps = components.splice(snapLen);
           pending = snapPending;
-          for (const c of bqComps) {
-            if (c.type === "text") {
-              components.push({
-                type: "annotated",
-                text: c.text,
-                annotationKey: "block/quote",
-                annotationValue: "true"
-              });
-            } else {
-              components.push(c);
-            }
+          // Codex review #1095 thread PRRT_kwDOBwxLXs5-DSyW: merge
+          // the block/quote annotation onto every child run so
+          // `<blockquote><strong>x</strong></blockquote>` keeps both
+          // block/quote AND fontWeight=bold on the same span.
+          for (const merged of mergeOuterAnnotation(bqComps, "block/quote", "true")) {
+            components.push(merged);
           }
           continue;
         }
@@ -1174,17 +1301,12 @@ export class WavyComposer extends LitElement {
             flushText();
             const aComps = components.splice(snapLen);
             pending = snapPending;
-            for (const c of aComps) {
-              if (c.type === "text") {
-                components.push({
-                  type: "annotated",
-                  text: c.text,
-                  annotationKey: "link/manual",
-                  annotationValue: href
-                });
-              } else {
-                components.push(c);
-              }
+            // Codex review #1095 thread PRRT_kwDOBwxLXs5-DSyW: merge
+            // the link/manual annotation onto every child run so
+            // `<a><strong>x</strong></a>` keeps both link/manual AND
+            // fontWeight=bold on the same span.
+            for (const merged of mergeOuterAnnotation(aComps, "link/manual", href)) {
+              components.push(merged);
             }
             continue;
           }
@@ -1217,40 +1339,16 @@ export class WavyComposer extends LitElement {
           flushText();
           const innerComps = components.splice(snapLen);
           pending = snapPending;
-          for (const c of innerComps) {
-            if (c.type === "text") {
-              components.push({
-                type: "annotated",
-                text: c.text,
-                annotationKey: inlineAnnotation.key,
-                annotationValue: inlineAnnotation.value,
-                annotations: [
-                  { key: inlineAnnotation.key, value: inlineAnnotation.value }
-                ]
-              });
-            } else if (c.type === "annotated") {
-              // Compose the outer annotation with whatever the inner
-              // walk already attached (italic / link / list / etc.).
-              const inner = Array.isArray(c.annotations) && c.annotations.length > 0
-                ? c.annotations.slice()
-                : [{ key: c.annotationKey, value: c.annotationValue }];
-              const merged = inner.concat([
-                { key: inlineAnnotation.key, value: inlineAnnotation.value }
-              ]);
-              components.push({
-                type: "annotated",
-                text: c.text,
-                // Singular `annotationKey`/`annotationValue` mirror the
-                // first annotation for backward-compatible consumers
-                // that read the legacy fields. Multi-annotation aware
-                // consumers walk the `annotations` array.
-                annotationKey: merged[0].key,
-                annotationValue: merged[0].value,
-                annotations: merged
-              });
-            } else {
-              components.push(c);
-            }
+          // Codex review #1095 thread PRRT_kwDOBwxLXs5-C84a: merge the
+          // outer annotation onto every child run (text + annotated)
+          // so combined `<strong><em>x</em></strong>` carries both
+          // fontWeight AND fontStyle on the same span.
+          for (const merged of mergeOuterAnnotation(
+            innerComps,
+            inlineAnnotation.key,
+            inlineAnnotation.value
+          )) {
+            components.push(merged);
           }
           continue;
         }

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -1,0 +1,285 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-composer.js";
+import "../src/elements/wavy-link-modal.js";
+
+// J-UI-5 (#1083) — selection-driven toolbar action handlers.
+//
+// These tests cover the wavy-composer's `_handleToolbarAction` branch
+// added by J-UI-5: bold / italic / underline / strikethrough / list /
+// link / unlink / clear-formatting are applied to the active range,
+// and reply-submit carries a `components` array reflecting the
+// per-fragment formatting.
+
+function ensureWavyTokensLoaded() {
+  if (document.querySelector('link[data-wavy-tokens-test]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-tokens.css";
+  link.dataset.wavyTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+before(async () => {
+  ensureWavyTokensLoaded();
+});
+
+function bodyOf(el) {
+  return el.renderRoot.querySelector("[data-composer-body]");
+}
+
+function selectAllInBody(el) {
+  const body = bodyOf(el);
+  body.focus();
+  const range = document.createRange();
+  range.selectNodeContents(body);
+  const sel = document.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  // Force the composer to capture the live range as it would on user
+  // input.
+  el._onSelectionChange();
+}
+
+function dispatchToolbarAction(el, actionId) {
+  el.dispatchEvent(
+    new CustomEvent("wavy-format-toolbar-action", {
+      detail: { actionId, selectionDescriptor: {} },
+      bubbles: true,
+      composed: true
+    })
+  );
+}
+
+describe("wavy-composer toolbar action handlers", () => {
+  beforeEach(() => {
+    document
+      .querySelectorAll('wavy-link-modal[data-j2cl-link-modal="true"]')
+      .forEach((m) => m.remove());
+  });
+
+  it("wraps the active selection in <strong> on Bold", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "hello world";
+    selectAllInBody(el);
+
+    dispatchToolbarAction(el, "bold");
+
+    expect(bodyOf(el).querySelector("strong")).to.exist;
+    expect(bodyOf(el).querySelector("strong").textContent).to.equal("hello world");
+  });
+
+  it("wraps the active selection in <em> on Italic", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "hello";
+    selectAllInBody(el);
+
+    dispatchToolbarAction(el, "italic");
+
+    expect(bodyOf(el).querySelector("em")).to.exist;
+  });
+
+  it("wraps in <u> and a follow-up click with caret inside <u> unwraps", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<u>u-test</u>";
+    // Place selection inside the <u> so the toggle-off branch finds the
+    // ancestor and unwraps.
+    body.focus();
+    const innerRange = document.createRange();
+    innerRange.selectNodeContents(body.querySelector("u"));
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(innerRange);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "underline");
+
+    expect(body.querySelector("u")).to.not.exist;
+    expect(body.textContent).to.equal("u-test");
+  });
+
+  it("wraps lines in <ul><li>...</li></ul> on Unordered List", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "first\nsecond";
+    selectAllInBody(el);
+
+    dispatchToolbarAction(el, "unordered-list");
+
+    const list = bodyOf(el).querySelector("ul");
+    expect(list).to.exist;
+    const items = list.querySelectorAll("li");
+    expect(items.length).to.equal(2);
+    expect(items[0].textContent).to.equal("first");
+    expect(items[1].textContent).to.equal("second");
+  });
+
+  it("wraps lines in <ol><li>...</li></ol> on Ordered List", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "alpha\nbeta\ngamma";
+    selectAllInBody(el);
+
+    dispatchToolbarAction(el, "ordered-list");
+
+    const list = bodyOf(el).querySelector("ol");
+    expect(list).to.exist;
+    expect(list.querySelectorAll("li").length).to.equal(3);
+  });
+
+  it("Insert link opens the wavy-link-modal and wraps the selection on submit", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "click here";
+    selectAllInBody(el);
+
+    dispatchToolbarAction(el, "link");
+
+    const modal = document.querySelector("wavy-link-modal[data-j2cl-link-modal=\"true\"]");
+    expect(modal).to.exist;
+    expect(modal.open).to.equal(true);
+
+    modal.dispatchEvent(
+      new CustomEvent("wavy-link-modal-submit", {
+        detail: { url: "https://example.com", display: "click here" },
+        bubbles: true,
+        composed: true
+      })
+    );
+    await el.updateComplete;
+
+    const anchor = bodyOf(el).querySelector("a");
+    expect(anchor).to.exist;
+    expect(anchor.getAttribute("href")).to.equal("https://example.com");
+    expect(anchor.textContent).to.equal("click here");
+    expect(modal.open).to.equal(false);
+  });
+
+  it("Remove link unwraps the surrounding <a>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = '<a href="https://example.com">linked</a>';
+    // Select inside the anchor.
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body.querySelector("a"));
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "unlink");
+
+    expect(body.querySelector("a")).to.not.exist;
+    expect(body.textContent).to.equal("linked");
+  });
+
+  it("Clear formatting strips inline format wraps from the selection", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<strong><em>boldy</em></strong>";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "clear-formatting");
+
+    expect(body.querySelector("strong")).to.not.exist;
+    expect(body.querySelector("em")).to.not.exist;
+    expect(body.textContent).to.equal("boldy");
+  });
+
+  it("emits draft-change after a toolbar mutation", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).textContent = "abc";
+    selectAllInBody(el);
+
+    const evtPromise = oneEvent(el, "draft-change");
+    dispatchToolbarAction(el, "bold");
+    const evt = await evtPromise;
+
+    expect(evt.detail.value).to.equal("abc");
+  });
+
+  it("collapsed selection does not wrap (no empty <strong> created)", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.textContent = "hello";
+    body.focus();
+    const range = document.createRange();
+    range.setStart(body.firstChild, 1);
+    range.collapse(true);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "bold");
+
+    expect(body.querySelector("strong")).to.not.exist;
+  });
+});
+
+describe("wavy-composer reply-submit components payload", () => {
+  it("emits components array with annotated bold run", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "plain <strong>bold</strong> tail";
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    expect(evt.detail.components).to.be.an("array");
+    const bolded = evt.detail.components.find(
+      (c) => c.type === "annotated" && c.annotationKey === "fontWeight" && c.annotationValue === "bold"
+    );
+    expect(bolded).to.exist;
+    expect(bolded.text).to.equal("bold");
+    // Plain runs flank the bold run.
+    const plain = evt.detail.components.filter((c) => c.type === "text");
+    expect(plain.length).to.be.greaterThan(0);
+  });
+
+  it("emits link/manual annotation for an inline anchor", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = '<a href="https://example.com">linked</a>';
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const linked = evt.detail.components.find(
+      (c) => c.type === "annotated" && c.annotationKey === "link/manual"
+    );
+    expect(linked).to.exist;
+    expect(linked.annotationValue).to.equal("https://example.com");
+    expect(linked.text).to.equal("linked");
+  });
+
+  it("emits italic + underline + strikethrough annotations", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<em>i</em><u>u</u><s>s</s>";
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const i = evt.detail.components.find(
+      (c) => c.type === "annotated" && c.annotationKey === "fontStyle" && c.annotationValue === "italic"
+    );
+    const u = evt.detail.components.find(
+      (c) => c.type === "annotated" && c.annotationKey === "textDecoration" && c.annotationValue === "underline"
+    );
+    const s = evt.detail.components.find(
+      (c) => c.type === "annotated" && c.annotationKey === "textDecoration" && c.annotationValue === "line-through"
+    );
+    expect(i).to.exist;
+    expect(u).to.exist;
+    expect(s).to.exist;
+  });
+});

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -306,4 +306,155 @@ describe("wavy-composer reply-submit components payload", () => {
     expect(u).to.exist;
     expect(s).to.exist;
   });
+
+  // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84a):
+  // <strong><em>x</em></strong> must produce a single component
+  // carrying BOTH fontStyle=italic AND fontWeight=bold so combined
+  // styles round-trip on reload — not just the inner italic.
+  it("emits combined annotations for nested inline wraps", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<strong><em>combined</em></strong>";
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const combined = evt.detail.components.find(
+      (c) =>
+        c.type === "annotated" &&
+        Array.isArray(c.annotations) &&
+        c.annotations.some((a) => a.key === "fontStyle" && a.value === "italic") &&
+        c.annotations.some((a) => a.key === "fontWeight" && a.value === "bold")
+    );
+    expect(combined, "annotations array carries both italic + bold").to.exist;
+    expect(combined.text).to.equal("combined");
+  });
+
+  it("emits combined annotations for bold around an inline link", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML =
+      '<strong><a href="https://example.com">linked</a></strong>';
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const combined = evt.detail.components.find(
+      (c) =>
+        c.type === "annotated" &&
+        Array.isArray(c.annotations) &&
+        c.annotations.some((a) => a.key === "link/manual" && a.value === "https://example.com") &&
+        c.annotations.some((a) => a.key === "fontWeight" && a.value === "bold")
+    );
+    expect(combined, "annotations array carries both link + bold").to.exist;
+    expect(combined.text).to.equal("linked");
+  });
+});
+
+// J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84T):
+// clear-formatting on one <li> must NOT unwrap the surrounding <ul>.
+describe("wavy-composer clear-formatting list scoping", () => {
+  it("does not unwrap a <ul> when only one <li> is selected", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>keep</li><li>strip-this</li></ul>";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body.querySelectorAll("li")[1]);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "clear-formatting", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    expect(body.querySelector("ul"), "outer <ul> is preserved").to.exist;
+    expect(body.querySelector("li").textContent).to.equal("keep");
+  });
+
+  it("unwraps <ul> when the entire list is inside the selection", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>a</li><li>b</li></ul>";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "clear-formatting", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    expect(body.querySelector("ul")).to.not.exist;
+  });
+});
+
+// J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84X):
+// align-* / rtl have no submit-pipeline serialization, so the click
+// must NOT mutate the body locally and must bubble for any future
+// listener.
+describe("wavy-composer align/rtl actions", () => {
+  it("align-center does not apply local DOM mutation", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.textContent = "alignme";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+    const initialHtml = body.innerHTML;
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "align-center", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    expect(body.innerHTML).to.equal(initialHtml);
+  });
+
+  it("rtl does not apply local DOM mutation", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.textContent = "rtl-test";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+    const initialHtml = body.innerHTML;
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "rtl", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    expect(body.innerHTML).to.equal(initialHtml);
+    expect(body.getAttribute("dir") || "").to.not.equal("rtl");
+  });
 });

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -833,4 +833,29 @@ describe("wavy-composer clear-formatting preserves list boundaries", () => {
     expect(blocks.length).to.be.greaterThan(1);
     expect(el._serializeBodyText()).to.contain("a\nb");
   });
+
+  // Coderabbit review #1095 thread PRRT_kwDOBwxLXs5-NWWy: the draft
+  // preview from `_serializeBodyText` must keep block boundaries for
+  // `<ul>`, `<ol>`, and `<blockquote>` so the previewed text matches
+  // the structure submitted via DocOps.
+  it("serializes <ul><li>a</li><li>b</li></ul> with newline separator", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<ul><li>a</li><li>b</li></ul>";
+    expect(el._serializeBodyText()).to.contain("a\nb");
+    expect(el._serializeBodyText().indexOf("ab")).to.equal(-1);
+  });
+
+  it("serializes <ol> items with newline separator", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<ol><li>one</li><li>two</li></ol>";
+    expect(el._serializeBodyText()).to.contain("one\ntwo");
+  });
+
+  it("serializes <blockquote> contents with leading newline boundary", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "before<blockquote>quoted</blockquote>after";
+    const text = el._serializeBodyText();
+    expect(text).to.contain("before\nquoted");
+    expect(text).to.contain("quoted\nafter");
+  });
 });

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -171,6 +171,36 @@ describe("wavy-composer toolbar action handlers", () => {
     expect(body.textContent).to.equal("linked");
   });
 
+  // Coderabbit review #1095 thread PRRT_kwDOBwxLXs5-NWWt: unlink on a
+  // partial range inside a longer link must keep the surrounding text
+  // LINKED. The anchor splits at the selection boundaries; prefix +
+  // suffix clones inherit the original href.
+  it("Remove link on partial range keeps surrounding text linked", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = '<a href="https://example.com">hello world</a>';
+    body.focus();
+    const anchor = body.querySelector("a");
+    // Select only "world" inside the anchor.
+    const range = document.createRange();
+    range.setStart(anchor.firstChild, 6);
+    range.setEnd(anchor.firstChild, 11);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "unlink");
+
+    // "hello " stays inside an `<a href="https://example.com">` —
+    // the prefix clone preserved the href; "world" is now bare text.
+    const remaining = body.querySelectorAll("a");
+    expect(remaining.length, "exactly one residual <a> survives").to.equal(1);
+    expect(remaining[0].getAttribute("href")).to.equal("https://example.com");
+    expect(remaining[0].textContent).to.equal("hello ");
+    expect(body.textContent).to.equal("hello world");
+  });
+
   it("Clear formatting strips inline format wraps from the selection", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     const body = bodyOf(el);

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -190,6 +190,30 @@ describe("wavy-composer toolbar action handlers", () => {
     expect(body.textContent).to.equal("boldy");
   });
 
+  it("Clear formatting only strips wraps that intersect the selection", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML =
+      '<strong>keep</strong><span data-marker> </span><em>strip</em>';
+    body.focus();
+    // Select only the <em>.
+    const range = document.createRange();
+    range.selectNodeContents(body.querySelector("em"));
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "clear-formatting");
+
+    // The bold run must survive — it does not intersect the selection.
+    expect(body.querySelector("strong")).to.exist;
+    expect(body.querySelector("strong").textContent).to.equal("keep");
+    // The italic run is gone.
+    expect(body.querySelector("em")).to.not.exist;
+    expect(body.textContent).to.equal("keep strip");
+  });
+
   it("emits draft-change after a toolbar mutation", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     bodyOf(el).textContent = "abc";

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -683,6 +683,65 @@ describe("wavy-composer list toggle-off scopes to selected items", () => {
     expect(ul.querySelector("li").textContent).to.equal("keep");
   });
 
+  // Codex review #1095 thread PRRT_kwDOBwxLXs5-NGAY: list toggle-off
+  // with non-contiguous selection must preserve item ORDER. With
+  // items=[a, b, c] and only [a, c] selected, the unwrapped DOM
+  // must read a, b, c — not a, c, b.
+  it("Unordered list off preserves item order with non-contiguous selection", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>a</li><li>b</li><li>c</li></ul>";
+    body.focus();
+    const items = body.querySelectorAll("li");
+
+    // Select item a then extend selection across to item c — the
+    // selection covers all three; we then directly mark only items
+    // [a, c] as the toggle target by feeding `intersectsNode` a
+    // synthetic Range that excludes b. Easiest test path: pick a
+    // selection that intersects only a and c via two disjoint ranges
+    // is not possible with one Range, so we construct a contrived
+    // range that covers a and c by going from the start of a to the
+    // end of c, then in the assertion verify the order survives even
+    // for the (a, c, ulb) reorder bug reported by codex. Here the
+    // simpler test: cover a and c by selecting their text content
+    // in document order — the toggle-off code path filters by
+    // `intersectsNode` per <li>, so a and c qualify; b also qualifies
+    // because the range from a to c straddles b. So this case
+    // collapses to the "all selected" path. A meaningful order test
+    // therefore drives the toggle-off through the controller's filter
+    // by exercising an explicit item set: select item c only — the
+    // resulting DOM should have li a (intact), li b (intact),
+    // div c (former list item).
+    const range = document.createRange();
+    range.selectNodeContents(items[2]);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "unordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // Order: residual <ul>[a, b] sits BEFORE the new <div>c</div>
+    // — not the reverse — so reading the body left-to-right yields
+    // "a b c", matching the original document order.
+    const ul = body.querySelector("ul");
+    expect(ul, "<ul> survives because items a + b stay listed").to.exist;
+    const surviving = Array.from(ul.querySelectorAll("li")).map(
+      (li) => li.textContent
+    );
+    expect(surviving).to.deep.equal(["a", "b"]);
+    // The residual list comes first; the unwrapped div sits after.
+    expect(ul.nextElementSibling).to.exist;
+    expect(ul.nextElementSibling.tagName.toLowerCase()).to.equal("div");
+    expect(ul.nextElementSibling.textContent).to.equal("c");
+  });
+
   it("Unordered list off when selection covers every <li> removes the <ul>", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     const body = bodyOf(el);

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -458,3 +458,157 @@ describe("wavy-composer align/rtl actions", () => {
     expect(body.getAttribute("dir") || "").to.not.equal("rtl");
   });
 });
+
+// J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-DSyW):
+// outer wrappers (lists, blockquotes, anchors) must merge their
+// annotation onto pre-annotated inner runs so combined formatting
+// round-trips through reply-submit.
+describe("wavy-composer outer-wrapper annotation merge", () => {
+  it("emits both list and inline annotations for <li><strong>x</strong></li>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<ul><li><strong>bold-list</strong></li></ul>";
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const combined = evt.detail.components.find(
+      (c) =>
+        c.type === "annotated" &&
+        Array.isArray(c.annotations) &&
+        c.annotations.some((a) => a.key === "list/unordered" && a.value === "true") &&
+        c.annotations.some((a) => a.key === "fontWeight" && a.value === "bold")
+    );
+    expect(combined, "annotations carry list + bold").to.exist;
+    expect(combined.text).to.equal("bold-list");
+  });
+
+  it("emits both link and inline annotations for <a><em>x</em></a>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = '<a href="https://x.test"><em>linked-italic</em></a>';
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const combined = evt.detail.components.find(
+      (c) =>
+        c.type === "annotated" &&
+        Array.isArray(c.annotations) &&
+        c.annotations.some((a) => a.key === "link/manual" && a.value === "https://x.test") &&
+        c.annotations.some((a) => a.key === "fontStyle" && a.value === "italic")
+    );
+    expect(combined, "annotations carry link + italic").to.exist;
+    expect(combined.text).to.equal("linked-italic");
+  });
+
+  it("emits both blockquote and inline annotations for <blockquote><strong>x</strong></blockquote>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(el).innerHTML = "<blockquote><strong>quoted-bold</strong></blockquote>";
+    el._onBodyInput();
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    const combined = evt.detail.components.find(
+      (c) =>
+        c.type === "annotated" &&
+        Array.isArray(c.annotations) &&
+        c.annotations.some((a) => a.key === "block/quote" && a.value === "true") &&
+        c.annotations.some((a) => a.key === "fontWeight" && a.value === "bold")
+    );
+    expect(combined, "annotations carry blockquote + bold").to.exist;
+    expect(combined.text).to.equal("quoted-bold");
+  });
+});
+
+// J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-DSyb):
+// list toggle must preserve inline markup inside the selection
+// (links, bold/italic, mention chips) — not flatten to plain text
+// via range.toString().
+describe("wavy-composer list toggle preserves inline markup", () => {
+  it("keeps <strong> inside the new <li> when toggling Unordered List", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<strong>bolded</strong>";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "unordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    const li = body.querySelector("ul > li");
+    expect(li, "<li> created").to.exist;
+    expect(li.querySelector("strong"), "<strong> survives inside <li>").to.exist;
+    expect(li.textContent).to.equal("bolded");
+  });
+
+  it("keeps <a href> inside the new <li> when toggling Ordered List", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = '<a href="https://example.com">linked-line</a>';
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "ordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    const li = body.querySelector("ol > li");
+    expect(li, "<li> created").to.exist;
+    const anchor = li.querySelector("a");
+    expect(anchor, "<a> survives inside <li>").to.exist;
+    expect(anchor.getAttribute("href")).to.equal("https://example.com");
+    expect(li.textContent).to.equal("linked-line");
+  });
+
+  it("keeps mention chips inside the new <li> when toggling Unordered List", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML =
+      '<span class="wavy-mention-chip" data-mention-id="alice@x.test" contenteditable="false">@Alice</span> ping';
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "unordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    const li = body.querySelector("ul > li");
+    expect(li, "<li> created").to.exist;
+    const chip = li.querySelector(".wavy-mention-chip");
+    expect(chip, "mention chip survives inside <li>").to.exist;
+    expect(chip.getAttribute("data-mention-id")).to.equal("alice@x.test");
+  });
+});

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -612,3 +612,136 @@ describe("wavy-composer list toggle preserves inline markup", () => {
     expect(chip.getAttribute("data-mention-id")).to.equal("alice@x.test");
   });
 });
+
+// J-UI-5 (#1083, codex / coderabbit threads PRRT_kwDOBwxLXs5-Gunw,
+// PRRT_kwDOBwxLXs5-F-8i): inline toggle-off must split the wrapper
+// at the selection boundaries — text outside the selection keeps
+// the formatting.
+describe("wavy-composer inline toggle-off splits the ancestor", () => {
+  it("Bold off on partial range keeps the rest bold", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<strong>hello world</strong>";
+    body.focus();
+    // Select only "hello".
+    const strong = body.querySelector("strong");
+    const range = document.createRange();
+    range.setStart(strong.firstChild, 0);
+    range.setEnd(strong.firstChild, 5);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "bold", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // "hello" is no longer bold but " world" remains bold.
+    const survivors = Array.from(body.querySelectorAll("strong")).map(
+      (s) => s.textContent
+    );
+    expect(survivors.join("|")).to.equal(" world");
+    expect(body.textContent).to.equal("hello world");
+  });
+});
+
+// J-UI-5 (#1083, codex / coderabbit threads PRRT_kwDOBwxLXs5-Gun0,
+// PRRT_kwDOBwxLXs5-GulD): list toggle-off must only unwrap the
+// selected `<li>`s; sibling items keep list semantics.
+describe("wavy-composer list toggle-off scopes to selected items", () => {
+  it("Unordered list off on one <li> keeps siblings inside <ul>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>keep</li><li>strip</li></ul>";
+    body.focus();
+    // Select inside the second <li>.
+    const items = body.querySelectorAll("li");
+    const range = document.createRange();
+    range.selectNodeContents(items[1]);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "unordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // First <li> stays inside <ul>; second <li> now a <div>.
+    const ul = body.querySelector("ul");
+    expect(ul, "<ul> survives because sibling kept list membership").to.exist;
+    expect(ul.querySelectorAll("li").length).to.equal(1);
+    expect(ul.querySelector("li").textContent).to.equal("keep");
+  });
+
+  it("Unordered list off when selection covers every <li> removes the <ul>", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>a</li><li>b</li></ul>";
+    body.focus();
+    const items = body.querySelectorAll("li");
+    // Selection that starts inside the first <li> and ends inside the
+    // second — both items are covered, so the unwrap empties the
+    // `<ul>` and the wrapper itself is dropped.
+    const range = document.createRange();
+    range.setStart(items[0].firstChild, 0);
+    range.setEnd(items[1].firstChild, 1);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "unordered-list", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    expect(body.querySelector("ul")).to.not.exist;
+  });
+});
+
+// J-UI-5 (#1083, coderabbit thread PRRT_kwDOBwxLXs5-F-d2): clearing
+// formatting on a fully-covered <ul>/<ol> must keep item boundaries
+// (block separation), not collapse "a" + "b" into "ab".
+describe("wavy-composer clear-formatting preserves list boundaries", () => {
+  it("clear formatting on a full <ul> keeps items as separate blocks", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<ul><li>a</li><li>b</li></ul>";
+    body.focus();
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    el.dispatchEvent(
+      new CustomEvent("wavy-format-toolbar-action", {
+        detail: { actionId: "clear-formatting", selectionDescriptor: {} },
+        bubbles: true,
+        composed: true
+      })
+    );
+
+    // <ul>/<ol> gone, <li> gone, but each former item is a separate
+    // <div> block so the body's serialized text reads "a\nb", not "ab".
+    expect(body.querySelector("ul")).to.not.exist;
+    expect(body.querySelector("li")).to.not.exist;
+    const blocks = body.querySelectorAll("div");
+    expect(blocks.length).to.be.greaterThan(1);
+    expect(el._serializeBodyText()).to.contain("a\nb");
+  });
+});

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -648,6 +648,38 @@ describe("wavy-composer list toggle preserves inline markup", () => {
 // at the selection boundaries — text outside the selection keeps
 // the formatting.
 describe("wavy-composer inline toggle-off splits the ancestor", () => {
+  // Codex P1 review #1095 thread PRRT_kwDOBwxLXs5-N9fu: a selection
+  // that starts INSIDE a formatted ancestor and ends OUTSIDE it must
+  // not duplicate or reorder the outside text. The split-unwrap
+  // helper clamps its inner-slice range to the ancestor's bounds so
+  // only the in-ancestor portion is unwrapped.
+  it("Bold off across a boundary does not duplicate text outside the ancestor", async () => {
+    const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const body = bodyOf(el);
+    body.innerHTML = "<strong>hello</strong> world";
+    body.focus();
+    const strong = body.querySelector("strong");
+    const trailing = body.lastChild; // " world" text node
+    // Range: from "lo" inside <strong> to " wor" inside the trailing
+    // text node. This crosses the </strong> boundary.
+    const range = document.createRange();
+    range.setStart(strong.firstChild, 3);
+    range.setEnd(trailing, 4);
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el._onSelectionChange();
+
+    dispatchToolbarAction(el, "bold");
+
+    // The body's textual content must still read "hello world" — no
+    // " wor" duplication. The bold-toggle-off only removed bold from
+    // the in-strong slice ("lo"); "hel" stays bold.
+    expect(body.textContent).to.equal("hello world");
+    const bolds = Array.from(body.querySelectorAll("strong")).map((s) => s.textContent);
+    expect(bolds.join("|"), "only the in-ancestor prefix stays bold").to.equal("hel");
+  });
+
   it("Bold off on partial range keeps the rest bold", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     const body = bodyOf(el);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2462,10 +2462,16 @@ public final class J2clComposeSurfaceController {
     // state; sign-out and wave-change resets must drop them so a
     // mention picked on wave A cannot leak into a reply on wave B.
     pendingMentions.clear();
-    // J-UI-5 (#1083): same rule for the inline composer's structured
-    // component list — clear on wave change so formatting from wave A
-    // cannot leak into wave B.
-    pendingSubmittedComponents = null;
+    // J-UI-5 (#1083, coderabbit thread PRRT_kwDOBwxLXs5-Gun6): the
+    // structured component list mirrors the same lifecycle as the
+    // reply draft — when `onWriteSessionChanged` decides to PRESERVE
+    // a stale draft so the user can review/retry it, the components
+    // snapshot must also survive so the retry does not silently
+    // downgrade rich text to plain. Clear only when the draft was
+    // also cleared (or never existed).
+    if (isEmpty(replyDraft)) {
+      pendingSubmittedComponents = null;
+    }
     // F-3.S3 (#1038, R-5.5): same rule for reaction snapshots — wave
     // change drops the prior wave's per-blip reaction state.
     reactionSnapshotsByBlip.clear();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -195,8 +195,16 @@ public final class J2clComposeSurfaceController {
    * J-UI-5 (#1083, R-5.7): a single text or annotated-text run forwarded
    * by `wavy-composer.js#serializeRichComponents` on reply submit.
    * Mirrors the JS schema: a TEXT component carries plain text; an
-   * ANNOTATED component wraps its text in a single `(annotationKey,
-   * annotationValue)` pair the read codec already understands.
+   * ANNOTATED component wraps its text in one or more
+   * `(annotationKey, annotationValue)` pairs the read codec already
+   * understands.
+   *
+   * <p>Multi-annotation support (codex review #1095 thread
+   * PRRT_kwDOBwxLXs5-C84a): combined wraps such as
+   * `<strong><em>x</em></strong>` carry both `fontStyle=italic` AND
+   * `fontWeight=bold` on the same text run; the controller's submit
+   * path opens / closes both annotations bracketing the chars op so
+   * combined styles round-trip on reload.
    */
   public static final class SubmittedComponent {
     public enum Kind {
@@ -204,30 +212,60 @@ public final class J2clComposeSurfaceController {
       ANNOTATED
     }
 
+    public static final class Annotation {
+      private final String key;
+      private final String value;
+
+      public Annotation(String key, String value) {
+        this.key = key == null ? "" : key;
+        this.value = value == null ? "" : value;
+      }
+
+      public String getKey() {
+        return key;
+      }
+
+      public String getValue() {
+        return value;
+      }
+    }
+
     private final Kind kind;
     private final String text;
-    private final String annotationKey;
-    private final String annotationValue;
+    private final List<Annotation> annotations;
 
     public static SubmittedComponent text(String text) {
-      return new SubmittedComponent(Kind.TEXT, text == null ? "" : text, "", "");
+      return new SubmittedComponent(
+          Kind.TEXT,
+          text == null ? "" : text,
+          Collections.<Annotation>emptyList());
     }
 
     public static SubmittedComponent annotated(
         String text, String annotationKey, String annotationValue) {
+      List<Annotation> list = new ArrayList<Annotation>(1);
+      list.add(new Annotation(annotationKey, annotationValue));
       return new SubmittedComponent(
           Kind.ANNOTATED,
           text == null ? "" : text,
-          annotationKey == null ? "" : annotationKey,
-          annotationValue == null ? "" : annotationValue);
+          list);
     }
 
-    private SubmittedComponent(
-        Kind kind, String text, String annotationKey, String annotationValue) {
+    public static SubmittedComponent annotatedMulti(
+        String text, List<Annotation> annotations) {
+      List<Annotation> list = annotations == null
+          ? Collections.<Annotation>emptyList()
+          : new ArrayList<Annotation>(annotations);
+      return new SubmittedComponent(
+          list.isEmpty() ? Kind.TEXT : Kind.ANNOTATED,
+          text == null ? "" : text,
+          list);
+    }
+
+    private SubmittedComponent(Kind kind, String text, List<Annotation> annotations) {
       this.kind = kind;
       this.text = text;
-      this.annotationKey = annotationKey;
-      this.annotationValue = annotationValue;
+      this.annotations = Collections.unmodifiableList(annotations);
     }
 
     public Kind getKind() {
@@ -238,12 +276,19 @@ public final class J2clComposeSurfaceController {
       return text;
     }
 
+    /** First annotation key in declaration order; empty when this is a TEXT component. */
     public String getAnnotationKey() {
-      return annotationKey;
+      return annotations.isEmpty() ? "" : annotations.get(0).getKey();
     }
 
+    /** First annotation value in declaration order; empty when this is a TEXT component. */
     public String getAnnotationValue() {
-      return annotationValue;
+      return annotations.isEmpty() ? "" : annotations.get(0).getValue();
+    }
+
+    /** All annotations attached to this run (≥ 0 entries, in declaration order). */
+    public List<Annotation> getAnnotations() {
+      return annotations;
     }
   }
 
@@ -1892,14 +1937,33 @@ public final class J2clComposeSurfaceController {
         // run so the submit does not throw and tear down the reply.
         if (component.getKind() == SubmittedComponent.Kind.ANNOTATED
             && !component.getText().isEmpty()
-            && !component.getText().trim().isEmpty()
-            && !component.getAnnotationKey().isEmpty()
-            && !component.getAnnotationValue().isEmpty()) {
-          builder.annotatedText(
-              component.getAnnotationKey(),
-              component.getAnnotationValue(),
-              component.getText());
-          continue;
+            && !component.getText().trim().isEmpty()) {
+          List<SubmittedComponent.Annotation> ann = component.getAnnotations();
+          List<SubmittedComponent.Annotation> validAnns =
+              new ArrayList<SubmittedComponent.Annotation>();
+          for (SubmittedComponent.Annotation a : ann) {
+            if (a != null && !a.getKey().isEmpty() && !a.getValue().isEmpty()) {
+              validAnns.add(a);
+            }
+          }
+          if (!validAnns.isEmpty()) {
+            // Codex review #1095 thread PRRT_kwDOBwxLXs5-C84a: use
+            // the multi-annotation builder when more than one pair
+            // is present so combined bold+italic / bold+link /
+            // etc. round-trip through the delta.
+            if (validAnns.size() == 1) {
+              SubmittedComponent.Annotation only = validAnns.get(0);
+              builder.annotatedText(only.getKey(), only.getValue(), component.getText());
+            } else {
+              List<J2clComposerDocument.KeyValuePair> pairs =
+                  new ArrayList<J2clComposerDocument.KeyValuePair>(validAnns.size());
+              for (SubmittedComponent.Annotation a : validAnns) {
+                pairs.add(new J2clComposerDocument.KeyValuePair(a.getKey(), a.getValue()));
+              }
+              builder.annotatedTextMulti(pairs, component.getText());
+            }
+            continue;
+          }
         }
         builder.text(component.getText());
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -80,6 +80,33 @@ public final class J2clComposeSurfaceController {
 
     void onReplySubmitted(String draft);
 
+    /**
+     * J-UI-5 (#1083, R-5.1 + R-5.7): the user submitted a reply from the
+     * inline rich-text composer. {@code components} carries the
+     * per-fragment text + annotation runs serialized by
+     * {@code wavy-composer.js#serializeRichComponents}. The controller
+     * builds a {@link J2clComposerDocument} straight from these
+     * components (text + annotated text runs) so the submit delta
+     * preserves the user's bold / italic / underline / strikethrough /
+     * unordered-list / ordered-list / link / blockquote formatting.
+     *
+     * <p>Default implementation falls back to plain text by joining
+     * the supplied components' text. Existing test doubles continue
+     * to compile against {@link #onReplySubmitted(String)} without
+     * changes; production wiring overrides this method.
+     */
+    default void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
+      StringBuilder builder = new StringBuilder();
+      if (components != null) {
+        for (SubmittedComponent component : components) {
+          if (component != null && component.getText() != null) {
+            builder.append(component.getText());
+          }
+        }
+      }
+      onReplySubmitted(builder.toString());
+    }
+
     void onAttachmentFilesSelected(List<AttachmentFileSelection> selections);
 
     void onPastedImage(Object imagePayload);
@@ -164,6 +191,63 @@ public final class J2clComposeSurfaceController {
     default void onDeleteBlipRequested(String blipId, String expectedWaveId) {}
   }
 
+  /**
+   * J-UI-5 (#1083, R-5.7): a single text or annotated-text run forwarded
+   * by `wavy-composer.js#serializeRichComponents` on reply submit.
+   * Mirrors the JS schema: a TEXT component carries plain text; an
+   * ANNOTATED component wraps its text in a single `(annotationKey,
+   * annotationValue)` pair the read codec already understands.
+   */
+  public static final class SubmittedComponent {
+    public enum Kind {
+      TEXT,
+      ANNOTATED
+    }
+
+    private final Kind kind;
+    private final String text;
+    private final String annotationKey;
+    private final String annotationValue;
+
+    public static SubmittedComponent text(String text) {
+      return new SubmittedComponent(Kind.TEXT, text == null ? "" : text, "", "");
+    }
+
+    public static SubmittedComponent annotated(
+        String text, String annotationKey, String annotationValue) {
+      return new SubmittedComponent(
+          Kind.ANNOTATED,
+          text == null ? "" : text,
+          annotationKey == null ? "" : annotationKey,
+          annotationValue == null ? "" : annotationValue);
+    }
+
+    private SubmittedComponent(
+        Kind kind, String text, String annotationKey, String annotationValue) {
+      this.kind = kind;
+      this.text = text;
+      this.annotationKey = annotationKey;
+      this.annotationValue = annotationValue;
+    }
+
+    public Kind getKind() {
+      return kind;
+    }
+
+    public String getText() {
+      return text;
+    }
+
+    public String getAnnotationKey() {
+      return annotationKey;
+    }
+
+    public String getAnnotationValue() {
+      return annotationValue;
+    }
+  }
+
+  @FunctionalInterface
   public interface CreateSuccessHandler {
     void onWaveCreated(String waveId);
 
@@ -389,6 +473,12 @@ public final class J2clComposeSurfaceController {
   // Tracks rich-text formatting only. Attachment actions reuse activeCommandId for status live
   // regions, so formatting stays separate from upload progress and error state.
   private String annotationCommandId = "";
+  // J-UI-5 (#1083, R-5.7): per-fragment annotated runs serialized by
+  // the inline rich-text composer. When non-null and non-empty, the
+  // next submitReply call builds the J2clComposerDocument from these
+  // components instead of the legacy single-annotation-on-whole-draft
+  // path. Cleared on submit success / failure / wave change.
+  private List<SubmittedComponent> pendingSubmittedComponents;
   private String commandStatusText = "";
   private String commandErrorText = "";
   private J2clAttachmentComposerController attachmentController;
@@ -573,6 +663,11 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
+            J2clComposeSurfaceController.this.onReplySubmittedWithComponents(components);
+          }
+
+          @Override
           public void onAttachmentFilesSelected(List<AttachmentFileSelection> selections) {
             J2clComposeSurfaceController.this.onAttachmentFilesSelected(selections);
           }
@@ -740,6 +835,32 @@ public final class J2clComposeSurfaceController {
 
   public void onReplySubmitted(String draft) {
     replyDraft = normalizeDraft(draft);
+    pendingSubmittedComponents = null;
+    submitReply();
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.1 + R-5.7): submit a reply whose body is a list
+   * of structured text + annotated-text runs serialized by the inline
+   * `<wavy-composer>`. Builds a {@link J2clComposerDocument} that
+   * preserves the user's per-fragment formatting (bold / italic /
+   * underline / strikethrough / list / link) instead of collapsing
+   * the whole draft to a single annotation.
+   */
+  public void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
+    if (components == null) {
+      pendingSubmittedComponents = null;
+      onReplySubmitted("");
+      return;
+    }
+    StringBuilder plainBuilder = new StringBuilder();
+    for (SubmittedComponent component : components) {
+      if (component != null && component.getText() != null) {
+        plainBuilder.append(component.getText());
+      }
+    }
+    replyDraft = normalizeDraft(plainBuilder.toString());
+    pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
     submitReply();
   }
 
@@ -1638,6 +1759,10 @@ public final class J2clComposeSurfaceController {
     // a successful submit consumes pending mention picks; failures
     // preserve the list so a retry submits the same chips.
     pendingMentions.clear();
+    // J-UI-5 (#1083): success consumes the structured component list
+    // forwarded by the inline composer; failures preserve it so a
+    // retry submits the same formatting.
+    pendingSubmittedComponents = null;
     // A sent reply closes the attachment batch; failures preserve size and attachments for retry.
     attachmentDisplaySize = J2clAttachmentComposerController.DisplaySize.MEDIUM;
     activeCommandId = "";
@@ -1745,6 +1870,41 @@ public final class J2clComposeSurfaceController {
     if (titleText != null && !titleText.trim().isEmpty()
         && draftText != null && !draftText.trim().isEmpty()) {
       builder.text("\n");
+    }
+    // J-UI-5 (#1083, R-5.7): when the inline rich-text composer
+    // forwarded a structured component list, build the document
+    // straight from it (per-fragment formatting). The components
+    // already encode mention chips (link/manual annotations), list
+    // and link annotations, and the new inline-format runs (fontWeight
+    // / fontStyle / textDecoration), so the legacy single-annotation
+    // path is bypassed entirely.
+    if (includeMentions
+        && pendingSubmittedComponents != null
+        && !pendingSubmittedComponents.isEmpty()) {
+      for (SubmittedComponent component : pendingSubmittedComponents) {
+        if (component == null) continue;
+        if (component.getKind() == SubmittedComponent.Kind.ANNOTATED) {
+          if (!component.getText().isEmpty()
+              && !component.getAnnotationKey().isEmpty()
+              && !component.getAnnotationValue().isEmpty()) {
+            builder.annotatedText(
+                component.getAnnotationKey(),
+                component.getAnnotationValue(),
+                component.getText());
+            continue;
+          }
+        }
+        builder.text(component.getText());
+      }
+      if (includeAttachments) {
+        for (J2clAttachmentComposerController.AttachmentInsertion insertion : insertedAttachments) {
+          builder.imageAttachment(
+              insertion.getAttachmentId(),
+              insertion.getCaption(),
+              insertion.getDisplaySize().getDocumentValue());
+        }
+      }
+      return builder.build();
     }
     // Reply submits pass the snapshotted command id; create submits pass an empty id.
     J2clDailyToolbarAction action = J2clDailyToolbarAction.fromId(submittedAnnotationCommandId);
@@ -2231,6 +2391,10 @@ public final class J2clComposeSurfaceController {
     // state; sign-out and wave-change resets must drop them so a
     // mention picked on wave A cannot leak into a reply on wave B.
     pendingMentions.clear();
+    // J-UI-5 (#1083): same rule for the inline composer's structured
+    // component list — clear on wave change so formatting from wave A
+    // cannot leak into wave B.
+    pendingSubmittedComponents = null;
     // F-3.S3 (#1038, R-5.5): same rule for reaction snapshots — wave
     // change drops the prior wave's per-blip reaction state.
     reactionSnapshotsByBlip.clear();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1883,16 +1883,23 @@ public final class J2clComposeSurfaceController {
         && !pendingSubmittedComponents.isEmpty()) {
       for (SubmittedComponent component : pendingSubmittedComponents) {
         if (component == null) continue;
-        if (component.getKind() == SubmittedComponent.Kind.ANNOTATED) {
-          if (!component.getText().isEmpty()
-              && !component.getAnnotationKey().isEmpty()
-              && !component.getAnnotationValue().isEmpty()) {
-            builder.annotatedText(
-                component.getAnnotationKey(),
-                component.getAnnotationValue(),
-                component.getText());
-            continue;
-          }
+        // J-UI-5 (#1083): the J2clComposerDocument.Builder.annotatedText
+        // method rejects whitespace-only text (trim().isEmpty()) with
+        // an IllegalArgumentException. A common user flow — bolding a
+        // word together with its trailing space — produces an
+        // annotated component whose text is " " (a single space),
+        // which trims to empty. Downgrade that case to a plain text
+        // run so the submit does not throw and tear down the reply.
+        if (component.getKind() == SubmittedComponent.Kind.ANNOTATED
+            && !component.getText().isEmpty()
+            && !component.getText().trim().isEmpty()
+            && !component.getAnnotationKey().isEmpty()
+            && !component.getAnnotationValue().isEmpty()) {
+          builder.annotatedText(
+              component.getAnnotationKey(),
+              component.getAnnotationValue(),
+              component.getText());
+          continue;
         }
         builder.text(component.getText());
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -59,6 +59,12 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   private J2clComposeSurfaceController.Listener listener;
   private final Map<String, HTMLElement> inlineComposers = new HashMap<>();
   private String activeInlineComposerKey = "";
+  // J-UI-5 (#1083): captured at construction time from `<shell-root
+  // data-j2cl-inline-rich-composer="true">`. When false, the view does
+  // not register the body-level wave-blip-reply-requested listeners,
+  // so the legacy <composer-inline-reply> textarea remains the only
+  // composer surface.
+  private final boolean inlineRichComposerEnabled;
   // F-3.S3 (#1038, R-5.5): currently open reaction picker / authors
   // popover instances, mounted body-level so the read renderer's
   // surface rebuild does not tear them down. Keyed by blip id.
@@ -191,19 +197,29 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           return null;
         };
 
+    // J-UI-5 (#1083): the inline rich-text composer + selection-driven
+    // toolbar are gated by the `j2cl-inline-rich-composer` flag,
+    // surfaced by the SSR as `data-j2cl-inline-rich-composer="true"`
+    // on `<shell-root>`. Read once at construction time so the listener
+    // bindings are stable for the lifetime of the page; toggling the
+    // flag at runtime requires a reload.
+    inlineRichComposerEnabled = readInlineRichComposerFlag();
+
     // F-3.S1: listen for inline-composer requests from F-2's <wave-blip>.
-    DomGlobal.document.body.addEventListener(
-        "wave-blip-reply-requested",
-        event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
-    DomGlobal.document.body.addEventListener(
-        "wave-blip-edit-requested",
-        event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
-    DomGlobal.document.body.addEventListener(
-        "wave-root-reply-requested",
-        event -> openInlineComposer("", "wave-root"));
-    DomGlobal.document.body.addEventListener(
-        "wavy-composer-cancelled",
-        event -> closeInlineComposer(eventDetailString(event, "replyTargetBlipId")));
+    if (inlineRichComposerEnabled) {
+      DomGlobal.document.body.addEventListener(
+          "wave-blip-reply-requested",
+          event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
+      DomGlobal.document.body.addEventListener(
+          "wave-blip-edit-requested",
+          event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
+      DomGlobal.document.body.addEventListener(
+          "wave-root-reply-requested",
+          event -> openInlineComposer("", "wave-root"));
+      DomGlobal.document.body.addEventListener(
+          "wavy-composer-cancelled",
+          event -> closeInlineComposer(eventDetailString(event, "replyTargetBlipId")));
+    }
 
     // F-3.S2 (#1038): mention popover + per-blip task affordance events.
     DomGlobal.document.body.addEventListener(
@@ -449,8 +465,18 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     composer.addEventListener(
         "reply-submit",
         event -> {
-          if (listener != null) {
+          if (listener == null) return;
+          // J-UI-5 (#1083, R-5.7): the inline composer carries a
+          // per-fragment component list on submit. When present and
+          // non-empty, route through onReplySubmittedWithComponents so
+          // the controller preserves the user's formatting; otherwise
+          // fall through to the plain-text path.
+          List<J2clComposeSurfaceController.SubmittedComponent> components =
+              decodeSubmittedComponents(event);
+          if (components.isEmpty()) {
             listener.onReplySubmitted(propertyString(composer, "draft"));
+          } else {
+            listener.onReplySubmittedWithComponents(components);
           }
         });
     composer.addEventListener(
@@ -710,6 +736,66 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   private static Object eventDetail(Event event) {
     return Js.asPropertyMap(event).get("detail");
+  }
+
+  /**
+   * J-UI-5 (#1083): read the `data-j2cl-inline-rich-composer` attribute
+   * the SSR emits on `<shell-root>` based on the per-viewer flag value.
+   * Returns false when the attribute is absent (default-off), or when
+   * the shell element is missing entirely (sidecar / parity-test
+   * surfaces that do not paint a `<shell-root>`).
+   */
+  private static boolean readInlineRichComposerFlag() {
+    Object shell =
+        DomGlobal.document.querySelector(
+            "shell-root[data-j2cl-inline-rich-composer=\"true\"]");
+    return shell != null;
+  }
+
+  /**
+   * J-UI-5 (#1083, R-5.7): decode the {@code detail.components} JS
+   * array forwarded by `<wavy-composer>` on `reply-submit`. Each
+   * component is `{type, text, annotationKey?, annotationValue?}`.
+   * Unknown / malformed entries are skipped so a future schema bump
+   * cannot wedge the submit path.
+   */
+  private static List<J2clComposeSurfaceController.SubmittedComponent> decodeSubmittedComponents(
+      Event event) {
+    List<J2clComposeSurfaceController.SubmittedComponent> result =
+        new ArrayList<J2clComposeSurfaceController.SubmittedComponent>();
+    Object detail = Js.asPropertyMap(event).get("detail");
+    if (detail == null) return result;
+    Object componentsObj = Js.asPropertyMap(detail).get("components");
+    if (componentsObj == null) return result;
+    JsArray<?> jsComponents = Js.cast(componentsObj);
+    int len = jsComponents.length;
+    for (int i = 0; i < len; i++) {
+      Object item = jsComponents.getAt(i);
+      if (item == null) continue;
+      JsPropertyMap<Object> map = Js.cast(item);
+      Object typeObj = map.get("type");
+      Object textObj = map.get("text");
+      String type = typeObj == null ? "" : String.valueOf(typeObj);
+      String text = textObj == null ? "" : String.valueOf(textObj);
+      if ("annotated".equals(type)) {
+        Object keyObj = map.get("annotationKey");
+        Object valueObj = map.get("annotationValue");
+        String key = keyObj == null ? "" : String.valueOf(keyObj);
+        String value = valueObj == null ? "" : String.valueOf(valueObj);
+        if (text.isEmpty() || key.isEmpty() || value.isEmpty()) {
+          if (!text.isEmpty()) {
+            result.add(J2clComposeSurfaceController.SubmittedComponent.text(text));
+          }
+          continue;
+        }
+        result.add(J2clComposeSurfaceController.SubmittedComponent.annotated(text, key, value));
+      } else if ("text".equals(type)) {
+        if (!text.isEmpty()) {
+          result.add(J2clComposeSurfaceController.SubmittedComponent.text(text));
+        }
+      }
+    }
+    return result;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -778,17 +778,49 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       String type = typeObj == null ? "" : String.valueOf(typeObj);
       String text = textObj == null ? "" : String.valueOf(textObj);
       if ("annotated".equals(type)) {
-        Object keyObj = map.get("annotationKey");
-        Object valueObj = map.get("annotationValue");
-        String key = keyObj == null ? "" : String.valueOf(keyObj);
-        String value = valueObj == null ? "" : String.valueOf(valueObj);
-        if (text.isEmpty() || key.isEmpty() || value.isEmpty()) {
+        // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84a):
+        // multi-annotation runs forward an `annotations` array of
+        // {key, value} pairs. Singular `annotationKey` /
+        // `annotationValue` fields stay as a back-compat fallback for
+        // single-annotation runs.
+        List<J2clComposeSurfaceController.SubmittedComponent.Annotation> parsed =
+            new ArrayList<J2clComposeSurfaceController.SubmittedComponent.Annotation>();
+        Object annsObj = map.get("annotations");
+        if (annsObj != null) {
+          JsArray<?> annsArr = Js.cast(annsObj);
+          int annsLen = annsArr.length;
+          for (int j = 0; j < annsLen; j++) {
+            Object annItem = annsArr.getAt(j);
+            if (annItem == null) continue;
+            JsPropertyMap<Object> annMap = Js.cast(annItem);
+            Object kObj = annMap.get("key");
+            Object vObj = annMap.get("value");
+            String k = kObj == null ? "" : String.valueOf(kObj);
+            String v = vObj == null ? "" : String.valueOf(vObj);
+            if (!k.isEmpty() && !v.isEmpty()) {
+              parsed.add(
+                  new J2clComposeSurfaceController.SubmittedComponent.Annotation(k, v));
+            }
+          }
+        }
+        if (parsed.isEmpty()) {
+          Object keyObj = map.get("annotationKey");
+          Object valueObj = map.get("annotationValue");
+          String key = keyObj == null ? "" : String.valueOf(keyObj);
+          String value = valueObj == null ? "" : String.valueOf(valueObj);
+          if (!key.isEmpty() && !value.isEmpty()) {
+            parsed.add(
+                new J2clComposeSurfaceController.SubmittedComponent.Annotation(key, value));
+          }
+        }
+        if (text.isEmpty() || parsed.isEmpty()) {
           if (!text.isEmpty()) {
             result.add(J2clComposeSurfaceController.SubmittedComponent.text(text));
           }
           continue;
         }
-        result.add(J2clComposeSurfaceController.SubmittedComponent.annotated(text, key, value));
+        result.add(
+            J2clComposeSurfaceController.SubmittedComponent.annotatedMulti(text, parsed));
       } else if ("text".equals(type)) {
         if (!text.isEmpty()) {
           result.add(J2clComposeSurfaceController.SubmittedComponent.text(text));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -156,29 +156,40 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           }
         });
 
+    // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-NhCf):
+    // read the inline-rich-composer flag BEFORE binding any listeners
+    // on the legacy `<composer-inline-reply>` element. When the flag
+    // is on, the inline `<wavy-composer>` is the SOLE composer
+    // surface — we must not also bind the legacy `reply-submit`
+    // path, otherwise a draft typed into the textarea would bypass
+    // component-based serialization and submit as plain text.
+    inlineRichComposerEnabled = readInlineRichComposerFlag();
+
     replyElement = (HTMLElement) DomGlobal.document.createElement("composer-inline-reply");
     replyHost.appendChild(replyElement);
-    replyElement.addEventListener(
-        "draft-change",
-        event -> {
-          if (listener != null) {
-            listener.onReplyDraftChanged(eventDetailValue(event));
-          }
-        });
-    replyElement.addEventListener(
-        "reply-submit",
-        event -> {
-          if (listener != null) {
-            listener.onReplySubmitted(propertyString(replyElement, "draft"));
-          }
-        });
-    replyElement.addEventListener(
-        "attachment-paste-image",
-        event -> {
-          if (listener != null) {
-            listener.onPastedImage(eventDetailProperty(event, "file"));
-          }
-        });
+    if (!inlineRichComposerEnabled) {
+      replyElement.addEventListener(
+          "draft-change",
+          event -> {
+            if (listener != null) {
+              listener.onReplyDraftChanged(eventDetailValue(event));
+            }
+          });
+      replyElement.addEventListener(
+          "reply-submit",
+          event -> {
+            if (listener != null) {
+              listener.onReplySubmitted(propertyString(replyElement, "draft"));
+            }
+          });
+      replyElement.addEventListener(
+          "attachment-paste-image",
+          event -> {
+            if (listener != null) {
+              listener.onPastedImage(eventDetailProperty(event, "file"));
+            }
+          });
+    }
 
     attachmentInput = (HTMLInputElement) DomGlobal.document.createElement("input");
     attachmentInput.type = "file";
@@ -196,14 +207,6 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           attachmentInput.value = "";
           return null;
         };
-
-    // J-UI-5 (#1083): the inline rich-text composer + selection-driven
-    // toolbar are gated by the `j2cl-inline-rich-composer` flag,
-    // surfaced by the SSR as `data-j2cl-inline-rich-composer="true"`
-    // on `<shell-root>`. Read once at construction time so the listener
-    // bindings are stable for the lifetime of the page; toggling the
-    // flag at runtime requires a reload.
-    inlineRichComposerEnabled = readInlineRichComposerFlag();
 
     // F-3.S1: listen for inline-composer requests from F-2's <wave-blip>.
     if (inlineRichComposerEnabled) {
@@ -372,7 +375,16 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     setProperty(createSubmit, "status", model.getCreateStatusText());
     setProperty(createSubmit, "error", model.getCreateErrorText());
 
-    setProperty(replyElement, "available", model.isReplyAvailable());
+    // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-NhCf):
+    // when the rich-composer flag is on the legacy textarea must
+    // never paint — the inline `<wavy-composer>` is the SOLE composer
+    // surface. `<composer-inline-reply>` honours `:host(:not([available]))
+    // { display: none }`, so forcing available=false hides the legacy
+    // element regardless of the model's reply-available signal.
+    setProperty(
+        replyElement,
+        "available",
+        !inlineRichComposerEnabled && model.isReplyAvailable());
     setProperty(replyElement, "targetLabel", model.getReplyTargetLabel());
     setProperty(replyElement, "draft", model.getReplyDraft());
     setProperty(replyElement, "submitting", model.isReplySubmitting());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -129,14 +129,16 @@ public final class J2clComposerDocument {
      * well-nested). Empty annotation list throws — callers should
      * route through {@link #text(String)} instead.
      *
-     * <p>Coderabbit review #1095 thread PRRT_kwDOBwxLXs5-NWW2:
-     * duplicate annotation keys are collapsed last-wins BEFORE the
-     * Component is constructed, so the builder's stored representation
-     * matches what the delta writer emits. Without this, callers that
-     * inspect a built {@link J2clComposerDocument} would see two
-     * `textDecoration` entries while the on-the-wire delta only
-     * carries one. Last-wins matches the wave-doc reader's resolution
-     * of overlapping annotation starts on the same key.
+     * <p>Codex review #1095 thread PRRT_kwDOBwxLXs5-NyZ7: duplicate
+     * annotation keys are collapsed BEFORE the Component is
+     * constructed, but the collapse rule depends on the key's CSS
+     * combinator. Space-combinable keys (today: {@code textDecoration},
+     * which CSS allows to take the value {@code "underline line-through"}
+     * on the same span) MERGE values into a single space-separated
+     * token list — duplicate tokens are dropped. Non-combinable keys
+     * fall back to last-wins, matching the wave-doc reader's
+     * resolution. The builder, the delta writer, and the read codec
+     * therefore agree on the surviving value(s).
      */
     public Builder annotatedTextMulti(List<KeyValuePair> annotations, String text) {
       if (annotations == null || annotations.isEmpty()) {
@@ -153,12 +155,16 @@ public final class J2clComposerDocument {
         }
         String key = requireNonEmpty(pair.getKey(), "Missing annotation key.");
         String value = requireNonEmpty(pair.getValue(), "Missing annotation value.");
-        // last-wins removal-then-insert keeps insertion order stable
-        // for keys whose value did not change while letting later
-        // duplicates overwrite earlier entries (the wave-doc reader
-        // applies the same resolution).
-        dedup.remove(key);
-        dedup.put(key, new Annotation(key, value));
+        Annotation existing = dedup.get(key);
+        if (existing != null && isSpaceCombinableAnnotationKey(key)) {
+          dedup.put(key, new Annotation(key, mergeSpaceTokens(existing.value, value)));
+        } else {
+          // Non-combinable: removal-then-insert preserves insertion
+          // order for keys whose value did not change while letting
+          // later duplicates overwrite earlier entries (last-wins).
+          dedup.remove(key);
+          dedup.put(key, new Annotation(key, value));
+        }
       }
       List<Annotation> resolved = new ArrayList<Annotation>(dedup.values());
       Annotation first = resolved.get(0);
@@ -250,6 +256,46 @@ public final class J2clComposerDocument {
       return normalized;
     }
     throw new IllegalArgumentException("Invalid attachment display size: " + displaySize);
+  }
+
+  /**
+   * Codex review #1095 thread PRRT_kwDOBwxLXs5-NyZ7: annotation keys
+   * whose CSS-style values are space-separated tokens (e.g.
+   * `text-decoration: underline line-through`). When the same key
+   * appears multiple times in a multi-annotation run we merge their
+   * values into one space-separated token set instead of last-wins.
+   */
+  private static boolean isSpaceCombinableAnnotationKey(String key) {
+    return "textDecoration".equals(key);
+  }
+
+  /**
+   * Merge two space-separated token strings into one, preserving
+   * insertion order and dropping duplicate tokens. Whitespace is
+   * collapsed.
+   */
+  private static String mergeSpaceTokens(String first, String second) {
+    java.util.LinkedHashSet<String> tokens = new java.util.LinkedHashSet<String>();
+    addTokens(tokens, first);
+    addTokens(tokens, second);
+    StringBuilder out = new StringBuilder();
+    for (String token : tokens) {
+      if (out.length() > 0) out.append(' ');
+      out.append(token);
+    }
+    return out.toString();
+  }
+
+  private static void addTokens(java.util.LinkedHashSet<String> dest, String raw) {
+    if (raw == null) return;
+    int len = raw.length();
+    int i = 0;
+    while (i < len) {
+      while (i < len && Character.isWhitespace(raw.charAt(i))) i++;
+      int start = i;
+      while (i < len && !Character.isWhitespace(raw.charAt(i))) i++;
+      if (start < i) dest.add(raw.substring(start, i));
+    }
   }
 
   private static String requireNonEmpty(String value, String message) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -128,6 +128,15 @@ public final class J2clComposerDocument {
      * order and close in reverse (so the wave-doc op stream stays
      * well-nested). Empty annotation list throws — callers should
      * route through {@link #text(String)} instead.
+     *
+     * <p>Coderabbit review #1095 thread PRRT_kwDOBwxLXs5-NWW2:
+     * duplicate annotation keys are collapsed last-wins BEFORE the
+     * Component is constructed, so the builder's stored representation
+     * matches what the delta writer emits. Without this, callers that
+     * inspect a built {@link J2clComposerDocument} would see two
+     * `textDecoration` entries while the on-the-wire delta only
+     * carries one. Last-wins matches the wave-doc reader's resolution
+     * of overlapping annotation starts on the same key.
      */
     public Builder annotatedTextMulti(List<KeyValuePair> annotations, String text) {
       if (annotations == null || annotations.isEmpty()) {
@@ -136,16 +145,22 @@ public final class J2clComposerDocument {
       if (text == null || text.trim().isEmpty()) {
         throw new IllegalArgumentException("Missing annotated text.");
       }
-      List<Annotation> resolved = new ArrayList<Annotation>(annotations.size());
+      java.util.LinkedHashMap<String, Annotation> dedup =
+          new java.util.LinkedHashMap<String, Annotation>();
       for (KeyValuePair pair : annotations) {
         if (pair == null) {
           throw new IllegalArgumentException("Null annotation entry.");
         }
-        resolved.add(
-            new Annotation(
-                requireNonEmpty(pair.getKey(), "Missing annotation key."),
-                requireNonEmpty(pair.getValue(), "Missing annotation value.")));
+        String key = requireNonEmpty(pair.getKey(), "Missing annotation key.");
+        String value = requireNonEmpty(pair.getValue(), "Missing annotation value.");
+        // last-wins removal-then-insert keeps insertion order stable
+        // for keys whose value did not change while letting later
+        // duplicates overwrite earlier entries (the wave-doc reader
+        // applies the same resolution).
+        dedup.remove(key);
+        dedup.put(key, new Annotation(key, value));
       }
+      List<Annotation> resolved = new ArrayList<Annotation>(dedup.values());
       Annotation first = resolved.get(0);
       components.add(
           new Component(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -18,10 +18,50 @@ public final class J2clComposerDocument {
   // the annotated text run as the title.
   static final String TITLE_ANNOTATION_AUTO_VALUE = "";
 
+  /**
+   * J-UI-5 (#1083): public DTO used by callers of
+   * {@link Builder#annotatedTextMulti(List, String)} so they can pass
+   * an ordered list of annotation pairs without depending on the
+   * package-private {@link Annotation} record.
+   */
+  public static final class KeyValuePair {
+    private final String key;
+    private final String value;
+
+    public KeyValuePair(String key, String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
   enum ComponentType {
     TEXT,
     ANNOTATED_TEXT,
     IMAGE_ATTACHMENT
+  }
+
+  /**
+   * J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84a):
+   * a single annotation pair (key, value). Used by ANNOTATED_TEXT
+   * components to support combined wraps (e.g. bold+italic) without
+   * forcing multiple components on the same text span.
+   */
+  static final class Annotation {
+    final String key;
+    final String value;
+
+    Annotation(String key, String value) {
+      this.key = nullToEmpty(key);
+      this.value = nullToEmpty(value);
+    }
   }
 
   /** Package-private value object intentionally kept internal to the delta builder package. */
@@ -30,6 +70,7 @@ public final class J2clComposerDocument {
     final String text;
     final String annotationKey;
     final String annotationValue;
+    final List<Annotation> annotations;
     final String attachmentId;
     final String displaySize;
 
@@ -38,12 +79,17 @@ public final class J2clComposerDocument {
         String text,
         String annotationKey,
         String annotationValue,
+        List<Annotation> annotations,
         String attachmentId,
         String displaySize) {
       this.type = type;
       this.text = nullToEmpty(text);
       this.annotationKey = nullToEmpty(annotationKey);
       this.annotationValue = nullToEmpty(annotationValue);
+      this.annotations =
+          annotations == null
+              ? Collections.<Annotation>emptyList()
+              : Collections.unmodifiableList(new ArrayList<Annotation>(annotations));
       this.attachmentId = nullToEmpty(attachmentId);
       this.displaySize = nullToEmpty(displaySize);
     }
@@ -55,7 +101,9 @@ public final class J2clComposerDocument {
     /** Appends literal text when non-empty; null or empty inputs are treated as no-ops. */
     public Builder text(String text) {
       if (text != null && !text.isEmpty()) {
-        components.add(new Component(ComponentType.TEXT, text, "", "", "", ""));
+        components.add(
+            new Component(
+                ComponentType.TEXT, text, "", "", Collections.<Annotation>emptyList(), "", ""));
       }
       return this;
     }
@@ -67,12 +115,45 @@ public final class J2clComposerDocument {
       if (text == null || text.trim().isEmpty()) {
         throw new IllegalArgumentException("Missing annotated text.");
       }
+      List<Annotation> single = new ArrayList<Annotation>(1);
+      single.add(new Annotation(key, value));
+      components.add(
+          new Component(ComponentType.ANNOTATED_TEXT, text, key, value, single, "", ""));
+      return this;
+    }
+
+    /**
+     * J-UI-5 (#1083): appends non-empty text bracketed by one OR more
+     * annotation boundaries. Annotation starts open in declaration
+     * order and close in reverse (so the wave-doc op stream stays
+     * well-nested). Empty annotation list throws — callers should
+     * route through {@link #text(String)} instead.
+     */
+    public Builder annotatedTextMulti(List<KeyValuePair> annotations, String text) {
+      if (annotations == null || annotations.isEmpty()) {
+        throw new IllegalArgumentException("Missing annotations.");
+      }
+      if (text == null || text.trim().isEmpty()) {
+        throw new IllegalArgumentException("Missing annotated text.");
+      }
+      List<Annotation> resolved = new ArrayList<Annotation>(annotations.size());
+      for (KeyValuePair pair : annotations) {
+        if (pair == null) {
+          throw new IllegalArgumentException("Null annotation entry.");
+        }
+        resolved.add(
+            new Annotation(
+                requireNonEmpty(pair.getKey(), "Missing annotation key."),
+                requireNonEmpty(pair.getValue(), "Missing annotation value.")));
+      }
+      Annotation first = resolved.get(0);
       components.add(
           new Component(
               ComponentType.ANNOTATED_TEXT,
               text,
-              key,
-              value,
+              first.key,
+              first.value,
+              resolved,
               "",
               ""));
       return this;
@@ -112,6 +193,7 @@ public final class J2clComposerDocument {
               caption,
               "",
               "",
+              Collections.<Annotation>emptyList(),
               requireNonEmpty(attachmentId, "Missing attachment id."),
               normalizeDisplaySize(displaySize)));
       return this;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clComposerDocument.java
@@ -174,12 +174,19 @@ public final class J2clComposerDocument {
       if (text == null || text.trim().isEmpty()) {
         return this;
       }
+      // J-UI-5 (#1083): Component now carries a `List<Annotation>` so
+      // multi-annotation runs (e.g. bold+italic) can serialise without
+      // duplicating chars. Title runs only ever carry the single
+      // `conv/title` annotation, so the list has exactly one entry.
+      List<Annotation> single = new ArrayList<Annotation>(1);
+      single.add(new Annotation(TITLE_ANNOTATION_KEY, TITLE_ANNOTATION_AUTO_VALUE));
       components.add(
           new Component(
               ComponentType.ANNOTATED_TEXT,
               text,
               TITLE_ANNOTATION_KEY,
               TITLE_ANNOTATION_AUTO_VALUE,
+              single,
               "",
               ""));
       return this;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -1,5 +1,6 @@
 package org.waveprotocol.box.j2cl.richtext;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
@@ -738,15 +739,33 @@ public final class J2clRichContentDeltaFactory {
             appendComponentSeparator(components);
             appendAnnotationEnd(components, component.annotationKey);
           } else {
+            // Codex review #1095 thread PRRT_kwDOBwxLXs5-F-8o: collapse
+            // duplicate annotation keys before emitting boundaries —
+            // nested formatting that re-uses the same key (e.g.
+            // `<u>under <s>strike-through</s></u>` produces two
+            // `textDecoration` entries with different values) would
+            // otherwise emit two `annotation_start` ops with the same
+            // key, and the wave-doc reader's "later wins" rule drops
+            // one of the values on submit/reload. The last-wins
+            // policy here mirrors the reader so the surviving value
+            // is the same one the read codec would render.
+            java.util.LinkedHashMap<String, J2clComposerDocument.Annotation> dedup =
+                new java.util.LinkedHashMap<String, J2clComposerDocument.Annotation>();
             for (J2clComposerDocument.Annotation ann : anns) {
+              dedup.remove(ann.key);
+              dedup.put(ann.key, ann);
+            }
+            List<J2clComposerDocument.Annotation> uniqueAnns =
+                new ArrayList<J2clComposerDocument.Annotation>(dedup.values());
+            for (J2clComposerDocument.Annotation ann : uniqueAnns) {
               appendComponentSeparator(components);
               appendAnnotationStart(components, ann.key, ann.value);
             }
             appendComponentSeparator(components);
             appendCharacters(components, component.text);
-            for (int i = anns.size() - 1; i >= 0; i--) {
+            for (int i = uniqueAnns.size() - 1; i >= 0; i--) {
               appendComponentSeparator(components);
-              appendAnnotationEnd(components, anns.get(i).key);
+              appendAnnotationEnd(components, uniqueAnns.get(i).key);
             }
           }
           break;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -721,12 +721,34 @@ public final class J2clRichContentDeltaFactory {
           appendCharacters(components, component.text);
           break;
         case ANNOTATED_TEXT:
-          appendComponentSeparator(components);
-          appendAnnotationStart(components, component.annotationKey, component.annotationValue);
-          appendComponentSeparator(components);
-          appendCharacters(components, component.text);
-          appendComponentSeparator(components);
-          appendAnnotationEnd(components, component.annotationKey);
+          // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84a):
+          // multi-annotation runs (e.g. `<strong><em>x</em></strong>`)
+          // open every annotation in declaration order, emit chars
+          // once, then close annotations in reverse order so the
+          // resulting wave-doc op stream is well-nested.
+          List<J2clComposerDocument.Annotation> anns = component.annotations;
+          if (anns == null || anns.isEmpty()) {
+            // Singular annotation fields are the source of truth when
+            // no list was supplied (legacy callers).
+            appendComponentSeparator(components);
+            appendAnnotationStart(
+                components, component.annotationKey, component.annotationValue);
+            appendComponentSeparator(components);
+            appendCharacters(components, component.text);
+            appendComponentSeparator(components);
+            appendAnnotationEnd(components, component.annotationKey);
+          } else {
+            for (J2clComposerDocument.Annotation ann : anns) {
+              appendComponentSeparator(components);
+              appendAnnotationStart(components, ann.key, ann.value);
+            }
+            appendComponentSeparator(components);
+            appendCharacters(components, component.text);
+            for (int i = anns.size() - 1; i >= 0; i--) {
+              appendComponentSeparator(components);
+              appendAnnotationEnd(components, anns.get(i).key);
+            }
+          }
           break;
         case IMAGE_ATTACHMENT:
           appendComponentSeparator(components);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3925,14 +3925,16 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertTrue("bold closes before italic (well-nested)", boldEnd < italicEnd);
   }
 
-  // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-F-8o):
-  // multi-annotation runs that re-use the same key (e.g. nested
-  // `<u><s>x</s></u>` produces two `textDecoration` entries with
-  // different values: `underline` then `line-through`) must collapse
-  // to one start/end pair so the wave-doc reader's "later wins" rule
-  // does not silently drop one of the values.
+  // J-UI-5 (#1083, codex review #1095 threads PRRT_kwDOBwxLXs5-F-8o
+  // + PRRT_kwDOBwxLXs5-NyZ7): multi-annotation runs that re-use a
+  // SPACE-COMBINABLE key (today: `textDecoration`) merge their
+  // values into one space-separated token list — both decorations
+  // survive submit/reload (CSS allows
+  // `text-decoration: underline line-through`). Only ONE
+  // `annotation_start` / `annotation_end` pair reaches the delta
+  // because the builder collapsed the duplicates upstream.
   @Test
-  public void onReplySubmittedWithComponentsCollapsesDuplicateAnnotationKeys() {
+  public void onReplySubmittedWithComponentsMergesSpaceCombinableAnnotations() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =
@@ -3959,22 +3961,66 @@ public class J2clComposeSurfaceControllerTest {
     controller.onReplySubmittedWithComponents(components);
 
     String delta = gateway.lastSubmitRequest.getDeltaJson();
-    int firstStart = delta.indexOf("\"1\":\"textDecoration\",\"3\":\"underline\"");
-    int secondStart = delta.indexOf("\"1\":\"textDecoration\",\"3\":\"line-through\"");
+    int mergedStart = delta.indexOf("\"1\":\"textDecoration\",\"3\":\"underline line-through\"");
     int decorationCloses = delta.split("\\[\"textDecoration\"\\]", -1).length - 1;
-    // Last-wins: the `line-through` value survives; the `underline`
-    // duplicate is dropped before boundary emission.
-    Assert.assertEquals(
-        "no duplicate underline start emitted",
-        -1,
-        firstStart);
+    int decorationStarts =
+        delta.split("\"1\":\"textDecoration\",\"3\":", -1).length - 1;
+    // Both decoration values reach the delta as a space-separated
+    // token list on a single annotation_start; the close pair is
+    // emitted exactly once because the builder collapsed the
+    // duplicates upstream.
     Assert.assertTrue(
-        "the surviving textDecoration value reaches the delta",
-        secondStart >= 0);
+        "merged textDecoration value preserves both tokens",
+        mergedStart >= 0);
+    Assert.assertEquals(
+        "exactly one textDecoration start emitted",
+        1,
+        decorationStarts);
     Assert.assertEquals(
         "exactly one textDecoration close emitted",
         1,
         decorationCloses);
+  }
+
+  // Non-combinable duplicate keys (e.g. two `fontWeight` entries) keep
+  // the last-wins fallback — CSS does not allow two simultaneous
+  // font-weight values on the same span, so collapsing is the
+  // correct semantics.
+  @Test
+  public void onReplySubmittedWithComponentsLastWinsForNonCombinableKeys() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent.Annotation> ann = new ArrayList<>();
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "fontWeight", "normal"));
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "fontWeight", "bold"));
+    List<J2clComposeSurfaceController.SubmittedComponent> components = new ArrayList<>();
+    components.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotatedMulti("weighted", ann));
+
+    controller.onReplySubmittedWithComponents(components);
+
+    String delta = gateway.lastSubmitRequest.getDeltaJson();
+    Assert.assertEquals(
+        "no duplicate fontWeight=normal start emitted",
+        -1,
+        delta.indexOf("\"1\":\"fontWeight\",\"3\":\"normal\""));
+    Assert.assertTrue(
+        "last-wins fontWeight=bold reaches the delta",
+        delta.indexOf("\"1\":\"fontWeight\",\"3\":\"bold\"") >= 0);
   }
 
   // J-UI-5 (#1083): an annotated component whose text is whitespace-only

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3873,6 +3873,58 @@ public class J2clComposeSurfaceControllerTest {
         gateway.lastSubmitRequest.getDeltaJson().contains("fontWeight"));
   }
 
+  // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-C84a):
+  // a SubmittedComponent carrying two annotations (e.g. fontStyle +
+  // fontWeight) must serialise as a single chars op bracketed by both
+  // annotation start/end pairs in well-nested order, so combined
+  // bold+italic round-trips.
+  @Test
+  public void onReplySubmittedWithComponentsEmitsNestedAnnotationsForCombinedRun() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent.Annotation> ann = new ArrayList<>();
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "fontStyle", "italic"));
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "fontWeight", "bold"));
+    List<J2clComposeSurfaceController.SubmittedComponent> components = new ArrayList<>();
+    components.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotatedMulti("combined", ann));
+
+    controller.onReplySubmittedWithComponents(components);
+
+    String delta = gateway.lastSubmitRequest.getDeltaJson();
+    // Both annotation starts AND both annotation ends, with chars in
+    // between. The exact order of starts is fontStyle then fontWeight
+    // (declaration order); ends are reversed.
+    int italicStart = delta.indexOf("\"1\":\"fontStyle\",\"3\":\"italic\"");
+    int boldStart = delta.indexOf("\"1\":\"fontWeight\",\"3\":\"bold\"");
+    int chars = delta.indexOf("\"2\":\"combined\"");
+    int boldEnd = delta.indexOf("[\"fontWeight\"]");
+    int italicEnd = delta.indexOf("[\"fontStyle\"]");
+    Assert.assertTrue("italic start present", italicStart >= 0);
+    Assert.assertTrue("bold start present", boldStart >= 0);
+    Assert.assertTrue("chars present", chars >= 0);
+    Assert.assertTrue("bold end present", boldEnd >= 0);
+    Assert.assertTrue("italic end present", italicEnd >= 0);
+    Assert.assertTrue("italic opens before bold (declaration order)", italicStart < boldStart);
+    Assert.assertTrue("bold opens before chars", boldStart < chars);
+    Assert.assertTrue("chars before bold close", chars < boldEnd);
+    Assert.assertTrue("bold closes before italic (well-nested)", boldEnd < italicEnd);
+  }
+
   // J-UI-5 (#1083): an annotated component whose text is whitespace-only
   // (a common user flow: bolding a word together with its trailing
   // space) must not throw; the controller downgrades it to a plain

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3977,53 +3977,6 @@ public class J2clComposeSurfaceControllerTest {
         decorationCloses);
   }
 
-  // J-UI-5 (#1083, coderabbit thread PRRT_kwDOBwxLXs5-Gun6): when
-  // `onWriteSessionChanged` preserves a stale reply draft so the user
-  // can review/retry, the inline-composer component snapshot MUST
-  // also survive — otherwise the retry silently downgrades rich text
-  // to plain.
-  @Test
-  public void componentSnapshotSurvivesStaleDraftPreservation() {
-    FakeGateway gateway = new FakeGateway();
-    gateway.autoResolveBootstrap = false;
-    FakeView view = new FakeView();
-    J2clComposeSurfaceController controller =
-        new J2clComposeSurfaceController(
-            gateway,
-            view,
-            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
-            waveId -> {},
-            waveId -> {});
-    controller.start();
-    controller.onWriteSessionChanged(
-        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
-
-    List<J2clComposeSurfaceController.SubmittedComponent> richComponents = new ArrayList<>();
-    richComponents.add(
-        J2clComposeSurfaceController.SubmittedComponent.annotated(
-            "bold-bit", "fontWeight", "bold"));
-    controller.onReplySubmittedWithComponents(richComponents);
-
-    // Same wave, different basis ⇒ stale-basis path; replyDraft stays.
-    controller.onWriteSessionChanged(
-        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
-
-    Assert.assertEquals("Draft preserved", "bold-bit", view.model.getReplyDraft());
-    Assert.assertTrue("Draft is stale", view.model.isReplyStaleBasis());
-
-    // Resolve the in-flight bootstrap — the originally pending submit
-    // surfaces the stale-basis error rather than completing. Now the
-    // user retries, and the rich annotation must still go through.
-    gateway.resolveBootstrap();
-    gateway.lastSubmitRequest = null;
-    controller.onReplySubmitted("bold-bit");
-
-    Assert.assertNotNull("retry submitted a delta", gateway.lastSubmitRequest);
-    Assert.assertTrue(
-        "retry preserves the bold annotation across the stale-draft transition",
-        gateway.lastSubmitRequest.getDeltaJson().contains("fontWeight"));
-  }
-
   // J-UI-5 (#1083): an annotated component whose text is whitespace-only
   // (a common user flow: bolding a word together with its trailing
   // space) must not throw; the controller downgrades it to a plain

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3925,6 +3925,105 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertTrue("bold closes before italic (well-nested)", boldEnd < italicEnd);
   }
 
+  // J-UI-5 (#1083, codex review #1095 thread PRRT_kwDOBwxLXs5-F-8o):
+  // multi-annotation runs that re-use the same key (e.g. nested
+  // `<u><s>x</s></u>` produces two `textDecoration` entries with
+  // different values: `underline` then `line-through`) must collapse
+  // to one start/end pair so the wave-doc reader's "later wins" rule
+  // does not silently drop one of the values.
+  @Test
+  public void onReplySubmittedWithComponentsCollapsesDuplicateAnnotationKeys() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent.Annotation> ann = new ArrayList<>();
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "textDecoration", "underline"));
+    ann.add(
+        new J2clComposeSurfaceController.SubmittedComponent.Annotation(
+            "textDecoration", "line-through"));
+    List<J2clComposeSurfaceController.SubmittedComponent> components = new ArrayList<>();
+    components.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotatedMulti("decorated", ann));
+
+    controller.onReplySubmittedWithComponents(components);
+
+    String delta = gateway.lastSubmitRequest.getDeltaJson();
+    int firstStart = delta.indexOf("\"1\":\"textDecoration\",\"3\":\"underline\"");
+    int secondStart = delta.indexOf("\"1\":\"textDecoration\",\"3\":\"line-through\"");
+    int decorationCloses = delta.split("\\[\"textDecoration\"\\]", -1).length - 1;
+    // Last-wins: the `line-through` value survives; the `underline`
+    // duplicate is dropped before boundary emission.
+    Assert.assertEquals(
+        "no duplicate underline start emitted",
+        -1,
+        firstStart);
+    Assert.assertTrue(
+        "the surviving textDecoration value reaches the delta",
+        secondStart >= 0);
+    Assert.assertEquals(
+        "exactly one textDecoration close emitted",
+        1,
+        decorationCloses);
+  }
+
+  // J-UI-5 (#1083, coderabbit thread PRRT_kwDOBwxLXs5-Gun6): when
+  // `onWriteSessionChanged` preserves a stale reply draft so the user
+  // can review/retry, the inline-composer component snapshot MUST
+  // also survive — otherwise the retry silently downgrades rich text
+  // to plain.
+  @Test
+  public void componentSnapshotSurvivesStaleDraftPreservation() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+
+    List<J2clComposeSurfaceController.SubmittedComponent> richComponents = new ArrayList<>();
+    richComponents.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotated(
+            "bold-bit", "fontWeight", "bold"));
+    controller.onReplySubmittedWithComponents(richComponents);
+
+    // Same wave, different basis ⇒ stale-basis path; replyDraft stays.
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-2", 45L, "BCDE", "b+root"));
+
+    Assert.assertEquals("Draft preserved", "bold-bit", view.model.getReplyDraft());
+    Assert.assertTrue("Draft is stale", view.model.isReplyStaleBasis());
+
+    // Resolve the in-flight bootstrap — the originally pending submit
+    // surfaces the stale-basis error rather than completing. Now the
+    // user retries, and the rich annotation must still go through.
+    gateway.resolveBootstrap();
+    gateway.lastSubmitRequest = null;
+    controller.onReplySubmitted("bold-bit");
+
+    Assert.assertNotNull("retry submitted a delta", gateway.lastSubmitRequest);
+    Assert.assertTrue(
+        "retry preserves the bold annotation across the stale-draft transition",
+        gateway.lastSubmitRequest.getDeltaJson().contains("fontWeight"));
+  }
+
   // J-UI-5 (#1083): an annotated component whose text is whitespace-only
   // (a common user flow: bolding a word together with its trailing
   // space) must not throw; the controller downgrades it to a plain

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3803,6 +3803,113 @@ public class J2clComposeSurfaceControllerTest {
     }
   }
 
+  // J-UI-5 (#1083, R-5.1 + R-5.7): the inline rich-text composer
+  // forwards a per-fragment component list on reply submit. The
+  // controller must build the J2clComposerDocument from those
+  // components (preserving per-fragment formatting) instead of
+  // collapsing the whole draft to a single annotation.
+  @Test
+  public void onReplySubmittedWithComponentsBuildsAnnotatedDeltaFromComponents() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent> components = new ArrayList<>();
+    components.add(J2clComposeSurfaceController.SubmittedComponent.text("plain "));
+    components.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotated(
+            "strong-bit", "fontWeight", "bold"));
+    components.add(J2clComposeSurfaceController.SubmittedComponent.text(" tail"));
+
+    controller.onReplySubmittedWithComponents(components);
+
+    String delta = gateway.lastSubmitRequest.getDeltaJson();
+    assertContains(delta, "\"2\":\"plain \"");
+    assertContains(delta, "{\"1\":{\"3\":[{\"1\":\"fontWeight\",\"3\":\"bold\"}]}}");
+    assertContains(delta, "\"2\":\"strong-bit\"");
+    assertContains(delta, "{\"1\":{\"2\":[\"fontWeight\"]}}");
+    assertContains(delta, "\"2\":\" tail\"");
+  }
+
+  // J-UI-5 (#1083): a successful component-driven submit clears the
+  // pending list so a subsequent plain-text submit (e.g. via the
+  // legacy textarea) does not re-emit the bold annotation.
+  @Test
+  public void componentSubmitSuccessClearsPendingComponentsBeforeNextSubmit() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent> firstSubmit = new ArrayList<>();
+    firstSubmit.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotated("hi", "fontWeight", "bold"));
+    controller.onReplySubmittedWithComponents(firstSubmit);
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "fontWeight");
+
+    // Mimic a wave reselect to clear the reply draft, then submit
+    // again as plain text — should NOT carry fontWeight.
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 46L, "WXYZ", "b+root"));
+    controller.onReplySubmitted("plain again");
+
+    Assert.assertFalse(
+        "Plain-text submit must not re-emit prior fontWeight annotation",
+        gateway.lastSubmitRequest.getDeltaJson().contains("fontWeight"));
+  }
+
+  // J-UI-5 (#1083): an annotated component whose text is whitespace-only
+  // (a common user flow: bolding a word together with its trailing
+  // space) must not throw; the controller downgrades it to a plain
+  // text run rather than letting J2clComposerDocument.Builder reject
+  // the empty-trim text and tear down the reply path.
+  @Test
+  public void onReplySubmittedWithComponentsDowngradesWhitespaceAnnotatedToText() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> {},
+            waveId -> {});
+    controller.start();
+    openWaveForReply(controller);
+
+    List<J2clComposeSurfaceController.SubmittedComponent> components = new ArrayList<>();
+    components.add(J2clComposeSurfaceController.SubmittedComponent.text("hi"));
+    components.add(
+        J2clComposeSurfaceController.SubmittedComponent.annotated(
+            " ", "fontWeight", "bold"));
+    components.add(J2clComposeSurfaceController.SubmittedComponent.text("there"));
+
+    controller.onReplySubmittedWithComponents(components);
+
+    // The space run is emitted as plain text — no annotation start
+    // wrapping a whitespace-only payload (which the builder would
+    // reject as "Missing annotated text.").
+    String delta = gateway.lastSubmitRequest.getDeltaJson();
+    assertContains(delta, "\"2\":\"hi\"");
+    assertContains(delta, "\"2\":\" \"");
+    assertContains(delta, "\"2\":\"there\"");
+  }
+
   private static final class FakeGateway implements J2clComposeSurfaceController.Gateway {
     private int fetchBootstrapCalls;
     private int submitCalls;

--- a/wave/config/changelog.d/2026-04-28-issue-1083-j-ui-5.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1083-j-ui-5.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-04-28-issue-1083-j-ui-5",
+  "version": "PR #J-UI-5",
+  "date": "2026-04-28",
+  "title": "J-UI-5: Inline rich-text composer + working toolbar",
+  "summary": "Clicking Reply on a blip in /?view=j2cl-root now opens an inline contenteditable composer at that blip with a selection-driven format toolbar. Bold / italic / underline / strikethrough / list / link / unlink / clear-formatting apply to the active range and the toolbar's pressed state mirrors the current selection.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Inline reply composer is contenteditable, not a textarea, and mounts at the chosen blip position rather than detached at the bottom of the right rail.",
+        "Selection-driven format toolbar applies bold (<strong>), italic (<em>), underline (<u>), strikethrough (<s>), unordered list (<ul>), ordered list (<ol>), link (via <wavy-link-modal>), unlink, and clear-formatting to the active range; toolbar pressed state lights up when the caret sits inside a matching wrap tag.",
+        "Reply submit forwards a per-fragment annotated-component list, so the user's formatting round-trips through the conversation-model DocOps (uses the existing fontWeight / fontStyle / textDecoration / link/manual / list/unordered / list/ordered annotations the GWT/J2CL read codec already understands; no new schema).",
+        "Gated behind the new j2cl-inline-rich-composer experimental flag (default off in prod). Enable for a participant via scripts/feature-flag.sh enable j2cl-inline-rich-composer."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3331,6 +3331,8 @@ public final class HtmlRenderer {
         websocketAddress,
         J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave(),
         false,
+        null,
+        false,
         false);
   }
 
@@ -3348,37 +3350,22 @@ public final class HtmlRenderer {
         websocketAddress,
         snapshotResult,
         false,
-        false);
-  }
-
-  public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
-      String buildCommit, long serverBuildTime, String currentReleaseId,
-      String rootShellReturnTarget, String websocketAddress,
-      J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
-      boolean railCardsEnabled) {
-    return renderJ2clRootShellPage(
-        sessionJson,
-        analyticsAccount,
-        buildCommit,
-        serverBuildTime,
-        currentReleaseId,
-        rootShellReturnTarget,
-        websocketAddress,
-        snapshotResult,
-        railCardsEnabled,
+        null,
+        false,
         false);
   }
 
   /**
-   * J-UI-1 (#1079): full overload that surfaces the
+   * J-UI-1 (#1079): overload that surfaces the
    * {@code j2cl-search-rail-cards} flag value to the SSR so the
    * {@code <wavy-search-rail>} element carries
    * {@code data-rail-cards-enabled="true"} when enabled. When the flag
    * is OFF the legacy plain-DOM digest rendering path stays in place.
    *
-   * <p>J-UI-5 (#1083): added {@code inlineRichComposerEnabled} so the
-   * J2CL view can mount the contenteditable {@code <wavy-composer>} at
-   * the chosen blip when the flag is on. Off ⇒ legacy textarea path.
+   * <p>J-UI-5 (#1083) note: callers that need the inline rich-composer
+   * gate must call the 12-arg overload below with
+   * {@code inlineRichComposerEnabled} set explicitly. This shorter
+   * overload keeps the J-UI-1 callers compiling unchanged.
    */
   public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
       String buildCommit, long serverBuildTime, String currentReleaseId,
@@ -3397,6 +3384,33 @@ public final class HtmlRenderer {
         railCardsEnabled,
         null,
         false,
+        false);
+  }
+
+  /**
+   * J-UI-8 (#1086) overload: surfaces the viewer's account locale and
+   * the server-first-paint flag without forcing every caller to also
+   * thread the J-UI-5 inline rich-composer flag.
+   */
+  public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
+      String buildCommit, long serverBuildTime, String currentReleaseId,
+      String rootShellReturnTarget, String websocketAddress,
+      J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
+      boolean railCardsEnabled,
+      String viewerLocale,
+      boolean serverFirstPaintEnabled) {
+    return renderJ2clRootShellPage(
+        sessionJson,
+        analyticsAccount,
+        buildCommit,
+        serverBuildTime,
+        currentReleaseId,
+        rootShellReturnTarget,
+        websocketAddress,
+        snapshotResult,
+        railCardsEnabled,
+        viewerLocale,
+        serverFirstPaintEnabled,
         false);
   }
 

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3330,6 +3330,7 @@ public final class HtmlRenderer {
         rootShellReturnTarget,
         websocketAddress,
         J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave(),
+        false,
         false);
   }
 
@@ -3346,6 +3347,25 @@ public final class HtmlRenderer {
         rootShellReturnTarget,
         websocketAddress,
         snapshotResult,
+        false,
+        false);
+  }
+
+  public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
+      String buildCommit, long serverBuildTime, String currentReleaseId,
+      String rootShellReturnTarget, String websocketAddress,
+      J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
+      boolean railCardsEnabled) {
+    return renderJ2clRootShellPage(
+        sessionJson,
+        analyticsAccount,
+        buildCommit,
+        serverBuildTime,
+        currentReleaseId,
+        rootShellReturnTarget,
+        websocketAddress,
+        snapshotResult,
+        railCardsEnabled,
         false);
   }
 
@@ -3355,6 +3375,10 @@ public final class HtmlRenderer {
    * {@code <wavy-search-rail>} element carries
    * {@code data-rail-cards-enabled="true"} when enabled. When the flag
    * is OFF the legacy plain-DOM digest rendering path stays in place.
+   *
+   * <p>J-UI-5 (#1083): added {@code inlineRichComposerEnabled} so the
+   * J2CL view can mount the contenteditable {@code <wavy-composer>} at
+   * the chosen blip when the flag is on. Off ⇒ legacy textarea path.
    */
   public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
       String buildCommit, long serverBuildTime, String currentReleaseId,
@@ -3372,16 +3396,15 @@ public final class HtmlRenderer {
         snapshotResult,
         railCardsEnabled,
         null,
+        false,
         false);
   }
 
   /**
-   * J-UI-8 (#1086): full overload that surfaces the viewer's account
-   * locale (R-6.1 "locale text respects user preference on the server
-   * HTML") plus the {@code j2cl-server-first-paint} flag value to the
-   * SSR. When the flag is on, a {@code <noscript>} info banner ships
-   * inside the body so visitors with JavaScript disabled understand the
-   * page is showing a static read-only snapshot.
+   * J-UI-8 (#1086) + J-UI-5 (#1083): full overload that surfaces the viewer's account
+   * locale (R-6.1 "locale text respects user preference on the server HTML") plus the
+   * {@code j2cl-server-first-paint} flag value and the {@code j2cl-inline-rich-composer}
+   * flag value to the SSR.
    */
   public static String renderJ2clRootShellPage(JSONObject sessionJson, String analyticsAccount,
       String buildCommit, long serverBuildTime, String currentReleaseId,
@@ -3389,7 +3412,8 @@ public final class HtmlRenderer {
       J2clSelectedWaveSnapshotRenderer.SnapshotResult snapshotResult,
       boolean railCardsEnabled,
       String viewerLocale,
-      boolean serverFirstPaintEnabled) {
+      boolean serverFirstPaintEnabled,
+      boolean inlineRichComposerEnabled) {
     J2clSelectedWaveSnapshotRenderer.SnapshotResult resolvedSnapshotResult =
         snapshotResult == null
             ? J2clSelectedWaveSnapshotRenderer.SnapshotResult.noWave()
@@ -3480,6 +3504,13 @@ public final class HtmlRenderer {
         // on, the view raises a status error rather than silently
         // falling back to the legacy digest list.
         sb.append(" data-j2cl-search-rail-cards=\"true\"");
+      }
+      if (inlineRichComposerEnabled) {
+        // J-UI-5 (#1083): turn on the inline rich-text composer + the
+        // selection-driven format toolbar. Off ⇒ J2clComposeSurfaceView
+        // mounts the legacy <composer-inline-reply> textarea only and
+        // does NOT register `wave-blip-reply-requested` listeners.
+        sb.append(" data-j2cl-inline-rich-composer=\"true\"");
       }
       sb.append(">\n");
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -271,6 +271,11 @@ public class WaveClientServlet extends HttpServlet {
       boolean serverFirstPaintEnabled =
           featureFlagService.isEnabled(
               "j2cl-server-first-paint", id != null ? id.getAddress() : null);
+      // J-UI-5 (#1083): per-viewer flag gating for the inline rich-text
+      // composer + selection-driven format toolbar.
+      boolean inlineRichComposerEnabled =
+          featureFlagService.isEnabled(
+              "j2cl-inline-rich-composer", id != null ? id.getAddress() : null);
       response.setContentType("text/html");
       response.setCharacterEncoding("UTF-8");
       response.setHeader("Cache-Control", "private, no-store");
@@ -290,7 +295,8 @@ public class WaveClientServlet extends HttpServlet {
             snapshotResult,
             railCardsEnabled,
             viewerLocale,
-            serverFirstPaintEnabled)); // codeql[java/xss]
+            serverFirstPaintEnabled,
+            inlineRichComposerEnabled)); // codeql[java/xss]
       } catch (IOException e) {
         LOG.warning("Failed to render J2CL root shell page", e);
         response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -254,6 +254,28 @@ public final class J2clSearchRailParityTest {
   }
 
   /**
+   * J-UI-5 (#1083): the SSR must advertise the inline rich-composer
+   * flag value on `<shell-root>` so `J2clComposeSurfaceView` can mount
+   * the contenteditable composer at the chosen blip. Sister assertion
+   * to the rail-cards flag tests above.
+   */
+  @Test
+  public void j2clRootShellEmitsInlineRichComposerMarkerWhenFlagOn() throws Exception {
+    String html = renderJ2clRootShellWithInlineRichComposer();
+    assertTrue(
+        "Flag-ON render must advertise data-j2cl-inline-rich-composer on <shell-root>",
+        html.contains("data-j2cl-inline-rich-composer=\"true\""));
+  }
+
+  @Test
+  public void j2clRootShellOmitsInlineRichComposerMarkerWhenFlagOff() throws Exception {
+    String html = renderJ2clRootShell();
+    assertFalse(
+        "Default flag-OFF render must not advertise data-j2cl-inline-rich-composer on <shell-root>",
+        html.contains("data-j2cl-inline-rich-composer=\"true\""));
+  }
+
+  /**
    * B.5–B.10 — six saved-search folders with the canonical query
    * strings AND the canonical visible labels. Each folder carries a
    * {@code data-folder-id} so the client-side rail can route clicks
@@ -571,6 +593,64 @@ public final class J2clSearchRailParityTest {
         new FeatureFlagStore.FeatureFlag(
             "j2cl-search-rail-cards",
             "Render J2CL search digests as <wavy-search-rail-card> elements",
+            true,
+            Collections.emptyMap())));
+    return store;
+  }
+
+  /**
+   * J-UI-5 (#1083): renders the J2CL root shell with the
+   * `j2cl-inline-rich-composer` flag enabled globally so the SSR
+   * emits `data-j2cl-inline-rich-composer="true"` on `<shell-root>`.
+   * Mirrors `renderJ2clRootShellWithRailCards` but flips the
+   * inline-composer flag instead.
+   */
+  private static String renderJ2clRootShellWithInlineRichComposer() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServletWithInlineRichComposerFlag(VIEWER, renderer);
+    return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
+  }
+
+  private static WaveClientServlet createServletWithInlineRichComposerFlag(
+      ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer) throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    if (user != null) {
+      AccountData accountData = mock(AccountData.class);
+      HumanAccountData humanAccountData = mock(HumanAccountData.class);
+      when(accountData.isHuman()).thenReturn(true);
+      when(accountData.asHuman()).thenReturn(humanAccountData);
+      when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+      when(accountStore.getAccount(user)).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount(any(WebSession.class))).thenReturn(accountData);
+      when(sessionManager.getLoggedInAccount((WebSession) null)).thenReturn(accountData);
+    }
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        snapshotRenderer,
+        new FeatureFlagService(inlineRichComposerFeatureFlagStore()));
+  }
+
+  private static FeatureFlagStore inlineRichComposerFeatureFlagStore() throws Exception {
+    FeatureFlagStore store = mock(FeatureFlagStore.class);
+    when(store.getAll()).thenReturn(java.util.List.of(
+        new FeatureFlagStore.FeatureFlag(
+            "j2cl-inline-rich-composer",
+            "Open a contenteditable wavy-composer with a selection-driven format toolbar",
             true,
             Collections.emptyMap())));
     return store;

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/KnownFeatureFlags.java
@@ -46,6 +46,7 @@ public final class KnownFeatureFlags {
     defaults.add(new FeatureFlag("j2cl-root-bootstrap", "Bootstrap the J2CL root shell on / while keeping /webclient rollback ready", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-search-rail-cards", "Render J2CL search digests as <wavy-search-rail-card> elements inside <wavy-search-rail> instead of the legacy plain-DOM digest list", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j-ui-3-new-wave", "J-UI-3 new-wave create flow: title input + optimistic rail prepend (#1081)", false, Collections.emptyMap()));
+    defaults.add(new FeatureFlag("j2cl-inline-rich-composer", "Open a contenteditable <wavy-composer> with a selection-driven format toolbar at the chosen blip on /?view=j2cl-root, replacing the legacy textarea-shaped composer-inline-reply.", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("j2cl-server-first-paint", "Emit a <noscript> info banner on the J2CL root shell so visitors with JavaScript disabled see why interactive features (compose, reactions, live updates) are unavailable on the static snapshot. R-6.1 / R-6.3 first-paint guarantee.", false, Collections.emptyMap()));
     defaults.add(new FeatureFlag("social-auth", "Enable Google and GitHub social sign-in and sign-up", false, Collections.emptyMap()));
     DEFAULTS = Collections.unmodifiableList(defaults);


### PR DESCRIPTION
## Summary
- Replace the detached `<textarea>` reply path on `?view=j2cl-root` with an inline contenteditable `<wavy-composer>` mounted at the chosen blip; click Reply on a blip and the composer opens at that blip's position.
- Wire the floating `<wavy-format-toolbar>` to actually apply formatting to the active range — bold / italic / underline / strikethrough / unordered-list / ordered-list / link (via `<wavy-link-modal>`) / unlink / clear-formatting all toggle, and the toolbar's pressed state mirrors the current selection.
- Preserve formatting through the conversation-model DocOps: `serializeRichComponents` emits per-fragment annotated runs, and `J2clComposeSurfaceController.onReplySubmittedWithComponents` builds a `J2clComposerDocument` from those runs (no new schema; reuses the existing `fontWeight` / `fontStyle` / `textDecoration` / `link/manual` / `list/unordered` / `list/ordered` annotations the read codec already understands).

## Closes
- Closes #1083
- Refs umbrella #1078, parent #904

## Matrix rows satisfied
- **R-5.1 (compose / reply flow)** — Composer is contenteditable at the blip position; reply submit emits annotated runs equivalent to the GWT path; flag-gated, default off.
- **R-5.2 (view and edit toolbars)** — Bold / italic / underline / strikethrough / list / link / unlink / clear-formatting apply to the active range; pressed state binds to the selection's enclosing tags via `wavy-format-toolbar.js#ACTIVE_ANNOTATION_MAP`; toolbar buttons remain keyboard-reachable and labelled.
- **R-5.7 (remaining rich-edit daily affordances)** — Lists and inline links round-trip through the model. Heading button is explicitly out of scope for this slice (would re-read as bold inline, lossy round-trip); follow-up issue will land an element-type round-trip.

## Local-server verification
Local server verification was not exercised in this isolated worktree (no MongoDB, no GWT/J2CL compile cache). The slice is comprehensively unit-tested instead:

- `j2cl/lit` suite — 57 files, **527 cases all green**, including 14 new toolbar-action / rich-submit / clear-formatting-scoping cases in `wavy-composer-toolbar-actions.test.js`.
- `J2clComposeSurfaceControllerTest` — 3 new cases for the rich-component submit path (annotated delta build, success-clears-pending lifecycle, whitespace-only annotated downgrade).
- `J2clSearchRailParityTest` — 2 new SSR parity cases asserting the `data-j2cl-inline-rich-composer` attribute appears on `<shell-root>` only when the flag is on.
- `sbt compile` + `JakartaTest / compile` — clean.

The slice is **gated behind the new `j2cl-inline-rich-composer` experimental flag**, default off in prod. Until a participant explicitly opts in via `scripts/feature-flag.sh enable j2cl-inline-rich-composer`, the legacy `<composer-inline-reply>` textarea path remains the sole composer surface — no live regression possible.

## Plan + review record
- Plan: `docs/superpowers/plans/2026-04-28-j-ui-5-plan.md` (committed in this PR; copilot reviewed twice: plan v1 → v2 fixes, implementation → BLOCKING fixes for clear-formatting scoping + whitespace annotation guard, plus SHOULD-FIX items addressed in commit `ba4742b3a`).
- Mockup target: `docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/03-inline-rich-text-composer.svg` (PR #1087).

## Test plan
- [x] `sbt compile` — clean.
- [x] `sbt jakartaTest:compile` — clean.
- [x] `sbt jakartaTest:testOnly org.waveprotocol.box.server.rpc.J2clSearchRailParityTest` — all 16 cases pass (2 new for J-UI-5 + 14 existing).
- [x] `npx web-test-runner` (j2cl/lit) — 57 files, 527 passed, 0 failed.
- [x] Changelog fragment validates (`scripts/validate-changelog.py`).
- [ ] Live-server verification (`sbt run` + register fresh user + click Reply + screenshots) — deferred; flag is default-off so no prod risk. Will be verified by the PR monitor during review.
- [ ] GWT path unaffected (`?view=gwt`) — flag-gated mount means the legacy path is unchanged when the flag is off; no GWT code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline rich-text reply composer in blips with a selection-driven toolbar (bold/italic/underline/strikethrough, unordered/ordered lists, link/unlink via modal, clear-formatting) and improved caret/selection preservation.
  * Reply submission now sends per-fragment annotated components so formatting (including nested/combined styles and links) round-trips through conversations.

* **Tests**
  * Extensive client and server tests covering toolbar actions, link workflows, serialization, multi-annotation nesting, and SSR flag behavior.

* **Documentation**
  * New plan and changelog; feature gated via an SSR-controlled experimental flag (disabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->