### PR TITLE
Execute J2CL from search filter

### DIFF
--- a/docs/superpowers/plans/2026-04-30-issue-1092-from-filter.md
+++ b/docs/superpowers/plans/2026-04-30-issue-1092-from-filter.md
@@ -1,0 +1,70 @@
+# Issue #1092: Server-Side `from:` Search Filter
+
+## Context
+
+`from:me` is already emitted by the J2CL rail filter chip and parsed into
+`TokenQueryType.FROM`, but the server currently treats it as a no-op. Simple
+search filters `creator:` at the wavelet level, while this issue requires
+wave-level "started by" semantics: the conversation root wavelet creator must
+match the normalized `from:` value.
+
+## Acceptance Criteria
+
+- `from:me` resolves to the current viewer address, not `me@<domain>`.
+- `from:<address>` resolves to the literal address, lower-cased for matching.
+- Bare non-`me` values append the current user's local domain.
+- Simple search filters waves by conversation root wavelet creator after
+  folder/tag/attachment filtering and before title/content/mentions/tasks/unread
+  filtering.
+- Solr-backed search mirrors the same behavior with an in-memory post-filter so
+  Simple and Solr do not diverge.
+- Solr pagination treats active `from:` filtering as a post-filter, fetching
+  from offset zero and applying `startAt` after filtering.
+- Unknown/no-match `from:` values return zero results, not a broader no-op set.
+- `creator:` behavior remains unchanged.
+
+## Implementation Plan
+
+- Add `FromQueryNormalizer` in `org.waveprotocol.box.server.waveserver`, modeled
+  after `MentionQueryNormalizer`, with `me`, explicit address, and bare local
+  name normalization.
+- Add a shared package-private `FromSearchFilter` that:
+  - detects active `TokenQueryType.FROM` values;
+  - normalizes values for the current user;
+  - filters mutable `List<WaveViewData>` results by conversation root wavelet
+    creator using case-insensitive canonical address comparison.
+- Wire `SimpleSearchProviderImpl` to:
+  - compute normalized `from:` values after query parsing;
+  - apply the `FromSearchFilter` after `has:attachment` and before text-like
+    filters;
+  - include the filter count in the summary log.
+- Wire `SolrSearchProviderImpl` to:
+  - keep stripping `from:` from the Solr text query;
+  - treat active `from:` as a post-filter for Solr offset calculations;
+  - apply `FromSearchFilter` after materializing `resultsList`.
+- Update tests:
+  - `FromQueryNormalizerTest` for `me`, explicit address, bare local names, and
+    invalid inputs.
+  - `SimpleSearchProviderImplTest` for `in:inbox from:me`, literal address,
+    bare local name, no-match behavior, and coexistence with `creator:`.
+  - `SolrSearchProviderImplTest` for active-query detection, root-author
+    filtering, no-match behavior, and Solr pagination helper behavior.
+- Add a changelog fragment for the J2CL-visible search filter behavior.
+
+## Verification Plan
+
+- `sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.FromQueryNormalizerTest org.waveprotocol.box.server.waveserver.QueryHelperTest org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'`
+- `sbt --batch compile j2clSearchTest`
+- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+- `git diff --check origin/main...HEAD`
+
+## Self-Review
+
+- The plan keeps `from:` separate from `creator:` so existing wavelet-level
+  `creator:` semantics are not silently changed.
+- The plan makes Solr pagination post-filter aware; this avoids repeating the
+  double-pagination issue fixed in #1091.
+- The plan does not require UI changes because J-UI-2 already emits and
+  round-trips the canonical token.
+- The filter is shared between providers to reduce divergence while keeping
+  provider-specific pagination and query-stripping behavior local.

