### PR TITLE
Automate GWT inline reply parity

### DIFF
--- a/docs/superpowers/plans/2026-04-29-issue-1121-gwt-inline-reply-e2e-parity.md
+++ b/docs/superpowers/plans/2026-04-29-issue-1121-gwt-inline-reply-e2e-parity.md
@@ -1,0 +1,834 @@
+# Issue #1121 GWT Inline Reply E2E Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `inline-reply-parity.spec.ts` so the GWT half drives the same reply, bold, send, and new-blip assertions that the J2CL half already covers.
+
+**Architecture:** Add stable, inert GWT DOM hooks for the legacy blip menu and edit toolbar, then use those hooks from the parity E2E instead of hover-only or debounced accessibility selectors. Keep the change test-infrastructure-only: no command behavior, wave loading strategy, or production data flow changes.
+
+**Tech Stack:** GWT client Java, existing toolbar/button view abstractions, Playwright parity harness under `wave/src/e2e/j2cl-gwt-parity`, SBT verification only for JVM/build gates.
+
+---
+
+## Scope And Non-Goals
+
+- In scope: GWT `?view=gwt` inline reply automation for the existing Welcome wave flow in `wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts`.
+- In scope: stable `data-e2e-action` hooks for GWT blip menu `REPLY`, GWT edit-done `EDIT_DONE`, and the GWT Bold toolbar button.
+- In scope: small unit coverage proving the generated menu/toolbar hook contract does not regress.
+- Out of scope: J2CL UI behavior changes, GWT visual redesign, toolbar command rewrites, whole-wave loading changes, server-first HTML work, or changing default root routing.
+
+## File Map
+
+- Modify `wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts`: keep the GWT shell sentinel and existing editor locator knowledge reusable from the page object.
+- Modify `wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts`: replace the GWT baseline-only assertion with full reply/bold/send flow and helper functions.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java`: add stable action attributes for `REPLY` and `EDIT_DONE` menu spans.
+- Modify `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipViewBuilderTest.java`: assert rendered menu HTML contains the stable GWT reply and edit-done hooks.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java`: add a toolbar-view method for stable E2E action metadata.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/AbstractToolbarButton.java`: delegate stable E2E action metadata to the concrete button UI.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxy.java`: preserve/copy stable E2E action metadata when toolbar items move between top-level and overflow delegates.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java`: forward stable E2E action metadata through the UI proxy used by top-level and overflow toolbar buttons.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.java`: emit `data-e2e-action` on the horizontal toolbar button root.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/VerticalToolbarButtonWidget.java`: emit `data-e2e-action` on the vertical/overflow toolbar button root.
+- Add `wave/src/test/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxyTest.java`: prove `setE2eAction` copies and clears across delegate swaps.
+- Modify `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`: mark the Bold button with `data-e2e-action="bold"`.
+- Add `wave/config/changelog.d/2026-04-29-gwt-inline-reply-e2e-parity.json`: changelog fragment for the harness-visible parity coverage.
+
+## Acceptance Criteria
+
+- The GWT parity test registers a fresh user, opens the Welcome wave, confirms the GWT shell sentinel, records the current GWT blip count, clicks a real per-blip Reply action, types a unique `hello <suffix> world` reply, applies Bold to `world`, clicks the real GWT edit-done action, and observes a new reply blip in the GWT wave body.
+- The J2CL half remains unchanged except for shared helper cleanup if needed; it must continue passing in the same spec file.
+- The test must not use fixed sleeps as the primary synchronization for the new reply/bold/send flow; use locator waits and `expect.poll` for GWT deferred DOM work.
+- The implementation must not rely on hidden text labels, hover-only menu reveal, or unstable obfuscated GWT CSS classes.
+- Local verification evidence must include TypeScript no-emit, focused parity Playwright against local server, changelog validation, `sbt --batch j2clSearchTest`, and `sbt --batch compile`.
+
+---
+
+### Task 1: Prove The Current GWT Full Flow Has No Stable Path
+
+**Files:**
+- Modify: `wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts`
+
+- [ ] **Step 1: Add temporary GWT helper calls behind the existing GWT test**
+
+Add helpers with the target selectors before implementing Java hooks. Keep them local to the spec only for the RED proof and do not commit this intermediate state:
+
+```ts
+async function clickReplyOnFirstBlipGwt(page: Page) {
+  const reply = page.locator("[data-e2e-action='reply']").first();
+  await expect(reply, "GWT reply action must expose a stable data-e2e-action hook").toBeVisible({
+    timeout: 5_000
+  });
+  await reply.click({ timeout: 10_000 });
+}
+```
+
+Change the GWT test temporarily to call `await clickReplyOnFirstBlipGwt(page);` immediately after the welcome-wave body assertion.
+
+- [ ] **Step 2: Assert the GWT sentinel before the RED click**
+
+The GWT test already uses `const gwt = new GwtPage(page, BASE_URL); await gwt.goto("/"); await gwt.assertInboxLoaded();`. Keep that sentinel in the RED run and in the final test so a future J2CL selector cannot accidentally satisfy the GWT path.
+
+- [ ] **Step 3: Run the focused RED proof**
+
+Run:
+
+```bash
+cd wave/src/e2e/j2cl-gwt-parity
+CI=true WAVE_E2E_BASE_URL=http://127.0.0.1:9931 npx playwright test tests/inline-reply-parity.spec.ts --project=chromium --grep "GWT:"
+```
+
+Expected before Java hooks:
+
+```text
+FAIL ... GWT reply action must expose a stable data-e2e-action hook
+```
+
+If the failure is server startup, auth, or welcome-wave load instead of missing `[data-e2e-action='reply']`, stop and fix the harness setup before continuing.
+
+- [ ] **Step 4: Revert the temporary RED-only edit before starting Java changes**
+
+Use `git diff` to confirm the only remaining planned changes after the RED proof are intentional plan or implementation edits. The final commit must contain the permanent GWT helpers from Task 4, not this temporary RED-only helper.
+
+Run this guard before the final implementation commit:
+
+```bash
+rg -n "GWT reply action must expose a stable data-e2e-action hook" wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts && exit 1 || true
+```
+
+Expected: no match. The final spec may contain Task 4 helper names, but not the temporary RED-only assertion text.
+
+---
+
+### Task 2: Add Stable GWT Blip Menu Hooks
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java`
+- Modify: `wave/src/test/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipViewBuilderTest.java`
+
+- [ ] **Step 1: Add an action-name helper**
+
+Add this helper near `menuBuilder` in `BlipMetaViewBuilder.java`:
+
+```java
+  private static String e2eActionFor(MenuOption option) {
+    switch (option) {
+      case REPLY:
+        return "reply";
+      case EDIT_DONE:
+        return "edit-done";
+      default:
+        return null;
+    }
+  }
+```
+
+- [ ] **Step 2: Emit stable attributes in `menuBuilder`**
+
+Update the `extra` construction inside `menuBuilder`:
+
+```java
+          String extra = OPTION_ID_ATTRIBUTE + "='" + MENU_CODES.get(option).asString() + "'"
+              + " title='" + title + "'"
+              + " data-option='" + dataOption + "'"
+              + (selected.contains(option) ? " " + OPTION_SELECTED_ATTRIBUTE + "='s'" : "");
+          String e2eAction = e2eActionFor(option);
+          if (e2eAction != null) {
+            extra += " data-e2e-action='" + e2eAction + "'";
+          }
+```
+
+Do not change `OPTION_ID_ATTRIBUTE`, menu option codes, click handling, or menu ordering.
+
+- [ ] **Step 3: Add unit coverage for menu hooks**
+
+Add this test to `BlipViewBuilderTest.java`:
+
+```java
+  public void testMenuActionsExposeStableE2eHooks() {
+    Set<MenuOption> options = CollectionUtils.newHashSet();
+    options.add(MenuOption.REPLY);
+    options.add(MenuOption.EDIT_DONE);
+    String html = UiBuilderTestHelper.render(
+        BlipMetaViewBuilder.menuBuilder(options, CollectionUtils.<MenuOption>newHashSet(), css));
+
+    assertTrue(html.contains("data-e2e-action='reply'"));
+    assertTrue(html.contains("data-e2e-action='edit-done'"));
+    assertTrue(html.contains("data-option='reply'"));
+    assertTrue(html.contains("data-option='edit_done'"));
+  }
+```
+
+Required imports:
+
+```java
+import org.waveprotocol.wave.client.wavepanel.view.IntrinsicBlipMetaView.MenuOption;
+import org.waveprotocol.wave.model.util.CollectionUtils;
+import java.util.Set;
+```
+
+- [ ] **Step 4: Run the focused JVM test**
+
+Run:
+
+```bash
+sbt --batch "testOnly org.waveprotocol.wave.client.wavepanel.view.dom.full.BlipViewBuilderTest"
+```
+
+Expected: test exits `0`. If the SBT task cannot isolate this legacy JUnit test, record the exact SBT limitation in #1121 and rely on `sbt --batch compile` plus the Playwright GREEN proof later.
+
+---
+
+### Task 3: Add Stable GWT Bold Toolbar Hook
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/AbstractToolbarButton.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxy.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/VerticalToolbarButtonWidget.java`
+- Add: `wave/src/test/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxyTest.java`
+- Modify: `wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java`
+
+- [ ] **Step 1: Extend the toolbar view contract**
+
+Add to `ToolbarButtonView.java`:
+
+```java
+  /**
+   * Sets a stable E2E action identifier on the rendered button, or clears it
+   * when {@code action} is null.
+   */
+  void setE2eAction(String action);
+```
+
+Also add the no-op implementation to `ToolbarButtonView.EMPTY`.
+
+```java
+    @Override
+    public void setE2eAction(String action) {
+    }
+```
+
+- [ ] **Step 2: Delegate and preserve the metadata through toolbar proxies**
+
+Add to `AbstractToolbarButton.java`:
+
+```java
+  @Override
+  public void setE2eAction(String action) {
+    button.setE2eAction(action);
+  }
+```
+
+Add to `ToolbarButtonViewProxy.java`:
+
+```java
+  private String e2eAction;
+
+  @Override
+  public void setE2eAction(String action) {
+    this.e2eAction = action;
+    if (delegate != null) {
+      delegate.setE2eAction(action);
+    }
+  }
+```
+
+Then call it unconditionally from `copyInto` so stale metadata is also cleared if a future button sets the action to null:
+
+```java
+    display.setE2eAction(e2eAction);
+```
+
+Add to `ToolbarButtonUiProxy.java` in the trivial delegation section:
+
+```java
+  @Override
+  public void setE2eAction(String action) {
+    proxy.setE2eAction(action);
+  }
+```
+
+Current code facts to verify before editing:
+
+```bash
+rg -n "interface ToolbarButtonUi extends ToolbarButtonView|private final ToolbarButtonViewProxy proxy|void setDelegate" \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUi.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java
+```
+
+Expected:
+
+```text
+ToolbarButtonUi extends ToolbarButtonView.
+ToolbarButtonUiProxy has a private final ToolbarButtonViewProxy field named proxy.
+ToolbarButtonUiProxy.setDelegate(...) calls proxy.setDelegate(delegate), so delegate swaps route through ToolbarButtonViewProxy.copyInto(...).
+```
+
+- [ ] **Step 3: Emit attributes from concrete toolbar widgets**
+
+Add to `HorizontalToolbarButtonWidget.java`:
+
+```java
+  @Override
+  public void setE2eAction(String action) {
+    if (action == null || action.isEmpty()) {
+      getElement().removeAttribute("data-e2e-action");
+    } else {
+      getElement().setAttribute("data-e2e-action", action);
+    }
+  }
+```
+
+Add the same method to `VerticalToolbarButtonWidget.java`.
+
+- [ ] **Step 4: Mark the Bold button**
+
+Update `createBoldButton` in `EditToolbar.java`:
+
+```java
+  private void createBoldButton(ToolbarView toolbar) {
+    ToolbarToggleButton b = toolbar.addToggleButton();
+    new ToolbarButtonViewBuilder()
+        .setTooltip("Bold")
+        .applyTo(b, createTextSelectionController(b, "fontWeight", "bold"));
+    b.setE2eAction("bold");
+    b.setVisualElement(createSvgIcon(ICON_BOLD));
+  }
+```
+
+Do not add hooks to every toolbar button in this issue. Keep the selector contract to the one GWT action needed by #1121.
+
+- [ ] **Step 5: Add proxy unit coverage for action copy and clear**
+
+Create `ToolbarButtonViewProxyTest.java`:
+
+```java
+package org.waveprotocol.wave.client.widget.toolbar.buttons;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
+import junit.framework.TestCase;
+
+public final class ToolbarButtonViewProxyTest extends TestCase {
+  // Plain JUnit3 stub; ToolbarButtonUi extends ToolbarButtonView in the current code.
+  private static class RecordingView implements ToolbarButtonView {
+    String action;
+
+    @Override public void setState(State state) {}
+    @Override public void setText(String text) {}
+    @Override public void setVisualElement(Element element) {}
+    @Override public void setTooltip(String tooltip) {}
+    @Override public void setShowDropdownArrow(boolean showDropdown) {}
+    @Override public void setShowDivider(boolean showDivider) {}
+    @Override public void addDebugClass(String dc) {}
+    @Override public void removeDebugClass(String dc) {}
+    @Override public Widget hackGetWidget() { return null; }
+    @Override public void setE2eAction(String action) { this.action = action; }
+  }
+
+  private static final class RecordingUi extends RecordingView implements ToolbarButtonUi {
+    @Override public void setDown(boolean isDown) {}
+    @Override public void setListener(Listener listener) {}
+  }
+
+  public void testE2eActionCopiesAndClearsAcrossDelegates() {
+    RecordingView first = new RecordingView();
+    ToolbarButtonViewProxy proxy = new ToolbarButtonViewProxy(first);
+
+    proxy.setE2eAction("bold");
+    assertEquals("bold", first.action);
+
+    RecordingView second = new RecordingView();
+    proxy.setDelegate(second);
+    assertEquals("bold", second.action);
+
+    proxy.setE2eAction(null);
+    assertNull(second.action);
+
+    RecordingView third = new RecordingView();
+    third.action = "stale";
+    proxy.setDelegate(third);
+    assertNull(third.action);
+  }
+
+  public void testUiProxyForwardsE2eActionToDelegates() {
+    RecordingUi first = new RecordingUi();
+    ToolbarButtonUiProxy proxy = new ToolbarButtonUiProxy(first);
+
+    proxy.setE2eAction("bold");
+    assertEquals("bold", first.action);
+
+    RecordingUi second = new RecordingUi();
+    proxy.setDelegate(second);
+    assertEquals("bold", second.action);
+
+    proxy.setE2eAction(null);
+    assertNull(second.action);
+
+    RecordingUi third = new RecordingUi();
+    third.action = "stale";
+    proxy.setDelegate(third);
+    assertNull(third.action);
+  }
+}
+```
+
+Run:
+
+```bash
+sbt --batch "testOnly org.waveprotocol.wave.client.widget.toolbar.buttons.ToolbarButtonViewProxyTest"
+```
+
+Expected: test exits `0`. If legacy SBT filtering cannot isolate the test, record the exact limitation in #1121 and rely on `sbt --batch compile` plus focused Playwright.
+
+- [ ] **Step 6: Compile the changed Java contract**
+
+Run:
+
+```bash
+sbt --batch compile
+```
+
+Expected: compilation exits `0`; any missing interface method errors must be fixed before E2E work continues. Keep this compile even though `j2clSearchTest` also compiles part of the tree, because this task changes legacy GWT toolbar interfaces outside the J2CL-focused test target.
+
+---
+
+### Task 4: Drive Full GWT Inline Reply In The Parity Spec
+
+**Files:**
+- Modify: `wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts`
+- Modify: `wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts`
+
+- [ ] **Step 1: Probe the live GWT editor and bold wrapper before coding final helpers**
+
+Run the GWT baseline locally and inspect the live DOM after clicking Reply. Confirm these facts before writing the final helper:
+
+```ts
+const editorCandidates = await page.evaluate(() =>
+  [
+    '[kind="document"] [editabledocmarker="true"]',
+    '[kind="document"] .wave-editor-on',
+    '[kind="document"][contenteditable]',
+    '[kind="document"] [contenteditable]'
+  ].flatMap((selector) =>
+    Array.from(document.querySelectorAll(selector)).map((node) => ({
+      selector,
+      tag: node.nodeName,
+      text: (node.textContent || "").slice(0, 80),
+      editable: (node as HTMLElement).getAttribute("contenteditable"),
+      visible: !!((node as HTMLElement).offsetWidth || (node as HTMLElement).offsetHeight)
+    }))
+  )
+);
+```
+
+Expected decision:
+
+```text
+Use the narrowest selector that points at the active reply editor after Reply.
+Prefer the existing GwtPage selector list if it matches; otherwise document the observed selector in #1121 before implementing.
+Confirm the union selector count and ordering; `.last()` is allowed only if the last candidate is the active reply editor after Reply.
+```
+
+Also verify whether selecting `world` with a programmatic `Range` changes the editor DOM after Bold. If not, use keyboard selection by making `world` the last word of the phrase and selecting it with `Shift+ArrowLeft`.
+
+Record the probe outcome in #1121 before coding the final helpers:
+
+```text
+Live DOM probe:
+- Active editor selector chosen: <selector or GwtPage method>
+- Selection strategy: Range path accepted / keyboard fallback required
+- Bold wrapper assertion: enabled with observed wrapper / omitted with residual-risk note
+```
+
+- [ ] **Step 2: Reuse GWT page-object shell sentinel and selector knowledge**
+
+Keep `GwtPage.assertInboxLoaded()` in the GWT test as the route sentinel. Put reusable GWT selectors in `GwtPage.ts`; do not duplicate these selectors as local functions in the spec:
+
+```ts
+gwtBlips(): Locator {
+  return this.page.locator("[kind='b'][data-blip-id]");
+}
+
+gwtActiveEditableDocument(): Locator {
+  return this.page.locator(
+    [
+      '[kind="document"] [editabledocmarker="true"]',
+      '[kind="document"] .wave-editor-on',
+      '[kind="document"][contenteditable]',
+      '[kind="document"] [contenteditable]'
+    ].join(", ")
+  ).last();
+}
+```
+
+If the live probe requires a selector adjustment, update `GwtPage.ts` and keep the spec helpers calling these page-object methods.
+
+- [ ] **Step 3: Replace the GWT baseline-only follow-up with full flow helpers**
+
+Add helpers below the J2CL helpers. These helpers must call `GwtPage` locator methods instead of duplicating GWT selectors:
+
+```ts
+async function clickReplyOnFirstBlipGwt(gwt: GwtPage) {
+  const firstBlip = gwt.gwtBlips().first();
+  await expect(firstBlip, "GWT welcome wave must expose at least one rendered blip").toBeVisible({
+    timeout: 15_000
+  });
+  await firstBlip.hover();
+  const reply = firstBlip.locator("[data-e2e-action='reply']").first();
+  await expect(reply, "GWT reply action must be reachable through a stable hook").toBeVisible({
+    timeout: 15_000
+  });
+  await reply.click({ timeout: 10_000 });
+  await expect(
+    gwt.gwtActiveEditableDocument(),
+    "GWT editor must open after Reply"
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function typeInComposerGwt(page: Page, gwt: GwtPage, phrase: string) {
+  const editor = gwt.gwtActiveEditableDocument();
+  await editor.click({ timeout: 10_000 });
+  await editor.evaluate((el) => (el as HTMLElement).focus());
+  await page.keyboard.insertText(phrase);
+  await expect
+    .poll(
+      async () => editor.evaluate((el) => (el.textContent || "").trim()),
+      { message: "GWT editor must contain the typed draft", timeout: 10_000 }
+    )
+    .toContain(phrase);
+  return editor;
+}
+
+async function selectWordInGwtEditor(page: Page, gwt: GwtPage, word: string): Promise<boolean> {
+  const editor = gwt.gwtActiveEditableDocument();
+  const selected = await editor.evaluate((el, targetWord) => {
+    (el as HTMLElement).focus();
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.textContent || "";
+      const index = text.indexOf(targetWord);
+      if (index >= 0) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + targetWord.length);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+        return true;
+      }
+      node = walker.nextNode();
+    }
+    return false;
+  }, word);
+  if (!selected) {
+    return false;
+  }
+  return await page.evaluate(
+    (targetWord) => window.getSelection()?.toString() === targetWord,
+    word
+  );
+}
+
+async function selectTrailingWordWithKeyboard(page: Page, gwt: GwtPage, word: string) {
+  const editor = gwt.gwtActiveEditableDocument();
+  await editor.click({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () => await editor.evaluate((el) => (el.textContent || "").trim().endsWith(word)),
+      { message: `GWT editor text must end with '${word}' before keyboard selection`, timeout: 5_000 }
+    )
+    .toBe(true);
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+ArrowRight" : "Control+ArrowRight");
+  for (let i = 0; i < word.length; i += 1) {
+    await page.keyboard.press("Shift+ArrowLeft");
+  }
+  await expect
+    .poll(
+      async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
+      { message: `GWT keyboard fallback must select trailing '${word}'`, timeout: 5_000 }
+    )
+    .toBe(word);
+}
+
+async function applyBoldToWordGwt(page: Page, gwt: GwtPage, word: string) {
+  const selectedByRange = await selectWordInGwtEditor(page, gwt, word);
+  if (!selectedByRange) {
+    await selectTrailingWordWithKeyboard(page, gwt, word);
+  }
+  await expect
+    .poll(
+      async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
+      { message: `GWT selection must target '${word}' before Bold`, timeout: 5_000 }
+    )
+    .toBe(word);
+
+  const bold = page.locator("[data-e2e-action='bold']").first();
+  await expect(bold, "GWT bold toolbar action must be stable").toBeVisible({ timeout: 10_000 });
+  await bold.click({ timeout: 10_000 });
+}
+
+async function finishInlineReplyGwt(page: Page, gwt: GwtPage, initialBlipCount: number, draftText: string) {
+  const done = page.locator("[data-e2e-action='edit-done']").last();
+  await expect(done, "GWT edit-done action must be stable").toBeVisible({ timeout: 10_000 });
+  await done.click({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () => await gwt.gwtBlips().count(),
+      { message: "GWT reply submit must add a new blip", timeout: 25_000 }
+    )
+    .toBeGreaterThan(initialBlipCount);
+  await expect(
+    gwt.gwtBlips().filter({ hasText: draftText }).last(),
+    "the newly submitted GWT reply blip must carry the draft text"
+  ).toBeVisible({ timeout: 20_000 });
+}
+```
+
+If live DOM probing shows the active editor is not reachable by the existing selector list, replace `GwtPage.gwtActiveEditableDocument()` with the narrowest stable selector discovered from the GWT DOM, and record the reason in the issue comment.
+
+- [ ] **Step 4: Replace the GWT test body after the welcome-wave assertion**
+
+Remove the follow-up annotation and baseline-only participant toolbar assertion from the existing GWT test. Specifically delete the `test.info().annotations.push({ type: "follow-up", ... "Full GWT bold-and-send drive tracked at #1121." })` block and the final participant-control assertion using `page.locator("[aria-label*='participant']").first()`. Use this flow instead:
+
+```ts
+    const phrase = `hello ${Date.now().toString(36)} world`;
+    await expect(
+      gwt.gwtBlips().filter({ hasText: phrase }),
+      "unique reply payload must not already exist in the welcome wave"
+    ).toHaveCount(0);
+    const initialBlipCount = await gwt.gwtBlips().count();
+    await clickReplyOnFirstBlipGwt(gwt);
+    await typeInComposerGwt(page, gwt, phrase);
+    await applyBoldToWordGwt(page, gwt, "world");
+    await finishInlineReplyGwt(page, gwt, initialBlipCount, phrase);
+```
+
+- [ ] **Step 5: Treat bold-wrapper assertion as contingent on live wrapper proof**
+
+Mandatory bold proof for #1121 is: the test selects `world`, confirms the selection is `world`, clicks the real `[data-e2e-action='bold']` toolbar action, and then submits a new blip. Do not add a brittle wrapper assertion unless the Task 4 Step 1 probe proves the GWT editor emits a stable wrapper. If it does, use this broadened matcher:
+
+```ts
+  const editorHtml = await gwt.gwtActiveEditableDocument().evaluate((el) => el.innerHTML);
+  const boldMatcher = /<(strong|b)\b[^>]*>world<\/\1>|<span\b[^>]*(?:font-weight\s*:\s*(?:bold|[6-9]00)|fontWeight\s*:\s*(?:bold|[6-9]00))[^>]*>world<\/span>/i;
+  expect(boldMatcher.test(editorHtml), `GWT editor must wrap 'world' as bold; saw: ${editorHtml}`).toBe(true);
+```
+
+If GWT serializes formatting into non-obvious internal spans before submit, omit this wrapper assertion and record the observed wrapper shape or absence in #1121 as residual test risk.
+
+The selection-success check in `applyBoldToWordGwt` is required. It deterministically triggers the keyboard fallback before the Bold click when the programmatic Range path is not honored by GWT.
+
+- [ ] **Step 6: Run TypeScript validation**
+
+Run:
+
+```bash
+cd wave/src/e2e/j2cl-gwt-parity
+npx tsc --noEmit
+```
+
+Expected: TypeScript exits `0`.
+
+---
+
+### Task 5: Add Changelog Fragment And Run Full Local Verification
+
+**Files:**
+- Add: `wave/config/changelog.d/2026-04-29-gwt-inline-reply-e2e-parity.json`
+- Modify: generated `wave/config/changelog.json` only through `scripts/assemble-changelog.py`
+
+- [ ] **Step 1: Add changelog fragment**
+
+Create:
+
+```json
+{
+  "date": "2026-04-29",
+  "type": "fixed",
+  "title": "Covered legacy GWT inline replies in the J2CL parity harness",
+  "body": "The parity E2E suite now drives the legacy GWT inline reply, bold toolbar, and send path with stable selectors so J2CL/GWT compose parity can be checked end to end."
+}
+```
+
+- [ ] **Step 2: Assemble and validate changelog**
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Expected: validation exits `0`.
+
+- [ ] **Step 3: Run local server sanity**
+
+Run from the worktree:
+
+```bash
+bash scripts/worktree-boot.sh --port 9931
+PORT=9931 bash scripts/wave-smoke.sh start
+PORT=9931 bash scripts/wave-smoke.sh check
+```
+
+Expected: server starts and `wave-smoke.sh check` exits `0`.
+
+- [ ] **Step 4: Run focused parity Playwright**
+
+Run:
+
+```bash
+cd wave/src/e2e/j2cl-gwt-parity
+CI=true WAVE_E2E_BASE_URL=http://127.0.0.1:9931 npx playwright test tests/inline-reply-parity.spec.ts --project=chromium
+```
+
+Expected: J2CL and GWT tests both pass.
+
+- [ ] **Step 5: Run SBT-only repo gates**
+
+Run:
+
+```bash
+sbt --batch j2clSearchTest
+sbt --batch compile
+git diff --check
+```
+
+Expected: each command exits `0`.
+
+- [ ] **Step 6: Stop local server**
+
+Run:
+
+```bash
+PORT=9931 bash scripts/wave-smoke.sh stop
+```
+
+Expected: server stops without killing unrelated lane ports.
+
+---
+
+### Task 6: Review, Issue Evidence, PR, And Monitor
+
+**Files:**
+- No new files unless review requires fixes.
+
+- [ ] **Step 1: Run direct self-review**
+
+Checklist:
+
+```text
+- No J2CL behavior changes.
+- GWT menu action codes and MenuController behavior unchanged.
+- Toolbar data action metadata survives proxy delegate changes.
+- GWT E2E no longer contains #1121 follow-up annotation.
+- GWT E2E asserts the GWT shell sentinel before clicking Reply.
+- GWT E2E drives real Reply, Bold, and Done/Send path.
+- GWT E2E proves a new blip count increase and phrase visibility inside a GWT blip.
+- GWT selectors live in `GwtPage.ts`; the spec does not duplicate the selector union.
+- Bold selection is verified before clicking Bold; keyboard fallback is used if Range selection is not honored.
+- Temporary Task 1 RED helper is deleted; final spec contains only Task 4 helpers.
+- Live DOM probe outcome is recorded in #1121 before final implementation proceeds.
+- `ToolbarButtonViewProxy.setDelegate(...)` remains the public delegate-swap API, and its private `copyInto(...)` path propagates `setE2eAction` unconditionally.
+- `ToolbarButtonUiProxy.setDelegate(...)` also forwards `setE2eAction` through its inner `ToolbarButtonViewProxy`, so the marker survives top-level and overflow delegate swaps.
+- Verification commands and outputs are captured for issue comments.
+```
+
+- [ ] **Step 2: Run Claude Opus implementation review**
+
+Run:
+
+```bash
+export REVIEW_TASK="Issue #1121 GWT inline reply E2E parity"
+export REVIEW_GOAL="Ensure the GWT parity harness drives the same inline reply + bold + send flow as J2CL without production behavior drift."
+export REVIEW_ACCEPTANCE=$'- GWT test clicks stable Reply, Bold, and Done hooks\n- J2CL half still passes\n- No product behavior changes beyond inert DOM test hooks\n- SBT-only verification passes'
+export REVIEW_RUNTIME="GWT Java + Playwright + SBT"
+export REVIEW_RISKY="Legacy GWT editor DOM, toolbar proxy metadata, parity E2E flake risk"
+export REVIEW_TEST_COMMANDS="<fill with exact commands run>"
+export REVIEW_TEST_RESULTS="<fill with exact pass/fail results>"
+export REVIEW_TEMPLATE="task"
+export REVIEW_DIFF_SPEC="$(git merge-base origin/main HEAD)..HEAD"
+/Users/vega/.codex/skills/public/claude-review/scripts/review_task.sh
+```
+
+Address all blockers and important comments, then rerun the review until there are no required follow-ups.
+
+- [ ] **Step 3: Commit and push**
+
+Use narrow commits:
+
+```bash
+git add docs/superpowers/plans/2026-04-29-issue-1121-gwt-inline-reply-e2e-parity.md \
+  wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java \
+  wave/src/test/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipViewBuilderTest.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/AbstractToolbarButton.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxy.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.java \
+  wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/VerticalToolbarButtonWidget.java \
+  wave/src/test/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxyTest.java \
+  wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java \
+  wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts \
+  wave/config/changelog.d/2026-04-29-gwt-inline-reply-e2e-parity.json \
+  wave/config/changelog.json
+git commit -m "test(g-port-4): automate GWT inline reply parity"
+git push -u origin codex/g-port-4-gwt-inline-reply-20260429
+```
+
+- [ ] **Step 4: Update issues and open PR**
+
+Add a #1121 comment containing:
+
+```text
+Plan: docs/superpowers/plans/2026-04-29-issue-1121-gwt-inline-reply-e2e-parity.md
+Worktree: /Users/vega/devroot/worktrees/g-port-4-gwt-inline-reply-20260429
+Branch: codex/g-port-4-gwt-inline-reply-20260429
+Verification:
+- <exact command> -> <result>
+Review:
+- Claude Opus final round: <summary>
+```
+
+Open a PR against `main` that references `#1121` and parent `#904`, then enable auto-merge if checks allow it.
+
+- [ ] **Step 5: Monitor until merged**
+
+Use GitHub GraphQL review threads as the source of truth. Required closeout state:
+
+```text
+- PR merged.
+- Review threads: 0 unresolved.
+- #1121 has final merge evidence.
+- #904 has concise lane completion update.
+```
+
+## Self-Review
+
+Spec coverage:
+- Issue task 1 is covered by Task 2: `REPLY` gets `data-e2e-action="reply"` directly in the GWT menu builder.
+- Issue task 2 is covered by Task 3: Bold gets `data-e2e-action="bold"` through the toolbar abstraction, not a one-off current-delegate mutation.
+- Issue task 3 is covered by Task 4: the GWT spec path drives reply, type, bold, finish, and new-blip visibility.
+- The need to finish/send the GWT edit is not explicitly listed in the issue tasks but is required by the stated "bold + send" goal; Task 2 adds `EDIT_DONE` as the minimum stable hook for that.
+
+Placeholder scan:
+- No placeholder implementation steps remain. Runtime-dependent review result placeholders are explicitly filled during Task 6 with actual execution evidence.
+
+Type and selector consistency:
+- Java selectors use `data-e2e-action` consistently for GWT menu and toolbar hooks.
+- Playwright helper names use the existing J2CL naming pattern with `Gwt` suffixes.
+- The plan avoids relying on obfuscated CssResource classes or debug-class `dc` attributes, because debug classes are disabled unless explicitly turned on.
+- GWT blip selectors use the existing `[kind='b'][data-blip-id]` contract from G-PORT-3, and the GWT route sentinel uses the existing `GwtPage.assertInboxLoaded()` checks.
+- `GwtPage.ts` is the single home for reusable GWT selectors; the spec helpers accept a `GwtPage` instance.
+
+Risk notes:
+- The active GWT editor selector must be verified by the required live DOM probe before final helper implementation. The plan defaults to the selector list already documented in `GwtPage.ts`.
+- GWT may serialize bold formatting through internal spans rather than obvious `<b>` or `<strong>`. The mandatory assertion remains that the real Bold control is clicked and the reply is submitted as a new blip; wrapper-shape assertion is added only if live DOM proves it stable.
+- If programmatic Range selection is not honored by the GWT editor, the fallback keyboard-selection path uses a trailing `world` token so the selection can be driven by real key events.
+- `applyBoldToWordGwt` must assert `window.getSelection().toString() === "world"` before clicking Bold, either through the Range path or the keyboard fallback.
+- Current production scope only labels Bold and never clears it, but the proxy tests still cover null clearing so the interface remains safe for future callers.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -770,6 +770,7 @@ public final class J2clSelectedWaveController
           String requiredBlipId = nullToEmpty(requiredLoadedBlipId);
           if (!requiredBlipId.isEmpty()
               && !fragmentsContainLoadedBlip(response.getFragments(), requiredBlipId)) {
+            emitExtensionOutcome(normalizedDirection, "missing-required-blip");
             fragmentFetchesInFlight.remove(edgeKey);
             if (onMissingRequiredLoadedBlip != null) {
               onMissingRequiredLoadedBlip.run();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -767,7 +767,7 @@ public final class J2clSelectedWaveController
           // For post-submit fetches (allowSameWaveWriteSessionAdvance=true) the write
           // session's version legitimately advances when the reply ACK arrives, so we
           // skip the version/hash staleness check.  However we still reject the response
-          // if the write session disappeared entirely — that indicates the wave was
+          // if the write session disappeared entirely: that indicates the wave was
           // closed or reset rather than a normal submit acknowledgement, and merging
           // those fragments could overwrite content brought in by a live-stream update.
           boolean sessionDisappeared = hadWriteSession && currentModel.getWriteSession() == null;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -15,6 +15,8 @@ import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragment;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveFragments;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveUpdate;
 import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
@@ -29,6 +31,7 @@ public final class J2clSelectedWaveController
   private static final int MAX_RECONNECT_DELAY_MS = 2000;
   private static final int MAX_RECONNECT_ATTEMPTS = 8;
   private static final int POST_SUBMIT_LIVE_UPDATE_GRACE_MS = 250;
+  private static final int POST_SUBMIT_FRAGMENT_FETCH_MAX_ATTEMPTS = 3;
   // Matches the current server default viewport window until growth-size config is exposed to J2CL.
   private static final int FRAGMENT_GROWTH_LIMIT = 5;
   private static final String FRAGMENT_GROWTH_FAILURE_STATUS =
@@ -404,7 +407,7 @@ public final class J2clSelectedWaveController
     final String createdBlipId = submittedBlipId == null ? "" : submittedBlipId;
     if (targetVersion >= 0
         && currentVisibleViewportVersion() >= targetVersion
-        && currentViewportHasLoadedBlip(createdBlipId)) {
+        && submittedBlipObservedOrUnknown(createdBlipId)) {
       return;
     }
     final long visibleVersionAtSubmit = currentVisibleViewportVersion();
@@ -438,12 +441,21 @@ public final class J2clSelectedWaveController
       return true;
     }
     long currentVisibleVersion = currentVisibleViewportVersion();
+    // Version-only or metadata-only live updates are not enough for a known submitted blip; the
+    // post-submit handoff is complete only after that exact blip is loaded in the viewport.
     return (targetVersion >= 0
             && currentVisibleVersion >= targetVersion
-            && currentViewportHasLoadedBlip(createdBlipId))
+            && submittedBlipObservedOrUnknown(createdBlipId))
         || (targetVersion < 0
             && visibleVersionAtSubmit >= 0
-            && currentVisibleVersion > visibleVersionAtSubmit);
+            && currentVisibleVersion > visibleVersionAtSubmit
+            && submittedBlipObservedOrUnknown(createdBlipId));
+  }
+
+  private boolean submittedBlipObservedOrUnknown(String createdBlipId) {
+    return createdBlipId == null
+        || createdBlipId.isEmpty()
+        || currentViewportHasLoadedBlip(createdBlipId);
   }
 
   @Override
