### PR TITLE
Refactor resolveUpdateAttributes in PreservationPreservationTransformer

### DIFF
--- a/wave/config/changelog.d/2026-04-30-fix-silly-attribute-composition.json
+++ b/wave/config/changelog.d/2026-04-30-fix-silly-attribute-composition.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-fix-silly-attribute-composition",
+  "version": "PR #1154",
+  "date": "2026-04-30",
+  "title": "Refactor attribute update composition in PreservationPreservationTransformer",
+  "summary": "Fixes inefficient attribute composition by correctly sizing and allocating an AttributesUpdateImpl using triplets.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Avoids excessive repetitive allocation and composeWith loops inside PreservationPreservationTransformer's resolveUpdateAttributes."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/wave/model/operation/testing/reference/PreservationPreservationTransformer.java
+++ b/wave/src/test/java/org/waveprotocol/wave/model/operation/testing/reference/PreservationPreservationTransformer.java
@@ -234,20 +234,19 @@ final class PreservationPreservationTransformer {
         for (int i = 0; i < update.changeSize(); ++i) {
           updated.put(update.getChangeKey(i), update.getNewValue(i));
         }
-        AttributesUpdate newUpdate = new AttributesUpdateImpl();
-        // TODO: This is a little silly. We should do this a better way.
+        String[] triplets = new String[this.update.changeSize() * 3];
+        Set<String> keySet = new HashSet<String>();
         for (int i = 0; i < this.update.changeSize(); ++i) {
           String key = this.update.getChangeKey(i);
           String newOldValue = updated.containsKey(key) ? updated.get(key)
               : this.update.getOldValue(i);
-          newUpdate = newUpdate.composeWith(new AttributesUpdateImpl(key,
-              newOldValue, this.update.getNewValue(i)));
+          triplets[i * 3] = key;
+          triplets[i * 3 + 1] = newOldValue;
+          triplets[i * 3 + 2] = this.update.getNewValue(i);
+          keySet.add(key);
         }
+        AttributesUpdate newUpdate = new AttributesUpdateImpl(triplets);
         targetDocument.updateAttributes(newUpdate);
-        Set<String> keySet = new HashSet<String>();
-        for (int i = 0; i < this.update.changeSize(); ++i) {
-          keySet.add(this.update.getChangeKey(i));
-        }
         AttributesUpdate transformedAttributes = update.exclude(keySet);
         otherTarget.targetDocument.updateAttributes(transformedAttributes);
       }


### PR DESCRIPTION
This PR addresses a TODO comment regarding an awkward iteration and re-creation of attribute updates in `PreservationPreservationTransformer` by refactoring `resolveUpdateAttributes` to use an array of strings.

---
*PR created automatically by Jules for task [4454078180739165246](https://jules.google.com/task/4454078180739165246) started by @vega113*