--- a/wave/config/changelog.d/2026-04-30-j2cl-from-filter.json
+++ b/wave/config/changelog.d/2026-04-30-j2cl-from-filter.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-04-30-j2cl-from-filter",
+  "version": "Issue #1092",
+  "date": "2026-04-30",
+  "title": "J2CL From me search chip filters server-side",
+  "summary": "The J2CL From me search chip now filters waves server-side for both simple and Solr search providers.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Executes canonical from:me and from:<address> queries by matching the conversation root wavelet creator while preserving existing creator: behavior."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/FromQueryNormalizer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/FromQueryNormalizer.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the
+ * License.
+ */
+package org.waveprotocol.box.server.waveserver;
+
+import java.util.Locale;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+/** Utility methods for normalizing `from:` query values. */
+public final class FromQueryNormalizer {
+
+  private FromQueryNormalizer() {
+  }
+
+  /**
+   * Normalizes a raw from token to the canonical lower-case participant address.
+   *
+   * @param raw raw query token value
+   * @param user current user, used to resolve `me` and local-domain names
+   * @return canonical lower-case participant address
+   */
+  public static String normalize(String raw, ParticipantId user) {
+    if (raw == null || raw.trim().isEmpty()) {
+      throw new IllegalArgumentException("raw from value cannot be null or empty");
+    }
+    if (user == null) {
+      throw new IllegalArgumentException("user cannot be null");
+    }
+    String address = user.getAddress();
+    String domain = user.getDomain();
+    if (address == null || domain == null) {
+      throw new IllegalArgumentException("user address and domain cannot be null");
+    }
+
+    String trimmed = raw.trim();
+    String normalized;
+    if ("me".equalsIgnoreCase(trimmed)) {
+      normalized = address;
+    } else if (trimmed.contains("@")) {
+      normalized = trimmed;
+    } else {
+      normalized = trimmed + "@" + domain;
+    }
+    return normalized.toLowerCase(Locale.ROOT);
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/FromSearchFilter.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/FromSearchFilter.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.waveprotocol.box.server.waveserver;
+
+import org.waveprotocol.wave.model.id.IdUtil;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
+import org.waveprotocol.wave.model.wave.data.WaveViewData;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Shared implementation for the canonical J2CL {@code from:} search chip. */
+final class FromSearchFilter {
+
+  private FromSearchFilter() {
+  }
+
+  static boolean isFromQuery(Map<TokenQueryType, Set<String>> queryParams) {
+    Set<String> values = queryParams.get(TokenQueryType.FROM);
+    return values != null && !values.isEmpty();
+  }
+
+  static Set<String> normalizeFromValues(
+      Map<TokenQueryType, Set<String>> queryParams, ParticipantId user) {
+    Set<String> rawValues = queryParams.get(TokenQueryType.FROM);
+    if (rawValues == null || rawValues.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> normalized = new LinkedHashSet<String>();
+    for (String raw : rawValues) {
+      normalized.add(FromQueryNormalizer.normalize(raw, user));
+    }
+    return normalized;
+  }
+
+  static void filterByRootAuthor(List<WaveViewData> results, Set<String> requiredAuthors) {
+    if (requiredAuthors == null || requiredAuthors.isEmpty()) {
+      return;
+    }
+    Iterator<WaveViewData> it = results.iterator();
+    while (it.hasNext()) {
+      WaveViewData wave = it.next();
+      ParticipantId rootCreator = rootConversationCreator(wave);
+      if (!matchesRequiredAuthors(rootCreator, requiredAuthors)) {
+        it.remove();
+      }
+    }
+  }
+
+  private static ParticipantId rootConversationCreator(WaveViewData wave) {
+    for (ObservableWaveletData wavelet : wave.getWavelets()) {
+      if (IdUtil.isConversationRootWaveletId(wavelet.getWaveletId())) {
+        return wavelet.getCreator();
+      }
+    }
+    return null;
+  }
+
+  private static boolean matchesRequiredAuthors(
+      ParticipantId rootCreator, Set<String> requiredAuthors) {
+    if (rootCreator == null || rootCreator.getAddress() == null) {
+      return false;
+    }
+    String creatorAddress = rootCreator.getAddress().toLowerCase(Locale.ROOT);
+    for (String requiredAuthor : requiredAuthors) {
+      if (!creatorAddress.equals(requiredAuthor)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -316,6 +316,9 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     }
 
     if (!fromAuthorValues.isEmpty()) {
+      // from: is a wave-level root-author filter, so it must see the root even when
+      // creator:/with: matched only a reply wavelet.
+      ensureConversationRootWaveletPresent(results);
       LOG.fine("From-author filter: required=" + fromAuthorValues + ", candidates="
           + results.size());
       FromSearchFilter.filterByRootAuthor(results, fromAuthorValues);
@@ -550,6 +553,66 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
         }
       }
     }
+  }
+
+  private void ensureConversationRootWaveletPresent(List<WaveViewData> results) {
+    Map<WaveId, Wave> loadedWaves = waveMap.getWaves();
+    for (WaveViewData wave : results) {
+      if (hasConversationRootWavelet(wave)) {
+        continue;
+      }
+
+      WaveletId rootWaveletId = findConversationRootWaveletId(wave.getWaveId(), loadedWaves);
+      if (rootWaveletId == null) {
+        continue;
+      }
+
+      WaveletName waveletName = WaveletName.of(wave.getWaveId(), rootWaveletId);
+      try {
+        WaveletContainer container = waveMap.getWavelet(waveletName);
+        if (container != null) {
+          wave.addWavelet(container.copyWaveletData());
+        }
+      } catch (WaveletStateException e) {
+        LOG.warning("Failed to load root wavelet " + waveletName, e);
+      }
+    }
+  }
+
+  private boolean hasConversationRootWavelet(WaveViewData wave) {
+    for (ObservableWaveletData waveletData : wave.getWavelets()) {
+      if (IdUtil.isConversationRootWaveletId(waveletData.getWaveletId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private WaveletId findConversationRootWaveletId(WaveId waveId, Map<WaveId, Wave> loadedWaves) {
+    try {
+      Set<WaveletId> storedWaveletIds = waveMap.lookupWavelets(waveId);
+      if (storedWaveletIds != null) {
+        for (WaveletId waveletId : storedWaveletIds) {
+          if (IdUtil.isConversationRootWaveletId(waveletId)) {
+            return waveletId;
+          }
+        }
+      }
+    } catch (WaveletStateException e) {
+      LOG.warning("Failed to look up stored wavelets for " + waveId, e);
+    }
+
+    Wave loadedWave = loadedWaves.get(waveId);
+    if (loadedWave == null) {
+      return null;
+    }
+    for (WaveletContainer container : loadedWave) {
+      WaveletId waveletId = container.getWaveletName().waveletId;
+      if (IdUtil.isConversationRootWaveletId(waveletId)) {
+        return waveletId;
+      }
+    }
+    return null;
   }
 
   /**

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImpl.java
@@ -255,11 +255,12 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     // canonical token `is:unread` (parsed under TokenQueryType.IS). Treat
     // it as a synonym for `unread:true` so the chip actually filters
     // server-side. Any other `is:<value>` stays a no-op for now —
-    // `from:me` is deferred to a follow-up issue.
+    // `from:me` is handled below as a root-author filter.
     final boolean isUnreadOnlyQuery =
         queryParams.containsKey(TokenQueryType.UNREAD)
             || QueryHelper.hasIsValue(queryParams, "unread");
     final boolean hasAttachmentQuery = AttachmentSearchFilter.isHasAttachmentQuery(queryParams);
+    final Set<String> fromAuthorValues = FromSearchFilter.normalizeFromValues(queryParams, user);
 
     LinkedHashMultimap<WaveId, WaveletId> currentUserWavesView =
         createWavesViewToFilter(user, isAllQuery);
@@ -275,7 +276,7 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     int candidatesBefore = results.size();
 
     // Per-filter result counts for the combined summary log (-1 means filter was not active).
-    int tagsAfter = -1, attachmentsAfter = -1, titleAfter = -1, contentAfter = -1;
+    int tagsAfter = -1, attachmentsAfter = -1, fromAfter = -1, titleAfter = -1, contentAfter = -1;
     int mentionsAfter = -1, tasksAfter = -1, unreadAfter = -1;
 
     // Shared caches for supplement-building across all filter stages.
@@ -312,6 +313,14 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
       AttachmentSearchFilter.filterByHasAttachment(results);
       attachmentsAfter = results.size();
       LOG.fine("Attachment filter result: " + attachmentsAfter + " remain");
+    }
+
+    if (!fromAuthorValues.isEmpty()) {
+      LOG.fine("From-author filter: required=" + fromAuthorValues + ", candidates="
+          + results.size());
+      FromSearchFilter.filterByRootAuthor(results, fromAuthorValues);
+      fromAfter = results.size();
+      LOG.fine("From-author filter result: " + fromAfter + " remain");
     }
 
     // Extract title filter values (e.g., "title:meeting").
@@ -430,13 +439,15 @@ public class SimpleSearchProviderImpl extends AbstractSearchProviderImpl {
     summary.append(", query=\"").append(query).append("\"");
     summary.append(", results=").append(searchResult.size()).append("/").append(totalBeforePagination);
     summary.append(", candidatesBefore=").append(candidatesBefore);
-    boolean hasFilters = tagsAfter >= 0 || attachmentsAfter >= 0 || titleAfter >= 0 || contentAfter >= 0
-        || mentionsAfter >= 0 || tasksAfter >= 0 || unreadAfter >= 0;
+    boolean hasFilters = tagsAfter >= 0 || attachmentsAfter >= 0 || fromAfter >= 0
+        || titleAfter >= 0 || contentAfter >= 0 || mentionsAfter >= 0 || tasksAfter >= 0
+        || unreadAfter >= 0;
     if (hasFilters) {
       summary.append(" (");
       String sep = "";
       if (tagsAfter >= 0) { summary.append(sep).append("tags:").append(tagsAfter); sep = ", "; }
       if (attachmentsAfter >= 0) { summary.append(sep).append("attachments:").append(attachmentsAfter); sep = ", "; }
+      if (fromAfter >= 0) { summary.append(sep).append("from:").append(fromAfter); sep = ", "; }
       if (titleAfter >= 0) { summary.append(sep).append("title:").append(titleAfter); sep = ", "; }
       if (contentAfter >= 0) { summary.append(sep).append("content:").append(contentAfter); sep = ", "; }
       if (mentionsAfter >= 0) { summary.append(sep).append("mentions:").append(mentionsAfter); sep = ", "; }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -155,7 +155,8 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     if (numResults > 0) {
 
       int start = computeSolrStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery, hasFromQuery);
-      int rows = Math.max(numResults, ROWS);
+      int rows =
+          computeSolrRows(startAt, numResults, isUnreadOnlyQuery, hasAttachmentQuery, hasFromQuery);
 
       /*-
        * "fq" stands for Filter Query. see
@@ -398,6 +399,23 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
   static int computeInMemoryStart(
       int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery, boolean hasFromQuery) {
     return isUnreadOnlyQuery || hasAttachmentQuery || hasFromQuery ? startAt : 0;
+  }
+
+  static int computeSolrRows(
+      int startAt,
+      int numResults,
+      boolean isUnreadOnlyQuery,
+      boolean hasAttachmentQuery,
+      boolean hasFromQuery) {
+    int rows = Math.max(numResults, ROWS);
+    if (!(isUnreadOnlyQuery || hasAttachmentQuery || hasFromQuery)) {
+      return rows;
+    }
+    long requestedWindow = (long) Math.max(0, startAt) + Math.max(0, numResults);
+    if (requestedWindow > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    }
+    return Math.max(rows, (int) requestedWindow);
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImpl.java
@@ -143,6 +143,8 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
         queryParams.containsKey(TokenQueryType.UNREAD)
             || QueryHelper.hasIsValue(queryParams, "unread");
     final boolean hasAttachmentQuery = AttachmentSearchFilter.isHasAttachmentQuery(queryParams);
+    final Set<String> fromAuthorValues = FromSearchFilter.normalizeFromValues(queryParams, user);
+    final boolean hasFromQuery = !fromAuthorValues.isEmpty();
     if (queryParams.containsKey(TokenQueryType.MENTIONS)) {
       LOG.warning("Mentions queries are not supported by Solr search.");
       return new SearchResult(query);
@@ -152,7 +154,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
 
     if (numResults > 0) {
 
-      int start = computeSolrStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery);
+      int start = computeSolrStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery, hasFromQuery);
       int rows = Math.max(numResults, ROWS);
 
       /*-
@@ -187,9 +189,16 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
 
     List<WaveViewData> resultsList = Lists.newArrayList(results.values());
 
-    if (hasAttachmentQuery) {
+    if (hasAttachmentQuery || hasFromQuery) {
       expandConversationalWavelets(resultsList, user, isAllQuery);
+    }
+
+    if (hasAttachmentQuery) {
       AttachmentSearchFilter.filterByHasAttachment(resultsList);
+    }
+
+    if (hasFromQuery) {
+      FromSearchFilter.filterByRootAuthor(resultsList, fromAuthorValues);
     }
 
     // Solr does not index tags, so perform post-filtering for tag: queries.
@@ -209,7 +218,7 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     Collection<WaveViewData> searchResult =
         computeSearchResult(
             user,
-            computeInMemoryStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery),
+            computeInMemoryStart(startAt, isUnreadOnlyQuery, hasAttachmentQuery, hasFromQuery),
             numResults,
             resultsList);
     LOG.info("Search response to '" + query + "': " + searchResult.size() + " results, user: "
@@ -357,8 +366,8 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
    * J-UI-2 (#1080): the rail's filter chips emit {@code is:unread},
    * {@code has:attachment}, and {@code from:me}. {@code is:unread} is
    * handled equivalently to {@code unread:true} via post-filtering, and
-   * {@code has:attachment} is post-filtered by attachment metadata docs.
-   * {@code from:me} is URL-only this slice (deferred follow-up).
+   * {@code has:attachment} and {@code from:*} are post-filtered from
+   * materialized wave metadata.
    * In all three cases the token must be stripped before the query is
    * forwarded to Solr — Solr's schema does not know these prefixes and
    * a literal {@code is:unread} term in the user-query clause fails the
@@ -381,13 +390,14 @@ public class SolrSearchProviderImpl extends AbstractSearchProviderImpl {
     return !IN_PATTERN.matcher(query).find() || IN_ALL_PATTERN.matcher(query).find();
   }
 
-  static int computeSolrStart(int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
-    return isUnreadOnlyQuery || hasAttachmentQuery ? 0 : startAt;
+  static int computeSolrStart(
+      int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery, boolean hasFromQuery) {
+    return isUnreadOnlyQuery || hasAttachmentQuery || hasFromQuery ? 0 : startAt;
   }
 
   static int computeInMemoryStart(
-      int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery) {
-    return isUnreadOnlyQuery || hasAttachmentQuery ? startAt : 0;
+      int startAt, boolean isUnreadOnlyQuery, boolean hasAttachmentQuery, boolean hasFromQuery) {
+    return isUnreadOnlyQuery || hasAttachmentQuery || hasFromQuery ? startAt : 0;
   }
 
   private static String buildUserQuery(String query, ParticipantId sharedDomainParticipantId) {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/FromQueryNormalizerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/FromQueryNormalizerTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the
+ * License.
+ */
+
+package org.waveprotocol.box.server.waveserver;
+
+import junit.framework.TestCase;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class FromQueryNormalizerTest extends TestCase {
+
+  public void testNormalizeResolvesMeToCurrentUser() {
+    assertEquals(
+        "user@example.com",
+        FromQueryNormalizer.normalize("me", ParticipantId.ofUnsafe("User@Example.com")));
+  }
+
+  public void testNormalizeAppendsLocalDomainForBareNames() {
+    assertEquals(
+        "alice@example.com",
+        FromQueryNormalizer.normalize("Alice", ParticipantId.ofUnsafe("user@example.com")));
+  }
+
+  public void testNormalizeLowercasesExplicitAddresses() {
+    assertEquals(
+        "alice@example.com",
+        FromQueryNormalizer.normalize("Alice@Example.com",
+            ParticipantId.ofUnsafe("user@example.com")));
+  }
+
+  public void testNormalizeRejectsEmptyInput() {
+    try {
+      FromQueryNormalizer.normalize("", ParticipantId.ofUnsafe("user@example.com"));
+      fail("Expected empty from value to be rejected");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("raw from value"));
+    }
+  }
+
+  public void testNormalizeRejectsNullInput() {
+    try {
+      FromQueryNormalizer.normalize(null, ParticipantId.ofUnsafe("user@example.com"));
+      fail("Expected null from value to be rejected");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("raw from value"));
+    }
+  }
+
+  public void testNormalizeRejectsNullUser() {
+    try {
+      FromQueryNormalizer.normalize("me", null);
+      fail("Expected null user to be rejected");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("user cannot be null"));
+    }
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -788,6 +788,34 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(1, creatorUser2.getNumResults());
   }
 
+  public void testSearchFilterByFromComposesWithReplyCreatorAndWithFilters() throws Exception {
+    WaveletName root =
+        WaveletName.of(WaveId.of(DOMAIN, "from-reply-composition"), WAVELET_ID);
+    WaveletName reply =
+        WaveletName.of(root.waveId, WaveletId.of(DOMAIN, "conv+from-reply"));
+
+    submitDeltaToNewWavelet(root, USER1, addParticipantToWavelet(USER1, root));
+    addWaveletToUserView(reply, USER1);
+    submitDeltaToNewWaveletWithoutView(
+        reply,
+        USER2,
+        new AddParticipant(CONTEXT, USER1),
+        new AddParticipant(CONTEXT, USER2));
+
+    SearchResult results =
+        searchProvider.search(
+            USER1,
+            "in:inbox creator:" + USER2.getAddress()
+                + " with:" + USER2.getAddress()
+                + " from:me",
+            0,
+            10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("from-reply-composition",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
   public void testSearchFilterByImplicitContentWorks() throws Exception {
     WaveletName matchingWave = WaveletName.of(WaveId.of(DOMAIN, "matching"), WAVELET_ID);
     WaveletName partialWave = WaveletName.of(WaveId.of(DOMAIN, "partial"), WAVELET_ID);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SimpleSearchProviderImplTest.java
@@ -739,6 +739,55 @@ public class SimpleSearchProviderImplTest extends TestCase {
     assertEquals(0, results.getNumResults());
   }
 
+  public void testSearchFilterByFromMeUsesRootCreator() throws Exception {
+    createRootWave("from-user1", USER1, USER1);
+    createRootWave("from-user2", USER2, USER1, USER2);
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox from:me", 0, 10);
+
+    assertEquals(1, results.getNumResults());
+    assertEquals("from-user1",
+        WaveId.deserialise(results.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchFilterByFromLiteralAndBareAddress() throws Exception {
+    createRootWave("from-literal-user1", USER1, USER1);
+    createRootWave("from-literal-user2", USER2, USER1, USER2);
+
+    SearchResult literal =
+        searchProvider.search(USER1, "in:inbox from:" + USER2.getAddress(), 0, 10);
+    SearchResult bare = searchProvider.search(USER1, "in:inbox from:user2", 0, 10);
+
+    assertEquals(1, literal.getNumResults());
+    assertEquals("from-literal-user2",
+        WaveId.deserialise(literal.getDigests().get(0).getWaveId()).getId());
+    assertEquals(1, bare.getNumResults());
+    assertEquals("from-literal-user2",
+        WaveId.deserialise(bare.getDigests().get(0).getWaveId()).getId());
+  }
+
+  public void testSearchFilterByFromNoMatchReturnsEmpty() throws Exception {
+    createRootWave("from-no-match", USER1, USER1);
+
+    SearchResult results = searchProvider.search(USER1, "in:inbox from:missing", 0, 10);
+
+    assertEquals(0, results.getNumResults());
+  }
+
+  public void testSearchFilterByFromDoesNotChangeCreatorSemantics() throws Exception {
+    createRootWave("from-creator-user1", USER1, USER1);
+    createRootWave("from-creator-user2", USER2, USER1, USER2);
+
+    SearchResult fromMeAndCreatorUser2 =
+        searchProvider.search(
+            USER1, "in:inbox from:me creator:" + USER2.getAddress(), 0, 10);
+    SearchResult creatorUser2 =
+        searchProvider.search(USER1, "in:inbox creator:" + USER2.getAddress(), 0, 10);
+
+    assertEquals(0, fromMeAndCreatorUser2.getNumResults());
+    assertEquals(1, creatorUser2.getNumResults());
+  }
+
   public void testSearchFilterByImplicitContentWorks() throws Exception {
     WaveletName matchingWave = WaveletName.of(WaveId.of(DOMAIN, "matching"), WAVELET_ID);
     WaveletName partialWave = WaveletName.of(WaveId.of(DOMAIN, "partial"), WAVELET_ID);
@@ -1264,6 +1313,16 @@ public class SimpleSearchProviderImplTest extends TestCase {
     HashedVersion version = V0_HASH_FACTORY.createVersionZero(name);
     addWaveletToUserView(name, user);
     submitDelta(name, user, version, ops);
+  }
+
+  private void createRootWave(String waveId, ParticipantId creator, ParticipantId... participants)
+      throws Exception {
+    WaveletName name = WaveletName.of(WaveId.of(DOMAIN, waveId), WAVELET_ID);
+    List<WaveletOperation> ops = new ArrayList<WaveletOperation>();
+    for (ParticipantId participant : participants) {
+      ops.add(addParticipantToWavelet(participant, name));
+    }
+    submitDeltaToNewWavelet(name, creator, ops.toArray(new WaveletOperation[ops.size()]));
   }
 
   private void submitDeltaToExistingWavelet(WaveletName name, ParticipantId user,

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -190,6 +190,13 @@ public class SolrSearchProviderImplTest extends TestCase {
     assertEquals(0, SolrSearchProviderImpl.computeInMemoryStart(5, false, false, false));
   }
 
+  public void testSolrPostFilteredQueriesFetchRequestedPageWindow() {
+    assertEquals(30, SolrSearchProviderImpl.computeSolrRows(20, 10, true, false, false));
+    assertEquals(30, SolrSearchProviderImpl.computeSolrRows(20, 10, false, true, false));
+    assertEquals(30, SolrSearchProviderImpl.computeSolrRows(20, 10, false, false, true));
+    assertEquals(10, SolrSearchProviderImpl.computeSolrRows(20, 10, false, false, false));
+  }
+
   public void testSearchRejectsMentionsQueries() {
     Config config = ConfigFactory.parseMap(ImmutableMap.<String, Object>of(
         "core.wave_server_domain", "example.com",

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SolrSearchProviderImplTest.java
@@ -133,6 +133,42 @@ public class SolrSearchProviderImplTest extends TestCase {
     assertTrue(results.isEmpty());
   }
 
+  public void testFromFilterKeepsConversationRootCreator() throws Exception {
+    WaveViewData userWave = waveWithCreator("from-user", USER);
+    WaveViewData otherWave =
+        waveWithCreator("from-other", ParticipantId.ofUnsafe("other@" + DOMAIN));
+    List<WaveViewData> results = new ArrayList<WaveViewData>();
+    results.add(userWave);
+    results.add(otherWave);
+
+    FromSearchFilter.filterByRootAuthor(
+        results, Collections.singleton(USER.getAddress().toLowerCase()));
+
+    assertEquals(1, results.size());
+    assertSame(userWave, results.get(0));
+  }
+
+  public void testFromFilterReturnsNoMatchForDifferentRootCreator() throws Exception {
+    WaveViewData userWave = waveWithCreator("from-user-no-match", USER);
+    List<WaveViewData> results = new ArrayList<WaveViewData>();
+    results.add(userWave);
+
+    FromSearchFilter.filterByRootAuthor(
+        results, Collections.singleton("other@" + DOMAIN));
+
+    assertTrue(results.isEmpty());
+  }
+
+  public void testFromQueryNormalizesValues() throws Exception {
+    assertTrue(FromSearchFilter.isFromQuery(QueryHelper.parseQuery("in:inbox from:me")));
+    assertEquals(
+        Collections.singleton(USER.getAddress().toLowerCase()),
+        FromSearchFilter.normalizeFromValues(QueryHelper.parseQuery("from:me"), USER));
+    assertEquals(
+        Collections.singleton("alice@" + DOMAIN),
+        FromSearchFilter.normalizeFromValues(QueryHelper.parseQuery("from:Alice"), USER));
+  }
+
   public void testIsHasAttachmentQueryOnlyMatchesAttachmentValue() throws Exception {
     assertTrue(AttachmentSearchFilter.isHasAttachmentQuery(
         QueryHelper.parseQuery("in:inbox has:attachment")));
@@ -143,13 +179,15 @@ public class SolrSearchProviderImplTest extends TestCase {
   }
 
   public void testSolrPostFilteredQueriesStartAtZeroBeforeInMemoryPagination() {
-    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, true, false));
-    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, true));
-    assertEquals(5, SolrSearchProviderImpl.computeSolrStart(5, false, false));
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, true, false, false));
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, true, false));
+    assertEquals(0, SolrSearchProviderImpl.computeSolrStart(5, false, false, true));
+    assertEquals(5, SolrSearchProviderImpl.computeSolrStart(5, false, false, false));
 
-    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, true, false));
-    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, false, true));
-    assertEquals(0, SolrSearchProviderImpl.computeInMemoryStart(5, false, false));
+    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, true, false, false));
+    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, false, true, false));
+    assertEquals(5, SolrSearchProviderImpl.computeInMemoryStart(5, false, false, true));
+    assertEquals(0, SolrSearchProviderImpl.computeInMemoryStart(5, false, false, false));
   }
 
   public void testSearchRejectsMentionsQueries() {
@@ -168,14 +206,24 @@ public class SolrSearchProviderImplTest extends TestCase {
 
   private static WaveViewData waveWithDocument(String waveIdToken, String documentId)
       throws Exception {
+    return waveWithDocumentAndCreator(waveIdToken, documentId, USER);
+  }
+
+  private static WaveViewData waveWithCreator(String waveIdToken, ParticipantId creator)
+      throws Exception {
+    return waveWithDocumentAndCreator(waveIdToken, "b+plain", creator);
+  }
+
+  private static WaveViewData waveWithDocumentAndCreator(
+      String waveIdToken, String documentId, ParticipantId creator) throws Exception {
     WaveId waveId = WaveId.of(DOMAIN, waveIdToken);
     WaveletName waveletName =
         WaveletName.of(waveId, WaveletId.of(DOMAIN, IdConstants.CONVERSATION_ROOT_WAVELET));
     ObservableWaveletData wavelet = WaveletDataUtil.createEmptyWavelet(
-        waveletName, USER, HashedVersion.unsigned(0), 1234567890);
+        waveletName, creator, HashedVersion.unsigned(0), 1234567890);
     wavelet.createDocument(
         documentId,
-        USER,
+        creator,
         Collections.<ParticipantId>emptySet(),
         new DocInitializationBuilder().characters("metadata").build(),
         1234567890,


### PR DESCRIPTION
## Summary

Fixes #1092.

Adds server-side execution for the canonical J2CL `from:` search chip:
- normalizes `from:me`, explicit addresses, and bare local names;
- filters SimpleSearch and SolrSearch results by conversation root wavelet creator;
- treats Solr `from:` as a post-filter so pagination applies after filtering;
- preserves existing `creator:` wavelet-level behavior.

## Verification

- `sbt --batch 'Test / testOnly org.waveprotocol.box.server.waveserver.FromQueryNormalizerTest org.waveprotocol.box.server.waveserver.QueryHelperTest org.waveprotocol.box.server.waveserver.SolrSearchProviderImplTest org.waveprotocol.box.server.waveserver.SimpleSearchProviderImplTest'` -> PASS, 103 tests.
- `sbt --batch compile j2clSearchTest` -> PASS.
- `python3 scripts/assemble-changelog.py` and `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> PASS.
- `git diff --check origin/main...HEAD` -> PASS.

## Review Note

Claude Opus plan and implementation review attempts are quota-blocked until May 2 21:00 Asia/Jerusalem, so no external Claude approval is claimed. Proceeding with self-review plus GitHub review/check gates as recorded on #1092/#904.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side `from:` search filtering implemented for all search providers; `from:me` resolves to the current user and addresses are normalized case-insensitively.
  * Results are post-filtered by conversation-root creator; non-matching `from:` queries return zero results.
  * Pagination adjusted so active `from:` filtering is treated as a post-filtered stage.

* **Bug Fixes**
  * Ensured Solr and in-memory search behaviors match for `from:` filtering.

* **Tests**
  * Added comprehensive tests for normalization, filtering, and pagination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->