### PR TITLE
feat: add J2CL New Wave keyboard shortcut

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1076-new-wave-shortcut.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1076-new-wave-shortcut.md
@@ -1,0 +1,60 @@
+# Issue #1076: Shift+Cmd/Ctrl+O New Wave Shortcut
+
+## Context
+
+Issue #1076 closes the F-3 follow-up for B.3: the search rail already renders the New Wave button and advertises `Shift+Meta+O Shift+Control+O`, but the shortcut behavior must match the issue acceptance before the lane can close.
+
+Current code already has a partial G-PORT-7 implementation:
+
+- `j2cl/lit/src/shortcuts/keybindings.js` maps Shift+Cmd+O on Mac and Shift+Ctrl+O elsewhere to `OPEN_NEW_WAVE`.
+- `j2cl/lit/src/elements/shell-root.js` listens for window keydown and dispatches `wavy-new-wave-requested` with `source="keyboard-shortcut"`.
+- `J2clRootShellController` listens for `wavy-new-wave-requested` on `document.body` and calls `composeController.focusCreateSurface()`.
+- `J2clComposeSurfaceView.focusCreateSurface()` focuses the title input, which is correct for the button path from #1081 but not enough for #1076's shortcut-body-focus acceptance.
+
+## Gaps
+
+1. The current keybinding marks `OPEN_NEW_WAVE` as global, so it fires from inputs/contenteditable surfaces. #1076 explicitly says the shortcut must not fire when an editable element owns focus.
+2. The shortcut currently reuses the button path and focuses the create title input. #1076 asks the shortcut to focus the create-wave composer body and scroll it into view.
+3. There is no `compose.opened` telemetry event with `trigger="shortcut"` for the shortcut path.
+4. Existing Lit shortcut tests assert dispatch but not the editable suppression required by #1076.
+
+## Implementation Plan
+
+1. Tighten Lit shortcut semantics.
+   - Change `matchShortcut()` so `OPEN_NEW_WAVE` returns `global: false`.
+   - Update comments to state that Esc remains global, but Shift+Cmd/Ctrl+O is suppressed from editable targets.
+   - Update keybindings tests for the new `global: false` contract.
+   - Add a `shell-root` integration test proving Shift+Cmd/Ctrl+O from an input/contenteditable target does not dispatch `wavy-new-wave-requested`.
+
+2. Preserve event bridge and source.
+   - Keep `shell-root` dispatching `wavy-new-wave-requested` with `detail.source="keyboard-shortcut"` so the Java root shell can distinguish the shortcut from the button path.
+   - Change the search rail button click to emit `detail.source="button"` for explicit telemetry parity and future menu-trigger symmetry.
+
+3. Add trigger-aware create focus in Java.
+   - Add `J2clComposeSurfaceController.focusCreateSurface(String trigger)`.
+   - Keep existing `focusCreateSurface()` delegating to trigger `"button"` and focusing the title input.
+   - For trigger `"shortcut"`, call a new view method `focusCreateComposer()` that focuses the create body textarea and scrolls it into view.
+   - Record `compose.opened` telemetry with fields `mode="create"` and `trigger=<button|shortcut|menu>`; sanitize unknown values to `"button"`.
+
+4. Wire Java root event detail to trigger.
+   - In `J2clRootShellController`, read `detail.source` from `wavy-new-wave-requested`.
+   - Map `keyboard-shortcut` to telemetry trigger `"shortcut"`.
+   - Call `composeController.focusCreateSurface(trigger)`.
+
+5. Tests and verification.
+   - Lit: `j2cl/lit/test/shortcuts/keybindings.test.js`, `j2cl/lit/test/shortcuts/shell-root-keys.test.js`, and `j2cl/lit/test/wavy-search-rail.test.js`.
+   - Java: `J2clComposeSurfaceControllerTest` for button vs shortcut focus calls and `compose.opened` telemetry trigger fields.
+   - Java root pure helper test for source-to-trigger mapping if direct DOM event testing is too brittle.
+   - Verification:
+     - `cd j2cl/lit && npm test -- --files test/shortcuts/keybindings.test.js test/shortcuts/shell-root-keys.test.js test/wavy-search-rail.test.js`
+     - `cd j2cl/lit && npm run build`
+     - `sbt --batch compile j2clSearchTest`
+     - changelog assemble/validate
+     - `git diff --check`
+
+## Self Review
+
+- The plan treats the existing G-PORT-7 code as a partial implementation instead of rewriting it.
+- It preserves the button/title-focus behavior added by #1081 while giving the shortcut its requested body-focus behavior.
+- It makes the editable suppression testable in the Lit layer where the keydown target path is available.
+- It keeps telemetry in the Java compose controller so both button and shortcut paths are recorded consistently.

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -84,7 +84,13 @@ export class ShellRoot extends LitElement {
     const match = matchShortcut(evt);
     if (!match) return;
     if (!match.global && isEditableTarget(evt)) {
-      // j/k and New Wave shortcuts inside inputs must reach the input.
+      // j/k inside inputs must reach the input. New Wave uses a
+      // browser-level Ctrl/Meta shortcut, so suppress the browser
+      // default while leaving the editable content untouched.
+      if (match.action === KEY_ACTION.OPEN_NEW_WAVE) {
+        evt.preventDefault();
+        evt.stopPropagation();
+      }
       // Esc remains global per the matcher and bypasses this guard.
       return;
     }

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -84,8 +84,8 @@ export class ShellRoot extends LitElement {
     const match = matchShortcut(evt);
     if (!match) return;
     if (!match.global && isEditableTarget(evt)) {
-      // j / k inside an input must reach the input. Esc and
-      // Shift+Cmd+O are global per the matcher and bypass this guard.
+      // j/k and New Wave shortcuts inside inputs must reach the input.
+      // Esc remains global per the matcher and bypasses this guard.
       return;
     }
     const handled = this._dispatchAction(match.action, evt);

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -516,7 +516,7 @@ export class WavySearchRail extends LitElement {
           class="new-wave"
           data-shortcut="Shift+Cmd+O"
           aria-keyshortcuts="Shift+Meta+O Shift+Control+O"
-          @click=${() => this._emit("wavy-new-wave-requested")}
+          @click=${() => this._emit("wavy-new-wave-requested", { source: "button" })}
         >
           New Wave
         </button>

--- a/j2cl/lit/src/shortcuts/keybindings.js
+++ b/j2cl/lit/src/shortcuts/keybindings.js
@@ -31,10 +31,10 @@ export const KEY_ACTION = Object.freeze({
 /**
  * Returns true when the keyboard event originated inside an editable
  * surface (input, textarea, select, contenteditable). Bindings tagged
- * `global: true` (Esc, Shift+Cmd+O) STILL fire when the target is
- * editable — Esc to close a popover that ate keyboard focus, and
- * Shift+Cmd+O to open a new wave from inside the search box are both
- * cases where the user reasonably expects the shortcut to win.
+ * `global: true` actions still fire when the target is editable. Esc
+ * remains global for native dialog semantics. Shift+Cmd/Ctrl+O is not
+ * global because #1076 requires New Wave to stay suppressed while the
+ * user is typing in a composer body, search input, or form field.
  */
 export function isEditableTarget(evt) {
   if (!evt) return false;
@@ -116,8 +116,8 @@ export function matchShortcut(evt, opts = {}) {
     return { action: KEY_ACTION.CLOSE_TOPMOST, global: true };
   }
 
-  // Shift+Cmd+O on Mac, Shift+Ctrl+O elsewhere. Global so it fires
-  // even from the search input. Block repeats (no benefit to auto-fire).
+  // Shift+Cmd+O on Mac, Shift+Ctrl+O elsewhere. Not global: #1076 says
+  // the shortcut must not fire from editable targets. Block repeats.
   if (
     (evt.key === "O" || evt.key === "o") &&
     evt.shiftKey &&
@@ -126,7 +126,7 @@ export function matchShortcut(evt, opts = {}) {
       (!isMac && evt.ctrlKey && !evt.metaKey))
   ) {
     if (evt.repeat) return null;
-    return { action: KEY_ACTION.OPEN_NEW_WAVE, global: true };
+    return { action: KEY_ACTION.OPEN_NEW_WAVE, global: false };
   }
 
   // j / k — blip navigation. Bare key only; not global. Modifiers

--- a/j2cl/lit/test/shortcuts/keybindings.test.js
+++ b/j2cl/lit/test/shortcuts/keybindings.test.js
@@ -74,19 +74,19 @@ describe("matchShortcut", () => {
     expect(matchShortcut(fakeEvent("Escape", { ctrlKey: true }), { isMac: true })).to.equal(null);
   });
 
-  it("matches Shift+Cmd+O on Mac -> OPEN_NEW_WAVE (global)", () => {
+  it("matches Shift+Cmd+O on Mac -> OPEN_NEW_WAVE (not global)", () => {
     expect(
       matchShortcut(fakeEvent("o", { shiftKey: true, metaKey: true }), { isMac: true })
-    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: true });
+    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: false });
     expect(
       matchShortcut(fakeEvent("O", { shiftKey: true, metaKey: true }), { isMac: true })
-    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: true });
+    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: false });
   });
 
-  it("matches Shift+Ctrl+O on non-Mac -> OPEN_NEW_WAVE (global)", () => {
+  it("matches Shift+Ctrl+O on non-Mac -> OPEN_NEW_WAVE (not global)", () => {
     expect(
       matchShortcut(fakeEvent("o", { shiftKey: true, ctrlKey: true }), { isMac: false })
-    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: true });
+    ).to.deep.equal({ action: KEY_ACTION.OPEN_NEW_WAVE, global: false });
   });
 
   it("does not match Shift+Cmd+O on non-Mac (wrong primary modifier)", () => {

--- a/j2cl/lit/test/shortcuts/shell-root-keys.test.js
+++ b/j2cl/lit/test/shortcuts/shell-root-keys.test.js
@@ -89,7 +89,11 @@ describe("<shell-root> shell-level keydown dispatcher", () => {
 
   it("Shift+Cmd+O dispatches wavy-new-wave-requested on document.body", () => {
     let sawCount = 0;
-    const handler = () => { sawCount += 1; };
+    let source = "";
+    const handler = (event) => {
+      sawCount += 1;
+      source = event.detail && event.detail.source;
+    };
     document.body.addEventListener("wavy-new-wave-requested", handler);
     try {
       fireKey("o", { shiftKey: true, metaKey: true });
@@ -104,6 +108,42 @@ describe("<shell-root> shell-level keydown dispatcher", () => {
       document.body.removeEventListener("wavy-new-wave-requested", handler);
     }
     expect(sawCount).to.equal(1);
+    expect(source).to.equal("keyboard-shortcut");
+  });
+
+  it("Shift+Cmd/Ctrl+O inside editable targets does not open New Wave", () => {
+    let sawCount = 0;
+    const handler = () => { sawCount += 1; };
+    const input = document.createElement("input");
+    const composerBody = document.createElement("div");
+    composerBody.contentEditable = "true";
+    document.body.appendChild(input);
+    document.body.appendChild(composerBody);
+    document.body.addEventListener("wavy-new-wave-requested", handler);
+    const fireFrom = (target, mods) => {
+      target.focus();
+      target.dispatchEvent(new KeyboardEvent("keydown", {
+        key: "o",
+        code: "KeyO",
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        shiftKey: true,
+        metaKey: !!mods.metaKey,
+        ctrlKey: !!mods.ctrlKey
+      }));
+    };
+    try {
+      fireFrom(input, { metaKey: true });
+      fireFrom(input, { ctrlKey: true });
+      fireFrom(composerBody, { metaKey: true });
+      fireFrom(composerBody, { ctrlKey: true });
+    } finally {
+      document.body.removeEventListener("wavy-new-wave-requested", handler);
+      input.remove();
+      composerBody.remove();
+    }
+    expect(sawCount).to.equal(0);
   });
 
   it("Esc closes an open dialog before dropping blip focus", () => {

--- a/j2cl/lit/test/shortcuts/shell-root-keys.test.js
+++ b/j2cl/lit/test/shortcuts/shell-root-keys.test.js
@@ -5,6 +5,7 @@
 import { fixture, expect, html } from "@open-wc/testing";
 import "../../src/elements/shell-root.js";
 import "../../src/elements/wave-blip.js";
+import { isMacPlatform } from "../../src/shortcuts/keybindings.js";
 
 // Stand-in confirm dialog so we don't pull in the F-3.S4 one + its
 // styling deps; the dispatcher only cares about open/close.
@@ -111,18 +112,19 @@ describe("<shell-root> shell-level keydown dispatcher", () => {
     expect(source).to.equal("keyboard-shortcut");
   });
 
-  it("Shift+Cmd/Ctrl+O inside editable targets does not open New Wave", () => {
+  it("Shift+Cmd/Ctrl+O inside editable targets suppresses browser default without opening New Wave", () => {
     let sawCount = 0;
     const handler = () => { sawCount += 1; };
     const input = document.createElement("input");
     const composerBody = document.createElement("div");
     composerBody.contentEditable = "true";
+    const events = [];
     document.body.appendChild(input);
     document.body.appendChild(composerBody);
     document.body.addEventListener("wavy-new-wave-requested", handler);
     const fireFrom = (target, mods) => {
       target.focus();
-      target.dispatchEvent(new KeyboardEvent("keydown", {
+      const evt = new KeyboardEvent("keydown", {
         key: "o",
         code: "KeyO",
         bubbles: true,
@@ -131,19 +133,21 @@ describe("<shell-root> shell-level keydown dispatcher", () => {
         shiftKey: true,
         metaKey: !!mods.metaKey,
         ctrlKey: !!mods.ctrlKey
-      }));
+      });
+      target.dispatchEvent(evt);
+      events.push(evt);
     };
+    const primaryMod = isMacPlatform() ? { metaKey: true } : { ctrlKey: true };
     try {
-      fireFrom(input, { metaKey: true });
-      fireFrom(input, { ctrlKey: true });
-      fireFrom(composerBody, { metaKey: true });
-      fireFrom(composerBody, { ctrlKey: true });
+      fireFrom(input, primaryMod);
+      fireFrom(composerBody, primaryMod);
     } finally {
       document.body.removeEventListener("wavy-new-wave-requested", handler);
       input.remove();
       composerBody.remove();
     }
     expect(sawCount).to.equal(0);
+    expect(events.every((evt) => evt.defaultPrevented)).to.equal(true);
   });
 
   it("Esc closes an open dialog before dropping blip focus", () => {

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -75,6 +75,7 @@ describe("<wavy-search-rail>", () => {
     setTimeout(() => newWave.click(), 0);
     const evt = await oneEvent(el, "wavy-new-wave-requested");
     expect(evt).to.exist;
+    expect(evt.detail.source).to.equal("button");
   });
 
   it("Manage saved searches click emits wavy-manage-saved-searches-requested (B.4)", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -53,6 +53,14 @@ public final class J2clComposeSurfaceController {
      * Default no-op so existing test doubles compile unchanged.
      */
     default void focusCreateSurface() {}
+
+    /**
+     * #1076: focus the create body composer for the keyboard shortcut path.
+     * Defaults to the title-focus method so older view doubles remain valid.
+     */
+    default void focusCreateComposer() {
+      focusCreateSurface();
+    }
   }
 
   public interface Listener {
@@ -922,9 +930,42 @@ public final class J2clComposeSurfaceController {
    * Public entrypoint for the rail's New Wave button via the root shell.
    */
   public void focusCreateSurface() {
+    focusCreateSurface("button");
+  }
+
+  /** #1076: shortcut-triggered New Wave focuses the create body and records trigger telemetry. */
+  public void focusCreateSurface(String trigger) {
     if (started) {
-      view.focusCreateSurface();
+      String normalizedTrigger = normalizeCreateOpenTrigger(trigger);
+      if ("shortcut".equals(normalizedTrigger)) {
+        view.focusCreateComposer();
+      } else {
+        view.focusCreateSurface();
+      }
+      recordComposeOpenedTelemetry(normalizedTrigger);
     }
+  }
+
+  private void recordComposeOpenedTelemetry(String trigger) {
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event("compose.opened")
+              .field("mode", "create")
+              .field("trigger", normalizeCreateOpenTrigger(trigger))
+              .build());
+    } catch (RuntimeException ignored) {
+      // Telemetry must never affect focus or shortcut behavior.
+    }
+  }
+
+  private static String normalizeCreateOpenTrigger(String trigger) {
+    String normalized = trigger == null ? "" : trigger.trim().toLowerCase(Locale.ROOT);
+    if ("shortcut".equals(normalized)
+        || "button".equals(normalized)
+        || "menu".equals(normalized)) {
+      return normalized;
+    }
+    return "button";
   }
 
   public void onReplyDraftChanged(String draft) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -935,15 +935,20 @@ public final class J2clComposeSurfaceController {
 
   /** #1076: shortcut-triggered New Wave focuses the create body and records trigger telemetry. */
   public void focusCreateSurface(String trigger) {
-    if (started) {
-      String normalizedTrigger = normalizeCreateOpenTrigger(trigger);
-      if ("shortcut".equals(normalizedTrigger)) {
-        view.focusCreateComposer();
-      } else {
-        view.focusCreateSurface();
-      }
-      recordComposeOpenedTelemetry(normalizedTrigger);
+    if (!started || !isCreateSurfaceInteractive()) {
+      return;
     }
+    String normalizedTrigger = normalizeCreateOpenTrigger(trigger);
+    if ("shortcut".equals(normalizedTrigger)) {
+      view.focusCreateComposer();
+    } else {
+      view.focusCreateSurface();
+    }
+    recordComposeOpenedTelemetry(normalizedTrigger);
+  }
+
+  private boolean isCreateSurfaceInteractive() {
+    return !signedOut && !createSubmitting;
   }
 
   private void recordComposeOpenedTelemetry(String trigger) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -438,6 +438,16 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     }
   }
 
+  @Override
+  public void focusCreateComposer() {
+    // #1076: the keyboard shortcut drops the user straight into the body
+    // composer and scrolls it into view without changing the button/title path.
+    if (!createInput.disabled) {
+      createInput.scrollIntoView();
+      createInput.focus();
+    }
+  }
+
   /** F-3.S1 entrypoint: mount a `<wavy-composer>` inline at the originating blip. */
   private void openInlineComposer(String blipId, String mode) {
     String key = blipId == null ? "" : blipId;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -6,6 +6,7 @@ import elemental2.dom.HTMLElement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import jsinterop.base.Js;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.CreateSuccessHandler;
@@ -169,7 +170,7 @@ public final class J2clRootShellController {
     // up regardless of where the rail is currently mounted.
     elemental2.dom.DomGlobal.document.body.addEventListener(
         "wavy-new-wave-requested",
-        evt -> composeController.focusCreateSurface());
+        evt -> composeController.focusCreateSurface(newWaveTriggerFromEvent(evt)));
     elemental2.dom.DomGlobal.document.body.addEventListener(
         "wave-new-with-participants-requested",
         evt -> composeController.onCreateRequestedWithParticipants(participantsFromEvent(evt)));
@@ -358,6 +359,28 @@ public final class J2clRootShellController {
       return;
     }
     view.setDepthFocus(depthBlipId, "", "");
+  }
+
+  private static String newWaveTriggerFromEvent(Event evt) {
+    if (evt == null) {
+      return "button";
+    }
+    Object detail = Js.asPropertyMap(evt).get("detail");
+    if (detail == null) {
+      return "button";
+    }
+    return newWaveTriggerFromSource(Js.asPropertyMap(detail).get("source"));
+  }
+
+  static String newWaveTriggerFromSource(Object source) {
+    String normalized = source == null ? "" : String.valueOf(source).trim().toLowerCase(Locale.ROOT);
+    if ("keyboard-shortcut".equals(normalized) || "shortcut".equals(normalized)) {
+      return "shortcut";
+    }
+    if ("menu".equals(normalized)) {
+      return "menu";
+    }
+    return "button";
   }
 
   private static HTMLElement createChildHost(HTMLElement parent, String className) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -785,6 +785,32 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void focusCreateSurfaceRecordsOpenedTelemetryAndUsesShortcutBodyFocus() {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller = newControllerWithTelemetry(view, telemetry);
+
+    controller.start();
+    controller.focusCreateSurface();
+
+    Assert.assertEquals(1, view.focusCreateSurfaceCalls);
+    Assert.assertEquals(0, view.focusCreateComposerCalls);
+    J2clClientTelemetry.Event buttonEvent = telemetry.lastEvent();
+    Assert.assertEquals("compose.opened", buttonEvent.getName());
+    Assert.assertEquals("create", buttonEvent.getFields().get("mode"));
+    Assert.assertEquals("button", buttonEvent.getFields().get("trigger"));
+
+    controller.focusCreateSurface("shortcut");
+
+    Assert.assertEquals(1, view.focusCreateSurfaceCalls);
+    Assert.assertEquals(1, view.focusCreateComposerCalls);
+    J2clClientTelemetry.Event shortcutEvent = telemetry.lastEvent();
+    Assert.assertEquals("compose.opened", shortcutEvent.getName());
+    Assert.assertEquals("create", shortcutEvent.getFields().get("mode"));
+    Assert.assertEquals("shortcut", shortcutEvent.getFields().get("trigger"));
+  }
+
+  @Test
   public void throwingTelemetrySinkDoesNotBreakRichEditCommand() {
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =
@@ -4350,6 +4376,8 @@ public class J2clComposeSurfaceControllerTest {
     private J2clComposeSurfaceModel model;
     private int openAttachmentPickerCalls;
     private int focusReplyComposerCalls;
+    private int focusCreateSurfaceCalls;
+    private int focusCreateComposerCalls;
 
     @Override
     public void bind(J2clComposeSurfaceController.Listener listener) {
@@ -4368,6 +4396,16 @@ public class J2clComposeSurfaceControllerTest {
     @Override
     public void focusReplyComposer() {
       focusReplyComposerCalls++;
+    }
+
+    @Override
+    public void focusCreateSurface() {
+      focusCreateSurfaceCalls++;
+    }
+
+    @Override
+    public void focusCreateComposer() {
+      focusCreateComposerCalls++;
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -811,6 +811,46 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void focusCreateSurfaceDoesNotRecordTelemetryWhenCreateUnavailable() {
+    RecordingTelemetrySink signedOutTelemetry = new RecordingTelemetrySink();
+    FakeView signedOutView = new FakeView();
+    J2clComposeSurfaceController signedOutController =
+        newControllerWithTelemetry(signedOutView, signedOutTelemetry);
+
+    signedOutController.start();
+    signedOutController.onSignedOut();
+    signedOutController.focusCreateSurface();
+    signedOutController.focusCreateSurface("shortcut");
+
+    Assert.assertEquals(0, signedOutView.focusCreateSurfaceCalls);
+    Assert.assertEquals(0, signedOutView.focusCreateComposerCalls);
+    Assert.assertTrue(signedOutTelemetry.events().isEmpty());
+
+    FakeGateway pendingGateway = new FakeGateway();
+    pendingGateway.autoResolveBootstrap = false;
+    RecordingTelemetrySink pendingTelemetry = new RecordingTelemetrySink();
+    FakeView pendingView = new FakeView();
+    J2clComposeSurfaceController pendingController =
+        new J2clComposeSurfaceController(
+            pendingGateway,
+            pendingView,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            pendingTelemetry);
+
+    pendingController.start();
+    pendingController.onCreateSubmittedWithTitle("Title", "Body");
+    Assert.assertTrue(pendingView.model.isCreateSubmitting());
+    pendingController.focusCreateSurface();
+    pendingController.focusCreateSurface("shortcut");
+
+    Assert.assertEquals(0, pendingView.focusCreateSurfaceCalls);
+    Assert.assertEquals(0, pendingView.focusCreateComposerCalls);
+    Assert.assertTrue(pendingTelemetry.events().isEmpty());
+  }
+
+  @Test
   public void throwingTelemetrySinkDoesNotBreakRichEditCommand() {
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -38,6 +38,18 @@ public class J2clRootShellControllerTest {
             Arrays.asList(" Friend@Example.COM ", "", null, 123, "team@example.com")));
   }
 
+  @Test
+  public void newWaveTriggerFromSourceMapsShortcutAndDefaultsToButton() {
+    Assert.assertEquals(
+        "shortcut", J2clRootShellController.newWaveTriggerFromSource("keyboard-shortcut"));
+    Assert.assertEquals(
+        "shortcut", J2clRootShellController.newWaveTriggerFromSource("Keyboard-Shortcut"));
+    Assert.assertEquals("menu", J2clRootShellController.newWaveTriggerFromSource("menu"));
+    Assert.assertEquals("button", J2clRootShellController.newWaveTriggerFromSource("button"));
+    Assert.assertEquals("button", J2clRootShellController.newWaveTriggerFromSource("unknown"));
+    Assert.assertEquals("button", J2clRootShellController.newWaveTriggerFromSource(null));
+  }
+
   private static final class FakeToolbarView implements J2clToolbarSurfaceController.View {
     private J2clToolbarSurfaceModel model;
 

--- a/wave/config/changelog.d/2026-04-30-j2cl-new-wave-shortcut.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-new-wave-shortcut.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-04-30-j2cl-new-wave-shortcut",
+  "version": "Issue #1076",
+  "date": "2026-04-30",
+  "title": "J2CL New Wave keyboard shortcut",
+  "summary": "Completes the J2CL New Wave shortcut by focusing the create composer body from Shift+Cmd/Ctrl+O while preserving button title-focus behavior.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Suppresses the New Wave shortcut while editable fields own focus, matching the J2CL parity acceptance.",
+        "Adds trigger-aware compose.opened telemetry for New Wave button and shortcut invocations."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1076. Adds the J2CL Shift+Cmd/Ctrl+O New Wave shortcut parity behavior while preserving the existing button path.

- Makes the New Wave shortcut non-global so editable targets keep their input.
- Keeps shell shortcut dispatch source as `keyboard-shortcut` and button dispatch source as `button`.
- Maps the root shell event source into create-focus triggers and records `compose.opened` telemetry with `mode=create` and `trigger`.
- Focuses the create composer body for shortcut-triggered opens while preserving title focus for the button path.
- Adds the issue plan and changelog fragment.

## Verification

- `cd j2cl/lit && npm test -- --files test/shortcuts/keybindings.test.js test/shortcuts/shell-root-keys.test.js test/wavy-search-rail.test.js` -> PASS (73/73).
- `cd j2cl/lit && npm run build` -> PASS.
- `sbt --batch compile j2clSearchTest` -> PASS.
- `python3 scripts/assemble-changelog.py` -> PASS.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> PASS.
- `git diff --check HEAD` -> PASS.

## Review

Claude Opus implementation review was attempted with fallback disabled, but the provider is quota-blocked: `You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)`.

## Notes

The branch was rebased onto `origin/main` at `68b5dec35` after resolving the root-shell conflict with the already-merged profile direct-message participant listener.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift+Cmd/Ctrl+O now focuses the compose body when used; the New Wave button continues to focus the title. Shortcut dispatch is suppressed while typing in editable fields. Compose-opened telemetry records mode and trigger (distinguishing shortcut vs button/menu).

* **Tests**
  * Added/updated tests for shortcut suppression, event source values, focus routing, and telemetry mapping.

* **Documentation**
  * Added plan and changelog describing behavior and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->