### PR TITLE
Fix J2CL task toggle persistence

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1129-task-toggle-persistence.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1129-task-toggle-persistence.md
@@ -1,0 +1,98 @@
+# Issue #1129 Task Toggle Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make J2CL task toggles, task metadata updates, and blip deletion annotation deltas persist by carrying the target blip body item count into the writer and activating the reload/cross-context parity test that is currently blocked by issue #1129.
+
+**Architecture:** Carry the authoritative wavelet document body item count from selected-wave sidecar decoding into the J2CL read model, rendered DOM, Lit event detail, compose controller, and rich-content delta factory. Size-aware annotation writers emit `annotation-open`, `retain(bodyItemCount)`, and `annotation-close`; missing or non-positive sizes fail before submission instead of emitting invalid adjacent annotation boundaries.
+
+**Tech Stack:** Java/J2CL sidecar transport, J2CL read/compose surfaces, Lit task/blip elements, Playwright parity suite, SBT-only JVM verification.
+
+---
+
+## Constraints
+
+- Work only in `/Users/vega/devroot/worktrees/issue-1129-task-toggle-persistence-20260430`.
+- Do not use Maven directly. Verification must be SBT-only for Java/server code.
+- Run Node/Lit commands only from `j2cl/lit/`.
+- Preserve GWT behavior; this issue only fixes the J2CL write path and parity coverage.
+- Add a changelog fragment because the fix changes user-visible J2CL task persistence behavior.
+- Keep #1129 and umbrella #904 updated with worktree, branch, plan, commits, verification, review status, and PR URL.
+
+## Acceptance Criteria
+
+- J2CL task toggle deltas retain the full target blip body between task annotation open and close boundaries.
+- J2CL task metadata deltas use the same valid annotation-boundary shape.
+- J2CL blip delete annotation deltas use the same valid annotation-boundary shape.
+- The body item count is derived from selected-wave document operations, including chars plus body/line element starts and ends, and excluding annotation-boundary components.
+- Lit task and blip events carry body size to the compose surface for toggle, metadata, and delete actions.
+- Missing or non-positive body size cannot submit an invalid J2CL mutation; the controller records the failure path and leaves persistence unchanged.
+- The `tasks-parity.spec.ts` reload/cross-context J2CL persistence check is changed from `fixme` to a live assertion.
+- Targeted unit tests, Lit tests, TypeScript checks, and SBT verification pass.
+
+## Tasks
+
+- [ ] Add failing delta-shape tests in `J2clRichContentDeltaFactoryTest`.
+  - Cover task toggle, task metadata, and blip delete requests with a representative body item count.
+  - Assert annotation-open and annotation-close are separated by `retain(bodyItemCount)`.
+  - Add a focused helper that fails if adjacent annotation boundaries remain in the generated request.
+
+- [ ] Make `J2clRichContentDeltaFactory` size-aware.
+  - Add body-item-count parameters to task toggle, task metadata, and blip delete request creation.
+  - Validate `bodyItemCount > 0` before building the delta.
+  - Update `buildBlipAnnotationRequest` to emit `appendRetain(components, bodyItemCount)` between the annotation boundary open and close components.
+  - Update existing callers and tests instead of preserving any production path that can still emit adjacent annotation boundaries.
+
+- [ ] Derive and expose selected-wave document body item counts.
+  - Extend `SidecarTransportCodec.DocumentExtraction` and `SidecarSelectedWaveDocument` with `bodyItemCount`.
+  - Count one item for each element start/end and one item per character in char components.
+  - Do not count annotation boundary components.
+  - Add transport decoding tests proving the count for existing selected-wave fixtures.
+
+- [ ] Plumb body item counts through the J2CL read model and renderer.
+  - Extend `J2clReadBlip` with `bodyItemCount`, preserving the value in copy/enrichment helpers.
+  - Update `J2clSelectedWaveProjector` to pass the count from decoded documents into read blips.
+  - Keep viewport-fragment-only blips at `0` unless an authoritative selected-wave document count is available.
+  - Update `J2clReadSurfaceDomRenderer` to render `data-blip-doc-size` for positive counts and remove it otherwise.
+  - Add or update read/projector/renderer tests.
+
+- [ ] Plumb body size through Lit task and blip events.
+  - Add a numeric body-size property/attribute to `wavy-task-affordance` and `wave-blip`.
+  - Include `bodySize` in task toggle and task metadata event details.
+  - Include `bodySize` in blip delete request event details.
+  - Keep event re-dispatch behavior stable while adding the new field.
+  - Update `wavy-task-affordance.test.js` and `wave-blip.test.js`.
+
+- [ ] Make the compose controller require size-aware events.
+  - Add event-detail integer parsing in `J2clComposeSurfaceView`.
+  - Change task toggle, task metadata, and delete listener/controller paths to accept `bodyItemCount`.
+  - Block submission and record telemetry when body size is missing or non-positive.
+  - Route valid requests to the size-aware delta factory methods.
+  - Update compose controller/view tests to assert valid retain shape and missing-size rejection.
+
+- [ ] Activate the blocked parity coverage.
+  - Change the #1129 `test.fixme` in `wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts` to a live `test`.
+  - Remove or update stale blocker comments that say J2CL cannot persist task reload/cross-context state.
+  - Keep the existing optimistic UI parity coverage intact.
+
+- [ ] Add release and verification evidence.
+  - Add `wave/config/changelog.d/2026-04-30-j2cl-task-toggle-persistence.json`.
+  - Add `journal/local-verification/2026-04-30-issue-1129-task-toggle-persistence.md` with exact commands and outcomes.
+  - Run changelog assemble/validate if the changelog fragment changes generated output.
+
+## Verification Commands
+
+- `sbt --batch j2clSearchTest`
+- `sbt --batch Test/compile compile Universal/stage j2clSearchTest`
+- `cd j2cl/lit && npm test -- --files test/wavy-task-affordance.test.js test/wave-blip.test.js`
+- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit`
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
+- `git diff --check`
+- Focused local/browser parity verification for `tasks-parity.spec.ts` before PR if the local server can be booted in the lane.
+
+## Review Loop
+
+- Self-review this plan against #1129 acceptance criteria before implementation.
+- Attempt Claude Opus plan review. If Claude remains quota-blocked, record the exact blocker in #1129/#904 and continue with direct review plus GitHub review gates, per the repo orchestration failure-handling guidance.
+- After implementation, run self-review and attempt Claude Opus implementation review before opening the PR. Record any quota blocker explicitly instead of claiming external approval.
+

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -44,7 +44,7 @@ import "./wavy-task-affordance.js";
  *   (compose) listens.
  * - `wave-blip-edit-requested` — `{detail: {blipId, waveId}}`. F-3 owns
  *   the edit surface; F-2 only emits the request.
- * - `wave-blip-delete-requested` — `{detail: {blipId, waveId}}`. F-3.S4
+ * - `wave-blip-delete-requested` — `{detail: {blipId, waveId, bodySize}}`. F-3.S4
  *   (#1038, R-5.6) listens; the compose view shows a styled wavy
  *   confirm dialog and on confirm calls the controller's
  *   onDeleteBlipRequested listener which builds the deletion delta
@@ -109,7 +109,8 @@ export class WaveBlip extends LitElement {
     // live-update path (task/done annotation on the blip body).
     taskCompleted: { type: Boolean, attribute: "data-task-completed", reflect: true },
     taskAssignee: { type: String, attribute: "data-task-assignee", reflect: true },
-    taskDueDate: { type: String, attribute: "data-task-due-date", reflect: true }
+    taskDueDate: { type: String, attribute: "data-task-due-date", reflect: true },
+    bodySize: { type: Number, attribute: "data-blip-doc-size", reflect: true }
   };
 
   static styles = css`
@@ -326,6 +327,7 @@ export class WaveBlip extends LitElement {
     this.taskCompleted = false;
     this.taskAssignee = "";
     this.taskDueDate = "";
+    this.bodySize = 0;
     this.blipDepth = "";
     this.threadCollapsed = false;
     this.dataBlipAuthor = "";
@@ -506,7 +508,11 @@ export class WaveBlip extends LitElement {
       new CustomEvent("wave-blip-delete-requested", {
         bubbles: true,
         composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId }
+        detail: {
+          blipId: this.blipId,
+          waveId: this.waveId,
+          bodySize: this.bodySize || 0
+        }
       })
     );
   }
