### PR TITLE
feat(j2cl): wire version history overlay

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1054-version-history-wiring.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1054-version-history-wiring.md
@@ -10,7 +10,7 @@
 
 ## Constraints
 
-- Work only in `/Users/vega/devroot/worktrees/issue-1054-version-history-wiring-20260430`.
+- Work only in the checked-out worktree for this issue.
 - Do not use Maven. Java/server verification must be SBT-only.
 - Run Node/Lit commands only from `j2cl/lit/`.
 - Preserve GWT behavior and the standalone `/history/*` page; this issue only wires the J2CL overlay to the existing API.

--- a/docs/superpowers/plans/2026-04-30-issue-1054-version-history-wiring.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1054-version-history-wiring.md
@@ -1,0 +1,94 @@
+# Issue #1054 J2CL Version History Wiring Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Make the J2CL/Lit version-history overlay functional by loading real history data, previewing selected historical snapshots, enabling restore only when the server allows it, and submitting restore through the existing server endpoint.
+
+**Architecture:** Reuse the existing Jakarta `VersionHistoryServlet` instead of adding a new backend path. That servlet already gates access, calls `WaveletProvider.getHistory` for delta metadata, reconstructs snapshots, and submits content-only restore operations. The J2CL/Lit action-bar controller already owns the `wave-nav-version-history-requested` click and opens `<wavy-version-history>`; extend that controller to wire `versionLoader`, `restoreEnabled`, `wavy-version-changed`, and `wavy-version-restore-confirmed` against `/history/{waveDomain}/{waveId}/{waveletDomain}/{waveletId}/api/*`.
+
+---
+
+## Constraints
+
+- Work only in `/Users/vega/devroot/worktrees/issue-1054-version-history-wiring-20260430`.
+- Do not use Maven. Java/server verification must be SBT-only.
+- Run Node/Lit commands only from `j2cl/lit/`.
+- Preserve GWT behavior and the standalone `/history/*` page; this issue only wires the J2CL overlay to the existing API.
+- Do not refactor `WaveletProvider.getHistory`; use `VersionHistoryServlet` as the compatibility seam.
+- Restore must stay destructive-confirmation gated and only enabled after `/api/info` reports `canRestore=true`.
+- Add a changelog fragment because the J2CL user-facing version-history overlay changes from preview-only chrome to a functional feature.
+- Keep #1054 and #904 updated with worktree, branch, plan, commits, verification, review status, and PR URL.
+
+## Current Code Facts
+
+- `<wavy-version-history>` already supports `versionLoader`, `restoreEnabled`, `wavy-version-changed`, and `wavy-version-restore-confirmed`, but defaults to no loader and restore disabled.
+- `j2cl/lit/src/controllers/wave-action-bar-controller.js` already listens for `wave-nav-version-history-requested` and opens the document-level overlay.
+- `VersionHistoryServlet` already exposes:
+  - `GET /history/.../api/info` with current version and `canRestore`.
+  - `GET /history/.../api/history?start=S&end=E` with delta metadata from `WaveletProvider.getHistory`.
+  - `GET /history/.../api/snapshot?version=N` with reconstructed snapshot JSON.
+  - `POST /history/.../api/restore?version=N` with existing server-side restore permission checks.
+- J2CL selected-wave IDs are shaped as `{domain}/{waveId}` and the root wavelet is `{domain}/conv+root`, matching `J2clSearchGateway.defaultWaveletId`.
+
+## Acceptance Criteria
+
+- Clicking the J2CL version-history action on a selected wave opens the overlay and loads real version entries from `/history/.../api/history`.
+- The Restore button is enabled only after `/api/info` returns `canRestore=true`; otherwise the existing preview-only hint remains.
+- Moving the slider fetches `/api/snapshot?version=N` and renders a read-only preview summary in the overlay.
+- Confirming Restore sends `POST /api/restore?version=N`, handles non-2xx failures visibly, closes or refreshes on success, and requests the selected-wave/read surface to refresh.
+- Missing or malformed `source-wave-id` remains a no-op and does not dispatch network calls.
+- Existing archive/pin action-bar behavior remains unchanged.
+- Tests cover URL construction, loader wiring, restore gating, snapshot preview, and restore success/failure.
+
+## Tasks
+
+- [ ] Extend `<wavy-version-history>` with preview/status state.
+  - Add properties for `loading`, `error`, `snapshot`, and `restoreStatus`.
+  - Render the current version label, loading/error text, and a text-only snapshot summary from `/api/snapshot`.
+  - Keep the existing slider, toggles, confirmation dialog, Escape handling, and restore-gate behavior.
+  - Add Lit tests for loaded snapshot preview, loader failures, restore status, and current-label rendering.
+
+- [ ] Wire real history API calls in `wave-action-bar-controller.js`.
+  - Parse J2CL wave ids into `{waveDomain, waveId, waveletDomain, waveletId}` and build encoded `/history/...` API URLs.
+  - On version-history request, configure the overlay for that source wave before opening it.
+  - Set `overlay.versionLoader = (start, end) => Promise<Version[]>` that calls `/api/info` and `/api/history`, maps deltas to overlay versions, and sets `restoreEnabled` from `canRestore`.
+  - Listen to `wavy-version-changed` and fetch `/api/snapshot?version=...` for a read-only preview.
+  - Listen to `wavy-version-restore-confirmed` and POST `/api/restore?version=...`.
+  - Dispatch a `wavy-selected-wave-refresh-requested` or equivalent local event after restore success so the J2CL read surface can reload.
+
+- [ ] Connect restore-success refresh to the J2CL selected-wave controller.
+  - Prefer an existing refresh/event path if one exists in `J2clSearchPanelView` or selected-wave route/controller code.
+  - If no path exists, add a small listener that reopens the current selected wave or requests a viewport refresh without changing route state.
+  - Keep the event scoped to the current wave id to avoid refreshing after a stale restore response.
+
+- [ ] Preserve backend boundaries.
+  - Do not change `VersionHistoryServlet` unless tests expose an API-shape bug.
+  - If restore needs better JSON/error text for the overlay, keep it minimal and covered by `VersionHistoryServletTest`.
+
+- [ ] Add parity and release evidence.
+  - Add or extend Playwright coverage under `wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts` for J2CL overlay loader/restore gating; keep GWT assertion to "history action opens without breaking shell" unless full GWT restore automation is already stable.
+  - Add `wave/config/changelog.d/2026-04-30-j2cl-version-history-wiring.json`.
+  - Record exact local verification in #1054 and #904.
+
+## Verification Commands
+
+- `cd j2cl/lit && npm test -- --files test/wavy-version-history.test.js test/wave-action-bar-controller.test.js`
+- `cd j2cl/lit && npm run build`
+- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit`
+- `sbt --batch Test/compile compile j2clSearchTest`
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+- `git diff --check`
+- Focused local Playwright run for the version-history path if a local server is available in the lane.
+
+## Self-Review
+
+- This plan keeps the backend source of truth in `VersionHistoryServlet`, which already uses `WaveletProvider.getHistory`, rather than adding a second history API.
+- The plan does not make Restore available by default; `restoreEnabled` stays false until `/api/info` confirms permission.
+- The plan includes stale-wave guards because the action-bar controller can outlive a selected-wave DOM reuse.
+- The plan keeps GWT behavior untouched and treats the J2CL overlay as a client of the same server seam.
+
+## Review Loop
+
+- Attempt Claude Opus plan review before implementation.
+- If Claude remains quota-blocked, record the exact blocker on #1054/#904 and continue with self-review plus GitHub review gates; do not claim external approval.
+- After implementation, run self-review and attempt Claude Opus implementation review before opening the PR.

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -391,6 +391,7 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
   unbindOverlay(overlay);
   resetOverlayForWave(overlay);
   let snapshotRequestToken = 0;
+  let restoreInFlight = false;
   overlay.versionLoader = async (start, end) => {
     const info = await fetchJson(buildHistoryUrl(apiBase, "/api/info"));
     const versions = await fetchJson(
@@ -431,7 +432,15 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
 
   const onRestoreConfirmed = async (event) => {
     const version = versionNumberFromDetail(event.detail);
-    if (version == null || !overlay.restoreEnabled || !isCurrentWave(host, waveId)) return;
+    if (
+      version == null ||
+      restoreInFlight ||
+      !overlay.restoreEnabled ||
+      !isCurrentWave(host, waveId)
+    ) return;
+    restoreInFlight = true;
+    const restoreEnabledBeforeSubmit = overlay.restoreEnabled;
+    overlay.restoreEnabled = false;
     overlay.restoreStatus = `Restoring version ${version}…`;
     overlay.error = "";
     try {
@@ -463,6 +472,11 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
       if (isCurrentWave(host, waveId)) {
         overlay.restoreStatus = "";
         overlay.error = messageFromError(err, "Unable to restore version.");
+      }
+    } finally {
+      restoreInFlight = false;
+      if (isCurrentWave(host, waveId)) {
+        overlay.restoreEnabled = restoreEnabledBeforeSubmit;
       }
     }
   };

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -37,6 +37,7 @@ const ATTR_BUSY_WAVE_ID = "data-folder-busy-wave-id";
 let installed = false;
 let observer = null;
 const boundRows = new Set();
+const overlayBindings = new WeakMap();
 
 function isNavRow(node) {
   return (
@@ -264,6 +265,209 @@ function buildFolderUrl(params) {
   return "/folder/?" + search.toString();
 }
 
+function parseSelectedWaveId(waveId) {
+  if (typeof waveId !== "string") return null;
+  const slash = waveId.indexOf("/");
+  if (slash <= 0 || slash >= waveId.length - 1) return null;
+  const waveDomain = waveId.slice(0, slash);
+  const waveIdPart = waveId.slice(slash + 1);
+  if (!waveDomain || !waveIdPart) return null;
+  return {
+    waveDomain,
+    waveId: waveIdPart,
+    waveletDomain: waveDomain,
+    waveletId: "conv+root"
+  };
+}
+
+function enc(segment) {
+  return encodeURIComponent(segment);
+}
+
+function buildHistoryApiBase(parts) {
+  return (
+    "/history/" +
+    enc(parts.waveDomain) +
+    "/" +
+    enc(parts.waveId) +
+    "/" +
+    enc(parts.waveletDomain) +
+    "/" +
+    enc(parts.waveletId)
+  );
+}
+
+function buildHistoryUrl(apiBase, endpoint, params = {}) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+    if (typeof value === "number" && !Number.isFinite(value)) continue;
+    search.set(key, String(value));
+  }
+  const query = search.toString();
+  return apiBase + endpoint + (query ? "?" + query : "");
+}
+
+async function fetchJson(url, init = {}) {
+  const { headers = {}, ...rest } = init;
+  const response = await fetch(url, {
+    ...rest,
+    credentials: "same-origin",
+    headers: { accept: "application/json", ...headers }
+  });
+  if (!response.ok) {
+    let text = "";
+    try { text = await response.text(); } catch (_e) {}
+    throw new Error(text || `Request failed with status ${response.status}`);
+  }
+  return await response.json();
+}
+
+function mapHistoryEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries.map((entry, index) => {
+    const version = Number(
+      entry && entry.resultingVersion != null
+        ? entry.resultingVersion
+        : entry && entry.version != null
+          ? entry.version
+          : index
+    );
+    return {
+      index,
+      version,
+      label: Number.isFinite(version) ? `v${version}` : `v${index}`,
+      timestamp: entry && entry.timestamp != null ? String(entry.timestamp) : "",
+      appliedAt: entry && entry.appliedAt != null ? Number(entry.appliedAt) : null,
+      author: entry && entry.author ? String(entry.author) : "",
+      opCount: entry && entry.opCount != null ? Number(entry.opCount) : 0
+    };
+  });
+}
+
+function versionNumberFromDetail(detail) {
+  if (!detail || !detail.version) return null;
+  const candidate =
+    detail.version.version != null
+      ? detail.version.version
+      : detail.version.resultingVersion != null
+        ? detail.version.resultingVersion
+        : detail.version.index;
+  const parsed = Number(candidate);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function messageFromError(err, fallback) {
+  if (!err) return fallback;
+  if (typeof err.message === "string" && err.message) return err.message;
+  const text = String(err);
+  return text || fallback;
+}
+
+function resetOverlayForWave(overlay) {
+  if (overlay && typeof overlay.resetForWave === "function") {
+    overlay.resetForWave();
+    return;
+  }
+  overlay.versions = [];
+  overlay.value = 0;
+  overlay.loading = false;
+  overlay.error = "";
+  overlay.snapshot = null;
+  overlay.restoreStatus = "";
+  overlay.restoreEnabled = false;
+  overlay._loaderRan = false;
+}
+
+function unbindOverlay(overlay) {
+  const binding = overlayBindings.get(overlay);
+  if (!binding) return;
+  overlay.removeEventListener("wavy-version-changed", binding.onVersionChanged);
+  overlay.removeEventListener("wavy-version-restore-confirmed", binding.onRestoreConfirmed);
+  overlayBindings.delete(overlay);
+}
+
+function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
+  unbindOverlay(overlay);
+  resetOverlayForWave(overlay);
+  overlay.versionLoader = async (start, end) => {
+    const info = await fetchJson(buildHistoryUrl(apiBase, "/api/info"));
+    const versions = await fetchJson(
+      buildHistoryUrl(apiBase, "/api/history", { start, end })
+    );
+    const mapped = mapHistoryEntries(versions);
+    if (isCurrentWave(host, waveId)) {
+      overlay.restoreEnabled = !!(info && info.canRestore) && mapped.length > 0;
+    }
+    return mapped;
+  };
+
+  const onVersionChanged = async (event) => {
+    const version = versionNumberFromDetail(event.detail);
+    if (version == null || !isCurrentWave(host, waveId)) return;
+    overlay.loading = true;
+    overlay.error = "";
+    try {
+      const snapshot = await fetchJson(
+        buildHistoryUrl(apiBase, "/api/snapshot", { version })
+      );
+      if (!isCurrentWave(host, waveId)) return;
+      overlay.snapshot = snapshot;
+      overlay.error = "";
+    } catch (err) {
+      if (isCurrentWave(host, waveId)) {
+        overlay.error = messageFromError(err, "Unable to load version snapshot.");
+      }
+    } finally {
+      if (isCurrentWave(host, waveId)) {
+        overlay.loading = false;
+      }
+    }
+  };
+
+  const onRestoreConfirmed = async (event) => {
+    const version = versionNumberFromDetail(event.detail);
+    if (version == null || !overlay.restoreEnabled || !isCurrentWave(host, waveId)) return;
+    overlay.restoreStatus = `Restoring version ${version}…`;
+    overlay.error = "";
+    try {
+      const result = await fetchJson(
+        buildHistoryUrl(apiBase, "/api/restore", { version }),
+        {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: ""
+        }
+      );
+      if (!isCurrentWave(host, waveId)) return;
+      const restoredToVersion = Number(
+        result && result.restoredToVersion != null ? result.restoredToVersion : version
+      );
+      overlay.restoreStatus = `Version ${Number.isFinite(restoredToVersion) ? restoredToVersion : version} restored. Refreshing wave.`;
+      host.dispatchEvent(
+        new CustomEvent("wavy-selected-wave-refresh-requested", {
+          bubbles: true,
+          composed: true,
+          detail: {
+            waveId,
+            reason: "version-restore",
+            restoredToVersion: Number.isFinite(restoredToVersion) ? restoredToVersion : version
+          }
+        })
+      );
+    } catch (err) {
+      if (isCurrentWave(host, waveId)) {
+        overlay.restoreStatus = "";
+        overlay.error = messageFromError(err, "Unable to restore version.");
+      }
+    }
+  };
+
+  overlay.addEventListener("wavy-version-changed", onVersionChanged);
+  overlay.addEventListener("wavy-version-restore-confirmed", onRestoreConfirmed);
+  overlayBindings.set(overlay, { onVersionChanged, onRestoreConfirmed });
+}
+
 function folderFetchTimeoutMs() {
   if (typeof window === "undefined") return 15_000;
   const override = window.__G_PORT_8_FOLDER_TIMEOUT_MS;
@@ -434,6 +638,10 @@ function onVersionHistoryRequest(event) {
   const doc = (host && host.ownerDocument) || document;
   const overlay = doc.querySelector(VERSION_HISTORY_TAG.toLowerCase());
   if (!overlay) return;
+  const waveId = readWaveId(event);
+  const parsed = parseSelectedWaveId(waveId);
+  if (!parsed) return;
+  configureVersionHistoryOverlay(overlay, host, waveId, buildHistoryApiBase(parsed));
   // Open the overlay. The element reflects to the `open` attribute
   // and removes `hidden` in its _syncOpen. The overlay's own keydown
   // handler closes it on Esc and restores focus.

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -407,6 +407,7 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
     if (version == null || !isCurrentWave(host, waveId)) return;
     overlay.loading = true;
     overlay.error = "";
+    overlay.snapshot = null;
     try {
       const snapshot = await fetchJson(
         buildHistoryUrl(apiBase, "/api/snapshot", { version })

--- a/j2cl/lit/src/controllers/wave-action-bar-controller.js
+++ b/j2cl/lit/src/controllers/wave-action-bar-controller.js
@@ -390,6 +390,7 @@ function unbindOverlay(overlay) {
 function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
   unbindOverlay(overlay);
   resetOverlayForWave(overlay);
+  let snapshotRequestToken = 0;
   overlay.versionLoader = async (start, end) => {
     const info = await fetchJson(buildHistoryUrl(apiBase, "/api/info"));
     const versions = await fetchJson(
@@ -405,6 +406,7 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
   const onVersionChanged = async (event) => {
     const version = versionNumberFromDetail(event.detail);
     if (version == null || !isCurrentWave(host, waveId)) return;
+    const requestToken = ++snapshotRequestToken;
     overlay.loading = true;
     overlay.error = "";
     overlay.snapshot = null;
@@ -412,15 +414,16 @@ function configureVersionHistoryOverlay(overlay, host, waveId, apiBase) {
       const snapshot = await fetchJson(
         buildHistoryUrl(apiBase, "/api/snapshot", { version })
       );
-      if (!isCurrentWave(host, waveId)) return;
+      if (!isCurrentWave(host, waveId) || requestToken !== snapshotRequestToken) return;
       overlay.snapshot = snapshot;
       overlay.error = "";
     } catch (err) {
-      if (isCurrentWave(host, waveId)) {
+      if (isCurrentWave(host, waveId) && requestToken === snapshotRequestToken) {
+        overlay.snapshot = null;
         overlay.error = messageFromError(err, "Unable to load version snapshot.");
       }
     } finally {
-      if (isCurrentWave(host, waveId)) {
+      if (isCurrentWave(host, waveId) && requestToken === snapshotRequestToken) {
         overlay.loading = false;
       }
     }

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -49,7 +49,11 @@ export class WavyVersionHistory extends LitElement {
       type: Boolean,
       attribute: "restore-enabled",
       reflect: true
-    }
+    },
+    loading: { type: Boolean, reflect: true },
+    error: { attribute: false },
+    snapshot: { attribute: false },
+    restoreStatus: { attribute: false }
   };
 
   static styles = css`
