### PR TITLE
J2CL selected-wave header parity actions

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1074-wave-header-actions.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1074-wave-header-actions.md
@@ -1,0 +1,403 @@
+# Issue 1074 Wave Header Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the J2CL selected-wave header actions to GWT parity for D.4 Add participant, D.5 New wave with current participants, D.6 public/private toggle, and D.8 wave lock controls.
+
+**Architecture:** Add a focused Lit header-action component mounted by `J2clSelectedWaveView`, then bridge its CustomEvents through `J2clRootShellController` into `J2clComposeSurfaceController` so writes reuse the existing root-session bootstrap and sidecar submit pipeline. Match the current GWT/server semantics: public/private is shared-domain participant add/remove, and lock state is the `m/lock` data document with `mode="root|all"` instead of a `lock/state` annotation.
+
+**Tech Stack:** J2CL Java, Lit web components, sidecar `SidecarSubmitRequest` delta JSON, existing `wavy-confirm-dialog`, SBT `j2clSearchTest`, `j2cl/lit` Web Test Runner.
+
+---
+
+## Discovery Notes
+
+- The issue body says F-2 already wired `wave-add-participant-requested`, `wave-publicity-toggle-requested`, and `wave-root-lock-toggle-requested`. Current code does not contain these runtime events; only `wave-new-with-participants-requested` exists via `wavy-profile-overlay` and `J2clRootShellController`.
+- The selected-wave surface currently renders participant text and `wavy-wave-nav-row` from `J2clSelectedWaveView`; there is no dedicated selected-wave header action component.
+- GWT public/private behavior lives in `ParticipantController.handleTogglePublicClicked`: it toggles the shared-domain participant, e.g. `@example.com`, not a supplement flag.
+- GWT lock behavior lives in `ParticipantController.handleToggleLockClicked`, `Conversation.setLockState`, `LockDocument`, and `WaveLockValidator`: lock state is stored in document `m/lock` as `<lock mode="root"/>` or `<lock mode="all"/>`.
+- `J2clRichContentDeltaFactory` already has the right stand-alone writer pattern for task metadata, reactions, and tombstone delete. Reuse that pattern for participant and lock writes.
+
+## File Map
+
+- Create: `j2cl/lit/src/elements/wavy-wave-header-actions.js`
+- Create: `j2cl/lit/test/wavy-wave-header-actions.test.js`
+- Modify: `j2cl/lit/src/index.js`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java`
+- Create: `wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json`
+
+## Scope Decisions
+
+- Implement all four issue affordances in this lane; keep each task separately testable and commit after each green slice.
+- Use a new `wavy-wave-header-actions` component instead of overloading `wavy-wave-nav-row`, because `wavy-wave-nav-row` is already the E.1-E.10 GWT toolbar parity strip.
+- Use the existing `wavy-confirm-dialog` for public/private and lock transitions. Confirm both public->private and private->public because both change visibility semantics.
+- For D.5, the PR implementation uses the current participant set by default and starts a fresh wave with that set. The GWT participant-pruning popup is a separate enhancement and is not required for this issue's acceptance.
+- For D.8, implement the GWT lock cycle `unlocked -> root -> all -> unlocked`; the label can emphasize root lock for the first transition, but the stored state must match `WaveLockState`.
+
+## Task 1: Lit Header-Actions Component
+
+**Files:**
+- Create: `j2cl/lit/src/elements/wavy-wave-header-actions.js`
+- Create: `j2cl/lit/test/wavy-wave-header-actions.test.js`
+- Modify: `j2cl/lit/src/index.js`
+
+- [ ] **Step 1: Write failing Lit tests for render and event contracts**
+
+Test cases in `wavy-wave-header-actions.test.js`:
+- renders Add participant, New wave with participants, Public/private, and Lock buttons when `sourceWaveId` is set.
+- disables write buttons when `sourceWaveId` is empty.
+- Add participant opens an inline dialog, accepts comma-separated addresses, and emits `wave-add-participant-requested` with `{sourceWaveId, addresses}`.
+- New wave emits `wave-new-with-participants-requested` with `{sourceWaveId, participants}` and filters the shared-domain participant out of the new-wave participant list.
+- Public/private opens `wavy-confirm-requested` and emits `wave-publicity-toggle-requested` only after confirm with `{sourceWaveId, currentlyPublic, nextPublic}`.
+- Lock opens `wavy-confirm-requested` and emits `wave-root-lock-toggle-requested` only after confirm with `{sourceWaveId, currentLockState, nextLockState}`.
+
+Run:
+```bash
+cd j2cl/lit
+npm test -- --files test/wavy-wave-header-actions.test.js
+```
+
+Expected before implementation: FAIL because the element is not registered.
+
+- [ ] **Step 2: Implement `wavy-wave-header-actions`**
+
+Element contract:
+- properties: `sourceWaveId`, `participants`, `public`, `lockState`, `disabled`.
+- participant values are plain address strings from Java.
+- compute `regularParticipants` by excluding addresses beginning with `@`.
+- lock cycle: `unlocked -> root -> all -> unlocked`.
+- dispatch events with `bubbles: true` and `composed: true`.
+- use `wavy-confirm-requested` for public/private and lock confirmation so the existing body-mounted confirm dialog owns UI consistency.
+
+- [ ] **Step 3: Import the component**
+
+Add this import near the other F-3/F-2 selected-wave component imports in `j2cl/lit/src/index.js`:
+```js
+import "./elements/wavy-wave-header-actions.js";
+```
+
+- [ ] **Step 4: Verify Lit slice**
+
+Run:
+```bash
+cd j2cl/lit
+npm test -- --files test/wavy-wave-header-actions.test.js
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit slice**
+
+```bash
+git add j2cl/lit/src/elements/wavy-wave-header-actions.js j2cl/lit/test/wavy-wave-header-actions.test.js j2cl/lit/src/index.js
+git commit -m "feat: add j2cl wave header actions component"
+```
+
+## Task 2: Mount Header Actions In Selected Wave View
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java`
+
+- [ ] **Step 1: Write failing J2CL view tests**
+
+Add tests in `J2clSelectedWaveViewChromeTest`:
+- cold mount creates one `wavy-wave-header-actions` after `.sidecar-selected-participants` and before `wavy-wave-nav-row`.
+- render with participants stamps the JS property or JSON attribute that the Lit component consumes.
+- render with selected wave id stamps `source-wave-id`.
+- render with no selection clears `source-wave-id`, `public`, and `lock-state`.
+- server-first rebind creates the element if SSR did not include it.
+
+Run:
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected before implementation: FAIL on missing element.
+
+- [ ] **Step 2: Add `waveHeaderActions` handle**
+
+In `J2clSelectedWaveView`, add:
+- field `private final HTMLElement waveHeaderActions;`
+- helper `ensureWaveHeaderActions(HTMLElement card)` that inserts the element after `.sidecar-selected-participants`.
+- cold-mount creation next to `participantSummary`.
+- server-first rebind using `ensureWaveHeaderActions(existingCard)`.
+
+- [ ] **Step 3: Publish selected-wave state**
+
+During `render(J2clSelectedWaveModel model)`:
+- if no selection: clear `source-wave-id`, `participants`, `public`, and `lock-state`.
+- if selection: set `source-wave-id`, set participants from `model.getParticipantIds()`, set `lock-state` from `model.getLockState()`, and set `public` when participant ids contain a shared-domain address starting with `@`.
+
+- [ ] **Step 4: Verify view slice**
+
+Run:
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit slice**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+git commit -m "feat: mount j2cl wave header actions"
+```
+
+## Task 3: Project Lock State From The Selected-Wave Transport
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+
+- [ ] **Step 1: Write failing transport/projector tests**
+
+Transport tests:
+- decoding a selected-wave update with document id `m/lock` and component `<lock mode="root"/>` yields document lock state `"root"`.
+- `<lock mode="all"/>` yields `"all"`.
+- missing or unknown mode yields `"unlocked"`.
+
+Projector tests:
+- `J2clSelectedWaveModel` carries `"root"` or `"all"` when the selected update includes `m/lock`.
+- loading/no-update state preserves previous lock state for the same wave.
+
+- [ ] **Step 2: Extend document extraction**
+
+In `SidecarTransportCodec.extractDocument`, while processing element starts:
+- if `documentId.equals("m/lock")` and element type is `lock`, read attr `mode`.
+- normalize mode to `unlocked`, `root`, or `all`.
+- carry the value through `DocumentExtraction` into `SidecarSelectedWaveDocument`.
+
+- [ ] **Step 3: Extend model/projector**
+
+Add `lockState` to `J2clSelectedWaveModel` with getter `getLockState()`.
+In `J2clSelectedWaveProjector`, derive lock state from the `m/lock` document and preserve previous same-wave lock state when the update is incomplete.
+
+- [ ] **Step 4: Verify projection slice**
+
+Run:
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit slice**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+git commit -m "feat: project j2cl wave lock state"
+```
+
+## Task 4: Add Delta Writers For Participants, Publicity, And Lock State
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java`
+
+- [ ] **Step 1: Write failing delta factory tests**
+
+Add tests:
+- `addParticipantRequest` emits one or more AddParticipant operations (`{"1":"address"}`) on the current selected wavelet and normalizes/filters duplicates.
+- `publicityToggleRequest(..., true)` emits AddParticipant for `@domain`.
+- `publicityToggleRequest(..., false)` emits RemoveParticipant for `@domain` (`{"2":"@domain"}`).
+- `lockStateRequest(..., "unlocked", "root")` emits a document operation on `m/lock` inserting `<lock mode="root"/>`.
+- `lockStateRequest(..., "root", "all")` replaces the old lock element with mode `all`.
+- `lockStateRequest(..., "all", "unlocked")` removes the lock element and leaves the document empty.
+
+- [ ] **Step 2: Implement participant writers**
+
+Add public methods:
+- `SidecarSubmitRequest addParticipantRequest(String address, J2clSidecarWriteSession session, List<String> participantsToAdd)`
+- `SidecarSubmitRequest publicityToggleRequest(String address, J2clSidecarWriteSession session, String sharedDomainParticipant, boolean makePublic)`
+
+Use `buildDeltaJson(session.getBaseVersion(), session.getHistoryHash(), normalizedAddress, operations)` and `buildWaveletName(session.getSelectedWaveId())`.
+
+- [ ] **Step 3: Implement lock writer**
+
+Add:
+- `SidecarSubmitRequest lockStateRequest(String address, J2clSidecarWriteSession session, String currentLockState, String nextLockState)`
+
+Use document id `m/lock` and the existing document-operation JSON helpers. The server already authorizes lock writes in `WaveLockValidator`, so the client writer only needs to submit the `m/lock` op and surface server errors.
+
+- [ ] **Step 4: Verify delta slice**
+
+Run:
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit slice**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+git commit -m "feat: add j2cl wave header delta writers"
+```
+
+## Task 5: Bridge Events Into Compose Controller
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+
+- [ ] **Step 1: Write failing controller tests**
+
+Root-shell helper tests:
+- parse `wave-add-participant-requested` detail addresses from JS arrays and trim/filter invalid non-strings.
+- parse `wave-publicity-toggle-requested` booleans and source wave id.
+- parse `wave-root-lock-toggle-requested` current/next lock state strings and normalize to `unlocked|root|all`.
+
+Compose-controller tests:
+- add participant submit calls gateway once and records telemetry success.
+- public toggle to public submits shared-domain AddParticipant.
+- public toggle to private submits shared-domain RemoveParticipant.
+- lock toggle submits `m/lock` request.
+- all three drop stale writes when selected wave changes before bootstrap returns.
+- server submit errors record failure telemetry and do not clear active draft state.
+
+- [ ] **Step 2: Add DeltaFactory methods**
+
+Extend `J2clComposeSurfaceController.DeltaFactory` with default methods for:
+- `createAddParticipantRequest`
+- `createPublicityToggleRequest`
+- `createLockStateRequest`
+
+Wire `richContentDeltaFactory` to delegate to the new `J2clRichContentDeltaFactory` methods.
+
+- [ ] **Step 3: Add compose-controller write methods**
+
+Add public methods:
+- `onAddParticipantsRequested(String expectedWaveId, List<String> rawAddresses)`
+- `onPublicityToggleRequested(String expectedWaveId, boolean makePublic)`
+- `onLockStateToggleRequested(String expectedWaveId, String currentLockState, String nextLockState)`
+
+Each method mirrors `onTaskToggled` / `onDeleteBlipRequested`: signed-out guard, selected-wave guard, expected wave guard, bootstrap, same-logical-session guard, build request, submit, telemetry.
+
+- [ ] **Step 4: Wire root-shell events**
+
+In `J2clRootShellController.start()`, add document-body listeners:
+- `wave-add-participant-requested`
+- `wave-publicity-toggle-requested`
+- `wave-root-lock-toggle-requested`
+
+Keep the existing `wave-new-with-participants-requested` path and add source-wave validation so stale selected-wave header clicks do not write into a newly selected wave.
+
+- [ ] **Step 5: Verify controller slice**
+
+Run:
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit slice**
+
+```bash
+git add j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+git commit -m "feat: wire j2cl wave header actions"
+```
+
+## Task 6: User Feedback, Changelog, And End-To-End Verification
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json`
+
+- [ ] **Step 1: Add user-visible feedback**
+
+Use existing visible status surfaces first:
+- public/private and lock confirmations are handled through `wavy-confirm-dialog`.
+- submit failures surface through the compose status text already used by other J2CL write paths.
+- if the controller does not currently expose status for these new write paths, add short status strings on failure/success rather than introducing a generic toast subsystem in this PR.
+
+- [ ] **Step 2: Add changelog fragment**
+
+Create `wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json`:
+```json
+{
+  "date": "2026-04-30",
+  "type": "changed",
+  "title": "Added J2CL wave header actions",
+  "description": "The J2CL selected-wave surface now supports adding participants, creating a wave from the current participants, toggling public/private visibility, and cycling wave lock state."
+}
+```
+
+- [ ] **Step 3: Full local verification**
+
+Run:
+```bash
+cd j2cl/lit
+npm test -- --files test/wavy-wave-header-actions.test.js test/wavy-wave-nav-row.test.js
+npm run build
+cd ../..
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+sbt --batch compile j2clSearchTest
+git diff --check
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Browser sanity**
+
+Boot the app using the repo-standard local workflow for this worktree, open `/?view=j2cl-root`, select a wave, and verify visually:
+- header action row is visible and Wavy-styled.
+- Add participant dialog opens and can be cancelled without side effects.
+- New wave with current participants focuses the create surface.
+- Public/private and lock actions show styled confirmations.
+
+Record exact command/result in issue #1074 before PR.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json wave/config/changelog.json
+git commit -m "chore: record j2cl wave header actions changelog"
+```
+
+## PR And Monitoring
+
+- Push branch `codex/issue-1074-wave-header-actions-20260430`.
+- Open a ready PR linked to #1074 and #904.
+- PR body must include: worktree path, plan path, commit SHAs, Lit verification, SBT verification, changelog verification, and browser sanity evidence.
+- Monitor until merged:
+```bash
+gh pr view <PR> --json number,state,mergedAt,mergeStateStatus,reviewDecision,headRefOid,url
+gh pr checks <PR> --watch=false || true
+gh api graphql -f owner=vega113 -f name=supawave -F number=<PR> -f query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:50) { nodes { id isResolved path line comments(first:20) { nodes { author { login } body url createdAt } } } } } } }'
+```
+
+## Self-Review
+
+- Spec coverage: D.4 is covered by Task 1, Task 4, Task 5; D.5 is covered by Task 1 and existing `onCreateRequestedWithParticipants`; D.6 is covered by Task 1, Task 4, Task 5 using GWT shared-domain participant semantics; D.8 is covered by Task 1, Task 3, Task 4, Task 5 using existing GWT/server lock document semantics.
+- Parity correction: the plan intentionally replaces the issue body's stale `lock/state` annotation wording with `m/lock` document writes because that is what current GWT and `WaveLockValidator` enforce.
+- False-premise check: the plan includes creating the missing event source and listeners because current runtime lacks three of the four claimed F-2 CustomEvents.
+- Placeholder scan: the plan names concrete files, commands, and expected outcomes for each task.
+- Risk: if the selected-wave stream does not include `m/lock`, Task 3 must extend the selected-wave server payload to include the lock document or an explicit lock-state field before Task 2 can render authoritative lock state. That is not a human blocker; choose the narrower payload extension and cover it with codec/projector tests.
+
+## External Review Evidence
+
+- Claude Opus review attempt on 2026-04-30 was blocked by quota: "You've hit your limit - resets May 2 at 9pm (Asia/Jerusalem)". Fallback models were disabled by lane policy, so implementation proceeds with the self-review above and must rerun the Claude review loop when quota is available.

