### PR TITLE
fix(g-port-8): harden nav-row folder state marker

### DIFF
--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -228,7 +228,14 @@ function syncFolderStateForWave(host, waveId) {
     host.removeAttribute(ATTR_FOLDER_STATE_WAVE_ID);
     return;
   }
-  if (current === waveId) return;
+  if (current === waveId) {
+    // Java may stamp the new wave's marker synchronously before the
+    // source-wave-id MutationObserver fires, so the `current != null` path
+    // below never ran for the previous wave. Clear any stale busy owner now.
+    const busyOwner = host.getAttribute(ATTR_BUSY_WAVE_ID);
+    if (busyOwner && busyOwner !== waveId) setBusy(host, false, busyOwner);
+    return;
+  }
   if (current != null) {
     setBusy(host, false, current);
     // A mismatched marker means the visible folder flags still belong to the

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -28,6 +28,9 @@ const NAV_ROW_TAG = "WAVY-WAVE-NAV-ROW";
 const VERSION_HISTORY_TAG = "WAVY-VERSION-HISTORY";
 
 const ATTR_BOUND = "data-action-bar-bound";
+// Shared with J2clSelectedWaveView. Java owns model-published folder state;
+// Lit writes this marker on initial bind and source-wave-id reuse, and Java
+// overwrites it whenever it publishes authoritative folder state.
 const ATTR_FOLDER_STATE_WAVE_ID = "data-folder-state-wave-id";
 const ATTR_BUSY_WAVE_ID = "data-folder-busy-wave-id";
 
@@ -219,30 +222,14 @@ function syncFolderStateForWave(host, waveId) {
   if (current === waveId) return;
   if (current != null) {
     setBusy(host, false, current);
-    // Capture any values the Java model may have already published for the
-    // new wave via setNavRowFolderState before the MutationObserver fired.
-    // J2clSelectedWaveController always calls publishNavRowFolderState()
-    // synchronously after render(), so these reflect model-backed state for
-    // the incoming wave — not stale optimistic state from the previous wave.
-    const modelPinned = host.hasAttribute("pinned");
-    const modelArchived = host.hasAttribute("archived");
+    // A mismatched marker means the visible folder flags still belong to the
+    // previous wave or an optimistic request. Java-stamped model state updates
+    // the marker to waveId before this observer flushes, so current === waveId
+    // returns above and preserves authoritative model-published flags. After
+    // clearing stale flags, fall through to stamp the new wave and re-seed
+    // from rail digest as the only available pre-publish hint.
     host.removeAttribute("pinned");
     host.removeAttribute("archived");
-    if (!waveId) {
-      host.removeAttribute(ATTR_FOLDER_STATE_WAVE_ID);
-      return;
-    }
-    host.setAttribute(ATTR_FOLDER_STATE_WAVE_ID, waveId);
-    hydrateFromDigest(host, waveId);
-    // Restore model-published state when hydrateFromDigest found no
-    // matching rail card or active-folder context to recover it from.
-    if (modelPinned && !host.hasAttribute("pinned")) {
-      host.setAttribute("pinned", "");
-    }
-    if (modelArchived && !host.hasAttribute("archived")) {
-      host.setAttribute("archived", "");
-    }
-    return;
   }
   if (!waveId) {
     host.removeAttribute(ATTR_FOLDER_STATE_WAVE_ID);

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -219,6 +219,15 @@ function hydrateFromDigest(host, waveId) {
 function syncFolderStateForWave(host, waveId) {
   if (!host || typeof host.getAttribute !== "function") return;
   const current = host.getAttribute(ATTR_FOLDER_STATE_WAVE_ID);
+  if (!waveId) {
+    // No selected wave owns the row anymore, so clear any pending optimistic
+    // affordance regardless of the previous busy-wave-id owner.
+    setBusy(host, false);
+    host.removeAttribute("pinned");
+    host.removeAttribute("archived");
+    host.removeAttribute(ATTR_FOLDER_STATE_WAVE_ID);
+    return;
+  }
   if (current === waveId) return;
   if (current != null) {
     setBusy(host, false, current);
@@ -230,10 +239,6 @@ function syncFolderStateForWave(host, waveId) {
     // from rail digest as the only available pre-publish hint.
     host.removeAttribute("pinned");
     host.removeAttribute("archived");
-  }
-  if (!waveId) {
-    host.removeAttribute(ATTR_FOLDER_STATE_WAVE_ID);
-    return;
   }
   host.setAttribute(ATTR_FOLDER_STATE_WAVE_ID, waveId);
   // Seed initial folder state from a matching search-rail digest card.

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -834,6 +834,31 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
     expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+stale-b");
   });
 
+  it("clears stale busy owner when Java stamps new marker before observer fires", async () => {
+    // Wave A had an in-flight folder action; user switches to wave B.
+    // Java stamps data-folder-state-wave-id=B synchronously, so the observer
+    // sees current===waveId and must still clear the stale busy from A.
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+wave-a"
+        data-folder-state-wave-id="w+wave-a"
+        data-folder-busy
+        data-folder-busy-wave-id="w+wave-a"
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    // Java switches selection and stamps the new marker before the observer fires.
+    row.setAttribute("data-folder-state-wave-id", "w+wave-b");
+    row.setAttribute("source-wave-id", "w+wave-b");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.hasAttribute("data-folder-busy"), "stale busy from wave-a must be cleared").to.be.false;
+    expect(row.hasAttribute("data-folder-busy-wave-id"), "stale busy-wave-id from wave-a must be cleared").to.be.false;
+    expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+wave-b");
+  });
+
   it("preserves model-published archived state when source wave changes before observer flush", async () => {
     const row = await fixture(
       html`<wavy-wave-nav-row

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -764,19 +764,25 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
 
   it("syncFolderStateForWave preserves model-published pinned state when no rail card exists", async () => {
     // Simulates J2clSelectedWaveController.publishNavRowFolderState() setting
-    // pinned=true synchronously in the same JS task as render() sets source-wave-id.
+    // marker+pinned synchronously in the same JS task as render() sets source-wave-id.
     // The MutationObserver fires after both, so syncFolderStateForWave must
-    // restore model-backed state instead of leaving the attribute cleared.
+    // preserve model-backed state instead of treating it as stale optimistic state.
     stub = installFetchStub(async () => okResponse());
     const row = await fixture(
-      html`<wavy-wave-nav-row source-wave-id="w+modpin-a"></wavy-wave-nav-row>`
+      html`<wavy-wave-nav-row
+        source-wave-id="w+modpin-a"
+        data-folder-state-wave-id="w+modpin-a"
+        pinned
+      ></wavy-wave-nav-row>`
     );
     controllerModule.start();
     await Promise.resolve();
 
-    // Simulate the Java model setting source-wave-id AND pinned in one sync task:
-    // the setAttribute calls below both complete before the MutationObserver fires.
+    // Simulate Java setting source-wave-id, ownership marker, and pinned in
+    // one sync task: any order inside this task completes before
+    // MutationObserver fires.
     row.setAttribute("source-wave-id", "w+modpin-b");
+    row.setAttribute("data-folder-state-wave-id", "w+modpin-b");
     row.setAttribute("pinned", ""); // model published pinned=true for wave b
     await new Promise((r) => setTimeout(r, 0)); // let observer fire
 
@@ -784,6 +790,7 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
       row.hasAttribute("pinned"),
       "model-published pinned must survive wave-id switch with no rail card"
     ).to.be.true;
+    expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+modpin-b");
 
     // First click must send unpin (wave is already pinned per model).
     const completed = new Promise((resolve) =>
@@ -805,19 +812,110 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
   it("syncFolderStateForWave does not restore stale pinned when model clears it on wave switch", async () => {
     stub = installFetchStub(async () => okResponse());
     const row = await fixture(
-      html`<wavy-wave-nav-row source-wave-id="w+stale-a" pinned></wavy-wave-nav-row>`
+      html`<wavy-wave-nav-row
+        source-wave-id="w+stale-a"
+        data-folder-state-wave-id="w+stale-a"
+        pinned
+      ></wavy-wave-nav-row>`
     );
     controllerModule.start();
     await Promise.resolve();
 
-    // Model switches wave and clears pinned (wave-b is not pinned).
+    // Model switches wave and publishes cleared pinned state for wave-b.
     row.setAttribute("source-wave-id", "w+stale-b");
+    row.setAttribute("data-folder-state-wave-id", "w+stale-b");
     row.removeAttribute("pinned"); // model published pinned=false for wave b
     await new Promise((r) => setTimeout(r, 0));
 
     expect(
       row.hasAttribute("pinned"),
       "stale pinned from previous wave must not be restored"
+    ).to.be.false;
+    expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+stale-b");
+  });
+
+  it("preserves model-published archived state when source wave changes before observer flush", async () => {
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+old"
+        data-folder-state-wave-id="w+old"
+        archived
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    row.setAttribute("source-wave-id", "w+new");
+    row.setAttribute("data-folder-state-wave-id", "w+new");
+    row.setAttribute("archived", "");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.hasAttribute("archived"), "model-published archived must survive observer sync")
+      .to.be.true;
+    expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+new");
+  });
+
+  it("does not hydrate stale digest state over a model-published cleared state", async () => {
+    const card = document.createElement("wavy-search-rail-card");
+    card.setAttribute("data-wave-id", "w+clear");
+    card.setAttribute("pinned", "");
+    document.body.appendChild(card);
+    try {
+      const row = await fixture(
+        html`<wavy-wave-nav-row
+          source-wave-id="w+clear"
+          data-folder-state-wave-id="w+clear"
+        ></wavy-wave-nav-row>`
+      );
+      controllerModule.start();
+      await Promise.resolve();
+
+      expect(row.hasAttribute("pinned"), "model-owned cleared state must win over stale digest")
+        .to.be.false;
+      expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+clear");
+    } finally {
+      card.remove();
+    }
+  });
+
+  it("clears folder state and marker when source wave id is removed", async () => {
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+old"
+        data-folder-state-wave-id="w+old"
+        pinned
+        archived
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    row.removeAttribute("source-wave-id");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.hasAttribute("pinned")).to.be.false;
+    expect(row.hasAttribute("archived")).to.be.false;
+    expect(row.hasAttribute("data-folder-state-wave-id")).to.be.false;
+  });
+
+  it("clears stale optimistic folder state when ownership marker does not match source wave", async () => {
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+old"
+        data-folder-state-wave-id="w+old"
+        pinned
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    row.setAttribute("source-wave-id", "w+new");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.getAttribute("data-folder-state-wave-id")).to.equal("w+new");
+    expect(
+      row.hasAttribute("pinned"),
+      "stale optimistic pinned must clear when Java has not stamped model ownership"
     ).to.be.false;
   });
 

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -898,6 +898,52 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
     expect(row.hasAttribute("data-folder-state-wave-id")).to.be.false;
   });
 
+  it("clears in-flight busy state when source wave id is removed after marker cleanup", async () => {
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+old"
+        data-folder-state-wave-id="w+old"
+        data-folder-busy
+        data-folder-busy-wave-id="w+old"
+        pinned
+        archived
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    // Java clears the ownership marker synchronously with deselect before the
+    // source-wave-id MutationObserver callback runs. The controller still owns
+    // the pending optimistic busy affordance and must clear it on no-source.
+    row.removeAttribute("data-folder-state-wave-id");
+    row.removeAttribute("source-wave-id");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.hasAttribute("data-folder-busy")).to.be.false;
+    expect(row.hasAttribute("data-folder-busy-wave-id")).to.be.false;
+    expect(row.hasAttribute("pinned")).to.be.false;
+    expect(row.hasAttribute("archived")).to.be.false;
+    expect(row.hasAttribute("data-folder-state-wave-id")).to.be.false;
+  });
+
+  it("clears busy state for any previous owner when source wave id is removed", async () => {
+    const row = await fixture(
+      html`<wavy-wave-nav-row
+        source-wave-id="w+old"
+        data-folder-busy
+        data-folder-busy-wave-id="w+other"
+      ></wavy-wave-nav-row>`
+    );
+    controllerModule.start();
+    await Promise.resolve();
+
+    row.removeAttribute("source-wave-id");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(row.hasAttribute("data-folder-busy")).to.be.false;
+    expect(row.hasAttribute("data-folder-busy-wave-id")).to.be.false;
+  });
+
   it("clears stale optimistic folder state when ownership marker does not match source wave", async () => {
     const row = await fixture(
       html`<wavy-wave-nav-row

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -441,6 +441,11 @@ public final class J2clSelectedWaveController
    * authoritative result set came from an archive folder query. Direct deep
    * links and cross-tab folder mutations stay conservative until the next
    * rail refresh or the live folder-state feed lands.
+   *
+   * <p>CONTRACT: keep this synchronous and immediately after any {@link View#render}
+   * call that can change the nav-row {@code source-wave-id}. The Lit action-bar
+   * MutationObserver uses the same-task marker stamp to distinguish model-owned
+   * folder state from stale optimistic state on reused rows.
    */
   private void publishNavRowFolderState() {
     boolean pinned = selectedDigestItem != null && selectedDigestItem.isPinned();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -577,9 +577,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (sourceWaveId == null || sourceWaveId.isEmpty()) {
       waveNavRow.removeAttribute("pinned");
       waveNavRow.removeAttribute("archived");
-      // Keep the ownership marker so the async source-wave-id MutationObserver
-      // pass can call setBusy(host, false, current) to clear any in-flight busy
-      // affordance before removing the marker itself.
+      waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
       return;
     }
     if (pinned) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -577,7 +577,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (sourceWaveId == null || sourceWaveId.isEmpty()) {
       waveNavRow.removeAttribute("pinned");
       waveNavRow.removeAttribute("archived");
-      waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
+      // Keep the ownership marker so the async source-wave-id MutationObserver
+      // pass can call setBusy(host, false, current) to clear any in-flight busy
+      // affordance before removing the marker itself.
       return;
     }
     if (pinned) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -19,6 +19,10 @@ import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
+  // Keep in sync with j2cl/lit/src/controllers/wave-action-bar-controller.js.
+  // Java stamps model-published folder state; Lit also reconciles this marker
+  // while handling source-wave-id reuse before Java publishes for a wave.
+  private static final String ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID = "data-folder-state-wave-id";
 
   /**
    * F-3.S3 (#1038, R-5.5): hook the root-shell installs to forward
@@ -431,6 +435,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       contentList.removeAttribute("data-wave-id");
       if (waveNavRow != null) {
         waveNavRow.removeAttribute("source-wave-id");
+        waveNavRow.removeAttribute("pinned");
+        waveNavRow.removeAttribute("archived");
+        waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
       }
     } else {
       contentList.setAttribute("data-wave-id", renderedWaveId);
@@ -575,6 +582,17 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       waveNavRow.setAttribute("archived", "");
     } else {
       waveNavRow.removeAttribute("archived");
+    }
+    String sourceWaveId = waveNavRow.getAttribute("source-wave-id");
+    if (sourceWaveId == null || sourceWaveId.isEmpty()) {
+      waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
+    } else {
+      // The Lit action-bar controller also uses this marker to decide whether
+      // pinned/archived attributes are stale optimistic state or current
+      // model-published state. Stamp it even when both flags are false: that
+      // records the model-owned "not pinned and not archived" state and keeps
+      // the async MutationObserver from rehydrating stale digest state.
+      waveNavRow.setAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID, sourceWaveId);
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -573,6 +573,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (waveNavRow == null) {
       return;
     }
+    String sourceWaveId = waveNavRow.getAttribute("source-wave-id");
+    if (sourceWaveId == null || sourceWaveId.isEmpty()) {
+      waveNavRow.removeAttribute("pinned");
+      waveNavRow.removeAttribute("archived");
+      waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
+      return;
+    }
     if (pinned) {
       waveNavRow.setAttribute("pinned", "");
     } else {
@@ -583,17 +590,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     } else {
       waveNavRow.removeAttribute("archived");
     }
-    String sourceWaveId = waveNavRow.getAttribute("source-wave-id");
-    if (sourceWaveId == null || sourceWaveId.isEmpty()) {
-      waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
-    } else {
-      // The Lit action-bar controller also uses this marker to decide whether
-      // pinned/archived attributes are stale optimistic state or current
-      // model-published state. Stamp it even when both flags are false: that
-      // records the model-owned "not pinned and not archived" state and keeps
-      // the async MutationObserver from rehydrating stale digest state.
-      waveNavRow.setAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID, sourceWaveId);
-    }
+    // The Lit action-bar controller also uses this marker to decide whether
+    // pinned/archived attributes are stale optimistic state or current
+    // model-published state. Stamp it even when both flags are false: that
+    // records the model-owned "not pinned and not archived" state and keeps
+    // the async MutationObserver from rehydrating stale digest state.
+    waveNavRow.setAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID, sourceWaveId);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -577,6 +577,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (sourceWaveId == null || sourceWaveId.isEmpty()) {
       waveNavRow.removeAttribute("pinned");
       waveNavRow.removeAttribute("archived");
+      // Lit's no-source sync clears any busy affordance without consulting
+      // this marker, so Java can drop stale ownership synchronously.
       waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
       return;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -136,15 +136,132 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void setNavRowFolderStateStampsCurrentSourceWaveOwnership() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(selectedModel("example.com/w+folder"));
+    view.setNavRowFolderState(true, true);
+
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertTrue(row.hasAttribute("pinned"));
+    Assert.assertTrue(row.hasAttribute("archived"));
+    Assert.assertEquals(
+        "Model-published folder state must be keyed to the current source-wave-id",
+        "example.com/w+folder",
+        row.getAttribute("data-folder-state-wave-id"));
+  }
+
+  @Test
+  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsAbsent() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
+
+    view.setNavRowFolderState(false, false);
+
+    Assert.assertFalse(row.hasAttribute("pinned"));
+    Assert.assertFalse(row.hasAttribute("archived"));
+    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
+  }
+
+  @Test
+  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsEmpty() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    row.setAttribute("source-wave-id", "");
+    row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
+
+    view.setNavRowFolderState(false, false);
+
+    Assert.assertFalse(row.hasAttribute("pinned"));
+    Assert.assertFalse(row.hasAttribute("archived"));
+    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
+  }
+
+  @Test
+  public void setNavRowFolderStateStampsModelClearedStateForCurrentSourceWave() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedModel("example.com/w+clear"));
+    view.setNavRowFolderState(true, true);
+    view.setNavRowFolderState(false, false);
+
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertFalse(row.hasAttribute("pinned"));
+    Assert.assertFalse(row.hasAttribute("archived"));
+    Assert.assertEquals(
+        "example.com/w+clear",
+        row.getAttribute("data-folder-state-wave-id"));
+  }
+
+  @Test
+  public void setNavRowFolderStateKeepsOwnershipStableForSameWaveFolderSwitch() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedModel("example.com/w+same"));
+    view.setNavRowFolderState(true, false);
+    view.setNavRowFolderState(false, true);
+
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertEquals(
+        "example.com/w+same",
+        row.getAttribute("data-folder-state-wave-id"));
+    Assert.assertFalse(row.hasAttribute("pinned"));
+    Assert.assertTrue(row.hasAttribute("archived"));
+  }
+
+  @Test
+  public void setNavRowFolderStateRewritesOwnershipAcrossRenders() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedModel("example.com/w+a"));
+    view.setNavRowFolderState(true, false);
+    view.render(selectedModel("example.com/w+b"));
+    view.setNavRowFolderState(false, true);
+
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertEquals("example.com/w+b", row.getAttribute("source-wave-id"));
+    Assert.assertEquals(
+        "example.com/w+b",
+        row.getAttribute("data-folder-state-wave-id"));
+    Assert.assertFalse(row.hasAttribute("pinned"));
+    Assert.assertTrue(row.hasAttribute("archived"));
+  }
+
+  @Test
   public void renderClearsSourceWaveIdWhenSelectionIsEmpty() {
     assumeBrowserDom();
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(selectedModel("example.com/w+old"));
+    view.setNavRowFolderState(true, true);
+
     view.render(J2clSelectedWaveModel.clearedSelection());
+
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
     Assert.assertFalse(
         "Cleared selection clears the source wave id on the nav row",
         row.hasAttribute("source-wave-id"));
+    Assert.assertFalse(
+        "Cleared selection clears stale pinned state",
+        row.hasAttribute("pinned"));
+    Assert.assertFalse(
+        "Cleared selection clears stale archived state",
+        row.hasAttribute("archived"));
+    Assert.assertFalse(
+        "Cleared selection clears stale model ownership marker",
+        row.hasAttribute("data-folder-state-wave-id"));
   }
 
   @Test
@@ -238,7 +355,7 @@ public class J2clSelectedWaveViewChromeTest {
             + "</div>";
     HTMLElement bar = (HTMLElement) host.querySelector("wavy-depth-nav-bar");
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
-    new J2clSelectedWaveView(host);
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
     Assert.assertSame(
         "Server-first re-bind must re-use the same depth-nav-bar element (no replaceChild)",
         bar,
@@ -247,6 +364,16 @@ public class J2clSelectedWaveViewChromeTest {
         "Server-first re-bind must re-use the same wave-nav-row element (no replaceChild)",
         row,
         host.querySelector("wavy-wave-nav-row"));
+    Assert.assertFalse(
+        "Server-first re-bind starts without model-owned folder marker",
+        row.hasAttribute("data-folder-state-wave-id"));
+
+    view.render(selectedModel("example.com/w+server-first"));
+    view.setNavRowFolderState(true, false);
+
+    Assert.assertEquals(
+        "example.com/w+server-first",
+        row.getAttribute("data-folder-state-wave-id"));
   }
 
   // J-UI-8 (#1086, R-6.3): aria-busy is set by HtmlRenderer on the
@@ -325,6 +452,28 @@ public class J2clSelectedWaveViewChromeTest {
     currentHost = (HTMLElement) DomGlobal.document.createElement("div");
     DomGlobal.document.body.appendChild(currentHost);
     return currentHost;
+  }
+
+  private static J2clSelectedWaveModel selectedModel(String waveId) {
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        waveId,
+        "Selected wave",
+        "",
+        "Read.",
+        "",
+        "",
+        0,
+        Collections.<String>emptyList(),
+        Arrays.<String>asList(),
+        Arrays.<J2clReadBlip>asList(),
+        null,
+        0,
+        true,
+        true,
+        false);
   }
 
   private static void assumeBrowserDom() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -153,7 +153,7 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
-  public void setNavRowFolderStatePreservesMarkerWhenSourceWaveIsAbsent() {
+  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsAbsent() {
     assumeBrowserDom();
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
@@ -164,13 +164,11 @@ public class J2clSelectedWaveViewChromeTest {
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));
-    // Marker kept so the async source-wave-id observer can clear busy state.
-    Assert.assertTrue(row.hasAttribute("data-folder-state-wave-id"));
-    Assert.assertEquals("example.com/w+old", row.getAttribute("data-folder-state-wave-id"));
+    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
   }
 
   @Test
-  public void setNavRowFolderStatePreservesMarkerWhenSourceWaveIsEmpty() {
+  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsEmpty() {
     assumeBrowserDom();
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
@@ -182,9 +180,7 @@ public class J2clSelectedWaveViewChromeTest {
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));
-    // Marker kept so the async source-wave-id observer can clear busy state.
-    Assert.assertTrue(row.hasAttribute("data-folder-state-wave-id"));
-    Assert.assertEquals("example.com/w+old", row.getAttribute("data-folder-state-wave-id"));
+    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -153,7 +153,7 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
-  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsAbsent() {
+  public void setNavRowFolderStatePreservesMarkerWhenSourceWaveIsAbsent() {
     assumeBrowserDom();
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
@@ -164,11 +164,13 @@ public class J2clSelectedWaveViewChromeTest {
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));
-    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
+    // Marker kept so the async source-wave-id observer can clear busy state.
+    Assert.assertTrue(row.hasAttribute("data-folder-state-wave-id"));
+    Assert.assertEquals("example.com/w+old", row.getAttribute("data-folder-state-wave-id"));
   }
 
   @Test
-  public void setNavRowFolderStateClearsOwnershipWhenSourceWaveIsEmpty() {
+  public void setNavRowFolderStatePreservesMarkerWhenSourceWaveIsEmpty() {
     assumeBrowserDom();
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
@@ -180,7 +182,9 @@ public class J2clSelectedWaveViewChromeTest {
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));
-    Assert.assertFalse(row.hasAttribute("data-folder-state-wave-id"));
+    // Marker kept so the async source-wave-id observer can clear busy state.
+    Assert.assertTrue(row.hasAttribute("data-folder-state-wave-id"));
+    Assert.assertEquals("example.com/w+old", row.getAttribute("data-folder-state-wave-id"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -160,7 +160,7 @@ public class J2clSelectedWaveViewChromeTest {
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
     row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
 
-    view.setNavRowFolderState(false, false);
+    view.setNavRowFolderState(true, true);
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));
@@ -176,7 +176,7 @@ public class J2clSelectedWaveViewChromeTest {
     row.setAttribute("source-wave-id", "");
     row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
 
-    view.setNavRowFolderState(false, false);
+    view.setNavRowFolderState(true, true);
 
     Assert.assertFalse(row.hasAttribute("pinned"));
     Assert.assertFalse(row.hasAttribute("archived"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -158,6 +158,8 @@ public class J2clSelectedWaveViewChromeTest {
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    row.setAttribute("pinned", "");
+    row.setAttribute("archived", "");
     row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
 
     view.setNavRowFolderState(true, true);
@@ -174,6 +176,8 @@ public class J2clSelectedWaveViewChromeTest {
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
     row.setAttribute("source-wave-id", "");
+    row.setAttribute("pinned", "");
+    row.setAttribute("archived", "");
     row.setAttribute("data-folder-state-wave-id", "example.com/w+old");
 
     view.setNavRowFolderState(true, true);

--- a/wave/config/changelog.d/2026-04-29-g-port-8-folder-state-marker-followup.json
+++ b/wave/config/changelog.d/2026-04-29-g-port-8-folder-state-marker-followup.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-29-g-port-8-folder-state-marker-followup",
+  "version": "PR #1132",
+  "date": "2026-04-29",
+  "title": "G-PORT-8 follow-up: stable J2CL pin and archive state",
+  "summary": "The J2CL top-of-wave action bar now keeps server-published pin and archive state tied to the selected wave so stale optimistic state cannot leak across wave changes.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Track the source wave id on the J2CL nav-row folder-state attributes, preserve matching server-published pin/archive state during controller hydration, and clear stale optimistic state when the selected wave changes."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to merged PR #1130 for issue #1117 / J2CL parity tracker #904.

PR #1130 merged while a stricter review-thread fix was still being finalized. This follow-up carries that reviewed marker-contract fix onto current `main`.

Changes:
- Make `data-folder-state-wave-id` the explicit cross-language ownership marker between `J2clSelectedWaveView` and the Lit action-bar controller.
- Preserve Java model-published pinned/archived/cleared state across the async `source-wave-id` MutationObserver flush only when the marker already matches the new wave.
- Clear stale optimistic `pinned`/`archived` state on marker mismatch, then fall back to digest/active-folder hydration for pre-publish route restore.
- Clear `pinned`, `archived`, and marker when selection is empty or `setNavRowFolderState` is called without a current `source-wave-id`.
- Document the synchronous render-then-publish contract in `J2clSelectedWaveController`.

Intentional behavior note:
- If callers pass `setNavRowFolderState(true, true)` while the nav row has no `source-wave-id`, the view now clears `pinned`/`archived` instead of briefly setting them. A row without wave provenance should not carry folder state.

Verification:
- `cd j2cl/lit && npm ci && npm test -- test/wave-action-bar-controller.test.js` — PASS, Chromium 29 passed / 0 failed.
- `sbt --batch j2clSearchTest` — PASS.
- `git diff --check` — PASS.

Review:
- Self-review completed during conflict resolution.
- Claude Opus review loop reached approval with no blockers or important concerns after the synchronous publish contract and no-source cleanup were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder pin/archive state now follows the selected wave; stale optimistic folder-state and busy indicators are reliably cleared when selection changes or is absent, and authoritative server-published flags are preserved for the current wave.

* **Documentation**
  * Clarified timing between view render and folder-state publishing to make ownership semantics explicit.

* **Tests**
  * Expanded coverage for ownership-marker behavior, observer timing, busy-state cleanup, and transition scenarios.

* **Chore**
  * Added changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->