@@ -92,6 +96,46 @@ export class WavyVersionHistory extends LitElement {
     .slider-row {
       display: grid;
       gap: var(--wavy-spacing-2, 8px);
+    }
+    .history-status,
+    .current-version-label,
+    .restore-status {
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+    .history-status[role="alert"] {
+      color: var(--wavy-signal-red, #ef4444);
+    }
+    .snapshot-preview {
+      display: grid;
+      gap: var(--wavy-spacing-2, 8px);
+      padding: var(--wavy-spacing-3, 12px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      border-radius: var(--wavy-radius-card, 12px);
+      background: rgba(15, 23, 42, 0.68);
+    }
+    .snapshot-preview h3 {
+      margin: 0;
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+    }
+    .snapshot-preview p {
+      margin: 0;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+    }
+    .snapshot-documents {
+      display: grid;
+      gap: var(--wavy-spacing-2, 8px);
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .snapshot-documents li {
+      padding: var(--wavy-spacing-2, 8px);
+      border-radius: var(--wavy-radius-card, 12px);
+      background: rgba(34, 211, 238, 0.08);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      overflow-wrap: anywhere;
     }
     input[type="range"] {
       width: 100%;
@@ -181,6 +225,10 @@ export class WavyVersionHistory extends LitElement {
     this.showChanges = false;
     this.textOnly = false;
     this.restoreEnabled = false;
+    this.loading = false;
+    this.error = "";
+    this.snapshot = null;
+    this.restoreStatus = "";
     this.versionLoader = null;
     this._loaderRan = false;
     this._onKeyDown = this._onKeyDown.bind(this);
@@ -202,6 +250,8 @@ export class WavyVersionHistory extends LitElement {
       this._syncOpen();
       if (this.open && !this._loaderRan && typeof this.versionLoader === "function") {
         this._loaderRan = true;
+        this.loading = true;
+        this.error = "";
         try {
           // Range (0, Infinity) signals the loader to fetch the full
           // version history. Renderer can wrap with windowing as needed.
@@ -215,15 +265,24 @@ export class WavyVersionHistory extends LitElement {
           if (result && typeof result.then === "function") {
             result.then(
               (versions) => {
+                this.loading = false;
+                this.error = "";
                 if (Array.isArray(versions)) {
                   this.versions = versions;
                 }
               },
-              () => {}
+              (err) => {
+                this.loading = false;
+                this.error = messageFromError(err, "Unable to load version history.");
+              }
             );
+          } else {
+            this.loading = false;
           }
-        } catch (_e) {
+        } catch (err) {
           // Same — sync throws must not break the overlay chrome.
+          this.loading = false;
+          this.error = messageFromError(err, "Unable to load version history.");
         }
       }
     }
@@ -306,6 +365,17 @@ export class WavyVersionHistory extends LitElement {
 
   close_() {
     this.open = false;
+  }
+
+  resetForWave() {
+    this.versions = [];
+    this.value = 0;
+    this.loading = false;
+    this.error = "";
+    this.snapshot = null;
+    this.restoreStatus = "";
+    this.restoreEnabled = false;
+    this._loaderRan = false;
   }
 
   _onKeyDown(event) {
@@ -418,6 +488,7 @@ export class WavyVersionHistory extends LitElement {
     const idx = Math.min(Math.max(this.value || 0, 0), max);
     const current = versions[idx] || null;
     const restoreLabel = current ? `Restore version ${current.label}` : "Restore version";
+    const statusText = this.error || (this.loading ? "Loading version history…" : "");
 
     return html`
       <div class="backdrop" @click=${this._onExitClick}></div>
@@ -431,6 +502,15 @@ export class WavyVersionHistory extends LitElement {
           <span aria-hidden="true">×</span>
         </button>
         <h2>Version history</h2>
+        ${statusText
+          ? html`<p
+              class="history-status"
+              role=${this.error ? "alert" : "status"}
+            >${statusText}</p>`
+          : null}
+        <p class="current-version-label">
+          ${current ? `Current preview: ${current.label}` : "No versions loaded yet"}
+        </p>
         <div class="slider-row">
           <input
             type="range"
@@ -456,6 +536,7 @@ export class WavyVersionHistory extends LitElement {
             @click=${this._onTextOnlyClick}
           >Text only</button>
         </div>
+        ${this._renderSnapshotPreview()}
         <div class="actions">
           <button
             class="restore"
@@ -467,6 +548,9 @@ export class WavyVersionHistory extends LitElement {
           ${this.restoreEnabled
             ? null
             : html`<span class="restore-hint">Preview only — restore not available</span>`}
+          ${this.restoreStatus
+            ? html`<span class="restore-status" role="status">${this.restoreStatus}</span>`
+            : null}
         </div>
         <dialog class="confirm">
           <p>${restoreLabel}? This rewrites the wave to this point.</p>
@@ -478,6 +562,37 @@ export class WavyVersionHistory extends LitElement {
       </div>
     `;
   }
+
+  _renderSnapshotPreview() {
+    const snapshot = this.snapshot;
+    if (!snapshot) return null;
+    const docs = Array.isArray(snapshot.documents) ? snapshot.documents : [];
+    const participants = Array.isArray(snapshot.participants)
+      ? snapshot.participants.length
+      : 0;
+    const version = snapshot.version == null ? "selected" : snapshot.version;
+    return html`
+      <section class="snapshot-preview" aria-label="Read-only version preview">
+        <h3>Version ${version}</h3>
+        <p>${participants} participants · ${docs.length} documents</p>
+        <ul class="snapshot-documents">
+          ${docs.slice(0, 5).map((doc) => html`
+            <li>
+              <strong>${doc && doc.id ? doc.id : "document"}</strong>
+              <span>${doc && doc.content ? doc.content : ""}</span>
+            </li>
+          `)}
+        </ul>
+      </section>
+    `;
+  }
+}
+
+function messageFromError(err, fallback) {
+  if (!err) return fallback;
+  if (typeof err.message === "string" && err.message) return err.message;
+  const text = String(err);
+  return text || fallback;
 }
 
 if (!customElements.get("wavy-version-history")) {

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -488,7 +488,7 @@ export class WavyVersionHistory extends LitElement {
     const idx = Math.min(Math.max(this.value || 0, 0), max);
     const current = versions[idx] || null;
     const restoreLabel = current ? `Restore version ${current.label}` : "Restore version";
-    const statusText = this.error || (this.loading ? "Loading version history…" : "");
+    const statusText = this.error || (this.loading ? "Loading…" : "");
 
     return html`
       <div class="backdrop" @click=${this._onExitClick}></div>

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -231,6 +231,7 @@ export class WavyVersionHistory extends LitElement {
     this.restoreStatus = "";
     this.versionLoader = null;
     this._loaderRan = false;
+    this._loadToken = 0;
     this._onKeyDown = this._onKeyDown.bind(this);
   }
 
@@ -250,6 +251,7 @@ export class WavyVersionHistory extends LitElement {
       this._syncOpen();
       if (this.open && !this._loaderRan && typeof this.versionLoader === "function") {
         this._loaderRan = true;
+        const loadToken = ++this._loadToken;
         this.loading = true;
         this.error = "";
         try {
@@ -265,6 +267,7 @@ export class WavyVersionHistory extends LitElement {
           if (result && typeof result.then === "function") {
             result.then(
               (versions) => {
+                if (loadToken !== this._loadToken) return;
                 this.loading = false;
                 this.error = "";
                 if (Array.isArray(versions)) {
@@ -272,16 +275,24 @@ export class WavyVersionHistory extends LitElement {
                 }
               },
               (err) => {
+                if (loadToken !== this._loadToken) return;
                 this.loading = false;
+                this._loaderRan = false;
                 this.error = messageFromError(err, "Unable to load version history.");
               }
             );
           } else {
+            if (loadToken !== this._loadToken) return;
             this.loading = false;
+            if (Array.isArray(result)) {
+              this.versions = result;
+            }
           }
         } catch (err) {
+          if (loadToken !== this._loadToken) return;
           // Same — sync throws must not break the overlay chrome.
           this.loading = false;
+          this._loaderRan = false;
           this.error = messageFromError(err, "Unable to load version history.");
         }
       }
@@ -368,6 +379,7 @@ export class WavyVersionHistory extends LitElement {
   }
 
   resetForWave() {
+    this._loadToken += 1;
     this.versions = [];
     this.value = 0;
     this.loading = false;

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -849,6 +849,84 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
     }
   });
 
+  it("restore confirmation blocks duplicate POSTs while restore is in flight", async () => {
+    let restoreCalls = 0;
+    let resolveRestore;
+    stub = installFetchStub(async (url, init) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: true });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([{ appliedAt: 0, resultingVersion: 3, timestamp: 10, opCount: 1 }]);
+      }
+      if (parsed.pathname.endsWith("/api/restore")) {
+        restoreCalls += 1;
+        expect(init.method).to.equal("POST");
+        return new Promise((resolve) => {
+          resolveRestore = () => resolve(jsonResponse({ ok: true, restoredToVersion: 3 }));
+        });
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <section class="sidecar-selected-card">
+          <wavy-wave-nav-row source-wave-id="example.com/w+restore-dupe"></wavy-wave-nav-row>
+        </section>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    const abortController = new AbortController();
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+restore-dupe" }
+        })
+      );
+      await waitFor(() => expect(overlay.restoreEnabled).to.equal(true));
+
+      const refreshed = [];
+      document.addEventListener(
+        "wavy-selected-wave-refresh-requested",
+        (e) => { refreshed.push(e.detail); },
+        { signal: abortController.signal }
+      );
+      const confirmDetail = { index: 0, version: overlay.versions[0] };
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-restore-confirmed", {
+          bubbles: true,
+          composed: true,
+          detail: confirmDetail
+        })
+      );
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-restore-confirmed", {
+          bubbles: true,
+          composed: true,
+          detail: confirmDetail
+        })
+      );
+      await waitFor(() => expect(restoreCalls).to.equal(1));
+      expect(overlay.restoreEnabled).to.equal(false);
+
+      resolveRestore();
+      await waitFor(() => expect(refreshed).to.have.lengthOf(1));
+      expect(overlay.restoreEnabled).to.equal(true);
+      expect(restoreCalls).to.equal(1);
+    } finally {
+      abortController.abort();
+      overlay.remove();
+    }
+  });
+
   it("restore failure is visible and does not request selected-wave refresh", async () => {
     stub = installFetchStub(async (url) => {
       const parsed = new URL(String(url), window.location.origin);

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -579,6 +579,7 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
   });
 
   it("version-history changed fetches snapshot preview for the selected historical version", async () => {
+    let resolveSnapshot;
     stub = installFetchStub(async (url) => {
       const parsed = new URL(String(url), window.location.origin);
       if (parsed.pathname.endsWith("/api/info")) {
@@ -589,10 +590,15 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
       }
       if (parsed.pathname.endsWith("/api/snapshot")) {
         expect(parsed.searchParams.get("version")).to.equal("3");
-        return jsonResponse({
-          version: 3,
-          participants: ["alice@example.com"],
-          documents: [{ id: "b+root", content: "Historical root" }]
+        return new Promise((resolve) => {
+          resolveSnapshot = () =>
+            resolve(
+              jsonResponse({
+                version: 3,
+                participants: ["alice@example.com"],
+                documents: [{ id: "b+root", content: "Historical root" }]
+              })
+            );
         });
       }
       throw new Error(`unexpected fetch ${parsed.pathname}`);
@@ -619,6 +625,11 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
       await overlay.updateComplete;
       await waitFor(() => expect(overlay.versions).to.have.lengthOf(1));
       await overlay.updateComplete;
+      overlay.snapshot = {
+        version: 2,
+        documents: [{ id: "b+root", content: "Stale preview" }]
+      };
+      await overlay.updateComplete;
 
       overlay.dispatchEvent(
         new CustomEvent("wavy-version-changed", {
@@ -627,6 +638,11 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
           detail: { index: 0, version: overlay.versions[0] }
         })
       );
+      await waitFor(() => expect(resolveSnapshot).to.be.a("function"));
+      await overlay.updateComplete;
+      expect(overlay.snapshot).to.equal(null);
+
+      resolveSnapshot();
       await waitFor(() => expect(overlay.snapshot).to.exist);
       await overlay.updateComplete;
 

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -653,6 +653,90 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
     }
   });
 
+  it("version-history changed ignores stale snapshot responses after newer selections", async () => {
+    let resolveFirstSnapshot;
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: false });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([
+          { appliedAt: 0, resultingVersion: 3, timestamp: 10, opCount: 1 },
+          { appliedAt: 1, resultingVersion: 7, timestamp: 20, opCount: 2 }
+        ]);
+      }
+      if (parsed.pathname.endsWith("/api/snapshot")) {
+        const version = parsed.searchParams.get("version");
+        if (version === "3") {
+          return new Promise((resolve) => {
+            resolveFirstSnapshot = () =>
+              resolve(
+                jsonResponse({
+                  version: 3,
+                  documents: [{ id: "b+root", content: "Stale root" }]
+                })
+              );
+          });
+        }
+        if (version === "7") {
+          return jsonResponse({
+            version: 7,
+            documents: [{ id: "b+root", content: "Current root" }]
+          });
+        }
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <wavy-wave-nav-row source-wave-id="example.com/w+snap-race"></wavy-wave-nav-row>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+snap-race" }
+        })
+      );
+      await waitFor(() => expect(overlay.versions).to.have.lengthOf(2));
+
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-changed", {
+          bubbles: true,
+          composed: true,
+          detail: { index: 0, version: overlay.versions[0] }
+        })
+      );
+      await waitFor(() => expect(resolveFirstSnapshot).to.be.a("function"));
+
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-changed", {
+          bubbles: true,
+          composed: true,
+          detail: { index: 1, version: overlay.versions[1] }
+        })
+      );
+      await waitFor(() => expect(overlay.snapshot && overlay.snapshot.version).to.equal(7));
+      resolveFirstSnapshot();
+      await Promise.resolve();
+      await overlay.updateComplete;
+
+      expect(overlay.snapshot.version).to.equal(7);
+      expect(overlay.snapshot.documents[0].content).to.equal("Current root");
+    } finally {
+      overlay.remove();
+    }
+  });
+
   it("keeps restore disabled when the server allows restore but no history entries load", async () => {
     stub = installFetchStub(async (url) => {
       const parsed = new URL(String(url), window.location.origin);

--- a/j2cl/lit/test/wave-action-bar-controller.test.js
+++ b/j2cl/lit/test/wave-action-bar-controller.test.js
@@ -31,6 +31,27 @@ function okResponse() {
   return new Response("", { status: 200 });
 }
 
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" }
+  });
+}
+
+async function waitFor(assertion, attempts = 20) {
+  let lastError;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
 describe("wave-action-bar-controller (G-PORT-8)", () => {
   let stub;
 
@@ -448,9 +469,19 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
   });
 
   it("version-history click flips the document overlay's open property", async () => {
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 1, canRestore: false });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([]);
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
     const wrapper = await fixture(
       html`<div>
-        <wavy-wave-nav-row source-wave-id="w+v"></wavy-wave-nav-row>
+        <wavy-wave-nav-row source-wave-id="example.com/w+v"></wavy-wave-nav-row>
         <wavy-version-history hidden></wavy-version-history>
       </div>`
     );
@@ -467,13 +498,342 @@ describe("wave-action-bar-controller (G-PORT-8)", () => {
         new CustomEvent("wave-nav-version-history-requested", {
           bubbles: true,
           composed: true,
-          detail: { sourceWaveId: "w+v" }
+          detail: { sourceWaveId: "example.com/w+v" }
         })
       );
       // Reactive update microtask.
       await overlay.updateComplete;
       expect(overlay.open).to.be.true;
       expect(overlay.hasAttribute("hidden")).to.be.false;
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("version-history click wires /history loader and enables restore from canRestore", async () => {
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: true });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        expect(parsed.searchParams.get("start")).to.equal("0");
+        return jsonResponse([
+          {
+            appliedAt: 0,
+            resultingVersion: 3,
+            author: "alice@example.com",
+            timestamp: 1770000010000,
+            opCount: 2
+          },
+          {
+            appliedAt: 3,
+            resultingVersion: 7,
+            author: "bob@example.com",
+            timestamp: 1770000020000,
+            opCount: 1
+          }
+        ]);
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <wavy-wave-nav-row source-wave-id="example.com/w+v"></wavy-wave-nav-row>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+v" }
+        })
+      );
+      await overlay.updateComplete;
+      await waitFor(() => expect(stub.calls).to.have.lengthOf(2));
+      await waitFor(() => expect(overlay.versions).to.have.lengthOf(2));
+      await overlay.updateComplete;
+
+      expect(stub.calls).to.have.lengthOf(2);
+      const first = new URL(stub.calls[0].url, window.location.origin);
+      const second = new URL(stub.calls[1].url, window.location.origin);
+      expect(first.pathname).to.equal(
+        "/history/example.com/w%2Bv/example.com/conv%2Broot/api/info"
+      );
+      expect(second.pathname).to.equal(
+        "/history/example.com/w%2Bv/example.com/conv%2Broot/api/history"
+      );
+      expect(overlay.restoreEnabled).to.equal(true);
+      expect(overlay.versions.map((v) => v.version)).to.deep.equal([3, 7]);
+      expect(overlay.versions[0].label).to.equal("v3");
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("version-history changed fetches snapshot preview for the selected historical version", async () => {
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: false });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([{ appliedAt: 0, resultingVersion: 3, timestamp: 10, opCount: 1 }]);
+      }
+      if (parsed.pathname.endsWith("/api/snapshot")) {
+        expect(parsed.searchParams.get("version")).to.equal("3");
+        return jsonResponse({
+          version: 3,
+          participants: ["alice@example.com"],
+          documents: [{ id: "b+root", content: "Historical root" }]
+        });
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <wavy-wave-nav-row source-wave-id="example.com/w+snap"></wavy-wave-nav-row>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+snap" }
+        })
+      );
+      await overlay.updateComplete;
+      await waitFor(() => expect(overlay.versions).to.have.lengthOf(1));
+      await overlay.updateComplete;
+
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-changed", {
+          bubbles: true,
+          composed: true,
+          detail: { index: 0, version: overlay.versions[0] }
+        })
+      );
+      await waitFor(() => expect(overlay.snapshot).to.exist);
+      await overlay.updateComplete;
+
+      expect(overlay.snapshot.version).to.equal(3);
+      expect(overlay.snapshot.documents[0].content).to.equal("Historical root");
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("keeps restore disabled when the server allows restore but no history entries load", async () => {
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 0, canRestore: true });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([]);
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <wavy-wave-nav-row source-wave-id="example.com/w+empty"></wavy-wave-nav-row>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+empty" }
+        })
+      );
+      await waitFor(() => expect(stub.calls).to.have.lengthOf(2));
+      await overlay.updateComplete;
+
+      expect(overlay.versions).to.deep.equal([]);
+      expect(overlay.restoreEnabled).to.equal(false);
+      expect(overlay.renderRoot.querySelector("button.restore").hasAttribute("disabled")).to.equal(
+        true
+      );
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("restore confirmation POSTs existing API and requests selected-wave refresh", async () => {
+    stub = installFetchStub(async (url, init) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: true });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([{ appliedAt: 0, resultingVersion: 3, timestamp: 10, opCount: 1 }]);
+      }
+      if (parsed.pathname.endsWith("/api/restore")) {
+        expect(init.method).to.equal("POST");
+        expect(parsed.searchParams.get("version")).to.equal("3");
+        return jsonResponse({ ok: true, restoredToVersion: 3, opsApplied: 2 });
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <section class="sidecar-selected-card">
+          <wavy-wave-nav-row source-wave-id="example.com/w+restore"></wavy-wave-nav-row>
+        </section>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+restore" }
+        })
+      );
+      await overlay.updateComplete;
+      await waitFor(() => expect(overlay.versions).to.have.lengthOf(1));
+      await overlay.updateComplete;
+
+      const refreshed = new Promise((resolve) =>
+        document.addEventListener(
+          "wavy-selected-wave-refresh-requested",
+          (e) => resolve(e.detail),
+          { once: true }
+        )
+      );
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-restore-confirmed", {
+          bubbles: true,
+          composed: true,
+          detail: { index: 0, version: overlay.versions[0] }
+        })
+      );
+      const detail = await refreshed;
+      await overlay.updateComplete;
+
+      expect(detail).to.deep.equal({
+        waveId: "example.com/w+restore",
+        reason: "version-restore",
+        restoredToVersion: 3
+      });
+      expect(overlay.restoreStatus).to.match(/restored/i);
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("restore failure is visible and does not request selected-wave refresh", async () => {
+    stub = installFetchStub(async (url) => {
+      const parsed = new URL(String(url), window.location.origin);
+      if (parsed.pathname.endsWith("/api/info")) {
+        return jsonResponse({ version: 7, canRestore: true });
+      }
+      if (parsed.pathname.endsWith("/api/history")) {
+        return jsonResponse([{ appliedAt: 0, resultingVersion: 3, timestamp: 10, opCount: 1 }]);
+      }
+      if (parsed.pathname.endsWith("/api/restore")) {
+        return new Response("restore denied", { status: 403 });
+      }
+      throw new Error(`unexpected fetch ${parsed.pathname}`);
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <section class="sidecar-selected-card">
+          <wavy-wave-nav-row source-wave-id="example.com/w+denied"></wavy-wave-nav-row>
+        </section>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "example.com/w+denied" }
+        })
+      );
+      await waitFor(() => expect(overlay.versions).to.have.lengthOf(1));
+
+      let refreshed = false;
+      document.addEventListener(
+        "wavy-selected-wave-refresh-requested",
+        () => { refreshed = true; },
+        { once: true }
+      );
+      overlay.dispatchEvent(
+        new CustomEvent("wavy-version-restore-confirmed", {
+          bubbles: true,
+          composed: true,
+          detail: { index: 0, version: overlay.versions[0] }
+        })
+      );
+      await waitFor(() => expect(overlay.error).to.match(/restore denied/));
+      expect(refreshed).to.equal(false);
+      expect(overlay.restoreStatus).to.equal("");
+    } finally {
+      overlay.remove();
+    }
+  });
+
+  it("malformed source-wave-id leaves version history inert and does not fetch", async () => {
+    stub = installFetchStub(async () => {
+      throw new Error("fetch should not be called");
+    });
+    const wrapper = await fixture(
+      html`<div>
+        <wavy-wave-nav-row source-wave-id="malformed"></wavy-wave-nav-row>
+        <wavy-version-history hidden></wavy-version-history>
+      </div>`
+    );
+    const row = wrapper.querySelector("wavy-wave-nav-row");
+    const overlay = wrapper.querySelector("wavy-version-history");
+    document.body.appendChild(overlay);
+    try {
+      controllerModule.start();
+      await Promise.resolve();
+      row.dispatchEvent(
+        new CustomEvent("wave-nav-version-history-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { sourceWaveId: "malformed" }
+        })
+      );
+      await overlay.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+      expect(overlay.open).to.equal(false);
+      expect(stub.calls).to.have.lengthOf(0);
     } finally {
       overlay.remove();
     }

--- a/j2cl/lit/test/wavy-version-history.test.js
+++ b/j2cl/lit/test/wavy-version-history.test.js
@@ -274,6 +274,53 @@ describe("<wavy-version-history>", () => {
     );
   });
 
+  it("ignores stale version-loader completions after rebinding to another wave", async () => {
+    const el = await fixture(html`<wavy-version-history></wavy-version-history>`);
+    let resolveLoader;
+    el.versionLoader = () =>
+      new Promise((resolve) => {
+        resolveLoader = resolve;
+      });
+    el.open_();
+    await el.updateComplete;
+    expect(el.loading).to.equal(true);
+
+    el.resetForWave();
+    await el.updateComplete;
+    resolveLoader([{ index: 0, label: "stale", version: 9 }]);
+    await Promise.resolve();
+    await el.updateComplete;
+
+    expect(el.loading).to.equal(false);
+    expect(el.versions).to.deep.equal([]);
+  });
+
+  it("allows version history load retry after loader failure", async () => {
+    const el = await fixture(html`<wavy-version-history></wavy-version-history>`);
+    let calls = 0;
+    el.versionLoader = () => {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new Error("transient history failure"));
+      }
+      return [{ index: 0, label: "v8", version: 8 }];
+    };
+
+    el.open_();
+    await Promise.resolve();
+    await el.updateComplete;
+    expect(el.error).to.contain("transient history failure");
+
+    el.close_();
+    await el.updateComplete;
+    el.open_();
+    await el.updateComplete;
+
+    expect(calls).to.equal(2);
+    expect(el.error).to.equal("");
+    expect(el.versions.map((v) => v.version)).to.deep.equal([8]);
+  });
+
   it("renders current version label and read-only snapshot preview", async () => {
     const el = await fixture(html`<wavy-version-history open></wavy-version-history>`);
     el.versions = [

--- a/j2cl/lit/test/wavy-version-history.test.js
+++ b/j2cl/lit/test/wavy-version-history.test.js
@@ -253,4 +253,58 @@ describe("<wavy-version-history>", () => {
     expect(observed[0]).to.equal(0);
     expect(observed[1]).to.equal(Number.POSITIVE_INFINITY);
   });
+
+  it("shows loader progress and failed loader text without closing the overlay", async () => {
+    const el = await fixture(html`<wavy-version-history></wavy-version-history>`);
+    let rejectLoader;
+    el.versionLoader = () =>
+      new Promise((_resolve, reject) => {
+        rejectLoader = reject;
+      });
+    el.open_();
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector(".history-status").textContent).to.match(/Loading/);
+
+    rejectLoader(new Error("history unavailable"));
+    await Promise.resolve();
+    await el.updateComplete;
+    expect(el.open).to.equal(true);
+    expect(el.renderRoot.querySelector(".history-status").textContent).to.match(
+      /history unavailable/
+    );
+  });
+
+  it("renders current version label and read-only snapshot preview", async () => {
+    const el = await fixture(html`<wavy-version-history open></wavy-version-history>`);
+    el.versions = [
+      { index: 0, label: "v3", timestamp: "2026-04-26T10:05:00Z", version: 3 },
+      { index: 1, label: "v5", timestamp: "2026-04-26T10:15:00Z", version: 5 }
+    ];
+    el.value = 1;
+    el.snapshot = {
+      version: 5,
+      participants: ["alice@example.com", "bob@example.com"],
+      documents: [
+        { id: "b+root", content: "Older title and root body" },
+        { id: "b+child", content: "Nested historical reply" }
+      ]
+    };
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector(".current-version-label").textContent).to.contain("v5");
+    const preview = el.renderRoot.querySelector(".snapshot-preview");
+    expect(preview).to.exist;
+    expect(preview.textContent).to.contain("Version 5");
+    expect(preview.textContent).to.contain("2 participants");
+    expect(preview.textContent).to.contain("Older title and root body");
+  });
+
+  it("renders restore status text near the destructive action", async () => {
+    const el = await fixture(html`<wavy-version-history open></wavy-version-history>`);
+    el.restoreStatus = "Version restored. Refreshing wave.";
+    await el.updateComplete;
+    const status = el.renderRoot.querySelector(".restore-status");
+    expect(status).to.exist;
+    expect(status.textContent).to.contain("Version restored");
+  });
 });

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -145,6 +145,15 @@ public final class J2clSelectedWaveController
      */
     default void setAwarenessPill(int pendingCount) {
     }
+
+    /**
+     * F-2 (#1054): registers the DOM bridge used by the Lit version-history
+     * overlay after a successful restore. The view extracts the wave id from
+     * {@code wavy-selected-wave-refresh-requested}; the controller verifies it
+     * still matches the active selection before reopening the read surface.
+     */
+    default void setSelectedWaveRefreshHandler(SelectedWaveRefreshHandler handler) {
+    }
   }
 
   @FunctionalInterface
@@ -159,6 +168,11 @@ public final class J2clSelectedWaveController
   @FunctionalInterface
   public interface MarkBlipReadHandler {
     void markBlipRead(String blipId, Runnable onError);
+  }
+
+  @FunctionalInterface
+  public interface SelectedWaveRefreshHandler {
+    void refresh(String waveId);
   }
 
   public interface RetryScheduler {
@@ -354,6 +368,7 @@ public final class J2clSelectedWaveController
     this.view.render(currentModel);
     this.view.setViewportEdgeHandler(this::onViewportEdge);
     this.view.setMarkBlipReadHandler(this::onMarkBlipRead);
+    this.view.setSelectedWaveRefreshHandler(this::onSelectedWaveRefreshRequested);
     publishWriteSession();
     if (visibilitySource != null) {
       visibilitySource.addVisibilityListener(this::onVisible);
@@ -377,6 +392,16 @@ public final class J2clSelectedWaveController
     // A refresh happens after the reply already committed on the server, so transient bootstrap or
     // open failures should recover like a reconnect instead of strand the panel on stale content.
     fetchBootstrapAndOpenSelectedWave(generation, 0, true);
+  }
+
+  private void onSelectedWaveRefreshRequested(String waveId) {
+    if (waveId == null || waveId.isEmpty()) {
+      return;
+    }
+    if (selectedWaveId == null || !selectedWaveId.equals(waveId)) {
+      return;
+    }
+    refreshSelectedWave();
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -76,6 +76,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   // user's own chip as aria-pressed=true. Updated by the root shell
   // after each bootstrap response; empty when no user is signed in.
   private String currentUserAddress = "";
+  private J2clSelectedWaveController.SelectedWaveRefreshHandler selectedWaveRefreshHandler;
 
   public J2clSelectedWaveView(HTMLElement host) {
     this(host, J2clClientTelemetry.noop());
@@ -119,6 +120,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       this.waveNavRow = ensureWaveNavRow(existingCard);
       this.awarenessPill = ensureAwarenessPill(existingCard);
       bindChromeEvents(existingCard, effectiveTelemetrySink);
+      bindSelectedWaveRefreshListener(existingCard);
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
       serverFirstMode = J2clServerFirstRootShellDom.serverFirstMode(host);
@@ -206,6 +208,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     coldCard.appendChild(emptyState);
 
     bindChromeEvents(coldCard, effectiveTelemetrySink);
+    bindSelectedWaveRefreshListener(coldCard);
 
     serverFirstActive = false;
     serverFirstSwapRecorded = false;
@@ -338,6 +341,29 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             waveId = hostWaveId == null ? "" : hostWaveId;
           }
           renderer.noteOptimisticTaskState(waveId, blipId, completed);
+        });
+  }
+
+  private void bindSelectedWaveRefreshListener(HTMLElement card) {
+    if (card == null) {
+      return;
+    }
+    card.addEventListener(
+        "wavy-selected-wave-refresh-requested",
+        evt -> {
+          if (selectedWaveRefreshHandler == null) {
+            return;
+          }
+          Object detail = Js.asPropertyMap(evt).get("detail");
+          if (detail == null) {
+            return;
+          }
+          Object waveIdValue = Js.asPropertyMap(detail).get("waveId");
+          String waveId = waveIdValue == null ? "" : String.valueOf(waveIdValue);
+          if (waveId.isEmpty()) {
+            return;
+          }
+          selectedWaveRefreshHandler.refresh(waveId);
         });
   }
 
@@ -561,6 +587,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // hook in place so re-installation on visibility change works.
     readSurface.setMarkBlipReadListener(
         handler == null ? null : (blipId, onError) -> handler.markBlipRead(blipId, onError));
+  }
+
+  @Override
+  public void setSelectedWaveRefreshHandler(
+      J2clSelectedWaveController.SelectedWaveRefreshHandler handler) {
+    selectedWaveRefreshHandler = handler;
   }
 
   @Override

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -377,6 +377,28 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void selectedWaveRefreshHandlerRefreshesOnlyCurrentWave() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(false);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    Assert.assertNotNull(harness.selectedWaveRefreshHandler);
+    harness.selectedWaveRefreshHandler.refresh("example.com/w+other");
+    Assert.assertEquals(
+        "stale restore events for another wave must not reopen the socket",
+        1,
+        harness.bootstrapAttempts.size());
+
+    harness.selectedWaveRefreshHandler.refresh("example.com/w+1");
+    Assert.assertEquals(1, harness.closedCount);
+    Assert.assertEquals(2, harness.bootstrapAttempts.size());
+    Assert.assertTrue((Boolean) harness.modelValue("isLoading"));
+  }
+
+  @Test
   public void replySubmitHandoffWaitsForLiveUpdateBeforeFallbackRefresh() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
@@ -2368,6 +2390,7 @@ public class J2clSelectedWaveControllerTest {
     private List<String> lastPublishedParticipantIds = Collections.emptyList();
     private boolean lastNavRowPinned;
     private boolean lastNavRowArchived;
+    private J2clSelectedWaveController.SelectedWaveRefreshHandler selectedWaveRefreshHandler;
     private final J2clClientTelemetry.Sink telemetrySink;
 
     private Harness() {
@@ -2520,6 +2543,11 @@ public class J2clSelectedWaveControllerTest {
                   lastNavRowPinned = ((Boolean) args[0]).booleanValue();
                   lastNavRowArchived = ((Boolean) args[1]).booleanValue();
                   viewEvents.add("folder-state:" + lastNavRowPinned + ":" + lastNavRowArchived);
+                  return null;
+                }
+                if ("setSelectedWaveRefreshHandler".equals(method.getName())) {
+                  selectedWaveRefreshHandler =
+                      (J2clSelectedWaveController.SelectedWaveRefreshHandler) args[0];
                   return null;
                 }
                 return null;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -455,6 +455,28 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void selectedWaveRefreshEventInvokesRefreshHandler() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    final String[] refreshedWaveId = {null};
+    view.setSelectedWaveRefreshHandler(waveId -> refreshedWaveId[0] = waveId);
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    jsinterop.base.JsPropertyMap<Object> detail = jsinterop.base.JsPropertyMap.of();
+    detail.set("waveId", "example.com/w+restore");
+    init.setDetail(detail);
+    elemental2.dom.CustomEvent<Object> evt =
+        new elemental2.dom.CustomEvent<Object>("wavy-selected-wave-refresh-requested", init);
+    row.dispatchEvent(evt);
+
+    Assert.assertEquals("example.com/w+restore", refreshedWaveId[0]);
+  }
+
+  @Test
   public void depthNavEventsEmitTelemetry() {
     assumeBrowserDom();
     HTMLElement host = createHost();

--- a/wave/config/changelog.d/2026-04-30-j2cl-version-history-wiring.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-version-history-wiring.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-j2cl-version-history-wiring",
+  "version": "PR #TBD",
+  "date": "2026-04-30",
+  "title": "J2CL version history can preview and restore wave versions",
+  "summary": "The J2CL wave action bar now opens a functional version-history overlay backed by the existing history API, with read-only snapshot previews and restore gating.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Load version history from the existing /history API, show a read-only snapshot preview, and submit confirmed restores only when the server reports restore permission."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-04-30-j2cl-version-history-wiring.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-version-history-wiring.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-04-30-j2cl-version-history-wiring",
-  "version": "PR #TBD",
+  "version": "PR #1143",
   "date": "2026-04-30",
   "title": "J2CL version history can preview and restore wave versions",
   "summary": "The J2CL wave action bar now opens a functional version-history overlay backed by the existing history API, with read-only snapshot previews and restore gating.",

--- a/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
@@ -261,12 +261,12 @@ test.describe("G-PORT-8 top-of-wave action bar parity", () => {
     );
     await clickActionJ2cl(page, "version-history");
     const info = await (await infoResponse).json();
-    await historyResponse;
+    const history = await (await historyResponse).json();
     await expect(overlay).not.toHaveAttribute("hidden", "");
     await expect(overlay.locator(".current-version-label")).toBeVisible();
     await expect(overlay.locator("button.restore")).toHaveAttribute(
       "aria-disabled",
-      info.canRestore ? "false" : "true"
+      info.canRestore && Array.isArray(history) && history.length > 0 ? "false" : "true"
     );
     // Press Escape — the overlay's own keydown handler closes it and
     // reflects the hidden attribute back. The handler waits a frame

--- a/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
@@ -247,8 +247,27 @@ test.describe("G-PORT-8 top-of-wave action bar parity", () => {
     const overlay = page.locator("wavy-version-history");
     await expect(overlay).toHaveCount(1);
     await expect(overlay).toHaveAttribute("hidden", "");
+    const infoResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/history/") &&
+        response.url().includes("/api/info") &&
+        response.status() < 500
+    );
+    const historyResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/history/") &&
+        response.url().includes("/api/history") &&
+        response.status() < 500
+    );
     await clickActionJ2cl(page, "version-history");
+    const info = await (await infoResponse).json();
+    await historyResponse;
     await expect(overlay).not.toHaveAttribute("hidden", "");
+    await expect(overlay.locator(".current-version-label")).toBeVisible();
+    await expect(overlay.locator("button.restore")).toHaveAttribute(
+      "aria-disabled",
+      info.canRestore ? "false" : "true"
+    );
     // Press Escape — the overlay's own keydown handler closes it and
     // reflects the hidden attribute back. The handler waits a frame
     // before applying the attr; give it up to 5s.

--- a/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/wave-actions-parity.spec.ts
@@ -251,13 +251,13 @@ test.describe("G-PORT-8 top-of-wave action bar parity", () => {
       (response) =>
         response.url().includes("/history/") &&
         response.url().includes("/api/info") &&
-        response.status() < 500
+        response.ok()
     );
     const historyResponse = page.waitForResponse(
       (response) =>
         response.url().includes("/history/") &&
         response.url().includes("/api/history") &&
-        response.status() < 500
+        response.ok()
     );
     await clickActionJ2cl(page, "version-history");
     const info = await (await infoResponse).json();


### PR DESCRIPTION
## Summary

Closes #1054. Refs #904.

- Wire the J2CL/Lit version-history overlay to the existing `/history/.../api/*` `VersionHistoryServlet` endpoints.
- Add real history loading, snapshot preview state, visible loading/error/restore status, and restore gating from `/api/info` plus non-empty history.
- Submit confirmed restore via `/api/restore`, then bridge restore success back to `J2clSelectedWaveController.refreshSelectedWave()` through `wavy-selected-wave-refresh-requested` with a current-wave guard.
- Extend parity E2E coverage so the J2CL version-history action must call `/api/info` and `/api/history`, then match the Restore button gate to `canRestore`.

## Verification

- `cd j2cl/lit && npm test -- --files test/wavy-version-history.test.js test/wave-action-bar-controller.test.js` -> pass (`59 passed`).
- `cd j2cl/lit && npm run build` -> pass.
- `cd wave/src/e2e/j2cl-gwt-parity && npm install && npx tsc --noEmit` -> pass.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass (`assembled 308 entries`, validation passed).
- `sbt --batch Test/compile compile j2clSearchTest` -> pass.
- `git diff --check` -> pass.

## Review

- Self-review found and fixed one edge case: Restore is no longer enabled when `canRestore=true` but `/api/history` returns no selectable versions.
- Claude Opus plan and implementation review attempts were both blocked by provider quota: `You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)`. This is recorded on #1054/#904; no external approval is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version-history overlay: read-only snapshot previews, slider-driven preview, restore action gated by server permission, visible loading/error/restore status, and targeted refresh after successful restore; action-bar now launches and wires the overlay for the selected wave.

* **Documentation**
  * Added implementation plan detailing wiring, UI states, verification commands, and review steps.

* **Tests**
  * Expanded unit, integration, browser, and e2e coverage for loader, preview, restore flows, stale-response handling, and parity.

* **Chores**
  * Added changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->