### PR TITLE
Make J2CL search controls functional

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1162-j2cl-search-controls.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1162-j2cl-search-controls.md
@@ -1,0 +1,77 @@
+# Issue #1162 J2CL Search Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the J2CL search rail controls functionally match the GWT search panel for New Wave, saved searches, saved-search selection, refresh, filter chips, and sort controls.
+
+**Architecture:** Keep the server and GWT code unchanged. Fix the J2CL Lit rail so controls that are visible to users are real controls: manage saved searches opens a first-class modal backed by the existing `/searches` endpoint, pinned saved searches render as quick-access entries, sort opens working order-by options, filter opens working query chips, and all query-changing actions reuse the existing `wavy-search-submit` or `wavy-saved-search-selected` bridge already consumed by `J2clSearchPanelView`.
+
+**Tech Stack:** J2CL Java, Lit custom elements, existing `/searches` REST endpoint, Playwright parity tests, SBT project verification.
+
+---
+
+## Files
+
+- Modify `j2cl/lit/src/elements/wavy-search-rail.js`: implement saved-search state, modal UI, `/searches` GET/POST, pinned custom searches, sort menu, and stronger query composition.
+- Modify `j2cl/lit/test/wavy-search-rail.test.js`: add unit tests for manage modal behavior, pinned saved searches, apply flow, save flow, and sort options.
+- Modify `wave/src/e2e/j2cl-gwt-parity/tests/search-panel-parity.spec.ts`: assert visible J2CL controls cause observable UI/query changes instead of only checking that buttons exist.
+- Optionally modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchPanelView.java` only if a Lit event cannot be represented through existing events. Prefer no Java changes.
+
+## Current Findings
+
+- GWT `SearchPresenter.openSearchesEditor()` opens `SearchesEditorPopup`, loads/stores searches with `RemoteSearchesService`, applies a selected saved search by setting the query, and rebuilds pinned toolbar buttons.
+- J2CL `wavy-search-rail` currently emits `wavy-manage-saved-searches-requested`, but no Java or JS listener handles it.
+- J2CL sort currently emits `wavy-search-sort-requested`, but no listener handles it. The server already supports `orderby:datedesc`, `orderby:dateasc`, `orderby:createddesc`, and `orderby:createdasc`.
+- J2CL filter chips are bridged through `wavy-search-filter-toggled`, but the end-to-end parity test only checks visibility and does not prove that the result query changes.
+
+## Tasks
+
+### Task 1: Lit Unit Tests For Saved Searches And Sort
+
+- [ ] Add tests to `j2cl/lit/test/wavy-search-rail.test.js` that stub `globalThis.fetch` for `GET /searches` and `POST /searches`.
+- [ ] Assert clicking `.manage-saved` opens a modal/dialog with existing saved searches returned by `/searches`.
+- [ ] Assert a pinned saved search returned by `/searches` renders as a quick-access button and clicking it emits `wavy-saved-search-selected` with the saved search name and query.
+- [ ] Assert applying a saved search from the modal emits `wavy-saved-search-selected`, closes the modal, and does not call the backend when no edits were made.
+- [ ] Assert adding a saved search from the current query posts JSON to `/searches` and updates the quick-access list.
+- [ ] Assert clicking the sort button opens sort options and choosing `Created oldest` emits `wavy-search-submit` with `orderby:createdasc` added or replacing any prior `orderby:*` token.
+
+### Task 2: Implement J2CL Saved Searches In The Rail
+
+- [ ] Add reactive properties for saved-search list, modal open state, loading/error state, and draft fields.
+- [ ] Implement `_loadSavedSearches()` using `fetch("/searches", { credentials: "same-origin" })`; tolerate failures by showing an inline modal error rather than failing the rail.
+- [ ] Implement `_saveSavedSearches(next)` using `POST /searches` with `Content-Type: application/json`, `credentials: "same-origin"`, and a top-level JSON array payload of `{name, query, pinned}` objects matching `SearchesServlet`.
+- [ ] On GET/POST failure, keep the modal open, show an inline error, and leave the last successfully loaded quick-access list unchanged.
+- [ ] Implement `_openSavedSearches()`, `_closeSavedSearches()`, `_applySavedSearch(item)`, `_addCurrentSearch()`, `_removeSavedSearch(index)`, `_togglePinned(index)`, and `_updateSavedSearch(index, field, value)`.
+- [ ] Keep dispatching `wavy-manage-saved-searches-requested` when Manage is clicked so existing telemetry/listeners and tests remain valid.
+- [ ] Render pinned saved searches in a dedicated custom-search section below the built-in folders with `data-saved-search-name`, `data-query`, and accessible labels; do not change built-in active-folder derivation.
+- [ ] Render the modal as a plain Lit overlay with Add current search, editable name/query inputs, pin/remove/apply actions, Save, and Cancel.
+- [ ] Modal accessibility contract: `role="dialog"`, `aria-modal="true"`, Escape closes, outside click closes, focus returns to `.manage-saved` on close, and keyboard focus starts inside the dialog. A full focus trap can be a follow-up only if current GWT/Lit modal infrastructure lacks it.
+- [ ] Edits are draft-only until Save or Apply. Apply first saves pending drafts, then emits `wavy-saved-search-selected` so the Java side uses `onSavedSearchSelected`.
+
+### Task 3: Implement Functional Sort Options
+
+- [ ] Replace the placeholder sort event with an in-rail popover/menu.
+- [ ] Define options for newest modified (`orderby:datedesc`), oldest modified (`orderby:dateasc`), newest created (`orderby:createddesc`), and oldest created (`orderby:createdasc`).
+- [ ] Implement `_applySort(token)` that removes existing `orderby:*` tokens from the current query, appends the selected token unless it is the default `orderby:datedesc`, updates `query`, emits `wavy-search-submit`, and closes the menu.
+- [ ] Reflect active sort through `aria-pressed` or `aria-current` so keyboard and assistive tech users can tell which order is active.
+- [ ] Sort menu dismiss contract: applying a sort closes the menu; Escape/outside-click close can be follow-up if not already available in the rail. Sort must not emit `wavy-search-filter-toggled`, so the existing chip submit dedupe remains isolated to filters.
+
+### Task 4: Strengthen Browser Parity Coverage
+
+- [ ] Extend `search-panel-parity.spec.ts` so J2CL filter button click visibly opens the filter chip strip, clicking the unread chip changes the query to include `is:unread`, and clicking a sort option changes the query to include the selected `orderby:*` token.
+- [ ] Add a saved-search smoke path that seeds `/searches` by POSTing a raw `[{ "name": "...", "query": "...", "pinned": true }]` array through Playwright `APIRequestContext`, reloads J2CL, opens Manage saved searches, applies the saved search, and asserts the visible query changes. Clean up by POSTing `[]` after the test.
+- [ ] Keep GWT assertions focused on the existing GWT contract: manage saved searches opens an editor; saved-search apply drives a search query; New Wave remains reachable.
+
+### Task 5: Verification And Issue Evidence
+
+- [ ] Run `npm test -- --files test/wavy-search-rail.test.js` from `j2cl/lit/`.
+- [ ] Run the narrow parity Playwright spec from `wave/src/e2e/j2cl-gwt-parity/` against a local server if the server is already running; otherwise record the exact server-start blocker.
+- [ ] Run an SBT verification command that compiles the J2CL/search slice, preferably `./sbt j2cl/compile` from the worktree root if supported; if the project has a narrower documented selector, record that exact selector.
+- [ ] Comment on #1162 with worktree path, plan path, implementation summary, exact verification commands/results, CI/PR state, and PR URL once opened.
+
+## Self-Review
+
+- Spec coverage: The plan covers all #1162 gaps: New Wave remains on the existing root-shell bridge, manage saved searches becomes functional, saved-search selection gets pinned/custom entries, refresh remains bridged, filter chips get behavior assertions, and sort becomes functional instead of a placeholder.
+- Placeholder scan: No task depends on an unspecified backend; the plan reuses the existing `/searches` endpoint and existing J2CL event bridge.
+- Risk: Full GWT saved-search editor parity has more polish than this first J2CL modal. The acceptance target for this lane is functional parity, not pixel-perfect popup parity; visual parity can be refined after the control works.
+- Claude review: External Claude Opus plan review returned `approve-with-changes`; required follow-ups were incorporated here by pinning the `/searches` payload shape, modal accessibility contract, sort/menu behavior, saved-search test seeding/cleanup, and concrete verification commands.

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -781,7 +781,8 @@ export class WavySearchRail extends LitElement {
 
   _applySort(sort) {
     const explicitSort = this._explicitSortToken().toLowerCase();
-    if (explicitSort && explicitSort === sort.token.toLowerCase()) {
+    const sortToken = sort.token.toLowerCase();
+    if ((explicitSort && explicitSort === sortToken) || (!explicitSort && sort.default)) {
       this._setSortOpen(false);
       this._focusSortTrigger();
       return;
@@ -1080,6 +1081,10 @@ export class WavySearchRail extends LitElement {
 
   render() {
     const explicitSort = this._explicitSortToken().toLowerCase();
+    const defaultSort = (
+      WavySearchRail.SORTS.find((sort) => sort.default) || WavySearchRail.SORTS[0]
+    ).token.toLowerCase();
+    const effectiveSort = explicitSort || defaultSort;
     const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
       <div class="search">
@@ -1146,12 +1151,12 @@ export class WavySearchRail extends LitElement {
                     type="button"
                     class="sort-option"
                     role="menuitemradio"
-                    aria-checked=${explicitSort === sort.token.toLowerCase() ? "true" : "false"}
+                    aria-checked=${effectiveSort === sort.token.toLowerCase() ? "true" : "false"}
                     data-sort-token=${sort.token}
                     @click=${() => this._applySort(sort)}
                   >
                     <span>${sort.label}</span>
-                    ${explicitSort === sort.token.toLowerCase() ? html`<span aria-hidden="true">✓</span>` : null}
+                    ${effectiveSort === sort.token.toLowerCase() ? html`<span aria-hidden="true">✓</span>` : null}
                   </button>
                 `)}
               </div>`

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -27,8 +27,8 @@ import {
  * `data-digest-action="refresh|sort|filter"`. The buttons emit:
  *
  *   - refresh → wavy-search-refresh-requested (existing event)
- *   - sort    → wavy-search-sort-requested    (G-PORT-2 new; future
- *               slice hangs the menu on this)
+ *   - sort    → wavy-search-sort-requested with the selected orderby
+ *               token, plus wavy-search-submit when the query changes
  *   - filter  → wavy-search-filter-toggle-requested (G-PORT-2 new;
  *               toggles the existing <details> filter chip strip
  *               open / closed)
@@ -36,7 +36,10 @@ import {
  * All previously-existing events still fire (wavy-search-submit,
  * wavy-search-help-toggle, wavy-new-wave-requested,
  * wavy-manage-saved-searches-requested, wavy-saved-search-selected,
- * wavy-search-filter-toggled).
+ * wavy-search-filter-toggled). Built-in folder selections emit one of
+ * the six canonical folderId values; custom saved searches emit
+ * `kind: "custom"` and an empty folderId so folder-id consumers do not
+ * treat saved-search names as built-in folders.
  */
 export class WavySearchRail extends LitElement {
   static properties = {
@@ -45,6 +48,13 @@ export class WavySearchRail extends LitElement {
     resultCount: { type: String, attribute: "result-count", reflect: true },
     mentionsUnread: { type: Number, attribute: "mentions-unread" },
     tasksPending: { type: Number, attribute: "tasks-pending" },
+    savedSearches: { state: true },
+    savedSearchDrafts: { state: true },
+    savedSearchesOpen: { state: true },
+    savedSearchesLoading: { state: true },
+    savedSearchesError: { state: true },
+    savedSearchesDirty: { state: true },
+    sortOpen: { state: true },
     /**
      * G-PORT-2: track whether the filter chip strip is open. The
      * panel-level Filter action button toggles this. The user-driven
@@ -67,6 +77,13 @@ export class WavySearchRail extends LitElement {
     { id: "unread", label: "Unread only", token: "is:unread" },
     { id: "attachments", label: "With attachments", token: "has:attachment" },
     { id: "from-me", label: "From me", token: "from:me" }
+  ];
+
+  static SORTS = [
+    { id: "datedesc", label: "Newest activity", token: "orderby:datedesc", default: true },
+    { id: "dateasc", label: "Oldest activity", token: "orderby:dateasc" },
+    { id: "createddesc", label: "Newest created", token: "orderby:createddesc" },
+    { id: "createdasc", label: "Oldest created", token: "orderby:createdasc" }
   ];
 
   static styles = css`
