### PR TITLE
fix(g-port-7): sync J2CL blip focus marker

### DIFF
--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -138,6 +138,18 @@ describe("moveBlipFocus", () => {
     const focused = root.querySelector("wave-blip[focused]");
     expect(focused.getAttribute("data-blip-id")).to.equal("b3");
   });
+
+  it("j continues from renderer-established Lit focused attribute", async () => {
+    const root = await threeBlips();
+    const blips = Array.from(root.querySelectorAll("wave-blip"));
+    // Simulate the Java renderer reflecting its focus owner onto the
+    // Lit host marker that repeated j/k and the parity E2E observe.
+    blips[1].setAttribute("focused", "");
+    moveBlipFocus(1, root); // should continue from b2 -> b3
+    const focused = root.querySelector("wave-blip[focused]");
+    expect(focused.getAttribute("data-blip-id")).to.equal("b3");
+    expect(blips[1].hasAttribute("focused")).to.equal(false);
+  });
 });
 
 describe("clearBlipFocus", () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2081,14 +2081,31 @@ public final class J2clReadSurfaceDomRenderer {
     }
     clearFocusedBlip();
     focusedBlip = next;
-    focusedBlip.classList.add("j2cl-read-blip-focused");
-    focusedBlip.setAttribute("aria-current", "true");
+    setFocusMarkers(focusedBlip);
+    focusedBlip.setAttribute("tabindex", "0");
+    dispatchFocusChanged(focusedBlip, key);
+  }
+
+  private void setFocusMarkers(HTMLElement blip) {
+    blip.classList.add("j2cl-read-blip-focused");
+    blip.setAttribute("aria-current", "true");
     // G-PORT-3 (#1112): cross-view parity hook so the Playwright spec
     // can locate the focused blip with a single selector
     // ([data-blip-focused="true"]) on both J2CL and GWT.
-    focusedBlip.setAttribute("data-blip-focused", "true");
-    focusedBlip.setAttribute("tabindex", "0");
-    dispatchFocusChanged(focusedBlip, key);
+    blip.setAttribute("data-blip-focused", "true");
+    // G-PORT-7 (#1133): when keydown originates on a focused wave-blip,
+    // the renderer handles j/k before the Lit shell-level listener sees
+    // the event. Write both hooks synchronously: data-blip-focused is the
+    // immediate cross-view selector, while focused is the Lit host marker
+    // that Lit will later reflect back to the same data hook.
+    blip.setAttribute("focused", "");
+  }
+
+  private void clearFocusMarkers(HTMLElement blip) {
+    blip.classList.remove("j2cl-read-blip-focused");
+    blip.removeAttribute("aria-current");
+    blip.removeAttribute("data-blip-focused");
+    blip.removeAttribute("focused");
   }
 
   /**
@@ -2192,10 +2209,7 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void clearFocusedBlip() {
     for (HTMLElement blip : renderedBlips) {
-      blip.classList.remove("j2cl-read-blip-focused");
-      blip.removeAttribute("aria-current");
-      // G-PORT-3 (#1112): keep the cross-view parity hook in sync.
-      blip.removeAttribute("data-blip-focused");
+      clearFocusMarkers(blip);
       blip.setAttribute("tabindex", "-1");
     }
     focusedBlip = null;
@@ -2410,11 +2424,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
     for (HTMLElement blip : renderedBlips) {
       blip.setAttribute("tabindex", blip == tabStop ? "0" : "-1");
-      blip.classList.remove("j2cl-read-blip-focused");
-      blip.removeAttribute("aria-current");
-      // G-PORT-3 (#1112): clear the cross-view focus parity hook in
-      // step with the legacy class + aria-current.
-      blip.removeAttribute("data-blip-focused");
+      clearFocusMarkers(blip);
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -2289,6 +2289,40 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLElement after = blip(host, "b+after");
     Assert.assertEquals("0", after.getAttribute("tabindex"));
     Assert.assertTrue(after.classList.contains("j2cl-read-blip-focused"));
+    Assert.assertEquals(
+        "renderer key handling must keep the Lit host focus marker in sync",
+        "",
+        after.getAttribute("focused"));
+    Assert.assertFalse(root.hasAttribute("focused"));
+  }
+
+  @Test
+  public void repeatedJKeyKeepsFocusedAttributeAdvancing() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+middle\">Middle</div>"
+            + "<div class=\"blip\" data-blip-id=\"b+after\">After</div>"
+            + "</div></div>";
+    new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface();
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement middle = blip(host, "b+middle");
+    HTMLElement after = blip(host, "b+after");
+
+    root.focus();
+    dispatchKey(root, "j");
+    Assert.assertEquals("", middle.getAttribute("focused"));
+    Assert.assertFalse(root.hasAttribute("focused"));
+
+    dispatchKey(middle, "j");
+    Assert.assertEquals(
+        "second j press must advance the Lit host focus marker too",
+        "",
+        after.getAttribute("focused"));
+    Assert.assertFalse(middle.hasAttribute("focused"));
   }
 
   @Test
@@ -2310,6 +2344,11 @@ public class J2clReadSurfaceDomRendererTest {
         reply.classList.contains("j2cl-read-blip-focused")
             || root.classList.contains("j2cl-read-blip-focused");
     Assert.assertTrue("k must move focus to a previous visible blip", replyOrRootFocused);
+    HTMLElement focused = reply.classList.contains("j2cl-read-blip-focused") ? reply : root;
+    Assert.assertEquals(
+        "k alias must also keep the Lit host focus marker in sync",
+        "",
+        focused.getAttribute("focused"));
   }
 
   @Test

--- a/wave/config/changelog.d/2026-04-29-g-port-7-j-focus-followup.json
+++ b/wave/config/changelog.d/2026-04-29-g-port-7-j-focus-followup.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-29-g-port-7-j-focus-followup",
-  "version": "PR #TBD",
+  "version": "PR #1134",
   "date": "2026-04-29",
   "title": "G-PORT-7 follow-up: stable J2CL blip keyboard focus",
   "summary": "The J2CL read surface now keeps Java-owned j/k blip focus navigation synchronized with the Lit host focus marker, so repeated shortcut presses advance visibly between blips.",

--- a/wave/config/changelog.d/2026-04-29-g-port-7-j-focus-followup.json
+++ b/wave/config/changelog.d/2026-04-29-g-port-7-j-focus-followup.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-29-g-port-7-j-focus-followup",
+  "version": "PR #TBD",
+  "date": "2026-04-29",
+  "title": "G-PORT-7 follow-up: stable J2CL blip keyboard focus",
+  "summary": "The J2CL read surface now keeps Java-owned j/k blip focus navigation synchronized with the Lit host focus marker, so repeated shortcut presses advance visibly between blips.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Mirror Java read-surface keyboard focus into the Lit `focused` host attribute and clear it alongside the existing class/data focus hooks."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1133. Refs #904, #1109, #1116.

This fixes the G-PORT-7 keyboard parity regression where the second `j` press did not advance the observable J2CL focused blip. When keydown originates on a focused `<wave-blip>`, the Java read-surface renderer handles `j/k` before the Lit shell-level listener sees the event. The renderer now keeps the Lit `focused` host marker synchronized with its existing `j2cl-read-blip-focused`, `aria-current`, and `data-blip-focused` markers.

## Changes

- Centralized renderer focus marker writes/clears in `setFocusMarkers` / `clearFocusMarkers`.
- Added repeated-`j` Java regression coverage for the literal failing path.
- Added Lit shortcut coverage for renderer-established `focused` attributes.
- Added a changelog fragment for the keyboard parity fix.

## Verification

- `python3 scripts/assemble-changelog.py` — pass (`assembled 299 entries -> wave/config/changelog.json`)
- `python3 scripts/validate-changelog.py` — pass
- `git diff --check` — pass
- `sbt --batch pst/compile wave/compile` — pass
- `cd j2cl/lit && npm test -- test/shortcuts/blip-focus.test.js test/shortcuts/shell-root-keys.test.js` — pass (`27 passed`)
- `sbt --batch Universal/stage` — pass
- `CI=true WAVE_E2E_BASE_URL=http://127.0.0.1:9917 npx playwright test keyboard-shortcuts-parity.spec.ts` — pass (`2 passed`, `1 skipped` for known #1125 mention-popover follow-up)

## Review

- Self-review completed.
- Claude Opus review loop completed with final result: `Blockers: None. Important comments: None.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard focus navigation to properly update and display visual focus indicators when using `j` and `k` shortcuts to move between blips.

* **Tests**
  * Added end-to-end tests validating focus marker synchronization during keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->