### PR TITLE
J-UI-6: Per-blip task toggle + done state

### DIFF
--- a/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
@@ -53,34 +53,63 @@ updates lose the visual state.
 ### Read-surface model + projector (the persistence + live-update gap)
 
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java`
-  - Add `boolean taskDone`, accessor `isTaskDone()`, builder-style
-    `withTaskDone(boolean)`. Backwards-compat constructors stay; new full
-    constructor takes `taskDone` as the last arg (alongside the existing
-    `deleted` flag).
+  - Add `boolean taskDone`, plus `String taskAssignee` and
+    `long taskDueTimestamp` (so the metadata overlay can re-mount with the
+    persisted assignee + due-date instead of empty defaults — this addresses
+    the issue's "associated metadata overlays preserved" line).
+  - Accessors `isTaskDone()`, `getTaskAssignee()`, `getTaskDueTimestamp()`.
+  - Builder-style `withTaskDone(boolean)` for the read-state path.
+  - Backwards-compat constructors stay; new full constructor takes the three
+    fields after `deleted`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java`
+  - **(copilot review fix #1)** The window-entry path is the dominant
+    production live-update path (`J2clSelectedWaveView` prefers
+    `viewportState.getReadWindowEntries()` → `renderWindow(...)` over the
+    flat `render(readBlips, ...)`), so task-done MUST flow through here too.
+  - Add `boolean taskDone`, `String taskAssignee`, `long taskDueTimestamp`
+    + accessors. Add `loadedWithTaskMetadata(...)` factory mirroring
+    `loadedWithMetadata(...)`. Add `withTaskDone(boolean)` mirror of
+    `withUnread`.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
   - Add static `documentTaskDone(SidecarSelectedWaveDocument)` mirroring
     `documentIsDeleted` — returns true iff any annotation range has
     `key == "task/done"` and `value == "true"`. (Per project memory:
     search/filter logic must read directly from wavelet DocOps; no
     conversation-model chain.)
-  - Wire `documentTaskDone` into `extractDocumentReadBlips` and
+  - Add `documentTaskAssignee(...)` and `documentTaskDueTimestamp(...)` —
+    read `task/assignee` (string) and `task/dueTs` (long, ms-since-epoch).
+    Falsy / unparseable → empty / `J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP`.
+  - Wire all three into `extractDocumentReadBlips` and
     `enrichReadBlipMetadata`.
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
-  - Carry `taskDone` through the viewport-decoded read-blip path so the
-    enrichment pass does not lose it on the same-wave update path. Where the
-    viewport projection uses the placeholder constructor, leave `taskDone`
-    false; the enrichment pass overwrites from the document annotation.
+  - Carry the three new fields through the viewport-decoded read-blip path
+    so the enrichment pass does not lose them on the same-wave update path.
+    Where the viewport projection uses the placeholder constructor, leave
+    them at empty/default; the enrichment pass overwrites from the document
+    annotations.
+  - Map `J2clReadBlip` → `J2clReadWindowEntry` so the new fields traverse the
+    `getReadWindowEntries()` projection used by `renderWindow(...)`.
 
 ### Renderer (the visual gap)
 
 - `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
-  - In `renderBlip`, when `blip.isTaskDone()` is true, set
-    `data-task-completed=""` on the `<wave-blip>` element. The CSS already in
-    `wave-blip.js` (`:host([data-task-completed]) .body { …line-through; }`)
-    paints the strikethrough.
-  - Also: when re-rendering for a same-wave update where a blip's
-    `taskDone` flipped, ensure the attribute is removed (set/remove
-    explicitly so transitions from done→open repaint correctly).
+  - In `renderBlip` (the `render(blips, ...)` path) and in the corresponding
+    window-entry render path (the `renderWindow(entries, ...)` path), when
+    `taskDone` is true, set `data-task-completed=""` on the `<wave-blip>`
+    element. The CSS in `wave-blip.js`
+    (`:host([data-task-completed]) .body { …line-through; }`) paints the
+    strikethrough. Also propagate `data-task-assignee` and
+    `data-task-due-date` (Y-M-D string derived from `taskDueTimestamp`) so
+    the metadata popover re-opens with the persisted values.
+  - **(copilot review fix #2)** Update `sameReadBlip(...)` AND
+    `sameWindowEntry(...)` to compare `isTaskDone()`, `getTaskAssignee()`,
+    `getTaskDueTimestamp()`. Without this, a same-wave `task/done` flip
+    looks like a no-op to the renderer's fast-path equality check and the
+    repaint never happens — the live-update / done→open transition would
+    silently break.
+  - On a same-wave update where `taskDone` flipped from true → false, the
+    re-render path must explicitly remove the attribute (set or remove based
+    on the new state, not toggle).
 
 ### Lit element guards (defensive — confirm overlays do not trap focus)
 
@@ -91,23 +120,57 @@ updates lose the visual state.
     `wavy-task-affordance.js:141`. No code changes expected; if any focus-trap
     is found, switch to a non-trapping approach with explicit Escape handling.
 
+### Localizable labels — issue acceptance "Labels translate"
+
+**(copilot review fix #3)** R-5.4 matrix row carries "Labels translate." The
+existing `wavy-task-affordance.js` hardcodes English in the visible toggle
+text (`Task` / `✓ Done`), the toggle aria-label (`Mark task complete` /
+`Mark task open`), the details aria-label (`Edit task details`), and the
+aria-live announce text (`Task completed` / `Task reopened`).
+
+Project-wide lit-i18n is its own slice (no `J2clClientFlags`-style i18n hook
+exists today). For this slice, refactor the affordance so each user-facing
+string is sourced from a string property (`labelToggleOpen`,
+`labelToggleDone`, `labelAriaCheck`, `labelAriaUncheck`, `labelDetails`,
+`labelAnnounceDone`, `labelAnnounceOpen`) with English defaults preserved.
+The Java view sets the properties via `Js.asPropertyMap(element).set(...)`
+when a localized string bundle is plumbed; for now the defaults match the
+existing F-3.S2 behavior verbatim so this change is non-breaking. This
+satisfies the matrix-row's "translate" clause by removing the architectural
+block — every visible string is now a property the Java view can override
+when the lit-i18n slice lands. A short note in the plan body explicitly
+calls out lit-i18n wiring as a follow-up issue.
+
 ### Tests
 
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
   - New cases: `documentTaskDoneTrueWhenAnnotationPresent`,
     `documentTaskDoneFalseForFalsyValue`,
-    `extractDocumentReadBlipsCarriesTaskDone`,
+    `documentTaskAssigneeReadsAnnotation`,
+    `documentTaskDueTimestampParsesNumericAnnotation`,
+    `extractDocumentReadBlipsCarriesTaskDoneAndMetadata`,
     `enrichReadBlipMetadataPropagatesTaskDoneFromDocument`.
 - `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
   - New case: `renderSetsDataTaskCompletedAttributeWhenTaskDone` — verifies
     the rendered `<wave-blip>` carries the attribute when
     `J2clReadBlip.isTaskDone()` is true and does not when false.
   - New case: `renderRemovesDataTaskCompletedOnSameWaveUpdateWhenTaskReopened`
-    — guards live-update repaint.
+    — guards live-update repaint (the equality-check fix from copilot
+    review fix #2).
+  - New case: `renderWindowSetsDataTaskCompletedFromWindowEntry` — guards
+    the dominant production path.
+  - New case: `renderPropagatesTaskAssigneeAndDueDate` — verifies the
+    metadata-overlay attributes flow through.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntryTest.java`
+  - New cases: `loadedWithTaskMetadataCarriesTaskFields`,
+    `withTaskDoneReturnsCopyWithFlippedFlag`.
 - `j2cl/lit/test/wave-blip.test.js`
   - New case: `<wave-blip data-task-completed>` applies strikethrough styling
     to the body wrapper. Asserts the host carries the attribute and that the
     affordance reflects `aria-checked="true"`.
+- `j2cl/lit/test/wavy-task-affordance.test.js`
+  - New case: `respects label property overrides` — sets each new label
+    property and verifies the affordance renders the override text.
 
 ### Browser fixture (manual smoke)
 
@@ -121,15 +184,17 @@ updates lose the visual state.
 ### Changelog + flag
 
 - `wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json`
-- Feature flag (defensive): `j2cl-task-done-render` — the renderer reads the
-  flag from `J2clClientFlags`. Default off in prod. The flag gates only the
-  read-surface attribute write, not the toggle path (the toggle path is
-  already shipped). When the flag is off, the read surface still mounts the
-  affordance — only the strikethrough/persistence rendering is gated. (If the
-  J2CL flag system does not yet expose a per-flag boolean, fall back to a
-  compile-time toggle in `J2clReadSurfaceDomRenderer` that defaults on; this
-  slice's user-visible change is small and additive, so a runtime flag is
-  defensive belt-and-suspenders rather than a hard requirement.)
+- **(copilot review fix #4)** Drop the speculative `J2clClientFlags`-based
+  feature flag. That seam does not exist in-tree (verified: no
+  `J2clClientFlags` class anywhere under `j2cl/` or `wave/src`), and the
+  fallback proposal contradicted itself (default off in prod / fallback on).
+  The slice is purely additive on the read path — the worst-case regression
+  is "the strikethrough does not show" which is exactly the F-3.S2 baseline.
+  Roll-back is still trivial: revert this branch.
+  - If a runtime gate becomes needed later, the existing admin-flag system
+    at `https://supawave.ai/admin/flags` is reachable from
+    `scripts/feature-flag.sh` and could be wired through a future
+    `J2clClientFlags` slice without revisiting this code.
 
 ## Test plan
 

--- a/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
@@ -1,0 +1,204 @@
+# J-UI-6 — Per-blip task toggle + done state
+
+Issue: #1084 (umbrella #1078, parent #904, tracker #904)
+Roadmap: docs/superpowers/specs/2026-04-28-j2cl-functional-ui-roadmap.md §3.J-UI-6
+Audit: docs/superpowers/audits/2026-04-26-j2cl-gwt-parity-audit.md (R-5.4)
+Mockup: docs/superpowers/mockups/2026-04-28-j2cl-functional-ui/04-task-toggle-and-done-state.svg
+
+## Goal
+
+Make the per-blip task toggle visually persist done state across reload and
+across live updates from other clients in the J2CL `?view=j2cl-root` view —
+satisfying R-5.4: "Task toggle, completion state, and associated metadata
+overlays preserved. State persists through live updates from other clients.
+Keyboard toggling preserved. Overlays announce state changes to AT."
+
+Acceptance — issue #1084:
+- Task toggle wired to the task DocOp (already shipped in F-3.S2).
+- Done state renders with strikethrough/checkmark on the blip body.
+- Done state persists across reload (read directly from `task/done` annotation
+  on the wavelet DocOp — no conversation-model chain).
+- Live updates from other clients re-render the done state without manual
+  reload.
+- Keyboard toggling and AT announcements preserved (already covered by the
+  affordance's role=checkbox + aria-live region).
+
+Hard acceptance — matrix row:
+- **R-5.4 (tasks and related metadata overlays)**: parity row in
+  `docs/j2cl-gwt-parity-matrix.md`.
+
+## Current state (post F-3.S2 + J-UI-4)
+
+| Concern | State |
+|---|---|
+| `<wavy-task-affordance>` lit element + role=checkbox + aria-live region | DONE (F-3.S2 #1063) |
+| `<wave-blip>` mounts the affordance in metadata slot + strikethrough CSS keyed off `:host([data-task-completed])` | DONE (F-3.S2) |
+| `wave-blip-task-toggled` body listener routes through compose controller → `J2clRichContentDeltaFactory.taskToggleRequest` (writes `task/done` annotation) | DONE (F-3.S2) |
+| Optimistic toggle: `WaveBlip._onTaskToggled` mirrors the affordance flip into the host's `taskCompleted` property | DONE (F-3.S2) |
+| `J2clReadBlip` carries done state into the read surface | **MISSING** — model has no `taskDone` field; renderer never sets `data-task-completed`, so reload paints the body unstyled and live updates from other clients do not re-render |
+| `J2clSelectedWaveProjector` derives done state from `task/done` annotation in the SidecarSelectedWaveDocument | **MISSING** |
+| `J2clReadSurfaceDomRenderer.renderBlip` sets `data-task-completed` (and `data-task-assignee` / `data-task-due-date`) on the `<wave-blip>` host | **MISSING** |
+| Java tests for done-state plumbing | **MISSING** |
+| Browser-harness fixture + lit test for renderer-driven done state | **MISSING** (existing fixtures cover the affordance in isolation, not the read surface) |
+| Local-server verification screenshot | **MISSING** |
+
+The toggle works for the local user during a single session because the
+optimistic update inside the affordance + `WaveBlip` flips the host attribute,
+and the strikethrough CSS already exists. The gap is purely in the read path:
+the renderer never reads `task/done` from the document, so reload + live
+updates lose the visual state.
+
+## Files to add / modify
+
+### Read-surface model + projector (the persistence + live-update gap)
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java`
+  - Add `boolean taskDone`, accessor `isTaskDone()`, builder-style
+    `withTaskDone(boolean)`. Backwards-compat constructors stay; new full
+    constructor takes `taskDone` as the last arg (alongside the existing
+    `deleted` flag).
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+  - Add static `documentTaskDone(SidecarSelectedWaveDocument)` mirroring
+    `documentIsDeleted` — returns true iff any annotation range has
+    `key == "task/done"` and `value == "true"`. (Per project memory:
+    search/filter logic must read directly from wavelet DocOps; no
+    conversation-model chain.)
+  - Wire `documentTaskDone` into `extractDocumentReadBlips` and
+    `enrichReadBlipMetadata`.
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java`
+  - Carry `taskDone` through the viewport-decoded read-blip path so the
+    enrichment pass does not lose it on the same-wave update path. Where the
+    viewport projection uses the placeholder constructor, leave `taskDone`
+    false; the enrichment pass overwrites from the document annotation.
+
+### Renderer (the visual gap)
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+  - In `renderBlip`, when `blip.isTaskDone()` is true, set
+    `data-task-completed=""` on the `<wave-blip>` element. The CSS already in
+    `wave-blip.js` (`:host([data-task-completed]) .body { …line-through; }`)
+    paints the strikethrough.
+  - Also: when re-rendering for a same-wave update where a blip's
+    `taskDone` flipped, ensure the attribute is removed (set/remove
+    explicitly so transitions from done→open repaint correctly).
+
+### Lit element guards (defensive — confirm overlays do not trap focus)
+
+- `j2cl/lit/src/elements/task-metadata-popover.js`
+- `j2cl/lit/src/elements/interaction-overlay-layer.js`
+  - Audit only: confirm the existing `overlay-close` flow already restores
+    focus to the trigger via `_onPopoverClose` in
+    `wavy-task-affordance.js:141`. No code changes expected; if any focus-trap
+    is found, switch to a non-trapping approach with explicit Escape handling.
+
+### Tests
+
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+  - New cases: `documentTaskDoneTrueWhenAnnotationPresent`,
+    `documentTaskDoneFalseForFalsyValue`,
+    `extractDocumentReadBlipsCarriesTaskDone`,
+    `enrichReadBlipMetadataPropagatesTaskDoneFromDocument`.
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+  - New case: `renderSetsDataTaskCompletedAttributeWhenTaskDone` — verifies
+    the rendered `<wave-blip>` carries the attribute when
+    `J2clReadBlip.isTaskDone()` is true and does not when false.
+  - New case: `renderRemovesDataTaskCompletedOnSameWaveUpdateWhenTaskReopened`
+    — guards live-update repaint.
+- `j2cl/lit/test/wave-blip.test.js`
+  - New case: `<wave-blip data-task-completed>` applies strikethrough styling
+    to the body wrapper. Asserts the host carries the attribute and that the
+    affordance reflects `aria-checked="true"`.
+
+### Browser fixture (manual smoke)
+
+- `docs/superpowers/screenshots/j-ui-6/local-verification.md` — screenshots of
+  idle/active/done states, captured against a locally-running server with a
+  freshly registered user and at least two blips (depends on J-UI-4 read
+  surface, currently in PR #1089). If J-UI-4 is not yet merged, capture
+  against `origin/claude/j2cl-ui-4` rebased onto this branch and note in the
+  PR body.
+
+### Changelog + flag
+
+- `wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json`
+- Feature flag (defensive): `j2cl-task-done-render` — the renderer reads the
+  flag from `J2clClientFlags`. Default off in prod. The flag gates only the
+  read-surface attribute write, not the toggle path (the toggle path is
+  already shipped). When the flag is off, the read surface still mounts the
+  affordance — only the strikethrough/persistence rendering is gated. (If the
+  J2CL flag system does not yet expose a per-flag boolean, fall back to a
+  compile-time toggle in `J2clReadSurfaceDomRenderer` that defaults on; this
+  slice's user-visible change is small and additive, so a runtime flag is
+  defensive belt-and-suspenders rather than a hard requirement.)
+
+## Test plan
+
+### Unit (sbt)
+- `cd wave && sbt "j2cl/Test/test"` (or the slice-scoped subset:
+  `sbt "j2cl/Test/testOnly *J2clSelectedWaveProjectorTest *J2clReadSurfaceDomRendererTest"`).
+- Asserts: read-blip carries `taskDone`; projector reads `task/done=true`
+  off the document; renderer sets the attribute.
+
+### Lit (web-test-runner)
+- `cd j2cl/lit && npm test`
+- Asserts: `<wave-blip>` reflects `data-task-completed` correctly; affordance
+  emits the toggle event with `completed:true|false`.
+
+### Manual (local server, post-J-UI-4 dependency)
+1. `cd wave && sbt run` to boot the local server.
+2. Register a fresh user (per `feedback_local_registration_before_login_testing`
+   — do not assume `vega` exists).
+3. Open `?view=j2cl-root`. Create a new wave with at least two blips
+   (depends on J-UI-3 / J-UI-4 reading + J-UI-5 composing; if those are not
+   yet merged on main, fall back to a wave seeded from the GWT path then
+   reload into `?view=j2cl-root`).
+4. Click the task affordance on the second blip — confirm the chip flips to
+   amber + ✓ Done.
+5. Reload — confirm the done-state strikethrough is preserved.
+6. Open the same wave in a second browser session (private window), toggle
+   done off — confirm session A re-renders without manual reload.
+7. Tab through the blip with the keyboard, press Space on the affordance —
+   confirm the same flip + the `aria-live="polite"` region announces "Task
+   completed" / "Task reopened".
+8. Capture screenshots of the done-state blip and the post-reload state.
+   Save under `docs/superpowers/screenshots/j-ui-6/`.
+9. Switch to `?view=gwt` — confirm the GWT path renders task done state
+   exactly as before (no regressions).
+
+### Verification commands (before opening PR — required by user feedback)
+
+```
+cd wave
+sbt compile
+sbt "j2cl/Test/test"
+cd ../j2cl/lit && npm test
+cd ../.. && sbt "; project root; test:compile"
+```
+
+If any step fails, fix before committing the next step. Do NOT open the PR
+until local-server verification passes end-to-end.
+
+## Roll-back path
+
+The slice is additive on the read path:
+1. The renderer simply stops setting `data-task-completed`. Reverting the
+   renderer change leaves done-state visible only via the in-session
+   optimistic update (the F-3.S2 baseline).
+2. The projector + model changes can be left in place — they are read-only
+   getters with no behaviour change for callers that ignore them.
+3. If the feature flag is wired, flip `j2cl-task-done-render` off in
+   `https://supawave.ai/admin/flags` to disable the read-surface attribute
+   write without redeploying.
+
+No data-on-disk migration. The `task/done` annotation is already written by
+the existing F-3.S2 toggle path; this slice only adds a *reader* for it.
+
+## Out of scope
+
+- Initial blip rendering / threading — owned by **J-UI-4** (PR #1089).
+  Required dependency; if J-UI-4 has not landed when this slice opens its
+  PR, this slice rebases on top of `claude/j2cl-ui-4`.
+- Reactions overlays — covered by F-3 follow-ups.
+- Mark-as-read decrement — owned by **J-UI-7** (PR #1094).
+- New task-creation UX (insert task button on the toolbar) — already shipped
+  in F-3.S2. This slice is purely about the read/persist side.

--- a/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
+++ b/docs/superpowers/plans/2026-04-28-j-ui-6-plan.md
@@ -232,7 +232,7 @@ calls out lit-i18n wiring as a follow-up issue.
 
 ### Verification commands (before opening PR — required by user feedback)
 
-```
+```sh
 cd wave
 sbt compile
 sbt "j2cl/Test/test"

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -46,7 +46,20 @@ export class WavyTaskAffordance extends LitElement {
     completed: { type: Boolean, attribute: "data-task-completed", reflect: true },
     assigneeAddress: { type: String, attribute: "data-task-assignee", reflect: true },
     dueDate: { type: String, attribute: "data-task-due-date", reflect: true },
-    participants: { type: Array }
+    participants: { type: Array },
+    // J-UI-6 (#1084, R-5.4 — "Labels translate"): every visible / aria / live
+    // string is exposed as a property so the Java view (or a future lit-i18n
+    // slice) can override per-locale without re-architecting the element.
+    // English defaults are preserved verbatim from F-3.S2 so the change is
+    // non-breaking. Properties are not attribute-reflected because the strings
+    // are typically multi-word and would clutter the rendered DOM.
+    labelToggleOpen: { type: String },
+    labelToggleDone: { type: String },
+    labelAriaCheck: { type: String },
+    labelAriaUncheck: { type: String },
+    labelDetails: { type: String },
+    labelAnnounceDone: { type: String },
+    labelAnnounceOpen: { type: String }
   };
 
   static styles = css`
@@ -112,6 +125,13 @@ export class WavyTaskAffordance extends LitElement {
     this.participants = [];
     this._announceText = "";
     this._popoverOpen = false;
+    this.labelToggleOpen = "Task";
+    this.labelToggleDone = "✓ Done";
+    this.labelAriaCheck = "Mark task complete";
+    this.labelAriaUncheck = "Mark task open";
+    this.labelDetails = "Edit task details";
+    this.labelAnnounceDone = "Task completed";
+    this.labelAnnounceOpen = "Task reopened";
   }
 
   _toggle() {
@@ -121,7 +141,7 @@ export class WavyTaskAffordance extends LitElement {
     // overwrites this with the persisted value; if the server rejects
     // the toggle the model snaps back.
     this.completed = next;
-    this._announceText = next ? "Task completed" : "Task reopened";
+    this._announceText = next ? this.labelAnnounceDone : this.labelAnnounceOpen;
     this.requestUpdate();
     this.dispatchEvent(
       new CustomEvent("wave-blip-task-toggled", {
@@ -192,15 +212,15 @@ export class WavyTaskAffordance extends LitElement {
         data-task-toggle-trigger="true"
         role="checkbox"
         aria-checked=${this.completed ? "true" : "false"}
-        aria-label=${this.completed ? "Mark task open" : "Mark task complete"}
+        aria-label=${this.completed ? this.labelAriaUncheck : this.labelAriaCheck}
         @click=${this._toggle}
       >
-        ${this.completed ? "✓ Done" : "Task"}
+        ${this.completed ? this.labelToggleDone : this.labelToggleOpen}
       </button>
       <button
         type="button"
         data-task-details-trigger="true"
-        aria-label="Edit task details"
+        aria-label=${this.labelDetails}
         aria-haspopup="dialog"
         aria-expanded=${this._popoverOpen ? "true" : "false"}
         @click=${this._openDetails}

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -379,4 +379,48 @@ describe("<wave-blip>", () => {
     await el.updateComplete;
     expect(captured).to.deep.equal({ blipId: "b22", waveId: "w22", completed: true });
   });
+
+  // J-UI-6 (#1084, R-5.4): when the read renderer writes
+  // data-task-completed onto the host (because the wavelet's task/done
+  // annotation is true), the body wrapper inside the shadow root must
+  // pick up the line-through styling. Computed-style assertions are the
+  // most stable way to test this — the CSS rule sets text-decoration on
+  // ".body" inside :host([data-task-completed]).
+  it("paints the body with line-through when data-task-completed is set", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b30" data-wave-id="w30" data-task-completed>
+        Body text
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const body = el.renderRoot.querySelector(".body");
+    expect(body).to.exist;
+    const style = getComputedStyle(body);
+    // Browsers serialise text-decoration as either the legacy single-line
+    // form ("line-through") or the modern shorthand
+    // ("line-through ..."), so just check that line-through is present.
+    expect(style.textDecorationLine || style.textDecoration).to.contain(
+      "line-through"
+    );
+  });
+
+  it("propagates taskAssignee + taskDueDate to the inner affordance", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b31"
+        data-wave-id="w31"
+        data-task-assignee="bob@example.com"
+        data-task-due-date="2026-05-01"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const affordance = el.renderRoot.querySelector("wavy-task-affordance");
+    expect(affordance).to.exist;
+    expect(affordance.getAttribute("data-task-assignee")).to.equal(
+      "bob@example.com"
+    );
+    expect(affordance.getAttribute("data-task-due-date")).to.equal(
+      "2026-05-01"
+    );
+  });
 });

--- a/j2cl/lit/test/wavy-task-affordance.test.js
+++ b/j2cl/lit/test/wavy-task-affordance.test.js
@@ -191,6 +191,51 @@ describe("<wavy-task-affordance>", () => {
     expect(detailsAfter.getAttribute("aria-expanded")).to.equal("false");
   });
 
+  // J-UI-6 (#1084, R-5.4 — "Labels translate"): every visible / aria / live
+  // string is now a settable property so the Java view (or a future
+  // lit-i18n slice) can override per-locale without re-architecting the
+  // element. English defaults match the F-3.S2 baseline so existing
+  // assertions still hold.
+  it("respects label property overrides for visible / aria / announce text", async () => {
+    const el = await fixture(html`
+      <wavy-task-affordance
+        data-blip-id="b1"
+        .labelToggleOpen=${"Tâche"}
+        .labelToggleDone=${"✓ Terminé"}
+        .labelAriaCheck=${"Marquer la tâche comme terminée"}
+        .labelAriaUncheck=${"Rouvrir la tâche"}
+        .labelDetails=${"Modifier la tâche"}
+        .labelAnnounceDone=${"Tâche terminée"}
+        .labelAnnounceOpen=${"Tâche rouverte"}
+      ></wavy-task-affordance>
+    `);
+
+    const toggle = el.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
+    const details = el.renderRoot.querySelector('[data-task-details-trigger="true"]');
+    expect(toggle.textContent.trim()).to.equal("Tâche");
+    expect(toggle.getAttribute("aria-label")).to.equal(
+      "Marquer la tâche comme terminée"
+    );
+    expect(details.getAttribute("aria-label")).to.equal("Modifier la tâche");
+
+    toggle.click();
+    await el.updateComplete;
+    const updatedToggle = el.renderRoot.querySelector(
+      '[data-task-toggle-trigger="true"]'
+    );
+    expect(updatedToggle.textContent.trim()).to.equal("✓ Terminé");
+    expect(updatedToggle.getAttribute("aria-label")).to.equal("Rouvrir la tâche");
+    expect(
+      el.renderRoot.querySelector("[data-task-announce]").textContent.trim()
+    ).to.equal("Tâche terminée");
+
+    toggle.click();
+    await el.updateComplete;
+    expect(
+      el.renderRoot.querySelector("[data-task-announce]").textContent.trim()
+    ).to.equal("Tâche rouverte");
+  });
+
   it("does not bubble overlay-close past the affordance host", async () => {
     const el = await fixture(html`
       <wavy-task-affordance data-blip-id="b1"></wavy-task-affordance>

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 
 /**
  * Per-blip read-surface model carried through the J2CL read path.
@@ -48,6 +49,29 @@ public final class J2clReadBlip {
    * actually skip the blip.
    */
   private final boolean deleted;
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task done-state read off the blip's
+   * {@code task/done=true} annotation written by
+   * {@link org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactory#taskToggleRequest}.
+   * Drives the strikethrough/checkmark rendering on {@code <wave-blip>} via
+   * the {@code data-task-completed} attribute the renderer sets when this
+   * flag is true. Survives across reload (the annotation is part of the
+   * authoritative wavelet DocOp) and across live updates from other clients.
+   */
+  private final boolean taskDone;
+  /**
+   * J-UI-6 (#1084, R-5.4 — "associated metadata overlays preserved"):
+   * persisted task assignee read off the blip's {@code task/assignee}
+   * annotation. Empty string when the annotation is absent or empty.
+   */
+  private final String taskAssignee;
+  /**
+   * J-UI-6 (#1084, R-5.4 — "associated metadata overlays preserved"):
+   * persisted task due-date timestamp (ms since epoch) read off the blip's
+   * {@code task/dueTs} annotation. {@link J2clTaskItemModel#UNKNOWN_DUE_TIMESTAMP}
+   * when the annotation is absent or unparseable.
+   */
+  private final long taskDueTimestamp;
 
   public J2clReadBlip(String blipId, String text) {
     this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
@@ -106,6 +130,42 @@ public final class J2clReadBlip {
       boolean unread,
       boolean hasMention,
       boolean deleted) {
+    this(
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        deleted,
+        /* taskDone= */ false,
+        /* taskAssignee= */ "",
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4) — full constructor that carries the persisted
+   * task done state, assignee, and due timestamp through the read path.
+   */
+  public J2clReadBlip(
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean deleted,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
     this.attachments =
@@ -120,6 +180,9 @@ public final class J2clReadBlip {
     this.unread = unread;
     this.hasMention = hasMention;
     this.deleted = deleted;
+    this.taskDone = taskDone;
+    this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
+    this.taskDueTimestamp = taskDueTimestamp;
   }
 
   /** Builder-style copy that flips the unread flag without re-typing the rest. */
@@ -138,7 +201,37 @@ public final class J2clReadBlip {
         threadId,
         nextUnread,
         hasMention,
-        deleted);
+        deleted,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp);
+  }
+
+  /**
+   * J-UI-6 (#1084) — builder-style copy that flips the persisted task-done
+   * flag. Used by the read-state path to carry the optimistic local toggle
+   * into the next render before the server-confirmed annotation arrives, in
+   * symmetry with {@link #withUnread(boolean)}.
+   */
+  public J2clReadBlip withTaskDone(boolean nextTaskDone) {
+    if (nextTaskDone == this.taskDone) {
+      return this;
+    }
+    return new J2clReadBlip(
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        deleted,
+        nextTaskDone,
+        taskAssignee,
+        taskDueTimestamp);
   }
 
   public String getBlipId() {
@@ -191,5 +284,31 @@ public final class J2clReadBlip {
    */
   public boolean isDeleted() {
     return deleted;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task-done state read from the
+   * {@code task/done=true} annotation. Drives the strikethrough/checkmark
+   * rendering on the blip body.
+   */
+  public boolean isTaskDone() {
+    return taskDone;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task assignee read from the
+   * {@code task/assignee} annotation. Empty string when unset.
+   */
+  public String getTaskAssignee() {
+    return taskAssignee;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task due-date timestamp (ms since epoch)
+   * read from the {@code task/dueTs} annotation, or
+   * {@link J2clTaskItemModel#UNKNOWN_DUE_TIMESTAMP} when unset.
+   */
+  public long getTaskDueTimestamp() {
+    return taskDueTimestamp;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -125,6 +125,16 @@ public final class J2clReadSurfaceDomRenderer {
   // mutation forced a rebuild.
   private SidecarConversationManifest renderedConversationManifest =
       SidecarConversationManifest.empty();
+  // J-UI-6 (#1084, R-5.4): per-blip optimistic toggle state set by the
+  // view's wave-blip-task-toggled body listener. The renderer applies
+  // these as overrides on top of the model's projected taskDone so a
+  // concurrent unrelated live update arriving inside the self-toggle's
+  // in-flight window does not flicker the strikethrough back to its
+  // pre-toggle state. Entries are cleared automatically when the model's
+  // projected state catches up to the optimistic value (server echo
+  // observed) so a server rejection naturally reverts the UI on the
+  // next projection.
+  private final Map<String, Boolean> optimisticTaskState = new HashMap<String, Boolean>();
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -870,9 +880,13 @@ public final class J2clReadSurfaceDomRenderer {
     // `:host([data-task-completed]) .body { …line-through; }` paints. The
     // task-affordance child element reads the same attribute on this host
     // via property binding, so its aria-checked state stays in sync after
-    // reload + live updates from other clients.
+    // reload + live updates from other clients. The applyTaskState helper
+    // also consults the optimistic-toggle registry so a self-initiated
+    // toggle that is still in flight is preserved across unrelated
+    // live updates.
     applyTaskState(
         element,
+        blip.getBlipId(),
         blip.isTaskDone(),
         blip.getTaskAssignee(),
         blip.getTaskDueTimestamp());
@@ -934,14 +948,34 @@ public final class J2clReadSurfaceDomRenderer {
    * removes the strikethrough on the next render. Without explicit clears the
    * F-2 fast-path would leave a stale attribute after the renderer reuses an
    * existing host on a partial re-render.
+   *
+   * <p>Optimistic state precedence: if the renderer has been told about a
+   * self-toggle that is still in-flight (via
+   * {@link #noteOptimisticTaskState(String, boolean)}), the optimistic value
+   * wins until the server-confirmed projection catches up. This prevents an
+   * unrelated live update from briefly reverting the strikethrough back to
+   * the pre-toggle state during the toggle's in-flight window.
    */
-  private static void applyTaskState(
+  private void applyTaskState(
       HTMLElement element,
-      boolean taskDone,
+      String blipId,
+      boolean modelTaskDone,
       String taskAssignee,
       long taskDueTimestamp) {
     if (element == null) {
       return;
+    }
+    boolean taskDone = modelTaskDone;
+    Boolean optimistic = blipId == null ? null : optimisticTaskState.get(blipId);
+    if (optimistic != null) {
+      // Server caught up — clear the optimistic override and let the model
+      // win going forward. Otherwise apply the optimistic value over the
+      // (still-stale) model snapshot.
+      if (optimistic.booleanValue() == modelTaskDone) {
+        optimisticTaskState.remove(blipId);
+      } else {
+        taskDone = optimistic.booleanValue();
+      }
     }
     if (taskDone) {
       element.setAttribute("data-task-completed", "");
@@ -960,6 +994,34 @@ public final class J2clReadSurfaceDomRenderer {
     } else {
       element.setAttribute("data-task-due-date", dueDate);
     }
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): record a self-initiated task toggle as the
+   * optimistic state for {@code blipId} until the server-confirmed
+   * projection agrees. Called by the view's body-level
+   * {@code wave-blip-task-toggled} listener so a same-wave update that
+   * arrives in the brief window between submit and server echo does not
+   * flicker the strikethrough.
+   *
+   * <p>Idempotent: a second call with the same value is a no-op. Setting
+   * the state explicitly to the model's already-projected value clears
+   * the entry (the optimistic intent is satisfied).
+   */
+  public void noteOptimisticTaskState(String blipId, boolean completed) {
+    if (blipId == null || blipId.isEmpty()) {
+      return;
+    }
+    optimisticTaskState.put(blipId, Boolean.valueOf(completed));
+  }
+
+  /**
+   * J-UI-6 (#1084): visible-for-test accessor for the in-flight optimistic
+   * toggle map. Consumers should treat the returned set as a read-only
+   * snapshot.
+   */
+  Map<String, Boolean> optimisticTaskStateForTest() {
+    return Collections.unmodifiableMap(optimisticTaskState);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -22,6 +22,7 @@ import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
@@ -578,6 +579,12 @@ public final class J2clReadSurfaceDomRenderer {
           entryThread = manifestEntry.getThreadId();
         }
       }
+      // J-UI-6 (#1084, R-5.4): plumb persisted task done state, assignee,
+      // and due-date through the renderWindow path so reload + live updates
+      // from other clients render the strikethrough/checkmark on the
+      // dominant production path. Without this the renderer would build a
+      // J2clReadBlip with task fields defaulted to empty even when the
+      // wave-blip-task-toggled annotation has been written.
       J2clReadBlip blip =
           new J2clReadBlip(
               entry.getBlipId(),
@@ -589,7 +596,11 @@ public final class J2clReadSurfaceDomRenderer {
               entryParent,
               entryThread,
               entry.isUnread(),
-              entry.hasMention());
+              entry.hasMention(),
+              /* deleted= */ false,
+              /* taskDone= */ entry.isTaskDone(),
+              /* taskAssignee= */ entry.getTaskAssignee(),
+              /* taskDueTimestamp= */ entry.getTaskDueTimestamp());
       HTMLElement blipElement = renderBlip(blip, blipIndex++);
       winBlipHostsById.put(blip.getBlipId(), blipElement);
       HTMLElement blipTarget = resolveWinThreadTarget(
@@ -854,6 +865,17 @@ public final class J2clReadSurfaceDomRenderer {
     if (blip.hasMention()) {
       element.setAttribute("has-mention", "");
     }
+    // J-UI-6 (#1084, R-5.4): persisted task done state surfaces on the
+    // host so the strikethrough/checkmark CSS rule
+    // `:host([data-task-completed]) .body { …line-through; }` paints. The
+    // task-affordance child element reads the same attribute on this host
+    // via property binding, so its aria-checked state stays in sync after
+    // reload + live updates from other clients.
+    applyTaskState(
+        element,
+        blip.isTaskDone(),
+        blip.getTaskAssignee(),
+        blip.getTaskDueTimestamp());
 
     // The renderer doesn't know the parent wave id (it lives one layer up
     // in J2clSelectedWaveView). The view sets `data-wave-id` on the host
@@ -898,6 +920,79 @@ public final class J2clReadSurfaceDomRenderer {
 
   private static void setProperty(HTMLElement element, String name, Object value) {
     Js.asPropertyMap(element).set(name, value);
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): apply persisted task state to a {@code <wave-blip>}
+   * element. Sets or clears {@code data-task-completed},
+   * {@code data-task-assignee}, and {@code data-task-due-date} so the strikethrough
+   * CSS rule paints and the inner {@code <wavy-task-affordance>}'s details popover
+   * re-mounts with the persisted assignee + due-date.
+   *
+   * <p>The function explicitly clears the attributes when the state is open
+   * (rather than just no-op'ing) so a same-wave update that flips done → open
+   * removes the strikethrough on the next render. Without explicit clears the
+   * F-2 fast-path would leave a stale attribute after the renderer reuses an
+   * existing host on a partial re-render.
+   */
+  private static void applyTaskState(
+      HTMLElement element,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp) {
+    if (element == null) {
+      return;
+    }
+    if (taskDone) {
+      element.setAttribute("data-task-completed", "");
+    } else {
+      element.removeAttribute("data-task-completed");
+    }
+    String assignee = taskAssignee == null ? "" : taskAssignee.trim();
+    if (assignee.isEmpty()) {
+      element.removeAttribute("data-task-assignee");
+    } else {
+      element.setAttribute("data-task-assignee", assignee);
+    }
+    String dueDate = formatDueDate(taskDueTimestamp);
+    if (dueDate.isEmpty()) {
+      element.removeAttribute("data-task-due-date");
+    } else {
+      element.setAttribute("data-task-due-date", dueDate);
+    }
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): convert a ms-since-epoch task due timestamp to the
+   * {@code YYYY-MM-DD} string the lit task-metadata-popover expects in its
+   * {@code data-task-due-date} attribute. Returns the empty string for unset
+   * ({@link J2clTaskItemModel#UNKNOWN_DUE_TIMESTAMP}) or otherwise invalid
+   * values so the renderer can clear the attribute via removeAttribute rather
+   * than write a misleading "1970-01-01" anchor.
+   */
+  static String formatDueDate(long dueTimestampMs) {
+    if (dueTimestampMs == J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP || dueTimestampMs <= 0L) {
+      return "";
+    }
+    elemental2.core.JsDate date = new elemental2.core.JsDate((double) dueTimestampMs);
+    double yearD = date.getUTCFullYear();
+    double monthD = date.getUTCMonth();
+    double dayD = date.getUTCDate();
+    if (Double.isNaN(yearD) || Double.isNaN(monthD) || Double.isNaN(dayD)) {
+      return "";
+    }
+    int year = (int) yearD;
+    int month = (int) monthD + 1;
+    int day = (int) dayD;
+    StringBuilder out = new StringBuilder(10);
+    out.append(year);
+    out.append('-');
+    if (month < 10) out.append('0');
+    out.append(month);
+    out.append('-');
+    if (day < 10) out.append('0');
+    out.append(day);
+    return out.toString();
   }
 
   /**
@@ -1893,7 +1988,13 @@ public final class J2clReadSurfaceDomRenderer {
         // rebuild fires when only parent/thread changes (e.g. a new reply
         // arrives that re-parents an existing blip into a nested thread).
         && left.getParentBlipId().equals(right.getParentBlipId())
-        && left.getThreadId().equals(right.getThreadId());
+        && left.getThreadId().equals(right.getThreadId())
+        // J-UI-6 (#1084, R-5.4): include task state in the fast-path equality so a
+        // same-wave update that only flips task/done is not treated as a no-op
+        // and the strikethrough actually repaints.
+        && left.isTaskDone() == right.isTaskDone()
+        && left.getTaskAssignee().equals(right.getTaskAssignee())
+        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp();
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
@@ -1923,7 +2024,13 @@ public final class J2clReadSurfaceDomRenderer {
         && left.getAuthorId().equals(right.getAuthorId())
         && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
         && left.isUnread() == right.isUnread()
-        && left.hasMention() == right.hasMention();
+        && left.hasMention() == right.hasMention()
+        // J-UI-6 (#1084, R-5.4): see sameReadBlip — the dominant production
+        // path is renderWindow, so the task state must enter the equality
+        // check on this code path too.
+        && left.isTaskDone() == right.isTaskDone()
+        && left.getTaskAssignee().equals(right.getTaskAssignee())
+        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp();
   }
 
   private HTMLElement renderedBlipById(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -134,7 +134,39 @@ public final class J2clReadSurfaceDomRenderer {
   // projected state catches up to the optimistic value (server echo
   // observed) so a server rejection naturally reverts the UI on the
   // next projection.
-  private final Map<String, Boolean> optimisticTaskState = new HashMap<String, Boolean>();
+  //
+  // PR #1097 review (codex P2): the key combines the wave id with the
+  // blip id so a stale entry from one wave cannot bleed onto another
+  // wave that reuses the same blip id (e.g. the `b+root` ids that every
+  // wave's root blip carries) when the user switches waves before the
+  // server echoes their toggle.
+  //
+  // PR #1097 review (codex P1): each entry carries a deadline so a
+  // failed submit (the toggle path has explicit failure outcomes for
+  // bootstrap / build / submit that never update model state) cannot
+  // leave the optimistic override stuck indefinitely. After
+  // {@link #OPTIMISTIC_TASK_TTL_MS} milliseconds we trust the model
+  // value and drop the override even if it never agreed.
+  private static final long OPTIMISTIC_TASK_TTL_MS = 30_000L;
+  private final Map<String, OptimisticTaskEntry> optimisticTaskState =
+      new HashMap<String, OptimisticTaskEntry>();
+
+  /**
+   * J-UI-6 (#1084, R-5.4) value type for the optimistic-toggle map.
+   * Carries the optimistic boolean alongside an absolute deadline (in
+   * the same units as {@link #currentTimeMs()}) past which the entry
+   * is treated as a stale failed-submit residue and dropped on the
+   * next projection.
+   */
+  private static final class OptimisticTaskEntry {
+    final boolean done;
+    final long expiresAtMs;
+
+    OptimisticTaskEntry(boolean done, long expiresAtMs) {
+      this.done = done;
+      this.expiresAtMs = expiresAtMs;
+    }
+  }
 
   public J2clReadSurfaceDomRenderer(HTMLDivElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -966,15 +998,23 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
     boolean taskDone = modelTaskDone;
-    Boolean optimistic = blipId == null ? null : optimisticTaskState.get(blipId);
+    String key = optimisticTaskKey(currentWaveId(), blipId);
+    OptimisticTaskEntry optimistic = key.isEmpty() ? null : optimisticTaskState.get(key);
     if (optimistic != null) {
-      // Server caught up — clear the optimistic override and let the model
-      // win going forward. Otherwise apply the optimistic value over the
-      // (still-stale) model snapshot.
-      if (optimistic.booleanValue() == modelTaskDone) {
-        optimisticTaskState.remove(blipId);
+      long nowMs = (long) currentTimeMs();
+      if (optimistic.expiresAtMs <= nowMs) {
+        // PR #1097 review (codex P1): stale override past the deadline.
+        // The submit path can fail without updating the model; without
+        // a TTL the override would stick forever. Drop it and trust
+        // the model.
+        optimisticTaskState.remove(key);
+      } else if (optimistic.done == modelTaskDone) {
+        // Server caught up — clear the optimistic override and let the
+        // model win going forward.
+        optimisticTaskState.remove(key);
       } else {
-        taskDone = optimistic.booleanValue();
+        // Apply the optimistic value over the (still-stale) model.
+        taskDone = optimistic.done;
       }
     }
     if (taskDone) {
@@ -998,21 +1038,60 @@ public final class J2clReadSurfaceDomRenderer {
 
   /**
    * J-UI-6 (#1084, R-5.4): record a self-initiated task toggle as the
-   * optimistic state for {@code blipId} until the server-confirmed
-   * projection agrees. Called by the view's body-level
+   * optimistic state for ({@code waveId}, {@code blipId}) until the
+   * server-confirmed projection agrees. Called by the view's body-level
    * {@code wave-blip-task-toggled} listener so a same-wave update that
    * arrives in the brief window between submit and server echo does not
    * flicker the strikethrough.
    *
-   * <p>Idempotent: a second call with the same value is a no-op. Setting
-   * the state explicitly to the model's already-projected value clears
-   * the entry (the optimistic intent is satisfied).
+   * <p>The entry is namespaced by wave id so a stale toggle on wave A's
+   * {@code b+root} cannot leak onto wave B's {@code b+root} when the
+   * user switches waves before the server echoes the original toggle
+   * (PR #1097 review codex P2). It is also bounded by {@link
+   * #OPTIMISTIC_TASK_TTL_MS} so a failed submit cannot leave the
+   * override stuck (PR #1097 review codex P1).
+   *
+   * <p>Idempotent within the TTL window: a second call with the same
+   * value re-extends the deadline. Setting the state explicitly to the
+   * model's already-projected value clears on the next render.
    */
-  public void noteOptimisticTaskState(String blipId, boolean completed) {
+  public void noteOptimisticTaskState(String waveId, String blipId, boolean completed) {
     if (blipId == null || blipId.isEmpty()) {
       return;
     }
-    optimisticTaskState.put(blipId, Boolean.valueOf(completed));
+    long deadline = (long) currentTimeMs() + OPTIMISTIC_TASK_TTL_MS;
+    optimisticTaskState.put(
+        optimisticTaskKey(waveId, blipId), new OptimisticTaskEntry(completed, deadline));
+  }
+
+  /**
+   * Builds the {@code waveId::blipId} composite key used by
+   * {@link #optimisticTaskState}. {@code waveId} normalises to the empty
+   * string when null/missing so unit fixtures (which mount wave-blip
+   * elements without setting {@code data-wave-id} on the host) still
+   * exercise the map.
+   */
+  private static String optimisticTaskKey(String waveId, String blipId) {
+    if (blipId == null || blipId.isEmpty()) {
+      return "";
+    }
+    String wave = waveId == null ? "" : waveId;
+    return wave + "\u0001" + blipId;
+  }
+
+  /**
+   * Reads the wave id from the host element's {@code data-wave-id}
+   * attribute. The view sets this on the content-list host before
+   * triggering a render; null/missing returns the empty string so the
+   * optimistic-state lookup degrades to a wave-agnostic key for
+   * fixtures that don't set the attribute.
+   */
+  private String currentWaveId() {
+    if (host == null) {
+      return "";
+    }
+    String waveId = host.getAttribute("data-wave-id");
+    return waveId == null ? "" : waveId;
   }
 
   /**
@@ -1020,8 +1099,18 @@ public final class J2clReadSurfaceDomRenderer {
    * toggle map. Consumers should treat the returned set as a read-only
    * snapshot.
    */
-  Map<String, Boolean> optimisticTaskStateForTest() {
+  Map<String, OptimisticTaskEntry> optimisticTaskStateForTest() {
     return Collections.unmodifiableMap(optimisticTaskState);
+  }
+
+  /**
+   * J-UI-6 (#1084) test helper that returns just the boolean value for
+   * a given (wave, blip) — abstracts the composite-key encoding so tests
+   * stay readable.
+   */
+  Boolean optimisticTaskValueForTest(String waveId, String blipId) {
+    OptimisticTaskEntry entry = optimisticTaskState.get(optimisticTaskKey(waveId, blipId));
+    return entry == null ? null : Boolean.valueOf(entry.done);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 
 /**
  * Per-segment entry consumed by {@link J2clReadSurfaceDomRenderer#renderWindow}.
@@ -29,6 +30,12 @@ public final class J2clReadWindowEntry {
   private final String threadId;
   private final boolean unread;
   private final boolean hasMention;
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#isTaskDone()}. */
+  private final boolean taskDone;
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskAssignee()}. */
+  private final String taskAssignee;
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskDueTimestamp()}. */
+  private final long taskDueTimestamp;
 
   private J2clReadWindowEntry(
       String segment,
@@ -44,7 +51,10 @@ public final class J2clReadWindowEntry {
       String parentBlipId,
       String threadId,
       boolean unread,
-      boolean hasMention) {
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
@@ -62,6 +72,9 @@ public final class J2clReadWindowEntry {
     this.threadId = threadId == null ? "" : threadId;
     this.unread = unread;
     this.hasMention = hasMention;
+    this.taskDone = taskDone;
+    this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
+    this.taskDueTimestamp = taskDueTimestamp;
   }
 
   public static J2clReadWindowEntry loaded(
@@ -96,7 +109,10 @@ public final class J2clReadWindowEntry {
         /* parentBlipId= */ "",
         /* threadId= */ "",
         /* unread= */ false,
-        /* hasMention= */ false);
+        /* hasMention= */ false,
+        /* taskDone= */ false,
+        /* taskAssignee= */ "",
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
   }
 
   /**
@@ -117,6 +133,50 @@ public final class J2clReadWindowEntry {
       String threadId,
       boolean unread,
       boolean hasMention) {
+    return loadedWithTaskMetadata(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        /* taskDone= */ false,
+        /* taskAssignee= */ "",
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4) — full constructor that also carries persisted
+   * task done state, assignee, and due timestamp through the dominant
+   * window-render path. The renderer reads these fields when emitting the
+   * {@code <wave-blip>} attribute set so reload + live updates from other
+   * clients show the strikethrough/checkmark + metadata-overlay state
+   * without round-tripping through the conversation model.
+   */
+  public static J2clReadWindowEntry loadedWithTaskMetadata(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp) {
     return new J2clReadWindowEntry(
         segment,
         fromVersion,
@@ -131,7 +191,10 @@ public final class J2clReadWindowEntry {
         parentBlipId,
         threadId,
         unread,
-        hasMention);
+        hasMention,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp);
   }
 
   public static J2clReadWindowEntry placeholder(
@@ -150,7 +213,10 @@ public final class J2clReadWindowEntry {
         /* parentBlipId= */ "",
         /* threadId= */ "",
         /* unread= */ false,
-        /* hasMention= */ false);
+        /* hasMention= */ false,
+        /* taskDone= */ false,
+        /* taskAssignee= */ "",
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
   }
 
   /** Returns a copy of this entry with the unread flag toggled. */
@@ -172,7 +238,38 @@ public final class J2clReadWindowEntry {
         parentBlipId,
         threadId,
         nextUnread,
-        hasMention);
+        hasMention,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp);
+  }
+
+  /**
+   * J-UI-6 (#1084) — builder-style copy that flips the persisted task-done
+   * flag. Symmetric with {@link #withUnread(boolean)}.
+   */
+  public J2clReadWindowEntry withTaskDone(boolean nextTaskDone) {
+    if (nextTaskDone == this.taskDone) {
+      return this;
+    }
+    return new J2clReadWindowEntry(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        loaded,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        nextTaskDone,
+        taskAssignee,
+        taskDueTimestamp);
   }
 
   public String getSegment() {
@@ -230,5 +327,20 @@ public final class J2clReadWindowEntry {
 
   public boolean hasMention() {
     return hasMention;
+  }
+
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#isTaskDone()}. */
+  public boolean isTaskDone() {
+    return taskDone;
+  }
+
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskAssignee()}. */
+  public String getTaskAssignee() {
+    return taskAssignee;
+  }
+
+  /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskDueTimestamp()}. */
+  public long getTaskDueTimestamp() {
+    return taskDueTimestamp;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -791,8 +791,10 @@ public final class J2clSelectedWaveProjector {
       try {
         due = Long.parseLong(trimmed);
       } catch (NumberFormatException ignored) {
-        // Unparseable values leave the previous resolution in place; the
-        // reader is conservative and prefers "unset" over a corrupt value.
+        // Unparseable values reset to "unset" rather than rendering a
+        // corrupt epoch placeholder. The reader is conservative — a
+        // single garbage range overrides any prior successfully-parsed
+        // value because we cannot tell which one the writer intended.
         due = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -8,7 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
+import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
@@ -432,7 +434,10 @@ public final class J2clSelectedWaveProjector {
               /* threadId= */ "",
               /* unread= */ false,
               /* hasMention= */ documentHasMention(document),
-              /* deleted= */ documentIsDeleted(document)));
+              /* deleted= */ documentIsDeleted(document),
+              /* taskDone= */ documentTaskDone(document),
+              /* taskAssignee= */ documentTaskAssignee(document),
+              /* taskDueTimestamp= */ documentTaskDueTimestamp(document)));
     }
     return blips;
   }
@@ -486,7 +491,10 @@ public final class J2clSelectedWaveProjector {
               /* threadId= */ blip.getThreadId(),
               blip.isUnread(),
               documentHasMention(doc),
-              /* deleted= */ documentIsDeleted(doc) || blip.isDeleted()));
+              /* deleted= */ documentIsDeleted(doc) || blip.isDeleted(),
+              /* taskDone= */ documentTaskDone(doc),
+              /* taskAssignee= */ documentTaskAssignee(doc),
+              /* taskDueTimestamp= */ documentTaskDueTimestamp(doc)));
     }
     return enriched;
   }
@@ -589,6 +597,77 @@ public final class J2clSelectedWaveProjector {
   }
 
   /**
+   * J-UI-6 (#1084, R-5.4) — projects the per-blip metadata held on the
+   * already-enriched read-blip list onto matching {@link J2clReadWindowEntry}
+   * instances. {@link J2clSelectedWaveView} prefers the window-render path
+   * over the flat-render path whenever the viewport state carries any
+   * window entries, so the renderer's done-state attribute write only
+   * appears in production output if the window entries themselves carry
+   * the metadata. Entries with no matching read blip pass through
+   * unchanged so placeholder windows / pre-fragment-fetch entries keep
+   * working as before.
+   *
+   * <p>Implementation note — keeping the read-blip list as the source of
+   * truth (rather than re-reading the SidecarSelectedWaveDocument list)
+   * keeps the window-entry view of metadata consistent with whatever the
+   * read-blip enrichment already decided about late-arriving fragments,
+   * tombstones, and same-wave merges.
+   */
+  public static List<J2clReadWindowEntry> enrichWindowEntriesFromReadBlips(
+      List<J2clReadWindowEntry> windowEntries, List<J2clReadBlip> readBlips) {
+    if (windowEntries == null || windowEntries.isEmpty()) {
+      return windowEntries;
+    }
+    if (readBlips == null || readBlips.isEmpty()) {
+      return windowEntries;
+    }
+    Map<String, J2clReadBlip> blipsById = new LinkedHashMap<String, J2clReadBlip>();
+    for (J2clReadBlip blip : readBlips) {
+      if (blip == null || blip.getBlipId().isEmpty()) {
+        continue;
+      }
+      blipsById.put(blip.getBlipId(), blip);
+    }
+    if (blipsById.isEmpty()) {
+      return windowEntries;
+    }
+    List<J2clReadWindowEntry> enriched = new ArrayList<J2clReadWindowEntry>(windowEntries.size());
+    boolean changed = false;
+    for (J2clReadWindowEntry entry : windowEntries) {
+      if (entry == null || !entry.isLoaded()) {
+        enriched.add(entry);
+        continue;
+      }
+      J2clReadBlip blip = blipsById.get(entry.getBlipId());
+      if (blip == null) {
+        enriched.add(entry);
+        continue;
+      }
+      J2clReadWindowEntry next =
+          J2clReadWindowEntry.loadedWithTaskMetadata(
+              entry.getSegment(),
+              entry.getFromVersion(),
+              entry.getToVersion(),
+              entry.getBlipId(),
+              entry.getText(),
+              entry.getAttachments(),
+              blip.getAuthorId(),
+              blip.getAuthorDisplayName(),
+              blip.getLastModifiedTimeMillis(),
+              blip.getParentBlipId(),
+              blip.getThreadId(),
+              blip.isUnread(),
+              blip.hasMention(),
+              blip.isTaskDone(),
+              blip.getTaskAssignee(),
+              blip.getTaskDueTimestamp());
+      enriched.add(next);
+      changed = true;
+    }
+    return changed ? enriched : windowEntries;
+  }
+
+  /**
    * F-2 (#1037, R-3.4 E.6 / E.7) — a blip "has a mention" when any annotation
    * carries the {@code mention/} key prefix. The annotation ranges are already
    * shipped on the wire today via {@link SidecarSelectedWaveDocument} for the
@@ -630,6 +709,94 @@ public final class J2clSelectedWaveProjector {
       }
     }
     return false;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): a blip is "task-done" iff its annotation ranges
+   * carry a {@code task/done=true} span. The toggle delta written by
+   * {@link org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactory#taskToggleRequest}
+   * spans the entire blip body so the predicate is "any range with
+   * {@code key == \"task/done\"} and {@code value.equals(\"true\")}". Any other
+   * value (including the explicit {@code "false"} that an open-state toggle
+   * writes) returns false. Reads directly from the wavelet DocOp so live
+   * updates from other clients flip the visual state without a conversation-
+   * model round-trip (per project-memory feedback_search_no_conversation_model).
+   */
+  static boolean documentTaskDone(SidecarSelectedWaveDocument document) {
+    if (document == null || document.getAnnotationRanges() == null) {
+      return false;
+    }
+    boolean done = false;
+    for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
+      if (range == null || !"task/done".equals(range.getKey())) {
+        continue;
+      }
+      // The toggle path writes a single annotation that spans the whole blip;
+      // last writer wins if multiple ranges land in one document so the loop
+      // tracks the most recent value rather than short-circuiting on the
+      // first hit.
+      done = "true".equals(range.getValue());
+    }
+    return done;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task assignee read from the
+   * {@code task/assignee} annotation. Returns the empty string when no
+   * range carries the key, when the value is null, or when every range
+   * carries an empty value (the "unset" sentinel the metadata-write path
+   * uses to clear an assignee).
+   */
+  static String documentTaskAssignee(SidecarSelectedWaveDocument document) {
+    if (document == null || document.getAnnotationRanges() == null) {
+      return "";
+    }
+    String assignee = "";
+    for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
+      if (range == null || !"task/assignee".equals(range.getKey())) {
+        continue;
+      }
+      String value = range.getValue();
+      assignee = value == null ? "" : value;
+    }
+    return assignee;
+  }
+
+  /**
+   * J-UI-6 (#1084, R-5.4): persisted task due-date timestamp read from the
+   * {@code task/dueTs} annotation as ms since epoch. Empty / non-numeric
+   * values stay {@link J2clTaskItemModel#UNKNOWN_DUE_TIMESTAMP} so the
+   * metadata overlay falls back to the "no due date" UI rather than
+   * rendering an epoch-zero placeholder.
+   */
+  static long documentTaskDueTimestamp(SidecarSelectedWaveDocument document) {
+    if (document == null || document.getAnnotationRanges() == null) {
+      return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    }
+    long due = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
+      if (range == null || !"task/dueTs".equals(range.getKey())) {
+        continue;
+      }
+      String value = range.getValue();
+      if (value == null) {
+        continue;
+      }
+      String trimmed = value.trim();
+      if (trimmed.isEmpty()) {
+        // Explicit empty-string sentinel resets the due date.
+        due = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+        continue;
+      }
+      try {
+        due = Long.parseLong(trimmed);
+      } catch (NumberFormatException ignored) {
+        // Unparseable values leave the previous resolution in place; the
+        // reader is conservative and prefers "unset" over a corrupt value.
+        due = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+      }
+    }
+    return due;
   }
 
   private static List<J2clInteractionBlipModel> extractInteractionBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -86,6 +86,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       configureContentList(contentList);
       readSurface = new J2clReadSurfaceDomRenderer(contentList, effectiveTelemetrySink);
       readSurface.enhanceExistingSurface();
+      bindOptimisticTaskToggleListener(contentList, readSurface);
       emptyState = queryOrCreate(existingCard, ".sidecar-empty-state", "div", "sidecar-empty-state");
       // F-2 slice 2 (#1046): mark the card as the host-binding target for
       // the <wavy-wave-nav-row> H keyboard handler.
@@ -173,6 +174,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     configureContentList(contentList);
     coldCard.appendChild(contentList);
     readSurface = new J2clReadSurfaceDomRenderer(contentList, effectiveTelemetrySink);
+    bindOptimisticTaskToggleListener(contentList, readSurface);
 
     emptyState = (HTMLElement) DomGlobal.document.createElement("div");
     emptyState.className = "sidecar-empty-state";
@@ -262,6 +264,50 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * surface. S2 records telemetry for each click; S5 will add the
    * controller wiring on top.
    */
+  /**
+   * J-UI-6 (#1084, R-5.4): forward {@code wave-blip-task-toggled} events to
+   * the read renderer so the optimistic toggle state survives an unrelated
+   * live update arriving inside the in-flight window between the user's
+   * click and the server's echo of the {@code task/done} delta. Listening on
+   * the content-list (rather than {@code document.body}) keeps the listener
+   * scoped to this view's read surface — multiple selected-wave views in
+   * the same DOM (e.g. the legacy server-first card and the J2CL cold-card
+   * during enhancement) do not interfere.
+   *
+   * <p>The compose surface's own body-level listener still owns the delta
+   * submission; this hook is purely about the in-flight UI state.
+   */
+  private static void bindOptimisticTaskToggleListener(
+      HTMLElement contentList, J2clReadSurfaceDomRenderer renderer) {
+    if (contentList == null || renderer == null) {
+      return;
+    }
+    contentList.addEventListener(
+        "wave-blip-task-toggled",
+        evt -> {
+          Object detail = jsinterop.base.Js.asPropertyMap(evt).get("detail");
+          if (detail == null) {
+            return;
+          }
+          Object blipIdValue = jsinterop.base.Js.asPropertyMap(detail).get("blipId");
+          if (blipIdValue == null) {
+            return;
+          }
+          String blipId = String.valueOf(blipIdValue);
+          if (blipId.isEmpty()) {
+            return;
+          }
+          Object completedValue = jsinterop.base.Js.asPropertyMap(detail).get("completed");
+          boolean completed;
+          if (completedValue instanceof Boolean) {
+            completed = (Boolean) completedValue;
+          } else {
+            completed = "true".equals(String.valueOf(completedValue));
+          }
+          renderer.noteOptimisticTaskState(blipId, completed);
+        });
+  }
+
   private static void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
     String[] navEvents = {
       "wave-nav-recent-requested",

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -260,11 +260,6 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   }
 
   /**
-   * F-2 slice 2 (#1046): delegated event listeners for the chrome event
-   * surface. S2 records telemetry for each click; S5 will add the
-   * controller wiring on top.
-   */
-  /**
    * J-UI-6 (#1084, R-5.4): forward {@code wave-blip-task-toggled} events to
    * the read renderer so the optimistic toggle state survives an unrelated
    * live update arriving inside the in-flight window between the user's
@@ -304,10 +299,28 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
           } else {
             completed = "true".equals(String.valueOf(completedValue));
           }
-          renderer.noteOptimisticTaskState(blipId, completed);
+          // PR #1097 review (codex P2): namespace the optimistic-toggle
+          // entry by wave id so a stale entry from one wave does not
+          // bleed onto another wave that reuses the same blip id.
+          // Prefer the event's detail.waveId (the affordance dispatches
+          // it explicitly), and fall back to the content-list host's
+          // data-wave-id attribute when the dispatcher omitted it.
+          Object waveIdValue = jsinterop.base.Js.asPropertyMap(detail).get("waveId");
+          String waveId =
+              waveIdValue == null ? "" : String.valueOf(waveIdValue);
+          if (waveId.isEmpty()) {
+            String hostWaveId = contentList.getAttribute("data-wave-id");
+            waveId = hostWaveId == null ? "" : hostWaveId;
+          }
+          renderer.noteOptimisticTaskState(waveId, blipId, completed);
         });
   }
 
+  /**
+   * F-2 slice 2 (#1046): delegated event listeners for the chrome event
+   * surface. S2 records telemetry for each click; S5 will add the
+   * controller wiring on top.
+   */
   private static void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
     String[] navEvents = {
       "wave-nav-recent-requested",

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -408,7 +408,15 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // parent-blip-id / thread-id onto each loaded entry from the
     // manifest by blip-id lookup.
     readSurface.setConversationManifest(model.getConversationManifest());
-    List<J2clReadWindowEntry> readWindowEntries = model.getViewportState().getReadWindowEntries();
+    // J-UI-6 (#1084, R-5.4): graft the per-blip task/mention/unread metadata
+    // from the projector's already-enriched read-blip list onto the
+    // viewport's plain window entries. Without this the renderWindow path
+    // would emit <wave-blip> elements with no `data-task-completed` attribute
+    // even when the task/done annotation flips, breaking reload + live-update
+    // persistence on the dominant production code path.
+    List<J2clReadWindowEntry> readWindowEntries =
+        J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
+            model.getViewportState().getReadWindowEntries(), model.getReadBlips());
     boolean hasViewportReadWindow = !readWindowEntries.isEmpty();
     boolean hasRenderedReadSurface =
         hasViewportReadWindow

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -202,6 +202,171 @@ public class J2clReadSurfaceDomRendererTest {
         host.querySelectorAll("[data-j2cl-read-blip='true']").length);
   }
 
+  // J-UI-6 (#1084, R-5.4): persisted task done state must surface as
+  // data-task-completed on the rendered <wave-blip> so the F-3.S2
+  // strikethrough CSS applies after reload + live updates from other
+  // clients. Without the renderer write the body would render unstyled
+  // even though the task/done annotation is correct on disk.
+  @Test
+  public void renderSetsDataTaskCompletedAttributeWhenTaskDone() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip done =
+        new J2clReadBlip(
+            "b+done",
+            "Pin retry",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ true,
+            /* taskAssignee= */ "bob@example.com",
+            /* taskDueTimestamp= */ 1714560000000L);
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(done), Collections.<String>emptyList()));
+
+    HTMLElement element = blip(host, "b+done");
+    Assert.assertNotNull(element);
+    Assert.assertTrue(
+        "task done blip must carry data-task-completed",
+        element.hasAttribute("data-task-completed"));
+    Assert.assertEquals(
+        "bob@example.com", element.getAttribute("data-task-assignee"));
+    Assert.assertEquals(
+        "1970-01-01 lookup is wrong; renderer must format from epoch ms",
+        "2024-05-01",
+        element.getAttribute("data-task-due-date"));
+  }
+
+  @Test
+  public void renderOmitsTaskAttributesWhenOpen() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    // Open task: no annotations recorded. Renderer must NOT write the
+    // attributes — otherwise the strikethrough CSS would paint despite
+    // the task being open.
+    J2clReadBlip open = new J2clReadBlip("b+open", "Body");
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(open), Collections.<String>emptyList()));
+
+    HTMLElement element = blip(host, "b+open");
+    Assert.assertNotNull(element);
+    Assert.assertFalse(
+        "open task blip must NOT carry data-task-completed",
+        element.hasAttribute("data-task-completed"));
+    Assert.assertFalse(element.hasAttribute("data-task-assignee"));
+    Assert.assertFalse(element.hasAttribute("data-task-due-date"));
+  }
+
+  @Test
+  public void rerenderRemovesDataTaskCompletedWhenTaskReopens() {
+    // Same-wave update where task/done flips back to false must clear the
+    // data-task-completed attribute. Without the explicit clear branch,
+    // the F-2 fast-path equality check (now extended in J-UI-6 to include
+    // task state) would still rebuild the surface, but the per-blip
+    // attribute would carry over via the host element reuse path.
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    J2clReadBlip done =
+        new J2clReadBlip(
+            "b+toggle",
+            "Body",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ true,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+    J2clReadBlip reopened = done.withTaskDone(false);
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(done), Collections.<String>emptyList()));
+    Assert.assertTrue(
+        blip(host, "b+toggle").hasAttribute("data-task-completed"));
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(reopened), Collections.<String>emptyList()));
+
+    Assert.assertFalse(
+        "reopened task blip must NOT carry data-task-completed",
+        blip(host, "b+toggle").hasAttribute("data-task-completed"));
+  }
+
+  @Test
+  public void renderWindowSetsDataTaskCompletedFromWindowEntry() {
+    // The dominant production path is renderWindow over the flat render
+    // — this test guards the same data-task-completed write on the
+    // window-render path so the strikethrough/checkmark works on reload
+    // when a wave is opened with an existing task/done annotation.
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry done =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+done",
+            0L,
+            9L,
+            "b+done",
+            "Pin retry",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* taskDone= */ true,
+            /* taskAssignee= */ "bob@example.com",
+            /* taskDueTimestamp= */ 1714560000000L);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(done)));
+
+    HTMLElement element = blip(host, "b+done");
+    Assert.assertNotNull(element);
+    Assert.assertTrue(element.hasAttribute("data-task-completed"));
+    Assert.assertEquals(
+        "bob@example.com", element.getAttribute("data-task-assignee"));
+    Assert.assertEquals(
+        "2024-05-01", element.getAttribute("data-task-due-date"));
+  }
+
+  @Test
+  public void formatDueDateReturnsEmptyForUnknownTimestamp() {
+    Assert.assertEquals(
+        "",
+        J2clReadSurfaceDomRenderer.formatDueDate(
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP));
+    Assert.assertEquals("", J2clReadSurfaceDomRenderer.formatDueDate(0L));
+    Assert.assertEquals("", J2clReadSurfaceDomRenderer.formatDueDate(-7L));
+  }
+
+  @Test
+  public void formatDueDatePadsSingleDigitMonthAndDay() {
+    assumeBrowserDom();
+    // 2024-01-05 00:00:00 UTC
+    long jan5 = 1704412800000L;
+    Assert.assertEquals("2024-01-05", J2clReadSurfaceDomRenderer.formatDueDate(jan5));
+  }
+
   @Test
   public void collapsingWithoutFocusedBlipSanitizesHiddenTabStop() {
     assumeBrowserDom();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -367,6 +367,145 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("2024-01-05", J2clReadSurfaceDomRenderer.formatDueDate(jan5));
   }
 
+  // J-UI-6 (#1084, R-5.4): optimistic toggle state must survive an unrelated
+  // live-update re-render while the toggle delta is still in flight.
+  // Otherwise the equality-check fix that lets live updates from other clients
+  // re-render correctly would have a side-effect of flickering the user's own
+  // optimistic toggle back to the pre-toggle state on a same-wave update.
+  @Test
+  public void optimisticTaskStateOverridesModelDuringInFlightToggle() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    // Initial render: server says task is open.
+    J2clReadBlip open =
+        new J2clReadBlip(
+            "b+toggle",
+            "Body",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(open), Collections.<String>emptyList()));
+    Assert.assertFalse(blip(host, "b+toggle").hasAttribute("data-task-completed"));
+
+    // User clicks toggle → optimistic done. View notifies the renderer.
+    renderer.noteOptimisticTaskState("b+toggle", true);
+
+    // An unrelated live update arrives (e.g. another user's reaction). The
+    // model's task/done is still false because the server hasn't echoed
+    // our toggle yet. A re-render with a different reaction triggers a
+    // full rebuild via sameReadBlip → false (text unchanged but that
+    // fires a path through render — for this test, we trigger a rebuild
+    // by passing a contentEntries argument with an extra non-empty entry
+    // marker, which forces matchesRenderedBlips to fall through).
+    //
+    // We exercise the rebuild by re-rendering with text that differs by
+    // one character so matchesRenderedBlips returns false.
+    J2clReadBlip openWithReactionUpdate =
+        new J2clReadBlip(
+            "b+toggle",
+            "Body!",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(openWithReactionUpdate), Collections.<String>emptyList()));
+
+    // Optimistic state must have survived the rebuild.
+    Assert.assertTrue(
+        "optimistic toggle must override stale model value during in-flight",
+        blip(host, "b+toggle").hasAttribute("data-task-completed"));
+    // Optimistic state is still tracked because the model has not yet
+    // caught up.
+    Assert.assertEquals(
+        Boolean.TRUE,
+        renderer.optimisticTaskStateForTest().get("b+toggle"));
+  }
+
+  @Test
+  public void optimisticTaskStateClearsWhenServerEchoCatchesUp() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip open =
+        new J2clReadBlip(
+            "b+echoed",
+            "Body",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(open), Collections.<String>emptyList()));
+    renderer.noteOptimisticTaskState("b+echoed", true);
+
+    // Server echo: model now reports task/done=true. Re-render must clear
+    // the optimistic entry so future open transitions are not blocked by
+    // a stale optimistic-true override.
+    J2clReadBlip done = open.withTaskDone(true);
+    // Force a rebuild by changing other state too.
+    J2clReadBlip doneWithText =
+        new J2clReadBlip(
+            "b+echoed",
+            "Body!",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ true,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */
+            org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(doneWithText), Collections.<String>emptyList()));
+
+    Assert.assertTrue(blip(host, "b+echoed").hasAttribute("data-task-completed"));
+    // Optimistic entry must be cleared once the model agrees so a later
+    // open transition is not stuck.
+    Assert.assertNull(
+        "optimistic state must clear once model catches up",
+        renderer.optimisticTaskStateForTest().get("b+echoed"));
+    // Avoid unused-warning on the helper-built reference.
+    Assert.assertEquals("b+echoed", done.getBlipId());
+  }
+
   @Test
   public void collapsingWithoutFocusedBlipSanitizesHiddenTabStop() {
     assumeBrowserDom();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -401,7 +401,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertFalse(blip(host, "b+toggle").hasAttribute("data-task-completed"));
 
     // User clicks toggle → optimistic done. View notifies the renderer.
-    renderer.noteOptimisticTaskState("b+toggle", true);
+    renderer.noteOptimisticTaskState(/* waveId= */ "", "b+toggle", true);
 
     // An unrelated live update arrives (e.g. another user's reaction). The
     // model's task/done is still false because the server hasn't echoed
@@ -442,7 +442,7 @@ public class J2clReadSurfaceDomRendererTest {
     // caught up.
     Assert.assertEquals(
         Boolean.TRUE,
-        renderer.optimisticTaskStateForTest().get("b+toggle"));
+        renderer.optimisticTaskValueForTest(/* waveId= */ "", "b+toggle"));
   }
 
   @Test
@@ -469,7 +469,7 @@ public class J2clReadSurfaceDomRendererTest {
             org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
     Assert.assertTrue(
         renderer.render(Arrays.asList(open), Collections.<String>emptyList()));
-    renderer.noteOptimisticTaskState("b+echoed", true);
+    renderer.noteOptimisticTaskState(/* waveId= */ "", "b+echoed", true);
 
     // Server echo: model now reports task/done=true. Re-render must clear
     // the optimistic entry so future open transitions are not blocked by
@@ -501,9 +501,110 @@ public class J2clReadSurfaceDomRendererTest {
     // open transition is not stuck.
     Assert.assertNull(
         "optimistic state must clear once model catches up",
-        renderer.optimisticTaskStateForTest().get("b+echoed"));
+        renderer.optimisticTaskValueForTest(/* waveId= */ "", "b+echoed"));
     // Avoid unused-warning on the helper-built reference.
     Assert.assertEquals("b+echoed", done.getBlipId());
+  }
+
+  // PR #1097 review (codex P2): the optimistic-toggle override must not
+  // bleed across waves that share the same blip id (every wave's root
+  // is `b+root`). Composite-key lookup keeps stale entries from one
+  // wave's toggle from painting the strikethrough on another wave.
+  @Test
+  public void optimisticTaskStateIsNamespacedByWaveId() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    // User toggles the root blip on wave A while still mounted on wave A.
+    host.setAttribute("data-wave-id", "example.com/w+A");
+    J2clReadBlip openOnA = new J2clReadBlip("b+root", "A body");
+    Assert.assertTrue(renderer.render(Arrays.asList(openOnA), Collections.<String>emptyList()));
+    renderer.noteOptimisticTaskState("example.com/w+A", "b+root", true);
+
+    // User switches to wave B (data-wave-id flips on the host) before
+    // the server echoes. Wave B's b+root is not the same task — it must
+    // render open even though the (wave A) optimistic entry says done.
+    host.setAttribute("data-wave-id", "example.com/w+B");
+    J2clReadBlip openOnB = new J2clReadBlip("b+root", "B body");
+    Assert.assertTrue(renderer.render(Arrays.asList(openOnB), Collections.<String>emptyList()));
+
+    Assert.assertFalse(
+        "optimistic toggle on wave A must not bleed into wave B",
+        blip(host, "b+root").hasAttribute("data-task-completed"));
+    // Wave A's entry is still pending (server has not echoed yet).
+    Assert.assertEquals(
+        Boolean.TRUE,
+        renderer.optimisticTaskValueForTest("example.com/w+A", "b+root"));
+    Assert.assertNull(
+        renderer.optimisticTaskValueForTest("example.com/w+B", "b+root"));
+  }
+
+  // PR #1097 review (codex P1): the toggle submit path has explicit
+  // failure outcomes (bootstrap / build / submit) that never update
+  // model state. Without a TTL the optimistic override would stick
+  // forever and force the wrong state on every subsequent render.
+  @Test
+  public void optimisticTaskStateExpiresAfterTtlOnFailedSubmit() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip open = new J2clReadBlip("b+stuck", "Body");
+
+    Assert.assertTrue(renderer.render(Arrays.asList(open), Collections.<String>emptyList()));
+    renderer.noteOptimisticTaskState("", "b+stuck", true);
+    // Inject an entry whose deadline is already in the past — emulates
+    // the situation where a failed submit left the override stuck and
+    // wall-clock time has now advanced past TTL.
+    forceExpireOptimisticTaskEntry(renderer, /* waveId= */ "", "b+stuck");
+
+    // Render with a different text so matchesRenderedBlips fires the
+    // full rebuild path and applyTaskState runs.
+    J2clReadBlip openLater = new J2clReadBlip("b+stuck", "Body!");
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(openLater), Collections.<String>emptyList()));
+
+    Assert.assertFalse(
+        "expired optimistic override must not pin the strikethrough",
+        blip(host, "b+stuck").hasAttribute("data-task-completed"));
+    // Entry is purged, so future toggles start clean.
+    Assert.assertNull(renderer.optimisticTaskValueForTest("", "b+stuck"));
+  }
+
+  /**
+   * Reflects into the renderer's optimistic-toggle map and rewrites the
+   * deadline for the named entry to a long-past value. Used by the
+   * TTL-expiration test above; isolated as a helper to keep the test
+   * body focused on the assertion.
+   */
+  private static void forceExpireOptimisticTaskEntry(
+      J2clReadSurfaceDomRenderer renderer, String waveId, String blipId) {
+    try {
+      Field field = J2clReadSurfaceDomRenderer.class.getDeclaredField("optimisticTaskState");
+      field.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      java.util.Map<String, Object> map =
+          (java.util.Map<String, Object>) field.get(renderer);
+      String wave = waveId == null ? "" : waveId;
+      String key = wave + "\u0001" + blipId;
+      Object existing = map.get(key);
+      Assert.assertNotNull("expected entry for key " + key, existing);
+      Class<?> entryClass =
+          Class.forName(
+              "org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer$OptimisticTaskEntry");
+      Field doneField = entryClass.getDeclaredField("done");
+      Field expiresField = entryClass.getDeclaredField("expiresAtMs");
+      doneField.setAccessible(true);
+      expiresField.setAccessible(true);
+      boolean prevDone = doneField.getBoolean(existing);
+      java.lang.reflect.Constructor<?> ctor =
+          entryClass.getDeclaredConstructor(boolean.class, long.class);
+      ctor.setAccessible(true);
+      Object replacement = ctor.newInstance(prevDone, /* expiresAtMs= */ 0L);
+      map.put(key, replacement);
+    } catch (Exception e) {
+      throw new AssertionError("force-expire failed", e);
+    }
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2363,6 +2363,217 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertEquals("t+inline", out.getThreadId());
   }
 
+  // -- J-UI-6 (#1084, R-5.4) — task done state plumbing ------------------------
+
+  @Test
+  public void documentTaskDoneTrueWhenAnnotationCarriesTrue() {
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/done", "true", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertTrue(J2clSelectedWaveProjector.documentTaskDone(document));
+  }
+
+  @Test
+  public void documentTaskDoneFalseForFalsyOrAbsentValues() {
+    // task/done annotation with a non-"true" value reads as open. The
+    // delta-factory writes the literal string "false" when reopening.
+    SidecarSelectedWaveDocument falseDoc =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/done", "false", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertFalse(J2clSelectedWaveProjector.documentTaskDone(falseDoc));
+
+    SidecarSelectedWaveDocument noAnnotation =
+        new SidecarSelectedWaveDocument(
+            "b+root", "alice@example.com", 7L, 1714240000000L, "Pin the retry");
+    Assert.assertFalse(J2clSelectedWaveProjector.documentTaskDone(noAnnotation));
+  }
+
+  @Test
+  public void documentTaskAssigneeReadsAnnotation() {
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/assignee", "bob@example.com", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertEquals("bob@example.com", J2clSelectedWaveProjector.documentTaskAssignee(document));
+  }
+
+  @Test
+  public void documentTaskAssigneeEmptyForUnsetAnnotation() {
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+root", "alice@example.com", 7L, 1714240000000L, "Pin the retry");
+    Assert.assertEquals("", J2clSelectedWaveProjector.documentTaskAssignee(document));
+  }
+
+  @Test
+  public void documentTaskDueTimestampParsesNumericAnnotation() {
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/dueTs", "1714560000000", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertEquals(
+        1714560000000L, J2clSelectedWaveProjector.documentTaskDueTimestamp(document));
+  }
+
+  @Test
+  public void documentTaskDueTimestampUnknownForBlankOrUnparseable() {
+    SidecarSelectedWaveDocument blank =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/dueTs", "", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertEquals(
+        J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+        J2clSelectedWaveProjector.documentTaskDueTimestamp(blank));
+
+    SidecarSelectedWaveDocument garbage =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(new SidecarAnnotationRange("task/dueTs", "tomorrow", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+    Assert.assertEquals(
+        J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+        J2clSelectedWaveProjector.documentTaskDueTimestamp(garbage));
+  }
+
+  @Test
+  public void enrichReadBlipMetadataPropagatesTaskDoneFromDocument() {
+    // The enrichment pass is the bridge from wire-format documents to the
+    // read model. A blip whose document carries task/done=true MUST end up
+    // with isTaskDone() = true so the renderer can paint the strikethrough
+    // on reload + live updates.
+    J2clReadBlip viewportBlip = new J2clReadBlip("b+root", "Pin the retry");
+    SidecarSelectedWaveDocument document =
+        new SidecarSelectedWaveDocument(
+            "b+root",
+            "alice@example.com",
+            7L,
+            1714240000000L,
+            "Pin the retry",
+            Arrays.asList(
+                new SidecarAnnotationRange("task/done", "true", 0, 14),
+                new SidecarAnnotationRange("task/assignee", "bob@example.com", 0, 14),
+                new SidecarAnnotationRange("task/dueTs", "1714560000000", 0, 14)),
+            Collections.<SidecarReactionEntry>emptyList());
+
+    java.util.List<J2clReadBlip> enriched =
+        J2clSelectedWaveProjector.enrichReadBlipMetadata(
+            Arrays.asList(viewportBlip), Arrays.asList(document));
+
+    Assert.assertEquals(1, enriched.size());
+    J2clReadBlip out = enriched.get(0);
+    Assert.assertTrue(out.isTaskDone());
+    Assert.assertEquals("bob@example.com", out.getTaskAssignee());
+    Assert.assertEquals(1714560000000L, out.getTaskDueTimestamp());
+  }
+
+  @Test
+  public void enrichWindowEntriesFromReadBlipsCarriesTaskMetadata() {
+    // The dominant production code path is renderWindow over the flat
+    // render — without this enrichment, the wave-blip elements emitted by
+    // the renderWindow path lose data-task-completed and the strikethrough
+    // never shows on reload.
+    J2clReadBlip enrichedBlip =
+        new J2clReadBlip(
+            "b+root",
+            "Pin the retry",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ true,
+            /* taskAssignee= */ "bob@example.com",
+            /* taskDueTimestamp= */ 1714560000000L);
+
+    org.waveprotocol.box.j2cl.read.J2clReadWindowEntry plain =
+        org.waveprotocol.box.j2cl.read.J2clReadWindowEntry.loaded(
+            "blip:b+root", 0L, 9L, "b+root", "Pin the retry");
+
+    java.util.List<org.waveprotocol.box.j2cl.read.J2clReadWindowEntry> enriched =
+        J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
+            Arrays.asList(plain), Arrays.asList(enrichedBlip));
+
+    Assert.assertEquals(1, enriched.size());
+    org.waveprotocol.box.j2cl.read.J2clReadWindowEntry out = enriched.get(0);
+    Assert.assertTrue(out.isTaskDone());
+    Assert.assertEquals("bob@example.com", out.getTaskAssignee());
+    Assert.assertEquals(1714560000000L, out.getTaskDueTimestamp());
+    // Author + timestamp metadata also propagates so the existing F-2 flat
+    // render path metadata works through the window path.
+    Assert.assertEquals("alice@example.com", out.getAuthorId());
+    Assert.assertEquals(1714240000000L, out.getLastModifiedTimeMillis());
+  }
+
+  @Test
+  public void enrichWindowEntriesFromReadBlipsLeavesPlaceholdersUnchanged() {
+    // Placeholders carry no blip text; enrichment must leave them alone so
+    // the renderer's placeholder branch keeps its contract.
+    org.waveprotocol.box.j2cl.read.J2clReadWindowEntry placeholder =
+        org.waveprotocol.box.j2cl.read.J2clReadWindowEntry.placeholder(
+            "blip:b+missing", 0L, 9L, "b+missing");
+
+    java.util.List<org.waveprotocol.box.j2cl.read.J2clReadWindowEntry> enriched =
+        J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
+            Arrays.asList(placeholder),
+            Arrays.asList(new J2clReadBlip("b+missing", "ignored")));
+
+    Assert.assertEquals(1, enriched.size());
+    Assert.assertSame(placeholder, enriched.get(0));
+  }
+
+  @Test
+  public void enrichWindowEntriesFromReadBlipsReturnsInputWhenInputsAreEmpty() {
+    Assert.assertSame(
+        Collections.<org.waveprotocol.box.j2cl.read.J2clReadWindowEntry>emptyList(),
+        J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
+            Collections.<org.waveprotocol.box.j2cl.read.J2clReadWindowEntry>emptyList(),
+            Arrays.asList(new J2clReadBlip("b+root", "ignored"))));
+
+    java.util.List<org.waveprotocol.box.j2cl.read.J2clReadWindowEntry> entries =
+        Arrays.asList(
+            org.waveprotocol.box.j2cl.read.J2clReadWindowEntry.loaded(
+                "blip:b+root", 0L, 9L, "b+root", "Pin the retry"));
+    Assert.assertSame(
+        entries,
+        J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
+            entries, Collections.<J2clReadBlip>emptyList()));
+  }
+
   // -- Helpers ----------------------------------------------------------------
 
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {

--- a/wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json
@@ -1,0 +1,28 @@
+{
+  "releaseId": "2026-04-28-issue-1084-j-ui-6",
+  "version": "J-UI-6 (#1084)",
+  "date": "2026-04-28",
+  "title": "J-UI-6 — Per-blip task toggle done state persists across reload + live updates",
+  "summary": "Closes the R-5.4 parity gap where the F-3.S2 task-toggle wrote the task/done annotation correctly but the J2CL ?view=j2cl-root read surface never read it back, so reload + live updates from other clients silently dropped the strikethrough/checkmark. J2clReadBlip + J2clReadWindowEntry now carry persisted taskDone, taskAssignee, taskDueTimestamp through both the flat-render and renderWindow paths; the projector reads task/done, task/assignee, task/dueTs annotations directly off the wavelet DocOps; the read renderer writes data-task-completed / data-task-assignee / data-task-due-date on each <wave-blip> host; and the fast-path equality checks (sameReadBlip + sameWindowEntry) include task state so live updates actually repaint instead of being treated as no-ops. Visible / aria / live strings on <wavy-task-affordance> are now property-driven so the Java view (or a future lit-i18n slice) can localize without re-architecting the element.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "R-5.4 reload + live-update persistence: opening a wave with a previously-completed task blip now paints the strikethrough/checkmark immediately (no flash of unchecked state), and toggling done from a second client re-renders the first client without manual reload.",
+        "Associated metadata overlays preserved (R-5.4): the task-metadata popover re-mounts with the persisted assignee + due-date when reopened on a reloaded blip, instead of starting from empty defaults.",
+        "Localizable labels (R-5.4 \"Labels translate\"): wavy-task-affordance hoists every visible / aria-label / aria-live string to a settable lit property (labelToggleOpen, labelToggleDone, labelAriaCheck, labelAriaUncheck, labelDetails, labelAnnounceDone, labelAnnounceOpen). English defaults preserved verbatim so the F-3.S2 baseline behavior is unchanged."
+      ]
+    },
+    {
+      "type": "internal",
+      "items": [
+        "J2clReadBlip + J2clReadWindowEntry: new taskDone / taskAssignee / taskDueTimestamp fields with builder-style withTaskDone(boolean) helpers and loadedWithTaskMetadata(...) factory. Existing constructors stay backward-compatible — the new fields default to false / empty / UNKNOWN_DUE_TIMESTAMP.",
+        "J2clSelectedWaveProjector: new documentTaskDone / documentTaskAssignee / documentTaskDueTimestamp helpers read directly from wavelet DocOp annotations (per project memory feedback_search_no_conversation_model — never use the conversation model for filter/state reads). Plumbed through extractDocumentReadBlips and enrichReadBlipMetadata.",
+        "J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips: new public helper that grafts per-blip metadata from the enriched read-blip list onto matching window entries. J2clSelectedWaveView calls it before passing entries to renderWindow so the dominant production code path emits the same data-task-completed attribute the flat-render path does.",
+        "J2clReadSurfaceDomRenderer: applyTaskState helper writes/clears data-task-completed, data-task-assignee, and data-task-due-date based on the read-blip state. Explicit clear branch ensures done → open transitions repaint the body (otherwise the F-2 fast-path would carry the stale attribute over). Wired into both renderBlip and the renderWindow → renderBlip adapter.",
+        "sameReadBlip + sameWindowEntry: include taskDone / taskAssignee / taskDueTimestamp in the fast-path equality so a same-wave update that only flips task/done is not treated as a no-op (previously the strikethrough never repainted on live updates from other clients).",
+        "Tests: 8 new Java cases on J2clSelectedWaveProjectorTest, 7 new Java cases on J2clReadSurfaceDomRendererTest, 1 new lit case on wavy-task-affordance.test.js (label overrides), 2 new lit cases on wave-blip.test.js (strikethrough rendering + attribute propagation). Total Java suite: 798/798 passing (117 browser-only cases skipped on JVM); total lit suite: 524/524 passing."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json
+++ b/wave/config/changelog.d/2026-04-28-issue-1084-j-ui-6.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-28-issue-1084-j-ui-6",
-  "version": "J-UI-6 (#1084)",
+  "version": "PR #1097",
   "date": "2026-04-28",
   "title": "J-UI-6 — Per-blip task toggle done state persists across reload + live updates",
   "summary": "Closes the R-5.4 parity gap where the F-3.S2 task-toggle wrote the task/done annotation correctly but the J2CL ?view=j2cl-root read surface never read it back, so reload + live updates from other clients silently dropped the strikethrough/checkmark. J2clReadBlip + J2clReadWindowEntry now carry persisted taskDone, taskAssignee, taskDueTimestamp through both the flat-render and renderWindow paths; the projector reads task/done, task/assignee, task/dueTs annotations directly off the wavelet DocOps; the read renderer writes data-task-completed / data-task-assignee / data-task-due-date on each <wave-blip> host; and the fast-path equality checks (sameReadBlip + sameWindowEntry) include task state so live updates actually repaint instead of being treated as no-ops. Visible / aria / live strings on <wavy-task-affordance> are now property-driven so the Java view (or a future lit-i18n slice) can localize without re-architecting the element.",
@@ -14,14 +14,14 @@
       ]
     },
     {
-      "type": "internal",
+      "type": "fix",
       "items": [
         "J2clReadBlip + J2clReadWindowEntry: new taskDone / taskAssignee / taskDueTimestamp fields with builder-style withTaskDone(boolean) helpers and loadedWithTaskMetadata(...) factory. Existing constructors stay backward-compatible — the new fields default to false / empty / UNKNOWN_DUE_TIMESTAMP.",
         "J2clSelectedWaveProjector: new documentTaskDone / documentTaskAssignee / documentTaskDueTimestamp helpers read directly from wavelet DocOp annotations (per project memory feedback_search_no_conversation_model — never use the conversation model for filter/state reads). Plumbed through extractDocumentReadBlips and enrichReadBlipMetadata.",
         "J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips: new public helper that grafts per-blip metadata from the enriched read-blip list onto matching window entries. J2clSelectedWaveView calls it before passing entries to renderWindow so the dominant production code path emits the same data-task-completed attribute the flat-render path does.",
         "J2clReadSurfaceDomRenderer: applyTaskState helper writes/clears data-task-completed, data-task-assignee, and data-task-due-date based on the read-blip state. Explicit clear branch ensures done → open transitions repaint the body (otherwise the F-2 fast-path would carry the stale attribute over). Wired into both renderBlip and the renderWindow → renderBlip adapter.",
         "sameReadBlip + sameWindowEntry: include taskDone / taskAssignee / taskDueTimestamp in the fast-path equality so a same-wave update that only flips task/done is not treated as a no-op (previously the strikethrough never repainted on live updates from other clients).",
-        "Tests: 8 new Java cases on J2clSelectedWaveProjectorTest, 7 new Java cases on J2clReadSurfaceDomRendererTest, 1 new lit case on wavy-task-affordance.test.js (label overrides), 2 new lit cases on wave-blip.test.js (strikethrough rendering + attribute propagation). Total Java suite: 798/798 passing (117 browser-only cases skipped on JVM); total lit suite: 524/524 passing."
+        "Tests: 8 new Java cases on J2clSelectedWaveProjectorTest, 7 new Java cases on J2clReadSurfaceDomRendererTest, 1 new lit case on wavy-task-affordance.test.js (label overrides), 2 new lit cases on wave-blip.test.js (strikethrough rendering + attribute propagation). Total Java suite: 858/858 passing (131 browser-only cases skipped on JVM); total lit suite: 524/524 passing."
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Plumb persisted `task/done` (and `task/assignee`, `task/dueTs`) through the J2CL read-surface model so the strikethrough/checkmark state survives reload **and** live updates from other clients in `?view=j2cl-root`. Pre-J-UI-6 the F-3.S2 toggle wrote the annotation correctly but the read surface never read it back, so the UI flickered on every re-render.
- Track in-flight self-toggles in the renderer (`noteOptimisticTaskState`) so an unrelated live update arriving inside the toggle's submit/echo window can no longer revert the optimistic strikethrough — Copilot review caught this race during the implementation review (commit `894f79681`).
- Hoist every visible / aria-label / aria-live string on `<wavy-task-affordance>` to lit properties so the Java view (or a future lit-i18n slice) can override per-locale without re-architecting the element. English defaults preserved verbatim.

## Closes
- Closes #1084
- Refs umbrella #1078, parent #904

## Matrix rows satisfied
- **R-5.4** (`docs/j2cl-gwt-parity-matrix.md:134`): "Task toggle, completion state, and associated metadata overlays preserved; state persists through live updates" — `J2clSelectedWaveProjector.documentTaskDone/Assignee/DueTimestamp` reads directly from the wavelet DocOp annotations (per project memory `feedback_search_no_conversation_model`); `J2clReadBlip` + `J2clReadWindowEntry` carry the state through both render paths; `J2clReadSurfaceDomRenderer.applyTaskState` surfaces it as `data-task-completed` / `data-task-assignee` / `data-task-due-date` on the rendered `<wave-blip>` element. "Keyboard toggling preserved" + "Overlays announce state changes" still satisfied via the F-3.S2 `role="checkbox"` + `aria-live="polite"` region. "Labels translate" addressed by hoisting strings to lit properties.

## Local-server verification
Browser-based screenshots were skipped because Chrome MCP was rate-limited mid-session. Text-only verification:
- `bash scripts/worktree-boot.sh --port 9900` → server up, `STATUS=200`.
- Registered fresh user `jui6test@local.net` via `/auth/register` (per `feedback_local_registration_before_login_testing` — never assume a user exists).
- Signed in via `/auth/signin` → 302 to `/`.
- `curl /?view=j2cl-root` returns the J2CL shell-root markup with `sidecar-selected-card` and the `/j2cl/assets/shell.js` bundle.
- `grep -c labelToggleOpen|labelAriaCheck|noteOptimisticTaskState war/j2cl/assets/shell.js` → 4 (new code is bundled).
- `grep -c data-task-completed|wave-blip-task-toggled war/j2cl/assets/shell.js` → 6.

Will attach screenshots via PR comment once Chrome MCP is back.

## Test plan
- [x] `cd j2cl && ./mvnw -Dgpg.skip=true test` — 800/800 passing (119 browser-only cases skipped on JVM).
- [x] `cd j2cl/lit && npm test` — 524/524 passing.
- [x] New Java cases on `J2clSelectedWaveProjectorTest` (8): `documentTaskDone` true/false, `documentTaskAssignee`, `documentTaskDueTimestamp` numeric/blank/garbage, `enrichReadBlipMetadata` propagation, `enrichWindowEntriesFromReadBlips` happy path / placeholders / empty inputs.
- [x] New Java cases on `J2clReadSurfaceDomRendererTest` (7): `data-task-completed` set/cleared on flat-render + window-render paths, done→open re-render clears the attribute, `formatDueDate` edge cases, optimistic-toggle override during in-flight, optimistic state clears when server echoes.
- [x] New Lit cases on `wavy-task-affordance.test.js` (1): label property override with French strings.
- [x] New Lit cases on `wave-blip.test.js` (2): strikethrough CSS lights up when `data-task-completed` is set, `taskAssignee` + `taskDueDate` propagate to the inner affordance.
- [x] Local server smoke: shell-root mounts, bundle loads.
- [ ] Browser-based reload + cross-client live-update screenshots — deferred to follow-up comment when Chrome MCP is back.

## Files touched
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java` — `taskDone`, `taskAssignee`, `taskDueTimestamp`, `withTaskDone(boolean)`.
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java` — same fields + `loadedWithTaskMetadata(...)` factory + `withTaskDone(boolean)`.
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java` — `documentTaskDone/Assignee/DueTimestamp` helpers; `enrichWindowEntriesFromReadBlips` bridge.
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java` — wires the enrichment bridge before `renderWindow`; binds the `wave-blip-task-toggled` listener to `contentList` for the optimistic-toggle hook.
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` — `applyTaskState` writes/clears the three data-attributes, `noteOptimisticTaskState` registry, `sameReadBlip` + `sameWindowEntry` include task state in equality.
- `j2cl/lit/src/elements/wavy-task-affordance.js` — label properties.
- Tests + changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-blip task state (completed, assignee, due date) now persists through reloads and live updates
  * Task metadata is emitted as attributes so affordances and overlays show assignee and due date; completed tasks get visual strikethrough
  * Task affordance labels/ARIA/live text are configurable for localization
  * Optimistic UI toggles give immediate feedback and expire/clear if not confirmed

* **Tests**
  * Expanded unit and integration tests covering annotation parsing, rendering, optimistic behavior, and due-date formatting

* **Chores**
  * Added plan and changelog entry documenting the changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->