--- a/j2cl/lit/src/elements/wavy-confirm-dialog.js
+++ b/j2cl/lit/src/elements/wavy-confirm-dialog.js
@@ -43,23 +43,29 @@ export class WavyConfirmDialog extends LitElement {
 
   static styles = css`
     :host {
-      display: contents;
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 1100;
+    }
+    :host([open]) {
+      display: block;
     }
     /* F-3.S4 (#1038, R-5.6): styling uses /* ... *\/ comments only —
      * no back-tick characters appear inside the css\` ... \` template
      * literal (the F-3.S3 footgun called out in the slice plan). */
-    :host([open]) .backdrop {
-      display: grid;
-    }
     .backdrop {
-      display: none;
-      position: fixed;
+      display: grid;
+      position: absolute;
       inset: 0;
       background: rgba(8, 14, 28, 0.62);
       place-items: center;
-      z-index: 1100;
     }
     .dialog {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
       min-width: 280px;
       max-width: min(92vw, 420px);
       padding: var(--wavy-spacing-4, 20px);

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -1,0 +1,398 @@
+import { LitElement, css, html } from "lit";
+
+const LOCK_CYCLE = {
+  unlocked: "root",
+  root: "all",
+  all: "unlocked"
+};
+
+function normalizeLockState(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return normalized === "root" || normalized === "all" ? normalized : "unlocked";
+}
+
+function participantList(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry || "").trim()).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function uniqueValues(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+export class WavyWaveHeaderActions extends LitElement {
+  static properties = {
+    sourceWaveId: { type: String, attribute: "source-wave-id", reflect: true },
+    participants: { attribute: false },
+    public: { type: Boolean, reflect: true },
+    lockState: { type: String, attribute: "lock-state", reflect: true },
+    disabled: { type: Boolean, reflect: true },
+    _addDialogOpen: { state: true },
+    _participantDraft: { state: true }
+  };
+
+  static styles = css`
+    :host {
+      display: block;
+      box-sizing: border-box;
+      background: linear-gradient(
+        90deg,
+        var(--wavy-toolbar-pill-bg, #f0f4f8),
+        var(--wavy-bg-elevated, #ffffff)
+      );
+      border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-2, 8px);
+    }
+
+    .row {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--wavy-spacing-2, 8px);
+    }
+
+    button {
+      border: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      border-radius: 999px;
+      background: var(--wavy-bg-base, #ffffff);
+      color: var(--wavy-text-body, #1a202c);
+      cursor: pointer;
+      font: var(--wavy-type-meta, 12px / 1.35 Arial, sans-serif);
+      min-height: 30px;
+      padding: 0 var(--wavy-spacing-3, 12px);
+      transition: background-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        border-color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        color var(--wavy-motion-focus-duration, 180ms)
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+
+    button:hover:not([disabled]) {
+      background: var(--wavy-toolbar-tile-hover-bg, rgba(0, 119, 182, 0.08));
+      border-color: var(--wavy-signal-cyan, #0077b6);
+      color: var(--wavy-signal-cyan, #0077b6);
+    }
+
+    button:focus-visible,
+    input:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
+    }
+
+    button[disabled] {
+      cursor: not-allowed;
+      opacity: 0.48;
+    }
+
+    button[data-action="publicity-toggle"][aria-pressed="true"],
+    button[data-action="lock-toggle"][data-lock-state="root"],
+    button[data-action="lock-toggle"][data-lock-state="all"] {
+      background: var(--wavy-signal-amber-soft, #fff4e5);
+      border-color: var(--wavy-signal-amber, #9a6700);
+      color: var(--wavy-signal-amber, #9a6700);
+    }
+
+    .add-popover {
+      display: grid;
+      gap: var(--wavy-spacing-2, 8px);
+      margin-top: var(--wavy-spacing-2, 8px);
+      max-width: 460px;
+      padding: var(--wavy-spacing-3, 12px);
+      border: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      border-radius: var(--wavy-radius-card, 10px);
+      background: var(--wavy-bg-elevated, #ffffff);
+      box-shadow: var(--wavy-shadow-card, 0 8px 24px rgba(15, 23, 42, 0.12));
+    }
+
+    label {
+      display: grid;
+      gap: var(--wavy-spacing-1, 4px);
+      color: var(--wavy-text-muted, #64748b);
+      font: var(--wavy-type-meta, 12px / 1.35 Arial, sans-serif);
+    }
+
+    input {
+      border: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      border-radius: var(--wavy-radius-input, 8px);
+      color: var(--wavy-text-body, #1a202c);
+      font: var(--wavy-type-body, 14px / 1.45 Arial, sans-serif);
+      padding: var(--wavy-spacing-2, 8px);
+    }
+
+    .add-actions {
+      display: flex;
+      gap: var(--wavy-spacing-2, 8px);
+      justify-content: flex-end;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.sourceWaveId = "";
+    this.participants = [];
+    this.public = false;
+    this.lockState = "unlocked";
+    this.disabled = false;
+    this._addDialogOpen = false;
+    this._participantDraft = "";
+    this._pendingConfirm = null;
+    this._onConfirmResolved = this._onConfirmResolved.bind(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.body.addEventListener("wavy-confirm-resolved", this._onConfirmResolved);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.body.removeEventListener("wavy-confirm-resolved", this._onConfirmResolved);
+  }
+
+  render() {
+    const unavailable = this._unavailable();
+    const lockState = normalizeLockState(this.lockState);
+    return html`
+      <div class="row" role="toolbar" aria-label="Wave header actions">
+        <button
+          type="button"
+          data-action="add-participant"
+          aria-label="Add participant"
+          ?disabled=${unavailable}
+          @click=${this._openAddParticipant}
+        >
+          Add participant
+        </button>
+        <button
+          type="button"
+          data-action="new-with-participants"
+          aria-label="New wave with current participants"
+          ?disabled=${unavailable}
+          @click=${this._newWithParticipants}
+        >
+          New with participants
+        </button>
+        <button
+          type="button"
+          data-action="publicity-toggle"
+          aria-label=${this.public ? "Make wave private" : "Make wave public"}
+          aria-pressed=${this.public ? "true" : "false"}
+          ?disabled=${unavailable}
+          @click=${this._confirmPublicityToggle}
+        >
+          ${this.public ? "Public" : "Private"}
+        </button>
+        <button
+          type="button"
+          data-action="lock-toggle"
+          data-lock-state=${lockState}
+          aria-label=${this._lockLabel(lockState)}
+          ?disabled=${unavailable}
+          @click=${this._confirmLockToggle}
+        >
+          ${this._lockText(lockState)}
+        </button>
+      </div>
+      ${this._addDialogOpen ? this._renderAddParticipantDialog() : ""}
+    `;
+  }
+
+  _renderAddParticipantDialog() {
+    return html`
+      <form class="add-popover" @submit=${this._submitAddParticipant}>
+        <label>
+          Participant addresses
+          <input
+            name="participant-addresses"
+            autocomplete="off"
+            placeholder="alice@example.com, bob@example.com"
+            .value=${this._participantDraft}
+            @input=${this._onParticipantDraftInput}
+          />
+        </label>
+        <div class="add-actions">
+          <button
+            type="button"
+            data-action="add-participant-cancel"
+            @click=${this._closeAddParticipant}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-action="add-participant-submit"
+            ?disabled=${this._addParticipantAddresses().length === 0}
+          >
+            Add
+          </button>
+        </div>
+      </form>
+    `;
+  }
+
+  _unavailable() {
+    return this.disabled || String(this.sourceWaveId || "").trim() === "";
+  }
+
+  _regularParticipants() {
+    return uniqueValues(
+      participantList(this.participants).filter((participant) => !participant.startsWith("@"))
+    );
+  }
+
+  _addParticipantAddresses() {
+    return uniqueValues(
+      String(this._participantDraft || "")
+        .split(",")
+        .map((address) => address.trim())
+        .filter(Boolean)
+    );
+  }
+
+  _openAddParticipant(event) {
+    event.stopPropagation();
+    if (this._unavailable()) return;
+    this._addDialogOpen = true;
+  }
+
+  _closeAddParticipant(event) {
+    if (event) event.stopPropagation();
+    this._addDialogOpen = false;
+    this._participantDraft = "";
+  }
+
+  _onParticipantDraftInput(event) {
+    this._participantDraft = event.target.value;
+  }
+
+  _submitAddParticipant(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this._unavailable()) return;
+    const addresses = this._addParticipantAddresses();
+    if (addresses.length === 0) return;
+    this._emit("wave-add-participant-requested", { addresses });
+    this._closeAddParticipant();
+  }
+
+  _newWithParticipants(event) {
+    event.stopPropagation();
+    if (this._unavailable()) return;
+    this._emit("wave-new-with-participants-requested", {
+      participants: this._regularParticipants()
+    });
+  }
+
+  _confirmPublicityToggle(event) {
+    event.stopPropagation();
+    if (this._unavailable()) return;
+    const currentlyPublic = !!this.public;
+    const nextPublic = !currentlyPublic;
+    this._requestConfirmation(
+      "publicity",
+      currentlyPublic ? "Make this wave private?" : "Make this wave public?",
+      currentlyPublic ? "Make private" : "Make public",
+      "wave-publicity-toggle-requested",
+      { currentlyPublic, nextPublic }
+    );
+  }
+
+  _confirmLockToggle(event) {
+    event.stopPropagation();
+    if (this._unavailable()) return;
+    const currentLockState = normalizeLockState(this.lockState);
+    const nextLockState = LOCK_CYCLE[currentLockState] || "unlocked";
+    this._requestConfirmation(
+      "lock",
+      this._lockConfirmMessage(currentLockState, nextLockState),
+      this._lockConfirmLabel(nextLockState),
+      "wave-root-lock-toggle-requested",
+      { currentLockState, nextLockState }
+    );
+  }
+
+  _requestConfirmation(kind, message, confirmLabel, eventName, detail) {
+    const requestId = [
+      "wavy-wave-header-actions",
+      kind,
+      String(this.sourceWaveId || ""),
+      String(Date.now())
+    ].join(":");
+    this._pendingConfirm = { requestId, eventName, detail };
+    document.body.dispatchEvent(
+      new CustomEvent("wavy-confirm-requested", {
+        bubbles: true,
+        composed: true,
+        detail: {
+          requestId,
+          message,
+          confirmLabel,
+          cancelLabel: "Cancel",
+          tone: kind === "lock" || detail.nextPublic === false ? "warning" : "info"
+        }
+      })
+    );
+  }
+
+  _onConfirmResolved(event) {
+    const pending = this._pendingConfirm;
+    if (!pending || event.detail?.requestId !== pending.requestId) return;
+    this._pendingConfirm = null;
+    if (!event.detail?.confirmed) return;
+    this._emit(pending.eventName, pending.detail);
+  }
+
+  _emit(eventName, extra) {
+    this.dispatchEvent(
+      new CustomEvent(eventName, {
+        bubbles: true,
+        composed: true,
+        detail: {
+          sourceWaveId: this.sourceWaveId,
+          ...(extra || {})
+        }
+      })
+    );
+  }
+
+  _lockLabel(lockState) {
+    if (lockState === "root") return "Lock full wave";
+    if (lockState === "all") return "Unlock wave";
+    return "Lock root blip";
+  }
+
+  _lockText(lockState) {
+    if (lockState === "root") return "Root locked";
+    if (lockState === "all") return "Wave locked";
+    return "Unlocked";
+  }
+
+  _lockConfirmLabel(nextLockState) {
+    if (nextLockState === "root") return "Lock root";
+    if (nextLockState === "all") return "Lock all";
+    return "Unlock";
+  }
+
+  _lockConfirmMessage(currentLockState, nextLockState) {
+    if (nextLockState === "root") return "Lock the root blip?";
+    if (nextLockState === "all") return "Lock the full wave?";
+    return `Unlock this wave from ${currentLockState} lock?`;
+  }
+}
+
+if (!customElements.get("wavy-wave-header-actions")) {
+  customElements.define("wavy-wave-header-actions", WavyWaveHeaderActions);
+}

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -163,6 +163,14 @@ export class WavyWaveHeaderActions extends LitElement {
     document.body.removeEventListener("wavy-confirm-resolved", this._onConfirmResolved);
   }
 
+  willUpdate(changedProperties) {
+    if (changedProperties.has("sourceWaveId")) {
+      this._pendingConfirm = null;
+      this._addDialogOpen = false;
+      this._participantDraft = "";
+    }
+  }
+
   render() {
     const unavailable = this._unavailable();
     const lockState = normalizeLockState(this.lockState);
@@ -327,13 +335,14 @@ export class WavyWaveHeaderActions extends LitElement {
 
   _requestConfirmation(kind, message, confirmLabel, eventName, detail) {
     ensureWavyConfirmDialogMounted();
+    const sourceWaveId = String(this.sourceWaveId || "");
     const requestId = [
       "wavy-wave-header-actions",
       kind,
-      String(this.sourceWaveId || ""),
+      sourceWaveId,
       String(Date.now())
     ].join(":");
-    this._pendingConfirm = { requestId, eventName, detail };
+    this._pendingConfirm = { requestId, eventName, detail, sourceWaveId };
     document.body.dispatchEvent(
       new CustomEvent("wavy-confirm-requested", {
         bubbles: true,
@@ -354,16 +363,16 @@ export class WavyWaveHeaderActions extends LitElement {
     if (!pending || event.detail?.requestId !== pending.requestId) return;
     this._pendingConfirm = null;
     if (!event.detail?.confirmed) return;
-    this._emit(pending.eventName, pending.detail);
+    this._emit(pending.eventName, pending.detail, pending.sourceWaveId);
   }
 
-  _emit(eventName, extra) {
+  _emit(eventName, extra, sourceWaveIdOverride) {
     this.dispatchEvent(
       new CustomEvent(eventName, {
         bubbles: true,
         composed: true,
         detail: {
-          sourceWaveId: this.sourceWaveId,
+          sourceWaveId: sourceWaveIdOverride != null ? sourceWaveIdOverride : this.sourceWaveId,
           ...(extra || {})
         }
       })

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { ensureWavyConfirmDialogMounted } from "./wavy-confirm-dialog.js";
 
 const LOCK_CYCLE = {
   unlocked: "root",
@@ -325,6 +326,7 @@ export class WavyWaveHeaderActions extends LitElement {
   }
 
   _requestConfirmation(kind, message, confirmLabel, eventName, detail) {
+    ensureWavyConfirmDialogMounted();
     const requestId = [
       "wavy-wave-header-actions",
       kind,

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -343,7 +343,7 @@ export class WavyWaveHeaderActions extends LitElement {
           message,
           confirmLabel,
           cancelLabel: "Cancel",
-          tone: kind === "lock" || detail.nextPublic === false ? "warning" : "info"
+          tone: kind === "lock" || detail.nextPublic === false ? "destructive" : "default"
         }
       })
     );

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -42,6 +42,7 @@ import "./elements/wave-blip.js";
 // inside its host so the bounds-measurement and positioning ancestor
 // converge on the same node.
 import "./elements/wavy-focus-frame.js";
+import "./elements/wavy-wave-header-actions.js";
 import "./elements/wavy-wave-nav-row.js";
 import "./elements/wavy-depth-nav-bar.js";
 // F-2 slice 3 (#1047): search rail + search-help modal + wavy header

--- a/j2cl/lit/test/wavy-confirm-dialog.test.js
+++ b/j2cl/lit/test/wavy-confirm-dialog.test.js
@@ -54,6 +54,26 @@ describe("<wavy-confirm-dialog>", () => {
     el.remove();
   });
 
+  it("makes the backdrop visible while open", async () => {
+    const el = await fixture(html`<wavy-confirm-dialog></wavy-confirm-dialog>`);
+    document.body.appendChild(el);
+    document.body.dispatchEvent(
+      new CustomEvent("wavy-confirm-requested", {
+        detail: { requestId: "q-visible", message: "Proceed?" }
+      })
+    );
+    await el.updateComplete;
+
+    expect(getComputedStyle(el).position).to.equal("fixed");
+    const backdrop = el.renderRoot.querySelector(".backdrop");
+    expect(getComputedStyle(backdrop).display).to.not.equal("none");
+    const dialog = el.renderRoot.querySelector(".dialog");
+    expect(getComputedStyle(dialog).position).to.equal("absolute");
+    expect(getComputedStyle(dialog).transform).to.not.equal("none");
+    expect(backdrop.getAttribute("data-confirm-open")).to.equal("true");
+    el.remove();
+  });
+
   it("emits wavy-confirm-resolved with confirmed=true on confirm click", async () => {
     const el = await fixture(html`<wavy-confirm-dialog></wavy-confirm-dialog>`);
     document.body.appendChild(el);

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -1,0 +1,161 @@
+import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/wavy-wave-header-actions.js";
+
+function actionButton(el, action) {
+  return el.renderRoot.querySelector(`button[data-action="${action}"]`);
+}
+
+async function createActions(properties = {}) {
+  const defaults = {
+    sourceWaveId: "example.com/w+header",
+    participants: ["alice@example.com", "bob@example.com"],
+    public: false,
+    lockState: "unlocked"
+  };
+  const props = { ...defaults, ...properties };
+  const el = await fixture(
+    html`<wavy-wave-header-actions
+      source-wave-id=${props.sourceWaveId}
+      lock-state=${props.lockState}
+      .participants=${props.participants}
+      .public=${props.public}
+      ?disabled=${props.disabled || false}
+    ></wavy-wave-header-actions>`
+  );
+  await el.updateComplete;
+  return el;
+}
+
+describe("<wavy-wave-header-actions>", () => {
+  it("renders Add participant, New wave, Public/private, and Lock buttons", async () => {
+    const el = await createActions();
+
+    const actions = Array.from(
+      el.renderRoot.querySelectorAll("button[data-action]")
+    ).map((button) => button.dataset.action);
+
+    expect(actions).to.deep.equal([
+      "add-participant",
+      "new-with-participants",
+      "publicity-toggle",
+      "lock-toggle"
+    ]);
+    expect(actionButton(el, "add-participant").getAttribute("aria-label")).to.equal(
+      "Add participant"
+    );
+    expect(
+      actionButton(el, "new-with-participants").getAttribute("aria-label")
+    ).to.equal("New wave with current participants");
+    expect(actionButton(el, "publicity-toggle").getAttribute("aria-label")).to.equal(
+      "Make wave public"
+    );
+    expect(actionButton(el, "lock-toggle").getAttribute("aria-label")).to.equal(
+      "Lock root blip"
+    );
+  });
+
+  it("disables write buttons when no source wave is selected", async () => {
+    const el = await createActions({ sourceWaveId: "" });
+
+    for (const button of el.renderRoot.querySelectorAll("button[data-action]")) {
+      expect(button.disabled, `${button.dataset.action} should be disabled`).to.be.true;
+    }
+  });
+
+  it("opens add-participant dialog and emits trimmed addresses", async () => {
+    const el = await createActions();
+
+    actionButton(el, "add-participant").click();
+    await el.updateComplete;
+    const input = el.renderRoot.querySelector('input[name="participant-addresses"]');
+    expect(input).to.exist;
+    input.value = " carol@example.com, dave@example.com ,, ";
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    await el.updateComplete;
+
+    const eventPromise = oneEvent(el, "wave-add-participant-requested");
+    actionButton(el, "add-participant-submit").click();
+    const event = await eventPromise;
+
+    expect(event.detail).to.deep.equal({
+      sourceWaveId: "example.com/w+header",
+      addresses: ["carol@example.com", "dave@example.com"]
+    });
+    expect(event.bubbles).to.be.true;
+    expect(event.composed).to.be.true;
+  });
+
+  it("starts a new wave with current participants excluding the shared-domain participant", async () => {
+    const el = await createActions({
+      participants: ["@example.com", "alice@example.com", "bob@example.com"]
+    });
+
+    const eventPromise = oneEvent(el, "wave-new-with-participants-requested");
+    actionButton(el, "new-with-participants").click();
+    const event = await eventPromise;
+
+    expect(event.detail).to.deep.equal({
+      sourceWaveId: "example.com/w+header",
+      participants: ["alice@example.com", "bob@example.com"]
+    });
+  });
+
+  it("confirms public/private changes before emitting the toggle event", async () => {
+    const el = await createActions({ public: true });
+    let emitted = false;
+    el.addEventListener("wave-publicity-toggle-requested", () => {
+      emitted = true;
+    });
+
+    const confirmPromise = oneEvent(document.body, "wavy-confirm-requested");
+    actionButton(el, "publicity-toggle").click();
+    const confirmEvent = await confirmPromise;
+
+    expect(emitted).to.be.false;
+    expect(confirmEvent.detail.requestId).to.match(/^wavy-wave-header-actions:publicity:/);
+    expect(confirmEvent.detail.message).to.contain("Make this wave private");
+
+    const eventPromise = oneEvent(el, "wave-publicity-toggle-requested");
+    document.body.dispatchEvent(
+      new CustomEvent("wavy-confirm-resolved", {
+        bubbles: true,
+        composed: true,
+        detail: { requestId: confirmEvent.detail.requestId, confirmed: true }
+      })
+    );
+    const event = await eventPromise;
+
+    expect(event.detail).to.deep.equal({
+      sourceWaveId: "example.com/w+header",
+      currentlyPublic: true,
+      nextPublic: false
+    });
+  });
+
+  it("confirms lock-state changes before emitting the lock toggle event", async () => {
+    const el = await createActions({ lockState: "root" });
+
+    const confirmPromise = oneEvent(document.body, "wavy-confirm-requested");
+    actionButton(el, "lock-toggle").click();
+    const confirmEvent = await confirmPromise;
+
+    expect(confirmEvent.detail.requestId).to.match(/^wavy-wave-header-actions:lock:/);
+    expect(confirmEvent.detail.message).to.contain("Lock the full wave");
+
+    const eventPromise = oneEvent(el, "wave-root-lock-toggle-requested");
+    document.body.dispatchEvent(
+      new CustomEvent("wavy-confirm-resolved", {
+        bubbles: true,
+        composed: true,
+        detail: { requestId: confirmEvent.detail.requestId, confirmed: true }
+      })
+    );
+    const event = await eventPromise;
+
+    expect(event.detail).to.deep.equal({
+      sourceWaveId: "example.com/w+header",
+      currentLockState: "root",
+      nextLockState: "all"
+    });
+  });
+});

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -137,6 +137,45 @@ describe("<wavy-wave-header-actions>", () => {
     });
   });
 
+  it("drops pending confirmations when the selected source wave changes", async () => {
+    const el = await createActions({ lockState: "root" });
+    let emitted = false;
+    el.addEventListener("wave-root-lock-toggle-requested", () => {
+      emitted = true;
+    });
+
+    const confirmPromise = oneEvent(document.body, "wavy-confirm-requested");
+    actionButton(el, "lock-toggle").click();
+    const confirmEvent = await confirmPromise;
+    el.sourceWaveId = "example.com/w+other";
+    await el.updateComplete;
+
+    document.body.dispatchEvent(
+      new CustomEvent("wavy-confirm-resolved", {
+        bubbles: true,
+        composed: true,
+        detail: { requestId: confirmEvent.detail.requestId, confirmed: true }
+      })
+    );
+
+    expect(emitted).to.be.false;
+  });
+
+  it("closes the add-participant draft when the selected source wave changes", async () => {
+    const el = await createActions();
+    actionButton(el, "add-participant").click();
+    await el.updateComplete;
+    const input = el.renderRoot.querySelector('input[name="participant-addresses"]');
+    input.value = "carol@example.com";
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    await el.updateComplete;
+
+    el.sourceWaveId = "example.com/w+other";
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector('input[name="participant-addresses"]')).to.not.exist;
+  });
+
   it("mounts the shared confirm dialog before requesting public/private confirmation", async () => {
     const el = await createActions();
     expect(document.body.querySelector("wavy-confirm-dialog")).to.not.exist;

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -118,6 +118,7 @@ describe("<wavy-wave-header-actions>", () => {
     expect(emitted).to.be.false;
     expect(confirmEvent.detail.requestId).to.match(/^wavy-wave-header-actions:publicity:/);
     expect(confirmEvent.detail.message).to.contain("Make this wave private");
+    expect(confirmEvent.detail.tone).to.equal("destructive");
 
     const eventPromise = oneEvent(el, "wave-publicity-toggle-requested");
     document.body.dispatchEvent(
@@ -142,12 +143,13 @@ describe("<wavy-wave-header-actions>", () => {
 
     const confirmPromise = oneEvent(document.body, "wavy-confirm-requested");
     actionButton(el, "publicity-toggle").click();
-    await confirmPromise;
+    const confirmEvent = await confirmPromise;
 
     const dialog = document.body.querySelector("wavy-confirm-dialog");
     expect(dialog).to.exist;
     await dialog.updateComplete;
     expect(dialog.open).to.be.true;
+    expect(confirmEvent.detail.tone).to.equal("default");
   });
 
   it("confirms lock-state changes before emitting the lock toggle event", async () => {
@@ -159,6 +161,7 @@ describe("<wavy-wave-header-actions>", () => {
 
     expect(confirmEvent.detail.requestId).to.match(/^wavy-wave-header-actions:lock:/);
     expect(confirmEvent.detail.message).to.contain("Lock the full wave");
+    expect(confirmEvent.detail.tone).to.equal("destructive");
 
     const eventPromise = oneEvent(el, "wave-root-lock-toggle-requested");
     document.body.dispatchEvent(

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -27,6 +27,10 @@ async function createActions(properties = {}) {
 }
 
 describe("<wavy-wave-header-actions>", () => {
+  afterEach(() => {
+    document.body.querySelectorAll("wavy-confirm-dialog").forEach((dialog) => dialog.remove());
+  });
+
   it("renders Add participant, New wave, Public/private, and Lock buttons", async () => {
     const el = await createActions();
 
@@ -130,6 +134,20 @@ describe("<wavy-wave-header-actions>", () => {
       currentlyPublic: true,
       nextPublic: false
     });
+  });
+
+  it("mounts the shared confirm dialog before requesting public/private confirmation", async () => {
+    const el = await createActions();
+    expect(document.body.querySelector("wavy-confirm-dialog")).to.not.exist;
+
+    const confirmPromise = oneEvent(document.body, "wavy-confirm-requested");
+    actionButton(el, "publicity-toggle").click();
+    await confirmPromise;
+
+    const dialog = document.body.querySelector("wavy-confirm-dialog");
+    expect(dialog).to.exist;
+    await dialog.updateComplete;
+    expect(dialog.open).to.be.true;
   });
 
   it("confirms lock-state changes before emitting the lock toggle event", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1560,7 +1560,7 @@ public final class J2clComposeSurfaceController {
           notifyCurrentUserAddress(bootstrap.getAddress());
           SidecarSubmitRequest request;
           try {
-            request = requestBuilder.create(bootstrap.getAddress(), writeSession);
+            request = requestBuilder.create(bootstrap.getAddress(), submitSession);
           } catch (RuntimeException e) {
             recordWaveHeaderActionTelemetry(telemetryEventName, "failure-build");
             return;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -418,6 +418,30 @@ public final class J2clComposeSurfaceController {
       throw new UnsupportedOperationException(
           "Blip delete is only available with the rich-content delta factory.");
     }
+
+    default SidecarSubmitRequest createAddParticipantRequest(
+        String address, J2clSidecarWriteSession session, List<String> participantsToAdd) {
+      throw new UnsupportedOperationException(
+          "Add participant is only available with the rich-content delta factory.");
+    }
+
+    default SidecarSubmitRequest createPublicityToggleRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String sharedDomainParticipant,
+        boolean makePublic) {
+      throw new UnsupportedOperationException(
+          "Publicity toggle is only available with the rich-content delta factory.");
+    }
+
+    default SidecarSubmitRequest createLockStateRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String currentLockState,
+        String nextLockState) {
+      throw new UnsupportedOperationException(
+          "Lock toggle is only available with the rich-content delta factory.");
+    }
   }
 
   public interface AttachmentControllerFactory {
@@ -430,6 +454,10 @@ public final class J2clComposeSurfaceController {
 
   interface AttachmentUploadClientFactory {
     J2clAttachmentUploadClient create();
+  }
+
+  private interface WaveHeaderActionRequestBuilder {
+    SidecarSubmitRequest create(String address, J2clSidecarWriteSession session);
   }
 
   public static final class AttachmentFileSelection {
@@ -1464,6 +1492,117 @@ public final class J2clComposeSurfaceController {
         error -> recordTaskMetadataTelemetry("failure-bootstrap"));
   }
 
+  public void onAddParticipantsRequested(
+      final String expectedWaveId, List<String> rawParticipantAddresses) {
+    final List<String> participantsToAdd =
+        normalizeCreateParticipantAddresses(rawParticipantAddresses);
+    if (participantsToAdd.isEmpty()) {
+      recordWaveHeaderActionTelemetry("compose.participants_added", "missing-participants");
+      return;
+    }
+    submitWaveHeaderAction(
+        expectedWaveId,
+        "compose.participants_added",
+        (address, session) ->
+            deltaFactory.createAddParticipantRequest(address, session, participantsToAdd));
+  }
+
+  public void onPublicityToggleRequested(final String expectedWaveId, final boolean makePublic) {
+    submitWaveHeaderAction(
+        expectedWaveId,
+        "compose.publicity_toggled",
+        (address, session) ->
+            deltaFactory.createPublicityToggleRequest(
+                address, session, sharedDomainParticipantForSession(session), makePublic));
+  }
+
+  public void onLockStateToggleRequested(
+      final String expectedWaveId, String currentLockState, String nextLockState) {
+    final String current = currentLockState == null ? "" : currentLockState.trim();
+    final String next = nextLockState == null ? "" : nextLockState.trim();
+    submitWaveHeaderAction(
+        expectedWaveId,
+        "compose.lock_toggled",
+        (address, session) -> deltaFactory.createLockStateRequest(address, session, current, next));
+  }
+
+  private void submitWaveHeaderAction(
+      final String expectedWaveId,
+      final String telemetryEventName,
+      final WaveHeaderActionRequestBuilder requestBuilder) {
+    final String expected = expectedWaveId == null ? "" : expectedWaveId.trim();
+    if (signedOut) {
+      recordWaveHeaderActionTelemetry(telemetryEventName, "signed-out");
+      return;
+    }
+    if (expected.isEmpty()) {
+      recordWaveHeaderActionTelemetry(telemetryEventName, "missing-wave");
+      return;
+    }
+    if (!hasSelectedWave(writeSession)) {
+      recordWaveHeaderActionTelemetry(telemetryEventName, "no-selected-wave");
+      return;
+    }
+    if (!expected.equals(writeSession.getSelectedWaveId())) {
+      recordWaveHeaderActionTelemetry(telemetryEventName, "wave-changed");
+      return;
+    }
+    final J2clSidecarWriteSession submitSession = writeSession;
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (signedOut
+              || !sameLogicalSession(submitSession, writeSession)
+              || writeSession == null
+              || !expected.equals(writeSession.getSelectedWaveId())) {
+            recordWaveHeaderActionTelemetry(telemetryEventName, "wave-changed");
+            return;
+          }
+          notifyCurrentUserAddress(bootstrap.getAddress());
+          SidecarSubmitRequest request;
+          try {
+            request = requestBuilder.create(bootstrap.getAddress(), writeSession);
+          } catch (RuntimeException e) {
+            recordWaveHeaderActionTelemetry(telemetryEventName, "failure-build");
+            return;
+          }
+          gateway.submit(
+              bootstrap,
+              request,
+              response -> {
+                if (response != null && !response.getErrorMessage().isEmpty()) {
+                  recordWaveHeaderActionTelemetry(telemetryEventName, "failure-submit");
+                  return;
+                }
+                recordWaveHeaderActionTelemetry(telemetryEventName, "success");
+              },
+              error -> recordWaveHeaderActionTelemetry(telemetryEventName, "failure-submit"));
+        },
+        error -> recordWaveHeaderActionTelemetry(telemetryEventName, "failure-bootstrap"));
+  }
+
+  private static String sharedDomainParticipantForSession(J2clSidecarWriteSession session) {
+    if (session == null || session.getSelectedWaveId() == null) {
+      return "";
+    }
+    String waveId = session.getSelectedWaveId();
+    int separator = waveId.indexOf('/');
+    if (separator <= 0) {
+      return "";
+    }
+    return "@" + waveId.substring(0, separator).toLowerCase(Locale.ROOT);
+  }
+
+  private void recordWaveHeaderActionTelemetry(String eventName, String outcome) {
+    try {
+      telemetrySink.record(
+          J2clClientTelemetry.event(eventName)
+              .field("outcome", outcome)
+              .build());
+    } catch (Exception ignored) {
+      // Telemetry must never affect composer behavior.
+    }
+  }
+
   private void recordTaskMetadataTelemetry(String outcome) {
     try {
       telemetrySink.record(
@@ -2454,6 +2593,31 @@ public final class J2clComposeSurfaceController {
           String blipId,
           int bodyItemCount) {
         return factory.blipDeleteRequest(address, session, blipId, bodyItemCount);
+      }
+
+      @Override
+      public SidecarSubmitRequest createAddParticipantRequest(
+          String address, J2clSidecarWriteSession session, List<String> participantsToAdd) {
+        return factory.addParticipantRequest(address, session, participantsToAdd);
+      }
+
+      @Override
+      public SidecarSubmitRequest createPublicityToggleRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String sharedDomainParticipant,
+          boolean makePublic) {
+        return factory.publicityToggleRequest(
+            address, session, sharedDomainParticipant, makePublic);
+      }
+
+      @Override
+      public SidecarSubmitRequest createLockStateRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String currentLockState,
+          String nextLockState) {
+        return factory.lockStateRequest(address, session, currentLockState, nextLockState);
       }
     };
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
 import org.waveprotocol.box.j2cl.transport.SidecarReactionEntry;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
 
 /**
@@ -242,6 +243,84 @@ public final class J2clRichContentDeltaFactory {
         new String[] {"tombstone/deleted"},
         new String[] {"true"},
         bodyItemCount);
+  }
+
+  public SidecarSubmitRequest addParticipantRequest(
+      String address, J2clSidecarWriteSession session, List<String> participantsToAdd) {
+    WriteContext context = requireWriteContext(address, session);
+    Set<String> participantAddresses = new LinkedHashSet<String>();
+    if (participantsToAdd != null) {
+      for (String participant : participantsToAdd) {
+        if (participant == null || participant.trim().isEmpty()) {
+          continue;
+        }
+        String normalizedParticipant = normalizeAddress(participant);
+        extractDomain(normalizedParticipant);
+        if (!normalizedParticipant.equals(context.normalizedAddress)) {
+          participantAddresses.add(normalizedParticipant);
+        }
+      }
+    }
+    if (participantAddresses.isEmpty()) {
+      throw new IllegalArgumentException("No participants to add.");
+    }
+    String deltaJson =
+        buildDeltaJson(
+            context.baseVersion,
+            context.historyHash,
+            context.normalizedAddress,
+            buildAddParticipantOperations(participantAddresses));
+    return new SidecarSubmitRequest(context.waveletName(), deltaJson, context.channelId);
+  }
+
+  public SidecarSubmitRequest publicityToggleRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String sharedDomainParticipant,
+      boolean makePublic) {
+    WriteContext context = requireWriteContext(address, session);
+    String sharedParticipant =
+        normalizeSharedDomainParticipant(sharedDomainParticipant, context.normalizedAddress);
+    String operation =
+        makePublic
+            ? buildAddParticipantOperation(sharedParticipant)
+            : buildRemoveParticipantOperation(sharedParticipant);
+    String deltaJson =
+        buildDeltaJson(
+            context.baseVersion, context.historyHash, context.normalizedAddress, operation);
+    return new SidecarSubmitRequest(context.waveletName(), deltaJson, context.channelId);
+  }
+
+  public SidecarSubmitRequest lockStateRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String currentLockState,
+      String nextLockState) {
+    WriteContext context = requireWriteContext(address, session);
+    String current = SidecarSelectedWaveDocument.normalizeLockState(currentLockState);
+    String next = SidecarSelectedWaveDocument.normalizeLockState(nextLockState);
+    if (current.equals(next)) {
+      throw new IllegalArgumentException("Lock state unchanged.");
+    }
+    StringBuilder components = new StringBuilder();
+    if (!SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED.equals(current)) {
+      appendDeleteElementStart(components, "lock", "mode", current);
+      appendComponentSeparator(components);
+      appendDeleteElementEnd(components);
+    }
+    if (!SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED.equals(next)) {
+      appendComponentSeparator(components);
+      appendElementStartWithAttr(components, "lock", "mode", next);
+      appendComponentSeparator(components);
+      appendElementEnd(components);
+    }
+    String deltaJson =
+        buildDeltaJson(
+            context.baseVersion,
+            context.historyHash,
+            context.normalizedAddress,
+            buildRawDocumentOperation("m/lock", components.toString()));
+    return new SidecarSubmitRequest(context.waveletName(), deltaJson, context.channelId);
   }
 
   /**
@@ -955,6 +1034,10 @@ public final class J2clRichContentDeltaFactory {
     return "{\"1\":\"" + escapeJson(address) + "\"}";
   }
 
+  private static String buildRemoveParticipantOperation(String address) {
+    return "{\"2\":\"" + escapeJson(address) + "\"}";
+  }
+
   private static String buildAddParticipantOperations(Set<String> participantAddresses) {
     StringBuilder operations = new StringBuilder();
     for (String participantAddress : participantAddresses) {
@@ -1015,6 +1098,68 @@ public final class J2clRichContentDeltaFactory {
         + "/"
         + waveId.substring(separator + 1)
         + "/~/conv+root";
+  }
+
+  private WriteContext requireWriteContext(String address, J2clSidecarWriteSession session) {
+    requirePresent(session, "Missing write session.");
+    String normalizedAddress = normalizeAddress(address);
+    extractDomain(normalizedAddress);
+    String selectedWaveId =
+        requireNonEmpty(session.getSelectedWaveId(), "Missing selected wave id.");
+    String historyHash =
+        requireNonEmpty(session.getHistoryHash(), "Missing write-session history hash.");
+    String channelId =
+        requireNonEmpty(session.getChannelId(), "Missing write-session channel id.");
+    long baseVersion = session.getBaseVersion();
+    if (baseVersion < 0) {
+      throw new IllegalArgumentException("Invalid write-session base version.");
+    }
+    return new WriteContext(
+        normalizedAddress, selectedWaveId, channelId, baseVersion, historyHash);
+  }
+
+  private static String normalizeSharedDomainParticipant(
+      String sharedDomainParticipant, String normalizedAddress) {
+    String trimmed =
+        sharedDomainParticipant == null
+            ? ""
+            : sharedDomainParticipant.trim().toLowerCase(Locale.ROOT);
+    if (trimmed.isEmpty()) {
+      return "@" + extractDomain(normalizedAddress);
+    }
+    if (!trimmed.startsWith("@")
+        || trimmed.length() == 1
+        || trimmed.indexOf('/', 1) >= 0
+        || trimmed.indexOf('@', 1) >= 0) {
+      throw new IllegalArgumentException(
+          "Invalid shared-domain participant: " + sharedDomainParticipant);
+    }
+    return trimmed;
+  }
+
+  private final class WriteContext {
+    private final String normalizedAddress;
+    private final String selectedWaveId;
+    private final String channelId;
+    private final long baseVersion;
+    private final String historyHash;
+
+    WriteContext(
+        String normalizedAddress,
+        String selectedWaveId,
+        String channelId,
+        long baseVersion,
+        String historyHash) {
+      this.normalizedAddress = normalizedAddress;
+      this.selectedWaveId = selectedWaveId;
+      this.channelId = channelId;
+      this.baseVersion = baseVersion;
+      this.historyHash = historyHash;
+    }
+
+    String waveletName() {
+      return buildWaveletName(selectedWaveId);
+    }
   }
 
   private static <T> T requirePresent(T value, String message) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -23,6 +23,7 @@ import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceController;
 import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceView;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 
 public final class J2clRootShellController {
   private final HTMLElement host;
@@ -174,6 +175,23 @@ public final class J2clRootShellController {
     elemental2.dom.DomGlobal.document.body.addEventListener(
         "wave-new-with-participants-requested",
         evt -> composeController.onCreateRequestedWithParticipants(participantsFromEvent(evt)));
+    elemental2.dom.DomGlobal.document.body.addEventListener(
+        "wave-add-participant-requested",
+        evt ->
+            composeController.onAddParticipantsRequested(
+                sourceWaveIdFromEvent(evt), addParticipantAddressesFromEvent(evt)));
+    elemental2.dom.DomGlobal.document.body.addEventListener(
+        "wave-publicity-toggle-requested",
+        evt ->
+            composeController.onPublicityToggleRequested(
+                sourceWaveIdFromEvent(evt), nextPublicFromEvent(evt)));
+    elemental2.dom.DomGlobal.document.body.addEventListener(
+        "wave-root-lock-toggle-requested",
+        evt ->
+            composeController.onLockStateToggleRequested(
+                sourceWaveIdFromEvent(evt),
+                lockStateFromEvent(evt, "currentLockState"),
+                lockStateFromEvent(evt, "nextLockState")));
     // F-4 (#1039 / R-4.4): bridge the selected-wave controller's live read
     // state into the search panel so the matching digest's unread badge
     // decrements without re-rendering the whole list.
@@ -226,14 +244,42 @@ public final class J2clRootShellController {
   }
 
   static List<String> participantsFromEvent(Event event) {
+    return stringArrayFromEvent(event, "participants");
+  }
+
+  static List<String> addParticipantAddressesFromEvent(Event event) {
+    return stringArrayFromEvent(event, "addresses");
+  }
+
+  static String sourceWaveIdFromEvent(Event event) {
+    return normalizeSourceWaveId(detailValue(event, "sourceWaveId"));
+  }
+
+  static boolean nextPublicFromEvent(Event event) {
+    Object value = detailValue(event, "nextPublic");
+    return value instanceof Boolean
+        ? ((Boolean) value).booleanValue()
+        : Boolean.parseBoolean(String.valueOf(value));
+  }
+
+  static String lockStateFromEvent(Event event, String key) {
+    return normalizeLockStateValue(detailValue(event, key));
+  }
+
+  static String normalizeSourceWaveId(Object sourceWaveId) {
+    return sourceWaveId == null ? "" : String.valueOf(sourceWaveId).trim();
+  }
+
+  static String normalizeLockStateValue(Object value) {
+    return SidecarSelectedWaveDocument.normalizeLockState(
+        value == null ? null : String.valueOf(value).trim());
+  }
+
+  private static List<String> stringArrayFromEvent(Event event, String key) {
     if (event == null) {
       return Collections.emptyList();
     }
-    Object detail = Js.asPropertyMap(event).get("detail");
-    if (detail == null) {
-      return Collections.emptyList();
-    }
-    Object participantsObject = Js.asPropertyMap(detail).get("participants");
+    Object participantsObject = detailValue(event, key);
     if (participantsObject == null || !JsArray.isArray(participantsObject)) {
       return Collections.emptyList();
     }
@@ -244,6 +290,17 @@ public final class J2clRootShellController {
       values.add(participants.getAt(i));
     }
     return normalizeParticipantValues(values);
+  }
+
+  private static Object detailValue(Event event, String key) {
+    if (event == null || key == null || key.isEmpty()) {
+      return null;
+    }
+    Object detail = Js.asPropertyMap(event).get("detail");
+    if (detail == null) {
+      return null;
+    }
+    return Js.asPropertyMap(detail).get(key);
   }
 
   static List<String> normalizeParticipantValues(List<?> participants) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
+import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 
 public final class J2clSelectedWaveModel {
   public static final int UNKNOWN_UNREAD_COUNT = -1;
@@ -35,6 +36,7 @@ public final class J2clSelectedWaveModel {
   // viewport-windowed render path. Projector populates from
   // SidecarSelectedWaveUpdate.getConversationManifest().
   private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
+  private String lockState = SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED;
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -279,7 +281,8 @@ public final class J2clSelectedWaveModel {
         prevUnreadCount,
         prevRead,
         prevKnown,
-        prevStale);
+        prevStale)
+        .withLockState(sameWave ? previous.getLockState() : null);
   }
 
   public static J2clSelectedWaveModel error(
@@ -310,7 +313,8 @@ public final class J2clSelectedWaveModel {
         prevUnreadCount,
         prevRead,
         prevKnown,
-        prevStale);
+        prevStale)
+        .withLockState(sameWave ? previous.getLockState() : null);
   }
 
   private static String resolveTitle(String selectedWaveId, J2clSearchDigestItem digestItem) {
@@ -408,6 +412,15 @@ public final class J2clSelectedWaveModel {
     return this;
   }
 
+  public String getLockState() {
+    return lockState;
+  }
+
+  J2clSelectedWaveModel withLockState(String nextLockState) {
+    this.lockState = SidecarSelectedWaveDocument.normalizeLockState(nextLockState);
+    return this;
+  }
+
   public J2clSelectedWaveViewportState getViewportState() {
     return viewportState;
   }
@@ -448,7 +461,8 @@ public final class J2clSelectedWaveModel {
         readStateStale)
         // J-UI-4 (#1082, R-3.1): preserve manifest across clones so
         // viewport-windowed renders keep nesting after fragment growth.
-        .withConversationManifest(conversationManifest);
+        .withConversationManifest(conversationManifest)
+        .withLockState(lockState);
   }
 
   J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
@@ -473,7 +487,8 @@ public final class J2clSelectedWaveModel {
         read,
         readStateKnown,
         readStateStale)
-        .withConversationManifest(conversationManifest);
+        .withConversationManifest(conversationManifest)
+        .withLockState(lockState);
   }
 
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
@@ -500,7 +515,8 @@ public final class J2clSelectedWaveModel {
         read,
         readStateKnown,
         readStateStale)
-        .withConversationManifest(conversationManifest);
+        .withConversationManifest(conversationManifest)
+        .withLockState(lockState);
   }
 
   public int getUnreadCount() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -114,6 +114,7 @@ public final class J2clSelectedWaveProjector {
     SidecarConversationManifest manifestFromUpdate = updateManifest(update);
     SidecarConversationManifest effectiveManifest =
         chooseManifest(manifestFromUpdate, previousMatchesWave, previous);
+    String lockState = chooseLockState(update, previousMatchesWave, previous);
     if (!hasViewportWindow) {
       readBlips = applyConversationManifest(readBlips, effectiveManifest);
     }
@@ -192,7 +193,34 @@ public final class J2clSelectedWaveProjector {
         // document (live/fragment-only updates do this), preserve the
         // previous wave's manifest so the next renderWindow() does not
         // fall back to flat threading until a full snapshot resends.
-        .withConversationManifest(effectiveManifest);
+        .withConversationManifest(effectiveManifest)
+        .withLockState(lockState);
+  }
+
+  private static String chooseLockState(
+      SidecarSelectedWaveUpdate update,
+      boolean previousMatchesWave,
+      J2clSelectedWaveModel previous) {
+    String fromUpdate = lockStateFromDocuments(update.getDocuments());
+    if (fromUpdate != null) {
+      return fromUpdate;
+    }
+    if (previousMatchesWave && previous != null) {
+      return previous.getLockState();
+    }
+    return SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED;
+  }
+
+  private static String lockStateFromDocuments(List<SidecarSelectedWaveDocument> documents) {
+    if (documents == null) {
+      return null;
+    }
+    for (SidecarSelectedWaveDocument document : documents) {
+      if (document != null && "m/lock".equals(document.getDocumentId())) {
+        return document.getLockState();
+      }
+    }
+    return null;
   }
 
   /**
@@ -290,7 +318,8 @@ public final class J2clSelectedWaveProjector {
         // J-UI-4 (#1082, R-3.1): preserve manifest across read-state
         // re-projections — read-state updates carry no conversation
         // document and must not flatten threading.
-        .withConversationManifest(previous.getConversationManifest());
+        .withConversationManifest(previous.getConversationManifest())
+        .withLockState(previous.getLockState());
   }
 
   private static String appendStatus(String base, String suffix) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -631,12 +631,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     List<String> participants = model.getParticipantIds();
     boolean isPublic = containsSharedDomainParticipant(participants);
+    String lockState = model.getLockState();
     waveHeaderActions.setAttribute("source-wave-id", waveId);
-    waveHeaderActions.setAttribute("lock-state", "unlocked");
+    waveHeaderActions.setAttribute("lock-state", lockState);
     setProperty(waveHeaderActions, "sourceWaveId", waveId);
     setProperty(waveHeaderActions, "participants", buildStringArray(participants));
     setProperty(waveHeaderActions, "public", isPublic);
-    setProperty(waveHeaderActions, "lockState", "unlocked");
+    setProperty(waveHeaderActions, "lockState", lockState);
     if (isPublic) {
       waveHeaderActions.setAttribute("public", "");
     } else {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -619,10 +619,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     waveHeaderActions.removeAttribute("source-wave-id");
     waveHeaderActions.removeAttribute("public");
     waveHeaderActions.removeAttribute("lock-state");
+    waveHeaderActions.setAttribute("disabled", "");
     setProperty(waveHeaderActions, "sourceWaveId", "");
     setProperty(waveHeaderActions, "participants", buildStringArray(Collections.<String>emptyList()));
     setProperty(waveHeaderActions, "public", false);
     setProperty(waveHeaderActions, "lockState", "");
+    setProperty(waveHeaderActions, "disabled", true);
   }
 
   private void publishWaveHeaderActions(J2clSelectedWaveModel model, String waveId) {
@@ -632,12 +634,19 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     List<String> participants = model.getParticipantIds();
     boolean isPublic = containsSharedDomainParticipant(participants);
     String lockState = model.getLockState();
+    boolean disabled = model.getWriteSession() == null;
     waveHeaderActions.setAttribute("source-wave-id", waveId);
     waveHeaderActions.setAttribute("lock-state", lockState);
+    if (disabled) {
+      waveHeaderActions.setAttribute("disabled", "");
+    } else {
+      waveHeaderActions.removeAttribute("disabled");
+    }
     setProperty(waveHeaderActions, "sourceWaveId", waveId);
     setProperty(waveHeaderActions, "participants", buildStringArray(participants));
     setProperty(waveHeaderActions, "public", isPublic);
     setProperty(waveHeaderActions, "lockState", lockState);
+    setProperty(waveHeaderActions, "disabled", disabled);
     if (isPublic) {
       waveHeaderActions.setAttribute("public", "");
     } else {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -1,5 +1,6 @@
 package org.waveprotocol.box.j2cl.search;
 
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
@@ -58,6 +59,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   // server-first to avoid the upgrade reset bug.
   private final HTMLElement card;
   private final HTMLElement depthNavBar;
+  private final HTMLElement waveHeaderActions;
   private final HTMLElement waveNavRow;
   // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.
   // Hidden by default; setAwarenessPill toggles visibility + text.
@@ -117,6 +119,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       // the element is in the DOM — never replaceChild, only property set.
       this.card = existingCard;
       this.depthNavBar = ensureDepthNavBar(existingCard);
+      this.waveHeaderActions = ensureWaveHeaderActions(existingCard);
       this.waveNavRow = ensureWaveNavRow(existingCard);
       this.awarenessPill = ensureAwarenessPill(existingCard);
       bindChromeEvents(existingCard, effectiveTelemetrySink);
@@ -179,6 +182,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     participantSummary = (HTMLElement) DomGlobal.document.createElement("p");
     participantSummary.className = "sidecar-selected-participants";
     coldCard.appendChild(participantSummary);
+
+    // #1074: selected-wave write actions sit between participants and the
+    // navigation row so the controls read as wave metadata, not blip content.
+    waveHeaderActions = (HTMLElement) DomGlobal.document.createElement("wavy-wave-header-actions");
+    coldCard.appendChild(waveHeaderActions);
 
     // F-2 slice 2 (#1046, R-3.4): wave nav row (E.1–E.10). The
     // pin/archive props default to false in S2; S5 wires the data
@@ -285,6 +293,38 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       card.appendChild(row);
     }
     return row;
+  }
+
+  /**
+   * #1074: locate or create the selected-wave header action strip. Server-first
+   * markup may have been rendered before this element existed, so create it
+   * without replacing any upgraded custom elements.
+   */
+  private static HTMLElement ensureWaveHeaderActions(HTMLElement card) {
+    HTMLElement existing = (HTMLElement) card.querySelector("wavy-wave-header-actions");
+    if (existing != null) {
+      return existing;
+    }
+    HTMLElement actions =
+        (HTMLElement) DomGlobal.document.createElement("wavy-wave-header-actions");
+    HTMLElement row = (HTMLElement) card.querySelector("wavy-wave-nav-row");
+    if (row != null) {
+      card.insertBefore(actions, row);
+      return actions;
+    }
+    HTMLElement snippetEl = (HTMLElement) card.querySelector(".sidecar-selected-snippet");
+    if (snippetEl != null) {
+      card.insertBefore(actions, snippetEl);
+      return actions;
+    }
+    HTMLElement participants =
+        (HTMLElement) card.querySelector(".sidecar-selected-participants");
+    if (participants != null && participants.nextSibling != null) {
+      card.insertBefore(actions, participants.nextSibling);
+    } else {
+      card.appendChild(actions);
+    }
+    return actions;
   }
 
   /**
@@ -472,11 +512,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
         waveNavRow.removeAttribute("archived");
         waveNavRow.removeAttribute(ATTR_NAV_ROW_FOLDER_STATE_WAVE_ID);
       }
+      clearWaveHeaderActions();
     } else {
       contentList.setAttribute("data-wave-id", renderedWaveId);
       if (waveNavRow != null) {
         waveNavRow.setAttribute("source-wave-id", renderedWaveId);
       }
+      publishWaveHeaderActions(model, renderedWaveId);
     }
     // F-2 slice 2 (#1046, R-3.4): bind the unread count to the nav row's
     // E.2 cyan emphasis. unreadCount may be UNKNOWN_UNREAD_COUNT (-1)
@@ -568,6 +610,67 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             model.getSelectedWaveId() != null && !model.getSelectedWaveId().isEmpty());
       }
     }
+  }
+
+  private void clearWaveHeaderActions() {
+    if (waveHeaderActions == null) {
+      return;
+    }
+    waveHeaderActions.removeAttribute("source-wave-id");
+    waveHeaderActions.removeAttribute("public");
+    waveHeaderActions.removeAttribute("lock-state");
+    setProperty(waveHeaderActions, "sourceWaveId", "");
+    setProperty(waveHeaderActions, "participants", buildStringArray(Collections.<String>emptyList()));
+    setProperty(waveHeaderActions, "public", false);
+    setProperty(waveHeaderActions, "lockState", "");
+  }
+
+  private void publishWaveHeaderActions(J2clSelectedWaveModel model, String waveId) {
+    if (waveHeaderActions == null) {
+      return;
+    }
+    List<String> participants = model.getParticipantIds();
+    boolean isPublic = containsSharedDomainParticipant(participants);
+    waveHeaderActions.setAttribute("source-wave-id", waveId);
+    waveHeaderActions.setAttribute("lock-state", "unlocked");
+    setProperty(waveHeaderActions, "sourceWaveId", waveId);
+    setProperty(waveHeaderActions, "participants", buildStringArray(participants));
+    setProperty(waveHeaderActions, "public", isPublic);
+    setProperty(waveHeaderActions, "lockState", "unlocked");
+    if (isPublic) {
+      waveHeaderActions.setAttribute("public", "");
+    } else {
+      waveHeaderActions.removeAttribute("public");
+    }
+  }
+
+  private static boolean containsSharedDomainParticipant(List<String> participants) {
+    if (participants == null) {
+      return false;
+    }
+    for (String participant : participants) {
+      if (participant != null && participant.trim().startsWith("@")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static JsArray<Object> buildStringArray(List<String> values) {
+    JsArray<Object> array = JsArray.of();
+    if (values == null) {
+      return array;
+    }
+    for (String value : values) {
+      if (value != null) {
+        array.push(value);
+      }
+    }
+    return array;
+  }
+
+  private static void setProperty(HTMLElement element, String name, Object value) {
+    Js.asPropertyMap(element).set(name, value);
   }
 
   public HTMLElement getComposeHost() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
@@ -6,6 +6,9 @@ import java.util.List;
 
 public final class SidecarSelectedWaveDocument {
   private static final String REACTION_DATA_DOCUMENT_PREFIX = "react+";
+  public static final String LOCK_STATE_UNLOCKED = "unlocked";
+  public static final String LOCK_STATE_ROOT = "root";
+  public static final String LOCK_STATE_ALL = "all";
 
   private final String documentId;
   private final String author;
@@ -15,6 +18,7 @@ public final class SidecarSelectedWaveDocument {
   private final int bodyItemCount;
   private final List<SidecarAnnotationRange> annotationRanges;
   private final List<SidecarReactionEntry> reactionEntries;
+  private final String lockState;
 
   public SidecarSelectedWaveDocument(
       String documentId,
@@ -30,7 +34,8 @@ public final class SidecarSelectedWaveDocument {
         textContent,
         /* bodyItemCount= */ 0,
         Collections.<SidecarAnnotationRange>emptyList(),
-        Collections.<SidecarReactionEntry>emptyList());
+        Collections.<SidecarReactionEntry>emptyList(),
+        LOCK_STATE_UNLOCKED);
   }
 
   public SidecarSelectedWaveDocument(
@@ -49,7 +54,8 @@ public final class SidecarSelectedWaveDocument {
         textContent,
         /* bodyItemCount= */ 0,
         annotationRanges,
-        reactionEntries);
+        reactionEntries,
+        LOCK_STATE_UNLOCKED);
   }
 
   public SidecarSelectedWaveDocument(
@@ -61,6 +67,28 @@ public final class SidecarSelectedWaveDocument {
       int bodyItemCount,
       List<SidecarAnnotationRange> annotationRanges,
       List<SidecarReactionEntry> reactionEntries) {
+    this(
+        documentId,
+        author,
+        lastModifiedVersion,
+        lastModifiedTime,
+        textContent,
+        bodyItemCount,
+        annotationRanges,
+        reactionEntries,
+        LOCK_STATE_UNLOCKED);
+  }
+
+  public SidecarSelectedWaveDocument(
+      String documentId,
+      String author,
+      long lastModifiedVersion,
+      long lastModifiedTime,
+      String textContent,
+      int bodyItemCount,
+      List<SidecarAnnotationRange> annotationRanges,
+      List<SidecarReactionEntry> reactionEntries,
+      String lockState) {
     this.documentId = documentId;
     this.author = author;
     this.lastModifiedVersion = lastModifiedVersion;
@@ -75,6 +103,17 @@ public final class SidecarSelectedWaveDocument {
         reactionEntries == null
             ? Collections.<SidecarReactionEntry>emptyList()
             : Collections.unmodifiableList(new ArrayList<SidecarReactionEntry>(reactionEntries));
+    this.lockState = normalizeLockState(lockState);
+  }
+
+  public static String normalizeLockState(String value) {
+    if (LOCK_STATE_ROOT.equals(value)) {
+      return LOCK_STATE_ROOT;
+    }
+    if (LOCK_STATE_ALL.equals(value)) {
+      return LOCK_STATE_ALL;
+    }
+    return LOCK_STATE_UNLOCKED;
   }
 
   public String getDocumentId() {
@@ -107,6 +146,10 @@ public final class SidecarSelectedWaveDocument {
 
   public List<SidecarReactionEntry> getReactionEntries() {
     return reactionEntries;
+  }
+
+  public String getLockState() {
+    return lockState;
   }
 
   public boolean isReactionDataDocument() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -117,7 +117,8 @@ public final class SidecarTransportCodec {
                 extraction.textContent,
                 extraction.bodyItemCount,
                 extraction.annotationRanges,
-                extraction.reactionEntries));
+                extraction.reactionEntries,
+                extraction.lockState));
         if ("conversation".equals(documentId) && conversationManifest.isEmpty()) {
           conversationManifest = extractConversationManifest(documentOperation);
         }
@@ -512,10 +513,12 @@ public final class SidecarTransportCodec {
           "",
           0,
           new ArrayList<SidecarAnnotationRange>(),
-          new ArrayList<SidecarReactionEntry>());
+          new ArrayList<SidecarReactionEntry>(),
+          SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED);
     }
     StringBuilder text = new StringBuilder();
     int bodyItemCount = 0;
+    String lockState = SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED;
     Map<String, ActiveAnnotation> activeAnnotations =
         new LinkedHashMap<String, ActiveAnnotation>();
     List<SidecarAnnotationRange> annotationRanges = new ArrayList<SidecarAnnotationRange>();
@@ -561,6 +564,9 @@ public final class SidecarTransportCodec {
               && !reactionAddresses.contains(address)) {
             reactionAddresses.add(address);
           }
+        } else if ("m/lock".equals(documentId) && "lock".equals(type)) {
+          lockState =
+              SidecarSelectedWaveDocument.normalizeLockState(getAttribute(elementStart, "mode"));
         }
         if ("line".equals(type) && text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
           text.append('\n');
@@ -582,7 +588,8 @@ public final class SidecarTransportCodec {
         text.toString(),
         bodyItemCount,
         annotationRanges,
-        extractReactionEntries(documentId, reactionAddressesByEmoji));
+        extractReactionEntries(documentId, reactionAddressesByEmoji),
+        lockState);
   }
 
   private static void processAnnotationBoundary(
@@ -686,16 +693,19 @@ public final class SidecarTransportCodec {
     private final int bodyItemCount;
     private final List<SidecarAnnotationRange> annotationRanges;
     private final List<SidecarReactionEntry> reactionEntries;
+    private final String lockState;
 
     DocumentExtraction(
         String textContent,
         int bodyItemCount,
         List<SidecarAnnotationRange> annotationRanges,
-        List<SidecarReactionEntry> reactionEntries) {
+        List<SidecarReactionEntry> reactionEntries,
+        String lockState) {
       this.textContent = textContent;
       this.bodyItemCount = bodyItemCount;
       this.annotationRanges = annotationRanges;
       this.reactionEntries = reactionEntries;
+      this.lockState = lockState;
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3816,6 +3816,33 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void waveHeaderActionUsesCapturedSessionWhenSameWaveRefreshesBeforeBootstrapReturns() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+    controller.onLockStateToggleRequested("example.com/w+1", "unlocked", "root");
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 45L, "EFGH", "b+root"));
+
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "\"1\":44", "\"2\":\"ABCD\"");
+    Assert.assertFalse(
+        "header action must not mix the stale intent with refreshed base metadata",
+        gateway.lastSubmitRequest.getDeltaJson().contains("\"2\":\"EFGH\""));
+  }
+
+  @Test
   public void waveHeaderActionSubmitErrorRecordsFailureTelemetry() {
     RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
     FakeGateway gateway = new FakeGateway();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3706,6 +3706,143 @@ public class J2clComposeSurfaceControllerTest {
         gateway.submitCalls);
   }
 
+  @Test
+  public void onAddParticipantsRequestedSubmitsDeltaAndRecordsTelemetry() {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            telemetry);
+    controller.start();
+    openWaveForReply(controller);
+
+    controller.onAddParticipantsRequested(
+        "example.com/w+1", Arrays.asList("Alice@Example.COM", "bob@example.com"));
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    assertContains(
+        gateway.lastSubmitRequest.getDeltaJson(),
+        "{\"1\":\"alice@example.com\"}",
+        "{\"1\":\"bob@example.com\"}");
+    Assert.assertTrue(
+        "success telemetry recorded",
+        telemetry.events().stream()
+            .anyMatch(
+                e ->
+                    "compose.participants_added".equals(e.getName())
+                        && "success".equals(e.getFields().get("outcome"))));
+  }
+
+  @Test
+  public void onPublicityToggleRequestedSubmitsSharedDomainParticipantDelta() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+
+    controller.onPublicityToggleRequested("example.com/w+1", true);
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "{\"1\":\"@example.com\"}");
+
+    controller.onPublicityToggleRequested("example.com/w+1", false);
+    assertContains(gateway.lastSubmitRequest.getDeltaJson(), "{\"2\":\"@example.com\"}");
+  }
+
+  @Test
+  public void onLockStateToggleRequestedSubmitsLockDelta() {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            telemetry);
+    controller.start();
+    openWaveForReply(controller);
+
+    controller.onLockStateToggleRequested("example.com/w+1", "unlocked", "root");
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    assertContains(
+        gateway.lastSubmitRequest.getDeltaJson(),
+        "\"1\":\"m/lock\"",
+        "\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"root\"}]}");
+    Assert.assertTrue(
+        "success telemetry recorded",
+        telemetry.events().stream()
+            .anyMatch(
+                e ->
+                    "compose.lock_toggled".equals(e.getName())
+                        && "success".equals(e.getFields().get("outcome"))));
+  }
+
+  @Test
+  public void waveHeaderActionsDropWriteWhenWaveChangesBeforeBootstrapReturns() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.autoResolveBootstrap = false;
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { });
+    controller.start();
+    openWaveForReply(controller);
+    controller.onAddParticipantsRequested("example.com/w+1", Arrays.asList("alice@example.com"));
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+2", "chan-2", 1L, "ZZZZ", "b+root"));
+
+    gateway.resolveBootstrap();
+
+    Assert.assertEquals(0, gateway.submitCalls);
+  }
+
+  @Test
+  public void waveHeaderActionSubmitErrorRecordsFailureTelemetry() {
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitResponse = new SidecarSubmitResponse(1, "server rejected", 45L);
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            telemetry);
+    controller.start();
+    openWaveForReply(controller);
+
+    controller.onPublicityToggleRequested("example.com/w+1", true);
+
+    Assert.assertTrue(
+        "failure telemetry recorded",
+        telemetry.events().stream()
+            .anyMatch(
+                e ->
+                    "compose.publicity_toggled".equals(e.getName())
+                        && "failure-submit".equals(e.getFields().get("outcome"))));
+  }
+
   // F-3.S4 (#1038, R-5.6 step 1): drag-drop telemetry path. The
   // controller routes onDroppedFiles through the same upload plumbing
   // as the H.19 paperclip path, but emits a separate

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -589,6 +589,124 @@ public class J2clRichContentDeltaFactoryTest {
         () -> factory.blipDeleteRequest("user@example.com", session, "b+root"));
   }
 
+  @Test
+  public void addParticipantRequestEmitsDedupedAddParticipantOperations() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.addParticipantRequest(
+            "User@Example.COM",
+            session,
+            Arrays.asList(
+                " Alice@Example.COM ",
+                "alice@example.com",
+                "",
+                null,
+                "bob@example.com",
+                "user@example.com"));
+
+    Assert.assertEquals("example.com/w+x/~/conv+root", request.getWaveletName());
+    Assert.assertEquals("chan-2", request.getChannelId());
+    String deltaJson = request.getDeltaJson();
+    String alice = "{\"1\":\"alice@example.com\"}";
+    String bob = "{\"1\":\"bob@example.com\"}";
+    assertContains(
+        deltaJson, "\"1\":{\"1\":5,\"2\":\"HASH\"}", "\"2\":\"user@example.com\"", alice, bob);
+    Assert.assertEquals(1, countOccurrences(deltaJson, alice));
+    Assert.assertEquals(1, countOccurrences(deltaJson, bob));
+    Assert.assertEquals(0, countOccurrences(deltaJson, "{\"1\":\"user@example.com\"}"));
+  }
+
+  @Test
+  public void publicityToggleRequestAddsSharedDomainParticipantWhenMakingPublic() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.publicityToggleRequest("user@example.com", session, "@Example.COM", true);
+
+    assertContains(
+        request.getDeltaJson(),
+        "\"1\":{\"1\":5,\"2\":\"HASH\"}",
+        "\"2\":\"user@example.com\"",
+        "{\"1\":\"@example.com\"}");
+    Assert.assertFalse(request.getDeltaJson().contains("{\"2\":\"@example.com\"}"));
+  }
+
+  @Test
+  public void publicityToggleRequestRemovesSharedDomainParticipantWhenMakingPrivate() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.publicityToggleRequest("user@example.com", session, "@Example.COM", false);
+
+    assertContains(
+        request.getDeltaJson(),
+        "\"1\":{\"1\":5,\"2\":\"HASH\"}",
+        "\"2\":\"user@example.com\"",
+        "{\"2\":\"@example.com\"}");
+    Assert.assertFalse(request.getDeltaJson().contains("{\"1\":\"@example.com\"}"));
+  }
+
+  @Test
+  public void lockStateRequestInsertsRootLockWhenUnlocked() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.lockStateRequest("user@example.com", session, "unlocked", "root");
+
+    String deltaJson = request.getDeltaJson();
+    assertContains(
+        deltaJson,
+        "\"1\":\"m/lock\"",
+        "\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"root\"}]}",
+        "{\"4\":true}");
+    Assert.assertFalse(deltaJson.contains("\"7\":{\"1\":\"lock\""));
+  }
+
+  @Test
+  public void lockStateRequestReplacesRootLockWithAllLock() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.lockStateRequest("user@example.com", session, "root", "all");
+
+    assertContains(
+        request.getDeltaJson(),
+        "\"1\":\"m/lock\"",
+        "\"7\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"root\"}]}",
+        "{\"8\":true}",
+        "\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"all\"}]}",
+        "{\"4\":true}");
+  }
+
+  @Test
+  public void lockStateRequestRemovesAllLockWhenUnlocking() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+
+    SidecarSubmitRequest request =
+        factory.lockStateRequest("user@example.com", session, "all", "unlocked");
+
+    String deltaJson = request.getDeltaJson();
+    assertContains(
+        deltaJson,
+        "\"1\":\"m/lock\"",
+        "\"7\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"all\"}]}",
+        "{\"8\":true}");
+    Assert.assertFalse(deltaJson.contains("\"3\":{\"1\":\"lock\""));
+  }
+
   // F-3.S2 (#1038, R-5.4 step 5): metadata request emits both
   // task/assignee and task/dueTs annotations bracketing the blip body.
   // PR #1066 review thread PRRT_kwDOBwxLXs593gTP — task/dueTs must be

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -50,6 +50,16 @@ public class J2clRootShellControllerTest {
     Assert.assertEquals("button", J2clRootShellController.newWaveTriggerFromSource(null));
   }
 
+  @Test
+  public void normalizeWaveHeaderEventValuesTrimsSourceWaveAndLockState() {
+    Assert.assertEquals(
+        "example.com/w+1", J2clRootShellController.normalizeSourceWaveId(" example.com/w+1 "));
+    Assert.assertEquals("", J2clRootShellController.normalizeSourceWaveId(null));
+    Assert.assertEquals("root", J2clRootShellController.normalizeLockStateValue(" root "));
+    Assert.assertEquals("all", J2clRootShellController.normalizeLockStateValue("all"));
+    Assert.assertEquals("unlocked", J2clRootShellController.normalizeLockStateValue("bogus"));
+  }
+
   private static final class FakeToolbarView implements J2clToolbarSurfaceController.View {
     private J2clToolbarSurfaceModel model;
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModelCopyTest.java
@@ -54,6 +54,35 @@ public class J2clSelectedWaveModelCopyTest {
   }
 
   @Test
+  public void loadingSelectionPreservesLockStateForSameWave() {
+    J2clSelectedWaveModel previous =
+        new J2clSelectedWaveModel(
+                true,
+                false,
+                false,
+                "example.com/w+1",
+                "Current",
+                "",
+                "",
+                "",
+                "",
+                0,
+                Collections.<String>emptyList(),
+                Collections.<String>emptyList(),
+                null,
+                J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+                false,
+                false,
+                false)
+            .withLockState("root");
+
+    J2clSelectedWaveModel model =
+        J2clSelectedWaveModel.loading("example.com/w+1", null, 0, previous);
+
+    Assert.assertEquals("root", model.getLockState());
+  }
+
+  @Test
   public void errorSelectionDoesNotCarryReadStateAcrossWaveSwitch() {
     J2clSelectedWaveModel previous =
         new J2clSelectedWaveModel(
@@ -86,6 +115,40 @@ public class J2clSelectedWaveModelCopyTest {
     Assert.assertEquals(J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT, model.getUnreadCount());
     Assert.assertFalse(model.isRead());
     Assert.assertFalse(model.isReadStateKnown());
+  }
+
+  @Test
+  public void errorSelectionPreservesLockStateForSameWave() {
+    J2clSelectedWaveModel previous =
+        new J2clSelectedWaveModel(
+                true,
+                false,
+                false,
+                "example.com/w+1",
+                "Current",
+                "",
+                "",
+                "",
+                "",
+                0,
+                Collections.<String>emptyList(),
+                Collections.<String>emptyList(),
+                null,
+                J2clSelectedWaveModel.UNKNOWN_UNREAD_COUNT,
+                false,
+                false,
+                false)
+            .withLockState("all");
+
+    J2clSelectedWaveModel model =
+        J2clSelectedWaveModel.error(
+            "example.com/w+1",
+            null,
+            "Failed",
+            "detail",
+            previous);
+
+    Assert.assertEquals("all", model.getLockState());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -3408,6 +3408,106 @@ public class J2clSelectedWaveProjectorTest {
             entries, Collections.<J2clReadBlip>emptyList()));
   }
 
+  @Test
+  public void projectCarriesLockStateFromLockDocument() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(lockDocument("root")),
+                null),
+            null,
+            0);
+
+    Assert.assertEquals("root", projected.getLockState());
+  }
+
+  @Test
+  public void projectPreservesPreviousLockStateWhenSameWaveUpdateOmitsLockDocument() {
+    J2clSelectedWaveModel previous =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(lockDocument("all")),
+                null),
+            null,
+            0);
+
+    J2clSelectedWaveModel liveUpdate =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                45L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                null),
+            previous,
+            0);
+
+    Assert.assertEquals("all", liveUpdate.getLockState());
+  }
+
+  @Test
+  public void projectDropsPreviousLockStateAcrossWaveSwitch() {
+    J2clSelectedWaveModel previous =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                44L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(lockDocument("root")),
+                null),
+            null,
+            0);
+
+    J2clSelectedWaveModel switched =
+        J2clSelectedWaveProjector.project(
+            "example.com/w+2",
+            null,
+            new SidecarSelectedWaveUpdate(
+                2,
+                WAVELET_NAME_2,
+                true,
+                CHANNEL_ID,
+                45L,
+                "HASH2",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                null),
+            previous,
+            0);
+
+    Assert.assertEquals("unlocked", switched.getLockState());
+  }
+
   // -- Helpers ----------------------------------------------------------------
 
   private static J2clSearchDigestItem digest(String title, String snippet, int unreadCount) {
@@ -3426,6 +3526,19 @@ public class J2clSelectedWaveProjectorTest {
         Arrays.asList("user@example.com"),
         new ArrayList<SidecarSelectedWaveDocument>(),
         null);
+  }
+
+  private static SidecarSelectedWaveDocument lockDocument(String lockState) {
+    return new SidecarSelectedWaveDocument(
+        "m/lock",
+        "user@example.com",
+        44L,
+        45L,
+        "",
+        1,
+        Collections.<SidecarAnnotationRange>emptyList(),
+        Collections.<SidecarReactionEntry>emptyList(),
+        lockState);
   }
 
   private static SidecarSelectedWaveUpdate rootFragmentUpdate(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -173,7 +173,7 @@ public class J2clSelectedWaveViewChromeTest {
     HTMLElement host = createHost();
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
     J2clSelectedWaveModel model =
-        selectedModel(
+        selectedWritableModel(
             "example.com/w+actions",
             Arrays.asList("@example.com", "alice@example.com", "bob@example.com"));
 
@@ -191,6 +191,10 @@ public class J2clSelectedWaveViewChromeTest {
         "Lock state defaults to unlocked until the lock document is projected",
         "unlocked",
         actions.getAttribute("lock-state"));
+    Assert.assertFalse(
+        "Header actions are enabled when the selected wave has a write session",
+        actions.hasAttribute("disabled"));
+    Assert.assertFalse(Boolean.TRUE.equals(Js.asPropertyMap(actions).get("disabled")));
     Object participantsObject = Js.asPropertyMap(actions).get("participants");
     Assert.assertTrue(
         "Header actions receive participants as a JS array",
@@ -200,6 +204,21 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertEquals("@example.com", participants.getAt(0));
     Assert.assertEquals("alice@example.com", participants.getAt(1));
     Assert.assertEquals("bob@example.com", participants.getAt(2));
+  }
+
+  @Test
+  public void renderDisablesHeaderActionsWithoutWriteSession() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedModel("example.com/w+readonly"));
+
+    HTMLElement actions = (HTMLElement) host.querySelector("wavy-wave-header-actions");
+    Assert.assertTrue(
+        "Read-only selected waves must disable mutating header actions",
+        actions.hasAttribute("disabled"));
+    Assert.assertTrue(Boolean.TRUE.equals(Js.asPropertyMap(actions).get("disabled")));
   }
 
   @Test
@@ -486,6 +505,10 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertFalse(
         "Cleared selection clears stale lock state",
         actions.hasAttribute("lock-state"));
+    Assert.assertTrue(
+        "Cleared selection disables mutating header actions",
+        actions.hasAttribute("disabled"));
+    Assert.assertTrue(Boolean.TRUE.equals(Js.asPropertyMap(actions).get("disabled")));
     Object participantsObject = Js.asPropertyMap(actions).get("participants");
     Assert.assertTrue(JsArray.isArray(participantsObject));
     Assert.assertEquals(0, Js.<JsArray<?>>uncheckedCast(participantsObject).length);
@@ -716,6 +739,18 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   private static J2clSelectedWaveModel selectedModel(String waveId, List<String> participants) {
+    return selectedModel(waveId, participants, null);
+  }
+
+  private static J2clSelectedWaveModel selectedWritableModel(String waveId, List<String> participants) {
+    return selectedModel(
+        waveId,
+        participants,
+        new J2clSidecarWriteSession(waveId, "chan-1", 44L, "ABCD", "b+root"));
+  }
+
+  private static J2clSelectedWaveModel selectedModel(
+      String waveId, List<String> participants, J2clSidecarWriteSession writeSession) {
     return new J2clSelectedWaveModel(
         true,
         false,
@@ -730,7 +765,7 @@ public class J2clSelectedWaveViewChromeTest {
         participants,
         Arrays.<String>asList(),
         Arrays.<J2clReadBlip>asList(),
-        null,
+        writeSession,
         0,
         true,
         true,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -1,10 +1,13 @@
 package org.waveprotocol.box.j2cl.search;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import jsinterop.base.Js;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -18,8 +21,9 @@ import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
 /**
  * F-2 slice 2 (#1046) — coverage for the chrome elements
  * {@link J2clSelectedWaveView} mounts: {@code <wavy-depth-nav-bar>},
- * {@code <wavy-wave-nav-row>} (and indirectly {@code <wavy-focus-frame>}
- * which the renderer mounts inside its surface).
+ * {@code <wavy-wave-header-actions>}, {@code <wavy-wave-nav-row>} (and
+ * indirectly {@code <wavy-focus-frame>} which the renderer mounts inside its
+ * surface).
  *
  * <p>These tests run only when a real browser DOM is present (J2CL test
  * runner against Chromium); JVM test runs skip via {@code Assume}.
@@ -47,6 +51,32 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertNotNull(
         "Cold mount must insert <wavy-wave-nav-row>",
         host.querySelector("wavy-wave-nav-row"));
+    Assert.assertNotNull(
+        "Cold mount must insert <wavy-wave-header-actions>",
+        host.querySelector("wavy-wave-header-actions"));
+  }
+
+  @Test
+  public void coldMountPlacesHeaderActionsBetweenParticipantsAndNavRow() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    new J2clSelectedWaveView(host);
+
+    HTMLElement participants = (HTMLElement) host.querySelector(".sidecar-selected-participants");
+    HTMLElement actions = (HTMLElement) host.querySelector("wavy-wave-header-actions");
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+
+    Assert.assertNotNull(participants);
+    Assert.assertNotNull(actions);
+    Assert.assertNotNull(row);
+    Assert.assertSame(
+        "Header actions must sit after participants",
+        actions,
+        participants.nextSibling);
+    Assert.assertSame(
+        "Wave nav row must sit after header actions",
+        row,
+        actions.nextSibling);
   }
 
   @Test
@@ -135,6 +165,41 @@ public class J2clSelectedWaveViewChromeTest {
         "Nav-row receives the source wave id",
         "example.com/w+abc",
         row.getAttribute("source-wave-id"));
+  }
+
+  @Test
+  public void renderBindsSelectedWaveStateToHeaderActions() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    J2clSelectedWaveModel model =
+        selectedModel(
+            "example.com/w+actions",
+            Arrays.asList("@example.com", "alice@example.com", "bob@example.com"));
+
+    view.render(model);
+
+    HTMLElement actions = (HTMLElement) host.querySelector("wavy-wave-header-actions");
+    Assert.assertEquals(
+        "Header actions receive the selected wave id",
+        "example.com/w+actions",
+        actions.getAttribute("source-wave-id"));
+    Assert.assertTrue(
+        "Shared-domain participant marks the wave public",
+        actions.hasAttribute("public"));
+    Assert.assertEquals(
+        "Lock state defaults to unlocked until the lock document is projected",
+        "unlocked",
+        actions.getAttribute("lock-state"));
+    Object participantsObject = Js.asPropertyMap(actions).get("participants");
+    Assert.assertTrue(
+        "Header actions receive participants as a JS array",
+        JsArray.isArray(participantsObject));
+    JsArray<?> participants = Js.uncheckedCast(participantsObject);
+    Assert.assertEquals(3, participants.length);
+    Assert.assertEquals("@example.com", participants.getAt(0));
+    Assert.assertEquals("alice@example.com", participants.getAt(1));
+    Assert.assertEquals("bob@example.com", participants.getAt(2));
   }
 
   @Test
@@ -411,6 +476,19 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertFalse(
         "Cleared selection clears stale model ownership marker",
         row.hasAttribute("data-folder-state-wave-id"));
+    HTMLElement actions = (HTMLElement) host.querySelector("wavy-wave-header-actions");
+    Assert.assertFalse(
+        "Cleared selection clears the source wave id on header actions",
+        actions.hasAttribute("source-wave-id"));
+    Assert.assertFalse(
+        "Cleared selection clears stale public state",
+        actions.hasAttribute("public"));
+    Assert.assertFalse(
+        "Cleared selection clears stale lock state",
+        actions.hasAttribute("lock-state"));
+    Object participantsObject = Js.asPropertyMap(actions).get("participants");
+    Assert.assertTrue(JsArray.isArray(participantsObject));
+    Assert.assertEquals(0, Js.<JsArray<?>>uncheckedCast(participantsObject).length);
   }
 
   @Test
@@ -527,6 +605,7 @@ public class J2clSelectedWaveViewChromeTest {
     HTMLElement bar = (HTMLElement) host.querySelector("wavy-depth-nav-bar");
     HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
     J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    HTMLElement actions = (HTMLElement) host.querySelector("wavy-wave-header-actions");
     Assert.assertSame(
         "Server-first re-bind must re-use the same depth-nav-bar element (no replaceChild)",
         bar,
@@ -538,6 +617,13 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertFalse(
         "Server-first re-bind starts without model-owned folder marker",
         row.hasAttribute("data-folder-state-wave-id"));
+    Assert.assertNotNull(
+        "Server-first re-bind must create header actions when SSR lacks them",
+        actions);
+    Assert.assertSame(
+        "Server-first header actions must be inserted before the wave nav row",
+        row,
+        actions.nextSibling);
 
     view.render(selectedModel("example.com/w+server-first"));
     view.setNavRowFolderState(true, false);
@@ -626,6 +712,10 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   private static J2clSelectedWaveModel selectedModel(String waveId) {
+    return selectedModel(waveId, Collections.<String>emptyList());
+  }
+
+  private static J2clSelectedWaveModel selectedModel(String waveId, List<String> participants) {
     return new J2clSelectedWaveModel(
         true,
         false,
@@ -637,7 +727,7 @@ public class J2clSelectedWaveViewChromeTest {
         "",
         "",
         0,
-        Collections.<String>emptyList(),
+        participants,
         Arrays.<String>asList(),
         Arrays.<J2clReadBlip>asList(),
         null,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -208,6 +208,58 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateReadsRootLockDocumentState() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"m/lock\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"root\"}]}}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch-lock\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("m/lock", document.getDocumentId());
+    Assert.assertEquals("root", document.getLockState());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateReadsAllLockDocumentState() {
+    String json =
+        "{\"sequenceNumber\":15,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"m/lock\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"all\"}]}}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch-lock\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("all", document.getLockState());
+  }
+
+  @Test
+  public void decodeSelectedWaveUpdateNormalizesUnknownLockModeToUnlocked() {
+    String json =
+        "{\"sequenceNumber\":16,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"m/lock\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"lock\",\"2\":[{\"1\":\"mode\",\"2\":\"invalid\"}]}}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch-lock\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("unlocked", document.getLockState());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateReadsMentionAnnotationRanges() {
     String json =
         "{\"sequenceNumber\":17,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-wave-header-actions.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-j2cl-wave-header-actions",
+  "version": "Issue #1074",
+  "date": "2026-04-30",
+  "title": "J2CL selected-wave header actions",
+  "summary": "The J2CL selected-wave surface now has parity actions for adding participants, creating a wave from the current participants, toggling public or private visibility, and cycling wave lock state.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Adds Wavy-styled selected-wave header actions and bridges them through the J2CL root shell submit pipeline using the existing AddParticipant and m/lock wave semantics."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements the #1074 J2CL selected-wave header parity slice under #904:

- Adds `<wavy-wave-header-actions>` for Add participant, New with participants, Public/Private, and lock-state controls.
- Mounts the actions into the J2CL selected-wave chrome and keeps the server-first/read-only path safe.
- Projects `m/lock` state from selected-wave transport into the model and view.
- Bridges header CustomEvents through `J2clRootShellController` into the compose/write pipeline.
- Adds delta writers for AddParticipant, shared-domain public/private toggles, and `m/lock` root/all/unlocked transitions.
- Fixes browser-found confirm-dialog regressions so header public/lock actions mount a visible centered Wavy confirm dialog.
- Hardens review-found edge cases: stale confirmation source capture, captured write-session use, and read-only header-action disabling.
- Rebased on `origin/main` `58b0d412b` after #1146/#1147 landed; the only manual conflict was combining independent root-shell tests.

Closes #1074.
Part of #904.

## Plan / Evidence

Plan path:

- `docs/superpowers/plans/2026-04-30-issue-1074-wave-header-actions.md`

Worktree:

- `/Users/vega/devroot/worktrees/issue-1074-wave-header-actions-20260430`

Current key commits after rebase:

- `625d764e2` docs: plan j2cl wave header actions
- `240161d0e` feat: add j2cl wave header actions component
- `b11a40403` feat: mount j2cl wave header actions
- `cb00bbd4f` feat: project j2cl wave lock state
- `6b5738685` feat: add j2cl wave header delta writers
- `c2c8dceb1` feat: wire j2cl wave header actions
- `847fead5e` chore: record j2cl wave header actions changelog
- `deb0ef9a8` fix: mount j2cl header confirm dialog
- `ea788ffab` fix: align j2cl header confirm tones
- `f8d95cf33` fix: harden j2cl header action review gaps

## Verification

Post-rebase verification on top of `origin/main` `58b0d412b`:

- `cd j2cl/lit && npm test -- --files test/wavy-confirm-dialog.test.js test/wavy-wave-header-actions.test.js test/wavy-wave-nav-row.test.js` PASS, 43/43.
- `cd j2cl/lit && npm run build` PASS.
- `python3 scripts/assemble-changelog.py` PASS.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` PASS.
- `sbt --batch compile j2clSearchTest` PASS.
- `git diff --check` PASS.
- Copilot review follow-up: `cd j2cl/lit && npm test -- --files test/wavy-wave-header-actions.test.js test/wavy-confirm-dialog.test.js` PASS, 17/17.
- Copilot review follow-up: `cd j2cl/lit && npm run build` PASS.
- Copilot review follow-up: `git diff --check` PASS.
- CodeRabbit review follow-up: `cd j2cl/lit && npm test -- --files test/wavy-wave-header-actions.test.js test/wavy-confirm-dialog.test.js` PASS, 19/19.
- CodeRabbit review follow-up: `sbt --batch compile j2clSearchTest` PASS.
- CodeRabbit review follow-up: `cd j2cl/lit && npm run build` PASS.
- CodeRabbit review follow-up: `git diff --check` PASS.
- `PORT=9901 bash scripts/wave-smoke.sh check` PASS: root, explicit GWT, health, landing, J2CL root, J2CL index, sidecar, and legacy webclient assets all returned expected statuses.
- Browser signed-in sanity PASS using throwaway local accounts: selected welcome wave loaded, header actions were enabled, Add Participant popover opened and enabled submit for a registered peer account, public/private toggle opened a visible fixed Wavy confirm dialog, lock toggle opened a Wavy confirm dialog with cancel focused, and significant browser console warnings/errors were empty.

Earlier same-branch verification before rebase also covered signed-out J2CL root rendering and `bash scripts/worktree-boot.sh --port 9901`.

## Review Status

Claude Opus implementation review was attempted with fallback disabled, but the CLI is account-quota blocked:

`You've hit your limit · resets May 2 at 9pm (Asia/Jerusalem)`

PR was marked ready for review after the review-gate log showed draft PRs cannot pass. The Claude Opus quota blocker remains documented.

Copilot review produced one tone-contract thread; fixed in `ea788ffab`, replied with verification evidence, and resolved after the thread became outdated.

CodeRabbit produced three actionable threads; fixed in `f8d95cf33`, replied with verification evidence, and confirmed all review threads are resolved through GitHub GraphQL. Live checks are being monitored before merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selected-wave header actions: add participants, create a new wave from current participants, toggle publicity, and cycle lock state.

* **Bug Fixes**
  * Improved confirmation dialog overlay rendering and positioning for consistent visuals.

* **Tests**
  * Added comprehensive UI and unit tests covering header actions, confirmation flows, lock-state propagation, and transport decoding.

* **Documentation**
  * Added changelog and implementation plan for selected-wave header actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
