### PR TITLE
feat: add J2CL profile overlay actions

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1075-profile-actions.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1075-profile-actions.md
@@ -1,0 +1,61 @@
+# Issue #1075: J2CL Profile Overlay Actions
+
+## Context
+
+Issue #1075 completes the F-3 follow-up for profile-card actions in the J2CL/Lit UI:
+
+- L.2: Send Message from a non-self profile should start a 1:1 wave with that participant.
+- L.3: Edit Profile should be available only on the signed-in user's own profile and should route to the existing profile-edit page.
+
+The current `<wavy-profile-overlay>` intentionally left a named `actions` slot for later slices. The legacy GWT/server profile card already has these actions, so this lane closes the J2CL parity gap rather than adding a new product concept.
+
+## Current Findings
+
+- `j2cl/lit/src/elements/wavy-profile-overlay.js` opens and navigates participants, but renders only `<slot name="actions">`.
+- `j2cl/lit/test/wavy-profile-overlay.test.js` currently asserts only that the slot exists.
+- `J2clComposeSurfaceController.submitCreate()` builds create-wave requests that add only the signed-in user as participant.
+- `J2clRichContentDeltaFactory.createWaveRequest(...)` prepends one AddParticipant operation for the signed-in address.
+- Existing GWT/server profile card routes "Edit Profile" to `/userprofile/edit`; use that route unless a J2CL settings route exists.
+
+## Implementation Plan
+
+1. Lit overlay actions
+   - Add `currentUserId` and `editProfileUrl` properties to `<wavy-profile-overlay>`.
+   - Render native Wavy-styled action buttons alongside the existing slot:
+     - `Send Message` when the current profile is not self and has an address.
+     - `Edit Profile` when the current profile is self, either by `participant.isSelf` or address matching `currentUserId`.
+   - Emit `wave-new-with-participants-requested` with `{participants: [address], source: "profile-overlay"}` from Send Message.
+   - Emit a cancelable `wavy-profile-edit-requested` event with `{url, participant}` before navigating to `/userprofile/edit`, so tests and future shell routers can intercept without forcing `window.location`.
+
+2. Root-shell bridge
+   - Listen for `wave-new-with-participants-requested` in `J2clRootShellController`.
+   - Parse the event detail participants defensively.
+   - Route to a new compose-controller entrypoint that creates a wave with the requested participants, reusing the create-wave submit pipeline and optimistic digest handling.
+
+3. Create delta support
+   - Extend the compose `DeltaFactory` with a default overload accepting additional participant addresses.
+   - Extend `J2clRichContentDeltaFactory` to emit AddParticipant ops for the signed-in user plus deduped additional participants before the root blip document op.
+   - Preserve the existing overloads for current callers and tests.
+
+4. Tests
+   - Add Lit tests for action rendering/gating and events:
+     - non-self profile shows Send Message and emits participants.
+     - own profile hides Send Message, shows Edit Profile, and emits cancelable edit event.
+     - `participant.isSelf` gates Edit Profile even without `currentUserId`.
+   - Add Java delta-factory coverage for extra participant AddParticipant ops, including dedupe against the signed-in address.
+   - Add compose-controller/root bridge coverage where practical without broad shell bootstrapping; prefer the narrowest controller test if root-shell integration is not easily isolated.
+
+5. Verification
+   - `cd j2cl/lit && npm test -- --files test/wavy-profile-overlay.test.js`
+   - `cd j2cl/lit && npm run build`
+   - `sbt --batch compile j2clSearchTest`
+   - `python3 scripts/assemble-changelog.py`
+   - `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+   - `git diff --check`
+
+## Self Review
+
+- The plan is not just visual: it carries the Send Message click through a real create-wave delta with the requested participant.
+- The Edit Profile path follows the existing server/GWT route (`/userprofile/edit`) instead of inventing a new J2CL settings surface.
+- The Lit overlay remains extensible by preserving the named `actions` slot.
+- The risk is create-wave semantics for empty direct-message waves. The implementation should allow participant-driven create submits even when title/body are empty, but must not relax normal create validation for the regular create form.

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -424,7 +424,9 @@ export class WavyProfileOverlay extends LitElement {
       cancelable: true,
       detail: { url, participant }
     });
-    if (this.dispatchEvent(event)) {
+    const shouldNavigate = this.dispatchEvent(event);
+    this.close_();
+    if (shouldNavigate) {
       const loc = globalThis && globalThis.location;
       if (loc && typeof loc.assign === "function") {
         loc.assign(url);

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -3,8 +3,9 @@ import { LitElement, css, html } from "lit";
 /**
  * <wavy-profile-overlay> — F-2.S4 (#1048, L.1 + L.5) modal that opens
  * when an avatar is clicked on a <wave-blip>. Mounts the overlay
- * scaffolding only; L.2 (Send Message) and L.3 (Edit Profile) are
- * delegated to the named `actions` slot for later slices to fill.
+ * scaffolding and the profile-card parity actions for L.2 (Send Message)
+ * and L.3 (Edit Profile). The named `actions` slot remains for future
+ * shell-specific extensions.
  *
  * Open path (L.1):
  *   The element listens on `document` for `wave-blip-profile-requested`
@@ -18,11 +19,17 @@ import { LitElement, css, html } from "lit";
  *   - participants: Array<{ id, displayName, avatarUrl? }> — populated
  *     by the renderer from the wave model. Default [].
  *   - index: number — currently shown participant index. Default 0.
+ *   - currentUserId: string — signed-in participant address used to gate
+ *     own-profile actions.
+ *   - editProfileUrl: string — destination for the Edit Profile action.
  *
  * Events emitted (CustomEvent, bubbles + composed):
  *   - `wavy-profile-overlay-opened` — `{detail: {authorId}}`.
  *   - `wavy-profile-participant-changed` — `{detail: {index, participant}}`.
  *   - `wavy-profile-overlay-closed` — emitted on Exit / Escape.
+ *   - `wave-new-with-participants-requested` —
+ *     `{detail: {participants, source}}` from Send Message.
+ *   - `wavy-profile-edit-requested` — cancelable route hook from Edit Profile.
  *
  * L.4 (close): the inventory marks close as F-0-owned (style). S4
  * ships a tactical close (× button + Escape) using wavy tokens so the
@@ -33,7 +40,9 @@ export class WavyProfileOverlay extends LitElement {
   static properties = {
     open: { type: Boolean, reflect: true },
     participants: { attribute: false },
-    index: { type: Number, reflect: true }
+    index: { type: Number, reflect: true },
+    currentUserId: { type: String, attribute: "current-user-id" },
+    editProfileUrl: { type: String, attribute: "edit-profile-url" }
   };
 
   static styles = css`