@@ -675,6 +687,36 @@ public final class J2clSelectedWaveController
 
   private boolean requestViewportEdge(
       String anchorBlipId, String direction, boolean refreshSelectedWaveOnFailure) {
+    return requestViewportEdge(
+        anchorBlipId,
+        direction,
+        refreshSelectedWaveOnFailure,
+        /* allowSameWaveWriteSessionAdvance= */ false,
+        "",
+        null);
+  }
+
+  private boolean requestViewportEdge(
+      String anchorBlipId,
+      String direction,
+      boolean refreshSelectedWaveOnFailure,
+      boolean allowSameWaveWriteSessionAdvance) {
+    return requestViewportEdge(
+        anchorBlipId,
+        direction,
+        refreshSelectedWaveOnFailure,
+        allowSameWaveWriteSessionAdvance,
+        "",
+        null);
+  }
+
+  private boolean requestViewportEdge(
+      String anchorBlipId,
+      String direction,
+      boolean refreshSelectedWaveOnFailure,
+      boolean allowSameWaveWriteSessionAdvance,
+      String requiredLoadedBlipId,
+      Runnable onMissingRequiredLoadedBlip) {
     if (selectedWaveId == null || selectedWaveId.isEmpty() || currentModel == null) {
       return false;
     }
@@ -716,10 +758,22 @@ public final class J2clSelectedWaveController
           if (!isCurrentGeneration(generation) || !waveId.equals(selectedWaveId)) {
             return;
           }
-          if (isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash)) {
+          if (!allowSameWaveWriteSessionAdvance
+              && isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash)) {
             emitExtensionOutcome(normalizedDirection, "stale");
             fragmentFetchesInFlight.remove(edgeKey);
             if (refreshSelectedWaveOnFailure) {
+              refreshSelectedWave();
+            }
+            return;
+          }
+          String requiredBlipId = nullToEmpty(requiredLoadedBlipId);
+          if (!requiredBlipId.isEmpty()
+              && !fragmentsContainLoadedBlip(response.getFragments(), requiredBlipId)) {
+            fragmentFetchesInFlight.remove(edgeKey);
+            if (onMissingRequiredLoadedBlip != null) {
+              onMissingRequiredLoadedBlip.run();
+            } else if (refreshSelectedWaveOnFailure) {
               refreshSelectedWave();
             }
             return;
@@ -796,6 +850,15 @@ public final class J2clSelectedWaveController
 
   private boolean requestPostSubmitForwardFetch(
       int generation, String submittedWaveId, String submittedBlipId) {
+    return requestPostSubmitForwardFetch(
+        generation,
+        submittedWaveId,
+        submittedBlipId,
+        POST_SUBMIT_FRAGMENT_FETCH_MAX_ATTEMPTS);
+  }
+
+  private boolean requestPostSubmitForwardFetch(
+      int generation, String submittedWaveId, String submittedBlipId, int attemptsRemaining) {
     if (!isCurrentGeneration(generation)
         || selectedWaveId == null
         || !submittedWaveId.equals(selectedWaveId)
@@ -816,8 +879,62 @@ public final class J2clSelectedWaveController
     if (anchor.isEmpty()) {
       return false;
     }
+    final String requiredLoadedBlipId = submittedBlipId == null ? "" : submittedBlipId;
+    final int nextAttemptsRemaining = Math.max(0, attemptsRemaining - 1);
     return requestViewportEdge(
-        anchor, J2clViewportGrowthDirection.FORWARD, /* refreshSelectedWaveOnFailure= */ true);
+        anchor,
+        J2clViewportGrowthDirection.FORWARD,
+        /* refreshSelectedWaveOnFailure= */ true,
+        /* allowSameWaveWriteSessionAdvance= */ true,
+        requiredLoadedBlipId,
+        requiredLoadedBlipId.isEmpty()
+            ? null
+            : () -> {
+              if (!isCurrentGeneration(generation)
+                  || selectedWaveId == null
+                  || !submittedWaveId.equals(selectedWaveId)
+                  || currentViewportHasLoadedBlip(requiredLoadedBlipId)) {
+                return;
+              }
+              if (nextAttemptsRemaining <= 0) {
+                refreshSelectedWave();
+                return;
+              }
+              retryScheduler.scheduleRetry(
+                  POST_SUBMIT_LIVE_UPDATE_GRACE_MS,
+                  () -> {
+                    if (!isCurrentGeneration(generation)
+                        || selectedWaveId == null
+                        || !submittedWaveId.equals(selectedWaveId)
+                        || currentViewportHasLoadedBlip(requiredLoadedBlipId)) {
+                      return;
+                    }
+                    if (requestPostSubmitForwardFetch(
+                        generation,
+                        submittedWaveId,
+                        requiredLoadedBlipId,
+                        nextAttemptsRemaining)) {
+                      return;
+                    }
+                    refreshSelectedWave();
+                  });
+            });
+  }
+
+  private static boolean fragmentsContainLoadedBlip(
+      SidecarSelectedWaveFragments fragments, String blipId) {
+    if (fragments == null || blipId == null || blipId.isEmpty()) {
+      return false;
+    }
+    String segment = J2clSelectedWaveViewportState.BLIP_SEGMENT_PREFIX + blipId;
+    for (SidecarSelectedWaveFragment fragment : fragments.getEntries()) {
+      if (fragment != null
+          && segment.equals(fragment.getSegment())
+          && fragment.getRawSnapshot() != null) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean isStaleFragmentResponse(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -407,7 +407,7 @@ public final class J2clSelectedWaveController
     final String createdBlipId = submittedBlipId == null ? "" : submittedBlipId;
     if (targetVersion >= 0
         && currentVisibleViewportVersion() >= targetVersion
-        && submittedBlipObservedOrUnknown(createdBlipId)) {
+        && submittedBlipConfirmedInViewport(createdBlipId)) {
       return;
     }
     final long visibleVersionAtSubmit = currentVisibleViewportVersion();
@@ -445,17 +445,19 @@ public final class J2clSelectedWaveController
     // post-submit handoff is complete only after that exact blip is loaded in the viewport.
     return (targetVersion >= 0
             && currentVisibleVersion >= targetVersion
-            && submittedBlipObservedOrUnknown(createdBlipId))
+            && submittedBlipConfirmedInViewport(createdBlipId))
         || (targetVersion < 0
             && visibleVersionAtSubmit >= 0
             && currentVisibleVersion > visibleVersionAtSubmit
-            && submittedBlipObservedOrUnknown(createdBlipId));
+            && submittedBlipConfirmedInViewport(createdBlipId));
   }
 
-  private boolean submittedBlipObservedOrUnknown(String createdBlipId) {
-    return createdBlipId == null
-        || createdBlipId.isEmpty()
-        || currentViewportHasLoadedBlip(createdBlipId);
+  private boolean submittedBlipConfirmedInViewport(String createdBlipId) {
+    // Empty/null means the caller did not track the submitted blip's ID; we cannot confirm
+    // presence, so always proceed to the forward-fetch rather than treating unknown as "done".
+    return createdBlipId != null
+        && !createdBlipId.isEmpty()
+        && currentViewportHasLoadedBlip(createdBlipId);
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -405,6 +405,8 @@ public final class J2clSelectedWaveController
     final int generation = requestGeneration;
     final long targetVersion = Math.max(-1L, resultingVersion);
     final String createdBlipId = submittedBlipId == null ? "" : submittedBlipId;
+    // Legacy callers do not supply a blip id, so they intentionally miss this fast path and run
+    // one fallback fetch; version equality alone cannot prove the submitted reply is visible.
     if (targetVersion >= 0
         && currentVisibleViewportVersion() >= targetVersion
         && submittedBlipConfirmedInViewport(createdBlipId)) {
@@ -762,8 +764,16 @@ public final class J2clSelectedWaveController
           if (!isCurrentGeneration(generation) || !waveId.equals(selectedWaveId)) {
             return;
           }
-          if (!allowSameWaveWriteSessionAdvance
-              && isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash)) {
+          // For post-submit fetches (allowSameWaveWriteSessionAdvance=true) the write
+          // session's version legitimately advances when the reply ACK arrives, so we
+          // skip the version/hash staleness check.  However we still reject the response
+          // if the write session disappeared entirely — that indicates the wave was
+          // closed or reset rather than a normal submit acknowledgement, and merging
+          // those fragments could overwrite content brought in by a live-stream update.
+          boolean sessionDisappeared = hadWriteSession && currentModel.getWriteSession() == null;
+          if (sessionDisappeared
+              || (!allowSameWaveWriteSessionAdvance
+                  && isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash))) {
             emitExtensionOutcome(normalizedDirection, "stale");
             fragmentFetchesInFlight.remove(edgeKey);
             if (refreshSelectedWaveOnFailure) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -771,7 +771,10 @@ public final class J2clSelectedWaveController
           // closed or reset rather than a normal submit acknowledgement, and merging
           // those fragments could overwrite content brought in by a live-stream update.
           boolean sessionDisappeared = hadWriteSession && currentModel.getWriteSession() == null;
+          boolean staleLoadedFragmentOverlap =
+              hasStaleLoadedFragmentOverlap(response.getFragments());
           if (sessionDisappeared
+              || staleLoadedFragmentOverlap
               || (!allowSameWaveWriteSessionAdvance
                   && isStaleFragmentResponse(hadWriteSession, baseVersion, historyHash))) {
             emitExtensionOutcome(normalizedDirection, "stale");
@@ -861,6 +864,30 @@ public final class J2clSelectedWaveController
           }
         });
     return true;
+  }
+
+  private boolean hasStaleLoadedFragmentOverlap(SidecarSelectedWaveFragments fragments) {
+    if (currentModel == null || currentModel.getViewportState() == null || fragments == null) {
+      return false;
+    }
+    J2clSelectedWaveViewportState incoming = J2clSelectedWaveViewportState.fromFragments(fragments);
+    if (incoming.isEmpty()) {
+      return false;
+    }
+    for (J2clSelectedWaveViewportState.Entry incomingEntry : incoming.getEntries()) {
+      if (!incomingEntry.isLoaded()) {
+        continue;
+      }
+      for (J2clSelectedWaveViewportState.Entry currentEntry :
+          currentModel.getViewportState().getEntries()) {
+        if (currentEntry.isLoaded()
+            && incomingEntry.getSegment().equals(currentEntry.getSegment())
+            && currentEntry.getToVersion() > incomingEntry.getToVersion()) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private boolean requestPostSubmitForwardFetch(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -453,8 +453,10 @@ public final class J2clSelectedWaveController
   }
 
   private boolean submittedBlipConfirmedInViewport(String createdBlipId) {
-    // Empty/null means the caller did not track the submitted blip's ID; we cannot confirm
-    // presence, so always proceed to the forward-fetch rather than treating unknown as "done".
+    // Returns true only when the callback supplied a concrete blip id and the current viewport
+    // has loaded that exact blip. Empty/null means the caller did not track the submitted blip's
+    // ID; we cannot confirm presence, so always proceed to the forward-fetch rather than treating
+    // unknown as "done".
     return createdBlipId != null
         && !createdBlipId.isEmpty()
         && currentViewportHasLoadedBlip(createdBlipId);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -484,6 +484,35 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void replySubmitHandoffRejectsForwardFetchWhenWriteSessionDisappears()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", 45L, "b+created");
+    harness.runScheduledRetry(0);
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+
+    harness.clearCurrentWriteSession(controller);
+    Assert.assertNull(harness.modelValue("getWriteSession"));
+    harness.resolveFragmentFetch(
+        0,
+        fragmentsResponseForBlips(
+            "b+created", "Stale reply should not merge", null, null));
+
+    Assert.assertFalse(
+        String.valueOf(harness.modelValue("getContentEntries"))
+            .contains("Stale reply should not merge"));
+    Assert.assertEquals(1, harness.closedCount);
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+  }
+
+  @Test
   public void replySubmitHandoffRetriesForwardFetchWhenSnapshotLagsSubmittedBlip()
       throws Exception {
     Harness harness = new Harness();
@@ -2733,6 +2762,37 @@ public class J2clSelectedWaveControllerTest {
       currentModelField.setAccessible(true);
       J2clSelectedWaveModel currentModel = (J2clSelectedWaveModel) currentModelField.get(controller);
       J2clSelectedWaveModel nextModel = currentModel.withReadBlips(readBlips);
+      currentModelField.set(controller, nextModel);
+      lastModel = nextModel;
+    }
+
+    private void clearCurrentWriteSession(Object controller) throws Exception {
+      Field currentModelField = controller.getClass().getDeclaredField("currentModel");
+      currentModelField.setAccessible(true);
+      J2clSelectedWaveModel currentModel = (J2clSelectedWaveModel) currentModelField.get(controller);
+      J2clSelectedWaveModel nextModel =
+          new J2clSelectedWaveModel(
+              currentModel.hasSelection(),
+              currentModel.isLoading(),
+              currentModel.isError(),
+              currentModel.getSelectedWaveId(),
+              currentModel.getTitleText(),
+              currentModel.getSnippetText(),
+              currentModel.getUnreadText(),
+              currentModel.getStatusText(),
+              currentModel.getDetailText(),
+              currentModel.getReconnectCount(),
+              currentModel.getParticipantIds(),
+              currentModel.getContentEntries(),
+              currentModel.getReadBlips(),
+              currentModel.getViewportState(),
+              currentModel.getInteractionBlips(),
+              null,
+              currentModel.getUnreadCount(),
+              currentModel.isRead(),
+              currentModel.isReadStateKnown(),
+              currentModel.isReadStateStale())
+              .withConversationManifest(currentModel.getConversationManifest());
       currentModelField.set(controller, nextModel);
       lastModel = nextModel;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -749,6 +749,32 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void replySubmitHandoffFetchesForwardViewportWhenVersionAlreadyMetButBlipIdUnknown()
+      throws Exception {
+    // Regression: submittedBlipConfirmedInViewport must return false for empty blipId so that
+    // legacy callers (no blip ID) still trigger the forward-fetch even if the viewport version
+    // has already advanced to targetVersion via an unrelated live update.
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+    // An unrelated blip advances the version to 45 before the submit acknowledgement arrives.
+    harness.deliverRawUpdate(
+        0, liveReplyFragmentUpdate("Unrelated blip from live stream", -1L, null, 45L));
+
+    // Legacy caller: knows the resulting version but not the submitted blip ID.
+    harness.replySubmitted(controller, "example.com/w+1", 45L);
+    harness.runScheduledRetry(0);
+
+    Assert.assertEquals(
+        "unknown blip ID must not suppress the forward-fetch even when version is already met",
+        1,
+        harness.fragmentFetchAttempts.size());
+  }
+
+  @Test
   public void channelEstablishmentUpdateIsIgnoredUntilRealWaveletArrives() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -455,6 +455,125 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void replySubmitHandoffAppliesForwardFetchAfterWriteSessionAdvances()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", 45L, "b+created");
+    harness.runScheduledRetry(0);
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+
+    harness.deliverRawUpdate(0, metadataOnlyLiveUpdate(45L, "EFGH"));
+    harness.resolveFragmentFetch(
+        0,
+        fragmentsResponseForBlips(
+            "b+created", "Reply loaded despite write-session advance", null, null));
+
+    Assert.assertEquals(
+        "post-submit fetch must not be discarded just because the same-wave write session advanced",
+        0,
+        harness.closedCount);
+    Assert.assertEquals(
+        Arrays.asList("Root already loaded", "Reply loaded despite write-session advance"),
+        harness.modelValue("getContentEntries"));
+  }
+
+  @Test
+  public void replySubmitHandoffRetriesForwardFetchWhenSnapshotLagsSubmittedBlip()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", 45L, "b+created");
+    harness.runScheduledRetry(0);
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+
+    harness.resolveFragmentFetch(
+        0,
+        fragmentsResponseForBlips(
+            "b+stale", "Stale committed window without the submitted blip", null, null));
+
+    Assert.assertEquals(
+        "stale post-submit fragment windows must not be applied as terminal success",
+        Arrays.asList("Root already loaded"),
+        harness.modelValue("getContentEntries"));
+    Assert.assertEquals(
+        "snapshot lag should schedule one more post-submit fetch before falling back to refresh",
+        Arrays.asList(Integer.valueOf(250), Integer.valueOf(250)),
+        harness.scheduledDelays);
+
+    harness.runScheduledRetry(1);
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(1).startBlipId);
+
+    harness.resolveFragmentFetch(
+        1,
+        fragmentsResponseForBlips(
+            "b+created", "Reply loaded after snapshot catches up", null, null));
+
+    Assert.assertEquals(
+        Arrays.asList("Root already loaded", "Reply loaded after snapshot catches up"),
+        harness.modelValue("getContentEntries"));
+    Assert.assertEquals(0, harness.closedCount);
+  }
+
+  @Test
+  public void replySubmitHandoffRefreshesAfterForwardFetchExhaustion()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", 45L, "b+created");
+    harness.runScheduledRetry(0);
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+
+    harness.resolveFragmentFetch(
+        0,
+        fragmentsResponseForBlips("b+stale-1", "Stale committed window one", null, null));
+    harness.runScheduledRetry(1);
+    Assert.assertEquals(2, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(1).startBlipId);
+
+    harness.resolveFragmentFetch(
+        1,
+        fragmentsResponseForBlips("b+stale-2", "Stale committed window two", null, null));
+    harness.runScheduledRetry(2);
+    Assert.assertEquals(3, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(2).startBlipId);
+
+    harness.resolveFragmentFetch(
+        2,
+        fragmentsResponseForBlips("b+stale-3", "Stale committed window three", null, null));
+
+    Assert.assertEquals(
+        "post-submit fetch retries must terminate with a selected-wave refresh",
+        1,
+        harness.closedCount);
+    Assert.assertEquals(
+        "post-submit fetch must stop at the configured retry cap",
+        3,
+        harness.fragmentFetchAttempts.size());
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertEquals(
+        Arrays.asList(Integer.valueOf(250), Integer.valueOf(250), Integer.valueOf(250)),
+        harness.scheduledDelays);
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+  }
+
+  @Test
   public void replySubmitHandoffFetchesForwardViewportWhenLiveUpdateOnlyAdvancesMetadata()
       throws Exception {
     Harness harness = new Harness();
@@ -518,6 +637,49 @@ public class J2clSelectedWaveControllerTest {
     harness.runScheduledRetry(0);
 
     Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(0).startBlipId);
+  }
+
+  @Test
+  public void replySubmitHandoffWithUnknownVersionFetchesKnownBlipAfterVersionOnlyAdvance()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", -1L, "b+created");
+    harness.deliverRawUpdate(0, metadataOnlyLiveUpdate(45L, "EFGH"));
+    harness.runScheduledRetry(0);
+
+    Assert.assertEquals(
+        "unknown resultingVersion must not suppress fetch for a known submitted blip",
+        1,
+        harness.fragmentFetchAttempts.size());
+    Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(0).startBlipId);
+  }
+
+  @Test
+  public void replySubmitHandoffWithUnknownVersionFetchesKnownBlipAfterUnrelatedLiveBlip()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", -1L, "b+created");
+    harness.deliverRawUpdate(
+        0, liveReplyFragmentUpdate("Unrelated blip from live stream", -1L, null, 45L));
+    harness.runScheduledRetry(0);
+
+    Assert.assertEquals(
+        "unknown resultingVersion must not treat an unrelated live blip as the submitted blip",
+        1,
+        harness.fragmentFetchAttempts.size());
     Assert.assertEquals("b+created", harness.fragmentFetchAttempts.get(0).startBlipId);
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -513,6 +513,37 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void replySubmitHandoffRejectsOlderForwardFetchOverFreshLiveBlip()
+      throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverRawUpdate(0, updateWithPlaceholder("Root already loaded", 44L, "ABCD"));
+
+    harness.replySubmitted(controller, "example.com/w+1", 45L, "b+created");
+    harness.runScheduledRetry(0);
+    Assert.assertEquals(1, harness.fragmentFetchAttempts.size());
+
+    harness.deliverRawUpdate(
+        0,
+        liveBlipFragmentUpdate(
+            "b+created", "Fresh reply from live stream", 50L, "IJKL", 50L));
+    harness.resolveFragmentFetch(
+        0,
+        fragmentsResponseForBlips(
+            "b+created", "Stale reply should not overwrite live content", null, null));
+
+    Assert.assertFalse(
+        String.valueOf(harness.modelValue("getContentEntries"))
+            .contains("Stale reply should not overwrite live content"));
+    Assert.assertEquals(1, harness.closedCount);
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+  }
+
+  @Test
   public void replySubmitHandoffRetriesForwardFetchWhenSnapshotLagsSubmittedBlip()
       throws Exception {
     Harness harness = new Harness();
@@ -2881,9 +2912,20 @@ public class J2clSelectedWaveControllerTest {
 
   private static SidecarSelectedWaveUpdate liveReplyFragmentUpdate(
       String replySnapshot, long resultingVersion, String historyHash, long fragmentVersion) {
+    return liveBlipFragmentUpdate(
+        "b+reply", replySnapshot, resultingVersion, historyHash, fragmentVersion);
+  }
+
+  private static SidecarSelectedWaveUpdate liveBlipFragmentUpdate(
+      String blipId,
+      String rawSnapshot,
+      long resultingVersion,
+      String historyHash,
+      long fragmentVersion) {
     // Live deltas pushed from the server carry snapshotVersion = -1 (the codec default when the
     // server omits the field). Using -1L here ensures the projector treats this as an incremental
     // live delta and merges it into the prior viewport rather than replacing it.
+    String segment = "blip:" + blipId;
     return new SidecarSelectedWaveUpdate(
         2,
         "example.com!w+1/example.com!conv+root",
@@ -2899,9 +2941,9 @@ public class J2clSelectedWaveControllerTest {
             fragmentVersion,
             Arrays.asList(
                 new SidecarSelectedWaveFragmentRange(
-                    "blip:b+reply", Math.max(0L, fragmentVersion - 1L), fragmentVersion)),
+                    segment, Math.max(0L, fragmentVersion - 1L), fragmentVersion)),
             Arrays.asList(
-                new SidecarSelectedWaveFragment("blip:b+reply", replySnapshot, 0, 0))));
+                new SidecarSelectedWaveFragment(segment, rawSnapshot, 0, 0))));
   }
 
   private static SidecarSelectedWaveUpdate metadataOnlyLiveUpdate(

--- a/wave/config/changelog.d/2026-04-29-gwt-inline-reply-e2e-parity.json
+++ b/wave/config/changelog.d/2026-04-29-gwt-inline-reply-e2e-parity.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-29-gwt-inline-reply-e2e-parity",
+  "version": "PR #1121",
+  "date": "2026-04-29",
+  "title": "G-PORT-4 follow-up: GWT inline-reply parity automation",
+  "summary": "The J2CL <-> GWT parity E2E suite now drives the legacy GWT inline reply, Bold toolbar, and Done/send path with stable inert hooks so compose parity is checked end to end.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Added stable GWT-only test hooks and Playwright coverage for replying inline, applying Bold, finishing the edit, and observing the submitted reply as a new GWT blip."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
@@ -57,6 +57,25 @@ export class GwtPage extends WavePage {
     return this.page.locator('div[title^="New Wave"]').first();
   }
 
+  gwtBlips(): Locator {
+    return this.page.locator("[kind='b'][data-blip-id]");
+  }
+
+  gwtEditableDocuments(): Locator {
+    return this.page.locator(
+      [
+        '[kind="document"] [editabledocmarker="true"]',
+        '[kind="document"] .wave-editor-on',
+        '[kind="document"][contenteditable]',
+        '[kind="document"] [contenteditable]'
+      ].join(", ")
+    );
+  }
+
+  gwtActiveEditableDocument(): Locator {
+    return this.gwtEditableDocuments().last();
+  }
+
   /**
    * G-PORT-3: clicks into the document container of a blip and types
    * `text`, then presses Escape to commit (mirrors GWT's "Esc to exit"
@@ -92,14 +111,7 @@ export class GwtPage extends WavePage {
   }
 
   private gwtEditableDocument(): Locator {
-    return this.page.locator(
-      [
-        '[kind="document"] [editabledocmarker="true"]',
-        '[kind="document"] .wave-editor-on',
-        '[kind="document"][contenteditable]',
-        '[kind="document"] [contenteditable]'
-      ].join(", ")
-    );
+    return this.gwtEditableDocuments();
   }
 
   private async ensureEditableDocumentVisible(editable: Locator): Promise<void> {
@@ -116,7 +128,7 @@ export class GwtPage extends WavePage {
   }
 
   private async reopenLastBlipForEditing(): Promise<void> {
-    const blip = this.page.locator("[kind='b'][data-blip-id]").last();
+    const blip = this.gwtBlips().last();
     await expect(
       blip,
       "GWT should have a visible blip to reopen for editing"

--- a/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
@@ -30,16 +30,13 @@ import { WavePage } from "./WavePage";
 export const GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR = [
   ".wave-editor-on",
   '[contenteditable="true"]',
+  // Intentionally matches read-write and read-write-plaintext-only; both are active editors.
   '[style*="user-modify: read-write"]'
 ].join(", ");
 
 const GWT_ACTIVE_DOCUMENT_SELECTOR = [
-  '[kind="document"] .wave-editor-on',
-  '[kind="document"].wave-editor-on',
-  '[kind="document"][contenteditable="true"]',
-  '[kind="document"] [contenteditable="true"]',
-  '[kind="document"][style*="user-modify: read-write"]',
-  '[kind="document"] [style*="user-modify: read-write"]'
+  `[kind="document"]:is(${GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR})`,
+  `[kind="document"] :is(${GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR})`
 ].join(", ");
 
 export class GwtPage extends WavePage {

--- a/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/pages/GwtPage.ts
@@ -27,6 +27,21 @@
 import { expect, Locator, Page } from "@playwright/test";
 import { WavePage } from "./WavePage";
 
+export const GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR = [
+  ".wave-editor-on",
+  '[contenteditable="true"]',
+  '[style*="user-modify: read-write"]'
+].join(", ");
+
+const GWT_ACTIVE_DOCUMENT_SELECTOR = [
+  '[kind="document"] .wave-editor-on',
+  '[kind="document"].wave-editor-on',
+  '[kind="document"][contenteditable="true"]',
+  '[kind="document"] [contenteditable="true"]',
+  '[kind="document"][style*="user-modify: read-write"]',
+  '[kind="document"] [style*="user-modify: read-write"]'
+].join(", ");
+
 export class GwtPage extends WavePage {
   viewQuery(): string {
     return "view=gwt";
@@ -73,7 +88,7 @@ export class GwtPage extends WavePage {
   }
 
   gwtActiveEditableDocument(): Locator {
-    return this.gwtEditableDocuments().last();
+    return this.page.locator(GWT_ACTIVE_DOCUMENT_SELECTOR).last();
   }
 
   /**

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -311,7 +311,7 @@ async function selectTrailingWordWithGwtWebDriver(
       throw new Error(`GWT editor model does not contain '${targetWord}': ${content}`);
     }
 
-    const searchUpperBound = Math.min(content.length + 10, 500);
+    const searchUpperBound = content.length + 10;
     let firstSelectionError = "";
     for (let start = searchUpperBound; start >= 0; start -= 1) {
       for (let extraEnd = 0; extraEnd <= 4; extraEnd += 1) {

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -438,8 +438,9 @@ async function finishInlineReplyGwt(
     "the newly submitted GWT reply blip must carry the draft text"
   ).toBeVisible({ timeout: 20_000 });
   await expect(
+    // GWT keeps editabledocmarker on read-only documents, so only active editability signals count.
     persistedBlip.locator(
-      '[editabledocmarker="true"], .wave-editor-on, [contenteditable="true"]'
+      '.wave-editor-on, [contenteditable="true"], [style*="read-write"]'
     ),
     "the submitted GWT reply blip must not contain an open editor (must be persisted, not a draft)"
   ).toHaveCount(0, { timeout: 5_000 });

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -214,6 +214,170 @@ async function sendInlineReplyJ2cl(
   ).toBeVisible({ timeout: 20_000 });
 }
 
+async function clickReplyOnFirstBlipGwt(gwt: GwtPage): Promise<void> {
+  const firstBlip = gwt.gwtBlips().first();
+  await expect(
+    firstBlip,
+    "GWT welcome wave must expose at least one rendered blip"
+  ).toBeVisible({ timeout: 15_000 });
+  await firstBlip.hover();
+  const reply = firstBlip.locator("[data-e2e-action='reply']").first();
+  await expect(
+    reply,
+    "GWT reply action must be reachable through a stable hook"
+  ).toBeVisible({ timeout: 15_000 });
+  await reply.click({ timeout: 10_000 });
+  await expect(
+    gwt.gwtActiveEditableDocument(),
+    "GWT editor must open after Reply"
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+async function typeInComposerGwt(
+  page: Page,
+  gwt: GwtPage,
+  phrase: string
+): Promise<void> {
+  const editor = gwt.gwtActiveEditableDocument();
+  await editor.click({ timeout: 10_000 });
+  await editor.evaluate((el) => (el as HTMLElement).focus());
+  await expect
+    .poll(
+      async () =>
+        await editor.evaluate(
+          (el) => el === document.activeElement || el.contains(document.activeElement)
+        ),
+      { message: "GWT editor must own focus before typing", timeout: 5_000 }
+    )
+    .toBe(true);
+  await page.keyboard.insertText(phrase);
+  await expect
+    .poll(
+      async () => await editor.evaluate((el) => (el.textContent || "").trim()),
+      { message: "GWT editor must contain the typed draft", timeout: 10_000 }
+    )
+    .toContain(phrase);
+}
+
+async function selectWordInGwtEditor(
+  page: Page,
+  gwt: GwtPage,
+  word: string
+): Promise<boolean> {
+  const editor = gwt.gwtActiveEditableDocument();
+  const selected = await editor.evaluate((el, targetWord) => {
+    (el as HTMLElement).focus();
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.textContent || "";
+      const index = text.indexOf(targetWord);
+      if (index >= 0) {
+        const range = document.createRange();
+        range.setStart(node, index);
+        range.setEnd(node, index + targetWord.length);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
+        return true;
+      }
+      node = walker.nextNode();
+    }
+    return false;
+  }, word);
+  if (!selected) {
+    return false;
+  }
+  return await page.evaluate(
+    (targetWord) => window.getSelection()?.toString() === targetWord,
+    word
+  );
+}
+
+async function selectTrailingWordWithKeyboard(
+  page: Page,
+  gwt: GwtPage,
+  word: string
+): Promise<void> {
+  const editor = gwt.gwtActiveEditableDocument();
+  await editor.click({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () =>
+        await editor.evaluate(
+          (el, targetWord) => (el.textContent || "").trim().endsWith(targetWord),
+          word
+        ),
+      {
+        message: `GWT editor text must end with '${word}' before keyboard selection`,
+        timeout: 5_000
+      }
+    )
+    .toBe(true);
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+ArrowRight" : "Control+ArrowRight"
+  );
+  for (let i = 0; i < word.length; i += 1) {
+    await page.keyboard.press("Shift+ArrowLeft");
+  }
+  await expect
+    .poll(
+      async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
+      {
+        message: `GWT keyboard fallback must select trailing '${word}'`,
+        timeout: 5_000
+      }
+    )
+    .toBe(word);
+}
+
+async function applyBoldToWordGwt(
+  page: Page,
+  gwt: GwtPage,
+  word: string
+): Promise<void> {
+  const selectedByRange = await selectWordInGwtEditor(page, gwt, word);
+  if (!selectedByRange) {
+    await selectTrailingWordWithKeyboard(page, gwt, word);
+  }
+  await expect
+    .poll(
+      async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
+      { message: `GWT selection must target '${word}' before Bold`, timeout: 5_000 }
+    )
+    .toBe(word);
+
+  const bold = page.locator("[data-e2e-action='bold']").first();
+  await expect(bold, "GWT bold toolbar action must be stable").toBeVisible({
+    timeout: 10_000
+  });
+  await bold.click({ timeout: 10_000 });
+}
+
+async function finishInlineReplyGwt(
+  page: Page,
+  gwt: GwtPage,
+  initialBlipCount: number,
+  draftText: string
+): Promise<void> {
+  const done = page.locator("[data-e2e-action='edit-done']").last();
+  await expect(done, "GWT edit-done action must be stable").toBeVisible({
+    timeout: 10_000
+  });
+  await done.click({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () => await gwt.gwtBlips().count(),
+      { message: "GWT reply submit must add a new blip", timeout: 25_000 }
+    )
+    .toBeGreaterThan(initialBlipCount);
+  await expect(
+    gwt.gwtBlips().filter({ hasText: draftText }).last(),
+    "the newly submitted GWT reply blip must carry the draft text"
+  ).toBeVisible({ timeout: 20_000 });
+}
+
 // Each test registers a fresh user and operates on its own
 // authenticated session, so the suite is safe to run with the
 // harness's `fullyParallel: false, workers: 1` config without a
@@ -247,24 +411,11 @@ test.describe("G-PORT-4 inline reply + working compose toolbar parity", () => {
     await sendInlineReplyJ2cl(page, composer, phrase);
   });
 
-  test("GWT: welcome wave opens with multiple blips for parity", async ({ page }) => {
-    // Per umbrella #1109 policy: the GWT half ASSERTS the parity
-    // baseline (wave opens, blips render, format toolbar present)
-    // without skipping. Driving the full bold-and-send flow on
-    // ?view=gwt is currently blocked by the GWT shell's hover-only
-    // Reply affordance; that follow-up automation is tracked
-    // separately as issue #1121 (G-PORT-4 follow-up: automate GWT
-    // inline-reply E2E for parity). This test fails LOUDLY if any
-    // of the baseline parity invariants regress.
+  test("GWT: bold-applied inline reply ships a new blip", async ({ page }) => {
     const creds = freshCredentials("g4g");
     test.info().annotations.push({
       type: "test-user",
       description: creds.address
-    });
-    test.info().annotations.push({
-      type: "follow-up",
-      description:
-        "Full GWT bold-and-send drive tracked at #1121."
     });
     await registerAndSignIn(page, BASE_URL, creds);
 
@@ -315,13 +466,15 @@ test.describe("G-PORT-4 inline reply + working compose toolbar parity", () => {
       )
       .toBe(true);
 
-    // The GWT toolbar surfaces a per-wave action strip (lock,
-    // make-public, add-participant, …) above the wave panel. Assert
-    // at least one such control renders so we know the wave is
-    // interactive — full bold-and-send drive is tracked at #1121.
+    const phrase = `hello ${Date.now().toString(36)} world`;
     await expect(
-      page.locator("[aria-label*='participant']").first(),
-      "GWT view must surface the wave action toolbar with a participant control"
-    ).toBeAttached({ timeout: 15_000 });
+      gwt.gwtBlips().filter({ hasText: phrase }),
+      "unique reply payload must not already exist in the welcome wave"
+    ).toHaveCount(0);
+    const initialBlipCount = await gwt.gwtBlips().count();
+    await clickReplyOnFirstBlipGwt(gwt);
+    await typeInComposerGwt(page, gwt, phrase);
+    await applyBoldToWordGwt(page, gwt, "world");
+    await finishInlineReplyGwt(page, gwt, initialBlipCount, phrase);
   });
 });

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -353,6 +353,13 @@ async function applyBoldToWordGwt(
     timeout: 10_000
   });
   await bold.click({ timeout: 10_000 });
+  const editor = gwt.gwtActiveEditableDocument();
+  const editorHtml = await editor.evaluate((el: HTMLElement) => el.innerHTML);
+  const boldMatcher = new RegExp(`<(b|strong)[^>]*>${word}<\\/\\1>`, "i");
+  expect(
+    boldMatcher.test(editorHtml),
+    `GWT bold must wrap '${word}' in <b>/<strong>; saw: ${editorHtml}`
+  ).toBe(true);
 }
 
 async function finishInlineReplyGwt(

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -316,7 +316,7 @@ async function selectTrailingWordWithKeyboard(
     )
     .toBe(true);
   await page.keyboard.press(
-    process.platform === "darwin" ? "Meta+ArrowRight" : "Control+ArrowRight"
+    process.platform === "darwin" ? "Meta+ArrowRight" : "End"
   );
   for (let i = 0; i < word.length; i += 1) {
     await page.keyboard.press("Shift+ArrowLeft");

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -21,7 +21,10 @@
 // seeding is needed.
 import { test, expect, Page } from "@playwright/test";
 import { J2clPage } from "../pages/J2clPage";
-import { GwtPage } from "../pages/GwtPage";
+import {
+  GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR,
+  GwtPage
+} from "../pages/GwtPage";
 import { freshCredentials, registerAndSignIn } from "../fixtures/testUser";
 
 const BASE_URL = process.env.WAVE_E2E_BASE_URL ?? "http://127.0.0.1:9900";
@@ -412,6 +415,10 @@ async function finishInlineReplyGwt(
   initialBlipCount: number,
   draftText: string
 ): Promise<void> {
+  await expect(
+    gwt.gwtActiveEditableDocument(),
+    "GWT draft must expose an active editor before submit"
+  ).toBeVisible({ timeout: 5_000 });
   const done = page.locator("[data-e2e-action='edit-done']").last();
   await expect(done, "GWT edit-done action must be stable").toBeVisible({
     timeout: 10_000
@@ -439,9 +446,7 @@ async function finishInlineReplyGwt(
   ).toBeVisible({ timeout: 20_000 });
   await expect(
     // GWT keeps editabledocmarker on read-only documents, so only active editability signals count.
-    persistedBlip.locator(
-      '.wave-editor-on, [contenteditable="true"], [style*="read-write"]'
-    ),
+    persistedBlip.locator(GWT_ACTIVE_EDITOR_SIGNAL_SELECTOR),
     "the submitted GWT reply blip must not contain an open editor (must be persisted, not a draft)"
   ).toHaveCount(0, { timeout: 5_000 });
 }

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -494,11 +494,11 @@ test.describe("G-PORT-4 inline reply + working compose toolbar parity", () => {
     // pane; click its visible entry. Wait briefly first so GWT's
     // deferred relayout has settled — direct .first() can target a
     // hidden pre-render scratch node otherwise.
-    await page.waitForTimeout(2_500);
+    await page.waitForTimeout(2_500); // empirically calibrated: GWT deferred relayout before digest list renders
     const digest = page.locator("text=Welcome to SupaWave").first();
     await expect(digest).toBeVisible({ timeout: 10_000 });
     await digest.click({ timeout: 15_000 });
-    await page.waitForTimeout(6_000);
+    await page.waitForTimeout(6_000); // empirically calibrated: GWT deferred wave-open and blip render after click
 
     // GWT renders blip text inside multiple nested containers; assert
     // the body's text content carries a stable welcome-wave phrase

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -250,7 +250,10 @@ async function typeInComposerGwt(
       { message: "GWT editor must own focus before typing", timeout: 5_000 }
     )
     .toBe(true);
-  await page.keyboard.insertText(phrase);
+  // GWT's legacy editor updates its persistent model from keyboard events.
+  // insertText mutates the DOM text but can leave the editor model empty,
+  // which makes toolbar selection/annotation commands no-op.
+  await page.keyboard.type(phrase, { delay: 10 });
   await expect
     .poll(
       async () => await editor.evaluate((el) => (el.textContent || "").trim()),
@@ -259,44 +262,7 @@ async function typeInComposerGwt(
     .toContain(phrase);
 }
 
-async function selectWordInGwtEditor(
-  page: Page,
-  gwt: GwtPage,
-  word: string
-): Promise<boolean> {
-  const editor = gwt.gwtActiveEditableDocument();
-  const selected = await editor.evaluate((el, targetWord) => {
-    (el as HTMLElement).focus();
-    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
-    let node = walker.nextNode();
-    while (node) {
-      const text = node.textContent || "";
-      const index = text.indexOf(targetWord);
-      if (index >= 0) {
-        const range = document.createRange();
-        range.setStart(node, index);
-        range.setEnd(node, index + targetWord.length);
-        const selection = window.getSelection();
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-        document.dispatchEvent(new Event("selectionchange", { bubbles: true }));
-        return true;
-      }
-      node = walker.nextNode();
-    }
-    return false;
-  }, word);
-  if (!selected) {
-    return false;
-  }
-  return await page.evaluate(
-    (targetWord) => window.getSelection()?.toString() === targetWord,
-    word
-  );
-}
-
-async function selectTrailingWordWithKeyboard(
-  page: Page,
+async function selectTrailingWordWithGwtWebDriver(
   gwt: GwtPage,
   word: string
 ): Promise<void> {
@@ -310,22 +276,69 @@ async function selectTrailingWordWithKeyboard(
           word
         ),
       {
-        message: `GWT editor text must end with '${word}' before keyboard selection`,
+        message: `GWT editor text must end with '${word}' before webdriver selection`,
         timeout: 5_000
       }
     )
     .toBe(true);
-  await page.keyboard.press(
-    process.platform === "darwin" ? "Meta+ArrowRight" : "End"
-  );
-  for (let i = 0; i < word.length; i += 1) {
-    await page.keyboard.press("Shift+ArrowLeft");
-  }
+  await editor.evaluate((el: HTMLElement, targetWord: string) => {
+    const win = window as typeof window & {
+      webdriverEditorGetContent?: (editorDiv: Element) => string;
+      webdriverEditorSetSelection?: (editorDiv: Element, start: number, end: number) => void;
+    };
+    if (!win.webdriverEditorGetContent || !win.webdriverEditorSetSelection) {
+      throw new Error("GWT editor webdriver selection hooks are unavailable");
+    }
+    let editorDiv: HTMLElement | null = el;
+    let content = "";
+    while (editorDiv) {
+      // The GWT webdriver hook expects the content-owning editor div,
+      // which may be an ancestor of the editable document element.
+      content = win.webdriverEditorGetContent(editorDiv) || "";
+      if (
+        !content.startsWith("Error in webdriverEditorGetContent") &&
+        content.includes(targetWord)
+      ) {
+        break;
+      }
+      editorDiv = editorDiv.parentElement;
+    }
+    if (
+      !editorDiv ||
+      content.startsWith("Error in webdriverEditorGetContent") ||
+      !content.includes(targetWord)
+    ) {
+      throw new Error(`GWT editor model does not contain '${targetWord}': ${content}`);
+    }
+
+    const searchUpperBound = Math.min(content.length + 10, 500);
+    let firstSelectionError = "";
+    for (let start = searchUpperBound; start >= 0; start -= 1) {
+      for (let extraEnd = 0; extraEnd <= 4; extraEnd += 1) {
+        const end = start + targetWord.length + extraEnd;
+        try {
+          win.webdriverEditorSetSelection(editorDiv, start, end);
+        } catch (error) {
+          if (!firstSelectionError) {
+            firstSelectionError = error instanceof Error ? error.message : String(error);
+          }
+          continue;
+        }
+        if (window.getSelection()?.toString() === targetWord) {
+          return;
+        }
+      }
+    }
+    throw new Error(
+      `GWT webdriver selection could not target '${targetWord}' in content ${content}` +
+        (firstSelectionError ? `; first setSelection error: ${firstSelectionError}` : "")
+    );
+  }, word);
   await expect
     .poll(
-      async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
+      async () => await editor.evaluate(() => window.getSelection()?.toString() || ""),
       {
-        message: `GWT keyboard fallback must select trailing '${word}'`,
+        message: `GWT webdriver helper must select trailing '${word}'`,
         timeout: 5_000
       }
     )
@@ -337,10 +350,11 @@ async function applyBoldToWordGwt(
   gwt: GwtPage,
   word: string
 ): Promise<void> {
-  const selectedByRange = await selectWordInGwtEditor(page, gwt, word);
-  if (!selectedByRange) {
-    await selectTrailingWordWithKeyboard(page, gwt, word);
-  }
+  // GWT's editor selection controller reads the editor's native selection
+  // through its SelectionHelper. Direct DOM ranges can select browser text
+  // while bypassing the legacy editor model, so use the existing GWT webdriver
+  // selection hook to target the same SelectionHelper state the toolbar uses.
+  await selectTrailingWordWithGwtWebDriver(gwt, word);
   await expect
     .poll(
       async () => await page.evaluate(() => window.getSelection()?.toString() || ""),
@@ -354,12 +368,42 @@ async function applyBoldToWordGwt(
   });
   await bold.click({ timeout: 10_000 });
   const editor = gwt.gwtActiveEditableDocument();
-  const editorHtml = await editor.evaluate((el: HTMLElement) => el.innerHTML);
-  const boldMatcher = new RegExp(`<(b|strong)[^>]*>${word}<\\/\\1>`, "i");
-  expect(
-    boldMatcher.test(editorHtml),
-    `GWT bold must wrap '${word}' in <b>/<strong>; saw: ${editorHtml}`
-  ).toBe(true);
+  await expect
+    .poll(
+      async () =>
+        await editor.evaluate((el: HTMLElement, targetWord: string) => {
+          const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+          let node = walker.nextNode();
+          while (node) {
+            const text = node.textContent || "";
+            if (text.includes(targetWord)) {
+              let current = node.parentElement;
+              while (current && current !== el) {
+                const tagName = current.tagName.toLowerCase();
+                const inlineFontWeight = current.style.fontWeight;
+                const numericInlineWeight = Number(inlineFontWeight);
+                if (
+                  tagName === "b" ||
+                  tagName === "strong" ||
+                  inlineFontWeight === "bold" ||
+                  inlineFontWeight === "bolder" ||
+                  numericInlineWeight >= 700
+                ) {
+                  return true;
+                }
+                current = current.parentElement;
+              }
+            }
+            node = walker.nextNode();
+          }
+          return false;
+        }, word),
+      {
+        message: `GWT bold toolbar action must apply formatting to '${word}'`,
+        timeout: 5_000
+      }
+    )
+    .toBe(true);
 }
 
 async function finishInlineReplyGwt(

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -417,16 +417,32 @@ async function finishInlineReplyGwt(
     timeout: 10_000
   });
   await done.click({ timeout: 10_000 });
+  // Wait for the editor chrome to close — edit-done disappearing confirms
+  // the submit handler ran (not just that a draft blip existed beforehand).
+  await expect(
+    page.locator("[data-e2e-action='edit-done']"),
+    "GWT edit-done chrome must close after submit"
+  ).toHaveCount(0, { timeout: 15_000 });
+  // Confirm a new, non-editable blip was added.
   await expect
     .poll(
       async () => await gwt.gwtBlips().count(),
       { message: "GWT reply submit must add a new blip", timeout: 25_000 }
     )
     .toBeGreaterThan(initialBlipCount);
+  // The persisted blip must be visible and must not contain an open editor,
+  // distinguishing it from a pre-submit draft.
+  const persistedBlip = gwt.gwtBlips().filter({ hasText: draftText }).last();
   await expect(
-    gwt.gwtBlips().filter({ hasText: draftText }).last(),
+    persistedBlip,
     "the newly submitted GWT reply blip must carry the draft text"
   ).toBeVisible({ timeout: 20_000 });
+  await expect(
+    persistedBlip.locator(
+      '[editabledocmarker="true"], .wave-editor-on, [contenteditable="true"]'
+    ),
+    "the submitted GWT reply blip must not contain an open editor (must be persisted, not a draft)"
+  ).toHaveCount(0, { timeout: 5_000 });
 }
 
 // Each test registers a fresh user and operates on its own

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/FragmentsFetcherCompat.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/FragmentsFetcherCompat.java
@@ -166,12 +166,16 @@ public final class FragmentsFetcherCompat {
     // Filter to known metas
     List<String> filtered = new ArrayList<>(order.size());
     for (String id : order) if (metas.containsKey(id)) filtered.add(id);
-    if (filtered.isEmpty()) return Collections.emptyList();
+    if (filtered.isEmpty()) return slice(metas, startId, direction, limit);
     String dir = (direction == null) ? "forward" : direction.trim().toLowerCase();
     if (!"forward".equals(dir) && !"backward".equals(dir)) dir = "forward";
     int idx = 0;
-    if (startId != null && metas.containsKey(startId)) idx = filtered.indexOf(startId);
-    if (idx < 0) idx = 0;
+    if (startId != null && metas.containsKey(startId)) {
+      idx = filtered.indexOf(startId);
+      if (idx < 0) {
+        return slice(metas, startId, dir, limit);
+      }
+    }
     List<String> out = new ArrayList<>(limit);
     if ("backward".equals(dir)) {
       for (int i = Math.max(0, idx - limit + 1); i <= idx && out.size() < limit; i++) out.add(filtered.get(i));

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/toolbar/EditToolbar.java
@@ -366,6 +366,7 @@ public class EditToolbar {
     new ToolbarButtonViewBuilder()
         .setTooltip("Bold")
         .applyTo(b, createTextSelectionController(b, "fontWeight", "bold"));
+    b.setE2eAction("bold");
     b.setVisualElement(createSvgIcon(ICON_BOLD));
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/BlipMetaViewBuilder.java
@@ -358,6 +358,10 @@ public final class BlipMetaViewBuilder implements UiBuilder, IntrinsicBlipMetaVi
               + " title='" + title + "'"
               + " data-option='" + dataOption + "'"
               + (selected.contains(option) ? " " + OPTION_SELECTED_ATTRIBUTE + "='s'" : "");
+          String e2eAction = e2eActionFor(option);
+          if (e2eAction != null) {
+            extra += " data-e2e-action='" + e2eAction + "'";
+          }
           openSpanWith(out, null, style, TypeCodes.kind(Type.MENU_ITEM), extra);
           out.append(MENU_ICONS.get(option));
           closeSpan(out);
@@ -369,6 +373,17 @@ public final class BlipMetaViewBuilder implements UiBuilder, IntrinsicBlipMetaVi
         }
       }
     };
+  }
+
+  private static String e2eActionFor(MenuOption option) {
+    switch (option) {
+      case REPLY:
+        return "reply";
+      case EDIT_DONE:
+        return "edit-done";
+      default:
+        return null;
+    }
   }
 
   public static MenuOption getMenuOption(String id) {

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/AbstractToolbarButton.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/AbstractToolbarButton.java
@@ -166,6 +166,11 @@ public abstract class AbstractToolbarButton
   }
 
   @Override
+  public void setE2eAction(String action) {
+    button.setE2eAction(action);
+  }
+
+  @Override
   public void setVisualElement(Element element) {
     button.setVisualElement(element);
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/HorizontalToolbarButtonWidget.java
@@ -165,6 +165,15 @@ public final class HorizontalToolbarButtonWidget extends Composite implements To
   }
 
   @Override
+  public void setE2eAction(String action) {
+    if (action == null || action.isEmpty()) {
+      getElement().removeAttribute("data-e2e-action");
+    } else {
+      getElement().setAttribute("data-e2e-action", action);
+    }
+  }
+
+  @Override
   public void setVisualElement(Element element) {
     if (currentVisualElement != null) {
       currentVisualElement.removeFromParent();

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonUiProxy.java
@@ -141,6 +141,11 @@ public final class ToolbarButtonUiProxy implements ToolbarButtonUi {
   }
 
   @Override
+  public void setE2eAction(String action) {
+    proxy.setE2eAction(action);
+  }
+
+  @Override
   public void setVisualElement(Element element) {
     proxy.setVisualElement(element);
   }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java
@@ -62,6 +62,12 @@ public interface ToolbarButtonView {
   void setTooltip(String tooltip);
 
   /**
+   * Sets a stable E2E action identifier on the rendered button, or clears it
+   * when {@code action} is null.
+   */
+  void setE2eAction(String action);
+
+  /**
    * Sets whether the button should show the dropdown arrow.
    */
   void setShowDropdownArrow(boolean showDropdown);
@@ -100,6 +106,10 @@ public interface ToolbarButtonView {
 
     @Override
     public void setTooltip(String hovertext) {
+    }
+
+    @Override
+    public void setE2eAction(String action) {
     }
 
     @Override

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonView.java
@@ -63,7 +63,7 @@ public interface ToolbarButtonView {
 
   /**
    * Sets a stable E2E action identifier on the rendered button, or clears it
-   * when {@code action} is null.
+   * when {@code action} is null or empty.
    */
   void setE2eAction(String action);
 

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxy.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/ToolbarButtonViewProxy.java
@@ -42,6 +42,7 @@ public final class ToolbarButtonViewProxy implements ToolbarButtonView {
   private String text;
   private String tooltip;
   private Element element;
+  private String e2eAction;
   private Boolean showDropdownArrow;
   private Boolean showDivider;
   private final StringSet dcs = CollectionUtils.createStringSet();
@@ -74,6 +75,14 @@ public final class ToolbarButtonViewProxy implements ToolbarButtonView {
     this.tooltip = tooltip;
     if (delegate != null) {
       delegate.setTooltip(tooltip);
+    }
+  }
+
+  @Override
+  public void setE2eAction(String action) {
+    this.e2eAction = action;
+    if (delegate != null) {
+      delegate.setE2eAction(action);
     }
   }
 
@@ -153,6 +162,7 @@ public final class ToolbarButtonViewProxy implements ToolbarButtonView {
     if (tooltip != null) {
       display.setTooltip(tooltip);
     }
+    display.setE2eAction(e2eAction);
     if (element != null) {
       display.setVisualElement(element);
     }

--- a/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/VerticalToolbarButtonWidget.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/widget/toolbar/buttons/VerticalToolbarButtonWidget.java
@@ -141,6 +141,15 @@ public final class VerticalToolbarButtonWidget extends Composite implements Tool
   }
 
   @Override
+  public void setE2eAction(String action) {
+    if (action == null || action.isEmpty()) {
+      getElement().removeAttribute("data-e2e-action");
+    } else {
+      getElement().setAttribute("data-e2e-action", action);
+    }
+  }
+
+  @Override
   public void setVisualElement(Element element) {
     if (currentVisualElement != null) {
       currentVisualElement.removeFromParent();

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/FragmentsOrderingTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/FragmentsOrderingTest.java
@@ -57,5 +57,23 @@ public final class FragmentsOrderingTest {
         "b+3", "forward", 2);
     assertEquals(java.util.Arrays.asList("b+3", "b+1"), out);
   }
-}
 
+  @Test
+  public void sliceFallsBackToMtimeWhenStartIsMissingFromOrder() {
+    Map<String, BlipMeta> m = metas(5, 1, 3);
+    List<String> order = new ArrayList<>();
+    order.add("b+2"); order.add("b+1");
+    List<String> out = FragmentsFetcherCompat.sliceUsingOrder(m, order, "b+3", "forward", 2);
+    assertEquals(java.util.Arrays.asList("b+3", "b+1"), out);
+  }
+
+  @Test
+  public void sliceUsesProvidedOrderWhenUnknownStartIsMissingFromMetas() {
+    Map<String, BlipMeta> m = metas(5, 1, 3);
+    List<String> order = new ArrayList<>();
+    order.add("b+2"); order.add("b+3"); order.add("b+1");
+    List<String> out =
+        FragmentsFetcherCompat.sliceUsingOrder(m, order, "b+missing", "forward", 2);
+    assertEquals(java.util.Arrays.asList("b+2", "b+3"), out);
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/FragmentsServletViewportLimitTest.java
@@ -232,4 +232,27 @@ public final class FragmentsServletViewportLimitTest {
     assertEquals(Collections.singletonList("b+2"), window.getRangeBlipIds());
     assertEquals(Collections.singletonList("b+2"), window.getLoadedBlipIds());
   }
+
+  @Test
+  public void servletLoadsExplicitStartWhenManifestOrderMissesKnownBlip() {
+    Map<String, FragmentsFetcherCompat.BlipMeta> metas =
+        new LinkedHashMap<String, FragmentsFetcherCompat.BlipMeta>();
+    metas.put("b+1", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 10L));
+    metas.put("b+2", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 20L));
+    metas.put("b+3", new FragmentsFetcherCompat.BlipMeta(
+        ParticipantId.ofUnsafe("user@example.com"), 30L));
+
+    FragmentsServlet.SliceWindow window =
+        FragmentsServlet.buildSliceWindow(
+            metas,
+            Arrays.asList("b+1", "b+2"),
+            "b+3",
+            "forward",
+            1);
+
+    assertEquals(Arrays.asList("b+3"), window.getRangeBlipIds());
+    assertEquals(Collections.singletonList("b+3"), window.getLoadedBlipIds());
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1121.

Part of #904.

- Replace the GWT baseline-only inline-reply parity smoke with a full `?view=gwt` Reply -> type -> Bold -> Done -> new blip E2E flow.
- Add inert stable GWT E2E hooks for Reply, Edit Done, and Bold without changing command behavior or visuals.
- Harden J2CL post-submit viewport handoff so metadata/version-only updates do not suppress fetching the known submitted blip.
- Bound post-submit fetch retries and refresh after three missing-submitted-blip windows.
- Harden server fragment slicing so explicit known `startBlipId` requests still load when manifest order is incomplete/stale.

## Verification

- `sbt --batch compile j2clSearchTest "testOnly org.waveprotocol.box.server.frontend.FragmentsOrderingTest org.waveprotocol.box.server.rpc.FragmentsServletViewportLimitTest"` -> pass; server fragment tests 13/13.
- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit` -> pass.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass.
- `git diff --check` -> pass.
- `bash scripts/worktree-boot.sh --port 9932` -> rebuilt GWT/J2CL/stage successfully.
- `PORT=9932 bash scripts/wave-smoke.sh check` -> pass.
- `CI=true WAVE_E2E_BASE_URL=http://127.0.0.1:9932 npx playwright test tests/inline-reply-parity.spec.ts --project=chromium --grep 'J2CL: bold-applied inline reply ships a new blip' --repeat-each=5` -> 5/5 pass.
- `CI=true WAVE_E2E_BASE_URL=http://127.0.0.1:9932 npx playwright test tests/inline-reply-parity.spec.ts --project=chromium` -> 2/2 pass.

## Review

- Self-review completed.
- Claude Opus implementation review loop completed through round 3; round 3 reported no blockers and recommended ship.
- Issue evidence: https://github.com/vega113/supawave/issues/1121#issuecomment-4347728366


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds stable end-to-end hooks and toolbar action identifiers to drive legacy inline-reply and formatting flows; centralized GWT page locator helpers for parity tests.

* **Bug Fixes**
  * More robust post-submit forward-fetch with bounded retries and fallback to ensure replies appear reliably.

* **Tests**
  * Replaces baseline check with full inline-reply E2E flow (type, select, bold, submit, verify) and removes the older minimal GWT baseline test.
  * Adds unit tests covering post-submit fetch/retry and fragment-ordering edge cases.

* **Documentation**
  * New implementation plan and changelog entry documenting GWT inline-reply E2E parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->