### PR TITLE
Follow up J2CL task body count review fixes

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -105,10 +105,14 @@ public final class J2clRichContentDeltaFactory {
    * <p>The returned request is independent of any reply draft so a
    * task toggle on blip B does not clobber an in-flight reply on
    * blip A.
+   *
+   * @deprecated Body-wide annotation writes require the target blip body item count. Use
+   *     {@link #taskToggleRequest(String, J2clSidecarWriteSession, String, boolean, int)}.
    */
+  @Deprecated
   public SidecarSubmitRequest taskToggleRequest(
       String address, J2clSidecarWriteSession session, String blipId, boolean completed) {
-    return taskToggleRequest(address, session, blipId, completed, 0);
+    throw missingBodyItemCount("taskToggleRequest");
   }
 
   public SidecarSubmitRequest taskToggleRequest(
@@ -145,14 +149,18 @@ public final class J2clRichContentDeltaFactory {
    * the empty-string "unset" sentinel rather than written as a
    * non-numeric annotation that the reader silently drops.
    * (PR #1066 review thread PRRT_kwDOBwxLXs593gTP.)
+   *
+   * @deprecated Body-wide annotation writes require the target blip body item count. Use
+   *     {@link #taskMetadataRequest(String, J2clSidecarWriteSession, String, String, String, int)}.
    */
+  @Deprecated
   public SidecarSubmitRequest taskMetadataRequest(
       String address,
       J2clSidecarWriteSession session,
       String blipId,
       String assigneeAddress,
       String dueDate) {
-    return taskMetadataRequest(address, session, blipId, assigneeAddress, dueDate, 0);
+    throw missingBodyItemCount("taskMetadataRequest");
   }
 
   public SidecarSubmitRequest taskMetadataRequest(
@@ -196,10 +204,14 @@ public final class J2clRichContentDeltaFactory {
    * single-key writer so the delta JSON envelope is identical except
    * for the annotation key + value. Any future server-side migration
    * to a manifest-edit op only needs to swap this one method.
+   *
+   * @deprecated Body-wide annotation writes require the target blip body item count. Use
+   *     {@link #blipDeleteRequest(String, J2clSidecarWriteSession, String, int)}.
    */
+  @Deprecated
   public SidecarSubmitRequest blipDeleteRequest(
       String address, J2clSidecarWriteSession session, String blipId) {
-    return blipDeleteRequest(address, session, blipId, 0);
+    throw missingBodyItemCount("blipDeleteRequest");
   }
 
   public SidecarSubmitRequest blipDeleteRequest(
@@ -740,6 +752,11 @@ public final class J2clRichContentDeltaFactory {
       throw new IllegalArgumentException("Missing blip body item count.");
     }
     return bodyItemCount;
+  }
+
+  private static IllegalArgumentException missingBodyItemCount(String methodName) {
+    return new IllegalArgumentException(
+        methodName + " requires the overload with bodyItemCount.");
   }
 
   public SidecarSubmitRequest createReplyRequest(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -167,6 +167,7 @@ public final class J2clSelectedWaveViewportState {
                   existing.getRawSnapshot(),
                   existing.getAdjustOperationCount(),
                   existing.getDiffOperationCount(),
+                  existing.getBodyItemCount(),
                   existing.shouldParseAttachmentElements(),
                   existing.attachmentOverrides,
                   existing.parsedContent));
@@ -260,7 +261,8 @@ public final class J2clSelectedWaveViewportState {
                 mergedToVersion,
                 documentEntry.getRawSnapshot(),
                 existing.getAdjustOperationCount(),
-                existing.getDiffOperationCount()));
+                existing.getDiffOperationCount(),
+                documentEntry.getBodyItemCount()));
       } else {
         merged.add(documentEntry);
       }
@@ -651,7 +653,8 @@ public final class J2clSelectedWaveViewportState {
         String rawSnapshot,
         int adjustOperationCount,
         int diffOperationCount) {
-      // Default loaded entries are document text snapshots; fragment debug XML opts in below.
+      // Body-wide annotation writes need an authoritative document item count. Treat legacy
+      // call sites as unknown rather than deriving an unsafe proxy from raw text/XML length.
       return loaded(
           segment,
           fromVersion,
@@ -659,7 +662,7 @@ public final class J2clSelectedWaveViewportState {
           rawSnapshot,
           adjustOperationCount,
           diffOperationCount,
-          plainTextItemCount(rawSnapshot),
+          0,
           false);
     }
 
@@ -699,7 +702,7 @@ public final class J2clSelectedWaveViewportState {
           diffOperationCount,
           parseAttachmentElements
               ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
-              : plainTextItemCount(rawSnapshot),
+              : 0,
           parseAttachmentElements,
           Collections.<J2clAttachmentRenderModel>emptyList());
     }
@@ -743,7 +746,7 @@ public final class J2clSelectedWaveViewportState {
           diffOperationCount,
           parseAttachmentElements
               ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
-              : plainTextItemCount(rawSnapshot),
+              : 0,
           parseAttachmentElements,
           attachmentOverrides,
           null);
@@ -791,7 +794,7 @@ public final class J2clSelectedWaveViewportState {
           diffOperationCount,
           parseAttachmentElements
               ? SidecarSelectedWaveFragment.estimateBodyItemCount(rawSnapshot)
-              : plainTextItemCount(rawSnapshot),
+              : 0,
           parseAttachmentElements,
           attachmentOverrides,
           parsedContent);
@@ -990,8 +993,5 @@ public final class J2clSelectedWaveViewportState {
       return blipId == null ? "" : blipId;
     }
 
-    private static int plainTextItemCount(String rawSnapshot) {
-      return rawSnapshot == null ? 0 : rawSnapshot.length();
-    }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -537,9 +537,28 @@ public class J2clRichContentDeltaFactoryTest {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =
         new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
-    assertThrows(() -> factory.taskToggleRequest("user@example.com", session, "b+root", true));
-    assertThrows(
+    assertThrowsWithMessage(
+        "taskToggleRequest requires the overload with bodyItemCount.",
+        () -> factory.taskToggleRequest("user@example.com", session, "b+root", true));
+    assertThrowsWithMessage(
+        "Missing blip body item count.",
         () -> factory.taskToggleRequest("user@example.com", session, "b+root", true, 0));
+  }
+
+  @Test
+  public void bodyWideAnnotationWritersRejectLegacyNoSizeOverloads() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
+
+    assertThrowsWithMessage(
+        "taskMetadataRequest requires the overload with bodyItemCount.",
+        () ->
+            factory.taskMetadataRequest(
+                "user@example.com", session, "b+root", "alice@example.com", "2026-05-15"));
+    assertThrowsWithMessage(
+        "blipDeleteRequest requires the overload with bodyItemCount.",
+        () -> factory.blipDeleteRequest("user@example.com", session, "b+root"));
   }
 
   // F-3.S2 (#1038, R-5.4 step 5): metadata request emits both
@@ -1093,6 +1112,15 @@ public class J2clRichContentDeltaFactoryTest {
       Assert.fail("Expected IllegalArgumentException.");
     } catch (IllegalArgumentException expected) {
       // Expected.
+    }
+  }
+
+  private static void assertThrowsWithMessage(String message, ThrowingRunnable runnable) {
+    try {
+      runnable.run();
+      Assert.fail("Expected IllegalArgumentException.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals(message, expected.getMessage());
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -548,12 +548,21 @@ public class J2clSelectedWaveProjectorTest {
         state.mergeDocuments(
             Arrays.asList(
                 new SidecarSelectedWaveDocument(
-                    "b+root", "user@example.com", 7L, 10L, literalText)));
+                    "b+root",
+                    "user@example.com",
+                    7L,
+                    10L,
+                    literalText,
+                    /* bodyItemCount= */ 31,
+                    Collections.<SidecarAnnotationRange>emptyList(),
+                    Collections.<SidecarReactionEntry>emptyList())));
 
     Assert.assertEquals(literalText, state.getLoadedReadBlips().get(0).getText());
     Assert.assertTrue(state.getLoadedReadBlips().get(0).getAttachments().isEmpty());
+    Assert.assertEquals(31, state.getLoadedReadBlips().get(0).getBodyItemCount());
     Assert.assertEquals(literalText, state.getReadWindowEntries().get(0).getText());
     Assert.assertTrue(state.getReadWindowEntries().get(0).getAttachments().isEmpty());
+    Assert.assertEquals(31, state.getReadWindowEntries().get(0).getBodyItemCount());
   }
 
   @Test
@@ -599,6 +608,7 @@ public class J2clSelectedWaveProjectorTest {
                         "blip:b+root",
                         "Intro <image attachment=\"example.com/att+hero\">"
                             + "<caption>Hero</caption></image> outro",
+                        /* bodyItemCount= */ 42,
                         0,
                         0))));
 
@@ -614,7 +624,23 @@ public class J2clSelectedWaveProjectorTest {
 
     Assert.assertEquals("Intro  outro", state.getLoadedReadBlips().get(0).getText());
     Assert.assertEquals(1, state.getLoadedReadBlips().get(0).getAttachments().size());
+    Assert.assertEquals(42, state.getLoadedReadBlips().get(0).getBodyItemCount());
     Assert.assertEquals(1, state.getReadWindowEntries().get(0).getAttachments().size());
+    Assert.assertEquals(42, state.getReadWindowEntries().get(0).getBodyItemCount());
+  }
+
+  @Test
+  public void loadedEntryWithoutExplicitBodyItemCountTreatsSizeUnknown() {
+    J2clSelectedWaveViewportState.Entry entry =
+        J2clSelectedWaveViewportState.Entry.loaded(
+            "blip:b+root",
+            0L,
+            9L,
+            "<body><line/>Raw debug XML should not imply a body count</body>",
+            0,
+            0);
+
+    Assert.assertEquals(0, entry.getBodyItemCount());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-04-30-j2cl-task-toggle-review-followup.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-task-toggle-review-followup.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-30-j2cl-task-toggle-review-followup",
+  "version": "PR #1129 follow-up",
+  "date": "2026-04-30",
+  "title": "J2CL task toggle body-size follow-up",
+  "summary": "J2CL task and delete annotation writes now preserve authoritative blip body sizes during viewport refreshes and reject legacy no-size write calls with explicit errors.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Preserves server-computed blip body item counts when document refreshes replace viewport fragment entries.",
+        "Keeps unknown body sizes as unavailable instead of deriving unsafe counts from raw text or debug XML lengths."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #1129, #904, and post-merge review comments on #1140.

PR #1140 merged before late Codex/Copilot review threads arrived. This follow-up addresses those comments in a separate worktree/branch:

- Preserve authoritative `bodyItemCount` when document refreshes replace an existing viewport entry.
- Preserve known fragment body counts when placeholder range updates retain an existing loaded entry.
- Stop deriving unsafe body counts from generic raw text/debug-XML `Entry.loaded(...)` overloads; unknown stays `0` unless a caller passes a computed count or opts into fragment XML estimation.
- Make legacy no-body-size task/metadata/delete writer overloads explicitly deprecated and fail with clear body-count-required errors.

## Verification

From `/Users/vega/devroot/worktrees/issue-1129-review-followup-20260430`:

- `git diff --check` -> pass.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass.
- `sbt --batch Test/compile compile Universal/stage j2clSearchTest` -> pass. The run emitted the known Vertispan `DiskCacheThread` `ClosedWatchServiceException` shutdown noise, but SBT exited 0 and all requested tasks completed.
- `sbt --batch Test/compile compile j2clSearchTest` -> pass.

## Review note

Claude Opus review was attempted for this follow-up with fallback disabled, but the CLI is still quota-blocked:

```text
You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)
```

No Claude approval is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Three legacy annotation request methods now deprecated and throw explicit errors when invoked.

* **Bug Fixes**
  * Improved preservation of blip body sizes during viewport refresh and document merge operations.
  * Unknown body sizes now handled consistently rather than inferred from document text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->