@@ -176,6 +193,47 @@ export class WavySearchRail extends LitElement {
       background: rgba(0, 119, 182, 0.10);
       color: var(--wavy-signal-cyan, #0077b6);
     }
+    .sort-wrap {
+      position: relative;
+      display: inline-flex;
+    }
+    .sort-menu {
+      position: absolute;
+      z-index: 20;
+      top: calc(100% + 4px);
+      left: 0;
+      min-width: 180px;
+      padding: 6px;
+      border: 1px solid var(--wavy-border-hairline, #cbd5e1);
+      border-radius: 10px;
+      background: #ffffff;
+      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+    }
+    .sort-option {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      width: 100%;
+      min-height: 30px;
+      padding: 5px 8px;
+      border: 0;
+      border-radius: 7px;
+      background: transparent;
+      color: var(--wavy-text-body, #1a202c);
+      font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
+      cursor: pointer;
+      text-align: left;
+    }
+    .sort-option:hover,
+    .sort-option:focus-visible,
+    .sort-option[aria-checked="true"] {
+      background: rgba(0, 119, 182, 0.08);
+      color: var(--wavy-signal-cyan, #0077b6);
+    }
+    .sort-option:focus-visible {
+      outline: 2px solid var(--wavy-signal-cyan, #0077b6);
+      outline-offset: 1px;
+    }
 
     .actions {
       display: flex;
@@ -247,6 +305,45 @@ export class WavySearchRail extends LitElement {
     .folder:focus-visible {
       outline: none;
       background: rgba(0, 119, 182, 0.06);
+    }
+    .custom-searches {
+      margin: 0 0 8px;
+      padding: 0;
+      list-style: none;
+    }
+    .custom-search {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--wavy-spacing-2, 8px);
+      border: 0;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--wavy-text-body, #1a202c);
+      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
+      font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
+      text-align: left;
+      cursor: pointer;
+    }
+    .custom-search:hover,
+    .custom-search:focus-visible {
+      outline: none;
+      background: rgba(0, 119, 182, 0.06);
+    }
+    .custom-query {
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      color: var(--wavy-text-muted, #64748b);
+      font: var(--wavy-type-meta, 11px / 1.4 Arial, sans-serif);
+    }
+    .custom-name {
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
     .dot.mentions-dot {
       width: 8px;
@@ -325,6 +422,101 @@ export class WavySearchRail extends LitElement {
       border-color: var(--wavy-signal-cyan, #22d3ee);
       box-shadow: var(--wavy-pulse-ring, 0 0 0 2px rgba(34, 211, 238, 0.22));
     }
+    .saved-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: rgba(15, 23, 42, 0.42);
+    }
+    .saved-dialog {
+      width: min(720px, 100%);
+      max-height: min(720px, calc(100vh - 48px));
+      overflow: auto;
+      border-radius: 18px;
+      background: #ffffff;
+      color: var(--wavy-text-body, #1a202c);
+      box-shadow: 0 28px 80px rgba(15, 23, 42, 0.28);
+    }
+    .saved-header,
+    .saved-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 14px 18px;
+      border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
+    }
+    .saved-footer {
+      border-top: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      border-bottom: 0;
+      justify-content: flex-end;
+    }
+    .saved-title {
+      margin: 0;
+      font: 700 16px / 1.3 Arial, sans-serif;
+    }
+    .saved-body {
+      padding: 14px 18px;
+    }
+    .saved-error {
+      margin: 0 0 10px;
+      padding: 8px 10px;
+      border-radius: 8px;
+      background: #fff7ed;
+      color: #9a3412;
+      font: 12px / 1.4 Arial, sans-serif;
+    }
+    .saved-hint {
+      margin: 0 0 10px;
+      color: var(--wavy-text-muted, #64748b);
+      font: 12px / 1.4 Arial, sans-serif;
+    }
+    .saved-row {
+      display: grid;
+      grid-template-columns: minmax(120px, 1fr) minmax(180px, 1.4fr) auto auto auto;
+      gap: 8px;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--wavy-border-hairline, #edf2f7);
+    }
+    .saved-row input[type="text"] {
+      min-width: 0;
+      height: 30px;
+      border: 1px solid var(--wavy-border-hairline, #cbd5e1);
+      border-radius: 8px;
+      padding: 4px 8px;
+      font: 13px / 1.35 Arial, sans-serif;
+    }
+    .saved-empty {
+      color: var(--wavy-text-muted, #64748b);
+      font: 13px / 1.4 Arial, sans-serif;
+    }
+    .saved-button {
+      border: 1px solid var(--wavy-border-hairline, #cbd5e1);
+      border-radius: 999px;
+      background: #ffffff;
+      color: var(--wavy-text-body, #1a202c);
+      padding: 6px 10px;
+      font: 12px / 1.2 Arial, sans-serif;
+      cursor: pointer;
+    }
+    .saved-button.primary {
+      background: var(--wavy-signal-cyan, #0077b6);
+      border-color: var(--wavy-signal-cyan, #0077b6);
+      color: #ffffff;
+    }
+    .saved-button:disabled {
+      opacity: 0.55;
+      cursor: default;
+    }
+    .saved-button:focus-visible {
+      outline: 2px solid var(--wavy-signal-cyan, #0077b6);
+      outline-offset: 2px;
+    }
   `;
 
   constructor() {
@@ -335,6 +527,33 @@ export class WavySearchRail extends LitElement {
     this.mentionsUnread = 0;
     this.tasksPending = 0;
     this.filtersOpen = false;
+    this.savedSearches = [];
+    this.savedSearchDrafts = [];
+    this.savedSearchesOpen = false;
+    this.savedSearchesLoading = false;
+    this.savedSearchesError = "";
+    this.savedSearchesDirty = false;
+    this.sortOpen = false;
+    this._savedSearchReturnFocus = null;
+    this._savedSearchesLoaded = false;
+    this._savedSearchesLoadPromise = null;
+    this._savedSearchRows = [];
+    this._savedSearchesHadInvalidRows = false;
+    this._documentListenersAttached = false;
+    this._boundDocumentClick = (evt) => this._onDocumentClick(evt);
+    this._boundDocumentKeydown = (evt) => this._onDocumentKeydown(evt);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.hasAttribute("autoload-saved-searches")) {
+      this._loadSavedSearches();
+    }
+  }
+
+  disconnectedCallback() {
+    this._releaseDocumentListeners();
+    super.disconnectedCallback();
   }
 
   willUpdate(changed) {
@@ -427,6 +646,16 @@ export class WavySearchRail extends LitElement {
     this._emit("wavy-search-submit", { query: composed });
   }
 
+  _removeTokens(q, predicate) {
+    return this._tokenize(q).filter((token) => !predicate(token));
+  }
+
+  _queryWithToken(token, predicate) {
+    const next = this._removeTokens(this.query, predicate);
+    next.push(token);
+    return next.join(" ").replace(/\s+/g, " ").trim();
+  }
+
   _tokenize(q) {
     if (!q) return [];
     return q
@@ -443,12 +672,415 @@ export class WavySearchRail extends LitElement {
     });
   }
 
-  /** G-PORT-2: panel-level Sort button placeholder for the future menu. */
-  _onSortClick() {
-    this._emit("wavy-search-sort-requested");
+  _toggleSortMenu() {
+    this._setSortOpen(!this.sortOpen);
+    if (this.sortOpen) {
+      this.updateComplete.then(() => {
+        const active =
+          this.renderRoot?.querySelector('.sort-option[aria-checked="true"]') ||
+          this.renderRoot?.querySelector(".sort-option");
+        if (active && typeof active.focus === "function") {
+          active.focus();
+        }
+      });
+    }
+  }
+
+  _setSortOpen(open) {
+    this.sortOpen = open;
+    if (open) {
+      this._ensureDocumentListeners();
+    } else {
+      this._releaseDocumentListeners();
+    }
+  }
+
+  _ensureDocumentListeners() {
+    if (this._documentListenersAttached) {
+      return;
+    }
+    document.addEventListener("click", this._boundDocumentClick);
+    document.addEventListener("keydown", this._boundDocumentKeydown);
+    this._documentListenersAttached = true;
+  }
+
+  _releaseDocumentListeners() {
+    if (!this._documentListenersAttached) {
+      return;
+    }
+    document.removeEventListener("click", this._boundDocumentClick);
+    document.removeEventListener("keydown", this._boundDocumentKeydown);
+    this._documentListenersAttached = false;
+  }
+
+  _onDocumentClick(evt) {
+    if (!this.sortOpen) {
+      return;
+    }
+    const path = typeof evt.composedPath === "function" ? evt.composedPath() : [];
+    if (path.includes(this)) {
+      return;
+    }
+    this._setSortOpen(false);
+  }
+
+  _onDocumentKeydown(evt) {
+    if (evt.key !== "Escape") {
+      return;
+    }
+    if (this.sortOpen) {
+      evt.preventDefault();
+      this._setSortOpen(false);
+      const sort = this.renderRoot?.querySelector('[data-digest-action="sort"]');
+      if (sort && typeof sort.focus === "function") {
+        sort.focus();
+      }
+    }
+  }
+
+  _onSortMenuKeydown(evt) {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(evt.key)) {
+      return;
+    }
+    const options = Array.from(evt.currentTarget.querySelectorAll(".sort-option"));
+    if (options.length === 0) {
+      return;
+    }
+    const active = this.renderRoot?.activeElement || document.activeElement;
+    const current = Math.max(0, options.indexOf(active));
+    let next = -1;
+    if (evt.key === "ArrowDown") {
+      next = (current + 1) % options.length;
+    } else if (evt.key === "ArrowUp") {
+      next = (current - 1 + options.length) % options.length;
+    } else if (evt.key === "Home") {
+      next = 0;
+    } else if (evt.key === "End") {
+      next = options.length - 1;
+    }
+    if (next >= 0) {
+      evt.preventDefault();
+      options[next].focus();
+    }
+  }
+
+  _onSortMenuFocusout(evt) {
+    const next = evt.relatedTarget;
+    if (next && evt.currentTarget.contains(next)) {
+      return;
+    }
+    this._setSortOpen(false);
+  }
+
+  _explicitSortToken() {
+    const token = this._tokenize(this.query).find((part) =>
+      part.toLowerCase().startsWith("orderby:")
+    );
+    return token || "";
+  }
+
+  _applySort(sort) {
+    const explicitSort = this._explicitSortToken().toLowerCase();
+    if (explicitSort && explicitSort === sort.token.toLowerCase()) {
+      this._setSortOpen(false);
+      this._focusSortTrigger();
+      return;
+    }
+    const composed = this._queryWithToken(
+      sort.token,
+      (token) => token.toLowerCase().startsWith("orderby:")
+    );
+    this.query = composed;
+    this._setSortOpen(false);
+    this._focusSortTrigger();
+    this._emit("wavy-search-sort-requested", { sortId: sort.id, token: sort.token, query: composed });
+    this._emit("wavy-search-submit", { query: composed });
+  }
+
+  _focusSortTrigger() {
+    this.updateComplete.then(() => {
+      const sort = this.renderRoot?.querySelector('[data-digest-action="sort"]');
+      if (sort && typeof sort.focus === "function") {
+        sort.focus();
+      }
+    });
+  }
+
+  _normalizeSavedSearch(item) {
+    return {
+      name: String(item?.name || "").trim(),
+      query: String(item?.query || "").trim(),
+      pinned: item?.pinned === true
+    };
+  }
+
+  async _loadSavedSearches(force = false) {
+    if (!force && this._savedSearchesLoaded) {
+      this.savedSearchesError = this._savedSearchesHadInvalidRows
+        ? "Some saved searches need both a name and a query."
+        : "";
+      if (!this.savedSearchesDirty) {
+        const rows = this._savedSearchRows.length > 0 ? this._savedSearchRows : this.savedSearches;
+        this.savedSearchDrafts = rows.map((item) => ({ ...item }));
+      }
+      return;
+    }
+    if (!force && this._savedSearchesLoadPromise) {
+      return this._savedSearchesLoadPromise;
+    }
+    this.savedSearchesLoading = true;
+    this.savedSearchesError = "";
+    let loadPromise;
+    loadPromise = (async () => {
+      try {
+        const response = await fetch("/searches", { credentials: "same-origin" });
+        if (this._savedSearchesLoadPromise !== loadPromise) {
+          return;
+        }
+        if (response.status === 401 || response.status === 403) {
+          if (!this._savedSearchesLoaded && !this.savedSearchesDirty) {
+            this.savedSearches = [];
+            this.savedSearchDrafts = [];
+            this._savedSearchRows = [];
+            this._savedSearchesHadInvalidRows = false;
+            this.savedSearchesDirty = false;
+            if (this.savedSearchesOpen) {
+              this.savedSearchesError = "Sign in to manage saved searches.";
+            }
+          } else {
+            const authMessage = "Sign in to refresh saved searches.";
+            this.savedSearchesError = this._savedSearchesHadInvalidRows
+              ? `${authMessage} Some saved searches need both a name and a query.`
+              : authMessage;
+          }
+          return;
+        }
+        if (!response.ok) {
+          throw new Error(`Searches request failed (${response.status})`);
+        }
+        const payload = await response.json();
+        if (this._savedSearchesLoadPromise !== loadPromise) {
+          return;
+        }
+        const rows = Array.isArray(payload)
+          ? payload.map((item) => this._normalizeSavedSearch(item))
+          : [];
+        const invalid = rows.some((item) => !item.name || !item.query);
+        const list = rows.filter((item) => item.name && item.query);
+        this._savedSearchRows = rows.map((item) => ({ ...item }));
+        this._savedSearchesHadInvalidRows = invalid;
+        this.savedSearches = list;
+        if (!this.savedSearchesDirty) {
+          this.savedSearchDrafts = rows.map((item) => ({ ...item }));
+        }
+        if (invalid) {
+          this.savedSearchesError = "Some saved searches need both a name and a query.";
+        }
+        this._savedSearchesLoaded = true;
+      } catch (err) {
+        if (this._savedSearchesLoadPromise !== loadPromise) {
+          return;
+        }
+        console.warn("Unable to load saved searches", err);
+        this.savedSearchesError = "Unable to load saved searches.";
+        this.savedSearchDrafts = this.savedSearches.map((item) => ({ ...item }));
+      } finally {
+        if (this._savedSearchesLoadPromise === loadPromise) {
+          this._savedSearchesLoadPromise = null;
+          this.savedSearchesLoading = false;
+        }
+      }
+    })();
+    this._savedSearchesLoadPromise = loadPromise;
+    return this._savedSearchesLoadPromise;
+  }
+
+  async _saveSavedSearches(nextDrafts = this.savedSearchDrafts) {
+    const invalid = nextDrafts.some((item) => {
+      const normalized = this._normalizeSavedSearch(item);
+      return !normalized.name || !normalized.query;
+    });
+    if (invalid) {
+      this.savedSearchesError = "Each saved search needs both a name and a query.";
+      return false;
+    }
+    const next = nextDrafts
+      .map((item) => this._normalizeSavedSearch(item));
+    this.savedSearchesLoading = true;
+    this.savedSearchesError = "";
+    try {
+      const response = await fetch("/searches", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(next)
+      });
+      if (!response.ok) {
+        throw new Error(`Searches save failed (${response.status})`);
+      }
+      this.savedSearches = next;
+      this._savedSearchRows = next.map((item) => ({ ...item }));
+      this._savedSearchesHadInvalidRows = false;
+      this.savedSearchDrafts = next.map((item) => ({ ...item }));
+      this.savedSearchesDirty = false;
+      this._savedSearchesLoaded = true;
+      return true;
+    } catch (err) {
+      console.warn("Unable to save saved searches", err);
+      this.savedSearchesError = "Unable to save saved searches.";
+      return false;
+    } finally {
+      this.savedSearchesLoading = false;
+    }
+  }
+
+  _openSavedSearches() {
+    this._emit("wavy-manage-saved-searches-requested");
+    this._savedSearchReturnFocus = this.renderRoot?.querySelector(".manage-saved") || null;
+    this._setSortOpen(false);
+    this.savedSearchesOpen = true;
+    this._loadSavedSearches();
+    this.updateComplete.then(() => {
+      const firstInput = this.renderRoot?.querySelector(
+        '.saved-dialog input[type="text"], .saved-dialog button'
+      );
+      if (firstInput && typeof firstInput.focus === "function") {
+        firstInput.focus();
+      }
+    });
+  }
+
+  _closeSavedSearches() {
+    this.savedSearchesOpen = false;
+    this.savedSearchesError = "";
+    this.savedSearchDrafts = this.savedSearches.map((item) => ({ ...item }));
+    this.savedSearchesDirty = false;
+    const returnFocus = this._savedSearchReturnFocus;
+    this._savedSearchReturnFocus = null;
+    if (returnFocus && typeof returnFocus.focus === "function") {
+      this.updateComplete.then(() => returnFocus.focus());
+    }
+  }
+
+  _updateSavedSearch(index, field, value) {
+    const next = this.savedSearchDrafts.map((item) => ({ ...item }));
+    if (!next[index]) {
+      return;
+    }
+    next[index][field] = field === "pinned" ? value === true : String(value || "");
+    this.savedSearchDrafts = next;
+    this.savedSearchesDirty = true;
+  }
+
+  _addCurrentSearch() {
+    const query = (this.query || "").trim() || "in:inbox";
+    const next = this.savedSearchDrafts.map((item) => ({ ...item }));
+    next.push({ name: this._nextSavedSearchName(next), query, pinned: true });
+    this.savedSearchDrafts = next;
+    this.savedSearchesDirty = true;
+    this.updateComplete.then(() => {
+      const inputs = this.renderRoot?.querySelectorAll('input[aria-label="Saved search name"]');
+      const target = inputs?.[inputs.length - 1];
+      if (target && typeof target.focus === "function") {
+        target.focus();
+        target.select();
+      }
+    });
+  }
+
+  _nextSavedSearchName(existing) {
+    const names = new Set(existing.map((item) => this._normalizeSavedSearch(item).name));
+    let index = existing.length + 1;
+    let candidate = `Saved search ${index}`;
+    while (names.has(candidate)) {
+      index += 1;
+      candidate = `Saved search ${index}`;
+    }
+    return candidate;
+  }
+
+  _removeSavedSearch(index) {
+    this.savedSearchDrafts = this.savedSearchDrafts.filter((_, i) => i !== index);
+    this.savedSearchesDirty = true;
+  }
+
+  async _saveAndClose() {
+    if (await this._saveSavedSearches()) {
+      this._closeSavedSearches();
+    }
+  }
+
+  async _applySavedSearch(item) {
+    const normalized = this._normalizeSavedSearch(item);
+    if (!normalized.query) {
+      return;
+    }
+    // Compute before assigning this.query so same-query pinned shortcuts
+    // remain a true no-op while still preserving focus on the clicked button.
+    const sameQuery = (this.query || "").trim() === normalized.query;
+    this.query = normalized.query;
+    if (this.savedSearchesOpen) {
+      this._closeSavedSearches();
+    } else {
+      this._focusCustomSearch(normalized.name);
+    }
+    if (!sameQuery) {
+      this._emit("wavy-saved-search-selected", {
+        folderId: "",
+        kind: "custom",
+        label: normalized.name || normalized.query,
+        query: normalized.query,
+        savedSearchName: normalized.name
+      });
+    }
+  }
+
+  _focusCustomSearch(name) {
+    if (!name) {
+      return;
+    }
+    this.updateComplete.then(() => {
+      const target = Array.from(this.renderRoot?.querySelectorAll(".custom-search") || []).find(
+        (button) => button.dataset.savedSearchName === name
+      );
+      if (target && typeof target.focus === "function") {
+        target.focus();
+      }
+    });
+  }
+
+  _onSavedDialogKeydown(evt) {
+    if (evt.key === "Escape") {
+      evt.preventDefault();
+      this._closeSavedSearches();
+      return;
+    }
+    if (evt.key !== "Tab") {
+      return;
+    }
+    const controls = Array.from(
+      evt.currentTarget.querySelectorAll(
+        'button:not([disabled]), input:not([disabled]), [href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((control) => control.getClientRects().length > 0);
+    if (controls.length === 0) {
+      return;
+    }
+    const first = controls[0];
+    const last = controls[controls.length - 1];
+    const active = this.renderRoot?.activeElement || document.activeElement;
+    if (evt.shiftKey && active === first) {
+      evt.preventDefault();
+      last.focus();
+    } else if (!evt.shiftKey && active === last) {
+      evt.preventDefault();
+      first.focus();
+    }
   }
 
   render() {
+    const explicitSort = this._explicitSortToken().toLowerCase();
+    const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
       <div class="search">
         <span class="waveform" aria-hidden="true">
@@ -487,15 +1119,44 @@ export class WavySearchRail extends LitElement {
         >
           ${SEARCH_RAIL_ICON_REFRESH}
         </button>
-        <button
-          type="button"
-          data-digest-action="sort"
-          aria-label="Sort waves"
-          title="Sort waves"
-          @click=${this._onSortClick}
-        >
-          ${SEARCH_RAIL_ICON_SORT}
-        </button>
+        <span class="sort-wrap">
+          <button
+            type="button"
+            data-digest-action="sort"
+            aria-label="Sort waves"
+            title="Sort waves"
+            aria-haspopup="menu"
+            aria-controls="wavy-search-sort-menu"
+            aria-expanded=${this.sortOpen ? "true" : "false"}
+            @click=${this._toggleSortMenu}
+          >
+            ${SEARCH_RAIL_ICON_SORT}
+          </button>
+          ${this.sortOpen
+            ? html`<div
+                class="sort-menu"
+                id="wavy-search-sort-menu"
+                role="menu"
+                aria-label="Sort waves"
+                @keydown=${this._onSortMenuKeydown}
+                @focusout=${this._onSortMenuFocusout}
+              >
+                ${WavySearchRail.SORTS.map((sort) => html`
+                  <button
+                    type="button"
+                    class="sort-option"
+                    role="menuitemradio"
+                    aria-checked=${explicitSort === sort.token.toLowerCase() ? "true" : "false"}
+                    data-sort-token=${sort.token}
+                    @click=${() => this._applySort(sort)}
+                  >
+                    <span>${sort.label}</span>
+                    ${explicitSort === sort.token.toLowerCase() ? html`<span aria-hidden="true">✓</span>` : null}
+                  </button>
+                `)}
+              </div>`
+            : null}
+        </span>
         <button
           type="button"
           data-digest-action="filter"
@@ -523,7 +1184,8 @@ export class WavySearchRail extends LitElement {
         <button
           type="button"
           class="manage-saved"
-          @click=${() => this._emit("wavy-manage-saved-searches-requested")}
+          aria-haspopup="dialog"
+          @click=${this._openSavedSearches}
         >
           Manage saved searches
         </button>
@@ -566,6 +1228,27 @@ export class WavySearchRail extends LitElement {
           `;
         })}
       </ul>
+      ${pinnedSearches.length > 0
+        ? html`
+            <ul class="custom-searches" aria-label="Pinned saved searches">
+              ${pinnedSearches.map((item) => html`
+                <li>
+                  <button
+                    type="button"
+                    class="custom-search"
+                    data-saved-search-name=${item.name}
+                    data-query=${item.query}
+                    aria-label=${`Apply saved search ${item.name} (${item.query})`}
+                    @click=${() => this._applySavedSearch(item)}
+                  >
+                    <span class="custom-name">${item.name}</span>
+                    <span class="custom-query">${item.query}</span>
+                  </button>
+                </li>
+              `)}
+            </ul>
+          `
+        : null}
       <slot name="cards"></slot>
       <details
         class="filters"
@@ -597,6 +1280,99 @@ export class WavySearchRail extends LitElement {
         </div>
       </details>
       <p class="result-count" aria-live="polite">${this.resultCount || ""}</p>
+      ${this.savedSearchesOpen ? this._renderSavedSearchesDialog() : null}
+    `;
+  }
+
+  _renderSavedSearchesDialog() {
+    return html`
+      <div class="saved-overlay" @click=${(evt) => {
+        if (evt.target === evt.currentTarget) {
+          this._closeSavedSearches();
+        }
+      }}>
+        <section
+          class="saved-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="saved-searches-title"
+          @keydown=${this._onSavedDialogKeydown}
+        >
+          <div class="saved-header">
+            <h3 class="saved-title" id="saved-searches-title">Manage saved searches</h3>
+            <button type="button" class="saved-button" aria-label="Close saved searches" @click=${this._closeSavedSearches}>×</button>
+          </div>
+          <div class="saved-body">
+            ${this.savedSearchesError ? html`<p class="saved-error" role="alert">${this.savedSearchesError}</p>` : null}
+            ${this.savedSearchesDirty
+              ? html`<p class="saved-hint" role="status" aria-live="polite">Apply closes this dialog and discards unsaved edits. Use Save to persist them.</p>`
+              : null}
+            ${this.savedSearchesLoading ? html`<p class="saved-empty">Loading saved searches…</p>` : null}
+            ${!this.savedSearchesLoading && !this.savedSearchesError && this.savedSearchDrafts.length === 0
+              ? html`<p class="saved-empty">No saved searches yet. Add the current query to create one.</p>`
+              : null}
+            ${this.savedSearchDrafts.map((item, index) => html`
+              <div class="saved-row" data-saved-search-row>
+                <input
+                  type="text"
+                  aria-label="Saved search name"
+                  .value=${item.name}
+                  @input=${(evt) => this._updateSavedSearch(index, "name", evt.target.value)}
+                />
+                <input
+                  type="text"
+                  aria-label="Saved search query"
+                  .value=${item.query}
+                  @input=${(evt) => this._updateSavedSearch(index, "query", evt.target.value)}
+                />
+                <label>
+                  <input
+                    type="checkbox"
+                    .checked=${item.pinned}
+                    @change=${(evt) => this._updateSavedSearch(index, "pinned", evt.target.checked)}
+                  />
+                  Pin
+                </label>
+                <button
+                  type="button"
+                  class="saved-button"
+                  aria-label=${`Apply ${item.name || item.query || "saved search"}`}
+                  @click=${() => this._applySavedSearch(item)}
+                >
+                  Apply
+                </button>
+                <button
+                  type="button"
+                  class="saved-button"
+                  aria-label=${`Remove ${item.name || item.query || "saved search"}`}
+                  @click=${() => this._removeSavedSearch(index)}
+                >
+                  Remove
+                </button>
+              </div>
+            `)}
+          </div>
+          <div class="saved-footer">
+            <button
+              type="button"
+              class="saved-button"
+              ?disabled=${this.savedSearchesLoading}
+              @click=${this._addCurrentSearch}
+            >
+              Add current search
+            </button>
+            <button type="button" class="saved-button" @click=${this._closeSavedSearches}>Cancel</button>
+            <button
+              type="button"
+              class="saved-button primary"
+              ?disabled=${this.savedSearchesLoading}
+              @click=${this._saveAndClose}
+            >
+              Save
+            </button>
+          </div>
+        </section>
+      </div>
     `;
   }
 }

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -1112,15 +1112,40 @@ describe("<wavy-search-rail>", () => {
       expect(evt.detail.query).to.equal("in:inbox orderby:datedesc");
     });
 
-    it("choosing the default sort with no orderby writes an explicit token", async () => {
+    it("default sort option shows aria-checked=true when query has no orderby token", async () => {
       const el = await fixture(html`<wavy-search-rail query="in:inbox"></wavy-search-rail>`);
       await el.updateComplete;
       el.renderRoot.querySelector('[data-digest-action="sort"]').click();
       await el.updateComplete;
       const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
-      setTimeout(() => newestActivity.click(), 0);
-      const evt = await oneEvent(el, "wavy-search-submit");
-      expect(evt.detail.query).to.equal("in:inbox orderby:datedesc");
+      const oldest = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
+      expect(newestActivity.getAttribute("aria-checked")).to.equal("true");
+      expect(oldest.getAttribute("aria-checked")).to.equal("false");
+    });
+
+    it("choosing the implicit default sort with no orderby closes without re-submitting", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox"></wavy-search-rail>`);
+      await el.updateComplete;
+      let submitCount = 0;
+      let sortRequestedCount = 0;
+      el.addEventListener("wavy-search-submit", () => {
+        submitCount += 1;
+      });
+      el.addEventListener("wavy-search-sort-requested", () => {
+        sortRequestedCount += 1;
+      });
+      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
+      sort.click();
+      await el.updateComplete;
+      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
+      newestActivity.click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(el.query).to.equal("in:inbox");
+      expect(submitCount).to.equal(0);
+      expect(sortRequestedCount).to.equal(0);
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+      expect(el.renderRoot.activeElement).to.equal(sort);
     });
 
     it("focuses the explicitly checked sort option when reopening the menu", async () => {

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -1,6 +1,8 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
 import "../src/elements/wavy-search-rail.js";
 
+const waitForMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("<wavy-search-rail>", () => {
   it("registers the F-2.S3 search-rail element", () => {
     expect(customElements.get("wavy-search-rail")).to.exist;
@@ -79,12 +81,626 @@ describe("<wavy-search-rail>", () => {
   });
 
   it("Manage saved searches click emits wavy-manage-saved-searches-requested (B.4)", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response("[]", {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      const manage = el.renderRoot.querySelector(".manage-saved");
+      setTimeout(() => manage.click(), 0);
+      const evt = await oneEvent(el, "wavy-manage-saved-searches-requested");
+      expect(evt).to.exist;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("Manage saved searches opens a dialog populated from /searches", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      expect(url).to.equal("/searches");
+      return new Response(
+        JSON.stringify([{ name: "Mine", query: "creator:me", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const dialog = el.renderRoot.querySelector('[role="dialog"]');
+      expect(dialog, "saved-search dialog opens").to.exist;
+      expect(dialog.textContent).to.contain("Manage saved searches");
+      expect(dialog.querySelector('input[aria-label="Saved search name"]').value).to.equal("Mine");
+      expect(dialog.querySelector('input[aria-label="Saved search query"]').value).to.equal("creator:me");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("surfaces malformed saved-search rows from /searches instead of dropping them", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(
+      JSON.stringify([{ name: "", query: "tag:needs-name", pinned: true }]),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const dialog = el.renderRoot.querySelector('[role="dialog"]');
+      expect(dialog).to.exist;
+      expect(dialog.querySelector(".saved-error").textContent).to.contain(
+        "need both a name and a query"
+      );
+      expect(dialog.querySelector('input[aria-label="Saved search name"]').value).to.equal("");
+      expect(dialog.querySelector('input[aria-label="Saved search query"]').value).to.equal("tag:needs-name");
+      expect(dialog.querySelector(".saved-row .saved-button").getAttribute("aria-label")).to.equal(
+        "Apply tag:needs-name"
+      );
+      expect(
+        Array.from(dialog.querySelectorAll(".saved-row .saved-button"))
+          .at(-1)
+          .getAttribute("aria-label")
+      ).to.equal("Remove tag:needs-name");
+      expect(el.renderRoot.querySelector(".custom-search")).to.be.null;
+      el.renderRoot.querySelector('button[aria-label="Close saved searches"]').click();
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await el.updateComplete;
+      const reopened = el.renderRoot.querySelector('[role="dialog"]');
+      expect(reopened.querySelector(".saved-error").textContent).to.contain(
+        "need both a name and a query"
+      );
+      expect(reopened.querySelector('input[aria-label="Saved search query"]').value).to.equal("tag:needs-name");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("renders pinned saved searches as quick-access buttons that apply queries", async () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     await el.updateComplete;
-    const manage = el.renderRoot.querySelector(".manage-saved");
-    setTimeout(() => manage.click(), 0);
-    const evt = await oneEvent(el, "wavy-manage-saved-searches-requested");
-    expect(evt).to.exist;
+    el.savedSearches = [
+      { name: "Bugs", query: "tag:bug", pinned: true },
+      { name: "Hidden", query: "tag:hidden", pinned: false }
+    ];
+    await el.updateComplete;
+    const buttons = Array.from(el.renderRoot.querySelectorAll(".custom-search"));
+    expect(buttons.map((button) => button.dataset.savedSearchName)).to.deep.equal(["Bugs"]);
+    expect(buttons[0].getAttribute("aria-label")).to.equal("Apply saved search Bugs (tag:bug)");
+    setTimeout(() => buttons[0].click(), 0);
+    const evt = await oneEvent(el, "wavy-saved-search-selected");
+    expect(evt.detail.folderId).to.equal("");
+    expect(evt.detail.kind).to.equal("custom");
+    expect(evt.detail.label).to.equal("Bugs");
+    expect(evt.detail.query).to.equal("tag:bug");
+    expect(evt.detail.savedSearchName).to.equal("Bugs");
+  });
+
+  it("keeps focus on pinned saved search buttons and suppresses same-query apply", async () => {
+    const el = await fixture(html`<wavy-search-rail query="tag:bug"></wavy-search-rail>`);
+    await el.updateComplete;
+    el.savedSearches = [{ name: "Bugs", query: "tag:bug", pinned: true }];
+    await el.updateComplete;
+    let selectedCount = 0;
+    el.addEventListener("wavy-saved-search-selected", () => {
+      selectedCount += 1;
+    });
+    const button = el.renderRoot.querySelector(".custom-search");
+    button.click();
+    await waitForMicrotasks();
+    await el.updateComplete;
+    expect(selectedCount).to.equal(0);
+    expect(el.renderRoot.activeElement).to.equal(button);
+  });
+
+  it("autoloads pinned saved searches when requested by SSR", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(
+      JSON.stringify([{ name: "Auto", query: "tag:auto", pinned: true }]),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+    const el = await fixture(html`<wavy-search-rail autoload-saved-searches></wavy-search-rail>`);
+    try {
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const button = el.renderRoot.querySelector(".custom-search");
+      expect(button, "autoloaded pinned saved search renders").to.exist;
+      expect(button.dataset.savedSearchName).to.equal("Auto");
+      expect(button.dataset.query).to.equal("tag:auto");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not autoload saved searches without the SSR opt-in attribute", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return new Response("[]", {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    };
+    try {
+      await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+      await waitForMicrotasks();
+      expect(calls).to.equal(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("treats unauthorized saved-search autoload as an empty list", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return new Response("", { status: 401 });
+    };
+    const el = await fixture(html`<wavy-search-rail autoload-saved-searches></wavy-search-rail>`);
+    try {
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(el.savedSearches).to.deep.equal([]);
+      expect(el.savedSearchesError).to.equal("");
+      expect(el._savedSearchesLoaded).to.equal(false);
+      await el._loadSavedSearches();
+      expect(calls).to.equal(2);
+      expect(el.renderRoot.querySelector(".custom-search")).to.be.null;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows a sign-in message when saved-search management is unauthorized", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response("", { status: 401 });
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const dialog = el.renderRoot.querySelector('[role="dialog"]');
+      expect(dialog).to.exist;
+      expect(dialog.querySelector(".saved-error").textContent).to.equal(
+        "Sign in to manage saved searches."
+      );
+      expect(dialog.querySelector(".saved-empty")).to.be.null;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not wipe a cached saved-search list after a later unauthorized reload", async () => {
+    const originalFetch = globalThis.fetch;
+    const responses = [
+      new Response(
+        JSON.stringify([{ name: "Cached", query: "tag:cached", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+      new Response("", { status: 401 })
+    ];
+    globalThis.fetch = async () => responses.shift();
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el._loadSavedSearches();
+      expect(el.savedSearches[0].name).to.equal("Cached");
+      el.savedSearchesOpen = true;
+      await el._loadSavedSearches(true);
+      expect(el.savedSearches[0].name).to.equal("Cached");
+      expect(el.savedSearchesError).to.equal("Sign in to refresh saved searches.");
+      expect(el._savedSearchesLoaded).to.equal(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps malformed saved-search warnings after an unauthorized forced reload", async () => {
+    const originalFetch = globalThis.fetch;
+    const responses = [
+      new Response(
+        JSON.stringify([{ name: "", query: "tag:needs-name", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      ),
+      new Response("", { status: 401 })
+    ];
+    globalThis.fetch = async () => responses.shift();
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el._loadSavedSearches();
+      expect(el.savedSearchesError).to.contain("need both a name and a query");
+      await el._loadSavedSearches(true);
+      expect(el.savedSearchesError).to.contain("need both a name and a query");
+      expect(el.savedSearchDrafts[0].query).to.equal("tag:needs-name");
+      expect(el._savedSearchesLoaded).to.equal(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("surfaces a friendly saved-search load failure message", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response("", { status: 500 });
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".saved-error").textContent).to.equal(
+        "Unable to load saved searches."
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("saves an added current search through /searches", async () => {
+    const originalFetch = globalThis.fetch;
+    const posts = [];
+    globalThis.fetch = async (url, options = {}) => {
+      if (!options.method || options.method === "GET") {
+        return new Response("[]", {
+          status: 200,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      posts.push({ url, options });
+      return new Response("", { status: 200 });
+    };
+    const el = await fixture(html`<wavy-search-rail query="tag:work"></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      const manage = el.renderRoot.querySelector(".manage-saved");
+      manage.click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      await waitForMicrotasks();
+      await el.updateComplete;
+      el.renderRoot.querySelector(".saved-footer .saved-button").click();
+      await el.updateComplete;
+      el.renderRoot.querySelector(".saved-button.primary").click();
+      await waitForMicrotasks();
+      expect(posts.length).to.equal(1);
+      expect(posts[0].url).to.equal("/searches");
+      expect(posts[0].options.method).to.equal("POST");
+      expect(JSON.parse(posts[0].options.body)).to.deep.equal([
+        { name: "Saved search 1", query: "tag:work", pinned: true }
+      ]);
+      await el.updateComplete;
+      await waitForMicrotasks();
+      expect(el.renderRoot.activeElement).to.equal(manage);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("applying a dirty saved-search draft does not persist it implicitly", async () => {
+    const originalFetch = globalThis.fetch;
+    const posts = [];
+    globalThis.fetch = async (url, options = {}) => {
+      if (options.method === "POST") {
+        posts.push({ url, options });
+        return new Response("", { status: 200 });
+      }
+      return new Response(
+        JSON.stringify([{ name: "Draft", query: "tag:old", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      const manage = el.renderRoot.querySelector(".manage-saved");
+      manage.click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const queryInput = el.renderRoot.querySelector('input[aria-label="Saved search query"]');
+      queryInput.value = "tag:new";
+      queryInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".saved-hint").textContent).to.contain(
+        "discards unsaved edits"
+      );
+      expect(el.renderRoot.querySelector(".saved-hint").getAttribute("role")).to.equal("status");
+      setTimeout(() => el.renderRoot.querySelector(".saved-row .saved-button").click(), 0);
+      const evt = await oneEvent(el, "wavy-saved-search-selected");
+      expect(evt.detail.query).to.equal("tag:new");
+      expect(posts.length).to.equal(0);
+      await el.updateComplete;
+      await waitForMicrotasks();
+      expect(el.renderRoot.activeElement).to.equal(manage);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shows validation instead of dropping invalid saved-search rows", async () => {
+    const originalFetch = globalThis.fetch;
+    let postCount = 0;
+    globalThis.fetch = async (_url, options = {}) => {
+      if (options.method === "POST") {
+        postCount += 1;
+        return new Response("", { status: 200 });
+      }
+      return new Response(
+        JSON.stringify([{ name: "Broken", query: "tag:work", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const nameInput = el.renderRoot.querySelector('input[aria-label="Saved search name"]');
+      nameInput.value = "";
+      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+      el.renderRoot.querySelector(".saved-button.primary").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(postCount).to.equal(0);
+      expect(el.renderRoot.querySelector(".saved-error").textContent).to.contain(
+        "needs both a name and a query"
+      );
+      expect(el.renderRoot.querySelector(".saved-error").getAttribute("role")).to.equal("alert");
+      expect(el.renderRoot.querySelector('[role="dialog"]')).to.exist;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("dedupes concurrent saved-search loads", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    let resolveFetch;
+    const responseReady = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    globalThis.fetch = async () => {
+      calls += 1;
+      await responseReady;
+      return new Response("[]", {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      const first = el._loadSavedSearches();
+      const second = el._loadSavedSearches();
+      expect(calls).to.equal(1);
+      resolveFetch();
+      await Promise.all([first, second]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("shares saved-search load failures across concurrent callers without rejecting", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return new Response("", { status: 500 });
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      const first = el._loadSavedSearches();
+      const second = el._loadSavedSearches();
+      await Promise.all([first, second]);
+      expect(calls).to.equal(1);
+      expect(el.savedSearchesError).to.equal("Unable to load saved searches.");
+      expect(el.savedSearchesLoading).to.equal(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps a forced saved-search reload in flight when an older load finishes", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    let resolveFirst;
+    let resolveSecond;
+    const firstReady = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondReady = new Promise((resolve) => {
+      resolveSecond = resolve;
+    });
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        await firstReady;
+        return new Response(
+          JSON.stringify([{ name: "Old", query: "tag:old", pinned: true }]),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      await secondReady;
+      return new Response(
+        JSON.stringify([{ name: "Fresh", query: "tag:fresh", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      const first = el._loadSavedSearches();
+      const second = el._loadSavedSearches(true);
+      expect(calls).to.equal(2);
+      resolveFirst();
+      await first;
+      expect(el.savedSearchesLoading).to.equal(true);
+      const third = el._loadSavedSearches();
+      expect(calls).to.equal(2);
+      resolveSecond();
+      await Promise.all([second, third]);
+      expect(el.savedSearches[0].name).to.equal("Fresh");
+      expect(el.savedSearchesLoading).to.equal(false);
+      expect(el._savedSearchesLoadPromise).to.equal(null);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not let an older saved-search load overwrite a newer forced reload", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    let resolveFirst;
+    let resolveSecond;
+    const firstReady = new Promise((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondReady = new Promise((resolve) => {
+      resolveSecond = resolve;
+    });
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        await firstReady;
+        return new Response(
+          JSON.stringify([{ name: "Old", query: "tag:old", pinned: true }]),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      await secondReady;
+      return new Response(
+        JSON.stringify([{ name: "Fresh", query: "tag:fresh", pinned: true }]),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      const first = el._loadSavedSearches();
+      const second = el._loadSavedSearches(true);
+      resolveSecond();
+      await second;
+      expect(el.savedSearches[0].name).to.equal("Fresh");
+      expect(el.savedSearchesLoading).to.equal(false);
+      resolveFirst();
+      await first;
+      expect(el.savedSearches[0].name).to.equal("Fresh");
+      expect(calls).to.equal(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("disables adding saved searches until the dialog load settles", async () => {
+    const originalFetch = globalThis.fetch;
+    let resolveFetch;
+    const responseReady = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    globalThis.fetch = async () => {
+      await responseReady;
+      return new Response("[]", {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    };
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await el.updateComplete;
+      const add = el.renderRoot.querySelector(".saved-footer .saved-button");
+      expect(add.disabled).to.equal(true);
+      resolveFetch();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".saved-footer .saved-button").disabled).to.equal(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("clears stale saved-search errors on cached reopen", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    el.savedSearches = [{ name: "Cached", query: "tag:cached", pinned: true }];
+    el.savedSearchesError = "Previous failure";
+    el._savedSearchesLoaded = true;
+    await el._loadSavedSearches();
+    expect(el.savedSearchesError).to.equal("");
+    expect(el.savedSearchDrafts[0].name).to.equal("Cached");
+  });
+
+  it("does not overwrite dirty drafts on cached saved-search reload", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    el.savedSearches = [{ name: "Cached", query: "tag:cached", pinned: true }];
+    el.savedSearchDrafts = [{ name: "Dirty", query: "tag:dirty", pinned: true }];
+    el.savedSearchesDirty = true;
+    el._savedSearchesLoaded = true;
+    await el._loadSavedSearches();
+    expect(el.savedSearchDrafts[0].name).to.equal("Dirty");
+  });
+
+  it("opening saved-search management closes the sort menu", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response("[]", {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
+      el.renderRoot.querySelector(".manage-saved").click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+      expect(el.renderRoot.querySelector('[role="dialog"]')).to.exist;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("close button restores focus and discards dirty saved-search drafts", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(
+      JSON.stringify([{ name: "Close me", query: "tag:close", pinned: true }]),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    try {
+      await el.updateComplete;
+      const manage = el.renderRoot.querySelector(".manage-saved");
+      manage.click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      await waitForMicrotasks();
+      await el.updateComplete;
+      const nameInput = el.renderRoot.querySelector('input[aria-label="Saved search name"]');
+      nameInput.value = "Unsaved";
+      nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+      await el.updateComplete;
+      el.renderRoot.querySelector('button[aria-label="Close saved searches"]').click();
+      await el.updateComplete;
+      await waitForMicrotasks();
+      expect(el.renderRoot.activeElement).to.equal(manage);
+      expect(el.savedSearchesDirty).to.equal(false);
+      expect(el.savedSearchDrafts[0].name).to.equal("Close me");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("Refresh click emits wavy-search-refresh-requested (B.11)", async () => {
@@ -461,16 +1077,136 @@ describe("<wavy-search-rail>", () => {
       const filter = el.renderRoot.querySelector('[data-digest-action="filter"]');
       expect(refresh.getAttribute("aria-label")).to.equal("Refresh search results");
       expect(sort.getAttribute("aria-label")).to.equal("Sort waves");
+      expect(sort.getAttribute("aria-haspopup")).to.equal("menu");
+      expect(sort.getAttribute("aria-controls")).to.equal("wavy-search-sort-menu");
       expect(filter.getAttribute("aria-label")).to.equal("Filter waves");
     });
 
-    it("Sort button click emits wavy-search-sort-requested", async () => {
+    it("Sort button opens options and applying one submits an orderby query", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:datedesc"></wavy-search-rail>`);
+      await el.updateComplete;
+      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
+      sort.click();
+      await el.updateComplete;
+      const createdOldest = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
+      expect(createdOldest, "created oldest sort option mounts").to.exist;
+      setTimeout(() => createdOldest.click(), 0);
+      const evt = await oneEvent(el, "wavy-search-submit");
+      expect(evt.detail.query).to.equal("in:inbox orderby:createdasc");
+      await el.updateComplete;
+      await waitForMicrotasks();
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+      expect(el.renderRoot.activeElement).to.equal(sort);
+    });
+
+    it("applying the default sort writes an explicit orderby token", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:dateasc"></wavy-search-rail>`);
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
+      await el.updateComplete;
+      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
+      expect(newestActivity.getAttribute("aria-checked")).to.equal("false");
+      expect(newestActivity.hasAttribute("aria-current")).to.equal(false);
+      setTimeout(() => newestActivity.click(), 0);
+      const evt = await oneEvent(el, "wavy-search-submit");
+      expect(evt.detail.query).to.equal("in:inbox orderby:datedesc");
+    });
+
+    it("choosing the default sort with no orderby writes an explicit token", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox"></wavy-search-rail>`);
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
+      await el.updateComplete;
+      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
+      setTimeout(() => newestActivity.click(), 0);
+      const evt = await oneEvent(el, "wavy-search-submit");
+      expect(evt.detail.query).to.equal("in:inbox orderby:datedesc");
+    });
+
+    it("focuses the explicitly checked sort option when reopening the menu", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:createdasc"></wavy-search-rail>`);
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
+      await el.updateComplete;
+      await waitForMicrotasks();
+      const selected = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
+      const unchecked = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
+      expect(selected.getAttribute("aria-checked")).to.equal("true");
+      expect(unchecked.getAttribute("aria-checked")).to.equal("false");
+      expect(el.renderRoot.activeElement).to.equal(selected);
+    });
+
+    it("choosing the current sort closes the menu without re-submitting", async () => {
+      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:datedesc"></wavy-search-rail>`);
+      await el.updateComplete;
+      let submitCount = 0;
+      let sortRequestedCount = 0;
+      el.addEventListener("wavy-search-submit", () => {
+        submitCount += 1;
+      });
+      el.addEventListener("wavy-search-sort-requested", () => {
+        sortRequestedCount += 1;
+      });
+      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
+      sort.click();
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]').click();
+      await waitForMicrotasks();
+      await el.updateComplete;
+      expect(submitCount).to.equal(0);
+      expect(sortRequestedCount).to.equal(0);
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+      expect(el.renderRoot.activeElement).to.equal(sort);
+    });
+
+    it("Escape and outside click close the sort menu", async () => {
       const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
       await el.updateComplete;
       const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      setTimeout(() => sort.click(), 0);
-      const evt = await oneEvent(el, "wavy-search-sort-requested");
-      expect(evt).to.exist;
+      sort.click();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+
+      sort.click();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
+      document.body.click();
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+    });
+
+    it("focus leaving the sort menu closes it", async () => {
+      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+      await el.updateComplete;
+      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
+      sort.click();
+      await el.updateComplete;
+      const menu = el.renderRoot.querySelector(".sort-menu");
+      const filter = el.renderRoot.querySelector('[data-digest-action="filter"]');
+      menu.dispatchEvent(new FocusEvent("focusout", {
+        bubbles: true,
+        composed: true,
+        relatedTarget: filter
+      }));
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
+    });
+
+    it("Arrow keys move through sort options", async () => {
+      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+      await el.updateComplete;
+      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
+      await el.updateComplete;
+      const menu = el.renderRoot.querySelector(".sort-menu");
+      const options = Array.from(menu.querySelectorAll(".sort-option"));
+      options[0].focus();
+      menu.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+      expect(el.renderRoot.activeElement).to.equal(options[1]);
+      menu.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+      expect(el.renderRoot.activeElement).to.equal(options[options.length - 1]);
     });
 
     it("Filter button click toggles the chip strip open and emits an event", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchViewListener.java
@@ -28,7 +28,9 @@ public interface J2clSearchViewListener {
    * keyboard focus to the new folder. The default forwards to
    * {@code onQuerySubmitted} so older listeners keep compiling.
    *
-   * @param folderId stable identifier from the rail (e.g. {@code "mentions"})
+   * @param folderId stable built-in identifier from the rail (for example
+   *     {@code "mentions"}); custom saved searches pass an empty folder id and
+   *     rely on {@code label}/{@code query}.
    * @param label    user-visible label for screen-reader announcement
    * @param query    canonical query token for the folder (e.g. {@code "mentions:me"})
    */

--- a/wave/config/changelog.d/2026-05-01-j2cl-search-controls-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-search-controls-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-search-controls-parity",
+  "version": "Issue #1162",
+  "date": "2026-05-01",
+  "title": "J2CL search controls and saved searches parity",
+  "summary": "Makes the J2CL search rail controls functional for saved-search management and wave sorting while preserving the existing GWT route.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Adds a J2CL Manage saved searches dialog backed by the existing /searches endpoint, including pinned saved-search shortcuts in the search rail.",
+        "Replaces the placeholder J2CL sort affordance with a keyboard-accessible sort menu that writes supported orderby tokens and submits the updated query."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3610,7 +3610,7 @@ public final class HtmlRenderer {
       // <shell-nav-rail> wrapper is preserved so future slices can
       // co-mount additional nav-area elements alongside the rail.
       sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-      appendWavySearchRail(sb, safeInitialQuery, railCardsEnabled);
+      appendWavySearchRail(sb, safeInitialQuery, railCardsEnabled, true);
       sb.append("  </shell-nav-rail>\n");
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
@@ -3870,7 +3870,7 @@ public final class HtmlRenderer {
         sb, resolvedAddress, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, "en");
     sb.append("  </shell-header>\n");
     sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
-    appendWavySearchRail(sb, safeInitialQuery, false);
+    appendWavySearchRail(sb, safeInitialQuery, false, false);
     sb.append("  </shell-nav-rail>\n");
     appendWavySearchHelpModal(sb);
     sb.append("  <shell-main-region slot=\"main\">\n");
@@ -4325,13 +4325,19 @@ public final class HtmlRenderer {
    * light DOM covers B.1–B.12.
    */
   private static void appendWavySearchRail(
-      StringBuilder sb, String safeInitialQuery, boolean railCardsEnabled) {
+      StringBuilder sb,
+      String safeInitialQuery,
+      boolean railCardsEnabled,
+      boolean autoloadSavedSearches) {
     // Derive the active folder from the initial query so the SSR folder highlight
     // matches the query pre-upgrade (mirrors WavySearchRail._deriveActiveFolder).
     String activeFolder = deriveActiveFolder(safeInitialQuery);
     sb.append("    <wavy-search-rail query=\"").append(safeInitialQuery)
         .append("\" data-active-folder=\"").append(activeFolder)
         .append("\" result-count=\"\"");
+    if (autoloadSavedSearches) {
+      sb.append(" autoload-saved-searches");
+    }
     if (railCardsEnabled) {
       // J-UI-1 (#1079): when the flag is on the J2CL search panel projects
       // <wavy-search-rail-card> instances into this rail's `cards` slot
@@ -4357,12 +4363,12 @@ public final class HtmlRenderer {
     // so the parity test resolves it on both views with one selector.
     sb.append("      <div class=\"action-row\" role=\"group\" aria-label=\"Search actions\" data-digest-action-row>\n");
     sb.append("        <button type=\"button\" data-digest-action=\"refresh\" aria-label=\"Refresh search results\" title=\"Refresh search results\">↻</button>\n");
-    sb.append("        <button type=\"button\" data-digest-action=\"sort\" aria-label=\"Sort waves\" title=\"Sort waves\">⇅</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"sort\" aria-label=\"Sort waves\" title=\"Sort waves\" aria-haspopup=\"menu\">⇅</button>\n");
     sb.append("        <button type=\"button\" data-digest-action=\"filter\" aria-label=\"Filter waves\" title=\"Filter waves\" aria-pressed=\"false\" aria-expanded=\"false\" aria-controls=\"wavy-search-filter-strip\">▽</button>\n");
     sb.append("      </div>\n");
     sb.append("      <div class=\"actions\">\n");
     sb.append("        <button type=\"button\" class=\"new-wave\" data-shortcut=\"Shift+Cmd+O\" aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\">New Wave</button>\n");
-    sb.append("        <button type=\"button\" class=\"manage-saved\">Manage saved searches</button>\n");
+    sb.append("        <button type=\"button\" class=\"manage-saved\" aria-haspopup=\"dialog\">Manage saved searches</button>\n");
     sb.append("      </div>\n");
     sb.append("      <div class=\"folders-header\">\n");
     sb.append("        <h2 id=\"folders-title\">Saved searches</h2>\n");

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -200,6 +200,20 @@ public final class J2clSearchRailParityTest {
     assertTrue(
         "Rail defaults to data-active-folder=inbox",
         html.contains("data-active-folder=\"inbox\""));
+    assertTrue(
+        "J2CL rail opts in to saved-search autoload for pinned custom searches",
+        html.contains("autoload-saved-searches"));
+  }
+
+  @Test
+  public void readSurfacePreviewRailDoesNotAutoloadSavedSearches() throws Exception {
+    String html = renderReadSurfacePreviewShell();
+    assertTrue(
+        "Read-surface preview keeps the search rail mounted for visual parity",
+        html.contains("<wavy-search-rail "));
+    assertFalse(
+        "Read-surface preview is a static fixture and must not fetch /searches",
+        html.contains("autoload-saved-searches"));
   }
 
   /**
@@ -597,6 +611,13 @@ public final class J2clSearchRailParityTest {
     return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise());
   }
 
+  private static String renderReadSurfacePreviewShell() throws Exception {
+    WaveletProvider provider = providerForWave(buildWaveletData(6));
+    J2clSelectedWaveSnapshotRenderer renderer = new J2clSelectedWaveSnapshotRenderer(provider);
+    WaveClientServlet servlet = createServlet(VIEWER, renderer);
+    return invokeServlet(servlet, "j2cl-root", WAVE_ID.serialise(), "read-surface-preview");
+  }
+
   private static WaveClientServlet createServletWithRailCardsFlag(
       ParticipantId user, J2clSelectedWaveSnapshotRenderer snapshotRenderer) throws Exception {
     Config config = ConfigFactory.parseString(
@@ -797,12 +818,18 @@ public final class J2clSearchRailParityTest {
 
   private static String invokeServlet(WaveClientServlet servlet, String view, String waveId)
       throws Exception {
+    return invokeServlet(servlet, view, waveId, null);
+  }
+
+  private static String invokeServlet(
+      WaveClientServlet servlet, String view, String waveId, String query) throws Exception {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getParameter("view")).thenReturn(view);
     when(request.getParameterValues("view")).thenReturn(new String[]{view});
     when(request.getParameter("wave")).thenReturn(waveId);
+    when(request.getParameter("q")).thenReturn(query);
     when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getSession(false)).thenReturn(mock(HttpSession.class));
     when(response.getWriter()).thenReturn(new PrintWriter(body));


### PR DESCRIPTION
Closes #1162.
Part of #904.

## Summary
- Make the J2CL search rail controls functional for the parity lane: New Wave event, sort menu, filter-strip toggle, and owned Manage saved searches dialog.
- Wire `/searches` load/save, validation, pinned custom saved-search shortcuts, dirty-draft behavior, focus restoration, and friendly auth/error states.
- Harden saved-search loading against concurrent failures, forced reload overlap, and stale out-of-order responses.
- Add SSR `autoload-saved-searches` on the main J2CL rail while keeping the read-surface preview static and preserving the legacy GWT route.

## Review
- Plan artifact: `docs/superpowers/plans/2026-05-01-issue-1162-j2cl-search-controls.md`.
- Claude plan and implementation review loops completed.
- Latest targeted Claude pass: `/tmp/claude-review-1162-race-r17.out`, verdict: ship-ready; no blockers or required fixes.

## Verification
- `cd j2cl/lit && npm test -- --files test/wavy-search-rail.test.js` -> 71 passed, 0 failed.
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json` -> changelog validation passed.
- `cd j2cl/lit && npm run build` -> completed successfully.
- `git diff --check` -> exit 0.
- `sbt j2clLitTest` -> 791 passed, 0 failed.
- `sbt "JakartaTest / testOnly org.waveprotocol.box.server.rpc.J2clSearchRailParityTest"` -> 17 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage saved searches modal (create/edit/save, client validation, pinned quick-access buttons, apply/restore focus, autoload opt-in)
  * Interactive, keyboard-accessible sort menu that composes/updates orderby tokens and emits query submissions

* **Documentation**
  * New implementation plan for search-controls parity and updated changelog; Javadoc clarification

* **Tests**
  * Expanded coverage for saved-search workflows, auth/error handling, sort menu behavior, SSR parity checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->