### PR TITLE
fix(gwt): add private cache headers to legacy route

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1062-gwt-cache-headers.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1062-gwt-cache-headers.md
@@ -1,0 +1,65 @@
+# Issue #1062 Legacy GWT Cache Headers Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add explicit private no-store cache headers to the legacy GWT `?view=gwt` fall-through response so the rollback route has the same session-safety cache policy as the J2CL root response.
+
+**Architecture:** Keep the legacy GWT route behavior unchanged except for HTTP response headers. The servlet already sets `Cache-Control: private, no-store` and `Vary: Cookie` on J2CL root responses; apply the same two headers immediately before the legacy HTML response is committed, and lock it with a servlet test that proves the request stayed on the GWT path.
+
+**Tech Stack:** Jakarta servlet override, existing servlet unit tests, SBT-only verification.
+
+---
+
+## Constraints
+
+- Work only in `/Users/vega/devroot/worktrees/issue-1062-gwt-cache-headers-20260430`.
+- Do not use Maven. Verification must be SBT-only.
+- Keep the change narrow: no GWT SSR restoration, no J2CL route behavior changes, no renderer refactor.
+- Preserve the existing `?view=gwt` fallback skeleton and top-bar behavior.
+- Add a changelog fragment because response cache policy is user-facing operational behavior.
+- Keep #1062 and #904 updated with worktree, branch, plan, commit, verification, review status, and PR URL.
+
+## Acceptance Criteria
+
+- Legacy GWT fall-through responses set `Cache-Control: private, no-store`.
+- Legacy GWT fall-through responses set `Vary: Cookie`.
+- The regression test proves it exercised the legacy GWT route, not the J2CL root route.
+- J2CL root cache headers remain unchanged.
+- `WaveClientServletJ2clBootstrapTest` passes through SBT.
+
+## Tasks
+
+- [ ] Add a focused failing test in `WaveClientServletJ2clBootstrapTest`.
+  - Use a signed-in user with `j2cl-root-bootstrap` disabled.
+  - Assert the rendered HTML includes the legacy `webclient/webclient.nocache.js` script.
+  - Assert the rendered HTML does not include `data-j2cl-root-shell`.
+  - Verify `Cache-Control: private, no-store` and `Vary: Cookie`.
+
+- [ ] Add the two response headers in the Jakarta-active `WaveClientServlet`.
+  - Edit `wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java`, not the legacy main-tree copy.
+  - Set headers after content type/encoding and before `SC_OK`/writer commit on the legacy GWT branch.
+  - Avoid comments that imply the route now embeds a server-first selected-wave snapshot; current `origin/main` intentionally passes `null` for that fragment.
+
+- [ ] Add release and execution evidence.
+  - Add `wave/config/changelog.d/2026-04-30-legacy-gwt-cache-headers.json`.
+  - Run changelog assemble/validate if the generated changelog changes.
+  - Record exact verification commands and outcomes on #1062 and #904.
+
+## Verification Commands
+
+- `git diff --check`
+- `sbt --batch "Test/testOnly *WaveClientServletJ2clBootstrapTest"`
+- `sbt --batch Test/compile compile`
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+
+## Self-Review
+
+- This plan intentionally does not reopen #1050's closed PR behavior. #1050's GWT-route SSR restoration was closed as obsolete; #1062 owns only the independently useful cache-header fix.
+- The runtime edit target is the Jakarta override because that is the active servlet source in this repo.
+- The test must include route-shape assertions so a future refactor cannot pass the header verification by accidentally exercising the J2CL root branch.
+
+## Review Loop
+
+- Attempt Claude Opus plan review before implementation.
+- If Claude remains quota-blocked, record the exact blocker on #1062/#904 and continue with self-review plus GitHub review gates; do not claim external approval.
+- After implementation, run self-review and attempt Claude Opus implementation review before opening the PR.

--- a/wave/config/changelog.d/2026-04-30-legacy-gwt-cache-headers.json
+++ b/wave/config/changelog.d/2026-04-30-legacy-gwt-cache-headers.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-30-legacy-gwt-cache-headers",
+  "version": "PR #1062",
+  "date": "2026-04-30",
+  "title": "Legacy GWT cache headers",
+  "summary": "The explicit legacy GWT route now opts out of shared caching with the same private no-store policy used by the J2CL root response.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Adds Cache-Control: private, no-store and Vary: Cookie to the legacy GWT fall-through response while preserving the existing GWT skeleton route.",
+        "Adds servlet coverage proving the header assertion exercises the legacy GWT path rather than the J2CL root shell."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -327,6 +327,8 @@ public class WaveClientServlet extends HttpServlet {
 
     response.setContentType("text/html");
     response.setCharacterEncoding("UTF-8");
+    response.setHeader("Cache-Control", "private, no-store");
+    response.setHeader("Vary", "Cookie");
     response.setStatus(HttpServletResponse.SC_OK);
     try (var w = response.getWriter()) {
       String username = null;

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clBootstrapTest.java
@@ -213,6 +213,25 @@ public final class WaveClientServletJ2clBootstrapTest {
   }
 
   @Test
+  public void legacyWaveClientResponseSetsPrivateCacheHeaders() throws Exception {
+    WaveClientServlet servlet = createServlet(ParticipantId.ofUnsafe("alice@example.com"), false);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("webclient/webclient.nocache.js"));
+    assertFalse(html.contains("data-j2cl-root-shell"));
+    verify(response).setHeader("Cache-Control", "private, no-store");
+    verify(response).setHeader("Vary", "Cookie");
+  }
+
+  @Test
   public void humanLocaleRedirectUsesRequestUriInsteadOfAbsoluteRequestUrl() throws Exception {
     ParticipantId user = ParticipantId.ofUnsafe("alice@example.com");
     SessionManager sessionManager = mock(SessionManager.class);


### PR DESCRIPTION
## Summary
- Add `Cache-Control: private, no-store` and `Vary: Cookie` to the legacy GWT fall-through response in the Jakarta-active `WaveClientServlet`.
- Add servlet coverage that proves the request stayed on the legacy GWT route (`webclient/webclient.nocache.js`, no `data-j2cl-root-shell`) before asserting the headers.
- Add #1062 plan/evidence doc and changelog fragment.

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass (`assembled 307 entries`, validation passed).
- `git diff --check` -> pass.
- `sbt --batch "Test/testOnly *WaveClientServletJ2clBootstrapTest"` -> pass (`11 total, 0 failed`).
- `sbt --batch Test/compile compile` -> pass.

## Review
- Self-review: narrow scope confirmed; no #1050 SSR restoration or unrelated route changes.
- Claude Opus review attempt was blocked by CLI quota: `You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)`. No external approval claimed.

Closes #1062
Refs #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cache behavior for legacy web client responses to include explicit cache control headers, preventing unintended shared caching and ensuring responses are treated as private.
* **Tests**
  * Added test coverage to verify cache control headers are correctly applied to legacy web client responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->