### PR TITLE
G-PORT-4 follow-up: deterministic typing in inline-reply E2E (fix flake on main)

### DIFF
--- a/wave/config/changelog.d/2026-04-29-g-port-4-followup-typing.json
+++ b/wave/config/changelog.d/2026-04-29-g-port-4-followup-typing.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-29-g-port-4-followup-typing",
+  "version": "PR #1123",
+  "date": "2026-04-29",
+  "title": "G-PORT-4 follow-up: deterministic typing in inline-reply E2E",
+  "summary": "Stabilises the J2CL <-> GWT parity E2E by replacing page.keyboard.type with a single execCommand(\"insertText\") call inside the contenteditable composer body. keyboard.type drops both leading and trailing characters when Lit's input listener races the keystrokes (observed 5/5 fail with 'ello world mo' instead of 'hello world ...' both locally and in CI). execCommand fires real beforeinput/input events through the browser's text-editing pipeline, so wavy-composer's mutation observer and draft-change listener see the canonical text. No production code changes.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Replaced page.keyboard.type with execCommand(\"insertText\") in wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts so the J2CL inline-reply E2E no longer drops leading/trailing characters under CI load."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -69,22 +69,19 @@ async function clickReplyOnFirstBlipJ2cl(page: Page) {
 }
 
 /**
- * Type the given phrase into the composer body using real keystrokes
- * so wavy-composer's input listener tracks the change through its
- * normal mutation path. Setting `textContent` directly desynchronizes
- * the rich-component serializer — observed: composer unmounts on
- * send (so the click registered) but no new blip is created on the
- * server (the controller saw an empty/stale rich-component list).
+ * Insert the given phrase into the composer body via
+ * `execCommand("insertText")` so wavy-composer observes the change
+ * through the browser's normal editing/input pipeline. Setting
+ * `textContent` directly desynchronizes the rich-component serializer
+ * — observed: composer unmounts on send (so the click registered) but
+ * no new blip is created on the server (the controller saw an
+ * empty/stale rich-component list).
  *
- * Compensates for two Playwright/Lit races observed in CI:
- * - the leading keystroke can land before Lit attaches the input
- *   listener (run 25095688687: typed "hello…" → got "ello…");
- * - long phrases under CI load can drop tail characters too.
- *
- * Strategy: type the phrase, then in a small retry loop add the
- * missing prefix or suffix using execCommand("insertText") (which
- * dispatches real input events through the browser's text-editing
- * pipeline, keeping wavy-composer's mutation observer in sync).
+ * Strategy: focus the editable body, insert the full phrase in one
+ * browser editing command, then poll until the composer state/draft
+ * reflects the expected text. This keeps the mutation observer and
+ * serialized draft in sync without relying on per-character
+ * Playwright keystrokes.
  */
 async function typeInComposerJ2cl(
   page: Page,

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -69,10 +69,22 @@ async function clickReplyOnFirstBlipJ2cl(page: Page) {
 }
 
 /**
- * Type the given phrase into the composer body. Compensates for the
- * one-keystroke focus race observed when the composer was just
- * mounted: if the resulting draft is missing the leading character,
- * we prepend it programmatically.
+ * Type the given phrase into the composer body using real keystrokes
+ * so wavy-composer's input listener tracks the change through its
+ * normal mutation path. Setting `textContent` directly desynchronizes
+ * the rich-component serializer — observed: composer unmounts on
+ * send (so the click registered) but no new blip is created on the
+ * server (the controller saw an empty/stale rich-component list).
+ *
+ * Compensates for two Playwright/Lit races observed in CI:
+ * - the leading keystroke can land before Lit attaches the input
+ *   listener (run 25095688687: typed "hello…" → got "ello…");
+ * - long phrases under CI load can drop tail characters too.
+ *
+ * Strategy: type the phrase, then in a small retry loop add the
+ * missing prefix or suffix using execCommand("insertText") (which
+ * dispatches real input events through the browser's text-editing
+ * pipeline, keeping wavy-composer's mutation observer in sync).
  */
 async function typeInComposerJ2cl(
   page: Page,
@@ -81,33 +93,47 @@ async function typeInComposerJ2cl(
 ): Promise<void> {
   const body = composerLocator.locator("[data-composer-body]");
   await body.click();
-  // Composer just mounted — give Lit a tick to attach its input
-  // listener before the first keystroke lands. Otherwise the
-  // leading character can be dropped.
   await page.waitForTimeout(400);
-  await page.keyboard.type(phrase, { delay: 30 });
-  await page.waitForTimeout(350);
 
-  // Fire a synthetic input event so wavy-composer + its host controller
-  // both flush any pending draft state. Do NOT overwrite textContent —
-  // if keyboard input was lost the finalDraft assertion below will catch
-  // it cleanly instead of masking the regression.
-  await composerLocator.evaluate((host: HTMLElement) => {
-    const root = (host as any).shadowRoot as ShadowRoot;
-    const b = root.querySelector("[data-composer-body]") as HTMLElement;
-    b.dispatchEvent(new InputEvent("input", { bubbles: true }));
-  });
-  await page.waitForTimeout(300);
-  // Final verification: the draft on the composer matches what we
-  // typed. If not, the test fails fast rather than racing the
-  // submit-empty-draft path.
-  const finalDraft = await composerLocator.evaluate(
-    (host: HTMLElement) => (host as any).draft || ""
+  const readDraft = async () =>
+    await composerLocator.evaluate(
+      (host: HTMLElement) => (host as any).draft || ""
+    );
+
+  // Drive the input via execCommand("insertText") so the browser's
+  // text-editing pipeline fires real beforeinput/input events that
+  // wavy-composer's mutation observer + draft-change listener both
+  // honour. `keyboard.type` consistently drops both leading and
+  // trailing characters under any load — the browser delivers them
+  // before Lit attaches the input listener, so the controller's
+  // serializer never sees them. execCommand-driven input fires the
+  // events synchronously and is the same path the user-visible
+  // composer takes when the user pastes or types.
+  await composerLocator.evaluate(
+    (host: HTMLElement, args: { phrase: string }) => {
+      const root = (host as any).shadowRoot as ShadowRoot;
+      const b = root.querySelector("[data-composer-body]") as HTMLElement;
+      b.focus();
+      // Move caret to a clean end-of-body position before insert so
+      // the new text appends rather than splitting an existing node.
+      const range = document.createRange();
+      range.selectNodeContents(b);
+      range.collapse(false);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      document.execCommand("insertText", false, args.phrase);
+    },
+    { phrase }
   );
-  expect(
-    finalDraft,
-    `composer draft must equal '${phrase}' before submit; saw '${finalDraft}'`
-  ).toBe(phrase);
+
+  await expect
+    .poll(readDraft, {
+      message: `composer draft must equal '${phrase}' before submit`,
+      timeout: 5_000,
+      intervals: [100, 200, 300]
+    })
+    .toBe(phrase);
 }
 
 /**


### PR DESCRIPTION
Refs umbrella #1109, parent #904, original slice #1113 (PR #1122 — merged).

## Why

The `J2CL ↔ GWT Parity E2E` workflow has been failing on main since
PR #1122 merged because the inline-reply E2E uses
`page.keyboard.type` to drive the composer body. Across both local
and CI runs, keyboard.type drops both leading and trailing
characters when Lit's input listener races the keystrokes — observed
on the merge run (058616923) of PR #1122 and on five repeat runs
locally (5/5 fail with "ello world mo" instead of "hello world …").

## Fix

Replace `page.keyboard.type` with a single `execCommand("insertText")`
call inside the contenteditable. execCommand fires real
beforeinput/input events through the browser's text-editing
pipeline, so wavy-composer's mutation observer + draft-change
listener see the canonical text. This is the same DOM path the
user-visible composer takes when the user pastes text.

## Test plan

- 5x local repeat-each: `(cd wave/src/e2e/j2cl-gwt-parity && WAVE_E2E_BASE_URL=http://127.0.0.1:9905 npx playwright test inline-reply-parity --project chromium --repeat-each 5)`
  - Before this change: 0/5 J2CL passes (all dropped chars).
  - After this change: 4/5 J2CL passes (one separate flake where
    the new blip didn't materialize on the server — that's a
    distinct issue tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed E2E test instability for inline-reply by resolving character drop failures in the composer. Tests now achieve deterministic typing through improved state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->