@@ -645,6 +651,8 @@ export class WaveBlip extends LitElement {
               ?data-task-completed=${this.taskCompleted}
               data-task-assignee=${this.taskAssignee || ""}
               data-task-due-date=${this.taskDueDate || ""}
+              data-blip-doc-size=${ifDefined(this.bodySize > 0 ? String(this.bodySize) : undefined)}
+              .bodySize=${this.bodySize || 0}
               .participants=${this._participants}
               @wave-blip-task-toggled=${this._onTaskToggled}
             ></wavy-task-affordance>

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -15,15 +15,17 @@ import "./task-metadata-popover.js";
  * - assigneeAddress (String, attribute "data-task-assignee") —
  *   currently-assigned owner's address.
  * - dueDate (String, attribute "data-task-due-date") — YYYY-MM-DD.
+ * - bodySize (Number, attribute "data-blip-doc-size") — wavelet item
+ *   count for the backing blip body.
  * - participants (Array of {address, displayName}) — passed to the
  *   inner <task-metadata-popover>.
  *
  * Events emitted (CustomEvent, bubbles + composed):
- * - `wave-blip-task-toggled` — `{detail: {blipId, waveId, completed}}`
+ * - `wave-blip-task-toggled` — `{detail: {blipId, waveId, completed, bodySize}}`
  *   when the toggle button is clicked. The compose-surface view
- *   listener routes this to `Listener.onTaskToggled(blipId, completed)`.
+ *   listener routes this to `Listener.onTaskToggled(blipId, completed, bodySize)`.
  * - `wave-blip-task-metadata-changed` —
- *   `{detail: {blipId, waveId, assigneeAddress, dueDate}}` when the
+ *   `{detail: {blipId, waveId, assigneeAddress, dueDate, bodySize}}` when the
  *   inner <task-metadata-popover> emits its `task-metadata-submit`.
  *
  * UX rationale (per the slice plan):
@@ -46,6 +48,7 @@ export class WavyTaskAffordance extends LitElement {
     completed: { type: Boolean, attribute: "data-task-completed", reflect: true },
     assigneeAddress: { type: String, attribute: "data-task-assignee", reflect: true },
     dueDate: { type: String, attribute: "data-task-due-date", reflect: true },
+    bodySize: { type: Number, attribute: "data-blip-doc-size", reflect: true },
     participants: { type: Array },
     // J-UI-6 (#1084, R-5.4 — "Labels translate"): every visible / aria / live
     // string is exposed as a property so the Java view (or a future lit-i18n
@@ -125,6 +128,7 @@ export class WavyTaskAffordance extends LitElement {
     this.completed = false;
     this.assigneeAddress = "";
     this.dueDate = "";
+    this.bodySize = 0;
     this.participants = [];
     this._announceText = "";
     this._popoverOpen = false;
@@ -150,7 +154,12 @@ export class WavyTaskAffordance extends LitElement {
       new CustomEvent("wave-blip-task-toggled", {
         bubbles: true,
         composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId, completed: next }
+        detail: {
+          blipId: this.blipId,
+          waveId: this.waveId,
+          completed: next,
+          bodySize: this.bodySize || 0
+        }
       })
     );
   }
@@ -200,7 +209,8 @@ export class WavyTaskAffordance extends LitElement {
           blipId: this.blipId,
           waveId: this.waveId,
           assigneeAddress: assignee,
-          dueDate: due
+          dueDate: due,
+          bodySize: this.bodySize || 0
         }
       })
     );

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -123,12 +123,17 @@ describe("<wave-blip>", () => {
 
   // F-3.S4 (#1038, R-5.6 F.6): the Delete button on the per-blip
   // toolbar bubbles wave-blip-toolbar-delete; wave-blip re-emits
-  // wave-blip-delete-requested with {blipId, waveId} so the J2CL
+  // wave-blip-delete-requested with {blipId, waveId, bodySize} so the J2CL
   // compose view can route through the wavy confirm dialog and the
   // controller's onDeleteBlipRequested listener.
   it("re-emits wave-blip-delete-requested when toolbar Delete fires", async () => {
     const el = await fixture(html`
-      <wave-blip data-blip-id="b9" data-wave-id="w9" author-name="A"></wave-blip>
+      <wave-blip
+        data-blip-id="b9"
+        data-wave-id="w9"
+        data-blip-doc-size="17"
+        author-name="A"
+      ></wave-blip>
     `);
     await el.updateComplete;
     const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
@@ -139,6 +144,7 @@ describe("<wave-blip>", () => {
     const ev = await oneEvent(el, "wave-blip-delete-requested");
     expect(ev.detail.blipId).to.equal("b9");
     expect(ev.detail.waveId).to.equal("w9");
+    expect(ev.detail.bodySize).to.equal(17);
     expect(ev.bubbles).to.be.true;
     expect(ev.composed).to.be.true;
   });
@@ -384,7 +390,7 @@ describe("<wave-blip>", () => {
 
   it("re-emits wave-blip-task-toggled from the inner affordance with full detail", async () => {
     const el = await fixture(html`
-      <wave-blip data-blip-id="b22" data-wave-id="w22"></wave-blip>
+      <wave-blip data-blip-id="b22" data-wave-id="w22" data-blip-doc-size="17"></wave-blip>
     `);
     await el.updateComplete;
     const affordance = el.renderRoot.querySelector("wavy-task-affordance");
@@ -395,7 +401,12 @@ describe("<wave-blip>", () => {
     });
     toggle.click();
     await el.updateComplete;
-    expect(captured).to.deep.equal({ blipId: "b22", waveId: "w22", completed: true });
+    expect(captured).to.deep.equal({
+      blipId: "b22",
+      waveId: "w22",
+      completed: true,
+      bodySize: 17
+    });
   });
 
   // J-UI-6 (#1084, R-5.4): when the read renderer writes

--- a/j2cl/lit/test/wavy-task-affordance.test.js
+++ b/j2cl/lit/test/wavy-task-affordance.test.js
@@ -51,7 +51,11 @@ describe("<wavy-task-affordance>", () => {
 
   it("emits wave-blip-task-toggled when the toggle button is clicked", async () => {
     const el = await fixture(html`
-      <wavy-task-affordance data-blip-id="b42" data-wave-id="w7"></wavy-task-affordance>
+      <wavy-task-affordance
+        data-blip-id="b42"
+        data-wave-id="w7"
+        data-blip-doc-size="17"
+      ></wavy-task-affordance>
     `);
     const toggle = el.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
     const eventPromise = oneEvent(el, "wave-blip-task-toggled");
@@ -60,6 +64,7 @@ describe("<wavy-task-affordance>", () => {
     expect(event.detail.blipId).to.equal("b42");
     expect(event.detail.waveId).to.equal("w7");
     expect(event.detail.completed).to.equal(true);
+    expect(event.detail.bodySize).to.equal(17);
   });
 
   it("flips aria-checked and the data-task-completed attribute on toggle", async () => {
@@ -134,6 +139,7 @@ describe("<wavy-task-affordance>", () => {
       <wavy-task-affordance
         data-blip-id="b1"
         data-wave-id="w1"
+        data-blip-doc-size="17"
         .participants=${[{ address: "alice@example.com", displayName: "Alice" }]}
       ></wavy-task-affordance>
     `);
@@ -155,6 +161,7 @@ describe("<wavy-task-affordance>", () => {
     expect(event.detail.blipId).to.equal("b1");
     expect(event.detail.assigneeAddress).to.equal("alice@example.com");
     expect(event.detail.dueDate).to.equal("2026-05-01");
+    expect(event.detail.bodySize).to.equal(17);
   });
 
   it("closes the popover and restores focus to the trigger on overlay-close", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -141,14 +141,15 @@ public final class J2clComposeSurfaceController {
      * F-3.S2 (#1038, R-5.4): the per-blip task affordance was clicked.
      * The controller emits a stand-alone `task/done` toggle delta.
      */
-    default void onTaskToggled(String blipId, boolean completed) {}
+    default void onTaskToggled(String blipId, boolean completed, int bodyItemCount) {}
 
     /**
      * F-3.S2 (#1038, R-5.4 step 5): the task-metadata popover emitted
      * a submit. The controller emits a stand-alone delta carrying
      * `task/assignee` + `task/dueTs` annotations.
      */
-    default void onTaskMetadataChanged(String blipId, String assigneeAddress, String dueDate) {}
+    default void onTaskMetadataChanged(
+        String blipId, String assigneeAddress, String dueDate, int bodyItemCount) {}
 
     /**
      * F-3.S3 (#1038, R-5.5): the user picked a reaction emoji in the
@@ -188,7 +189,8 @@ public final class J2clComposeSurfaceController {
      * submits it via the gateway. Default no-op so existing test
      * doubles compile unchanged.
      */
-    default void onDeleteBlipRequested(String blipId, String expectedWaveId) {}
+    default void onDeleteBlipRequested(
+        String blipId, String expectedWaveId, int bodyItemCount) {}
   }
 
   /**
@@ -341,7 +343,11 @@ public final class J2clComposeSurfaceController {
      * {@link J2clRichContentDeltaFactory#taskToggleRequest}.
      */
     default SidecarSubmitRequest createTaskToggleRequest(
-        String address, J2clSidecarWriteSession session, String blipId, boolean completed) {
+        String address,
+        J2clSidecarWriteSession session,
+        String blipId,
+        boolean completed,
+        int bodyItemCount) {
       throw new UnsupportedOperationException(
           "Task toggle is only available with the rich-content delta factory.");
     }
@@ -355,7 +361,8 @@ public final class J2clComposeSurfaceController {
         J2clSidecarWriteSession session,
         String blipId,
         String assigneeAddress,
-        String dueDate) {
+        String dueDate,
+        int bodyItemCount) {
       throw new UnsupportedOperationException(
           "Task metadata is only available with the rich-content delta factory.");
     }
@@ -386,7 +393,7 @@ public final class J2clComposeSurfaceController {
      * {@link J2clRichContentDeltaFactory#blipDeleteRequest}.
      */
     default SidecarSubmitRequest createBlipDeleteRequest(
-        String address, J2clSidecarWriteSession session, String blipId) {
+        String address, J2clSidecarWriteSession session, String blipId, int bodyItemCount) {
       throw new UnsupportedOperationException(
           "Blip delete is only available with the rich-content delta factory.");
     }
@@ -748,15 +755,16 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
-          public void onTaskToggled(String blipId, boolean completed) {
-            J2clComposeSurfaceController.this.onTaskToggled(blipId, completed);
+          public void onTaskToggled(String blipId, boolean completed, int bodyItemCount) {
+            J2clComposeSurfaceController.this.onTaskToggled(
+                blipId, completed, bodyItemCount);
           }
 
           @Override
           public void onTaskMetadataChanged(
-              String blipId, String assigneeAddress, String dueDate) {
+              String blipId, String assigneeAddress, String dueDate, int bodyItemCount) {
             J2clComposeSurfaceController.this.onTaskMetadataChanged(
-                blipId, assigneeAddress, dueDate);
+                blipId, assigneeAddress, dueDate, bodyItemCount);
           }
 
           @Override
@@ -780,8 +788,10 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
-          public void onDeleteBlipRequested(String blipId, String expectedWaveId) {
-            J2clComposeSurfaceController.this.onDeleteBlipRequested(blipId, expectedWaveId);
+          public void onDeleteBlipRequested(
+              String blipId, String expectedWaveId, int bodyItemCount) {
+            J2clComposeSurfaceController.this.onDeleteBlipRequested(
+                blipId, expectedWaveId, bodyItemCount);
           }
         });
     render();
@@ -1143,7 +1153,8 @@ public final class J2clComposeSurfaceController {
    * On signed-out, missing wave, or empty {@code blipId} the call is a
    * no-op (with a telemetry event recording the reason).
    */
-  public void onDeleteBlipRequested(final String blipId, final String expectedWaveId) {
+  public void onDeleteBlipRequested(
+      final String blipId, final String expectedWaveId, final int bodyItemCount) {
     if (signedOut) {
       recordBlipDeleteTelemetry("signed-out");
       return;
@@ -1162,6 +1173,10 @@ public final class J2clComposeSurfaceController {
       recordBlipDeleteTelemetry("no-selected-wave");
       return;
     }
+    if (bodyItemCount <= 0) {
+      recordBlipDeleteTelemetry("failure-build");
+      return;
+    }
     final String trimmed = blipId.trim();
     final J2clSidecarWriteSession submitSession = writeSession;
     gateway.fetchRootSessionBootstrap(
@@ -1174,7 +1189,7 @@ public final class J2clComposeSurfaceController {
           try {
             request =
                 deltaFactory.createBlipDeleteRequest(
-                    bootstrap.getAddress(), writeSession, trimmed);
+                    bootstrap.getAddress(), writeSession, trimmed, bodyItemCount);
           } catch (RuntimeException e) {
             recordBlipDeleteTelemetry("failure-build");
             return;
@@ -1262,10 +1277,15 @@ public final class J2clComposeSurfaceController {
    * bails out if the user has signed out or switched waves since the
    * click, preventing stale-session writes.
    */
-  public void onTaskToggled(final String blipId, final boolean completed) {
+  public void onTaskToggled(
+      final String blipId, final boolean completed, final int bodyItemCount) {
     if (signedOut) return;
     if (blipId == null || blipId.trim().isEmpty()) return;
     if (!hasSelectedWave(writeSession)) return;
+    if (bodyItemCount <= 0) {
+      recordTaskToggleTelemetry(completed, "failure-build");
+      return;
+    }
     final J2clSidecarWriteSession submitSession = writeSession;
     final String trimmedBlipId = blipId.trim();
     gateway.fetchRootSessionBootstrap(
@@ -1282,7 +1302,11 @@ public final class J2clComposeSurfaceController {
           try {
             request =
                 deltaFactory.createTaskToggleRequest(
-                    bootstrap.getAddress(), writeSession, trimmedBlipId, completed);
+                    bootstrap.getAddress(),
+                    writeSession,
+                    trimmedBlipId,
+                    completed,
+                    bodyItemCount);
           } catch (RuntimeException e) {
             // Toggling a task is best-effort; log telemetry and return.
             recordTaskToggleTelemetry(completed, "failure-build");
@@ -1309,10 +1333,17 @@ public final class J2clComposeSurfaceController {
    * carrying both annotations.
    */
   public void onTaskMetadataChanged(
-      final String blipId, final String assigneeAddress, final String dueDate) {
+      final String blipId,
+      final String assigneeAddress,
+      final String dueDate,
+      final int bodyItemCount) {
     if (signedOut) return;
     if (blipId == null || blipId.trim().isEmpty()) return;
     if (!hasSelectedWave(writeSession)) return;
+    if (bodyItemCount <= 0) {
+      recordTaskMetadataTelemetry("failure-build");
+      return;
+    }
     final J2clSidecarWriteSession submitSession = writeSession;
     final String trimmedBlipId = blipId.trim();
     final String normalizedAssignee = assigneeAddress == null ? "" : assigneeAddress.trim();
@@ -1334,7 +1365,8 @@ public final class J2clComposeSurfaceController {
                     writeSession,
                     trimmedBlipId,
                     normalizedAssignee,
-                    normalizedDue);
+                    normalizedDue,
+                    bodyItemCount);
           } catch (RuntimeException e) {
             recordTaskMetadataTelemetry("failure-build");
             return;
@@ -2272,8 +2304,12 @@ public final class J2clComposeSurfaceController {
 
       @Override
       public SidecarSubmitRequest createTaskToggleRequest(
-          String address, J2clSidecarWriteSession session, String blipId, boolean completed) {
-        return factory.taskToggleRequest(address, session, blipId, completed);
+          String address,
+          J2clSidecarWriteSession session,
+          String blipId,
+          boolean completed,
+          int bodyItemCount) {
+        return factory.taskToggleRequest(address, session, blipId, completed, bodyItemCount);
       }
 
       @Override
@@ -2282,8 +2318,10 @@ public final class J2clComposeSurfaceController {
           J2clSidecarWriteSession session,
           String blipId,
           String assigneeAddress,
-          String dueDate) {
-        return factory.taskMetadataRequest(address, session, blipId, assigneeAddress, dueDate);
+          String dueDate,
+          int bodyItemCount) {
+        return factory.taskMetadataRequest(
+            address, session, blipId, assigneeAddress, dueDate, bodyItemCount);
       }
 
       @Override
@@ -2300,8 +2338,11 @@ public final class J2clComposeSurfaceController {
 
       @Override
       public SidecarSubmitRequest createBlipDeleteRequest(
-          String address, J2clSidecarWriteSession session, String blipId) {
-        return factory.blipDeleteRequest(address, session, blipId);
+          String address,
+          J2clSidecarWriteSession session,
+          String blipId,
+          int bodyItemCount) {
+        return factory.blipDeleteRequest(address, session, blipId, bodyItemCount);
       }
     };
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -231,7 +231,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           if (listener == null) return;
           String blipId = eventDetailString(event, "blipId");
           boolean completed = eventDetailBoolean(event, "completed");
-          listener.onTaskToggled(blipId, completed);
+          int bodyItemCount = eventDetailInt(event, "bodySize", 0);
+          listener.onTaskToggled(blipId, completed, bodyItemCount);
         });
     DomGlobal.document.body.addEventListener(
         "wave-blip-task-metadata-changed",
@@ -240,7 +241,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           String blipId = eventDetailString(event, "blipId");
           String assignee = eventDetailString(event, "assigneeAddress");
           String due = dueDateToEpochMs(eventDetailString(event, "dueDate"));
-          listener.onTaskMetadataChanged(blipId, assignee, due);
+          int bodyItemCount = eventDetailInt(event, "bodySize", 0);
+          listener.onTaskMetadataChanged(blipId, assignee, due, bodyItemCount);
         });
     DomGlobal.document.body.addEventListener(
         "wavy-composer-mention-picked",
@@ -333,7 +335,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           String blipId = eventDetailString(event, "blipId");
           if (blipId == null || blipId.trim().isEmpty()) return;
           String waveId = eventDetailString(event, "waveId");
-          requestBlipDeleteConfirmation(blipId, waveId);
+          int bodyItemCount = eventDetailInt(event, "bodySize", 0);
+          requestBlipDeleteConfirmation(blipId, waveId, bodyItemCount);
         });
     DomGlobal.document.body.addEventListener(
         "wavy-confirm-resolved",
@@ -344,9 +347,13 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           String suffix = requestId.substring(BLIP_DELETE_REQUEST_PREFIX.length());
           int sep = suffix.indexOf('|');
           String blipId = sep >= 0 ? suffix.substring(0, sep) : suffix;
-          String expectedWaveId = sep >= 0 ? suffix.substring(sep + 1) : "";
+          String rest = sep >= 0 ? suffix.substring(sep + 1) : "";
+          int secondSep = rest.indexOf('|');
+          String expectedWaveId = secondSep >= 0 ? rest.substring(0, secondSep) : rest;
+          int bodyItemCount =
+              secondSep >= 0 ? parseInt(rest.substring(secondSep + 1), 0) : 0;
           if (confirmed && listener != null && !blipId.isEmpty()) {
-            listener.onDeleteBlipRequested(blipId, expectedWaveId);
+            listener.onDeleteBlipRequested(blipId, expectedWaveId, bodyItemCount);
           }
         });
   }
@@ -748,6 +755,17 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     }
   }
 
+  private static int parseInt(String value, int fallback) {
+    if (value == null || value.isEmpty()) {
+      return fallback;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException ignored) {
+      return fallback;
+    }
+  }
+
   private static boolean eventDetailBoolean(Event event, String key) {
     Object detail = Js.asPropertyMap(event).get("detail");
     if (detail == null) {
@@ -941,8 +959,14 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
    * requestId. The view caches no per-request state — the requestId
    * encodes the blip id so the resolved-listener can route directly.
    */
-  private void requestBlipDeleteConfirmation(String blipId, String waveId) {
-    String requestId = BLIP_DELETE_REQUEST_PREFIX + blipId + "|" + (waveId != null ? waveId : "");
+  private void requestBlipDeleteConfirmation(String blipId, String waveId, int bodyItemCount) {
+    String requestId =
+        BLIP_DELETE_REQUEST_PREFIX
+            + blipId
+            + "|"
+            + (waveId != null ? waveId : "")
+            + "|"
+            + Math.max(0, bodyItemCount);
     JsPropertyMap<Object> detail = Js.uncheckedCast(JsPropertyMap.of());
     detail.set("requestId", requestId);
     detail.set("message", "Delete this blip?");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -72,6 +72,12 @@ public final class J2clReadBlip {
    * when the annotation is absent or unparseable.
    */
   private final long taskDueTimestamp;
+  /**
+   * Issue #1129: authoritative wavelet document item count for this blip
+   * body, including characters and element starts/ends. Annotation writers
+   * need this to retain across the body before closing the annotation.
+   */
+  private final int bodyItemCount;
 
   public J2clReadBlip(String blipId, String text) {
     this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
@@ -166,6 +172,40 @@ public final class J2clReadBlip {
       boolean taskDone,
       String taskAssignee,
       long taskDueTimestamp) {
+    this(
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        deleted,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp,
+        /* bodyItemCount= */ 0);
+  }
+
+  public J2clReadBlip(
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean deleted,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
     this.attachments =
@@ -183,6 +223,7 @@ public final class J2clReadBlip {
     this.taskDone = taskDone;
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
+    this.bodyItemCount = Math.max(0, bodyItemCount);
   }
 
   /** Builder-style copy that flips the unread flag without re-typing the rest. */
@@ -204,7 +245,8 @@ public final class J2clReadBlip {
         deleted,
         taskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        bodyItemCount);
   }
 
   /**
@@ -231,7 +273,8 @@ public final class J2clReadBlip {
         deleted,
         nextTaskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        bodyItemCount);
   }
 
   public String getBlipId() {
@@ -310,5 +353,9 @@ public final class J2clReadBlip {
    */
   public long getTaskDueTimestamp() {
     return taskDueTimestamp;
+  }
+
+  public int getBodyItemCount() {
+    return bodyItemCount;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -5,25 +5,48 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 
 /** Parsed text and attachment placeholders extracted from a selected-wave blip snapshot. */
 public final class J2clReadBlipContent {
   private static final String IMAGE_CLOSE_TAG = "</image>";
+  private static final String ANNOTATION_PI_PREFIX = "<?a";
+  private static final String ANNOTATION_PI_SUFFIX = "?>";
+  private static final String TASK_DONE_ANNOTATION = "task/done";
+  private static final String TASK_ASSIGNEE_ANNOTATION = "task/assignee";
+  private static final String TASK_DUE_ANNOTATION = "task/dueTs";
+  private static final String TOMBSTONE_DELETED_ANNOTATION = "tombstone/deleted";
+
   private final String text;
   private final List<J2clAttachmentRenderModel> attachments;
+  private final boolean taskDone;
+  private final String taskAssignee;
+  private final long taskDueTimestamp;
+  private final boolean deleted;
 
-  private J2clReadBlipContent(String text, List<J2clAttachmentRenderModel> attachments) {
+  private J2clReadBlipContent(
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      boolean deleted) {
     this.text = text == null ? "" : text;
     this.attachments =
         attachments == null
             ? Collections.<J2clAttachmentRenderModel>emptyList()
             : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
+    this.taskDone = taskDone;
+    this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
+    this.taskDueTimestamp = taskDueTimestamp;
+    this.deleted = deleted;
   }
 
   public static J2clReadBlipContent parseRawSnapshot(String rawSnapshot) {
     // Sidecar fragments currently provide DocOp debug XML, not a browser XML document. Keep this
     // parser narrow to the Wave image doodad shape and treat malformed input as visible text.
     String raw = rawSnapshot == null ? "" : rawSnapshot;
+    AnnotationSnapshot annotations = parseAnnotationSnapshot(raw);
     List<J2clAttachmentRenderModel> attachments =
         new ArrayList<J2clAttachmentRenderModel>();
     StringBuilder visibleText = new StringBuilder(raw.length());
@@ -64,7 +87,12 @@ public final class J2clReadBlipContent {
       }
     }
     return new J2clReadBlipContent(
-        decodeEntities(stripTags(visibleText.toString())), attachments);
+        decodeEntities(stripTags(visibleText.toString())),
+        attachments,
+        annotations.taskDone,
+        annotations.taskAssignee,
+        annotations.taskDueTimestamp,
+        annotations.deleted);
   }
 
   public String getText() {
@@ -73,6 +101,22 @@ public final class J2clReadBlipContent {
 
   public List<J2clAttachmentRenderModel> getAttachments() {
     return attachments;
+  }
+
+  public boolean isTaskDone() {
+    return taskDone;
+  }
+
+  public String getTaskAssignee() {
+    return taskAssignee;
+  }
+
+  public long getTaskDueTimestamp() {
+    return taskDueTimestamp;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
   }
 
   private static String attributeValue(String tag, String name) {
@@ -200,6 +244,105 @@ public final class J2clReadBlipContent {
     }
   }
 
+  private static AnnotationSnapshot parseAnnotationSnapshot(String raw) {
+    AnnotationSnapshot snapshot = new AnnotationSnapshot();
+    int cursor = 0;
+    while (cursor < raw.length()) {
+      int start = raw.indexOf(ANNOTATION_PI_PREFIX, cursor);
+      if (start < 0) {
+        break;
+      }
+      int end = raw.indexOf(ANNOTATION_PI_SUFFIX, start + ANNOTATION_PI_PREFIX.length());
+      if (end < 0) {
+        break;
+      }
+      applyAnnotationInstruction(
+          raw.substring(start + ANNOTATION_PI_PREFIX.length(), end), snapshot);
+      cursor = end + ANNOTATION_PI_SUFFIX.length();
+    }
+    return snapshot;
+  }
+
+  private static void applyAnnotationInstruction(String instruction, AnnotationSnapshot snapshot) {
+    int cursor = 0;
+    while (cursor < instruction.length()) {
+      int keyStart = instruction.indexOf('"', cursor);
+      if (keyStart < 0) {
+        return;
+      }
+      QuotedToken key = readQuotedToken(instruction, keyStart);
+      if (key == null) {
+        return;
+      }
+      cursor = skipWhitespace(instruction, key.end + 1);
+      if (cursor >= instruction.length() || instruction.charAt(cursor) != '=') {
+        // DocOpUtil renders annotation ends as <?a "key"?>. Ends do not change
+        // the persisted task/metadata value we need for a fragment snapshot.
+        continue;
+      }
+      cursor = skipWhitespace(instruction, cursor + 1);
+      QuotedToken value = readQuotedToken(instruction, cursor);
+      if (value == null) {
+        return;
+      }
+      applyAnnotationValue(key.value, value.value, snapshot);
+      cursor = value.end + 1;
+    }
+  }
+
+  private static void applyAnnotationValue(
+      String key, String value, AnnotationSnapshot snapshot) {
+    if (TASK_DONE_ANNOTATION.equals(key)) {
+      snapshot.taskDone = "true".equals(value);
+    } else if (TASK_ASSIGNEE_ANNOTATION.equals(key)) {
+      snapshot.taskAssignee = value == null ? "" : value.trim();
+    } else if (TASK_DUE_ANNOTATION.equals(key)) {
+      snapshot.taskDueTimestamp = parseTimestamp(value);
+    } else if (TOMBSTONE_DELETED_ANNOTATION.equals(key)) {
+      snapshot.deleted = "true".equals(value);
+    }
+  }
+
+  private static QuotedToken readQuotedToken(String value, int quoteStart) {
+    if (quoteStart < 0 || quoteStart >= value.length() || value.charAt(quoteStart) != '"') {
+      return null;
+    }
+    StringBuilder token = new StringBuilder();
+    boolean escaping = false;
+    for (int i = quoteStart + 1; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (escaping) {
+        token.append('\\').append(c);
+        escaping = false;
+      } else if (c == '\\') {
+        escaping = true;
+      } else if (c == '"') {
+        return new QuotedToken(decodeAnnotationToken(token.toString()), i);
+      } else {
+        token.append(c);
+      }
+    }
+    return null;
+  }
+
+  private static String decodeAnnotationToken(String value) {
+    return decodeEntities(value)
+        .replace("\\q", "?")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\");
+  }
+
+  private static long parseTimestamp(String value) {
+    if (value == null || value.isEmpty()) {
+      return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException ex) {
+      return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    }
+  }
+
   private static String decodeEntities(String value) {
     return value.replace("&quot;", "\"")
         .replace("&apos;", "'")
@@ -211,5 +354,22 @@ public final class J2clReadBlipContent {
   private static String firstNonEmpty(String first, String fallback) {
     String normalized = first == null ? "" : first.trim();
     return normalized.isEmpty() ? fallback : normalized;
+  }
+
+  private static final class AnnotationSnapshot {
+    private boolean taskDone;
+    private String taskAssignee = "";
+    private long taskDueTimestamp = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
+    private boolean deleted;
+  }
+
+  private static final class QuotedToken {
+    private final String value;
+    private final int end;
+
+    private QuotedToken(String value, int end) {
+      this.value = value == null ? "" : value;
+      this.end = end;
+    }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -665,7 +665,8 @@ public final class J2clReadSurfaceDomRenderer {
               /* deleted= */ false,
               /* taskDone= */ entry.isTaskDone(),
               /* taskAssignee= */ entry.getTaskAssignee(),
-              /* taskDueTimestamp= */ entry.getTaskDueTimestamp());
+              /* taskDueTimestamp= */ entry.getTaskDueTimestamp(),
+              /* bodyItemCount= */ entry.getBodyItemCount());
       HTMLElement blipElement = renderBlip(blip, blipIndex++);
       // V-4 (#1102): mark blip depth so the larger root avatar paints
       // and the timestamp picks up the ` · root` suffix. Check parent
@@ -1082,7 +1083,8 @@ public final class J2clReadSurfaceDomRenderer {
         blip.getBlipId(),
         blip.isTaskDone(),
         blip.getTaskAssignee(),
-        blip.getTaskDueTimestamp());
+        blip.getTaskDueTimestamp(),
+        blip.getBodyItemCount());
 
     // The renderer doesn't know the parent wave id (it lives one layer up
     // in J2clSelectedWaveView). The view sets `data-wave-id` on the host
@@ -1238,7 +1240,8 @@ public final class J2clReadSurfaceDomRenderer {
       String blipId,
       boolean modelTaskDone,
       String taskAssignee,
-      long taskDueTimestamp) {
+      long taskDueTimestamp,
+      int bodyItemCount) {
     if (element == null) {
       return;
     }
@@ -1278,6 +1281,11 @@ public final class J2clReadSurfaceDomRenderer {
       element.removeAttribute("data-task-due-date");
     } else {
       element.setAttribute("data-task-due-date", dueDate);
+    }
+    if (bodyItemCount > 0) {
+      element.setAttribute("data-blip-doc-size", String.valueOf(bodyItemCount));
+    } else {
+      element.removeAttribute("data-blip-doc-size");
     }
   }
 
@@ -2502,7 +2510,8 @@ public final class J2clReadSurfaceDomRenderer {
         // and the strikethrough actually repaints.
         && left.isTaskDone() == right.isTaskDone()
         && left.getTaskAssignee().equals(right.getTaskAssignee())
-        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp();
+        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp()
+        && left.getBodyItemCount() == right.getBodyItemCount();
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
@@ -2579,7 +2588,8 @@ public final class J2clReadSurfaceDomRenderer {
         // check on this code path too.
         && left.isTaskDone() == right.isTaskDone()
         && left.getTaskAssignee().equals(right.getTaskAssignee())
-        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp();
+        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp()
+        && left.getBodyItemCount() == right.getBodyItemCount();
   }
 
   private HTMLElement renderedBlipById(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -36,6 +36,8 @@ public final class J2clReadWindowEntry {
   private final String taskAssignee;
   /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskDueTimestamp()}. */
   private final long taskDueTimestamp;
+  /** Issue #1129: see {@link J2clReadBlip#getBodyItemCount()}. */
+  private final int bodyItemCount;
 
   private J2clReadWindowEntry(
       String segment,
@@ -54,7 +56,8 @@ public final class J2clReadWindowEntry {
       boolean hasMention,
       boolean taskDone,
       String taskAssignee,
-      long taskDueTimestamp) {
+      long taskDueTimestamp,
+      int bodyItemCount) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
@@ -75,6 +78,7 @@ public final class J2clReadWindowEntry {
     this.taskDone = taskDone;
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
+    this.bodyItemCount = Math.max(0, bodyItemCount);
   }
 
   public static J2clReadWindowEntry loaded(
@@ -112,7 +116,8 @@ public final class J2clReadWindowEntry {
         /* hasMention= */ false,
         /* taskDone= */ false,
         /* taskAssignee= */ "",
-        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+        /* bodyItemCount= */ 0);
   }
 
   /**
@@ -177,6 +182,44 @@ public final class J2clReadWindowEntry {
       boolean taskDone,
       String taskAssignee,
       long taskDueTimestamp) {
+    return loadedWithTaskMetadata(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp,
+        /* bodyItemCount= */ 0);
+  }
+
+  public static J2clReadWindowEntry loadedWithTaskMetadata(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount) {
     return new J2clReadWindowEntry(
         segment,
         fromVersion,
@@ -194,7 +237,8 @@ public final class J2clReadWindowEntry {
         hasMention,
         taskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        bodyItemCount);
   }
 
   public static J2clReadWindowEntry placeholder(
@@ -216,7 +260,8 @@ public final class J2clReadWindowEntry {
         /* hasMention= */ false,
         /* taskDone= */ false,
         /* taskAssignee= */ "",
-        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP);
+        /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+        /* bodyItemCount= */ 0);
   }
 
   /** Returns a copy of this entry with the unread flag toggled. */
@@ -241,7 +286,8 @@ public final class J2clReadWindowEntry {
         hasMention,
         taskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        bodyItemCount);
   }
 
   /**
@@ -269,7 +315,8 @@ public final class J2clReadWindowEntry {
         hasMention,
         nextTaskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        bodyItemCount);
   }
 
   public String getSegment() {
@@ -342,5 +389,9 @@ public final class J2clReadWindowEntry {
   /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#getTaskDueTimestamp()}. */
   public long getTaskDueTimestamp() {
     return taskDueTimestamp;
+  }
+
+  public int getBodyItemCount() {
+    return bodyItemCount;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -108,12 +108,22 @@ public final class J2clRichContentDeltaFactory {
    */
   public SidecarSubmitRequest taskToggleRequest(
       String address, J2clSidecarWriteSession session, String blipId, boolean completed) {
+    return taskToggleRequest(address, session, blipId, completed, 0);
+  }
+
+  public SidecarSubmitRequest taskToggleRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      boolean completed,
+      int bodyItemCount) {
     return buildBlipAnnotationRequest(
         address,
         session,
         blipId,
         new String[] {"task/done"},
-        new String[] {completed ? "true" : "false"});
+        new String[] {completed ? "true" : "false"},
+        bodyItemCount);
   }
 
   /**
@@ -142,6 +152,16 @@ public final class J2clRichContentDeltaFactory {
       String blipId,
       String assigneeAddress,
       String dueDate) {
+    return taskMetadataRequest(address, session, blipId, assigneeAddress, dueDate, 0);
+  }
+
+  public SidecarSubmitRequest taskMetadataRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      String assigneeAddress,
+      String dueDate,
+      int bodyItemCount) {
     String assignee = assigneeAddress == null ? "" : assigneeAddress.trim();
     String due = normalizeDueTimestamp(dueDate);
     return buildBlipAnnotationRequest(
@@ -149,7 +169,8 @@ public final class J2clRichContentDeltaFactory {
         session,
         blipId,
         new String[] {"task/assignee", "task/dueTs"},
-        new String[] {assignee, due});
+        new String[] {assignee, due},
+        bodyItemCount);
   }
 
   /**
@@ -178,12 +199,18 @@ public final class J2clRichContentDeltaFactory {
    */
   public SidecarSubmitRequest blipDeleteRequest(
       String address, J2clSidecarWriteSession session, String blipId) {
+    return blipDeleteRequest(address, session, blipId, 0);
+  }
+
+  public SidecarSubmitRequest blipDeleteRequest(
+      String address, J2clSidecarWriteSession session, String blipId, int bodyItemCount) {
     return buildBlipAnnotationRequest(
         address,
         session,
         blipId,
         new String[] {"tombstone/deleted"},
-        new String[] {"true"});
+        new String[] {"true"},
+        bodyItemCount);
   }
 
   /**
@@ -656,7 +683,8 @@ public final class J2clRichContentDeltaFactory {
       J2clSidecarWriteSession session,
       String blipId,
       String[] keys,
-      String[] values) {
+      String[] values,
+      int bodyItemCount) {
     requirePresent(session, "Missing write session.");
     if (keys == null || values == null || keys.length != values.length || keys.length == 0) {
       throw new IllegalArgumentException("Mismatched annotation keys/values.");
@@ -673,6 +701,7 @@ public final class J2clRichContentDeltaFactory {
     if (baseVersion < 0) {
       throw new IllegalArgumentException("Invalid write-session base version.");
     }
+    int retainedBodyItemCount = requirePositiveBodyItemCount(bodyItemCount);
     StringBuilder components = new StringBuilder();
     components.append("{\"1\":{\"3\":[");
     for (int i = 0; i < keys.length; i++) {
@@ -686,11 +715,8 @@ public final class J2clRichContentDeltaFactory {
     }
     components.append("]}}");
     appendComponentSeparator(components);
-    // No characters in between — the annotation brackets the empty
-    // body span. The supplement live-update interprets a no-text
-    // boundary as "apply this annotation to the whole body". Mirror
-    // the GWT supplement-writer shape here so the read-side parity
-    // assertion holds.
+    appendRetain(components, retainedBodyItemCount);
+    appendComponentSeparator(components);
     components.append("{\"1\":{\"2\":[");
     for (int i = 0; i < keys.length; i++) {
       if (i > 0) components.append(",");
@@ -707,6 +733,13 @@ public final class J2clRichContentDeltaFactory {
     String deltaJson =
         buildDeltaJson(baseVersion, historyHash, normalizedAddress, operation.toString());
     return new SidecarSubmitRequest(buildWaveletName(selectedWaveId), deltaJson, channelId);
+  }
+
+  private static int requirePositiveBodyItemCount(int bodyItemCount) {
+    if (bodyItemCount <= 0) {
+      throw new IllegalArgumentException("Missing blip body item count.");
+    }
+    return bodyItemCount;
   }
 
   public SidecarSubmitRequest createReplyRequest(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1090,7 +1090,8 @@ public final class J2clSelectedWaveController
         existing.isDeleted(),
         existing.isTaskDone(),
         existing.getTaskAssignee(),
-        existing.getTaskDueTimestamp());
+        existing.getTaskDueTimestamp(),
+        existing.getBodyItemCount());
   }
 
   private static String nullToEmpty(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -534,7 +534,8 @@ public final class J2clSelectedWaveProjector {
               /* deleted= */ documentIsDeleted(document),
               /* taskDone= */ documentTaskDone(document),
               /* taskAssignee= */ documentTaskAssignee(document),
-              /* taskDueTimestamp= */ documentTaskDueTimestamp(document)));
+              /* taskDueTimestamp= */ documentTaskDueTimestamp(document),
+              /* bodyItemCount= */ document.getBodyItemCount()));
     }
     return blips;
   }
@@ -591,7 +592,8 @@ public final class J2clSelectedWaveProjector {
               /* deleted= */ documentIsDeleted(doc) || blip.isDeleted(),
               /* taskDone= */ documentTaskDone(doc),
               /* taskAssignee= */ documentTaskAssignee(doc),
-              /* taskDueTimestamp= */ documentTaskDueTimestamp(doc)));
+              /* taskDueTimestamp= */ documentTaskDueTimestamp(doc),
+              /* bodyItemCount= */ doc.getBodyItemCount()));
     }
     return enriched;
   }
@@ -644,7 +646,8 @@ public final class J2clSelectedWaveProjector {
                 blip.isDeleted(),
                 blip.isTaskDone(),
                 blip.getTaskAssignee(),
-                blip.getTaskDueTimestamp()));
+                blip.getTaskDueTimestamp(),
+                blip.getBodyItemCount()));
       } else {
         patched.add(blip);
       }
@@ -779,7 +782,8 @@ public final class J2clSelectedWaveProjector {
         deleted,
         taskDone,
         taskAssignee,
-        taskDueTimestamp);
+        taskDueTimestamp,
+        blip.getBodyItemCount());
   }
 
   /**
@@ -864,7 +868,11 @@ public final class J2clSelectedWaveProjector {
               entry.getThreadId(),
               existing.isUnread(),
               existing.hasMention(),
-              existing.isDeleted()));
+              existing.isDeleted(),
+              existing.isTaskDone(),
+              existing.getTaskAssignee(),
+              existing.getTaskDueTimestamp(),
+              existing.getBodyItemCount()));
     }
     // Append any blip that the manifest didn't reference so we don't
     // silently drop content from non-conversational data documents.
@@ -943,7 +951,8 @@ public final class J2clSelectedWaveProjector {
               blip.hasMention(),
               blip.isTaskDone(),
               blip.getTaskAssignee(),
-              blip.getTaskDueTimestamp());
+              blip.getTaskDueTimestamp(),
+              blip.getBodyItemCount());
       enriched.add(next);
       changed = true;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
@@ -114,7 +115,15 @@ public final class J2clSelectedWaveViewportState {
       long version = document.getLastModifiedVersion();
       minVersion = Math.min(minVersion, version);
       maxVersion = Math.max(maxVersion, version);
-      entries.add(Entry.loaded(segment, version, version, textContent, 0, 0));
+      entries.add(
+          Entry.loaded(
+              segment,
+              version,
+              version,
+              textContent,
+              0,
+              0,
+              document.getBodyItemCount()));
     }
     if (entries.isEmpty()) {
       return empty();
@@ -376,9 +385,37 @@ public final class J2clSelectedWaveViewportState {
             new J2clReadBlip(
                 entry.getBlipId(),
                 content.getText(),
-                resolveAttachments(entry, content)));
+                resolveAttachments(entry, content),
+                /* authorId= */ "",
+                /* authorDisplayName= */ "",
+                /* lastModifiedTimeMillis= */ 0L,
+                /* parentBlipId= */ "",
+                /* threadId= */ "",
+                /* unread= */ false,
+                /* hasMention= */ false,
+                /* deleted= */ content.isDeleted(),
+                /* taskDone= */ content.isTaskDone(),
+                /* taskAssignee= */ content.getTaskAssignee(),
+                /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
+                entry.getBodyItemCount()));
       } else {
-        readBlips.add(new J2clReadBlip(entry.getBlipId(), entry.getRawSnapshot()));
+        readBlips.add(
+            new J2clReadBlip(
+                entry.getBlipId(),
+                entry.getRawSnapshot(),
+                Collections.<J2clAttachmentRenderModel>emptyList(),
+                /* authorId= */ "",
+                /* authorDisplayName= */ "",
+                /* lastModifiedTimeMillis= */ 0L,
+                /* parentBlipId= */ "",
+                /* threadId= */ "",
+                /* unread= */ false,
+                /* hasMention= */ false,
+                /* deleted= */ false,
+                /* taskDone= */ false,
+                /* taskAssignee= */ "",
+                /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+                entry.getBodyItemCount()));
       }
     }
     return readBlips;
@@ -394,21 +431,44 @@ public final class J2clSelectedWaveViewportState {
         if (entry.shouldParseAttachmentElements()) {
           J2clReadBlipContent content = entry.getParsedContent();
           windowEntries.add(
-              J2clReadWindowEntry.loaded(
+              J2clReadWindowEntry.loadedWithTaskMetadata(
                   entry.getSegment(),
                   entry.getFromVersion(),
                   entry.getToVersion(),
                   entry.getBlipId(),
                   content.getText(),
-                  resolveAttachments(entry, content)));
+                  resolveAttachments(entry, content),
+                  /* authorId= */ "",
+                  /* authorDisplayName= */ "",
+                  /* lastModifiedTimeMillis= */ 0L,
+                  /* parentBlipId= */ "",
+                  /* threadId= */ "",
+                  /* unread= */ false,
+                  /* hasMention= */ false,
+                  /* taskDone= */ content.isTaskDone(),
+                  /* taskAssignee= */ content.getTaskAssignee(),
+                  /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
+                  entry.getBodyItemCount()));
         } else {
           windowEntries.add(
-              J2clReadWindowEntry.loaded(
+              J2clReadWindowEntry.loadedWithTaskMetadata(
                   entry.getSegment(),
                   entry.getFromVersion(),
                   entry.getToVersion(),
                   entry.getBlipId(),
-                  entry.getRawSnapshot()));
+                  entry.getRawSnapshot(),
+                  Collections.<J2clAttachmentRenderModel>emptyList(),
+                  /* authorId= */ "",
+                  /* authorDisplayName= */ "",
+                  /* lastModifiedTimeMillis= */ 0L,
+                  /* parentBlipId= */ "",
+                  /* threadId= */ "",
+                  /* unread= */ false,
+                  /* hasMention= */ false,
+                  /* taskDone= */ false,
+                  /* taskAssignee= */ "",
+                  /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+                  entry.getBodyItemCount()));
         }
       } else {
         windowEntries.add(
@@ -509,6 +569,7 @@ public final class J2clSelectedWaveViewportState {
     private final String rawSnapshot;
     private final int adjustOperationCount;
     private final int diffOperationCount;
+    private final int bodyItemCount;
     private final boolean loaded;
     private final boolean parseAttachmentElements;
     private final List<J2clAttachmentRenderModel> attachmentOverrides;
@@ -524,6 +585,7 @@ public final class J2clSelectedWaveViewportState {
         String rawSnapshot,
         int adjustOperationCount,
         int diffOperationCount,
+        int bodyItemCount,
         boolean loaded,
         boolean parseAttachmentElements,
         List<J2clAttachmentRenderModel> attachmentOverrides,
@@ -534,6 +596,7 @@ public final class J2clSelectedWaveViewportState {
       this.rawSnapshot = rawSnapshot == null ? "" : rawSnapshot;
       this.adjustOperationCount = adjustOperationCount;
       this.diffOperationCount = diffOperationCount;
+      this.bodyItemCount = Math.max(0, bodyItemCount);
       this.loaded = loaded;
       this.parseAttachmentElements = parseAttachmentElements;
       this.attachmentOverrides =
@@ -556,6 +619,7 @@ public final class J2clSelectedWaveViewportState {
           fragment.getRawSnapshot(),
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
+          fragment.getBodyItemCount(),
           true,
           true,
           Collections.<J2clAttachmentRenderModel>emptyList(),
@@ -573,6 +637,7 @@ public final class J2clSelectedWaveViewportState {
           fragment.getRawSnapshot(),
           fragment.getAdjustOperationCount(),
           fragment.getDiffOperationCount(),
+          fragment.getBodyItemCount(),
           true,
           true,
           Collections.<J2clAttachmentRenderModel>emptyList(),
@@ -594,6 +659,26 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          plainTextItemCount(rawSnapshot),
+          false);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        int bodyItemCount) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          bodyItemCount,
           false);
     }
 
@@ -612,6 +697,30 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          parseAttachmentElements
+              ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
+              : plainTextItemCount(rawSnapshot),
+          parseAttachmentElements,
+          Collections.<J2clAttachmentRenderModel>emptyList());
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        int bodyItemCount,
+        boolean parseAttachmentElements) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          bodyItemCount,
           parseAttachmentElements,
           Collections.<J2clAttachmentRenderModel>emptyList());
     }
@@ -632,6 +741,32 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          parseAttachmentElements
+              ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
+              : plainTextItemCount(rawSnapshot),
+          parseAttachmentElements,
+          attachmentOverrides,
+          null);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        int bodyItemCount,
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          bodyItemCount,
           parseAttachmentElements,
           attachmentOverrides,
           null);
@@ -647,6 +782,32 @@ public final class J2clSelectedWaveViewportState {
         boolean parseAttachmentElements,
         List<J2clAttachmentRenderModel> attachmentOverrides,
         J2clReadBlipContent parsedContent) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          parseAttachmentElements
+              ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
+              : plainTextItemCount(rawSnapshot),
+          parseAttachmentElements,
+          attachmentOverrides,
+          parsedContent);
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        int bodyItemCount,
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides,
+        J2clReadBlipContent parsedContent) {
       return new Entry(
           segment,
           fromVersion,
@@ -654,6 +815,7 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          bodyItemCount,
           true,
           parseAttachmentElements,
           attachmentOverrides,
@@ -666,6 +828,7 @@ public final class J2clSelectedWaveViewportState {
           fromVersion,
           toVersion,
           "",
+          0,
           0,
           0,
           false,
@@ -693,6 +856,7 @@ public final class J2clSelectedWaveViewportState {
                 rawSnapshot,
                 adjustOperationCount,
                 diffOperationCount,
+                bodyItemCount,
                 parseAttachmentElements,
                 Collections.<J2clAttachmentRenderModel>emptyList(),
                 content);
@@ -745,6 +909,7 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          bodyItemCount,
           parseAttachmentElements,
           nextAttachments,
           content);
@@ -763,6 +928,7 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
+          bodyItemCount,
           parseAttachmentElements,
           existing.attachmentOverrides,
           existing.parsedContent);
@@ -792,6 +958,10 @@ public final class J2clSelectedWaveViewportState {
       return diffOperationCount;
     }
 
+    public int getBodyItemCount() {
+      return bodyItemCount;
+    }
+
     public boolean isLoaded() {
       return loaded;
     }
@@ -818,6 +988,10 @@ public final class J2clSelectedWaveViewportState {
     public String getBlipId() {
       String blipId = blipIdOrNull(segment);
       return blipId == null ? "" : blipId;
+    }
+
+    private static int plainTextItemCount(String rawSnapshot) {
+      return rawSnapshot == null ? 0 : rawSnapshot.length();
     }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponse.java
@@ -83,10 +83,16 @@ public final class SidecarFragmentsResponse {
     if (rawFragments != null) {
       for (Object rawFragment : asList(rawFragments)) {
         Map<String, Object> fragment = getObject(rawFragment);
+        String rawSnapshot = getNullableString(fragment, "rawSnapshot");
+        int bodyItemCount =
+            fragment.containsKey("bodyItemCount")
+                ? (int) getOptionalLong(fragment, "bodyItemCount")
+                : SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot);
         entries.add(
             new SidecarSelectedWaveFragment(
                 getRequiredString(fragment, "segment"),
-                getNullableString(fragment, "rawSnapshot"),
+                rawSnapshot,
+                bodyItemCount,
                 // TODO(#967 Task 5): decode operation bodies when growth windows apply deltas.
                 getArrayLength(fragment.get("adjust")),
                 getArrayLength(fragment.get("diff"))));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
@@ -12,6 +12,7 @@ public final class SidecarSelectedWaveDocument {
   private final long lastModifiedVersion;
   private final long lastModifiedTime;
   private final String textContent;
+  private final int bodyItemCount;
   private final List<SidecarAnnotationRange> annotationRanges;
   private final List<SidecarReactionEntry> reactionEntries;
 
@@ -27,6 +28,7 @@ public final class SidecarSelectedWaveDocument {
         lastModifiedVersion,
         lastModifiedTime,
         textContent,
+        /* bodyItemCount= */ 0,
         Collections.<SidecarAnnotationRange>emptyList(),
         Collections.<SidecarReactionEntry>emptyList());
   }
@@ -39,11 +41,32 @@ public final class SidecarSelectedWaveDocument {
       String textContent,
       List<SidecarAnnotationRange> annotationRanges,
       List<SidecarReactionEntry> reactionEntries) {
+    this(
+        documentId,
+        author,
+        lastModifiedVersion,
+        lastModifiedTime,
+        textContent,
+        /* bodyItemCount= */ 0,
+        annotationRanges,
+        reactionEntries);
+  }
+
+  public SidecarSelectedWaveDocument(
+      String documentId,
+      String author,
+      long lastModifiedVersion,
+      long lastModifiedTime,
+      String textContent,
+      int bodyItemCount,
+      List<SidecarAnnotationRange> annotationRanges,
+      List<SidecarReactionEntry> reactionEntries) {
     this.documentId = documentId;
     this.author = author;
     this.lastModifiedVersion = lastModifiedVersion;
     this.lastModifiedTime = lastModifiedTime;
     this.textContent = textContent;
+    this.bodyItemCount = Math.max(0, bodyItemCount);
     this.annotationRanges =
         annotationRanges == null
             ? Collections.<SidecarAnnotationRange>emptyList()
@@ -72,6 +95,10 @@ public final class SidecarSelectedWaveDocument {
 
   public String getTextContent() {
     return textContent;
+  }
+
+  public int getBodyItemCount() {
+    return bodyItemCount;
   }
 
   public List<SidecarAnnotationRange> getAnnotationRanges() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragment.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveFragment.java
@@ -3,13 +3,29 @@ package org.waveprotocol.box.j2cl.transport;
 public final class SidecarSelectedWaveFragment {
   private final String segment;
   private final String rawSnapshot;
+  private final int bodyItemCount;
   private final int adjustOperationCount;
   private final int diffOperationCount;
 
   public SidecarSelectedWaveFragment(
       String segment, String rawSnapshot, int adjustOperationCount, int diffOperationCount) {
+    this(
+        segment,
+        rawSnapshot,
+        estimateBodyItemCount(rawSnapshot),
+        adjustOperationCount,
+        diffOperationCount);
+  }
+
+  public SidecarSelectedWaveFragment(
+      String segment,
+      String rawSnapshot,
+      int bodyItemCount,
+      int adjustOperationCount,
+      int diffOperationCount) {
     this.segment = segment;
     this.rawSnapshot = rawSnapshot;
+    this.bodyItemCount = Math.max(0, bodyItemCount);
     this.adjustOperationCount = adjustOperationCount;
     this.diffOperationCount = diffOperationCount;
   }
@@ -22,11 +38,85 @@ public final class SidecarSelectedWaveFragment {
     return rawSnapshot;
   }
 
+  public int getBodyItemCount() {
+    return bodyItemCount;
+  }
+
   public int getAdjustOperationCount() {
     return adjustOperationCount;
   }
 
   public int getDiffOperationCount() {
     return diffOperationCount;
+  }
+
+  public static int estimateBodyItemCount(String rawSnapshot) {
+    if (rawSnapshot == null || rawSnapshot.isEmpty()) {
+      return 0;
+    }
+    int count = 0;
+    int cursor = 0;
+    while (cursor < rawSnapshot.length()) {
+      int tagStart = rawSnapshot.indexOf('<', cursor);
+      if (tagStart < 0) {
+        count += decodedTextLength(rawSnapshot, cursor, rawSnapshot.length());
+        break;
+      }
+      if (tagStart > cursor) {
+        count += decodedTextLength(rawSnapshot, cursor, tagStart);
+      }
+      int tagEnd = findTagEnd(rawSnapshot, tagStart + 1);
+      if (tagEnd < 0) {
+        count += decodedTextLength(rawSnapshot, tagStart, rawSnapshot.length());
+        break;
+      }
+      String tag = rawSnapshot.substring(tagStart + 1, tagEnd).trim();
+      cursor = tagEnd + 1;
+      if (tag.isEmpty() || tag.startsWith("?") || tag.startsWith("!")) {
+        continue;
+      }
+      count++;
+      if (!tag.startsWith("/") && tag.endsWith("/")) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int findTagEnd(String rawSnapshot, int cursor) {
+    char quote = 0;
+    for (int i = cursor; i < rawSnapshot.length(); i++) {
+      char c = rawSnapshot.charAt(i);
+      if (quote != 0) {
+        if (c == quote) {
+          quote = 0;
+        }
+        continue;
+      }
+      if (c == '"' || c == '\'') {
+        quote = c;
+      } else if (c == '>') {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static int decodedTextLength(String value, int start, int end) {
+    int length = 0;
+    int cursor = start;
+    while (cursor < end) {
+      if (value.charAt(cursor) == '&') {
+        int semi = value.indexOf(';', cursor + 1);
+        if (semi > cursor && semi < end) {
+          length++;
+          cursor = semi + 1;
+          continue;
+        }
+      }
+      length++;
+      cursor++;
+    }
+    return length;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -115,6 +115,7 @@ public final class SidecarTransportCodec {
                 getLong(document, "5"),
                 getLong(document, "6"),
                 extraction.textContent,
+                extraction.bodyItemCount,
                 extraction.annotationRanges,
                 extraction.reactionEntries));
         if ("conversation".equals(documentId) && conversationManifest.isEmpty()) {
@@ -509,10 +510,12 @@ public final class SidecarTransportCodec {
     if (rawComponents == null) {
       return new DocumentExtraction(
           "",
+          0,
           new ArrayList<SidecarAnnotationRange>(),
           new ArrayList<SidecarReactionEntry>());
     }
     StringBuilder text = new StringBuilder();
+    int bodyItemCount = 0;
     Map<String, ActiveAnnotation> activeAnnotations =
         new LinkedHashMap<String, ActiveAnnotation>();
     List<SidecarAnnotationRange> annotationRanges = new ArrayList<SidecarAnnotationRange>();
@@ -531,10 +534,15 @@ public final class SidecarTransportCodec {
         continue;
       }
       if (component.containsKey("2")) {
-        text.append(getString(component, "2"));
+        String characters = getString(component, "2");
+        if (characters != null) {
+          text.append(characters);
+          bodyItemCount += characters.length();
+        }
         continue;
       }
       if (component.containsKey("3")) {
+        bodyItemCount++;
         Map<String, Object> elementStart = getOptionalObject(component, "3");
         String type = getString(elementStart, "1");
         elementStack.add(type == null ? "" : type);
@@ -560,6 +568,7 @@ public final class SidecarTransportCodec {
         continue;
       }
       if (component.containsKey("4")) {
+        bodyItemCount++;
         if (!elementStack.isEmpty()) {
           String ended = elementStack.remove(elementStack.size() - 1);
           if ("reaction".equals(ended)) {
@@ -571,6 +580,7 @@ public final class SidecarTransportCodec {
     closeAllAnnotations(text.length(), activeAnnotations, annotationRanges);
     return new DocumentExtraction(
         text.toString(),
+        bodyItemCount,
         annotationRanges,
         extractReactionEntries(documentId, reactionAddressesByEmoji));
   }
@@ -673,14 +683,17 @@ public final class SidecarTransportCodec {
 
   private static final class DocumentExtraction {
     private final String textContent;
+    private final int bodyItemCount;
     private final List<SidecarAnnotationRange> annotationRanges;
     private final List<SidecarReactionEntry> reactionEntries;
 
     DocumentExtraction(
         String textContent,
+        int bodyItemCount,
         List<SidecarAnnotationRange> annotationRanges,
         List<SidecarReactionEntry> reactionEntries) {
       this.textContent = textContent;
+      this.bodyItemCount = bodyItemCount;
       this.annotationRanges = annotationRanges;
       this.reactionEntries = reactionEntries;
     }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -24,6 +24,8 @@ import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
 
 @J2clTestInput(J2clComposeSurfaceControllerTest.class)
 public class J2clComposeSurfaceControllerTest {
+  private static final int TEST_BODY_ITEM_COUNT = 17;
+
   @Test
   public void initialModelEnablesCreateAndKeepsReplyUnavailableUntilWriteSession() {
     FakeGateway gateway = new FakeGateway();
@@ -3291,8 +3293,13 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onTaskToggled("b+root", true);
+    controller.onTaskToggled("b+root", true, TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeSubmits + 1, gateway.submitCalls);
+    assertContains(
+        gateway.lastSubmitRequest.getDeltaJson(),
+        "{\"1\":{\"3\":[{\"1\":\"task/done\",\"3\":\"true\"}]}}",
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
+        "{\"1\":{\"2\":[\"task/done\"]}}");
     Assert.assertTrue(
         "compose.task_toggled (completed) event should be recorded",
         telemetry.events().stream()
@@ -3317,7 +3324,7 @@ public class J2clComposeSurfaceControllerTest {
             telemetry);
     controller.start();
     openWaveForReply(controller);
-    controller.onTaskToggled("b+root", false);
+    controller.onTaskToggled("b+root", false, TEST_BODY_ITEM_COUNT);
     Assert.assertTrue(
         "compose.task_toggled (open) event should be recorded",
         telemetry.events().stream()
@@ -3336,8 +3343,8 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onTaskToggled("", true);
-    controller.onTaskToggled(null, true);
+    controller.onTaskToggled("", true, TEST_BODY_ITEM_COUNT);
+    controller.onTaskToggled(null, true, TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
   }
 
@@ -3354,7 +3361,7 @@ public class J2clComposeSurfaceControllerTest {
             waveId -> { });
     controller.start();
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onTaskToggled("b+root", true);
+    controller.onTaskToggled("b+root", true, TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
   }
 
@@ -3504,8 +3511,14 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onTaskMetadataChanged("b+root", "alice@example.com", "2026-05-15");
+    controller.onTaskMetadataChanged(
+        "b+root", "alice@example.com", "2026-05-15", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeSubmits + 1, gateway.submitCalls);
+    assertContains(
+        gateway.lastSubmitRequest.getDeltaJson(),
+        "{\"1\":\"task/assignee\",\"3\":\"alice@example.com\"}",
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
+        "{\"1\":{\"2\":[\"task/assignee\",\"task/dueTs\"]}}");
   }
 
   // F-3.S2 (#1068): regression — a no-op session refresh (same wave id,
@@ -3528,7 +3541,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onTaskToggled("b+root", true);
+    controller.onTaskToggled("b+root", true, TEST_BODY_ITEM_COUNT);
     // Bootstrap is still pending — simulate a no-op session refresh on
     // the same wave between the click and the bootstrap response.
     controller.onWriteSessionChanged(
@@ -3557,7 +3570,8 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onTaskMetadataChanged("b+root", "alice@example.com", "2026-05-15");
+    controller.onTaskMetadataChanged(
+        "b+root", "alice@example.com", "2026-05-15", TEST_BODY_ITEM_COUNT);
     controller.onWriteSessionChanged(
         new J2clSidecarWriteSession("example.com/w+1", "chan-1", 45L, "EFGH", "b+root"));
     gateway.resolveBootstrap();
@@ -3584,7 +3598,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onTaskToggled("b+root", true);
+    controller.onTaskToggled("b+root", true, TEST_BODY_ITEM_COUNT);
     // Genuine wave switch — the captured session no longer matches the
     // current selected wave; the write must be dropped.
     controller.onWriteSessionChanged(
@@ -3742,7 +3756,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeSubmits = gateway.submitCalls;
-    controller.onDeleteBlipRequested("b+target", "example.com/w+1");
+    controller.onDeleteBlipRequested("b+target", "example.com/w+1", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeSubmits + 1, gateway.submitCalls);
     String deltaJson = gateway.lastSubmitRequest.getDeltaJson();
     Assert.assertTrue(
@@ -3752,6 +3766,10 @@ public class J2clComposeSurfaceControllerTest {
         "delta must carry tombstone/deleted=true annotation",
         deltaJson.contains("tombstone/deleted")
             && deltaJson.contains("\"3\":\"true\""));
+    assertContains(
+        deltaJson,
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
+        "{\"1\":{\"2\":[\"tombstone/deleted\"]}}");
     Assert.assertTrue(
         "success telemetry recorded",
         telemetry.events().stream()
@@ -3778,7 +3796,7 @@ public class J2clComposeSurfaceControllerTest {
     openWaveForReply(controller);
     controller.onSignedOut();
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onDeleteBlipRequested("b+target", "example.com/w+1");
+    controller.onDeleteBlipRequested("b+target", "example.com/w+1", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
     Assert.assertTrue(
         "signed-out telemetry recorded",
@@ -3805,9 +3823,9 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller);
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onDeleteBlipRequested("", "example.com/w+1");
-    controller.onDeleteBlipRequested("   ", "example.com/w+1");
-    controller.onDeleteBlipRequested(null, "example.com/w+1");
+    controller.onDeleteBlipRequested("", "example.com/w+1", TEST_BODY_ITEM_COUNT);
+    controller.onDeleteBlipRequested("   ", "example.com/w+1", TEST_BODY_ITEM_COUNT);
+    controller.onDeleteBlipRequested(null, "example.com/w+1", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
     Assert.assertTrue(
         "missing-blip telemetry recorded for empty inputs",
@@ -3833,7 +3851,7 @@ public class J2clComposeSurfaceControllerTest {
             telemetry);
     controller.start();
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onDeleteBlipRequested("b+target", "");
+    controller.onDeleteBlipRequested("b+target", "", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
     Assert.assertTrue(
         "no-selected-wave telemetry recorded",
@@ -3863,7 +3881,8 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     openWaveForReply(controller); // selected wave = example.com/w+1
     int beforeFetches = gateway.fetchBootstrapCalls;
-    controller.onDeleteBlipRequested("b+target", "example.com/w+other");
+    controller.onDeleteBlipRequested(
+        "b+target", "example.com/w+other", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals(beforeFetches, gateway.fetchBootstrapCalls);
     Assert.assertTrue(
         "wave-changed telemetry recorded",

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -165,6 +165,40 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void parsesTaskAnnotationsFromRawFragmentSnapshot() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><?a \"task/done\"=\"true\" \"task/assignee\"=\"alice@local.net\" "
+                + "\"task/dueTs\"=\"1777593600000\"?>Review launch"
+                + "<?a \"task/done\" \"task/assignee\" \"task/dueTs\"?></body>");
+
+    Assert.assertEquals("Review launch", parsed.getText());
+    Assert.assertTrue(parsed.isTaskDone());
+    Assert.assertEquals("alice@local.net", parsed.getTaskAssignee());
+    Assert.assertEquals(1777593600000L, parsed.getTaskDueTimestamp());
+  }
+
+  @Test
+  public void parsesFalseTaskDoneAsOpenFromRawFragmentSnapshot() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><?a \"task/done\"=\"false\"?>Review launch"
+                + "<?a \"task/done\"?></body>");
+
+    Assert.assertFalse(parsed.isTaskDone());
+  }
+
+  @Test
+  public void parsesTombstoneAnnotationFromRawFragmentSnapshot() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><?a \"tombstone/deleted\"=\"true\"?>Deleted"
+                + "<?a \"tombstone/deleted\"?></body>");
+
+    Assert.assertTrue(parsed.isDeleted());
+  }
+
+  @Test
   public void leadingLineBeforeImageDoesNotAddSeparator() {
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -232,7 +232,8 @@ public class J2clReadSurfaceDomRendererTest {
             /* deleted= */ false,
             /* taskDone= */ true,
             /* taskAssignee= */ "bob@example.com",
-            /* taskDueTimestamp= */ 1714560000000L);
+            /* taskDueTimestamp= */ 1714560000000L,
+            /* bodyItemCount= */ 17);
 
     Assert.assertTrue(
         renderer.render(Arrays.asList(done), Collections.<String>emptyList()));
@@ -248,6 +249,7 @@ public class J2clReadSurfaceDomRendererTest {
         "1970-01-01 lookup is wrong; renderer must format from epoch ms",
         "2024-05-01",
         element.getAttribute("data-task-due-date"));
+    Assert.assertEquals("17", element.getAttribute("data-blip-doc-size"));
   }
 
   @Test
@@ -270,6 +272,7 @@ public class J2clReadSurfaceDomRendererTest {
         element.hasAttribute("data-task-completed"));
     Assert.assertFalse(element.hasAttribute("data-task-assignee"));
     Assert.assertFalse(element.hasAttribute("data-task-due-date"));
+    Assert.assertFalse(element.hasAttribute("data-blip-doc-size"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -13,6 +13,8 @@ import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 
 @J2clTestInput(J2clRichContentDeltaFactoryTest.class)
 public class J2clRichContentDeltaFactoryTest {
+  private static final int TEST_BODY_ITEM_COUNT = 17;
+
   @Test
   public void createWaveRequestEmitsTextAnnotationsAndAttachmentElements() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
@@ -480,7 +482,8 @@ public class J2clRichContentDeltaFactoryTest {
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+reply", "chan-9", 12L, "HIST", "b+root");
     SidecarSubmitRequest request =
-        factory.taskToggleRequest("User@Example.COM", session, "b+root", true);
+        factory.taskToggleRequest(
+            "User@Example.COM", session, "b+root", true, TEST_BODY_ITEM_COUNT);
     Assert.assertEquals("example.com/w+reply/~/conv+root", request.getWaveletName());
     Assert.assertEquals("chan-9", request.getChannelId());
     String deltaJson = request.getDeltaJson();
@@ -490,7 +493,9 @@ public class J2clRichContentDeltaFactoryTest {
         "\"2\":\"user@example.com\"",
         "\"1\":\"b+root\"",
         "{\"1\":{\"3\":[{\"1\":\"task/done\",\"3\":\"true\"}]}}",
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
         "{\"1\":{\"2\":[\"task/done\"]}}");
+    assertAnnotationBoundaryRetainShape(deltaJson, TEST_BODY_ITEM_COUNT);
   }
 
   @Test
@@ -499,9 +504,15 @@ public class J2clRichContentDeltaFactoryTest {
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
     String openJson =
-        factory.taskToggleRequest("user@example.com", session, "b+root", false).getDeltaJson();
+        factory
+            .taskToggleRequest(
+                "user@example.com", session, "b+root", false, TEST_BODY_ITEM_COUNT)
+            .getDeltaJson();
     String closedJson =
-        factory.taskToggleRequest("user@example.com", session, "b+root", true).getDeltaJson();
+        factory
+            .taskToggleRequest(
+                "user@example.com", session, "b+root", true, TEST_BODY_ITEM_COUNT)
+            .getDeltaJson();
     assertContains(openJson, "{\"1\":\"task/done\",\"3\":\"false\"}");
     assertContains(closedJson, "{\"1\":\"task/done\",\"3\":\"true\"}");
   }
@@ -511,8 +522,24 @@ public class J2clRichContentDeltaFactoryTest {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
-    assertThrows(() -> factory.taskToggleRequest("user@example.com", session, "", true));
-    assertThrows(() -> factory.taskToggleRequest("user@example.com", session, "   ", true));
+    assertThrows(
+        () ->
+            factory.taskToggleRequest(
+                "user@example.com", session, "", true, TEST_BODY_ITEM_COUNT));
+    assertThrows(
+        () ->
+            factory.taskToggleRequest(
+                "user@example.com", session, "   ", true, TEST_BODY_ITEM_COUNT));
+  }
+
+  @Test
+  public void taskToggleRequestRejectsMissingBodyItemCount() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
+    assertThrows(() -> factory.taskToggleRequest("user@example.com", session, "b+root", true));
+    assertThrows(
+        () -> factory.taskToggleRequest("user@example.com", session, "b+root", true, 0));
   }
 
   // F-3.S2 (#1038, R-5.4 step 5): metadata request emits both
@@ -527,14 +554,21 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
     SidecarSubmitRequest request =
         factory.taskMetadataRequest(
-            "user@example.com", session, "b+root", "alice@example.com", "2026-05-15");
+            "user@example.com",
+            session,
+            "b+root",
+            "alice@example.com",
+            "2026-05-15",
+            TEST_BODY_ITEM_COUNT);
     String deltaJson = request.getDeltaJson();
     assertContains(
         deltaJson,
         "\"1\":\"b+root\"",
         "{\"1\":\"task/assignee\",\"3\":\"alice@example.com\"}",
         "{\"1\":\"task/dueTs\",\"3\":\"1778803200000\"}",
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
         "{\"1\":{\"2\":[\"task/assignee\",\"task/dueTs\"]}}");
+    assertAnnotationBoundaryRetainShape(deltaJson, TEST_BODY_ITEM_COUNT);
   }
 
   // PR #1066 review thread PRRT_kwDOBwxLXs593gTP — explicit
@@ -548,7 +582,12 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
     SidecarSubmitRequest request =
         factory.taskMetadataRequest(
-            "user@example.com", session, "b+root", "alice@example.com", "2026-05-15");
+            "user@example.com",
+            session,
+            "b+root",
+            "alice@example.com",
+            "2026-05-15",
+            TEST_BODY_ITEM_COUNT);
     String deltaJson = request.getDeltaJson();
     String marker = "\"1\":\"task/dueTs\",\"3\":\"";
     int start = deltaJson.indexOf(marker) + marker.length();
@@ -568,7 +607,12 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
     SidecarSubmitRequest request =
         factory.taskMetadataRequest(
-            "user@example.com", session, "b+root", "alice@example.com", "1714000000000");
+            "user@example.com",
+            session,
+            "b+root",
+            "alice@example.com",
+            "1714000000000",
+            TEST_BODY_ITEM_COUNT);
     String deltaJson = request.getDeltaJson();
     assertContains(
         deltaJson,
@@ -585,7 +629,12 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
     SidecarSubmitRequest request =
         factory.taskMetadataRequest(
-            "user@example.com", session, "b+root", "alice@example.com", "tomorrow");
+            "user@example.com",
+            session,
+            "b+root",
+            "alice@example.com",
+            "tomorrow",
+            TEST_BODY_ITEM_COUNT);
     String deltaJson = request.getDeltaJson();
     assertContains(deltaJson, "{\"1\":\"task/dueTs\",\"3\":\"\"}");
   }
@@ -596,7 +645,8 @@ public class J2clRichContentDeltaFactoryTest {
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
     SidecarSubmitRequest request =
-        factory.taskMetadataRequest("user@example.com", session, "b+root", "", "");
+        factory.taskMetadataRequest(
+            "user@example.com", session, "b+root", "", "", TEST_BODY_ITEM_COUNT);
     String deltaJson = request.getDeltaJson();
     assertContains(
         deltaJson,
@@ -860,6 +910,21 @@ public class J2clRichContentDeltaFactoryTest {
     }
   }
 
+  private static void assertAnnotationBoundaryRetainShape(String deltaJson, int bodyItemCount) {
+    int annotationOpen = deltaJson.indexOf("{\"1\":{\"3\":[");
+    int retain = deltaJson.indexOf("{\"5\":" + bodyItemCount + "}", annotationOpen);
+    int annotationClose = deltaJson.indexOf("{\"1\":{\"2\":[", retain);
+    Assert.assertTrue("Missing annotation open in JSON: " + deltaJson, annotationOpen >= 0);
+    Assert.assertTrue("Missing body retain in JSON: " + deltaJson, retain > annotationOpen);
+    Assert.assertTrue(
+        "Missing annotation close after retain in JSON: " + deltaJson,
+        annotationClose > retain);
+    String betweenOpenAndClose = deltaJson.substring(annotationOpen, annotationClose);
+    Assert.assertFalse(
+        "Annotation boundaries must not remain adjacent: " + deltaJson,
+        betweenOpenAndClose.endsWith("]}}},"));
+  }
+
   private static void assertInvalidSessionDoesNotAdvanceReplyBlipCounter(
       J2clSidecarWriteSession invalidSession) {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
@@ -991,7 +1056,8 @@ public class J2clRichContentDeltaFactoryTest {
         new J2clSidecarWriteSession(
             "example.com/w+abc", "chan-9", 13L, "HIST", "b+root");
     SidecarSubmitRequest request =
-        factory.blipDeleteRequest("User@Example.COM", session, "b+target");
+        factory.blipDeleteRequest(
+            "User@Example.COM", session, "b+target", TEST_BODY_ITEM_COUNT);
     Assert.assertEquals("example.com/w+abc/~/conv+root", request.getWaveletName());
     Assert.assertEquals("chan-9", request.getChannelId());
     String deltaJson = request.getDeltaJson();
@@ -1001,7 +1067,9 @@ public class J2clRichContentDeltaFactoryTest {
         "\"2\":\"user@example.com\"",
         "\"1\":\"b+target\"",
         "{\"1\":{\"3\":[{\"1\":\"tombstone/deleted\",\"3\":\"true\"}]}}",
+        "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
         "{\"1\":{\"2\":[\"tombstone/deleted\"]}}");
+    assertAnnotationBoundaryRetainShape(deltaJson, TEST_BODY_ITEM_COUNT);
   }
 
   @Test
@@ -1009,8 +1077,14 @@ public class J2clRichContentDeltaFactoryTest {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
-    assertThrows(() -> factory.blipDeleteRequest("user@example.com", session, ""));
-    assertThrows(() -> factory.blipDeleteRequest("user@example.com", session, "   "));
+    assertThrows(
+        () ->
+            factory.blipDeleteRequest(
+                "user@example.com", session, "", TEST_BODY_ITEM_COUNT));
+    assertThrows(
+        () ->
+            factory.blipDeleteRequest(
+                "user@example.com", session, "   ", TEST_BODY_ITEM_COUNT));
   }
 
   private static void assertThrows(ThrowingRunnable runnable) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -185,6 +185,46 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void viewportFragmentsProjectBodyItemCountToReadModelsAndWindowEntries() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    9L,
+                    0L,
+                    9L,
+                    Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+task", 0L, 9L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(
+                            "blip:b+task",
+                            "<body><line/>Review launch<?a \"task/done\"=\"true\"?></body>",
+                            0,
+                            0)))),
+            null,
+            0);
+
+    Assert.assertEquals(1, projected.getReadBlips().size());
+    Assert.assertEquals("Review launch", projected.getReadBlips().get(0).getText());
+    Assert.assertTrue(projected.getReadBlips().get(0).isTaskDone());
+    Assert.assertEquals(17, projected.getReadBlips().get(0).getBodyItemCount());
+    Assert.assertTrue(
+        projected.getViewportState().getReadWindowEntries().get(0).isTaskDone());
+    Assert.assertEquals(
+        17,
+        projected.getViewportState().getReadWindowEntries().get(0).getBodyItemCount());
+  }
+
+  @Test
   public void projectExtractsAttachmentModelsFromImageElementsInFragments() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(
@@ -3244,6 +3284,7 @@ public class J2clSelectedWaveProjectorTest {
             7L,
             1714240000000L,
             "Pin the retry",
+            18,
             Arrays.asList(
                 new SidecarAnnotationRange("task/done", "true", 0, 14),
                 new SidecarAnnotationRange("task/assignee", "bob@example.com", 0, 14),
@@ -3259,6 +3300,7 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertTrue(out.isTaskDone());
     Assert.assertEquals("bob@example.com", out.getTaskAssignee());
     Assert.assertEquals(1714560000000L, out.getTaskDueTimestamp());
+    Assert.assertEquals(18, out.getBodyItemCount());
   }
 
   @Test
@@ -3282,7 +3324,8 @@ public class J2clSelectedWaveProjectorTest {
             /* deleted= */ false,
             /* taskDone= */ true,
             /* taskAssignee= */ "bob@example.com",
-            /* taskDueTimestamp= */ 1714560000000L);
+            /* taskDueTimestamp= */ 1714560000000L,
+            /* bodyItemCount= */ 18);
 
     org.waveprotocol.box.j2cl.read.J2clReadWindowEntry plain =
         org.waveprotocol.box.j2cl.read.J2clReadWindowEntry.loaded(
@@ -3297,6 +3340,7 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertTrue(out.isTaskDone());
     Assert.assertEquals("bob@example.com", out.getTaskAssignee());
     Assert.assertEquals(1714560000000L, out.getTaskDueTimestamp());
+    Assert.assertEquals(18, out.getBodyItemCount());
     // Author + timestamp metadata also propagates so the existing F-2 flat
     // render path metadata works through the window path.
     Assert.assertEquals("alice@example.com", out.getAuthorId());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
@@ -30,8 +30,38 @@ public class SidecarFragmentsResponseTest {
     Assert.assertEquals(
         "blip:b+root", response.getFragments().getEntries().get(1).getSegment());
     Assert.assertEquals("Root text", response.getFragments().getEntries().get(1).getRawSnapshot());
+    Assert.assertEquals(9, response.getFragments().getEntries().get(1).getBodyItemCount());
     Assert.assertEquals(1, response.getFragments().getEntries().get(1).getAdjustOperationCount());
     Assert.assertEquals(2, response.getFragments().getEntries().get(1).getDiffOperationCount());
+  }
+
+  @Test
+  public void rawBlipFragmentEstimatesDocOpItemCountFromDebugXml() {
+    SidecarFragmentsResponse response =
+        SidecarFragmentsResponse.fromJson(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+                + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44},"
+                + "\"ranges\":[{\"segment\":\"blip:b+task\",\"from\":41,\"to\":44}],"
+                + "\"fragments\":[{\"segment\":\"blip:b+task\","
+                + "\"rawSnapshot\":\"<body><line/>Review launch"
+                + "<?a \\\"task/done\\\"=\\\"true\\\"?></body>\","
+                + "\"adjust\":[],\"diff\":[]}]}");
+
+    Assert.assertEquals(17, response.getFragments().getEntries().get(0).getBodyItemCount());
+  }
+
+  @Test
+  public void explicitBodyItemCountOverridesRawSnapshotEstimate() {
+    SidecarFragmentsResponse response =
+        SidecarFragmentsResponse.fromJson(
+            "{\"status\":\"ok\",\"waveRef\":\"example.com/w+abc/~/conv+root\","
+                + "\"version\":{\"snapshot\":44,\"start\":40,\"end\":44},"
+                + "\"ranges\":[{\"segment\":\"blip:b+task\",\"from\":41,\"to\":44}],"
+                + "\"fragments\":[{\"segment\":\"blip:b+task\","
+                + "\"rawSnapshot\":\"short\",\"bodyItemCount\":27,"
+                + "\"adjust\":[],\"diff\":[]}]}");
+
+    Assert.assertEquals(27, response.getFragments().getEntries().get(0).getBodyItemCount());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -158,6 +158,7 @@ public class SidecarTransportCodecTest {
     SidecarSelectedWaveFragment fragment = fragments.getEntries().get(1);
     Assert.assertEquals("blip:b+root", fragment.getSegment());
     Assert.assertEquals("Hello from the sidecar", fragment.getRawSnapshot());
+    Assert.assertEquals(22, fragment.getBodyItemCount());
   }
 
   @Test
@@ -202,6 +203,7 @@ public class SidecarTransportCodecTest {
     Assert.assertEquals(1, update.getDocuments().size());
     Assert.assertEquals("b+abc123", update.getDocuments().get(0).getDocumentId());
     Assert.assertEquals("  Welcome to SupaWave  ", update.getDocuments().get(0).getTextContent());
+    Assert.assertEquals(27, update.getDocuments().get(0).getBodyItemCount());
     Assert.assertEquals(0, update.getFragments().getEntries().size());
   }
 
@@ -257,6 +259,7 @@ public class SidecarTransportCodecTest {
 
     SidecarSelectedWaveDocument document = update.getDocuments().get(0);
     Assert.assertEquals("Review launch", document.getTextContent());
+    Assert.assertEquals(17, document.getBodyItemCount());
     Assert.assertEquals(3, document.getAnnotationRanges().size());
     Assert.assertEquals("task/id", document.getAnnotationRanges().get(0).getKey());
     Assert.assertEquals("task-123", document.getAnnotationRanges().get(0).getValue());

--- a/journal/local-verification/2026-04-30-branch-codex-issue-1129-task-toggle-persistence-20260430.md
+++ b/journal/local-verification/2026-04-30-branch-codex-issue-1129-task-toggle-persistence-20260430.md
@@ -1,0 +1,33 @@
+# Local Verification
+
+- Branch: codex/issue-1129-task-toggle-persistence-20260430
+- Worktree: /Users/vega/devroot/worktrees/issue-1129-task-toggle-persistence-20260430
+- Date: 2026-04-30
+
+## Commands
+
+- `bash scripts/worktree-boot.sh --port 9912`
+- `PORT=9912 bash scripts/wave-smoke.sh check`
+- `WAVE_E2E_BASE_URL=http://127.0.0.1:9912 npx playwright test tests/tasks-parity.spec.ts --grep "J2CL: task toggle persists"`
+- `git diff --check`
+- `rg -n "DEBUG_|__lastTaskToggleDetail|console\\.log\\(" wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts`
+- `cd j2cl/lit && npm test -- --files test/wavy-task-affordance.test.js test/wave-blip.test.js`
+- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit`
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
+- `sbt --batch Test/compile compile Universal/stage j2clSearchTest`
+
+## Results
+
+- `wave-smoke.sh check`: passed on port 9912 (`ROOT_STATUS=200`, `GWT_VIEW_STATUS=200`, `J2CL_ROOT_STATUS=200`, `SIDECAR_STATUS=200`, `WEBCLIENT_STATUS=200`).
+- Focused Playwright parity: passed, 1/1 Chromium test (`J2CL: task toggle persists across reload + cross-context`).
+- `git diff --check`: passed.
+- Debug-log scan: passed; no temporary diagnostics remain in `tasks-parity.spec.ts`.
+- Lit unit tests: passed, 46/46 Chromium tests.
+- E2E TypeScript check: passed.
+- Changelog assembly/validation: passed (`assembled 305 entries`, validation passed).
+- SBT: passed. GWT emitted existing CSS parser warnings and a non-fatal Vertispan `ClosedWatchServiceException` from `DiskCacheThread`, but the command exited 0 with `[success]` for the requested tasks.
+
+## Follow-up
+
+- PR: pending
+- Issue: #1129 under #904

--- a/wave/config/changelog.d/2026-04-30-j2cl-task-toggle-persistence.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-task-toggle-persistence.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-04-30-j2cl-task-toggle-persistence",
+  "version": "PR #1129",
+  "date": "2026-04-30",
+  "title": "J2CL task toggle persistence",
+  "summary": "J2CL task toggles, task metadata updates, and blip deletion now build valid blip-body annotation deltas by retaining the target blip body between annotation boundaries.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Propagates selected-wave blip document body item counts through the J2CL read model, rendered wave-blip host, Lit task events, compose controller, and rich-content delta writer.",
+        "Prevents J2CL from submitting task or delete mutations when the body size is unavailable, avoiding server-rejected adjacent annotation boundaries.",
+        "Re-enables the J2CL reload and cross-context task persistence parity gate."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
@@ -33,25 +33,12 @@
 // (B-J for J2CL's per-blip annotation, B-G for GWT's inline check)
 // so the two task models don't co-exist on a single document.
 //
-// J2CL persistence blocker (issue #1129):
-//   The J2CL toggle delta (`J2clRichContentDeltaFactory.taskToggleRequest`)
-//   emits two adjacent annotation boundaries with no operation
-//   between them. The wavelet validator
-//   (`DocOpAutomaton.checkAnnotationBoundary`) rejects this with
-//   "ill-formed: adjacent annotation boundaries at original document
-//   position 0 / resulting document position 0", so the toggle never
-//   persists. The optimistic UI flips immediately on click, but
-//   reload returns the un-toggled state and a second context never
-//   sees the change. The fix needs to plumb the projected blip
-//   body's wavelet item count from the read renderer through to the
-//   delta factory so it can emit `retain(N)` between the boundaries.
-//   That work is tracked at issue #1129.
-//
-//   Until #1129 lands, the J2CL half of this spec asserts:
-//   - Optimistic UI: the host's `data-task-completed` flips on click.
-//   The reload + cross-context J2CL assertions are wrapped in
-//   `test.fixme` referencing #1129 so the gate flips back to live
-//   the moment that issue is fixed (no test rewrite required).
+// Issue #1129 regression coverage:
+//   J2CL task toggles are annotation writes. The delta must retain the
+//   backing blip body's wavelet item count between annotation open and
+//   close boundaries so the server accepts the mutation. This file now
+//   keeps both the immediate optimistic UI assertion and the authoritative
+//   reload + cross-context persistence contract live.
 import { test, expect, Browser, BrowserContext, Page } from "@playwright/test";
 import { J2clPage } from "../pages/J2clPage";
 import { GwtPage } from "../pages/GwtPage";
@@ -341,12 +328,10 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
       description: creds.address
     });
     test.info().annotations.push({
-      type: "blocker",
+      type: "scope",
       description:
-        "J2CL persistence + cross-context propagation gated on issue #1129 " +
-        "(taskToggleRequest emits adjacent annotation boundaries that the " +
-        "wavelet validator rejects). This test asserts only the optimistic " +
-        "UI flip — reload + cross-context assertions are gated below."
+        "Immediate J2CL optimistic UI assertion; reload + cross-context " +
+        "persistence is covered by the following live regression test."
     });
     await registerAndSignIn(page, BASE_URL, creds);
 
@@ -391,7 +376,6 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
     await toggle.click({ force: true });
 
     // Optimistic UI: the host's `data-task-completed` flips on click.
-    // (Persistence + cross-context propagation are blocked by #1129.)
     await expect
       .poll(async () => await j2cl.blipHasTaskCompleted(blipJ), {
         timeout: 10_000,
@@ -400,13 +384,8 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
       .toBe(true);
   });
 
-  // BLOCKED on #1129: the J2CL toggle delta is rejected by the
-  // wavelet validator (adjacent annotation boundaries) so the toggle
-  // never persists. Once that issue ships, flip `test.fixme` to
-  // `test` and the J2CL reload + cross-context contract goes live
-  // with no other rewrites needed.
-  test.fixme(
-    "J2CL: task toggle persists across reload + cross-context (BLOCKED on #1129)",
+  test(
+    "J2CL: task toggle persists across reload + cross-context",
     async ({ page, browser }) => {
       const creds = freshCredentials("g6jp");
       test.info().annotations.push({
@@ -433,6 +412,8 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
         .toBeGreaterThanOrEqual(1);
       await page.waitForTimeout(2_000);
 
+      const host = page.locator(`wave-blip[data-blip-id="${blipJ}"]`).first();
+      await expect(host).toHaveAttribute("data-blip-doc-size", /^[1-9]\d*$/);
       const toggle = j2cl.blipTaskToggle(blipJ);
       await toggle.scrollIntoViewIfNeeded();
       await toggle.click({ force: true });

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -893,7 +893,7 @@ test.describe("G-PORT-9 visual parity gates", () => {
       type: "scope",
       description:
         "Task overlay gate compares the J2CL/GWT dialog visuals only. " +
-        "J2CL task persistence remains out of scope until issue #1129 closes."
+        "Task persistence is covered by tasks-parity.spec.ts."
     });
     await registerAndSignIn(page, BASE_URL, creds);
 

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/RawFragmentsBuilder.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/RawFragmentsBuilder.java
@@ -24,7 +24,10 @@ import java.util.List;
 import java.util.Map;
 import org.waveprotocol.box.server.persistence.blocks.VersionRange;
 import org.waveprotocol.wave.concurrencycontrol.channel.dto.FragmentsPayload;
+import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
+import org.waveprotocol.wave.model.document.operation.Attributes;
 import org.waveprotocol.wave.model.document.operation.DocInitialization;
+import org.waveprotocol.wave.model.document.operation.DocInitializationCursor;
 import org.waveprotocol.wave.model.document.operation.impl.DocOpUtil;
 import org.waveprotocol.wave.model.id.IdConstants;
 import org.waveprotocol.wave.model.id.SegmentId;
@@ -59,7 +62,7 @@ public final class RawFragmentsBuilder {
         DocInitialization init = document.getContent().asOperation();
         String raw = DocOpUtil.debugToXmlString(init);
         fragments.add(new FragmentsPayload.Fragment(segment, raw,
-            Collections.emptyList(), Collections.emptyList()));
+            documentItemCount(init), Collections.emptyList(), Collections.emptyList()));
       } catch (Exception ex) {
         LOG.fine("Failed to build raw fragment for segment " + segment + ": " + ex.getMessage());
       }
@@ -85,5 +88,36 @@ public final class RawFragmentsBuilder {
       return (value.length() > 5) ? value.substring("blip:".length()) : null;
     }
     return null;
+  }
+
+  private static int documentItemCount(DocInitialization init) {
+    if (init == null) {
+      return 0;
+    }
+    final int[] count = {0};
+    init.apply(new DocInitializationCursor() {
+      @Override
+      public void annotationBoundary(AnnotationBoundaryMap map) {
+        // Annotation boundaries do not advance document position.
+      }
+
+      @Override
+      public void characters(String chars) {
+        if (chars != null) {
+          count[0] += chars.length();
+        }
+      }
+
+      @Override
+      public void elementStart(String type, Attributes attrs) {
+        count[0]++;
+      }
+
+      @Override
+      public void elementEnd() {
+        count[0]++;
+      }
+    });
+    return count[0];
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/rpc/FragmentsServlet.java
@@ -392,6 +392,7 @@ public final class FragmentsServlet extends HttpServlet {
                 ? Collections.<Map<String, Object>>emptyList()
                 : diff);
         fragmentMap.put("rawSnapshot", fragment.rawSnapshot == null ? "" : fragment.rawSnapshot);
+        fragmentMap.put("bodyItemCount", fragment.bodyItemCount);
         fragments.add(fragmentMap);
       }
       out.put("fragments", fragments);

--- a/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/dto/FragmentsPayload.java
+++ b/wave/src/main/java/org/waveprotocol/wave/concurrencycontrol/channel/dto/FragmentsPayload.java
@@ -55,13 +55,21 @@ public final class FragmentsPayload {
   public static final class Fragment {
     public final SegmentId segment;
     public final String rawSnapshot;
+    public final int bodyItemCount;
     public final List<Operation> adjustOperations;
     public final List<Operation> diffOperations;
 
     public Fragment(SegmentId segment, String rawSnapshot,
         List<Operation> adjustOperations, List<Operation> diffOperations) {
+      this(segment, rawSnapshot, rawSnapshot == null ? 0 : rawSnapshot.length(),
+          adjustOperations, diffOperations);
+    }
+
+    public Fragment(SegmentId segment, String rawSnapshot, int bodyItemCount,
+        List<Operation> adjustOperations, List<Operation> diffOperations) {
       this.segment = Objects.requireNonNull(segment, "segment");
       this.rawSnapshot = rawSnapshot;
+      this.bodyItemCount = Math.max(0, bodyItemCount);
       this.adjustOperations = Collections.unmodifiableList(new ArrayList<>(adjustOperations));
       this.diffOperations = Collections.unmodifiableList(new ArrayList<>(diffOperations));
     }


### PR DESCRIPTION
## Summary

Closes #1129. Refs #904.

This fixes the J2CL task-toggle persistence blocker by making blip annotation writes body-size aware instead of emitting adjacent annotation boundaries at position 0. The same size-aware request path is used for task done state, task metadata, and blip delete annotations.

## What changed

- Plumbs document item counts from selected-wave/fragments transport into read models, DOM attributes, Lit events, and compose controller handlers.
- Emits `retain(bodyItemCount)` between annotation open/close boundaries for body-wide blip annotations and rejects missing/invalid body sizes instead of submitting malformed deltas.
- Parses task/tombstone annotation state from viewport fragment snapshots so reload/fragment projection preserves the server-applied task state.
- Activates the previously blocked J2CL task reload/cross-context parity E2E.
- Adds journal evidence and a changelog fragment.

## Verification

Fresh PR-readiness checks from `/Users/vega/devroot/worktrees/issue-1129-task-toggle-persistence-20260430`:

- `git diff --check` -> pass.
- `rg -n "DEBUG_|__lastTaskToggleDetail|console\\.log\\(" wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts || true` -> no debug matches.
- `cd j2cl/lit && npm test -- --files test/wavy-task-affordance.test.js test/wave-blip.test.js` -> pass, 46/46.
- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit` -> pass.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass.
- `PORT=9912 bash scripts/wave-smoke.sh check` -> pass against the staged server from this worktree.
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9912 npx playwright test tests/tasks-parity.spec.ts --grep "J2CL: task toggle persists" --reporter=list` -> pass, 1/1.
- `sbt --batch Test/compile compile Universal/stage j2clSearchTest` -> pass.

## Review note

Self-review completed. The required Claude Opus review loop was attempted with fallback disabled, but the provider is quota-blocked:

```text
You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)
```

No Claude approval is claimed; this PR is proceeding with direct review, local evidence, and GitHub review/check gates per the #904 failure-handling rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Task toggles and metadata updates now persist correctly across reloads and contexts.
  * Blip deletion operations are properly recorded in the system.

* **Tests**
  * Cross-context task persistence parity validation re-enabled and passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->