### PR TITLE
Fix J2CL wave panel chrome parity

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1163-wave-panel-chrome.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1163-wave-panel-chrome.md
@@ -1,0 +1,97 @@
+# Issue #1163 J2CL Wave Panel Chrome Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the J2CL selected-wave panel layout, splitter/resize affordance, status chrome, and wave-navigation actions to practical GWT parity.
+
+**Architecture:** Keep GWT as the baseline and preserve the existing J2CL selected-wave data pipeline. Add the missing J2CL shell chrome in Lit/CSS, bridge visible controls to the existing Java selected-wave view/controller, and keep raw route/channel/debug strings hidden unless the debug overlay is enabled. Navigation actions should operate on rendered `<wave-blip>` elements in the current selected-wave viewport, matching GWT's toolbar behavior where feasible.
+
+**Tech Stack:** J2CL Java, Lit custom elements, CSS shell tokens, selected-wave read-surface DOM, SBT verification, Lit unit tests.
+
+---
+
+## Files
+
+- Modify `j2cl/lit/src/tokens/shell-tokens.css`: add the desktop splitter track between search rail and wave panel, full-width main behavior, and GWT-like spacing.
+- Modify `j2cl/src/main/webapp/assets/sidecar.css`: align server-first selected-wave width, gutters, scroll container, and debug/status visibility.
+- Modify `j2cl/lit/src/elements/shell-status-strip.js`: convert raw text status into compact icon/status chips with accessible labels.
+- Modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java`: publish live status into chip attributes instead of visible raw prose.
+- Modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java`: expose normalized connection/route/selection status values for icon chrome.
+- Modify `j2cl/lit/src/elements/wavy-wave-nav-row.js`: add disabled/available state and event semantics needed by controller wiring.
+- Modify `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java`: wire wave-nav events to concrete scrolling/focus behavior on the selected-wave content.
+- Modify or add tests:
+  - `j2cl/lit/test/shell-status-strip.test.js`
+  - `j2cl/lit/test/shell-root.test.js`
+  - `j2cl/lit/test/wavy-wave-nav-row.test.js`
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java`
+  - `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java`
+- Add `wave/config/changelog.d/2026-05-01-j2cl-wave-panel-chrome-parity.json`.
+
+## Current Findings
+
+- GWT uses `SplitLayoutPanel` in `WebClient` so the search panel and wave panel are separated by a real splitter and the wave panel consumes the remaining width.
+- GWT status is icon chrome: `netstatus` uses Wi-Fi icons and `SavedStateIndicator` renders saved/unsaved icons with tooltips.
+- J2CL currently has a fixed two-column root grid, no draggable splitter, and status text is still appended into `shell-status-strip`.
+- J2CL selected-wave nav buttons render SVG icons, but `J2clSelectedWaveView.bindChromeEvents()` only records telemetry; recent/next/previous/end/mention clicks do not move focus or scroll.
+- J2CL debug strings are partially hidden through `data-j2cl-debug-only`, but status surfaces still leak prose such as "Selected wave is active." and runtime details instead of compact chrome.
+
+## Tasks
+
+### Task 1: Layout And Splitter Tests
+
+- [ ] Add Lit tests that mount `shell-root` with nav/main slots and assert the desktop layout includes a splitter column via CSS custom properties.
+- [ ] Add a test that verifies the selected-wave main slot is not max-width constrained and can consume the remaining viewport.
+- [ ] Add a test for a `data-j2cl-rail-width` attribute or CSS variable update so resize state has a concrete observable contract.
+
+### Task 2: Implement GWT-Like Split Layout
+
+- [ ] Add a root-shell splitter element between nav and main in the server-rendered J2CL shell markup.
+- [ ] Add a small Lit or vanilla controller for pointer/keyboard resizing that updates `--j2cl-search-rail-width` and persists it to `localStorage`.
+- [ ] Clamp the rail width to a practical range matching the existing tokens: minimum `260px`, maximum `420px`, and viewport-safe maximum of `50vw`.
+- [ ] Keep mobile behavior single-column with no visible splitter under the current `860px` breakpoint.
+
+### Task 3: Status Icon Chrome
+
+- [ ] Change `shell-status-strip` to render named chips for `connection`, `saved`, and selected-wave route state using icons and `aria-label`; visible raw status text must be hidden from normal users.
+- [ ] Keep a screen-reader live region for state changes without showing route/channel/snapshot prose in the UI.
+- [ ] Update `J2clRootLiveSurfaceModel` and `J2clRootShellView` so the Java publisher sets status attributes such as `data-route-state="selected-wave"` and live text separately.
+- [ ] Preserve visible error text for selected-wave failures; only normal debug/status prose is hidden.
+
+### Task 4: Navigation Action Behavior
+
+- [ ] In `J2clSelectedWaveView`, implement handlers for:
+  - `wave-nav-recent-requested`: focus/scroll to the most recently timestamped rendered blip, falling back to last rendered blip.
+  - `wave-nav-next-unread-requested`: focus/scroll to the next rendered unread blip, falling back to first unread.
+  - `wave-nav-previous-requested`: focus/scroll to previous rendered `wave-blip`.
+  - `wave-nav-next-requested`: focus/scroll to next rendered `wave-blip`.
+  - `wave-nav-end-requested`: focus/scroll to last rendered `wave-blip`.
+  - `wave-nav-prev-mention-requested` and `wave-nav-next-mention-requested`: focus/scroll between rendered `wave-blip[has-mention]`.
+- [ ] Use `focus({ preventScroll: true })` followed by `scrollIntoView({ block: "center" })` so the action does not jump to the bottom unexpectedly.
+- [ ] Keep archive/pin/version-history behavior owned by the existing `wave-action-bar-controller.js`; do not duplicate it in Java.
+- [ ] Add tests that verify events move a focused marker across synthetic `wave-blip` elements.
+
+### Task 5: Server-First And Debug Surface Parity
+
+- [ ] Update `HtmlRenderer` server-first root markup so normal J2CL route/channel/snapshot details are emitted as debug-only attributes or hidden diagnostic text, not visible body copy.
+- [ ] Add/adjust Jakarta renderer tests to assert the public J2CL root shell has icon-status chrome and no visible raw `channel`/`snapshot` status copy in the normal path.
+- [ ] Keep the read-surface preview fixture diagnostic strings gated by `data-j2cl-debug-only`.
+
+### Task 6: Verification And Evidence
+
+- [ ] Run focused Lit tests:
+  - `cd j2cl/lit && npm test -- --files test/shell-status-strip.test.js test/shell-root.test.js test/wavy-wave-nav-row.test.js`
+- [ ] Run focused JVM tests:
+  - `sbt --batch j2clSearchTest`
+- [ ] Run broader SBT verification:
+  - `sbt --batch compile j2clSearchTest j2clLitTest`
+- [ ] Run changelog validation:
+  - `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+- [ ] Run `git diff --check`.
+- [ ] Update #1163 with worktree path, branch, plan path, commit SHAs, verification, review-comment handling, and PR URL.
+
+## Self-Review
+
+- Spec coverage: The plan covers #1163 layout width, search/wave spacing, splitter/resize, status icons, hidden raw status/debug text, and navigation action behavior. It intentionally leaves participants, editor buttons, attachment sizing, and inline blip/thread rendering to #1164-#1167.
+- Placeholder scan: No task says "TBD" or relies on an unspecified framework. All implementation seams and verification commands are named.
+- Risk: The hardest part is "recent activity" because the J2CL rendered viewport may not contain the whole wave. The task defines a viewport-local behavior with a fallback to last rendered blip; if full-wave navigation is required, it should become a follow-up that asks the backend for off-viewport anchors.
+- Review policy: Claude Code is not used for this lane. Review will be self-review plus GitHub PR review comments only.

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -5,8 +5,8 @@ import { closeTopmostDialog } from "../shortcuts/dialog-stack.js";
 
 export class ShellRoot extends LitElement {
   static RESIZE_STORAGE_KEY = "j2cl.searchRailWidth";
-  static MIN_RAIL_WIDTH = 260;
-  static MAX_RAIL_WIDTH = 420;
+  static MIN_RAIL_WIDTH = 360;
+  static MAX_RAIL_WIDTH = 400;
   static RAIL_STEP = 16;
 
   static styles = css`
@@ -149,11 +149,18 @@ export class ShellRoot extends LitElement {
     if (!this._resizeStart) return;
     this._setRailWidth(
       this._resizeStart.width + (evt.clientX - this._resizeStart.x),
-      this._resizeStart.splitter
+      this._resizeStart.splitter,
+      false
     );
   }
 
   _onResizePointerUp() {
+    if (this._resizeStart && typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(
+        ShellRoot.RESIZE_STORAGE_KEY,
+        String(Math.round(this._currentRailWidth()))
+      );
+    }
     this._stopResizeTracking();
   }
 
@@ -186,13 +193,17 @@ export class ShellRoot extends LitElement {
     return 296;
   }
 
-  _setRailWidth(width, splitter = null) {
+  _setRailWidth(width, splitter = null, persist = true) {
     const next = Math.round(this._clampRailWidth(width));
     this.style.setProperty("--j2cl-search-rail-width", `${next}px`);
     if (splitter && splitter.setAttribute) {
       splitter.setAttribute("aria-valuenow", String(next));
+    } else {
+      this.querySelectorAll('[slot="splitter"]').forEach(el => {
+        el.setAttribute("aria-valuenow", String(next));
+      });
     }
-    if (typeof window !== "undefined" && window.localStorage) {
+    if (persist && typeof window !== "undefined" && window.localStorage) {
       window.localStorage.setItem(ShellRoot.RESIZE_STORAGE_KEY, String(next));
     }
   }

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -67,6 +67,8 @@ export class ShellRoot extends LitElement {
     this._onResizePointerUp = this._onResizePointerUp.bind(this);
     this._onWaveControlsToggled = this._onWaveControlsToggled.bind(this);
     this._resizeStart = null;
+    this._resizePointerId = null;
+    this._resizePointerTarget = null;
   }
 
   connectedCallback() {
@@ -105,8 +107,7 @@ export class ShellRoot extends LitElement {
   }
 
   _restoreRailWidth() {
-    if (typeof window === "undefined" || !window.localStorage) return;
-    const stored = Number(window.localStorage.getItem(ShellRoot.RESIZE_STORAGE_KEY));
+    const stored = Number(this._readStoredRailWidth());
     if (!Number.isFinite(stored) || stored <= 0) return;
     this._setRailWidth(stored);
   }
@@ -139,14 +140,25 @@ export class ShellRoot extends LitElement {
       width: this._currentRailWidth(),
       splitter: evt.target
     };
+    this._resizePointerId = evt.pointerId;
+    this._resizePointerTarget = evt.target;
+    try {
+      evt.target.setPointerCapture?.(evt.pointerId);
+    } catch {
+      // Capture can fail if the pointer is already gone; document listeners still clean up.
+    }
     if (typeof document !== "undefined") {
       document.addEventListener("pointermove", this._onResizePointerMove);
-      document.addEventListener("pointerup", this._onResizePointerUp, { once: true });
+      document.addEventListener("pointerup", this._onResizePointerUp);
+      document.addEventListener("pointercancel", this._onResizePointerUp);
+    }
+    if (evt.target && evt.target.addEventListener) {
+      evt.target.addEventListener("lostpointercapture", this._onResizePointerUp);
     }
   }
 
   _onResizePointerMove(evt) {
-    if (!this._resizeStart) return;
+    if (!this._resizeStart || evt.pointerId !== this._resizePointerId) return;
     this._setRailWidth(
       this._resizeStart.width + (evt.clientX - this._resizeStart.x),
       this._resizeStart.splitter,
@@ -154,21 +166,32 @@ export class ShellRoot extends LitElement {
     );
   }
 
-  _onResizePointerUp() {
-    if (this._resizeStart && typeof window !== "undefined" && window.localStorage) {
-      window.localStorage.setItem(
-        ShellRoot.RESIZE_STORAGE_KEY,
-        String(Math.round(this._currentRailWidth()))
-      );
+  _onResizePointerUp(evt) {
+    if (!this._resizeStart) return;
+    if (evt && evt.pointerId !== this._resizePointerId) return;
+    this._writeStoredRailWidth(String(Math.round(this._currentRailWidth())));
+    if (this._resizePointerTarget && this._resizePointerTarget.releasePointerCapture) {
+      try {
+        this._resizePointerTarget.releasePointerCapture(this._resizePointerId);
+      } catch {
+        // The browser may have already released capture.
+      }
     }
     this._stopResizeTracking();
   }
 
   _stopResizeTracking() {
+    const target = this._resizePointerTarget;
     this._resizeStart = null;
+    this._resizePointerId = null;
+    this._resizePointerTarget = null;
     if (typeof document !== "undefined") {
       document.removeEventListener("pointermove", this._onResizePointerMove);
       document.removeEventListener("pointerup", this._onResizePointerUp);
+      document.removeEventListener("pointercancel", this._onResizePointerUp);
+    }
+    if (target && target.removeEventListener) {
+      target.removeEventListener("lostpointercapture", this._onResizePointerUp);
     }
   }
 
@@ -203,8 +226,36 @@ export class ShellRoot extends LitElement {
         el.setAttribute("aria-valuenow", String(next));
       });
     }
-    if (persist && typeof window !== "undefined" && window.localStorage) {
-      window.localStorage.setItem(ShellRoot.RESIZE_STORAGE_KEY, String(next));
+    if (persist) {
+      this._writeStoredRailWidth(String(next));
+    }
+  }
+
+  _storage() {
+    try {
+      return typeof window === "undefined" ? null : window.localStorage;
+    } catch {
+      return null;
+    }
+  }
+
+  _readStoredRailWidth() {
+    const storage = this._storage();
+    if (!storage) return "";
+    try {
+      return storage.getItem(ShellRoot.RESIZE_STORAGE_KEY) || "";
+    } catch {
+      return "";
+    }
+  }
+
+  _writeStoredRailWidth(value) {
+    const storage = this._storage();
+    if (!storage) return;
+    try {
+      storage.setItem(ShellRoot.RESIZE_STORAGE_KEY, value);
+    } catch {
+      // Storage can be blocked or over quota; resizing should remain usable.
     }
   }
 

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -4,6 +4,11 @@ import { moveBlipFocus, clearBlipFocus } from "../shortcuts/blip-focus.js";
 import { closeTopmostDialog } from "../shortcuts/dialog-stack.js";
 
 export class ShellRoot extends LitElement {
+  static RESIZE_STORAGE_KEY = "j2cl.searchRailWidth";
+  static MIN_RAIL_WIDTH = 260;
+  static MAX_RAIL_WIDTH = 420;
+  static RAIL_STEP = 16;
+
   static styles = css`
     /* V-1 (#1099): the canonical grid for <shell-root> lives in
      * j2cl/lit/src/tokens/shell-tokens.css and targets the host element
@@ -23,6 +28,11 @@ export class ShellRoot extends LitElement {
 
     slot[name="nav"] {
       grid-area: nav;
+      min-height: 0;
+    }
+
+    slot[name="splitter"] {
+      grid-area: splitter;
       min-height: 0;
     }
 
@@ -51,10 +61,22 @@ export class ShellRoot extends LitElement {
   constructor() {
     super();
     this._onWindowKeyDown = this._onWindowKeyDown.bind(this);
+    this._onResizeKeyDown = this._onResizeKeyDown.bind(this);
+    this._onResizePointerDown = this._onResizePointerDown.bind(this);
+    this._onResizePointerMove = this._onResizePointerMove.bind(this);
+    this._onResizePointerUp = this._onResizePointerUp.bind(this);
+    this._onWaveControlsToggled = this._onWaveControlsToggled.bind(this);
+    this._resizeStart = null;
   }
 
   connectedCallback() {
     super.connectedCallback();
+    this._restoreRailWidth();
+    this.addEventListener("keydown", this._onResizeKeyDown);
+    this.addEventListener("pointerdown", this._onResizePointerDown);
+    if (typeof document !== "undefined") {
+      document.addEventListener("wavy-wave-controls-toggled", this._onWaveControlsToggled);
+    }
     // G-PORT-7 (#1116): shell-level keyboard handler. Cloned from the
     // GWT keyboard registry (`KeySignalRouter` + `FocusFrameController.
     // onKeySignal`). The window-level listener captures the document
@@ -71,8 +93,125 @@ export class ShellRoot extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    this.removeEventListener("keydown", this._onResizeKeyDown);
+    this.removeEventListener("pointerdown", this._onResizePointerDown);
+    this._stopResizeTracking();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("wavy-wave-controls-toggled", this._onWaveControlsToggled);
+    }
     if (typeof window !== "undefined") {
       window.removeEventListener("keydown", this._onWindowKeyDown);
+    }
+  }
+
+  _restoreRailWidth() {
+    if (typeof window === "undefined" || !window.localStorage) return;
+    const stored = Number(window.localStorage.getItem(ShellRoot.RESIZE_STORAGE_KEY));
+    if (!Number.isFinite(stored) || stored <= 0) return;
+    this._setRailWidth(stored);
+  }
+
+  _onResizeKeyDown(evt) {
+    if (!this._isSplitterEvent(evt)) return;
+    const current = this._currentRailWidth();
+    let next = current;
+    if (evt.key === "ArrowLeft") {
+      next = current - ShellRoot.RAIL_STEP;
+    } else if (evt.key === "ArrowRight") {
+      next = current + ShellRoot.RAIL_STEP;
+    } else if (evt.key === "Home") {
+      next = ShellRoot.MIN_RAIL_WIDTH;
+    } else if (evt.key === "End") {
+      next = ShellRoot.MAX_RAIL_WIDTH;
+    } else {
+      return;
+    }
+    evt.preventDefault();
+    evt.stopPropagation();
+    this._setRailWidth(next, evt.target);
+  }
+
+  _onResizePointerDown(evt) {
+    if (!this._isSplitterEvent(evt) || evt.button !== 0) return;
+    evt.preventDefault();
+    this._resizeStart = {
+      x: evt.clientX,
+      width: this._currentRailWidth(),
+      splitter: evt.target
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("pointermove", this._onResizePointerMove);
+      document.addEventListener("pointerup", this._onResizePointerUp, { once: true });
+    }
+  }
+
+  _onResizePointerMove(evt) {
+    if (!this._resizeStart) return;
+    this._setRailWidth(
+      this._resizeStart.width + (evt.clientX - this._resizeStart.x),
+      this._resizeStart.splitter
+    );
+  }
+
+  _onResizePointerUp() {
+    this._stopResizeTracking();
+  }
+
+  _stopResizeTracking() {
+    this._resizeStart = null;
+    if (typeof document !== "undefined") {
+      document.removeEventListener("pointermove", this._onResizePointerMove);
+      document.removeEventListener("pointerup", this._onResizePointerUp);
+    }
+  }
+
+  _isSplitterEvent(evt) {
+    const target = evt && evt.target;
+    return !!(
+      target &&
+      target.getAttribute &&
+      target.getAttribute("slot") === "splitter"
+    );
+  }
+
+  _currentRailWidth() {
+    const inline = parseFloat(this.style.getPropertyValue("--j2cl-search-rail-width"));
+    if (Number.isFinite(inline) && inline > 0) return inline;
+    if (typeof window !== "undefined") {
+      const computed = parseFloat(
+        window.getComputedStyle(this).getPropertyValue("--j2cl-search-rail-width")
+      );
+      if (Number.isFinite(computed) && computed > 0) return computed;
+    }
+    return 296;
+  }
+
+  _setRailWidth(width, splitter = null) {
+    const next = Math.round(this._clampRailWidth(width));
+    this.style.setProperty("--j2cl-search-rail-width", `${next}px`);
+    if (splitter && splitter.setAttribute) {
+      splitter.setAttribute("aria-valuenow", String(next));
+    }
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(ShellRoot.RESIZE_STORAGE_KEY, String(next));
+    }
+  }
+
+  _clampRailWidth(width) {
+    const viewportMax =
+      typeof window === "undefined" || !window.innerWidth
+        ? ShellRoot.MAX_RAIL_WIDTH
+        : Math.max(ShellRoot.MIN_RAIL_WIDTH, Math.floor(window.innerWidth * 0.5));
+    const max = Math.min(ShellRoot.MAX_RAIL_WIDTH, viewportMax);
+    return Math.max(ShellRoot.MIN_RAIL_WIDTH, Math.min(max, width));
+  }
+
+  _onWaveControlsToggled(evt) {
+    const pressed = !!(evt.detail && evt.detail.pressed);
+    if (pressed) {
+      this.setAttribute("data-wave-controls-compact", "true");
+    } else {
+      this.removeAttribute("data-wave-controls-compact");
     }
   }
 
@@ -154,6 +293,7 @@ export class ShellRoot extends LitElement {
       <slot name="skip-link"></slot>
       <slot name="header"></slot>
       <slot name="nav"></slot>
+      <slot name="splitter"></slot>
       <slot name="main"></slot>
       <slot name="rail-extension"></slot>
       <slot name="status"></slot>

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -121,6 +121,7 @@ export class ShellStatusStrip extends LitElement {
       <aside role="status" aria-live="polite">
         <span
           class="chip"
+          role="img"
           data-status-chip="connection"
           data-state=${this.connectionState}
           aria-label=${this._connectionLabel()}
@@ -128,6 +129,7 @@ export class ShellStatusStrip extends LitElement {
         ></span>
         <span
           class="chip"
+          role="img"
           data-status-chip="saved"
           data-state=${this.saveState}
           aria-label=${this._saveLabel()}
@@ -135,6 +137,7 @@ export class ShellStatusStrip extends LitElement {
         ></span>
         <span
           class="chip"
+          role="img"
           data-status-chip="route"
           data-state=${this.routeState}
           aria-label=${this._routeLabel()}

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -1,22 +1,148 @@
 import { LitElement, css, html } from "lit";
 
 export class ShellStatusStrip extends LitElement {
+  static properties = {
+    connectionState: { type: String, attribute: "data-connection-state" },
+    saveState: { type: String, attribute: "data-save-state" },
+    routeState: { type: String, attribute: "data-route-state" }
+  };
+
   static styles = css`
     :host {
       display: block;
     }
 
     aside {
+      display: flex;
+      align-items: center;
+      gap: 8px;
       padding: 6px var(--shell-space-inset-panel, 18px);
       background: var(--shell-color-surface-shell, #fff);
       border-top: 1px solid var(--shell-color-divider-subtle, #e5edf5);
       color: var(--shell-color-text-muted, #5b6b80);
       font-size: 0.85rem;
     }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 999px;
+      border: 1px solid #d7e3ef;
+      background: #f0f4f8;
+      color: #0077b6;
+      font-size: 13px;
+      line-height: 1;
+    }
+
+    .chip[data-state="offline"],
+    .chip[data-state="unsaved"],
+    .chip[data-state="loading"] {
+      color: #8f5e00;
+      background: #fff7e6;
+      border-color: #f1d18a;
+    }
+
+    .chip::before {
+      content: "";
+      display: block;
+    }
+
+    .chip[data-status-chip="connection"]::before {
+      width: 11px;
+      height: 7px;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-radius: 0 0 12px 12px;
+    }
+
+    .chip[data-status-chip="saved"]::before {
+      width: 10px;
+      height: 5px;
+      border-left: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(-45deg);
+      margin-top: -2px;
+    }
+
+    .chip[data-status-chip="route"]::before {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: currentColor;
+    }
+
+    .status-live-text {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
+    }
   `;
 
+  constructor() {
+    super();
+    this.connectionState = "online";
+    this.saveState = "saved";
+    this.routeState = "ready";
+  }
+
+  _connectionLabel() {
+    return this.connectionState === "offline" ? "Offline" : "Online";
+  }
+
+  _saveLabel() {
+    return this.saveState === "unsaved" || this.saveState === "saving" ? "Saving changes" : "Saved";
+  }
+
+  _routeLabel() {
+    switch (this.routeState) {
+      case "selected-wave":
+        return "Selected wave active";
+      case "search":
+        return "Search results active";
+      case "loading":
+        return "Loading workspace";
+      default:
+        return "Workspace ready";
+    }
+  }
+
   render() {
-    return html`<aside role="status" aria-live="polite"><slot></slot></aside>`;
+    return html`
+      <aside role="status" aria-live="polite">
+        <span
+          class="chip"
+          data-status-chip="connection"
+          data-state=${this.connectionState}
+          aria-label=${this._connectionLabel()}
+          title=${this._connectionLabel()}
+        ></span>
+        <span
+          class="chip"
+          data-status-chip="saved"
+          data-state=${this.saveState}
+          aria-label=${this._saveLabel()}
+          title=${this._saveLabel()}
+        ></span>
+        <span
+          class="chip"
+          data-status-chip="route"
+          data-state=${this.routeState}
+          aria-label=${this._routeLabel()}
+          title=${this._routeLabel()}
+        ></span>
+        <slot class="status-live-text"></slot>
+      </aside>
+    `;
   }
 }
 

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -38,6 +38,7 @@ export class ShellStatusStrip extends LitElement {
     }
 
     .chip[data-state="offline"],
+    .chip[data-state="saving"],
     .chip[data-state="unsaved"],
     .chip[data-state="loading"] {
       color: #8f5e00;

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -72,6 +72,11 @@ export class WavyWaveControlsToggle extends LitElement {
       box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
       outline: none;
     }
+    svg {
+      width: 18px;
+      height: 18px;
+      display: block;
+    }
   `;
 
   constructor() {
@@ -99,7 +104,6 @@ export class WavyWaveControlsToggle extends LitElement {
     // (Enter / Space). The host carries no role/tabindex so AT does
     // not announce a nested-button antipattern; the toggle's
     // pressed/label state lives on the inner button.
-    const glyph = this.pressed ? "▸" : "▾";
     const label = this.pressed ? "Show wave controls" : "Hide wave controls";
     return html`
       <button
@@ -108,8 +112,26 @@ export class WavyWaveControlsToggle extends LitElement {
         aria-label=${label}
         @click=${this._onClick}
       >
-        <span aria-hidden="true">${glyph}</span>
+        ${this.pressed ? this._showIcon() : this._hideIcon()}
       </button>
+    `;
+  }
+
+  _hideIcon() {
+    return html`
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M5 7h14M5 12h14M5 17h14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+        <path d="M9 5v4M15 10v4M11 15v4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+      </svg>
+    `;
+  }
+
+  _showIcon() {
+    return html`
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M6 7h12M6 12h12M6 17h12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+        <path d="M9 9l3-3 3 3M9 15l3 3 3-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
     `;
   }
 }

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -48,11 +48,11 @@ shell-root-signed-out {
 shell-root {
   /* V-5 (#1103): density tokens flow from wavy-tokens.css so the rail
    * width and the wave-panel gutter can be tuned in one place. The
-   * fallbacks preserve V-1's 260-296 px rail when wavy-tokens.css has
-   * not been loaded (e.g. signed-out branch / SSR-only smoke). */
-  --j2cl-search-rail-width: var(--wavy-rail-width-max, 296px);
+   * fallbacks mirror wavy-tokens.css so SSR-only smoke and Lit runtime
+   * clamp to the same range. */
+  --j2cl-search-rail-width: var(--wavy-rail-width-max, 400px);
   grid-template-columns:
-    minmax(var(--wavy-rail-width-min, 260px), var(--j2cl-search-rail-width))
+    minmax(var(--wavy-rail-width-min, 360px), var(--j2cl-search-rail-width))
     6px
     minmax(0, 1fr);
   grid-template-rows: auto auto 1fr auto auto;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -102,6 +102,7 @@ shell-root-signed-out > [slot="main"] {
 }
 
 .j2cl-shell-splitter {
+  box-sizing: border-box;
   align-self: stretch;
   width: 6px;
   min-width: 6px;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -50,7 +50,11 @@ shell-root {
    * width and the wave-panel gutter can be tuned in one place. The
    * fallbacks preserve V-1's 260-296 px rail when wavy-tokens.css has
    * not been loaded (e.g. signed-out branch / SSR-only smoke). */
-  grid-template-columns: minmax(var(--wavy-rail-width-min, 260px), var(--wavy-rail-width-max, 296px)) 1fr;
+  --j2cl-search-rail-width: var(--wavy-rail-width-max, 296px);
+  grid-template-columns:
+    minmax(var(--wavy-rail-width-min, 260px), var(--j2cl-search-rail-width))
+    6px
+    minmax(0, 1fr);
   grid-template-rows: auto auto 1fr auto auto;
   /* V-1 (#1099): the rail-extension row leaves the left column empty
    * (".") so the nav rail does not span into row 4. When the slotted
@@ -58,11 +62,11 @@ shell-root {
    * and there is no blank strip under the wave panel even if the nav
    * rail has tall content (long digest list on a short viewport). */
   grid-template-areas:
-    "skip skip"
-    "header header"
-    "nav main"
-    ".   rail-extension"
-    "status status";
+    "skip skip skip"
+    "header header header"
+    "nav splitter main"
+    ".   .        rail-extension"
+    "status status status";
 }
 
 shell-root-signed-out {
@@ -88,9 +92,31 @@ shell-root > [slot="nav"] {
   grid-area: nav;
 }
 
+shell-root > [slot="splitter"] {
+  grid-area: splitter;
+}
+
 shell-root > [slot="main"],
 shell-root-signed-out > [slot="main"] {
   grid-area: main;
+}
+
+.j2cl-shell-splitter {
+  align-self: stretch;
+  width: 6px;
+  min-width: 6px;
+  padding: 0;
+  border: 0;
+  border-left: 1px solid #d7e3ef;
+  border-right: 1px solid #d7e3ef;
+  background: linear-gradient(90deg, #f8fafc, #eaf2f9, #f8fafc);
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.j2cl-shell-splitter:focus-visible {
+  outline: 2px solid var(--shell-color-accent-focus, #0077b6);
+  outline-offset: -2px;
 }
 
 shell-root > [slot="status"],
@@ -304,6 +330,11 @@ shell-status-strip {
       "main"
       "rail-extension"
       "status";
+  }
+
+  shell-root > [slot="splitter"],
+  .j2cl-shell-splitter {
+    display: none;
   }
 
   shell-header {

--- a/j2cl/lit/test/shell-root.test.js
+++ b/j2cl/lit/test/shell-root.test.js
@@ -45,7 +45,7 @@ describe("<shell-root>", () => {
   it("keyboard resizing updates and persists the search rail width", async () => {
     window.localStorage.removeItem("j2cl.searchRailWidth");
     const el = await fixture(html`
-      <shell-root style="--j2cl-search-rail-width: 296px">
+      <shell-root style="--j2cl-search-rail-width: 376px">
         <button slot="splitter" id="search-splitter">resize</button>
       </shell-root>
     `);
@@ -55,8 +55,8 @@ describe("<shell-root>", () => {
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
     );
 
-    expect(el.style.getPropertyValue("--j2cl-search-rail-width")).to.equal("312px");
-    expect(window.localStorage.getItem("j2cl.searchRailWidth")).to.equal("312");
+    expect(el.style.getPropertyValue("--j2cl-search-rail-width")).to.equal("392px");
+    expect(window.localStorage.getItem("j2cl.searchRailWidth")).to.equal("392");
   });
 
   it("document wave-controls toggle switches compact mode on the shell", async () => {

--- a/j2cl/lit/test/shell-root.test.js
+++ b/j2cl/lit/test/shell-root.test.js
@@ -7,6 +7,7 @@ describe("<shell-root>", () => {
     expect(el.renderRoot.querySelector("slot[name='skip-link']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='header']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='nav']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='splitter']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
   });
@@ -28,5 +29,55 @@ describe("<shell-root>", () => {
       .filter((n) => n.nodeType === Node.ELEMENT_NODE)
       .map((n) => n.id);
     expect(ids).to.include("plugin-mount");
+  });
+
+  it("projects a resize splitter between nav and main", async () => {
+    const el = await fixture(html`
+      <shell-root>
+        <button slot="splitter" id="search-splitter">resize</button>
+      </shell-root>
+    `);
+    const slot = el.renderRoot.querySelector("slot[name='splitter']");
+    const assigned = slot.assignedElements({ flatten: true });
+    expect(assigned.map((node) => node.id)).to.include("search-splitter");
+  });
+
+  it("keyboard resizing updates and persists the search rail width", async () => {
+    window.localStorage.removeItem("j2cl.searchRailWidth");
+    const el = await fixture(html`
+      <shell-root style="--j2cl-search-rail-width: 296px">
+        <button slot="splitter" id="search-splitter">resize</button>
+      </shell-root>
+    `);
+    const splitter = el.querySelector("#search-splitter");
+
+    splitter.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
+    );
+
+    expect(el.style.getPropertyValue("--j2cl-search-rail-width")).to.equal("312px");
+    expect(window.localStorage.getItem("j2cl.searchRailWidth")).to.equal("312");
+  });
+
+  it("document wave-controls toggle switches compact mode on the shell", async () => {
+    const el = await fixture(html`<shell-root></shell-root>`);
+
+    document.dispatchEvent(
+      new CustomEvent("wavy-wave-controls-toggled", {
+        bubbles: true,
+        composed: true,
+        detail: { pressed: true }
+      })
+    );
+    expect(el.getAttribute("data-wave-controls-compact")).to.equal("true");
+
+    document.dispatchEvent(
+      new CustomEvent("wavy-wave-controls-toggled", {
+        bubbles: true,
+        composed: true,
+        detail: { pressed: false }
+      })
+    );
+    expect(el.hasAttribute("data-wave-controls-compact")).to.be.false;
   });
 });

--- a/j2cl/lit/test/shell-root.test.js
+++ b/j2cl/lit/test/shell-root.test.js
@@ -59,6 +59,78 @@ describe("<shell-root>", () => {
     expect(window.localStorage.getItem("j2cl.searchRailWidth")).to.equal("392");
   });
 
+  it("keeps resizing usable when localStorage is blocked", async () => {
+    const originalGetItem = Storage.prototype.getItem;
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.getItem = () => {
+      throw new DOMException("blocked", "SecurityError");
+    };
+    Storage.prototype.setItem = () => {
+      throw new DOMException("blocked", "SecurityError");
+    };
+    try {
+      const el = await fixture(html`
+        <shell-root style="--j2cl-search-rail-width: 376px">
+          <button slot="splitter" id="search-splitter">resize</button>
+        </shell-root>
+      `);
+      const splitter = el.querySelector("#search-splitter");
+
+      splitter.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true })
+      );
+
+      expect(el.style.getPropertyValue("--j2cl-search-rail-width")).to.equal("392px");
+    } finally {
+      Storage.prototype.getItem = originalGetItem;
+      Storage.prototype.setItem = originalSetItem;
+    }
+  });
+
+  it("cleans resize tracking when pointer capture is canceled", async () => {
+    window.localStorage.removeItem("j2cl.searchRailWidth");
+    const el = await fixture(html`
+      <shell-root style="--j2cl-search-rail-width: 376px">
+        <button slot="splitter" id="search-splitter">resize</button>
+      </shell-root>
+    `);
+    const splitter = el.querySelector("#search-splitter");
+    let capturedPointer = null;
+    let releasedPointer = null;
+    splitter.setPointerCapture = (pointerId) => {
+      capturedPointer = pointerId;
+    };
+    splitter.releasePointerCapture = (pointerId) => {
+      releasedPointer = pointerId;
+    };
+
+    splitter.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        button: 0,
+        clientX: 100,
+        pointerId: 7
+      })
+    );
+    document.dispatchEvent(
+      new PointerEvent("pointercancel", {
+        bubbles: true,
+        pointerId: 7
+      })
+    );
+    document.dispatchEvent(
+      new PointerEvent("pointermove", {
+        bubbles: true,
+        clientX: 180,
+        pointerId: 7
+      })
+    );
+
+    expect(capturedPointer).to.equal(7);
+    expect(releasedPointer).to.equal(7);
+    expect(el.style.getPropertyValue("--j2cl-search-rail-width")).to.equal("376px");
+  });
+
   it("document wave-controls toggle switches compact mode on the shell", async () => {
     const el = await fixture(html`<shell-root></shell-root>`);
 

--- a/j2cl/lit/test/shell-status-strip.test.js
+++ b/j2cl/lit/test/shell-status-strip.test.js
@@ -13,4 +13,26 @@ describe("<shell-status-strip>", () => {
     const el = await fixture(html`<shell-status-strip>Connected</shell-status-strip>`);
     expect(el.renderRoot.querySelector("slot")).to.exist;
   });
+
+  it("renders compact status chips instead of visible raw status prose", async () => {
+    const el = await fixture(html`
+      <shell-status-strip
+        data-connection-state="online"
+        data-save-state="saved"
+        data-route-state="selected-wave"
+      >supawave.ai/w+1 · channel ch1 · snapshot v2</shell-status-strip>
+    `);
+    const chips = Array.from(el.renderRoot.querySelectorAll("[data-status-chip]"));
+    expect(chips.map((chip) => chip.getAttribute("data-status-chip"))).to.deep.equal([
+      "connection",
+      "saved",
+      "route"
+    ]);
+    expect(chips.map((chip) => chip.getAttribute("aria-label"))).to.deep.equal([
+      "Online",
+      "Saved",
+      "Selected wave active"
+    ]);
+    expect(el.renderRoot.querySelector("slot").classList.contains("status-live-text")).to.be.true;
+  });
 });

--- a/j2cl/lit/test/shell-status-strip.test.js
+++ b/j2cl/lit/test/shell-status-strip.test.js
@@ -35,4 +35,14 @@ describe("<shell-status-strip>", () => {
     ]);
     expect(el.renderRoot.querySelector("slot").classList.contains("status-live-text")).to.be.true;
   });
+
+  it("styles the saving chip as a transitional warning state", async () => {
+    const el = await fixture(html`
+      <shell-status-strip data-save-state="saving"></shell-status-strip>
+    `);
+    const chip = el.renderRoot.querySelector('[data-status-chip="saved"]');
+
+    expect(chip.getAttribute("aria-label")).to.equal("Saving changes");
+    expect(getComputedStyle(chip).backgroundColor).to.equal("rgb(255, 247, 230)");
+  });
 });

--- a/j2cl/lit/test/wavy-wave-controls-toggle.test.js
+++ b/j2cl/lit/test/wavy-wave-controls-toggle.test.js
@@ -14,6 +14,8 @@ describe("<wavy-wave-controls-toggle>", () => {
     const button = el.renderRoot.querySelector("button");
     expect(button.getAttribute("aria-pressed")).to.equal("false");
     expect(button.getAttribute("aria-label")).to.equal("Hide wave controls");
+    expect(button.querySelector("svg")).to.exist;
+    expect(button.textContent.trim()).to.equal("");
   });
 
   it("click toggles to pressed=true and inner button label flips to Show wave controls", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -88,6 +88,16 @@ public final class J2clRootLiveSurfaceModel {
     return "ready";
   }
 
+  public String getConnectionState() {
+    String status = statusText.toLowerCase();
+    return status.contains("offline") || status.contains("disconnected") ? "offline" : "online";
+  }
+
+  public String getSaveState() {
+    String status = statusText.toLowerCase();
+    return status.contains("saving") || status.contains("unsaved") ? "saving" : "saved";
+  }
+
   private static String routeStatus(String routeUrl, String query) {
     String normalizedQuery = nullToEmpty(query);
     if (!normalizedQuery.isEmpty()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -75,6 +75,19 @@ public final class J2clRootLiveSurfaceModel {
     return statusText;
   }
 
+  public String getRouteState() {
+    if (selectedWaveId != null) {
+      return "selected-wave";
+    }
+    if (!query.isEmpty()) {
+      return "search";
+    }
+    if (routeUrl.isEmpty()) {
+      return "loading";
+    }
+    return "ready";
+  }
+
   private static String routeStatus(String routeUrl, String query) {
     String normalizedQuery = nullToEmpty(query);
     if (!normalizedQuery.isEmpty()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -81,8 +81,6 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       String statusText = model == null ? "" : model.getStatusText();
       HTMLElement statusStrip = findStatusStrip(findRootShell());
       if (statusStrip != null) {
-        statusStrip.setAttribute("data-connection-state", "online");
-        statusStrip.setAttribute("data-save-state", "saved");
         statusStrip.setAttribute(
             "data-route-state", model == null ? "ready" : model.getRouteState());
         statusStrip.setAttribute("data-live-status-text", statusText);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -69,6 +69,7 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     HTMLElement returnTargetLabel =
         firstElementOwnedByRootShell(shell, "#j2cl-root-return-target-text");
     if (returnTargetLabel != null) {
+      returnTargetLabel.className = "j2cl-status-live-text";
       returnTargetLabel.textContent = "Return target: " + returnTarget;
     }
   }
@@ -78,6 +79,14 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     HTMLElement statusElement = ensureLiveStatusElement();
     if (statusElement != null) {
       String statusText = model == null ? "" : model.getStatusText();
+      HTMLElement statusStrip = findStatusStrip(findRootShell());
+      if (statusStrip != null) {
+        statusStrip.setAttribute("data-connection-state", "online");
+        statusStrip.setAttribute("data-save-state", "saved");
+        statusStrip.setAttribute(
+            "data-route-state", model == null ? "ready" : model.getRouteState());
+        statusStrip.setAttribute("data-live-status-text", statusText);
+      }
       String desiredSeparatorDisplay = statusText.isEmpty() ? "none" : "";
       if (statusText.equals(lastPublishedLiveStatusText)
           && (liveStatusSeparator == null
@@ -117,6 +126,7 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     if (liveStatusSeparator == null) {
       liveStatusSeparator = (HTMLElement) DomGlobal.document.createElement("span");
       liveStatusSeparator.id = LIVE_STATUS_SEPARATOR_ID;
+      liveStatusSeparator.className = "j2cl-status-live-separator";
       liveStatusSeparator.setAttribute("aria-hidden", "true");
       liveStatusSeparator.textContent = " | ";
       if (liveStatus != null && liveStatus.parentElement == statusStrip) {
@@ -132,6 +142,9 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       statusStrip.appendChild(liveStatus);
       lastPublishedLiveStatusText = null;
     }
+    liveStatusSeparator.className = "j2cl-status-live-separator";
+    liveStatus.className = "j2cl-status-live-text";
+    liveStatus.setAttribute("aria-live", "polite");
     return liveStatus;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -81,8 +81,12 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       String statusText = model == null ? "" : model.getStatusText();
       HTMLElement statusStrip = findStatusStrip(findRootShell());
       if (statusStrip != null) {
-        statusStrip.setAttribute(
-            "data-route-state", model == null ? "ready" : model.getRouteState());
+        String connectionState = model == null ? "online" : model.getConnectionState();
+        String saveState = model == null ? "saved" : model.getSaveState();
+        String routeState = model == null ? "ready" : model.getRouteState();
+        statusStrip.setAttribute("data-connection-state", connectionState);
+        statusStrip.setAttribute("data-save-state", saveState);
+        statusStrip.setAttribute("data-route-state", routeState);
         statusStrip.setAttribute("data-live-status-text", statusText);
       }
       String desiredSeparatorDisplay = statusText.isEmpty() ? "none" : "";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -479,16 +479,26 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       return;
     }
     HTMLElement newest = blips.get(blips.size() - 1);
-    String newestTime = newest.getAttribute("data-blip-time");
+    long newestTime = parseBlipTime(newest.getAttribute("data-blip-time"));
     for (HTMLElement blip : blips) {
-      String time = blip.getAttribute("data-blip-time");
-      if (time != null && !time.isEmpty()
-          && (newestTime == null || newestTime.isEmpty() || time.compareTo(newestTime) > 0)) {
+      long time = parseBlipTime(blip.getAttribute("data-blip-time"));
+      if (time > newestTime) {
         newest = blip;
         newestTime = time;
       }
     }
     focusBlip(newest);
+  }
+
+  private static long parseBlipTime(String value) {
+    if (value == null || value.isEmpty()) {
+      return Long.MIN_VALUE;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException ignored) {
+      return Long.MIN_VALUE;
+    }
   }
 
   private void focusLastBlip() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.search;
 
 import elemental2.core.JsArray;
+import elemental2.core.JsDate;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element.FocusOptionsType;
 import elemental2.dom.HTMLDivElement;
@@ -497,7 +498,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     try {
       return Long.parseLong(value);
     } catch (NumberFormatException ignored) {
-      return Long.MIN_VALUE;
+      double epochMs = new JsDate(value).getTime();
+      return Double.isNaN(epochMs) ? Long.MIN_VALUE : (long) epochMs;
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -2,8 +2,10 @@ package org.waveprotocol.box.j2cl.search;
 
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Element.FocusOptionsType;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.ScrollIntoViewOptions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -123,6 +125,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       this.waveNavRow = ensureWaveNavRow(existingCard);
       this.awarenessPill = ensureAwarenessPill(existingCard);
       bindChromeEvents(existingCard, effectiveTelemetrySink);
+      bindNavigationEvents(existingCard);
       bindSelectedWaveRefreshListener(existingCard);
       serverFirstActive = true;
       serverFirstWaveId = J2clServerFirstRootShellDom.serverFirstWaveId(host);
@@ -216,6 +219,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     coldCard.appendChild(emptyState);
 
     bindChromeEvents(coldCard, effectiveTelemetrySink);
+    bindNavigationEvents(coldCard);
     bindSelectedWaveRefreshListener(coldCard);
 
     serverFirstActive = false;
@@ -454,6 +458,126 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             }
           });
     }
+  }
+
+  private void bindNavigationEvents(HTMLElement card) {
+    card.addEventListener("wave-nav-recent-requested", evt -> focusMostRecentBlip());
+    card.addEventListener(
+        "wave-nav-next-unread-requested", evt -> focusNextMatchingBlip("unread", 1));
+    card.addEventListener("wave-nav-previous-requested", evt -> focusAdjacentBlip(-1));
+    card.addEventListener("wave-nav-next-requested", evt -> focusAdjacentBlip(1));
+    card.addEventListener("wave-nav-end-requested", evt -> focusLastBlip());
+    card.addEventListener(
+        "wave-nav-prev-mention-requested", evt -> focusNextMatchingBlip("has-mention", -1));
+    card.addEventListener(
+        "wave-nav-next-mention-requested", evt -> focusNextMatchingBlip("has-mention", 1));
+  }
+
+  private void focusMostRecentBlip() {
+    List<HTMLElement> blips = renderedBlips();
+    if (blips.isEmpty()) {
+      return;
+    }
+    HTMLElement newest = blips.get(blips.size() - 1);
+    String newestTime = newest.getAttribute("data-blip-time");
+    for (HTMLElement blip : blips) {
+      String time = blip.getAttribute("data-blip-time");
+      if (time != null && !time.isEmpty()
+          && (newestTime == null || newestTime.isEmpty() || time.compareTo(newestTime) > 0)) {
+        newest = blip;
+        newestTime = time;
+      }
+    }
+    focusBlip(newest);
+  }
+
+  private void focusLastBlip() {
+    List<HTMLElement> blips = renderedBlips();
+    if (!blips.isEmpty()) {
+      focusBlip(blips.get(blips.size() - 1));
+    }
+  }
+
+  private void focusAdjacentBlip(int direction) {
+    List<HTMLElement> blips = renderedBlips();
+    if (blips.isEmpty()) {
+      return;
+    }
+    int current = focusedBlipIndex(blips);
+    int next = current < 0 ? (direction > 0 ? 0 : blips.size() - 1) : current + direction;
+    if (next < 0) {
+      next = 0;
+    }
+    if (next >= blips.size()) {
+      next = blips.size() - 1;
+    }
+    focusBlip(blips.get(next));
+  }
+
+  private void focusNextMatchingBlip(String attributeName, int direction) {
+    List<HTMLElement> blips = renderedBlips();
+    if (blips.isEmpty()) {
+      return;
+    }
+    int current = focusedBlipIndex(blips);
+    int start = current < 0 ? (direction > 0 ? -1 : blips.size()) : current;
+    for (int offset = 1; offset <= blips.size(); offset++) {
+      int index = positiveModulo(start + (direction * offset), blips.size());
+      HTMLElement candidate = blips.get(index);
+      if (candidate.hasAttribute(attributeName)) {
+        focusBlip(candidate);
+        return;
+      }
+    }
+  }
+
+  private static int positiveModulo(int value, int modulo) {
+    int result = value % modulo;
+    return result < 0 ? result + modulo : result;
+  }
+
+  private int focusedBlipIndex(List<HTMLElement> blips) {
+    elemental2.dom.Element active = DomGlobal.document.activeElement;
+    if (active == null) {
+      return -1;
+    }
+    for (int index = 0; index < blips.size(); index++) {
+      HTMLElement blip = blips.get(index);
+      if (blip == active || blip.contains(active)) {
+        return index;
+      }
+    }
+    return -1;
+  }
+
+  private void focusBlip(HTMLElement target) {
+    if (target == null) {
+      return;
+    }
+    List<HTMLElement> blips = renderedBlips();
+    for (HTMLElement blip : blips) {
+      blip.setAttribute("tabindex", blip == target ? "0" : "-1");
+    }
+    FocusOptionsType focusOptions = FocusOptionsType.create();
+    focusOptions.setPreventScroll(true);
+    target.focus(focusOptions);
+    ScrollIntoViewOptions scrollOptions = ScrollIntoViewOptions.create();
+    scrollOptions.setBlock("center");
+    scrollOptions.setInline("nearest");
+    target.scrollIntoView(scrollOptions);
+  }
+
+  private List<HTMLElement> renderedBlips() {
+    elemental2.dom.NodeList<elemental2.dom.Element> nodes =
+        contentList.querySelectorAll("wave-blip[data-blip-id], div.blip[data-blip-id]");
+    List<HTMLElement> blips = new ArrayList<HTMLElement>();
+    for (int index = 0; index < nodes.length; index++) {
+      HTMLElement blip = (HTMLElement) nodes.item(index);
+      if (blip != null) {
+        blips.add(blip);
+      }
+    }
+    return blips;
   }
 
   static void configureContentList(HTMLElement contentList) {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -14,6 +14,23 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
   display: none !important;
 }
 
+.j2cl-status-live-text {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.j2cl-status-live-separator {
+  display: none !important;
+}
+
 .sidecar-shell {
   min-height: 100vh;
   display: flex;
@@ -22,7 +39,7 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 }
 
 .sidecar-root {
-  width: min(100%, 960px);
+  width: 100%;
 }
 
 .sidecar-card {
@@ -129,7 +146,7 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 
 .sidecar-split-layout {
   display: grid;
-  gap: 20px;
+  gap: 0;
   grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
   align-items: start;
 }
@@ -162,6 +179,11 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
   border-radius: 4px;
   box-shadow: none;
   padding: 12px;
+}
+
+shell-root[data-wave-controls-compact="true"] wavy-wave-header-actions,
+shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
+  display: none;
 }
 
 /* V-1 (#1099): on the server-first workflow the wave panel sits inside

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -270,8 +270,8 @@ public class J2clRootShellViewTest {
 
     view.publishLiveStatus(J2clRootLiveSurfaceModel.starting().withSelectedWaveId("example/w+1"));
 
-    Assert.assertNull(statusStrip.getAttribute("data-connection-state"));
-    Assert.assertNull(statusStrip.getAttribute("data-save-state"));
+    Assert.assertEquals("online", statusStrip.getAttribute("data-connection-state"));
+    Assert.assertEquals("saved", statusStrip.getAttribute("data-save-state"));
     Assert.assertEquals("selected-wave", statusStrip.getAttribute("data-route-state"));
     Assert.assertEquals(
         "Selected wave is active.", statusStrip.getAttribute("data-live-status-text"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -40,7 +40,9 @@ public class J2clRootShellViewTest {
     Assert.assertTrue(statusStrip.contains(separator));
     Assert.assertTrue(statusStrip.contains(liveStatus));
     Assert.assertNull(liveStatus.getAttribute("role"));
-    Assert.assertNull(liveStatus.getAttribute("aria-live"));
+    Assert.assertEquals("polite", liveStatus.getAttribute("aria-live"));
+    Assert.assertEquals("j2cl-status-live-text", liveStatus.className);
+    Assert.assertEquals("j2cl-status-live-separator", separator.className);
     Assert.assertEquals(liveStatus, separator.nextSibling);
     Assert.assertEquals("Selected wave is active.", liveStatus.textContent);
   }
@@ -258,6 +260,21 @@ public class J2clRootShellViewTest {
 
     HTMLElement liveStatus = (HTMLElement) host.querySelector("#j2cl-root-live-status-text");
     Assert.assertEquals("Loading workspace.", liveStatus.textContent);
+  }
+
+  @Test
+  public void publishLiveStatusStampsIconChromeAttributes() {
+    assumeBrowserDom();
+    J2clRootShellView view = createViewWithStatusStrip();
+    HTMLElement statusStrip = statusStrip();
+
+    view.publishLiveStatus(J2clRootLiveSurfaceModel.starting().withSelectedWaveId("example/w+1"));
+
+    Assert.assertEquals("online", statusStrip.getAttribute("data-connection-state"));
+    Assert.assertEquals("saved", statusStrip.getAttribute("data-save-state"));
+    Assert.assertEquals("selected-wave", statusStrip.getAttribute("data-route-state"));
+    Assert.assertEquals(
+        "Selected wave is active.", statusStrip.getAttribute("data-live-status-text"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -270,8 +270,8 @@ public class J2clRootShellViewTest {
 
     view.publishLiveStatus(J2clRootLiveSurfaceModel.starting().withSelectedWaveId("example/w+1"));
 
-    Assert.assertEquals("online", statusStrip.getAttribute("data-connection-state"));
-    Assert.assertEquals("saved", statusStrip.getAttribute("data-save-state"));
+    Assert.assertNull(statusStrip.getAttribute("data-connection-state"));
+    Assert.assertNull(statusStrip.getAttribute("data-save-state"));
     Assert.assertEquals("selected-wave", statusStrip.getAttribute("data-route-state"));
     Assert.assertEquals(
         "Selected wave is active.", statusStrip.getAttribute("data-live-status-text"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -585,7 +585,7 @@ public class J2clSelectedWaveViewChromeTest {
 
     dispatchNavEvent(view.getCardElement(), "wave-nav-recent-requested");
     Assert.assertEquals(
-        host.querySelector("wave-blip[data-blip-id='b+3']"),
+        host.querySelector("wave-blip[data-blip-id='b+2']"),
         DomGlobal.document.activeElement);
 
     dispatchNavEvent(view.getCardElement(), "wave-nav-end-requested");
@@ -843,7 +843,7 @@ public class J2clSelectedWaveViewChromeTest {
         Arrays.asList(
             readBlip("b+1", "one", 1000L, false, false),
             readBlip("b+2", "two", 2000L, true, false),
-            readBlip("b+3", "three", 3000L, false, true)),
+            readBlip("b+3", "three", 300L, false, true)),
         null,
         1,
         true,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -556,6 +556,60 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void navRowNextAndPreviousEventsMoveFocusedBlip() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(navigationModel());
+    HTMLElement first = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+1']");
+    HTMLElement second = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+2']");
+    Assert.assertNotNull(first);
+    Assert.assertNotNull(second);
+    first.focus();
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-next-requested");
+
+    Assert.assertEquals(second, DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-previous-requested");
+
+    Assert.assertEquals(first, DomGlobal.document.activeElement);
+  }
+
+  @Test
+  public void navRowRecentEndUnreadAndMentionEventsMoveFocusedBlip() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(navigationModel());
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-recent-requested");
+    Assert.assertEquals(
+        host.querySelector("wave-blip[data-blip-id='b+3']"),
+        DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-end-requested");
+    Assert.assertEquals(
+        host.querySelector("wave-blip[data-blip-id='b+3']"),
+        DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-next-unread-requested");
+    Assert.assertEquals(
+        host.querySelector("wave-blip[data-blip-id='b+2']"),
+        DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-next-mention-requested");
+    Assert.assertEquals(
+        host.querySelector("wave-blip[data-blip-id='b+3']"),
+        DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-prev-mention-requested");
+    Assert.assertEquals(
+        host.querySelector("wave-blip[data-blip-id='b+3']"),
+        DomGlobal.document.activeElement);
+  }
+
+  @Test
   public void selectedWaveRefreshEventInvokesRefreshHandler() {
     assumeBrowserDom();
     HTMLElement host = createHost();
@@ -770,6 +824,53 @@ public class J2clSelectedWaveViewChromeTest {
         true,
         true,
         false);
+  }
+
+  private static J2clSelectedWaveModel navigationModel() {
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        "example.com/w+nav",
+        "Selected wave",
+        "",
+        "1 unread.",
+        "",
+        "",
+        0,
+        Collections.<String>emptyList(),
+        Arrays.<String>asList(),
+        Arrays.asList(
+            readBlip("b+1", "one", 1000L, false, false),
+            readBlip("b+2", "two", 2000L, true, false),
+            readBlip("b+3", "three", 3000L, false, true)),
+        null,
+        1,
+        true,
+        true,
+        false);
+  }
+
+  private static J2clReadBlip readBlip(
+      String blipId, String text, long modifiedAt, boolean unread, boolean hasMention) {
+    return new J2clReadBlip(
+        blipId,
+        text,
+        Collections.emptyList(),
+        "vega@example.com",
+        "Vega",
+        modifiedAt,
+        "",
+        "",
+        unread,
+        hasMention);
+  }
+
+  private static void dispatchNavEvent(HTMLElement target, String eventName) {
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    target.dispatchEvent(new elemental2.dom.CustomEvent<Object>(eventName, init));
   }
 
   private static void assumeBrowserDom() {

--- a/wave/config/changelog.d/2026-05-01-j2cl-wave-panel-chrome-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-wave-panel-chrome-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-01-j2cl-wave-panel-chrome-parity",
+  "version": "Issue #1163",
+  "date": "2026-05-01",
+  "title": "J2CL wave panel chrome parity",
+  "summary": "Improves the J2CL selected-wave layout, resize affordance, compact status chrome, and wave navigation controls toward GWT parity.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Adds a keyboard and pointer resize splitter between the J2CL search rail and selected wave panel.",
+        "Replaces visible raw live-status prose with compact accessible status chips for connection, saved state, and selected-wave route state.",
+        "Wires selected-wave navigation controls to focus and scroll across rendered blips, unread blips, mentions, and recent activity."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3612,6 +3612,10 @@ public final class HtmlRenderer {
       sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
       appendWavySearchRail(sb, safeInitialQuery, railCardsEnabled, true);
       sb.append("  </shell-nav-rail>\n");
+      sb.append("  <button slot=\"splitter\" class=\"j2cl-shell-splitter\" type=\"button\"")
+          .append(" role=\"separator\" aria-orientation=\"vertical\"")
+          .append(" aria-label=\"Resize search results panel\"")
+          .append(" aria-valuemin=\"260\" aria-valuemax=\"420\" aria-valuenow=\"296\"></button>\n");
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
       // bubbles); a connectedCallback-installed listener on this
@@ -3648,7 +3652,7 @@ public final class HtmlRenderer {
           .append("\" data-active-folder=\"")
           .append(safeRailFolder)
           .append("\" data-j2cl-rail-extension=\"true\" hidden></wavy-rail-panel>\n");
-      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\">Return target: ")
+      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\" class=\"j2cl-status-live-text\">Return target: ")
           .append(safeResolvedReturnTarget)
           .append("</span></shell-status-strip>\n");
       sb.append("</shell-root>\n");
@@ -3718,7 +3722,7 @@ public final class HtmlRenderer {
       appendRootShellWorkflowMarkup(sb, resolvedSnapshotResult, false);
       sb.append("    </section>\n");
       sb.append("  </shell-main-region>\n");
-      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\">Return target: ")
+      sb.append("  <shell-status-strip slot=\"status\"><span id=\"j2cl-root-return-target-text\" class=\"j2cl-status-live-text\">Return target: ")
           .append(safeResolvedReturnTarget)
           .append("</span></shell-status-strip>\n");
       sb.append("</shell-root-signed-out>\n");
@@ -4895,7 +4899,7 @@ public final class HtmlRenderer {
     sb.append("  var brand=document.getElementById('j2cl-root-brand-link');\n");
     sb.append("  if(brand){brand.href=target;}\n");
     sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
-    sb.append("  if(targetText){targetText.textContent='Return target: ' + target;}\n");
+    sb.append("  if(targetText){targetText.className='j2cl-status-live-text';targetText.textContent='Return target: ' + target;}\n");
     sb.append("  document.querySelectorAll('[data-j2cl-root-signin]').forEach(function(anchor){anchor.href='/auth/signin?r=' + encoded;});\n");
     sb.append("  document.querySelectorAll('[data-j2cl-root-signout]').forEach(function(anchor){anchor.href='/auth/signout?r=' + encoded;});\n");
     sb.append("}\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3615,7 +3615,7 @@ public final class HtmlRenderer {
       sb.append("  <button slot=\"splitter\" class=\"j2cl-shell-splitter\" type=\"button\"")
           .append(" role=\"separator\" aria-orientation=\"vertical\"")
           .append(" aria-label=\"Resize search results panel\"")
-          .append(" aria-valuemin=\"260\" aria-valuemax=\"420\" aria-valuenow=\"296\"></button>\n");
+          .append(" aria-valuemin=\"360\" aria-valuemax=\"400\" aria-valuenow=\"400\"></button>\n");
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
       // bubbles); a connectedCallback-installed listener on this

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -35,6 +35,8 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(html.contains("<shell-root"));
     assertTrue(html.contains("<shell-header slot=\"header\" signed-in"));
     assertTrue(html.contains("<shell-nav-rail slot=\"nav\""));
+    assertTrue(html.contains("<button slot=\"splitter\" class=\"j2cl-shell-splitter\""));
+    assertTrue(html.contains("role=\"separator\" aria-orientation=\"vertical\""));
     assertTrue(html.contains("<shell-main-region slot=\"main\""));
     assertTrue(html.contains("<shell-status-strip slot=\"status\""));
     assertTrue(html.contains("<shell-skip-link slot=\"skip-link\""));
@@ -167,7 +169,9 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
         session, "", "commit", 0L, "rel", "/wave/inbox", "ws.example:443");
 
     assertTrue("Signed-out status strip must wrap return-target text in the syncable span",
-        html.contains("<span id=\"j2cl-root-return-target-text\">Return target: "));
+        html.contains(
+            "<span id=\"j2cl-root-return-target-text\" class=\"j2cl-status-live-text\">"
+                + "Return target: "));
   }
 
   public void testSignedOutPageAlsoIncludesReturnTargetBootstrap() {


### PR DESCRIPTION
Fixes #1163

## Summary
- Adds a J2CL shell splitter between the search rail and selected-wave panel, with pointer/keyboard resize and persisted rail width.
- Replaces visible raw live-status prose with compact accessible status chips plus hidden live-region text.
- Wires selected-wave navigation chrome to focus/scroll rendered blips, unread blips, mentions, and recent activity.
- Makes the wave-controls toggle use an icon affordance and compact-mode behavior instead of a confusing text/glyph surface.

## Verification
- `sbt --batch compile Test/compile j2clSearchTest j2clLitTest Universal/stage`
- `sbt --batch Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest`
- `sbt --batch compile Test/compile j2clSearchTest` after the final focus/scroll self-review fix
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `git diff --check`
- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `bash scripts/worktree-boot.sh --port 9903`
- `PORT=9903 bash scripts/wave-smoke.sh check`
- Browser verification on `http://127.0.0.1:9903/?view=j2cl-root&q=in%3Ainbox`: splitter present, keyboard resize persisted/updated aria-valuenow, compact controls mode toggled, status chips rendered as Online/Saved/Search results active, raw live/status text visually hidden.

## Review
- Claude Code review intentionally not used per updated instruction; this went through self-review plus PR review-comment follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search/side panel gains a visible splitter for keyboard (Arrow/Home/End) and pointer resizing with persisted width (server-rendered support); splitter hides on narrow viewports.
  * Status display replaced by compact accessible status chips (connection, save, route) with aria labels and live-region support; prose retained for screen readers.
  * Wave navigation actions now move focus/scroll to relevant blips (next/prev, unread, mentions, recent, end).

* **Tests**
  * Added/updated tests for splitter behavior, persistence/resilience, status chips/accessibility, toggle icon rendering, and navigation focus/scroll.

* **Documentation**
  * Added implementation plan and changelog entry for wave-panel chrome parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->