### PR TITLE
Execute J2CL has:attachment search filter

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1091-attachment-filter.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1091-attachment-filter.md
@@ -1,0 +1,400 @@
+# Issue 1091 Has Attachment Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the canonical `has:attachment` J2CL filter chip execute server-side for both in-memory and Solr-backed search without changing the behavior of unknown `has:<value>` tokens.
+
+**Architecture:** Keep attachment detection doc-based and provider-neutral. `QueryHelper` owns case-insensitive token-value lookup, a new package-local `AttachmentSearchFilter` owns `WaveViewData` attachment detection and mutable result filtering, and both search providers call it only when `HAS=attachment` is present.
+
+**Tech Stack:** Java, SBT, JUnit 3 style tests, existing Wave `WaveViewData` / `ObservableWaveletData` model, `IdUtil.isAttachmentDataDocument`.
+
+---
+
+## File Map
+
+- Modify `wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java`: add generic `hasTokenValue(...)` and keep `hasIsValue(...)` delegating to it.
+- Create `wave/src/main/java/org/waveprotocol/box/server/waveserver/AttachmentSearchFilter.java`: implement shared `has:attachment` query detection, wave attachment detection, and in-place result filtering.
+- Modify `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java`: activate the shared filter after folder/tag preparation and before text-style filters; include attachment counts in the search summary; update stale `has:attachment` deferred comment.
+- Modify `wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java`: mirror the shared post-filter after Solr result materialization and before unread pagination filtering.
+- Modify `wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java`: cover generic `HAS=attachment` token lookup and unknown `HAS` no-op predicate behavior.
+- Modify `wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java`: add integration coverage for `in:inbox has:attachment`, bare `has:attachment`, legacy `m/attachment/...` docs, and unknown `has:<value>`.
+- Modify `wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java`: cover the shared Solr post-filter seam without requiring a real Solr server.
+- Add `wave/config/changelog.d/2026-04-30-j2cl-has-attachment-filter.json`: user-facing parity change.
+
+## Task 1: Query Token Predicate
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java`
+
+- [ ] **Step 1: Add failing tests for generic token lookup**
+
+Add these tests after the existing `hasIsValue` tests:
+
+```java
+public void testHasTokenValueReturnsTrueForMatchingHasToken() throws Exception {
+  Map<TokenQueryType, Set<String>> queryParams =
+      QueryHelper.parseQuery("in:inbox has:attachment");
+  assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+}
+
+public void testHasTokenValueIsCaseInsensitive() throws Exception {
+  Map<TokenQueryType, Set<String>> queryParams =
+      QueryHelper.parseQuery("has:ATTACHMENT");
+  assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+  assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "ATTACHMENT"));
+}
+
+public void testHasTokenValueReturnsFalseForUnknownHasValue() throws Exception {
+  Map<TokenQueryType, Set<String>> queryParams =
+      QueryHelper.parseQuery("has:starred");
+  assertFalse(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+}
+```
+
+- [ ] **Step 2: Run the focused parser tests and confirm red**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.QueryHelperTest'
+```
+
+Expected: compile failure because `QueryHelper.hasTokenValue(...)` does not exist yet.
+
+- [ ] **Step 3: Implement the generic helper**
+
+Add this method near `hasIsValue(...)`, then replace the `hasIsValue` body with delegation:
+
+```java
+public static boolean hasTokenValue(
+    Map<TokenQueryType, Set<String>> queryParams, TokenQueryType type, String value) {
+  Set<String> values = queryParams.get(type);
+  if (values == null || values.isEmpty()) {
+    return false;
+  }
+  for (String candidate : values) {
+    if (candidate != null && candidate.equalsIgnoreCase(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+public static boolean hasIsValue(Map<TokenQueryType, Set<String>> queryParams, String value) {
+  return hasTokenValue(queryParams, TokenQueryType.IS, value);
+}
+```
+
+- [ ] **Step 4: Re-run parser tests**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.QueryHelperTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java \
+  wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java
+git commit -m "feat: add generic search token predicate"
+```
+
+## Task 2: Shared Attachment Filter
+
+**Files:**
+- Create: `wave/src/main/java/org/waveprotocol/box/server/waveserver/AttachmentSearchFilter.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java`
+
+- [ ] **Step 1: Add failing shared-filter tests**
+
+Add a package-local helper test in `SolrSearchProviderImplTest` because it already lives in `org.waveprotocol.box.server.waveserver` and avoids a second test class. The test should construct minimal `WaveViewData` instances with one conversational wavelet containing document ids `attach+modern` and `m/attachment/legacy`, then call `AttachmentSearchFilter.filterByHasAttachment(...)`.
+
+Expected assertions:
+
+```java
+assertEquals(1, filteredModern.size());
+assertSame(modernAttachmentWave, filteredModern.get(0));
+assertEquals(1, filteredLegacy.size());
+assertSame(legacyAttachmentWave, filteredLegacy.get(0));
+assertFalse(AttachmentSearchFilter.isHasAttachmentQuery(
+    QueryHelper.parseQuery("has:unknown")));
+```
+
+- [ ] **Step 2: Run Solr test and confirm red**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest'
+```
+
+Expected: compile failure because `AttachmentSearchFilter` does not exist yet.
+
+- [ ] **Step 3: Implement `AttachmentSearchFilter`**
+
+Create:
+
+```java
+package org.waveprotocol.box.server.waveserver;
+
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class AttachmentSearchFilter {
+  static boolean isHasAttachmentQuery(Map<TokenQueryType, Set<String>> queryParams) {
+    return QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment");
+  }
+
+  static void filterByHasAttachment(List<WaveViewData> results) {
+    Iterator<WaveViewData> it = results.iterator();
+    while (it.hasNext()) {
+      if (!hasAttachmentDocument(it.next())) {
+        it.remove();
+      }
+    }
+  }
+
+  static boolean hasAttachmentDocument(WaveViewData wave) {
+    for (ObservableWaveletData wavelet : wave.getWavelets()) {
+      if (!IdUtil.isConversationalId(wavelet.getWaveletId())) {
+        continue;
+      }
+      for (String documentId : wavelet.getDocumentIds()) {
+        if (IdUtil.isAttachmentDataDocument(documentId)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private AttachmentSearchFilter() {
+  }
+}
+```
+
+- [ ] **Step 4: Re-run Solr test**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/box/server/waveserver/AttachmentSearchFilter.java \
+  wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+git commit -m "feat: add shared attachment search filter"
+```
+
+## Task 3: Simple Search Execution
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java`
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java`
+
+- [ ] **Step 1: Add failing Simple integration tests**
+
+Add tests near `testSearchUnknownIsTokenIsNoOp`:
+
+```java
+public void testSearchHasAttachmentCombinesWithInbox() throws Exception {
+  WaveletName withAttachment = WaveletName.of(WaveId.of(DOMAIN, "with-attachment"), WAVELET_ID);
+  WaveletName withoutAttachment = WaveletName.of(WaveId.of(DOMAIN, "without-attachment"), WAVELET_ID);
+
+  submitDeltaToNewWavelet(withAttachment, USER1, addParticipantToWavelet(USER1, withAttachment));
+  addAttachmentDataDocumentToWavelet(withAttachment, USER1, "modern");
+  submitDeltaToNewWavelet(withoutAttachment, USER1, addParticipantToWavelet(USER1, withoutAttachment));
+
+  SearchResult results = searchProvider.search(USER1, "in:inbox has:attachment", 0, 10);
+
+  assertEquals(1, results.getNumResults());
+  assertEquals("with-attachment",
+      WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+}
+```
+
+Add equivalent bare `has:attachment`, legacy `m/attachment/legacy`, and unknown no-op tests. The unknown no-op test should query `in:inbox has:unknown` and assert both waves remain.
+
+Add this helper near `addTagToWavelet(...)`:
+
+```java
+private void addAttachmentDataDocumentToWavelet(
+    WaveletName name, ParticipantId user, String attachmentId) throws Exception {
+  addDocumentToWavelet(name, user,
+      IdUtil.join(IdConstants.ATTACHMENT_METADATA_PREFIX, attachmentId));
+}
+
+private void addLegacyAttachmentDataDocumentToWavelet(
+    WaveletName name, ParticipantId user, String attachmentId) throws Exception {
+  addDocumentToWavelet(name, user, "m/attachment/" + attachmentId);
+}
+
+private void addDocumentToWavelet(WaveletName name, ParticipantId user, String documentId)
+    throws Exception {
+  WaveletOperationContext context = new WaveletOperationContext(user, 0, 1);
+  WaveletOperation op =
+      new WaveletBlipOperation(documentId, new BlipContentOperation(context,
+          new DocOpBuilder().characters("attachment metadata").build()));
+  submitDeltaToExistingWavelet(name, user, op);
+}
+```
+
+- [ ] **Step 2: Run Simple test and confirm red**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'
+```
+
+Expected: new `has:attachment` tests fail because no provider calls the filter yet.
+
+- [ ] **Step 3: Implement Simple provider filtering**
+
+In `search(...)`, compute:
+
+```java
+final boolean hasAttachmentQuery = AttachmentSearchFilter.isHasAttachmentQuery(queryParams);
+```
+
+Add `attachmentsAfter` to the filter counters. After tag filtering and before title/content filtering, apply:
+
+```java
+if (hasAttachmentQuery) {
+  LOG.fine("Attachment filter: candidates=" + results.size());
+  AttachmentSearchFilter.filterByHasAttachment(results);
+  attachmentsAfter = results.size();
+  LOG.fine("Attachment filter result: " + attachmentsAfter + " remain");
+}
+```
+
+Include `attachmentsAfter` in `hasFilters` and the summary list. Update the stale comment so only `from:me` remains deferred.
+
+- [ ] **Step 4: Re-run Simple test**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java \
+  wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+git commit -m "feat: execute has attachment filter in simple search"
+```
+
+## Task 4: Solr Mirror, Changelog, Verification
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java`
+- Add: `wave/config/changelog.d/2026-04-30-j2cl-has-attachment-filter.json`
+
+- [ ] **Step 1: Mirror the post-filter in Solr**
+
+After `resultsList` is created and before tag/unread filtering, add:
+
+```java
+if (AttachmentSearchFilter.isHasAttachmentQuery(queryParams)) {
+  AttachmentSearchFilter.filterByHasAttachment(resultsList);
+}
+```
+
+Update the chip-token comment: `has:attachment` is post-filtered now; `from:me` remains deferred.
+
+- [ ] **Step 2: Add changelog fragment**
+
+Create:
+
+```json
+{
+  "date": "2026-04-30",
+  "type": "fixed",
+  "area": "j2cl-search",
+  "summary": "The J2CL With attachments search chip now filters waves server-side for both simple and Solr search providers."
+}
+```
+
+- [ ] **Step 3: Run changelog validation**
+
+Run:
+
+```bash
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run focused search verification**
+
+Run:
+
+```bash
+sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.QueryHelperTest org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run parity build smoke**
+
+Run:
+
+```bash
+sbt --batch compile j2clSearchTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java \
+  wave/config/changelog.d/2026-04-30-j2cl-has-attachment-filter.json
+git commit -m "feat: mirror has attachment filter in solr search"
+```
+
+## Review and PR Gate
+
+- [ ] Self-review the diff against issue #1091 acceptance criteria.
+- [ ] Attempt Claude Opus 4.7 plan review and implementation review. If quota is still exhausted, record the exact quota message in the issue and continue with self-review plus GitHub PR checks.
+- [ ] Post an issue update with worktree, plan path, commits, verification commands, and review status.
+- [ ] Push `codex/issue-1091-attachment-filter-20260430`.
+- [ ] Open a PR linked to #1091 and #904.
+- [ ] Monitor GitHub checks, CodeRabbit/Codex review comments, unresolved review threads, mergeability, and branch freshness until merged.
+
+## Self-Review
+
+- Spec coverage: Simple search, Solr search, doc-based attachment seam, unknown `has:<value>` no-op, folder composition, no-folder query, and tests are all mapped to tasks.
+- Placeholder scan: No task uses TBD/TODO/later placeholders; commands and expected outcomes are explicit.
+- Type consistency: `AttachmentSearchFilter.isHasAttachmentQuery(...)`, `filterByHasAttachment(...)`, and `QueryHelper.hasTokenValue(...)` are used consistently across plan tasks.
+- Scope check: No attachment indexing or UI changes are included; this remains the server-side execution follow-up requested by #1091.

--- a/wave/config/changelog.d/2026-04-30-j2cl-has-attachment-filter.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-has-attachment-filter.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-j2cl-has-attachment-filter",
+  "version": "Issue #1091",
+  "date": "2026-04-30",
+  "title": "J2CL attachment search chip filters server-side",
+  "summary": "The J2CL With attachments search chip now filters waves server-side for both simple and Solr search providers.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Executes canonical has:attachment queries by scanning conversational wavelet attachment metadata documents while leaving unknown has:<value> tokens as no-ops."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/AttachmentSearchFilter.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/AttachmentSearchFilter.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Shared server-side execution for the canonical {@code has:attachment} chip.
+ */
+final class AttachmentSearchFilter {
+
+  static boolean isHasAttachmentQuery(Map<TokenQueryType, Set<String>> queryParams) {
+    return QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment");
+  }
+
+  static void filterByHasAttachment(List<WaveViewData> results) {
+    Iterator<WaveViewData> it = results.iterator();
+    while (it.hasNext()) {
+      if (!hasAttachmentDocument(it.next())) {
+        it.remove();
+      }
+    }
+  }
+
+  static boolean hasAttachmentDocument(WaveViewData wave) {
+    for (ObservableWaveletData wavelet : wave.getWavelets()) {
+      if (!IdUtil.isConversationalId(wavelet.getWaveletId())) {
+        continue;
+      }
+      for (String documentId : wavelet.getDocumentIds()) {
+        if (IdUtil.isAttachmentDataDocument(documentId)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private AttachmentSearchFilter() {
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/QueryHelper.java
@@ -376,7 +376,16 @@ public class QueryHelper {
    * dependency on each other.
    */
   public static boolean hasIsValue(Map<TokenQueryType, Set<String>> queryParams, String value) {
-    Set<String> values = queryParams.get(TokenQueryType.IS);
+    return hasTokenValue(queryParams, TokenQueryType.IS, value);
+  }
+
+  /**
+   * Case-insensitive check for a parsed token value. The parser preserves value
+   * casing, while chip filters are canonicalized semantically.
+   */
+  public static boolean hasTokenValue(
+      Map<TokenQueryType, Set<String>> queryParams, TokenQueryType type, String value) {
+    Set<String> values = queryParams.get(type);
     if (values == null || values.isEmpty()) {
       return false;
     }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -255,10 +255,11 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     // canonical token `is:unread` (parsed under TokenQueryType.IS). Treat
     // it as a synonym for `unread:true` so the chip actually filters
     // server-side. Any other `is:<value>` stays a no-op for now —
-    // `has:attachment` and `from:me` are deferred to follow-up issues.
+    // `from:me` is deferred to a follow-up issue.
     final boolean isUnreadOnlyQuery =
         queryParams.containsKey(TokenQueryType.UNREAD)
             || QueryHelper.hasIsValue(queryParams, "unread");
+    final boolean hasAttachmentQuery = AttachmentSearchFilter.isHasAttachmentQuery(queryParams);
 
     LinkedHashMultimap<WaveId, WaveletId> currentUserWavesView =
         createWavesViewToFilter(user, isAllQuery);
@@ -274,7 +275,8 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     int candidatesBefore = results.size();
 
     // Per-filter result counts for the combined summary log (-1 means filter was not active).
-    int tagsAfter = -1, titleAfter = -1, contentAfter = -1, mentionsAfter = -1, tasksAfter = -1, unreadAfter = -1;
+    int tagsAfter = -1, attachmentsAfter = -1, titleAfter = -1, contentAfter = -1;
+    int mentionsAfter = -1, tasksAfter = -1, unreadAfter = -1;
 
     // Shared caches for supplement-building across all filter stages.
     // This prevents creating duplicate OpBasedWavelet adapters for the same
@@ -303,6 +305,13 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
       filterByTags(results, tagValues);
       tagsAfter = results.size();
       LOG.fine("Tag filter result: " + tagsAfter + " remain");
+    }
+
+    if (hasAttachmentQuery) {
+      LOG.fine("Attachment filter: candidates=" + results.size());
+      AttachmentSearchFilter.filterByHasAttachment(results);
+      attachmentsAfter = results.size();
+      LOG.fine("Attachment filter result: " + attachmentsAfter + " remain");
     }
 
     // Extract title filter values (e.g., "title:meeting").
@@ -421,12 +430,13 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     summary.append(", query=\"").append(query).append("\"");
     summary.append(", results=").append(searchResult.size()).append("/").append(totalBeforePagination);
     summary.append(", candidatesBefore=").append(candidatesBefore);
-    boolean hasFilters = tagsAfter >= 0 || titleAfter >= 0 || contentAfter >= 0
+    boolean hasFilters = tagsAfter >= 0 || attachmentsAfter >= 0 || titleAfter >= 0 || contentAfter >= 0
         || mentionsAfter >= 0 || tasksAfter >= 0 || unreadAfter >= 0;
     if (hasFilters) {
       summary.append(" (");
       String sep = "";
       if (tagsAfter >= 0) { summary.append(sep).append("tags:").append(tagsAfter); sep = ", "; }
+      if (attachmentsAfter >= 0) { summary.append(sep).append("attachments:").append(attachmentsAfter); sep = ", "; }
       if (titleAfter >= 0) { summary.append(sep).append("title:").append(titleAfter); sep = ", "; }
       if (contentAfter >= 0) { summary.append(sep).append("content:").append(contentAfter); sep = ", "; }
       if (mentionsAfter >= 0) { summary.append(sep).append("mentions:").append(mentionsAfter); sep = ", "; }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -37,6 +37,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.http.HttpStatus;
 import org.waveprotocol.box.stat.Timed;
+import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
 import org.waveprotocol.wave.model.id.WaveletName;
@@ -187,6 +188,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     List<WaveViewData> resultsList = Lists.newArrayList(results.values());
 
     if (hasAttachmentQuery) {
+      expandConversationalWavelets(resultsList, user, isAllQuery);
       AttachmentSearchFilter.filterByHasAttachment(resultsList);
     }
 
@@ -240,6 +242,68 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
       }
     }
     return results;
+  }
+
+  private void expandConversationalWavelets(List<WaveViewData> results,
+      final ParticipantId user, final boolean isAllQuery) {
+    Function<ReadableWaveletData, Boolean> matchesFunction =
+        new Function<ReadableWaveletData, Boolean>() {
+
+      @Override
+      public Boolean apply(ReadableWaveletData wavelet) {
+        try {
+          return isWaveletMatchesCriteria(wavelet, user, sharedDomainParticipantId, isAllQuery);
+        } catch (WaveletStateException e) {
+          LOG.warning(
+              "Failed to access wavelet "
+                  + WaveletName.of(wavelet.getWaveId(), wavelet.getWaveletId()), e);
+          return false;
+        }
+      }
+    };
+
+    Map<WaveId, Wave> loadedWaves = waveMap.getWaves();
+    for (WaveViewData wave : results) {
+      Set<WaveletId> visibleWaveletIds = new HashSet<WaveletId>();
+      for (ObservableWaveletData waveletData : wave.getWavelets()) {
+        visibleWaveletIds.add(waveletData.getWaveletId());
+      }
+
+      Set<WaveletId> conversationalWaveletIds = new HashSet<WaveletId>();
+      try {
+        Set<WaveletId> storedWaveletIds = waveMap.lookupWavelets(wave.getWaveId());
+        if (storedWaveletIds != null) {
+          conversationalWaveletIds.addAll(storedWaveletIds);
+        }
+      } catch (WaveletStateException e) {
+        LOG.warning("Failed to look up stored wavelets for " + wave.getWaveId(), e);
+      }
+
+      Wave loadedWave = loadedWaves.get(wave.getWaveId());
+      if (loadedWave != null) {
+        for (WaveletContainer container : loadedWave) {
+          conversationalWaveletIds.add(container.getWaveletName().waveletId);
+        }
+      }
+
+      for (WaveletId waveletId : conversationalWaveletIds) {
+        if (visibleWaveletIds.contains(waveletId) || !IdUtil.isConversationalId(waveletId)) {
+          continue;
+        }
+
+        WaveletName waveletName = WaveletName.of(wave.getWaveId(), waveletId);
+        try {
+          WaveletContainer container = waveMap.getWavelet(waveletName);
+          if (container == null || !container.applyFunction(matchesFunction)) {
+            continue;
+          }
+          wave.addWavelet(container.copyWaveletData());
+          visibleWaveletIds.add(waveletId);
+        } catch (WaveletStateException e) {
+          LOG.warning("Failed to expand wavelet " + waveletName, e);
+        }
+      }
+    }
   }
 
   private void addSearchResultsToCurrentWaveView(
@@ -314,7 +378,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
   }
 
   static int computeSolrStart(int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
-    return isUnreadOnlyQuery || hasAttachmentQuery ? 0 : startAt;
+    return 0;
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -207,7 +207,11 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     }
 
     Collection<WaveViewData> searchResult =
-        computeSearchResult(user, startAt, numResults, resultsList);
+        computeSearchResult(
+            user,
+            computeInMemoryStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery),
+            numResults,
+            resultsList);
     LOG.info("Search response to '" + query + "': " + searchResult.size() + " results, user: "
         + user);
 
@@ -378,7 +382,12 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
   }
 
   static int computeSolrStart(int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
-    return 0;
+    return isUnreadOnlyQuery || hasAttachmentQuery ? 0 : startAt;
+  }
+
+  static int computeInMemoryStart(
+      int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
+    return isUnreadOnlyQuery || hasAttachmentQuery ? startAt : 0;
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -185,6 +185,10 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
 
     List<WaveViewData> resultsList = Lists.newArrayList(results.values());
 
+    if (AttachmentSearchFilter.isHasAttachmentQuery(queryParams)) {
+      AttachmentSearchFilter.filterByHasAttachment(resultsList);
+    }
+
     // Solr does not index tags, so perform post-filtering for tag: queries.
     Set<String> tagValues = queryParams.containsKey(TokenQueryType.TAG)
         ? queryParams.get(TokenQueryType.TAG)
@@ -283,8 +287,9 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
   /**
    * J-UI-2 (#1080): the rail's filter chips emit {@code is:unread},
    * {@code has:attachment}, and {@code from:me}. {@code is:unread} is
-   * handled equivalently to {@code unread:true} via post-filtering; the
-   * other chip tokens are URL-only this slice (deferred follow-ups).
+   * handled equivalently to {@code unread:true} via post-filtering, and
+   * {@code has:attachment} is post-filtered by attachment metadata docs.
+   * {@code from:me} is URL-only this slice (deferred follow-up).
    * In all three cases the token must be stripped before the query is
    * forwarded to Solr — Solr's schema does not know these prefixes and
    * a literal {@code is:unread} term in the user-query clause fails the

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -141,6 +141,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     final boolean isUnreadOnlyQuery =
         queryParams.containsKey(TokenQueryType.UNREAD)
             || QueryHelper.hasIsValue(queryParams, "unread");
+    final boolean hasAttachmentQuery = AttachmentSearchFilter.isHasAttachmentQuery(queryParams);
     if (queryParams.containsKey(TokenQueryType.MENTIONS)) {
       LOG.warning("Mentions queries are not supported by Solr search.");
       return new SearchResult(query);
@@ -150,7 +151,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
 
     if (numResults > 0) {
 
-      int start = isUnreadOnlyQuery ? 0 : startAt;
+      int start = computeSolrStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery);
       int rows = Math.max(numResults, ROWS);
 
       /*-
@@ -185,7 +186,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
 
     List<WaveViewData> resultsList = Lists.newArrayList(results.values());
 
-    if (AttachmentSearchFilter.isHasAttachmentQuery(queryParams)) {
+    if (hasAttachmentQuery) {
       AttachmentSearchFilter.filterByHasAttachment(resultsList);
     }
 
@@ -310,6 +311,10 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     // The query is an "all" query if there is no 'in:' filter, or if
     // the explicit 'in:all' filter is used.
     return !IN_PATTERN.matcher(query).find() || IN_ALL_PATTERN.matcher(query).find();
+  }
+
+  static int computeSolrStart(int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
+    return isUnreadOnlyQuery || hasAttachmentQuery ? 0 : startAt;
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/QueryHelperTest.java
@@ -151,6 +151,25 @@ public class QueryHelperTest extends TestCase {
     assertFalse(QueryHelper.hasIsValue(queryParams, "unread"));
   }
 
+  public void testHasTokenValueReturnsTrueForMatchingHasToken() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams =
+        QueryHelper.parseQuery("in:inbox has:attachment");
+    assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+  }
+
+  public void testHasTokenValueIsCaseInsensitive() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams =
+        QueryHelper.parseQuery("has:ATTACHMENT");
+    assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+    assertTrue(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "ATTACHMENT"));
+  }
+
+  public void testHasTokenValueReturnsFalseForUnknownHasValue() throws Exception {
+    Map<TokenQueryType, Set<String>> queryParams =
+        QueryHelper.parseQuery("has:starred");
+    assertFalse(QueryHelper.hasTokenValue(queryParams, TokenQueryType.HAS, "attachment"));
+  }
+
   public void testParseQueryRejectsInvalidUnreadFilterValue() {
     try {
       QueryHelper.parseQuery("unread:maybe");

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -828,6 +828,76 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(2, results.getNumResults());
   }
 
+  public void testSearchHasAttachmentCombinesWithInbox() throws Exception {
+    WaveletName withAttachment = WaveletName.of(WaveId.of(DOMAIN, "with-attachment"), WAVELET_ID);
+    WaveletName withoutAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "without-attachment"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(withAttachment, USER1, addParticipantToWavelet(USER1, withAttachment));
+    addAttachmentDataDocumentToWavelet(withAttachment, USER1, "modern");
+    submitDeltaToNewWavelet(
+        withoutAttachment, USER1, addParticipantToWavelet(USER1, withoutAttachment));
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox has:attachment", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("with-attachment",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchHasAttachmentWorksWithoutFolder() throws Exception {
+    WaveletName withAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "attachment-no-folder"), WAVELET_ID);
+    WaveletName withoutAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "plain-no-folder"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(withAttachment, USER1, addParticipantToWavelet(USER1, withAttachment));
+    addAttachmentDataDocumentToWavelet(withAttachment, USER1, "bare");
+    submitDeltaToNewWavelet(
+        withoutAttachment, USER1, addParticipantToWavelet(USER1, withoutAttachment));
+
+    SearchResult results = searchProvider.search(USER1, "has:attachment", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("attachment-no-folder",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchHasAttachmentMatchesLegacyAttachmentDocument() throws Exception {
+    WaveletName legacyAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "legacy-attachment"), WAVELET_ID);
+    WaveletName withoutAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "legacy-plain"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(
+        legacyAttachment, USER1, addParticipantToWavelet(USER1, legacyAttachment));
+    addLegacyAttachmentDataDocumentToWavelet(legacyAttachment, USER1, "legacy-file");
+    submitDeltaToNewWavelet(
+        withoutAttachment, USER1, addParticipantToWavelet(USER1, withoutAttachment));
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox has:attachment", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("legacy-attachment",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchUnknownHasTokenIsNoOp() throws Exception {
+    WaveletName withAttachment = WaveletName.of(WaveId.of(DOMAIN, "has-unknown-attach"), WAVELET_ID);
+    WaveletName withoutAttachment =
+        WaveletName.of(WaveId.of(DOMAIN, "has-unknown-plain"), WAVELET_ID);
+
+    submitDeltaToNewWavelet(withAttachment, USER1, addParticipantToWavelet(USER1, withAttachment));
+    addAttachmentDataDocumentToWavelet(withAttachment, USER1, "unknown-no-op");
+    submitDeltaToNewWavelet(
+        withoutAttachment, USER1, addParticipantToWavelet(USER1, withoutAttachment));
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox has:unknown", 0, 10);
+
+    // Unknown has:<value> tokens are parsed but intentionally inert.
+    assertEquals(2, results.getNumResults());
+  }
+
   public void testSearchFilterByUnreadAppliesBeforePagination() throws Exception {
     WaveletName readFirst = WaveletName.of(WaveId.of(DOMAIN, "read-first"), WAVELET_ID);
     WaveletName unreadLater = WaveletName.of(WaveId.of(DOMAIN, "unread-later"), WAVELET_ID);
@@ -1309,6 +1379,26 @@ public class SimpleSearchProviderImplTest extends TestCase {
                 .elementEnd()
                 .build()));
     submitDeltaToExistingWavelet(name, user, addTagOp);
+  }
+
+  private void addAttachmentDataDocumentToWavelet(
+      WaveletName name, ParticipantId user, String attachmentId) throws Exception {
+    addDocumentToWavelet(name, user,
+        IdUtil.join(IdConstants.ATTACHMENT_METADATA_PREFIX, attachmentId));
+  }
+
+  private void addLegacyAttachmentDataDocumentToWavelet(
+      WaveletName name, ParticipantId user, String attachmentId) throws Exception {
+    addDocumentToWavelet(name, user, "m/attachment/" + attachmentId);
+  }
+
+  private void addDocumentToWavelet(WaveletName name, ParticipantId user, String documentId)
+      throws Exception {
+    WaveletOperationContext context = new WaveletOperationContext(user, 0, 1);
+    WaveletOperation op =
+        new WaveletBlipOperation(documentId, new BlipContentOperation(context,
+            new DocOpBuilder().characters("attachment metadata").build()));
+    submitDeltaToExistingWavelet(name, user, op);
   }
 
   private int documentLength(DocInitialization docOp) {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -142,10 +142,14 @@ public class SolrSearchProviderImplTest extends TestCase {
         QueryHelper.parseQuery("has:unknown")));
   }
 
-  public void testSolrQueriesStartAtZeroBeforeInMemoryPagination() {
+  public void testSolrPostFilteredQueriesStartAtZeroBeforeInMemoryPagination() {
     assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, true, false));
     assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, true));
-    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, false));
+    assertEquals(5, SolrSearchProviderImpl.computeSolrStart(5, false, false));
+
+    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, true, false));
+    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, false, true));
+    assertEquals(0, SolrSearchProviderImpl.computeInMemoryStart(5, false, false));
   }
 
   public void testSearchRejectsMentionsQueries() {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -142,10 +142,10 @@ public class SolrSearchProviderImplTest extends TestCase {
         QueryHelper.parseQuery("has:unknown")));
   }
 
-  public void testPostFilteredQueriesStartAtZeroBeforePagination() {
+  public void testSolrQueriesStartAtZeroBeforeInMemoryPagination() {
     assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, true, false));
     assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, true));
-    assertEquals(5, SolrSearchProviderImpl.computeSolrStart(5, false, false));
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, false));
   }
 
   public void testSearchRejectsMentionsQueries() {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -22,11 +22,29 @@ import junit.framework.TestCase;
 import com.google.wave.api.SearchResult;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
+import org.waveprotocol.wave.model.document.operation.impl.DocInitializationBuilder;
+import org.waveprotocol.wave.model.id.IdConstants;
 import org.waveprotocol.wave.model.id.IdGenerator;
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.id.WaveId;
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
+import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+import org.waveprotocol.wave.model.wave.data.impl.WaveViewDataImpl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class SolrSearchProviderImplTest extends TestCase {
+
+  private static final String DOMAIN = "example.com";
+  private static final ParticipantId USER = ParticipantId.ofUnsafe("user@" + DOMAIN);
 
   public void testStripUnreadFilterTokensRemovesStandaloneTokenOnly() {
     assertEquals(
@@ -64,6 +82,66 @@ public class SolrSearchProviderImplTest extends TestCase {
         SolrSearchProviderImpl.stripUnreadFilterTokens("in:inbox tag:work mentions:me"));
   }
 
+  public void testAttachmentFilterKeepsModernAttachmentDocument() throws Exception {
+    WaveViewData modernAttachmentWave =
+        waveWithDocument("modern", IdUtil.join(IdConstants.ATTACHMENT_METADATA_PREFIX, "modern"));
+    WaveViewData plainWave = waveWithDocument("plain", "b+plain");
+    List<WaveViewData> results = new ArrayList<WaveViewData>();
+    results.add(modernAttachmentWave);
+    results.add(plainWave);
+
+    AttachmentSearchFilter.filterByHasAttachment(results);
+
+    assertEquals(1, results.size());
+    assertSame(modernAttachmentWave, results.get(0));
+  }
+
+  public void testAttachmentFilterKeepsLegacyAttachmentDocument() throws Exception {
+    WaveViewData legacyAttachmentWave =
+        waveWithDocument("legacy", "m/attachment/legacy-file");
+    WaveViewData plainWave = waveWithDocument("plain-legacy", "b+plain");
+    List<WaveViewData> results = new ArrayList<WaveViewData>();
+    results.add(plainWave);
+    results.add(legacyAttachmentWave);
+
+    AttachmentSearchFilter.filterByHasAttachment(results);
+
+    assertEquals(1, results.size());
+    assertSame(legacyAttachmentWave, results.get(0));
+  }
+
+  public void testAttachmentFilterIgnoresNonConversationalWaveletDocuments() throws Exception {
+    WaveId waveId = WaveId.of(DOMAIN, "user-data");
+    WaveletName waveletName =
+        WaveletName.of(waveId, WaveletId.of(DOMAIN, "user+" + USER.getAddress()));
+    ObservableWaveletData wavelet = WaveletDataUtil.createEmptyWavelet(
+        waveletName, USER, HashedVersion.unsigned(0), 1234567890);
+    wavelet.createDocument(
+        IdUtil.join(IdConstants.ATTACHMENT_METADATA_PREFIX, "metadata"),
+        USER,
+        Collections.<ParticipantId>emptySet(),
+        new DocInitializationBuilder().characters("metadata").build(),
+        1234567890,
+        0);
+    WaveViewDataImpl wave = WaveViewDataImpl.create(waveId);
+    wave.addWavelet(wavelet);
+    List<WaveViewData> results = new ArrayList<WaveViewData>();
+    results.add(wave);
+
+    AttachmentSearchFilter.filterByHasAttachment(results);
+
+    assertTrue(results.isEmpty());
+  }
+
+  public void testIsHasAttachmentQueryOnlyMatchesAttachmentValue() throws Exception {
+    assertTrue(AttachmentSearchFilter.isHasAttachmentQuery(
+        QueryHelper.parseQuery("in:inbox has:attachment")));
+    assertTrue(AttachmentSearchFilter.isHasAttachmentQuery(
+        QueryHelper.parseQuery("has:ATTACHMENT")));
+    assertFalse(AttachmentSearchFilter.isHasAttachmentQuery(
+        QueryHelper.parseQuery("has:unknown")));
+  }
+
   public void testSearchRejectsMentionsQueries() {
     Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
         "core.wave_server_domain", "example.com",
@@ -76,5 +154,24 @@ public class SolrSearchProviderImplTest extends TestCase {
 
     assertEquals(0, results.getNumResults());
     assertEquals(0, results.getDigests().size());
+  }
+
+  private static WaveViewData waveWithDocument(String waveIdToken, String documentId)
+      throws Exception {
+    WaveId waveId = WaveId.of(DOMAIN, waveIdToken);
+    WaveletName waveletName =
+        WaveletName.of(waveId, WaveletId.of(DOMAIN, IdConstants.CONVERSATION_ROOT_WAVELET));
+    ObservableWaveletData wavelet = WaveletDataUtil.createEmptyWavelet(
+        waveletName, USER, HashedVersion.unsigned(0), 1234567890);
+    wavelet.createDocument(
+        documentId,
+        USER,
+        Collections.<ParticipantId>emptySet(),
+        new DocInitializationBuilder().characters("metadata").build(),
+        1234567890,
+        0);
+    WaveViewDataImpl wave = WaveViewDataImpl.create(waveId);
+    wave.addWavelet(wavelet);
+    return wave;
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -142,6 +142,12 @@ public class SolrSearchProviderImplTest extends TestCase {
         QueryHelper.parseQuery("has:unknown")));
   }
 
+  public void testPostFilteredQueriesStartAtZeroBeforePagination() {
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, true, false));
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, true));
+    assertEquals(5, SolrSearchProviderImpl.computeSolrStart(5, false, false));
+  }
+
   public void testSearchRejectsMentionsQueries() {
     Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
         "core.wave_server_domain", "example.com",


### PR DESCRIPTION
## Summary

Fixes #1091.
Refs #904.

This implements server-side execution for the canonical J2CL `has:attachment` filter chip:

- Adds shared doc-id based `AttachmentSearchFilter` using `IdUtil.isAttachmentDataDocument` on conversational wavelets.
- Wires SimpleSearch to filter `has:attachment` while leaving unknown `has:<value>` tokens as no-ops.
- Mirrors the same post-filter in SolrSearch and starts Solr retrieval at `0` for attachment/unread post-filtered queries so pagination is applied after filtering.
- Adds changelog coverage for the J2CL search parity fix.

## Verification

- `sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.QueryHelperTest org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'` PASS: 90 tests.
- `sbt --batch compile j2clSearchTest` PASS.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` PASS.
- `git diff --check origin/main...HEAD` PASS.

## Review Notes

- TDD reds were observed for the missing parser predicate, missing shared attachment filter, and unwired SimpleSearch behavior.
- Self-review found and fixed Solr post-filter pagination before PR.
- Claude Opus plan and implementation review attempts were made with fallback disabled, but quota is blocked until `May 2 at 9pm (Asia/Jerusalem)`, so this proceeds with self-review plus PR gates per current lane policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side execution of has:attachment across search providers (case-insensitive), including legacy attachment formats; unknown has:<value> tokens are no-ops.
  * Search summaries now reflect attachment-related filtering when active.

* **Tests**
  * Added unit and integration tests covering attachment filtering, legacy IDs, and paging behavior.

* **Documentation**
  * New changelog entry and implementation plan describing has:attachment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->