### PR TITLE
feat(j2cl): add superscript and subscript toolbar buttons

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1071-superscript-subscript.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1071-superscript-subscript.md
@@ -1,0 +1,266 @@
+# Superscript And Subscript Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add H.5 superscript and H.6 subscript to the J2CL rich-edit toolbar and preserve them through composer serialization and DocOp submit deltas.
+
+**Architecture:** Treat superscript and subscript as inline rich-text annotations, matching existing bold/italic/underline/strikethrough flow. The Lit toolbar exposes stable action ids, the composer wraps and serializes `<sup>` / `<sub>` as `style/verticalAlign=super|sub`, and `J2clRichContentDeltaFactory` already emits arbitrary annotated document runs, so Java work is a focused round-trip regression.
+
+**Tech Stack:** Lit web components and @open-wc tests under `j2cl/lit`; J2CL Java unit tests through SBT; changelog fragment JSON under `wave/config/changelog.d`.
+
+---
+
+## Files
+
+- Modify: `j2cl/lit/test/wavy-format-toolbar.test.js` to lock button order and event emission.
+- Modify: `j2cl/lit/src/elements/wavy-format-toolbar.js` to add two text-group actions between Strikethrough and Heading.
+- Modify: `j2cl/lit/src/icons/toolbar-icons.js` to add `superscript` and `subscript` SVG glyphs so the existing all-buttons-render-icons test remains meaningful.
+- Modify: `j2cl/lit/test/wavy-composer.test.js` to assert `<sup>` and `<sub>` serialization.
+- Modify: `j2cl/lit/src/elements/wavy-composer.js` to wrap selections with `<sup>` / `<sub>` and serialize them as `style/verticalAlign`.
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java` to assert DocOp annotation start/end for `super` and `sub`.
+- Add: `wave/config/changelog.d/2026-04-30-j2cl-superscript-subscript.json`.
+
+## Task 1: Toolbar Buttons
+
+- [ ] **Step 1: Write failing toolbar tests**
+
+Add assertions in `j2cl/lit/test/wavy-format-toolbar.test.js`:
+
+```js
+expect(actionIds.slice(0, 7)).to.deep.equal([
+  "bold",
+  "italic",
+  "underline",
+  "strikethrough",
+  "superscript",
+  "subscript",
+  "heading"
+]);
+expect(actionIds).to.include.members(["superscript", "subscript"]);
+```
+
+Add one event test per action:
+
+```js
+for (const actionId of ["superscript", "subscript"]) {
+  const button = el.renderRoot.querySelector(`[data-toolbar-action="${actionId}"]`);
+  const trigger = oneEvent(el, "wavy-format-toolbar-action");
+  button.dispatchEvent(new CustomEvent("toolbar-action", {
+    detail: { action: actionId },
+    bubbles: true,
+    composed: true
+  }));
+  const evt = await trigger;
+  expect(evt.detail.actionId).to.equal(actionId);
+}
+```
+
+- [ ] **Step 2: Verify toolbar tests fail**
+
+Run:
+
+```sh
+cd j2cl/lit && npm test -- --files test/wavy-format-toolbar.test.js
+```
+
+Expected before implementation: FAIL because `superscript` / `subscript` buttons are missing.
+
+- [ ] **Step 3: Implement toolbar buttons and icons**
+
+In `j2cl/lit/src/elements/wavy-format-toolbar.js`, insert the two actions immediately after `strikethrough`:
+
+```js
+{ id: "superscript", label: "Superscript", group: "text", toggle: true },
+{ id: "subscript", label: "Subscript", group: "text", toggle: true },
+```
+
+Update `ACTIVE_ANNOTATION_MAP` so active selection state can light the toggles:
+
+```js
+superscript: ["sup"],
+subscript: ["sub"],
+```
+
+In `j2cl/lit/src/icons/toolbar-icons.js`, add `superscript` and `subscript` entries keyed by the action ids. Keep 16x16 `currentColor` SVGs consistent with the existing toolbar icon set.
+
+- [ ] **Step 4: Verify toolbar tests pass**
+
+Run:
+
+```sh
+cd j2cl/lit && npm test -- --files test/wavy-format-toolbar.test.js
+```
+
+Expected after implementation: PASS.
+
+## Task 2: Composer Serialization
+
+- [ ] **Step 1: Write failing composer tests**
+
+Add tests in `j2cl/lit/test/wavy-composer.test.js` under `serializeRichComponents (F-3.S4 R-5.7)`:
+
+```js
+it("emits style/verticalAlign=super for <sup>", async () => {
+  const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+  document.body.appendChild(el);
+  const body = getBody(el);
+  body.innerHTML = "x<sup>2</sup>";
+  const components = el.serializeRichComponents();
+  const superRun = components.find(
+    c => c.type === "annotated"
+      && c.annotationKey === "style/verticalAlign"
+      && c.annotationValue === "super"
+  );
+  expect(superRun).to.exist;
+  expect(superRun.text).to.equal("2");
+  el.remove();
+});
+```
+
+Mirror it for `<sub>2</sub>` expecting `annotationValue === "sub"`.
+
+- [ ] **Step 2: Verify composer tests fail**
+
+Run:
+
+```sh
+cd j2cl/lit && npm test -- --files test/wavy-composer.test.js
+```
+
+Expected before implementation: FAIL because `<sup>` / `<sub>` fall through as plain text.
+
+- [ ] **Step 3: Implement composer wrapping and serialization**
+
+In `_handleToolbarAction`, extend `inlineWraps`:
+
+```js
+superscript: { tag: "sup", siblings: [] },
+subscript: { tag: "sub", siblings: [] }
+```
+
+In `inlineFormatAnnotation(tag)`, add:
+
+```js
+case "sup":
+  return { key: "style/verticalAlign", value: "super" };
+case "sub":
+  return { key: "style/verticalAlign", value: "sub" };
+```
+
+- [ ] **Step 4: Verify composer tests pass**
+
+Run:
+
+```sh
+cd j2cl/lit && npm test -- --files test/wavy-composer.test.js
+```
+
+Expected after implementation: PASS.
+
+## Task 3: Java DocOp Round Trip
+
+- [ ] **Step 1: Add Java round-trip tests**
+
+Add two tests near the F-3.S4 round-trip block in `J2clRichContentDeltaFactoryTest.java`:
+
+```java
+@Test
+public void createReplyRequestRoundTripsSuperscriptAnnotation() {
+  J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+  J2clSidecarWriteSession session =
+      new J2clSidecarWriteSession(
+          "example.com/w+abc", "chan-4", 3L, "HASH", "b+root");
+  J2clComposerDocument document =
+      J2clComposerDocument.builder()
+          .annotatedText("style/verticalAlign", "super", "x²")
+          .build();
+  String deltaJson =
+      factory.createReplyRequest("user@example.com", session, document).getDeltaJson();
+  assertContains(
+      deltaJson,
+      "{\"1\":{\"3\":[{\"1\":\"style/verticalAlign\",\"3\":\"super\"}]}}",
+      "\"2\":\"x²\"",
+      "{\"1\":{\"2\":[\"style/verticalAlign\"]}}");
+}
+```
+
+Mirror it for `annotationValue` `sub` and text such as `H₂O`.
+
+- [ ] **Step 2: Verify Java tests**
+
+Run:
+
+```sh
+sbt --batch j2clSearchTest
+```
+
+Expected: PASS. The attempted narrower command
+`sbt --batch "Test/testOnly org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactoryTest"`
+does not run this J2CL test class in the current SBT layout (`No tests to run`), so
+`j2clSearchTest` is the effective focused Java/J2CL gate for this file.
+
+## Task 4: Changelog And Final Verification
+
+- [ ] **Step 1: Add changelog fragment**
+
+Create `wave/config/changelog.d/2026-04-30-j2cl-superscript-subscript.json`:
+
+```json
+{
+  "releaseId": "2026-04-30-j2cl-superscript-subscript",
+  "version": "PR #1071",
+  "date": "2026-04-30",
+  "title": "J2CL superscript and subscript toolbar buttons",
+  "summary": "The J2CL rich-edit toolbar now exposes superscript and subscript controls and preserves their vertical-align annotations through rich reply submission.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Adds Superscript and Subscript buttons to the J2CL rich-edit toolbar between Strikethrough and Heading.",
+        "Serializes <sup> and <sub> rich-composer content as style/verticalAlign annotations for DocOp round trips."
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run focused and broader gates**
+
+Run:
+
+```sh
+cd j2cl/lit && npm test -- --files test/wavy-format-toolbar.test.js test/wavy-composer.test.js
+```
+
+Run:
+
+```sh
+cd j2cl/lit && npm run build
+```
+
+Run:
+
+```sh
+sbt --batch compile j2clSearchTest
+```
+
+Run:
+
+```sh
+python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Run:
+
+```sh
+git diff --check
+```
+
+Expected: all commands exit 0. If SBT exposes a narrower confirmed J2CL test command for `J2clRichContentDeltaFactoryTest`, run it before the broader `compile j2clSearchTest` gate and record both.
+
+## Self-Review
+
+- Spec coverage: The plan covers toolbar buttons/order/events, composer `<sup>/<sub>` serialization to `style/verticalAlign`, Java `J2clComposerDocument.builder().annotatedText("style/verticalAlign", ...)` reply delta round trips, changelog, and issue-visible verification.
+- Placeholder scan: No `TBD`, `TODO`, or unspecified "add tests" steps remain; each test and implementation seam is named directly.
+- Scope control: The plan does not implement font family, font size, colors, highlight, heading semantics, or alignment/RTL round-trip.
+- Risk: Existing inline annotations use bare `fontWeight` / `fontStyle` keys, but #1071 explicitly requires `style/verticalAlign`; the new behavior should not rename existing keys.

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -43,6 +43,13 @@ function rangeFullyContainsNode(range, node) {
   }
 }
 
+function fragmentHasContent(fragment) {
+  if (!fragment || !fragment.hasChildNodes()) return false;
+  const text = fragment.textContent || "";
+  const hasElementChild = Boolean(fragment.querySelector && fragment.querySelector("*"));
+  return text.length > 0 || hasElementChild;
+}
+
 function isSafeLinkHref(url) {
   if (!url || typeof url !== "string") return false;
   const trimmed = url.trim();
@@ -586,8 +593,8 @@ export class WavyComposer extends LitElement {
       italic: { tag: "em", siblings: ["i"] },
       underline: { tag: "u", siblings: [] },
       strikethrough: { tag: "s", siblings: ["strike", "del"] },
-      superscript: { tag: "sup", siblings: [] },
-      subscript: { tag: "sub", siblings: [] }
+      superscript: { tag: "sup", siblings: [], conflicts: ["sub"] },
+      subscript: { tag: "sub", siblings: [], conflicts: ["sup"] }
     };
     if (inlineWraps[actionId]) {
       this._toggleInlineWrapAtSelection(inlineWraps[actionId]);
@@ -697,9 +704,16 @@ export class WavyComposer extends LitElement {
       this._afterBodyMutation();
       return;
     }
+    const conflictTags = spec.conflicts || [];
+    if (conflictTags.length > 0 && this._replaceConflictingInlineWrapAtSelection(range, spec)) {
+      this._afterBodyMutation();
+      return;
+    }
     const wrapper = document.createElement(spec.tag);
     try {
-      wrapper.appendChild(range.extractContents());
+      const contents = range.extractContents();
+      this._unwrapTagsInFragment(contents, conflictTags);
+      wrapper.appendChild(contents);
       range.insertNode(wrapper);
       const restored = document.createRange();
       restored.selectNodeContents(wrapper);
@@ -710,6 +724,72 @@ export class WavyComposer extends LitElement {
       return;
     }
     this._afterBodyMutation();
+  }
+
+  _replaceConflictingInlineWrapAtSelection(range, spec) {
+    const conflictTags = spec.conflicts || [];
+    const ancestor = this._findAncestorTag(range.startContainer, conflictTags);
+    if (
+      !ancestor
+      || !(ancestor === range.endContainer || ancestor.contains(range.endContainer))
+    ) {
+      return false;
+    }
+    const parent = ancestor.parentNode;
+    if (!parent) return false;
+    let prefixFragment;
+    let middleFragment;
+    let suffixFragment;
+    try {
+      const prefixRange = document.createRange();
+      prefixRange.selectNodeContents(ancestor);
+      prefixRange.setEnd(range.startContainer, range.startOffset);
+      const middleRange = document.createRange();
+      middleRange.selectNodeContents(ancestor);
+      middleRange.setStart(range.startContainer, range.startOffset);
+      middleRange.setEnd(range.endContainer, range.endOffset);
+      const suffixRange = document.createRange();
+      suffixRange.selectNodeContents(ancestor);
+      suffixRange.setStart(range.endContainer, range.endOffset);
+      prefixFragment = prefixRange.cloneContents();
+      middleFragment = middleRange.cloneContents();
+      suffixFragment = suffixRange.cloneContents();
+    } catch (_e) {
+      return false;
+    }
+    if (!fragmentHasContent(middleFragment)) return false;
+    this._unwrapTagsInFragment(middleFragment, conflictTags);
+
+    const insertFragmentWrapper = (target, frag) => {
+      if (!fragmentHasContent(frag)) return null;
+      const wrapper = ancestor.cloneNode(false);
+      wrapper.appendChild(frag);
+      parent.insertBefore(wrapper, target);
+      return wrapper;
+    };
+
+    insertFragmentWrapper(ancestor, prefixFragment);
+    const replacement = document.createElement(spec.tag);
+    replacement.appendChild(middleFragment);
+    parent.insertBefore(replacement, ancestor);
+    insertFragmentWrapper(ancestor, suffixFragment);
+    parent.removeChild(ancestor);
+
+    const restored = document.createRange();
+    restored.selectNodeContents(replacement);
+    this._restoreSelectionRange(restored);
+    return true;
+  }
+
+  _unwrapTagsInFragment(fragment, tagNames) {
+    if (!fragment || !tagNames || tagNames.length === 0 || !fragment.querySelectorAll) return;
+    const selector = tagNames.join(",");
+    for (const node of Array.from(fragment.querySelectorAll(selector))) {
+      const parent = node.parentNode;
+      if (!parent) continue;
+      while (node.firstChild) parent.insertBefore(node.firstChild, node);
+      parent.removeChild(node);
+    }
   }
 
   /**
@@ -1310,13 +1390,13 @@ export class WavyComposer extends LitElement {
   _bodyHasRichContent() {
     if (!this._bodyElement) return false;
     // J-UI-5 (#1083): inline format wraps (bold/italic/underline/strike/
-    // link) and block wraps (lists, blockquote, headings) are also rich
+    // link/super/sub) and block wraps (lists, blockquote, headings) are also rich
     // content the plain-text `draft` cannot round-trip. Counting them
     // here keeps the next Lit re-render from clobbering the wraps via
     // a textContent overwrite.
     return Boolean(
       this._bodyElement.querySelector(
-        ".wavy-mention-chip, .wavy-task-list, strong, b, em, i, u, s, strike, del, a, ul, ol, blockquote, h1, h2, h3, h4"
+        ".wavy-mention-chip, .wavy-task-list, strong, b, em, i, u, s, strike, del, a, sup, sub, ul, ol, blockquote, h1, h2, h3, h4"
       )
     );
   }

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -188,6 +188,10 @@ function inlineFormatAnnotation(tag) {
     case "strike":
     case "del":
       return { key: "textDecoration", value: "line-through" };
+    case "sup":
+      return { key: "style/verticalAlign", value: "super" };
+    case "sub":
+      return { key: "style/verticalAlign", value: "sub" };
     default:
       return null;
   }
@@ -581,7 +585,9 @@ export class WavyComposer extends LitElement {
       bold: { tag: "strong", siblings: ["b"] },
       italic: { tag: "em", siblings: ["i"] },
       underline: { tag: "u", siblings: [] },
-      strikethrough: { tag: "s", siblings: ["strike", "del"] }
+      strikethrough: { tag: "s", siblings: ["strike", "del"] },
+      superscript: { tag: "sup", siblings: [] },
+      subscript: { tag: "sub", siblings: [] }
     };
     if (inlineWraps[actionId]) {
       this._toggleInlineWrapAtSelection(inlineWraps[actionId]);

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -1145,6 +1145,8 @@ export class WavyComposer extends LitElement {
       "s",
       "strike",
       "del",
+      "sup",
+      "sub",
       "a",
       "h1",
       "h2",

--- a/j2cl/lit/src/elements/wavy-format-toolbar.js
+++ b/j2cl/lit/src/elements/wavy-format-toolbar.js
@@ -6,8 +6,7 @@ import "./toolbar-group.js";
 /**
  * <wavy-format-toolbar> — F-3.S1 (#1038, R-5.2) selection-driven floating
  * toolbar for the rich-text composer. Wraps the F-0 `<wavy-edit-toolbar>`
- * recipe; mounts the H.* daily-rich-edit subset (H.1-H.4, H.9, H.12-H.18)
- * called out by the issue body.
+ * recipe; mounts the H.* daily-rich-edit subset called out by the issue body.
  *
  * Anchoring (R-5.2 step 1):
  * - position: fixed + transform: translate(<x>px, <y>px) keyed off
@@ -40,6 +39,8 @@ const ACTIVE_ANNOTATION_MAP = {
   italic: ["em", "i"],
   underline: ["u"],
   strikethrough: ["s", "strike", "del"],
+  superscript: ["sup"],
+  subscript: ["sub"],
   "unordered-list": ["ul"],
   "ordered-list": ["ol"],
   "align-left": [],
@@ -76,6 +77,8 @@ const DAILY_RICH_EDIT_ACTIONS = [
   { id: "italic", label: "Italic", group: "text", toggle: true },
   { id: "underline", label: "Underline", group: "text", toggle: true },
   { id: "strikethrough", label: "Strikethrough", group: "text", toggle: true },
+  { id: "superscript", label: "Superscript", group: "text", toggle: true },
+  { id: "subscript", label: "Subscript", group: "text", toggle: true },
   { id: "heading", label: "Heading", group: "block", toggle: false },
   { id: "unordered-list", label: "Bulleted list", group: "block", toggle: true },
   { id: "ordered-list", label: "Numbered list", group: "block", toggle: true },

--- a/j2cl/lit/src/icons/toolbar-icons.js
+++ b/j2cl/lit/src/icons/toolbar-icons.js
@@ -26,6 +26,16 @@ const ICON_TEMPLATES = {
     <path d="M5 11a3 3 0 0 0 3 2.5h.5a2.75 2.75 0 0 0 2.5-3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
     <line x1="2.5" y1="8" x2="13.5" y2="8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
   </svg>`,
+  superscript: svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none">
+    <path d="M3 11.5l5-7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    <path d="M3 4.5l5 7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    <path d="M10.5 3.25h2.75l-2.75 3.5h2.9" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`,
+  subscript: svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none">
+    <path d="M3 8.5l5-7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    <path d="M3 1.5l5 7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+    <path d="M10.5 10.25h2.75l-2.75 3.5h2.9" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`,
   heading: svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none">
     <line x1="3.5" y1="2.5" x2="3.5" y2="13.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
     <line x1="12.5" y1="2.5" x2="12.5" y2="13.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -278,7 +278,7 @@ describe("wavy-composer toolbar action handlers", () => {
   it("Clear formatting strips inline format wraps from the selection", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     const body = bodyOf(el);
-    body.innerHTML = "<strong><em>boldy</em></strong>";
+    body.innerHTML = "<strong><em>boldy</em></strong><sup>2</sup><sub>3</sub>";
     body.focus();
     const range = document.createRange();
     range.selectNodeContents(body);
@@ -291,7 +291,9 @@ describe("wavy-composer toolbar action handlers", () => {
 
     expect(body.querySelector("strong")).to.not.exist;
     expect(body.querySelector("em")).to.not.exist;
-    expect(body.textContent).to.equal("boldy");
+    expect(body.querySelector("sup")).to.not.exist;
+    expect(body.querySelector("sub")).to.not.exist;
+    expect(body.textContent).to.equal("boldy23");
   });
 
   it("Clear formatting only strips wraps that intersect the selection", async () => {

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -5,10 +5,10 @@ import "../src/elements/wavy-link-modal.js";
 // J-UI-5 (#1083) — selection-driven toolbar action handlers.
 //
 // These tests cover the wavy-composer's `_handleToolbarAction` branch
-// added by J-UI-5: bold / italic / underline / strikethrough / list /
-// link / unlink / clear-formatting are applied to the active range,
-// and reply-submit carries a `components` array reflecting the
-// per-fragment formatting.
+// added by J-UI-5: bold / italic / underline / strikethrough /
+// superscript / subscript / list / link / unlink / clear-formatting are
+// applied to the active range, and reply-submit carries a `components`
+// array reflecting the per-fragment formatting.
 
 function ensureWavyTokensLoaded() {
   if (document.querySelector('link[data-wavy-tokens-test]')) return;
@@ -76,6 +76,26 @@ describe("wavy-composer toolbar action handlers", () => {
     dispatchToolbarAction(el, "italic");
 
     expect(bodyOf(el).querySelector("em")).to.exist;
+  });
+
+  it("wraps the active selection in <sup> and <sub>", async () => {
+    const superscript = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(superscript).textContent = "2";
+    selectAllInBody(superscript);
+
+    dispatchToolbarAction(superscript, "superscript");
+
+    expect(bodyOf(superscript).querySelector("sup")).to.exist;
+    expect(bodyOf(superscript).querySelector("sup").textContent).to.equal("2");
+
+    const subscript = await fixture(html`<wavy-composer available></wavy-composer>`);
+    bodyOf(subscript).textContent = "2";
+    selectAllInBody(subscript);
+
+    dispatchToolbarAction(subscript, "subscript");
+
+    expect(bodyOf(subscript).querySelector("sub")).to.exist;
+    expect(bodyOf(subscript).querySelector("sub").textContent).to.equal("2");
   });
 
   it("wraps in <u> and a follow-up click with caret inside <u> unwraps", async () => {

--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -40,6 +40,27 @@ function selectAllInBody(el) {
   el._onSelectionChange();
 }
 
+function selectContents(el, node) {
+  bodyOf(el).focus();
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  const sel = document.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  el._onSelectionChange();
+}
+
+function selectTextRange(el, textNode, startOffset, endOffset) {
+  bodyOf(el).focus();
+  const range = document.createRange();
+  range.setStart(textNode, startOffset);
+  range.setEnd(textNode, endOffset);
+  const sel = document.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  el._onSelectionChange();
+}
+
 function dispatchToolbarAction(el, actionId) {
   el.dispatchEvent(
     new CustomEvent("wavy-format-toolbar-action", {
@@ -96,6 +117,39 @@ describe("wavy-composer toolbar action handlers", () => {
 
     expect(bodyOf(subscript).querySelector("sub")).to.exist;
     expect(bodyOf(subscript).querySelector("sub").textContent).to.equal("2");
+  });
+
+  it("replaces superscript and subscript instead of nesting them", async () => {
+    const superscript = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const supBody = bodyOf(superscript);
+    supBody.innerHTML = "<sup>2</sup>";
+    selectContents(superscript, supBody.querySelector("sup"));
+
+    dispatchToolbarAction(superscript, "subscript");
+
+    expect(supBody.querySelector("sup")).to.not.exist;
+    expect(supBody.querySelector("sub")).to.exist;
+    expect(supBody.querySelector("sub").textContent).to.equal("2");
+
+    const subscript = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const subBody = bodyOf(subscript);
+    subBody.innerHTML = "<sub>2</sub>";
+    selectContents(subscript, subBody.querySelector("sub"));
+
+    dispatchToolbarAction(subscript, "superscript");
+
+    expect(subBody.querySelector("sub")).to.not.exist;
+    expect(subBody.querySelector("sup")).to.exist;
+    expect(subBody.querySelector("sup").textContent).to.equal("2");
+
+    const partial = await fixture(html`<wavy-composer available></wavy-composer>`);
+    const partialBody = bodyOf(partial);
+    partialBody.innerHTML = "<sup>123</sup>";
+    selectTextRange(partial, partialBody.querySelector("sup").firstChild, 1, 2);
+
+    dispatchToolbarAction(partial, "subscript");
+
+    expect(partialBody.innerHTML).to.equal("<sup>1</sup><sub>2</sub><sup>3</sup>");
   });
 
   it("wraps in <u> and a follow-up click with caret inside <u> unwraps", async () => {

--- a/j2cl/lit/test/wavy-composer.test.js
+++ b/j2cl/lit/test/wavy-composer.test.js
@@ -889,33 +889,39 @@ describe("<wavy-composer> R-5.3 mentions", () => {
     it("emits style/verticalAlign=super for <sup>", async () => {
       const el = await fixture(html`<wavy-composer available></wavy-composer>`);
       document.body.appendChild(el);
-      const body = getBody(el);
-      body.innerHTML = "x<sup>2</sup>";
-      const components = el.serializeRichComponents();
-      const superRun = components.find(
-        c => c.type === "annotated"
-          && c.annotationKey === "style/verticalAlign"
-          && c.annotationValue === "super"
-      );
-      expect(superRun).to.exist;
-      expect(superRun.text).to.equal("2");
-      el.remove();
+      try {
+        const body = getBody(el);
+        body.innerHTML = "x<sup>2</sup>";
+        const components = el.serializeRichComponents();
+        const superRun = components.find(
+          c => c.type === "annotated"
+            && c.annotationKey === "style/verticalAlign"
+            && c.annotationValue === "super"
+        );
+        expect(superRun).to.exist;
+        expect(superRun.text).to.equal("2");
+      } finally {
+        el.remove();
+      }
     });
 
     it("emits style/verticalAlign=sub for <sub>", async () => {
       const el = await fixture(html`<wavy-composer available></wavy-composer>`);
       document.body.appendChild(el);
-      const body = getBody(el);
-      body.innerHTML = "H<sub>2</sub>O";
-      const components = el.serializeRichComponents();
-      const subRun = components.find(
-        c => c.type === "annotated"
-          && c.annotationKey === "style/verticalAlign"
-          && c.annotationValue === "sub"
-      );
-      expect(subRun).to.exist;
-      expect(subRun.text).to.equal("2");
-      el.remove();
+      try {
+        const body = getBody(el);
+        body.innerHTML = "H<sub>2</sub>O";
+        const components = el.serializeRichComponents();
+        const subRun = components.find(
+          c => c.type === "annotated"
+            && c.annotationKey === "style/verticalAlign"
+            && c.annotationValue === "sub"
+        );
+        expect(subRun).to.exist;
+        expect(subRun.text).to.equal("2");
+      } finally {
+        el.remove();
+      }
     });
 
     // review-1077 Bug 3: mention chips nested inside an <a> must not

--- a/j2cl/lit/test/wavy-composer.test.js
+++ b/j2cl/lit/test/wavy-composer.test.js
@@ -886,6 +886,38 @@ describe("<wavy-composer> R-5.3 mentions", () => {
       el.remove();
     });
 
+    it("emits style/verticalAlign=super for <sup>", async () => {
+      const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+      document.body.appendChild(el);
+      const body = getBody(el);
+      body.innerHTML = "x<sup>2</sup>";
+      const components = el.serializeRichComponents();
+      const superRun = components.find(
+        c => c.type === "annotated"
+          && c.annotationKey === "style/verticalAlign"
+          && c.annotationValue === "super"
+      );
+      expect(superRun).to.exist;
+      expect(superRun.text).to.equal("2");
+      el.remove();
+    });
+
+    it("emits style/verticalAlign=sub for <sub>", async () => {
+      const el = await fixture(html`<wavy-composer available></wavy-composer>`);
+      document.body.appendChild(el);
+      const body = getBody(el);
+      body.innerHTML = "H<sub>2</sub>O";
+      const components = el.serializeRichComponents();
+      const subRun = components.find(
+        c => c.type === "annotated"
+          && c.annotationKey === "style/verticalAlign"
+          && c.annotationValue === "sub"
+      );
+      expect(subRun).to.exist;
+      expect(subRun.text).to.equal("2");
+      el.remove();
+    });
+
     // review-1077 Bug 3: mention chips nested inside an <a> must not
     // be swallowed into the link's textContent.  Walking children
     // recursively keeps the chip as its own annotated component while

--- a/j2cl/lit/test/wavy-format-toolbar.test.js
+++ b/j2cl/lit/test/wavy-format-toolbar.test.js
@@ -32,11 +32,22 @@ describe("<wavy-format-toolbar>", () => {
     const el = await fixture(html`<wavy-format-toolbar></wavy-format-toolbar>`);
     const buttons = el.renderRoot.querySelectorAll("[data-toolbar-action]");
     const actionIds = Array.from(buttons).map((b) => b.getAttribute("data-toolbar-action"));
+    expect(actionIds.slice(0, 7)).to.deep.equal([
+      "bold",
+      "italic",
+      "underline",
+      "strikethrough",
+      "superscript",
+      "subscript",
+      "heading"
+    ]);
     expect(actionIds).to.include.members([
       "bold",
       "italic",
       "underline",
       "strikethrough",
+      "superscript",
+      "subscript",
       "heading",
       "unordered-list",
       "ordered-list",
@@ -109,6 +120,31 @@ describe("<wavy-format-toolbar>", () => {
     );
     const evt = await trigger;
     expect(evt.detail.actionId).to.equal("insert-task");
+  });
+
+  it("re-dispatches H.5/H.6 superscript and subscript actions", async () => {
+    const el = await fixture(html`<wavy-format-toolbar></wavy-format-toolbar>`);
+    el.selectionDescriptor = {
+      collapsed: false,
+      boundingRect: { top: 100, left: 100, width: 60, height: 18 },
+      activeAnnotations: []
+    };
+    await el.updateComplete;
+
+    for (const actionId of ["superscript", "subscript"]) {
+      const button = el.renderRoot.querySelector(`[data-toolbar-action="${actionId}"]`);
+      expect(button, `${actionId} button must render`).to.exist;
+      const trigger = oneEvent(el, "wavy-format-toolbar-action");
+      button.dispatchEvent(
+        new CustomEvent("toolbar-action", {
+          detail: { action: actionId },
+          bubbles: true,
+          composed: true
+        })
+      );
+      const evt = await trigger;
+      expect(evt.detail.actionId).to.equal(actionId);
+    }
   });
 
   it("hides itself when selection descriptor is collapsed", async () => {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -1064,6 +1064,44 @@ public class J2clRichContentDeltaFactoryTest {
         "\"2\":\" today\"");
   }
 
+  @Test
+  public void createReplyRequestRoundTripsSuperscriptAnnotation() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+abc", "chan-4", 3L, "HASH", "b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .annotatedText("style/verticalAlign", "super", "x²")
+            .build();
+    String deltaJson =
+        factory.createReplyRequest("user@example.com", session, document).getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"1\":{\"3\":[{\"1\":\"style/verticalAlign\",\"3\":\"super\"}]}}",
+        "\"2\":\"x²\"",
+        "{\"1\":{\"2\":[\"style/verticalAlign\"]}}");
+  }
+
+  @Test
+  public void createReplyRequestRoundTripsSubscriptAnnotation() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+abc", "chan-5", 4L, "HASH", "b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder()
+            .annotatedText("style/verticalAlign", "sub", "H₂O")
+            .build();
+    String deltaJson =
+        factory.createReplyRequest("user@example.com", session, document).getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"1\":{\"3\":[{\"1\":\"style/verticalAlign\",\"3\":\"sub\"}]}}",
+        "\"2\":\"H₂O\"",
+        "{\"1\":{\"2\":[\"style/verticalAlign\"]}}");
+  }
+
   // F-3.S4 (#1038, R-5.6 F.6): blip-delete request emits a
   // tombstone/deleted=true annotation on the blip body. The op shape
   // mirrors the existing taskToggleRequest single-key writer except for

--- a/wave/config/changelog.d/2026-04-30-j2cl-superscript-subscript.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-superscript-subscript.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-30-j2cl-superscript-subscript",
+  "version": "PR #1071",
+  "date": "2026-04-30",
+  "title": "J2CL superscript and subscript toolbar buttons",
+  "summary": "The J2CL rich-edit toolbar now exposes superscript and subscript controls and preserves their vertical-align annotations through rich reply submission.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Adds Superscript and Subscript buttons to the J2CL rich-edit toolbar between Strikethrough and Heading.",
+        "Serializes <sup> and <sub> rich-composer content as style/verticalAlign annotations for DocOp round trips."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1071. Refs #904.

- Add `superscript` and `subscript` buttons to `<wavy-format-toolbar>` between Strikethrough and Heading, including SVG icons and action re-dispatch coverage.
- Wire composer toolbar actions to wrap selected text in `<sup>` / `<sub>` and serialize those tags as `style/verticalAlign=super|sub` rich components.
- Add `J2clRichContentDeltaFactory` round-trip coverage for `J2clComposerDocument.builder().annotatedText("style/verticalAlign", ...)` on superscript and subscript.
- Add issue plan and changelog fragment for the user-facing toolbar behavior.

## Verification

- `cd j2cl/lit && npm test -- --files test/wavy-format-toolbar.test.js test/wavy-composer.test.js` -> pass (`64 passed, 0 failed`).
- `cd j2cl/lit && npm test -- --files test/wavy-composer-toolbar-actions.test.js` -> pass (`37 passed, 0 failed`).
- `cd j2cl/lit && npm run build` -> pass.
- `sbt --batch compile j2clSearchTest` -> pass.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> pass.
- `git diff --check` -> pass.

## Review

- Plan self-review passed and is recorded in `docs/superpowers/plans/2026-04-30-issue-1071-superscript-subscript.md`.
- Claude Opus plan and implementation review attempts were blocked by provider quota: `You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)`. No external approval is claimed.
- Narrow SBT `Test/testOnly org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactoryTest` probe compiled but reported `No tests to run`; `j2clSearchTest` is the effective J2CL verification gate for this lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Superscript and Subscript buttons to the rich-text toolbar, with toggle behavior that replaces conflicting vertical-alignment formatting and preserves selection.
  * Superscript/subscript formatting is serialized as vertical-align annotations and preserved across rich reply submissions.

* **Tests**
  * Added tests for toolbar ordering, toggle behavior, DOM wrapping/unwrapping, partial-range replacement, clearing formatting, and round-trip annotation serialization.

* **Documentation**
  * Added changelog entry describing the new toolbar controls and preserved serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->