@@ -139,7 +148,29 @@ export class WavyProfileOverlay extends LitElement {
     }
     .actions-slot {
       display: inline-flex;
+      flex-wrap: wrap;
+      justify-content: center;
       gap: var(--wavy-spacing-2, 8px);
+    }
+    .profile-action {
+      min-height: 34px;
+      padding: 0 var(--wavy-spacing-4, 16px);
+      border-radius: var(--wavy-radius-pill, 9999px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+      background: rgba(255, 255, 255, 0.06);
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      cursor: pointer;
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+      font-weight: 700;
+      letter-spacing: 0.01em;
+    }
+    .profile-action-primary {
+      background: var(--wavy-signal-cyan, #22d3ee);
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+      color: var(--wavy-bg-base, #0b1320);
+    }
+    .profile-action[hidden] {
+      display: none;
     }
   `;
 
@@ -148,6 +179,8 @@ export class WavyProfileOverlay extends LitElement {
     this.open = false;
     this.participants = [];
     this.index = 0;
+    this.currentUserId = "";
+    this.editProfileUrl = "/userprofile/edit";
     this._onAvatarRequest = this._onAvatarRequest.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
   }
@@ -347,6 +380,60 @@ export class WavyProfileOverlay extends LitElement {
     this.close_();
   }
 
+  _profileAddress(participant) {
+    return participant && participant.id ? String(participant.id).trim() : "";
+  }
+
+  _normalizedAddress(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  _isSelfParticipant(participant) {
+    if (!participant) return false;
+    if (participant.isSelf === true || participant.isSelf === "true") {
+      return true;
+    }
+    const profileAddress = this._normalizedAddress(this._profileAddress(participant));
+    const currentUserId = this._normalizedAddress(this.currentUserId);
+    return Boolean(profileAddress && currentUserId && profileAddress === currentUserId);
+  }
+
+  _onSendMessage(participant) {
+    const address = this._profileAddress(participant);
+    if (!address || this._isSelfParticipant(participant)) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent("wave-new-with-participants-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { participants: [address], source: "profile-overlay" }
+      })
+    );
+    this.close_();
+  }
+
+  _onEditProfile(participant) {
+    if (!this._isSelfParticipant(participant)) {
+      return;
+    }
+    const url = this.editProfileUrl || "/userprofile/edit";
+    const event = new CustomEvent("wavy-profile-edit-requested", {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+      detail: { url, participant }
+    });
+    if (this.dispatchEvent(event)) {
+      const loc = globalThis && globalThis.location;
+      if (loc && typeof loc.assign === "function") {
+        loc.assign(url);
+      } else if (loc) {
+        loc.href = url;
+      }
+    }
+  }
+
   _initials(displayName) {
     const name = String(displayName || "?").trim();
     if (!name) return "?";
@@ -361,6 +448,8 @@ export class WavyProfileOverlay extends LitElement {
     const current = list[idx] || null;
     const displayName = current ? current.displayName : "Unknown participant";
     const pid = current ? current.id : "";
+    const isSelf = this._isSelfParticipant(current);
+    const canSendMessage = Boolean(this._profileAddress(current)) && !isSelf;
     const prevDisabled = list.length === 0 || idx === 0;
     const nextDisabled = list.length === 0 || idx >= max;
 
@@ -401,6 +490,24 @@ export class WavyProfileOverlay extends LitElement {
         <h2 class="name" id="wavy-profile-name">${displayName}</h2>
         ${pid ? html`<p class="pid">${pid}</p>` : null}
         <div class="actions-slot">
+          <button
+            class="profile-action profile-action-primary"
+            type="button"
+            data-profile-send-message
+            ?hidden=${!canSendMessage}
+            @click=${() => this._onSendMessage(current)}
+          >
+            Send Message
+          </button>
+          <button
+            class="profile-action"
+            type="button"
+            data-profile-edit
+            ?hidden=${!isSelf}
+            @click=${() => this._onEditProfile(current)}
+          >
+            Edit Profile
+          </button>
           <slot name="actions"></slot>
         </div>
       </div>

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -192,6 +192,71 @@ describe("<wavy-profile-overlay>", () => {
     expect(slot).to.exist;
   });
 
+  it("shows Send Message for non-self profile and emits requested participant", async () => {
+    const el = await fixture(
+      html`<wavy-profile-overlay open current-user-id="alice@example.com"></wavy-profile-overlay>`
+    );
+    el.participants = PARTICIPANTS;
+    el.index = 1;
+    await el.updateComplete;
+
+    const send = el.renderRoot.querySelector("[data-profile-send-message]");
+    const edit = el.renderRoot.querySelector("[data-profile-edit]");
+    expect(send).to.exist;
+    expect(send.hasAttribute("hidden")).to.equal(false);
+    expect(edit).to.exist;
+    expect(edit.hasAttribute("hidden")).to.equal(true);
+
+    setTimeout(() => send.click());
+    const ev = await oneEvent(el, "wave-new-with-participants-requested");
+    expect(ev.detail).to.deep.equal({
+      participants: ["bob@example.com"],
+      source: "profile-overlay"
+    });
+    expect(el.open).to.equal(false);
+  });
+
+  it("shows Edit Profile for current user and emits a cancelable edit event", async () => {
+    const el = await fixture(
+      html`<wavy-profile-overlay open current-user-id="alice@example.com"></wavy-profile-overlay>`
+    );
+    el.participants = PARTICIPANTS;
+    await el.updateComplete;
+
+    const send = el.renderRoot.querySelector("[data-profile-send-message]");
+    const edit = el.renderRoot.querySelector("[data-profile-edit]");
+    expect(send).to.exist;
+    expect(send.hasAttribute("hidden")).to.equal(true);
+    expect(edit).to.exist;
+    expect(edit.hasAttribute("hidden")).to.equal(false);
+
+    let observed = null;
+    el.addEventListener("wavy-profile-edit-requested", (event) => {
+      observed = event;
+      event.preventDefault();
+    });
+    edit.click();
+
+    expect(observed).to.exist;
+    expect(observed.cancelable).to.equal(true);
+    expect(observed.detail.url).to.equal("/userprofile/edit");
+    expect(observed.detail.participant).to.deep.equal(PARTICIPANTS[0]);
+  });
+
+  it("participant isSelf gates Edit Profile without currentUserId", async () => {
+    const el = await fixture(html`<wavy-profile-overlay open></wavy-profile-overlay>`);
+    el.participants = [
+      { id: "viewer@example.com", displayName: "Viewer", isSelf: true },
+      { id: "bob@example.com", displayName: "Bob" }
+    ];
+    await el.updateComplete;
+
+    const send = el.renderRoot.querySelector("[data-profile-send-message]");
+    const edit = el.renderRoot.querySelector("[data-profile-edit]");
+    expect(send.hasAttribute("hidden")).to.equal(true);
+    expect(edit.hasAttribute("hidden")).to.equal(false);
+  });
+
   it("avatar event with empty participants list still opens; nav buttons disabled both ends", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = [];

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -241,6 +241,7 @@ describe("<wavy-profile-overlay>", () => {
     expect(observed.cancelable).to.equal(true);
     expect(observed.detail.url).to.equal("/userprofile/edit");
     expect(observed.detail.participant).to.deep.equal(PARTICIPANTS[0]);
+    expect(el.open).to.equal(false);
   });
 
   it("participant isSelf gates Edit Profile without currentUserId", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -328,6 +329,18 @@ public final class J2clComposeSurfaceController {
     CreateWaveRequest createWaveRequest(
         String address, String draftText, J2clComposerDocument document);
 
+    default CreateWaveRequest createWaveRequest(
+        String address,
+        String draftText,
+        J2clComposerDocument document,
+        List<String> additionalParticipantAddresses) {
+      if (additionalParticipantAddresses != null && !additionalParticipantAddresses.isEmpty()) {
+        throw new UnsupportedOperationException(
+            "Additional create participants require the rich-content delta factory.");
+      }
+      return createWaveRequest(address, draftText, document);
+    }
+
     SidecarSubmitRequest createReplyRequest(
         String address,
         J2clSidecarWriteSession session,
@@ -506,6 +519,7 @@ public final class J2clComposeSurfaceController {
   // Composed into the rich-content document on submit alongside the body so
   // WaveDigester picks the conv/title annotation up server-side.
   private String createTitleDraft = "";
+  private List<String> pendingCreateParticipantAddresses = Collections.emptyList();
 
   /**
    * F-3.S3 (#1038, R-5.5): callback fired after each successful
@@ -882,6 +896,25 @@ public final class J2clComposeSurfaceController {
   public void onCreateSubmittedWithTitle(String title, String draft) {
     createTitleDraft = normalizeTitleForSubmit(title);
     createDraft = normalizeDraft(draft);
+    submitCreate();
+  }
+
+  /**
+   * F-3 follow-up (#1075, L.2): create a direct wave from profile-card Send
+   * Message. Participant-driven creates may be title/body empty, but normal
+   * create-form submissions still require user content.
+   */
+  public void onCreateRequestedWithParticipants(List<String> participantAddresses) {
+    if (signedOut || createSubmitting) {
+      render();
+      return;
+    }
+    List<String> normalized = normalizeCreateParticipantAddresses(participantAddresses);
+    if (normalized.isEmpty()) {
+      focusCreateSurface();
+      return;
+    }
+    pendingCreateParticipantAddresses = normalized;
     submitCreate();
   }
 
@@ -1700,10 +1733,17 @@ public final class J2clComposeSurfaceController {
       render();
       return;
     }
+    final List<String> submittedParticipantAddresses =
+        pendingCreateParticipantAddresses.isEmpty()
+            ? Collections.emptyList()
+            : new ArrayList<String>(pendingCreateParticipantAddresses);
+    pendingCreateParticipantAddresses = Collections.emptyList();
     // J-UI-3 (#1081, R-5.1): allow submit when EITHER title or body has text.
     // The user story is "type a title and a message" so a body-only or
     // title-only submission is still a valid create.
-    if (createDraft.trim().isEmpty() && createTitleDraft.trim().isEmpty()) {
+    if (createDraft.trim().isEmpty()
+        && createTitleDraft.trim().isEmpty()
+        && submittedParticipantAddresses.isEmpty()) {
       createStatusText = "";
       createErrorText = "Enter some text before creating a wave.";
       render();
@@ -1747,7 +1787,8 @@ public final class J2clComposeSurfaceController {
                 deltaFactory.createWaveRequest(
                     bootstrap.getAddress(),
                     submittedDraft,
-                    buildDocument(submittedTitle, submittedDraft, false, ""));
+                    buildDocument(submittedTitle, submittedDraft, false, ""),
+                    submittedParticipantAddresses);
           } catch (RuntimeException e) {
             handleCreateFailure(generation, messageOrDefault(e, "Unable to build the create request."));
             return;
@@ -2288,8 +2329,17 @@ public final class J2clComposeSurfaceController {
       @Override
       public CreateWaveRequest createWaveRequest(
           String address, String draftText, J2clComposerDocument document) {
+        return createWaveRequest(address, draftText, document, Collections.emptyList());
+      }
+
+      @Override
+      public CreateWaveRequest createWaveRequest(
+          String address,
+          String draftText,
+          J2clComposerDocument document,
+          List<String> additionalParticipantAddresses) {
         J2clRichContentDeltaFactory.CreateWaveRequest request =
-            factory.createWaveRequest(address, document);
+            factory.createWaveRequest(address, document, additionalParticipantAddresses);
         return new CreateWaveRequest(request.getCreatedWaveId(), request.getSubmitRequest());
       }
 
@@ -2707,6 +2757,26 @@ public final class J2clComposeSurfaceController {
 
   private static String normalizeDraft(String draft) {
     return draft == null ? "" : draft;
+  }
+
+  private static List<String> normalizeCreateParticipantAddresses(List<String> participantAddresses) {
+    if (participantAddresses == null || participantAddresses.isEmpty()) {
+      return Collections.emptyList();
+    }
+    Set<String> normalized = new LinkedHashSet<String>();
+    for (String participantAddress : participantAddresses) {
+      if (participantAddress == null) {
+        continue;
+      }
+      String trimmed = participantAddress.trim().toLowerCase(Locale.ROOT);
+      if (!trimmed.isEmpty()) {
+        normalized.add(trimmed);
+      }
+    }
+    if (normalized.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return new ArrayList<String>(normalized);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -914,8 +914,7 @@ public final class J2clComposeSurfaceController {
       focusCreateSurface();
       return;
     }
-    pendingCreateParticipantAddresses = normalized;
-    submitCreate();
+    submitCreate("", "", normalized, false);
   }
 
   /**
@@ -1729,20 +1728,28 @@ public final class J2clComposeSurfaceController {
   }
 
   private void submitCreate() {
+    submitCreate(createTitleDraft, createDraft, pendingCreateParticipantAddresses, true);
+  }
+
+  private void submitCreate(
+      String submittedTitle,
+      String submittedDraft,
+      List<String> participantAddresses,
+      boolean clearCreateDraftOnSuccess) {
     if (signedOut || createSubmitting) {
       render();
       return;
     }
     final List<String> submittedParticipantAddresses =
-        pendingCreateParticipantAddresses.isEmpty()
+        participantAddresses == null || participantAddresses.isEmpty()
             ? Collections.emptyList()
-            : new ArrayList<String>(pendingCreateParticipantAddresses);
+            : new ArrayList<String>(participantAddresses);
     pendingCreateParticipantAddresses = Collections.emptyList();
     // J-UI-3 (#1081, R-5.1): allow submit when EITHER title or body has text.
     // The user story is "type a title and a message" so a body-only or
     // title-only submission is still a valid create.
-    if (createDraft.trim().isEmpty()
-        && createTitleDraft.trim().isEmpty()
+    if (submittedDraft.trim().isEmpty()
+        && submittedTitle.trim().isEmpty()
         && submittedParticipantAddresses.isEmpty()) {
       createStatusText = "";
       createErrorText = "Enter some text before creating a wave.";
@@ -1752,8 +1759,6 @@ public final class J2clComposeSurfaceController {
     createSubmitting = true;
     createStatusText = "Bootstrapping the root-shell submit session.";
     createErrorText = "";
-    final String submittedDraft = createDraft;
-    final String submittedTitle = createTitleDraft;
     final int generation = ++createGeneration;
     // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-CyWx: stamp the
     // pre-submit search query (via the root shell's hook) BEFORE the
@@ -1798,7 +1803,14 @@ public final class J2clComposeSurfaceController {
           gateway.submit(
               bootstrap,
               request.getSubmitRequest(),
-              response -> handleCreateResponse(generation, request, submittedTitle, submittedDraft, response),
+              response ->
+                  handleCreateResponse(
+                      generation,
+                      request,
+                      submittedTitle,
+                      submittedDraft,
+                      clearCreateDraftOnSuccess,
+                      response),
               error -> handleCreateFailure(generation, error));
         },
         error -> handleCreateFailure(generation, error));
@@ -1809,6 +1821,7 @@ public final class J2clComposeSurfaceController {
       CreateWaveRequest request,
       String submittedTitle,
       String submittedDraft,
+      boolean clearCreateDraftOnSuccess,
       SidecarSubmitResponse response) {
     if (generation != createGeneration) {
       // J-UI-3 codex P2 PRRT_kwDOBwxLXs5-DZqM: superseded; retire this
@@ -1826,8 +1839,10 @@ public final class J2clComposeSurfaceController {
     // stub title passed to the optimistic-digest handler.
     String createdTitle = submittedTitle;
     String createdBodyForStub = submittedDraft;
-    createDraft = "";
-    createTitleDraft = "";
+    if (clearCreateDraftOnSuccess) {
+      createDraft = "";
+      createTitleDraft = "";
+    }
     activeCommandId = "";
     annotationCommandId = "";
     commandStatusText = "";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -1,8 +1,10 @@
 package org.waveprotocol.box.j2cl.richtext;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
@@ -43,9 +45,26 @@ public final class J2clRichContentDeltaFactory {
   }
 
   public CreateWaveRequest createWaveRequest(String address, J2clComposerDocument document) {
+    return createWaveRequest(address, document, null);
+  }
+
+  public CreateWaveRequest createWaveRequest(
+      String address, J2clComposerDocument document, List<String> additionalParticipants) {
     requirePresent(document, "Missing composer document.");
     String normalizedAddress = normalizeAddress(address);
     String domain = extractDomain(normalizedAddress);
+    Set<String> participantAddresses = new LinkedHashSet<String>();
+    participantAddresses.add(normalizedAddress);
+    if (additionalParticipants != null) {
+      for (String participant : additionalParticipants) {
+        if (participant == null || participant.trim().isEmpty()) {
+          continue;
+        }
+        String normalizedParticipant = normalizeAddress(participant);
+        extractDomain(normalizedParticipant);
+        participantAddresses.add(normalizedParticipant);
+      }
+    }
     String waveToken = nextToken("w+");
     String createdWaveId = domain + "/" + waveToken;
     String versionZeroHistoryHash = buildVersionZeroHistoryHash(domain, waveToken);
@@ -54,7 +73,7 @@ public final class J2clRichContentDeltaFactory {
             0L,
             versionZeroHistoryHash,
             normalizedAddress,
-            buildAddParticipantOperation(normalizedAddress)
+            buildAddParticipantOperations(participantAddresses)
                 + ","
                 + buildConversationRootOperation("b+root")
                 + ","
@@ -934,6 +953,17 @@ public final class J2clRichContentDeltaFactory {
 
   private static String buildAddParticipantOperation(String address) {
     return "{\"1\":\"" + escapeJson(address) + "\"}";
+  }
+
+  private static String buildAddParticipantOperations(Set<String> participantAddresses) {
+    StringBuilder operations = new StringBuilder();
+    for (String participantAddress : participantAddresses) {
+      if (operations.length() > 0) {
+        operations.append(",");
+      }
+      operations.append(buildAddParticipantOperation(participantAddress));
+    }
+    return operations.toString();
   }
 
   private static void appendComponentSeparator(StringBuilder builder) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -254,7 +254,10 @@ public final class J2clRootShellController {
       if (participant == null) {
         continue;
       }
-      String address = String.valueOf(participant).trim();
+      if (!(participant instanceof String)) {
+        continue;
+      }
+      String address = ((String) participant).trim();
       if (!address.isEmpty()) {
         result.add(address);
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -1,7 +1,11 @@
 package org.waveprotocol.box.j2cl.root;
 
+import elemental2.core.JsArray;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLElement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.CreateSuccessHandler;
@@ -166,6 +170,9 @@ public final class J2clRootShellController {
     elemental2.dom.DomGlobal.document.body.addEventListener(
         "wavy-new-wave-requested",
         evt -> composeController.focusCreateSurface());
+    elemental2.dom.DomGlobal.document.body.addEventListener(
+        "wave-new-with-participants-requested",
+        evt -> composeController.onCreateRequestedWithParticipants(participantsFromEvent(evt)));
     // F-4 (#1039 / R-4.4): bridge the selected-wave controller's live read
     // state into the search panel so the matching digest's unread badge
     // decrements without re-rendering the whole list.
@@ -215,6 +222,44 @@ public final class J2clRootShellController {
   static J2clToolbarSurfaceController.EditState editStateForWriteSession(
       J2clSidecarWriteSession writeSession) {
     return new J2clToolbarSurfaceController.EditState(writeSession != null);
+  }
+
+  static List<String> participantsFromEvent(Event event) {
+    if (event == null) {
+      return Collections.emptyList();
+    }
+    Object detail = Js.asPropertyMap(event).get("detail");
+    if (detail == null) {
+      return Collections.emptyList();
+    }
+    Object participantsObject = Js.asPropertyMap(detail).get("participants");
+    if (participantsObject == null || !JsArray.isArray(participantsObject)) {
+      return Collections.emptyList();
+    }
+    JsArray<?> participants = Js.uncheckedCast(participantsObject);
+    List<Object> values = new ArrayList<Object>();
+    int length = participants.length;
+    for (int i = 0; i < length; i++) {
+      values.add(participants.getAt(i));
+    }
+    return normalizeParticipantValues(values);
+  }
+
+  static List<String> normalizeParticipantValues(List<?> participants) {
+    if (participants == null || participants.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> result = new ArrayList<String>();
+    for (Object participant : participants) {
+      if (participant == null) {
+        continue;
+      }
+      String address = String.valueOf(participant).trim();
+      if (!address.isEmpty()) {
+        result.add(address);
+      }
+    }
+    return result;
   }
 
   /**

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2879,6 +2879,31 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals("Wave created.", view.model.getCreateStatusText());
   }
 
+  @Test
+  public void createRequestedWithParticipantsAllowsEmptyDirectWaveAndNormalizesParticipants() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    List<String> created = new ArrayList<String>();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            created::add,
+            waveId -> {});
+    controller.start();
+
+    controller.onCreateRequestedWithParticipants(
+        Arrays.asList(" Friend@Example.COM ", "", null, "friend@example.com"));
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    Assert.assertEquals(Arrays.asList("example.com/w+direct"), created);
+    Assert.assertEquals(Arrays.asList("friend@example.com"), factory.lastAdditionalParticipants);
+    Assert.assertEquals("", factory.lastDraftText);
+    Assert.assertEquals("Wave created.", view.model.getCreateStatusText());
+  }
+
   // J-UI-3 — submitting with both fields blank surfaces the existing
   // "enter some text" validation error rather than calling the gateway.
   @Test
@@ -4358,6 +4383,40 @@ public class J2clComposeSurfaceControllerTest {
 
     void complete(int index, J2clAttachmentUploadClient.HttpResponse response) {
       handlers.get(index).onResponse(response);
+    }
+  }
+
+  private static final class CapturingDeltaFactory implements J2clComposeSurfaceController.DeltaFactory {
+    private List<String> lastAdditionalParticipants = Collections.emptyList();
+    private String lastDraftText = null;
+
+    @Override
+    public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
+        String address, String draftText, org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {
+      return createWaveRequest(address, draftText, document, Collections.emptyList());
+    }
+
+    @Override
+    public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
+        String address,
+        String draftText,
+        org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document,
+        List<String> additionalParticipants) {
+      lastDraftText = draftText;
+      lastAdditionalParticipants = new ArrayList<String>(additionalParticipants);
+      return new J2clComposeSurfaceController.CreateWaveRequest(
+          "example.com/w+direct",
+          new SidecarSubmitRequest(
+              "example.com/w+direct/~/conv+root", "{\"create\":true}", null));
+    }
+
+    @Override
+    public SidecarSubmitRequest createReplyRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String draftText,
+        org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {
+      throw new UnsupportedOperationException("Not needed by this test.");
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -2893,6 +2893,8 @@ public class J2clComposeSurfaceControllerTest {
             created::add,
             waveId -> {});
     controller.start();
+    controller.onCreateTitleChanged("Draft title");
+    controller.onCreateDraftChanged("Draft body");
 
     controller.onCreateRequestedWithParticipants(
         Arrays.asList(" Friend@Example.COM ", "", null, "friend@example.com"));
@@ -2901,6 +2903,9 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals(Arrays.asList("example.com/w+direct"), created);
     Assert.assertEquals(Arrays.asList("friend@example.com"), factory.lastAdditionalParticipants);
     Assert.assertEquals("", factory.lastDraftText);
+    Assert.assertEquals(0, factory.lastDocumentComponentCount);
+    Assert.assertEquals("Draft title", view.model.getCreateTitleDraft());
+    Assert.assertEquals("Draft body", view.model.getCreateDraft());
     Assert.assertEquals("Wave created.", view.model.getCreateStatusText());
   }
 
@@ -4389,6 +4394,7 @@ public class J2clComposeSurfaceControllerTest {
   private static final class CapturingDeltaFactory implements J2clComposeSurfaceController.DeltaFactory {
     private List<String> lastAdditionalParticipants = Collections.emptyList();
     private String lastDraftText = null;
+    private int lastDocumentComponentCount = -1;
 
     @Override
     public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
@@ -4404,6 +4410,7 @@ public class J2clComposeSurfaceControllerTest {
         List<String> additionalParticipants) {
       lastDraftText = draftText;
       lastAdditionalParticipants = new ArrayList<String>(additionalParticipants);
+      lastDocumentComponentCount = componentCount(document);
       return new J2clComposeSurfaceController.CreateWaveRequest(
           "example.com/w+direct",
           new SidecarSubmitRequest(
@@ -4417,6 +4424,16 @@ public class J2clComposeSurfaceControllerTest {
         String draftText,
         org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {
       throw new UnsupportedOperationException("Not needed by this test.");
+    }
+
+    private static int componentCount(org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {
+      try {
+        Field field = document.getClass().getDeclaredField("components");
+        field.setAccessible(true);
+        return ((List<?>) field.get(document)).size();
+      } catch (ReflectiveOperationException e) {
+        throw new AssertionError(e);
+      }
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -54,6 +54,34 @@ public class J2clRichContentDeltaFactoryTest {
             < deltaJson.indexOf("\"1\":\"b+root\""));
   }
 
+  @Test
+  public void createWaveRequestEmitsDedupedAdditionalParticipantsBeforeRoot() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clComposerDocument document = J2clComposerDocument.builder().text("Hi").build();
+
+    J2clRichContentDeltaFactory.CreateWaveRequest request =
+        factory.createWaveRequest(
+            "User@Example.COM ",
+            document,
+            Arrays.asList(
+                "friend@example.com",
+                " USER@example.COM ",
+                "friend@example.com",
+                " teammate@example.com "));
+
+    String deltaJson = request.getSubmitRequest().getDeltaJson();
+    String self = "{\"1\":\"user@example.com\"}";
+    String friend = "{\"1\":\"friend@example.com\"}";
+    String teammate = "{\"1\":\"teammate@example.com\"}";
+    assertContains(deltaJson, self, friend, teammate, "\"1\":\"b+root\"", "\"2\":\"Hi\"");
+    Assert.assertEquals(1, countOccurrences(deltaJson, self));
+    Assert.assertEquals(1, countOccurrences(deltaJson, friend));
+    Assert.assertEquals(1, countOccurrences(deltaJson, teammate));
+    Assert.assertTrue(deltaJson.indexOf(self) < deltaJson.indexOf(friend));
+    Assert.assertTrue(deltaJson.indexOf(friend) < deltaJson.indexOf(teammate));
+    Assert.assertTrue(deltaJson.indexOf(teammate) < deltaJson.indexOf("\"1\":\"b+root\""));
+  }
+
   // J-UI-3 (#1081, R-5.1): titleText emits an ANNOTATED_TEXT component
   // whose key is conv/title and whose value is the AUTO_VALUE empty string,
   // so WaveDigester.extractTitle (TitleHelper) picks it up server-side.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.root;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
@@ -27,6 +28,14 @@ public class J2clRootShellControllerTest {
             new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root")));
 
     Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+  }
+
+  @Test
+  public void normalizeParticipantValuesTrimsAndSkipsBlankEntries() {
+    Assert.assertEquals(
+        Arrays.asList("Friend@Example.COM", "team@example.com"),
+        J2clRootShellController.normalizeParticipantValues(
+            Arrays.asList(" Friend@Example.COM ", "", null, "team@example.com")));
   }
 
   private static final class FakeToolbarView implements J2clToolbarSurfaceController.View {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -35,7 +35,7 @@ public class J2clRootShellControllerTest {
     Assert.assertEquals(
         Arrays.asList("Friend@Example.COM", "team@example.com"),
         J2clRootShellController.normalizeParticipantValues(
-            Arrays.asList(" Friend@Example.COM ", "", null, "team@example.com")));
+            Arrays.asList(" Friend@Example.COM ", "", null, 123, "team@example.com")));
   }
 
   private static final class FakeToolbarView implements J2clToolbarSurfaceController.View {

--- a/wave/config/changelog.d/2026-04-30-j2cl-profile-overlay-actions.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-profile-overlay-actions.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-j2cl-profile-overlay-actions",
+  "version": "Issue #1075",
+  "date": "2026-04-30",
+  "title": "J2CL profile cards can send messages and edit own profile",
+  "summary": "The J2CL profile overlay now includes parity actions for starting a 1:1 wave with another participant and opening the existing profile editor for the signed-in user's own profile.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added Wavy-styled Send Message and Edit Profile actions to the J2CL profile overlay, bridged Send Message through the root compose pipeline, and emitted additional participant AddParticipant operations for direct-message creates."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3677,7 +3677,9 @@ public final class HtmlRenderer {
       sb.append("<wavy-wave-controls-toggle data-j2cl-floating-mount=\"true\"></wavy-wave-controls-toggle>\n");
       sb.append("<wavy-floating-scroll-to-new data-j2cl-floating-mount=\"true\" hidden></wavy-floating-scroll-to-new>\n");
       sb.append("<wavy-version-history data-j2cl-floating-mount=\"true\" hidden></wavy-version-history>\n");
-      sb.append("<wavy-profile-overlay data-j2cl-floating-mount=\"true\" hidden></wavy-profile-overlay>\n");
+      sb.append("<wavy-profile-overlay data-j2cl-floating-mount=\"true\" current-user-id=\"")
+          .append(safeAddress)
+          .append("\" hidden></wavy-profile-overlay>\n");
       sb.append("<script src=\"").append(safeResolvedBasePath).append("j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
       appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, true);
     } else {
@@ -3888,7 +3890,9 @@ public final class HtmlRenderer {
     sb.append("<wavy-wave-controls-toggle data-j2cl-floating-mount=\"true\"></wavy-wave-controls-toggle>\n");
     sb.append("<wavy-floating-scroll-to-new data-j2cl-floating-mount=\"true\"></wavy-floating-scroll-to-new>\n");
     sb.append("<wavy-version-history data-j2cl-floating-mount=\"true\" open></wavy-version-history>\n");
-    sb.append("<wavy-profile-overlay data-j2cl-floating-mount=\"true\" open data-participant=\"carol@example.com\"></wavy-profile-overlay>\n");
+    sb.append("<wavy-profile-overlay data-j2cl-floating-mount=\"true\" current-user-id=\"")
+        .append(safeAddress)
+        .append("\" open data-participant=\"carol@example.com\"></wavy-profile-overlay>\n");
     sb.append("<script src=\"").append(safeResolvedBasePath).append("j2cl-search/sidecar/j2cl-sidecar.js\"></script>\n");
     appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, true);
     sb.append("</body>\n</html>\n");


### PR DESCRIPTION
## Summary

Closes #1075. Part of #904.

Adds J2CL/Lit profile-card parity actions:

- `Send Message` appears for non-self profiles and emits `wave-new-with-participants-requested`.
- `Edit Profile` appears only for the signed-in user's own profile and routes through a cancelable `wavy-profile-edit-requested` event before `/userprofile/edit`.
- Root shell bridges profile Send Message into the create-wave pipeline.
- Rich create deltas add the signed-in user plus deduped requested participants before the root blip operation.
- SSR profile overlay mount carries `current-user-id` so own-profile gating works on first paint.

## Verification

- `cd j2cl/lit && npm test -- --files test/wavy-profile-overlay.test.js` PASS (21/21)
- `cd j2cl/lit && npm run build` PASS
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` PASS
- `sbt --batch compile j2clSearchTest` PASS
- `git diff --check` PASS

## Review Notes

- Self-review found and fixed one risk: non-rich delta factories now fail fast rather than silently ignoring additional create participants.
- Claude Opus review was attempted, but the provider is quota-blocked: `You've hit your limit - resets May 2 at 9pm (Asia/Jerusalem)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile overlay shows "Send Message" and "Edit Profile" with self vs. other gating; sending starts a direct-message compose flow and editing launches profile edit when allowed
  * Compose flow now supports creating waves with additional/deduplicated participants; server-side markup exposes current user context

* **Tests**
  * Coverage for overlay action rendering, emitted events, participant normalization, and multi-participant wave creation

* **Documentation**
  * Added changelog/planning entry for profile overlay actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->