### PR TITLE
Fix J2CL participant parity

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1164-participant-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1164-participant-parity.md
@@ -1,0 +1,63 @@
+# Issue #1164 J2CL Participant Parity Plan
+
+**Goal:** Bring J2CL participant chrome closer to GWT parity: avatar strip instead of raw text, real profile popup content instead of "Unknown participant", icon action buttons, and useful add-participant suggestions.
+
+**Review policy:** Claude Code review is intentionally not used for this lane. Use self-review plus GitHub PR review comments.
+
+## Current Findings
+
+- `J2clSelectedWaveView.render()` writes participants as plain text in `.sidecar-selected-participants`: `Participants: alice, bob`.
+- `wavy-profile-overlay` already supports participant objects and profile-card actions, but the selected-wave view does not populate it from `J2clSelectedWaveModel.getParticipantIds()`.
+- Blip avatar clicks emit `wave-blip-profile-requested`; when the overlay has no matching participant object it falls back to index `0`, which can display "Unknown participant".
+- `wavy-wave-header-actions` renders add/new/public/lock as text buttons, and add-participant is a free-text form only.
+- GWT has a remote contact manager backed by `/contacts` and `/contacts/search`; J2CL can use the same endpoint for frequent-contact suggestions without adding a new backend API.
+
+## Implementation Tasks
+
+- [ ] Add focused tests first:
+  - `J2clSelectedWaveViewChromeTest` asserts selected-wave participants render as avatar/icon buttons, not visible comma-separated text.
+  - `J2clSelectedWaveViewChromeTest` asserts the global `wavy-profile-overlay` receives participant objects from the selected wave.
+  - `wavy-profile-overlay.test.js` asserts unknown author fallback creates a meaningful participant from the triggering author id instead of rendering "Unknown participant".
+  - `wavy-wave-header-actions.test.js` asserts action buttons use icon affordances with accessible labels and add-participant suggestions can be loaded/selected.
+- [ ] Replace `.sidecar-selected-participants` text with a compact participant avatar strip:
+  - Use deterministic initials from participant address/display name.
+  - Use `<button>` affordances with `aria-label="Open <participant> profile"`.
+  - Dispatch `wave-blip-profile-requested` with `authorId` so the existing profile overlay path handles the popup.
+  - Preserve hidden/empty behavior when no participants exist.
+- [ ] Publish participant objects to `wavy-profile-overlay` whenever selected-wave model changes:
+  - Shape: `{ id, displayName, avatarToken }`.
+  - Use participant id as display name until richer profile data is available.
+  - Do not block rendering on profile fetch.
+- [ ] Improve `wavy-profile-overlay` fallback:
+  - If an avatar request carries an unknown `authorId`, render that id as a participant badge/card instead of "Unknown participant".
+  - Keep previous/next disabled for singleton fallback.
+- [ ] Convert `wavy-wave-header-actions` buttons to icon-style GWT-like action buttons:
+  - Keep visible labels available to screen readers.
+  - Keep existing event contracts unchanged.
+  - Do not break public/private and lock confirmations.
+- [ ] Add frequent-contact suggestions to add-participant:
+  - Fetch `/contacts?timestamp=0` on first add dialog open.
+  - Parse `contacts[].participant`, dedupe, and exclude current wave participants/shared-domain pseudo participants.
+  - Show suggestion chips that append to the draft or directly include the address for submit.
+  - Gracefully fall back to no suggestions if fetch fails.
+- [ ] Add a changelog fragment for user-facing participant chrome behavior.
+
+## Verification
+
+- Run focused Lit tests:
+  - `cd j2cl/lit && npm test -- --files test/wavy-wave-header-actions.test.js test/wavy-profile-overlay.test.js`
+- Run focused J2CL search tests:
+  - `sbt --batch j2clSearchTest`
+- Run broader verification before PR:
+  - `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`
+  - `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+  - `git diff --check`
+- Run local browser verification on J2CL root with file-store data:
+  - Open a selected wave with multiple participants.
+  - Confirm avatar strip, participant popup content, icon header actions, and add-participant suggestions.
+
+## Self-Review
+
+- Scope stays inside #1164. Mentions/editor behavior remains #1165, attachment sizing remains #1166, and inline/thread parity remains #1167.
+- The plan avoids adding a new backend endpoint by reusing the existing `/contacts` GWT-backed contact service.
+- Risk: profile display names and avatar URLs are not available from the current selected-wave model. This plan uses a meaningful participant-id badge now and leaves richer profile lookup as a follow-up if needed.

--- a/docs/superpowers/plans/2026-05-01-issue-1164-participant-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1164-participant-parity.md
@@ -40,7 +40,7 @@
   - Parse `contacts[].participant`, dedupe, and exclude current wave participants/shared-domain pseudo participants.
   - Show suggestion chips that append to the draft or directly include the address for submit.
   - Gracefully fall back to no suggestions if fetch fails.
-- [ ] Add a changelog fragment for user-facing participant chrome behavior.
+- [ ] Add a new changelog fragment for user-facing participant chrome behavior under `wave/config/changelog.d/`; do not hand-edit `wave/config/changelog.json`.
 
 ## Verification
 

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -199,6 +199,11 @@ export class WavyProfileOverlay extends LitElement {
     super.disconnectedCallback();
   }
 
+  _activeParticipants() {
+    const participantList = Array.isArray(this.participants) ? this.participants : [];
+    return this._fallbackParticipant ? [this._fallbackParticipant] : participantList;
+  }
+
   willUpdate(changed) {
     if (changed.has("open")) {
       this._syncOpen();
@@ -209,7 +214,7 @@ export class WavyProfileOverlay extends LitElement {
     // local idx, but the navigation handlers consume `this.index`
     // directly — keep them in lockstep.
     if (changed.has("participants") || changed.has("index")) {
-      const list = Array.isArray(this.participants) ? this.participants : [];
+      const list = this._activeParticipants();
       const max = list.length > 0 ? list.length - 1 : 0;
       const raw = Number.isFinite(this.index) ? this.index : 0;
       const clamped = Math.max(0, Math.min(raw, max));
@@ -231,7 +236,7 @@ export class WavyProfileOverlay extends LitElement {
       this.setAttribute("aria-modal", "true");
       // aria-labelledby cannot resolve across the shadow DOM boundary; use
       // aria-label so assistive tech can announce the dialog name.
-      const list = Array.isArray(this.participants) ? this.participants : [];
+      const list = this._activeParticipants();
       const max = list.length > 0 ? list.length - 1 : 0;
       const idx = Math.max(0, Math.min(Number.isFinite(this.index) ? this.index : 0, max));
       const name = (list[idx] && list[idx].displayName) || "Profile";
@@ -324,7 +329,7 @@ export class WavyProfileOverlay extends LitElement {
   open_(index) {
     this._fallbackParticipant = null;
     if (typeof index === "number") {
-      const list = Array.isArray(this.participants) ? this.participants : [];
+      const list = this._activeParticipants();
       const max = list.length > 0 ? list.length - 1 : 0;
       this.index = Math.min(Math.max(index, 0), max);
     }
@@ -357,7 +362,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   _next() {
-    const list = Array.isArray(this.participants) ? this.participants : [];
+    const list = this._activeParticipants();
     if (list.length === 0) return;
     if (this.index >= list.length - 1) return;
     this.index = this.index + 1;
@@ -365,7 +370,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   _prev() {
-    const list = Array.isArray(this.participants) ? this.participants : [];
+    const list = this._activeParticipants();
     if (list.length === 0) return;
     if (this.index <= 0) return;
     this.index = this.index - 1;
@@ -373,7 +378,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   _emitChange() {
-    const list = Array.isArray(this.participants) ? this.participants : [];
+    const list = this._activeParticipants();
     const participant = list[this.index] || null;
     this.dispatchEvent(
       new CustomEvent("wavy-profile-participant-changed", {
@@ -452,11 +457,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   render() {
-    const participantList = Array.isArray(this.participants) ? this.participants : [];
-    const list =
-      this._fallbackParticipant
-          ? [this._fallbackParticipant]
-          : participantList;
+    const list = this._activeParticipants();
     const max = list.length > 0 ? list.length - 1 : 0;
     const idx = Math.min(Math.max(this.index || 0, 0), max);
     const current = list[idx] || null;

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -204,6 +204,21 @@ export class WavyProfileOverlay extends LitElement {
     return this._fallbackParticipant ? [this._fallbackParticipant] : participantList;
   }
 
+  _setFallbackParticipant(participant) {
+    const previous = this._fallbackParticipant;
+    const same =
+      previous === participant ||
+      (previous &&
+        participant &&
+        previous.id === participant.id &&
+        previous.displayName === participant.displayName &&
+        previous.avatarUrl === participant.avatarUrl);
+    this._fallbackParticipant = participant;
+    if (!same) {
+      this.requestUpdate("_fallbackParticipant", previous);
+    }
+  }
+
   willUpdate(changed) {
     if (changed.has("open")) {
       this._syncOpen();
@@ -213,7 +228,7 @@ export class WavyProfileOverlay extends LitElement {
     // participants array shrinks under us. render() already clamps a
     // local idx, but the navigation handlers consume `this.index`
     // directly — keep them in lockstep.
-    if (changed.has("participants") || changed.has("index")) {
+    if (changed.has("participants") || changed.has("index") || changed.has("_fallbackParticipant")) {
       const list = this._activeParticipants();
       const max = list.length > 0 ? list.length - 1 : 0;
       const raw = Number.isFinite(this.index) ? this.index : 0;
@@ -303,17 +318,17 @@ export class WavyProfileOverlay extends LitElement {
     if (authorId) {
       const found = list.findIndex((p) => p && p.id === authorId);
       if (found >= 0) {
-        this._fallbackParticipant = null;
+        this._setFallbackParticipant(null);
         this.index = found;
       } else {
-        this._fallbackParticipant = {
+        this._setFallbackParticipant({
           id: String(authorId),
           displayName: String(authorId)
-        };
+        });
         this.index = 0;
       }
     } else {
-      this._fallbackParticipant = null;
+      this._setFallbackParticipant(null);
       this.index = 0;
     }
     this.open = true;
@@ -327,7 +342,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   open_(index) {
-    this._fallbackParticipant = null;
+    this._setFallbackParticipant(null);
     if (typeof index === "number") {
       const list = this._activeParticipants();
       const max = list.length > 0 ? list.length - 1 : 0;

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -181,6 +181,7 @@ export class WavyProfileOverlay extends LitElement {
     this.index = 0;
     this.currentUserId = "";
     this.editProfileUrl = "/userprofile/edit";
+    this._fallbackParticipant = null;
     this._onAvatarRequest = this._onAvatarRequest.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
   }
@@ -297,11 +298,17 @@ export class WavyProfileOverlay extends LitElement {
     if (authorId) {
       const found = list.findIndex((p) => p && p.id === authorId);
       if (found >= 0) {
+        this._fallbackParticipant = null;
         this.index = found;
       } else {
+        this._fallbackParticipant = {
+          id: String(authorId),
+          displayName: String(authorId)
+        };
         this.index = 0;
       }
     } else {
+      this._fallbackParticipant = null;
       this.index = 0;
     }
     this.open = true;
@@ -315,6 +322,7 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   open_(index) {
+    this._fallbackParticipant = null;
     if (typeof index === "number") {
       const list = Array.isArray(this.participants) ? this.participants : [];
       const max = list.length > 0 ? list.length - 1 : 0;
@@ -444,7 +452,11 @@ export class WavyProfileOverlay extends LitElement {
   }
 
   render() {
-    const list = Array.isArray(this.participants) ? this.participants : [];
+    const participantList = Array.isArray(this.participants) ? this.participants : [];
+    const list =
+      this._fallbackParticipant
+          ? [this._fallbackParticipant]
+          : participantList;
     const max = list.length > 0 ? list.length - 1 : 0;
     const idx = Math.min(Math.max(this.index || 0, 0), max);
     const current = list[idx] || null;

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -33,6 +33,19 @@ function uniqueValues(values) {
   return result;
 }
 
+function uniqueValuesCaseInsensitive(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of values) {
+    const normalizedValue = String(value || "").trim();
+    const normalizedKey = normalizedValue.toLowerCase();
+    if (!normalizedValue || seen.has(normalizedKey)) continue;
+    seen.add(normalizedKey);
+    result.push(normalizedValue);
+  }
+  return result;
+}
+
 const ACTION_ICON_PATHS = {
   addParticipant: svg`<path d="M8 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"></path>
     <path d="M2.5 18a5.5 5.5 0 0 1 11 0"></path>
@@ -414,7 +427,7 @@ export class WavyWaveHeaderActions extends LitElement {
     if (!values.some((value) => value.toLowerCase() === normalizedAddress.toLowerCase())) {
       values.push(normalizedAddress);
     }
-    this._participantDraft = uniqueValues(values).join(", ");
+    this._participantDraft = uniqueValuesCaseInsensitive(values).join(", ");
   }
 
   _openAddParticipant(event) {

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -33,23 +33,28 @@ function uniqueValues(values) {
   return result;
 }
 
+const ACTION_ICON_PATHS = {
+  addParticipant: svg`<path d="M8 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"></path>
+    <path d="M2.5 18a5.5 5.5 0 0 1 11 0"></path>
+    <path d="M17 8v6"></path>
+    <path d="M14 11h6"></path>`,
+  newWave: svg`<path d="M4 5.5h12a3 3 0 0 1 3 3v5a3 3 0 0 1-3 3H9l-5 3v-11a3 3 0 0 1 3-3Z"></path>
+    <path d="M11.5 8.5v5"></path>
+    <path d="M9 11h5"></path>`,
+  public: svg`<path d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"></path>
+    <path d="M4.5 9h15"></path>
+    <path d="M4.5 15h15"></path>
+    <path d="M12 4a12 12 0 0 1 0 16"></path>
+    <path d="M12 4a12 12 0 0 0 0 16"></path>`,
+  lock: svg`<rect x="5" y="10" width="14" height="10" rx="2"></rect>
+    <path d="M8 10V7a4 4 0 0 1 8 0v3"></path>`
+};
+
 function actionIcon(name) {
-  const paths = {
-    addParticipant: svg`<path d="M8 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"></path>
-      <path d="M2.5 18a5.5 5.5 0 0 1 11 0"></path>
-      <path d="M17 8v6"></path>
-      <path d="M14 11h6"></path>`,
-    newWave: svg`<path d="M4 5.5h12a3 3 0 0 1 3 3v5a3 3 0 0 1-3 3H9l-5 3v-11a3 3 0 0 1 3-3Z"></path>
-      <path d="M11.5 8.5v5"></path>
-      <path d="M9 11h5"></path>`,
-    public: svg`<path d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"></path>
-      <path d="M4.5 9h15"></path>
-      <path d="M4.5 15h15"></path>
-      <path d="M12 4a12 12 0 0 1 0 16"></path>
-      <path d="M12 4a12 12 0 0 0 0 16"></path>`,
-    lock: svg`<rect x="5" y="10" width="14" height="10" rx="2"></rect>
-      <path d="M8 10V7a4 4 0 0 1 8 0v3"></path>`
-  };
+  if (!(name in ACTION_ICON_PATHS)) {
+    console.warn(`actionIcon: unknown icon "${name}"`);
+    return svg``;
+  }
   return svg`<svg
     aria-hidden="true"
     viewBox="0 0 24 24"
@@ -58,7 +63,7 @@ function actionIcon(name) {
     stroke-width="1.8"
     stroke-linecap="round"
     stroke-linejoin="round"
-  >${paths[name]}</svg>`;
+  >${ACTION_ICON_PATHS[name]}</svg>`;
 }
 
 export class WavyWaveHeaderActions extends LitElement {

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -410,7 +410,10 @@ export class WavyWaveHeaderActions extends LitElement {
 
   _appendSuggestedParticipant(address) {
     const values = this._addParticipantAddresses();
-    values.push(address);
+    const normalizedAddress = String(address || "").trim();
+    if (!values.some((value) => value.toLowerCase() === normalizedAddress.toLowerCase())) {
+      values.push(normalizedAddress);
+    }
     this._participantDraft = uniqueValues(values).join(", ");
   }
 

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -451,7 +451,7 @@ export class WavyWaveHeaderActions extends LitElement {
       this._contactsLoaded = true;
     } catch (_err) {
       this._contactSuggestions = [];
-      this._contactsLoaded = true;
+      this._contactsLoaded = false;
     } finally {
       this._contactsLoading = false;
     }

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -1,4 +1,4 @@
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, svg } from "lit";
 import { ensureWavyConfirmDialogMounted } from "./wavy-confirm-dialog.js";
 
 const LOCK_CYCLE = {
@@ -33,6 +33,34 @@ function uniqueValues(values) {
   return result;
 }
 
+function actionIcon(name) {
+  const paths = {
+    addParticipant: svg`<path d="M8 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"></path>
+      <path d="M2.5 18a5.5 5.5 0 0 1 11 0"></path>
+      <path d="M17 8v6"></path>
+      <path d="M14 11h6"></path>`,
+    newWave: svg`<path d="M4 5.5h12a3 3 0 0 1 3 3v5a3 3 0 0 1-3 3H9l-5 3v-11a3 3 0 0 1 3-3Z"></path>
+      <path d="M11.5 8.5v5"></path>
+      <path d="M9 11h5"></path>`,
+    public: svg`<path d="M12 20a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z"></path>
+      <path d="M4.5 9h15"></path>
+      <path d="M4.5 15h15"></path>
+      <path d="M12 4a12 12 0 0 1 0 16"></path>
+      <path d="M12 4a12 12 0 0 0 0 16"></path>`,
+    lock: svg`<rect x="5" y="10" width="14" height="10" rx="2"></rect>
+      <path d="M8 10V7a4 4 0 0 1 8 0v3"></path>`
+  };
+  return svg`<svg
+    aria-hidden="true"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >${paths[name]}</svg>`;
+}
+
 export class WavyWaveHeaderActions extends LitElement {
   static properties = {
     sourceWaveId: { type: String, attribute: "source-wave-id", reflect: true },
@@ -41,7 +69,10 @@ export class WavyWaveHeaderActions extends LitElement {
     lockState: { type: String, attribute: "lock-state", reflect: true },
     disabled: { type: Boolean, reflect: true },
     _addDialogOpen: { state: true },
-    _participantDraft: { state: true }
+    _participantDraft: { state: true },
+    _contactSuggestions: { state: true },
+    _contactsLoaded: { state: true },
+    _contactsLoading: { state: true }
   };
 
   static styles = css`
@@ -79,6 +110,41 @@ export class WavyWaveHeaderActions extends LitElement {
           var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
         color var(--wavy-motion-focus-duration, 180ms)
           var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+
+    button svg {
+      width: 18px;
+      height: 18px;
+      display: block;
+      color: currentColor;
+      stroke: currentColor;
+      stroke-width: 2.4;
+      overflow: visible;
+      pointer-events: none;
+    }
+
+    .row > button[data-action] {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 42px;
+      padding: 0;
+      background: var(--wavy-signal-cyan-soft, #e6f6ff);
+      border-color: rgba(0, 119, 182, 0.32);
+      color: var(--wavy-signal-cyan-strong, #005f93);
+    }
+
+    .action-label {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
     }
 
     button:hover:not([disabled]) {
@@ -138,6 +204,23 @@ export class WavyWaveHeaderActions extends LitElement {
       gap: var(--wavy-spacing-2, 8px);
       justify-content: flex-end;
     }
+
+    .suggestions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wavy-spacing-1, 4px);
+    }
+
+    .suggestions-label {
+      flex-basis: 100%;
+      color: var(--wavy-text-muted, #64748b);
+      font: var(--wavy-type-meta, 12px / 1.35 Arial, sans-serif);
+    }
+
+    .suggestion {
+      min-height: 26px;
+      padding: 0 var(--wavy-spacing-2, 8px);
+    }
   `;
 
   constructor() {
@@ -149,6 +232,9 @@ export class WavyWaveHeaderActions extends LitElement {
     this.disabled = false;
     this._addDialogOpen = false;
     this._participantDraft = "";
+    this._contactSuggestions = [];
+    this._contactsLoaded = false;
+    this._contactsLoading = false;
     this._pendingConfirm = null;
     this._onConfirmResolved = this._onConfirmResolved.bind(this);
   }
@@ -183,7 +269,8 @@ export class WavyWaveHeaderActions extends LitElement {
           ?disabled=${unavailable}
           @click=${this._openAddParticipant}
         >
-          Add participant
+          ${actionIcon("addParticipant")}
+          <span class="action-label">Add participant</span>
         </button>
         <button
           type="button"
@@ -192,7 +279,8 @@ export class WavyWaveHeaderActions extends LitElement {
           ?disabled=${unavailable}
           @click=${this._newWithParticipants}
         >
-          New with participants
+          ${actionIcon("newWave")}
+          <span class="action-label">New with participants</span>
         </button>
         <button
           type="button"
@@ -202,7 +290,8 @@ export class WavyWaveHeaderActions extends LitElement {
           ?disabled=${unavailable}
           @click=${this._confirmPublicityToggle}
         >
-          ${this.public ? "Public" : "Private"}
+          ${actionIcon("public")}
+          <span class="action-label">${this.public ? "Public" : "Private"}</span>
         </button>
         <button
           type="button"
@@ -212,7 +301,8 @@ export class WavyWaveHeaderActions extends LitElement {
           ?disabled=${unavailable}
           @click=${this._confirmLockToggle}
         >
-          ${this._lockText(lockState)}
+          ${actionIcon("lock")}
+          <span class="action-label">${this._lockText(lockState)}</span>
         </button>
       </div>
       ${this._addDialogOpen ? this._renderAddParticipantDialog() : ""}
@@ -232,6 +322,7 @@ export class WavyWaveHeaderActions extends LitElement {
             @input=${this._onParticipantDraftInput}
           />
         </label>
+        ${this._renderContactSuggestions()}
         <div class="add-actions">
           <button
             type="button"
@@ -271,10 +362,58 @@ export class WavyWaveHeaderActions extends LitElement {
     );
   }
 
+  _renderContactSuggestions() {
+    const suggestions = this._availableContactSuggestions();
+    if (this._contactsLoading) {
+      return html`<div class="suggestions" aria-live="polite">Loading frequent contacts...</div>`;
+    }
+    if (suggestions.length === 0) {
+      return "";
+    }
+    return html`
+      <div class="suggestions" aria-label="Frequent contacts">
+        <span class="suggestions-label">Frequent contacts</span>
+        ${suggestions.map(
+          (address) => html`
+            <button
+              type="button"
+              class="suggestion"
+              data-contact-suggestion=${address}
+              @click=${() => this._appendSuggestedParticipant(address)}
+            >
+              ${address}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  _availableContactSuggestions() {
+    const current = new Set(this._regularParticipants().map((value) => value.toLowerCase()));
+    const draft = new Set(this._addParticipantAddresses().map((value) => value.toLowerCase()));
+    return uniqueValues(this._contactSuggestions || []).filter((address) => {
+      const normalized = String(address || "").trim().toLowerCase();
+      return (
+        normalized &&
+        !normalized.startsWith("@") &&
+        !current.has(normalized) &&
+        !draft.has(normalized)
+      );
+    });
+  }
+
+  _appendSuggestedParticipant(address) {
+    const values = this._addParticipantAddresses();
+    values.push(address);
+    this._participantDraft = uniqueValues(values).join(", ");
+  }
+
   _openAddParticipant(event) {
     event.stopPropagation();
     if (this._unavailable()) return;
     this._addDialogOpen = true;
+    this._loadContactSuggestions();
   }
 
   _closeAddParticipant(event) {
@@ -285,6 +424,32 @@ export class WavyWaveHeaderActions extends LitElement {
 
   _onParticipantDraftInput(event) {
     this._participantDraft = event.target.value;
+  }
+
+  async _loadContactSuggestions() {
+    if (this._contactsLoaded || this._contactsLoading || typeof fetch !== "function") {
+      return;
+    }
+    this._contactsLoading = true;
+    try {
+      const response = await fetch("/contacts?timestamp=0");
+      if (!response || !response.ok) {
+        throw new Error("contacts request failed");
+      }
+      const payload = await response.json();
+      const contacts = Array.isArray(payload && payload.contacts) ? payload.contacts : [];
+      this._contactSuggestions = uniqueValues(
+        contacts
+          .map((entry) => String(entry && entry.participant ? entry.participant : "").trim())
+          .filter(Boolean)
+      );
+      this._contactsLoaded = true;
+    } catch (_err) {
+      this._contactSuggestions = [];
+      this._contactsLoaded = true;
+    } finally {
+      this._contactsLoading = false;
+    }
   }
 
   _submitAddParticipant(event) {

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -89,6 +89,33 @@ describe("<wavy-profile-overlay>", () => {
     );
   });
 
+  it("unknown author fallback owns navigation state while displayed", async () => {
+    const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+    el.participants = PARTICIPANTS;
+    await el.updateComplete;
+    document.dispatchEvent(
+      new CustomEvent("wave-blip-profile-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { authorId: "ghost@example.com" }
+      })
+    );
+    await el.updateComplete;
+
+    let changed = false;
+    el.addEventListener("wavy-profile-participant-changed", () => {
+      changed = true;
+    });
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    await el.updateComplete;
+
+    expect(changed).to.equal(false);
+    expect(el.getAttribute("aria-label")).to.equal("ghost@example.com");
+    expect(el.renderRoot.querySelector(".name").textContent.trim()).to.equal(
+      "ghost@example.com"
+    );
+  });
+
   it("opening fires wavy-profile-overlay-opened with the trigger authorId", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = PARTICIPANTS;

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -68,6 +68,27 @@ describe("<wavy-profile-overlay>", () => {
     expect(el.index).to.equal(0);
   });
 
+  it("opening with an unknown authorId renders a meaningful participant badge", async () => {
+    const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+    el.participants = PARTICIPANTS;
+    await el.updateComplete;
+    document.dispatchEvent(
+      new CustomEvent("wave-blip-profile-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { authorId: "ghost@example.com" }
+      })
+    );
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector(".name").textContent.trim()).to.equal(
+      "ghost@example.com"
+    );
+    expect(el.renderRoot.querySelector(".pid").textContent.trim()).to.equal(
+      "ghost@example.com"
+    );
+  });
+
   it("opening fires wavy-profile-overlay-opened with the trigger authorId", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = PARTICIPANTS;
@@ -277,7 +298,7 @@ describe("<wavy-profile-overlay>", () => {
     expect(prev.hasAttribute("disabled")).to.equal(true);
     expect(next.hasAttribute("disabled")).to.equal(true);
     const name = el.renderRoot.querySelector(".name");
-    expect(name.textContent.trim()).to.equal("Unknown participant");
+    expect(name.textContent.trim()).to.equal("ghost@example.com");
   });
 
   it("renders <img> avatar when participant has avatarUrl, otherwise initials", async () => {

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -116,6 +116,38 @@ describe("<wavy-profile-overlay>", () => {
     );
   });
 
+  it("updates an already-open unknown author fallback when another unknown profile is requested", async () => {
+    const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+    el.participants = PARTICIPANTS;
+    await el.updateComplete;
+    document.dispatchEvent(
+      new CustomEvent("wave-blip-profile-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { authorId: "ghost-one@example.com" }
+      })
+    );
+    await el.updateComplete;
+
+    document.dispatchEvent(
+      new CustomEvent("wave-blip-profile-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { authorId: "ghost-two@example.com" }
+      })
+    );
+    await el.updateComplete;
+
+    expect(el.index).to.equal(0);
+    expect(el.getAttribute("aria-label")).to.equal("ghost-two@example.com");
+    expect(el.renderRoot.querySelector(".name").textContent.trim()).to.equal(
+      "ghost-two@example.com"
+    );
+    expect(el.renderRoot.querySelector(".pid").textContent.trim()).to.equal(
+      "ghost-two@example.com"
+    );
+  });
+
   it("opening fires wavy-profile-overlay-opened with the trigger authorId", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = PARTICIPANTS;

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -56,6 +56,10 @@ describe("<wavy-wave-header-actions>", () => {
     expect(actionButton(el, "lock-toggle").getAttribute("aria-label")).to.equal(
       "Lock root blip"
     );
+    expect(actionButton(el, "add-participant").querySelector("svg")).to.exist;
+    expect(actionButton(el, "add-participant").textContent.trim()).to.equal(
+      "Add participant"
+    );
   });
 
   it("disables write buttons when no source wave is selected", async () => {
@@ -87,6 +91,46 @@ describe("<wavy-wave-header-actions>", () => {
     });
     expect(event.bubbles).to.be.true;
     expect(event.composed).to.be.true;
+  });
+
+  it("loads frequent-contact suggestions and appends selected contact to the draft", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      expect(String(url)).to.equal("/contacts?timestamp=0");
+      return {
+        ok: true,
+        async json() {
+          return {
+            contacts: [
+              { participant: "alice@example.com", score: 10 },
+              { participant: "carol@example.com", score: 8 }
+            ]
+          };
+        }
+      };
+    };
+    try {
+      const el = await createActions({ participants: ["alice@example.com"] });
+
+      actionButton(el, "add-participant").click();
+      await el.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      expect(el.renderRoot.querySelector('[data-contact-suggestion="alice@example.com"]')).to.not
+        .exist;
+      const suggestion = el.renderRoot.querySelector(
+        '[data-contact-suggestion="carol@example.com"]'
+      );
+      expect(suggestion).to.exist;
+      suggestion.click();
+      await el.updateComplete;
+
+      const input = el.renderRoot.querySelector('input[name="participant-addresses"]');
+      expect(input.value).to.equal("carol@example.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("starts a new wave with current participants excluding the shared-domain participant", async () => {

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -133,6 +133,46 @@ describe("<wavy-wave-header-actions>", () => {
     }
   });
 
+  it("retries frequent-contact loading after a transient failure", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return { ok: false };
+      }
+      return {
+        ok: true,
+        async json() {
+          return { contacts: [{ participant: "retry@example.com" }] };
+        }
+      };
+    };
+    try {
+      const el = await createActions();
+
+      actionButton(el, "add-participant").click();
+      await el.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      expect(el.renderRoot.querySelector('[data-contact-suggestion="retry@example.com"]')).to.not
+        .exist;
+
+      actionButton(el, "add-participant-cancel").click();
+      await el.updateComplete;
+      actionButton(el, "add-participant").click();
+      await el.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      expect(calls).to.equal(2);
+      expect(el.renderRoot.querySelector('[data-contact-suggestion="retry@example.com"]')).to
+        .exist;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("starts a new wave with current participants excluding the shared-domain participant", async () => {
     const el = await createActions({
       participants: ["@example.com", "alice@example.com", "bob@example.com"]

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -173,6 +173,37 @@ describe("<wavy-wave-header-actions>", () => {
     }
   });
 
+  it("does not append a duplicate suggestion when draft already contains the email with different casing", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      async json() {
+        return { contacts: [{ participant: "Carol@example.com", score: 8 }] };
+      }
+    });
+    try {
+      const el = await createActions({ participants: [] });
+      el._participantDraft = "carol@example.com";
+
+      actionButton(el, "add-participant").click();
+      await el.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      const suggestion = el.renderRoot.querySelector(
+        '[data-contact-suggestion="Carol@example.com"]'
+      );
+      expect(suggestion).to.exist;
+      suggestion.click();
+      await el.updateComplete;
+
+      const input = el.renderRoot.querySelector('input[name="participant-addresses"]');
+      expect(input.value).to.equal("carol@example.com");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("starts a new wave with current participants excluding the shared-domain participant", async () => {
     const el = await createActions({
       participants: ["@example.com", "alice@example.com", "bob@example.com"]

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -173,35 +173,14 @@ describe("<wavy-wave-header-actions>", () => {
     }
   });
 
-  it("does not append a duplicate suggestion when draft already contains the email with different casing", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async () => ({
-      ok: true,
-      async json() {
-        return { contacts: [{ participant: "Carol@example.com", score: 8 }] };
-      }
-    });
-    try {
-      const el = await createActions({ participants: [] });
-      el._participantDraft = "carol@example.com";
+  it("deduplicates appended suggestions against differently-cased draft entries", async () => {
+    const el = await createActions({ participants: [] });
+    el._participantDraft = "carol@example.com, CAROL@example.com";
 
-      actionButton(el, "add-participant").click();
-      await el.updateComplete;
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      await el.updateComplete;
+    el._appendSuggestedParticipant("Carol@example.com");
+    await el.updateComplete;
 
-      const suggestion = el.renderRoot.querySelector(
-        '[data-contact-suggestion="Carol@example.com"]'
-      );
-      expect(suggestion).to.exist;
-      suggestion.click();
-      await el.updateComplete;
-
-      const input = el.renderRoot.querySelector('input[name="participant-addresses"]');
-      expect(input.value).to.equal("carol@example.com");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(el._participantDraft).to.equal("carol@example.com");
   });
 
   it("starts a new wave with current participants excluding the shared-domain participant", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -776,17 +776,19 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       if (address.isEmpty()) {
         continue;
       }
+      HTMLElement item = (HTMLElement) DomGlobal.document.createElement("span");
+      item.setAttribute("role", "listitem");
       HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
       button.className = "sidecar-selected-participant-avatar";
       button.setAttribute("type", "button");
-      button.setAttribute("role", "listitem");
       button.setAttribute("data-selected-participant-avatar", "true");
       button.setAttribute("data-participant-id", address);
       button.setAttribute("aria-label", "Open " + address + " profile");
       button.setAttribute("title", address);
       button.textContent = participantInitials(address);
       button.addEventListener("click", event -> dispatchParticipantProfileRequest(address));
-      participantSummary.appendChild(button);
+      item.appendChild(button);
+      participantSummary.appendChild(item);
     }
     participantSummary.hidden = participantSummary.childElementCount == 0;
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -2,6 +2,8 @@ package org.waveprotocol.box.j2cl.search;
 
 import elemental2.core.JsArray;
 import elemental2.core.JsDate;
+import elemental2.dom.CustomEvent;
+import elemental2.dom.CustomEventInit;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element.FocusOptionsType;
 import elemental2.dom.HTMLDivElement;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
@@ -687,11 +690,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     status.textContent = model.getStatusText();
     status.hidden = !model.isError() && !isDebugOverlayOn();
     detail.textContent = model.getDetailText();
-    participantSummary.textContent =
-        model.getParticipantIds().isEmpty()
-            ? ""
-            : "Participants: " + String.join(", ", model.getParticipantIds());
-    participantSummary.hidden = model.getParticipantIds().isEmpty();
+    renderParticipantStrip(model.getParticipantIds());
+    publishProfileOverlayParticipants(model.getParticipantIds());
     snippet.textContent = model.getSnippetText();
     snippet.hidden = model.getSnippetText().isEmpty();
 
@@ -761,6 +761,98 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     setProperty(waveHeaderActions, "public", false);
     setProperty(waveHeaderActions, "lockState", "");
     setProperty(waveHeaderActions, "disabled", true);
+  }
+
+  private void renderParticipantStrip(List<String> participantIds) {
+    participantSummary.textContent = "";
+    participantSummary.setAttribute("role", "list");
+    if (participantIds == null || participantIds.isEmpty()) {
+      participantSummary.hidden = true;
+      return;
+    }
+    participantSummary.hidden = false;
+    for (String participantId : participantIds) {
+      String address = participantId == null ? "" : participantId.trim();
+      if (address.isEmpty()) {
+        continue;
+      }
+      HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
+      button.className = "sidecar-selected-participant-avatar";
+      button.setAttribute("type", "button");
+      button.setAttribute("role", "listitem");
+      button.setAttribute("data-selected-participant-avatar", "true");
+      button.setAttribute("data-participant-id", address);
+      button.setAttribute("aria-label", "Open " + address + " profile");
+      button.setAttribute("title", address);
+      button.textContent = participantInitials(address);
+      button.addEventListener("click", event -> dispatchParticipantProfileRequest(address));
+      participantSummary.appendChild(button);
+    }
+    participantSummary.hidden = participantSummary.childElementCount == 0;
+  }
+
+  private void publishProfileOverlayParticipants(List<String> participantIds) {
+    HTMLElement overlay = (HTMLElement) DomGlobal.document.querySelector("wavy-profile-overlay");
+    if (overlay == null) {
+      return;
+    }
+    Js.asPropertyMap(overlay).set("participants", buildParticipantProfileArray(participantIds));
+  }
+
+  private static JsArray<Object> buildParticipantProfileArray(List<String> participantIds) {
+    JsArray<Object> participants = JsArray.of();
+    if (participantIds == null) {
+      return participants;
+    }
+    for (String participantId : participantIds) {
+      String address = participantId == null ? "" : participantId.trim();
+      if (address.isEmpty()) {
+        continue;
+      }
+      JsPropertyMap<Object> participant = JsPropertyMap.of();
+      participant.set("id", address);
+      participant.set("displayName", address);
+      participant.set("avatarToken", participantInitials(address));
+      participants.push(participant);
+    }
+    return participants;
+  }
+
+  private void dispatchParticipantProfileRequest(String participantId) {
+    JsPropertyMap<Object> detail = JsPropertyMap.of();
+    detail.set("authorId", participantId);
+    CustomEventInit<Object> init = CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    init.setDetail(Js.cast(detail));
+    participantSummary.dispatchEvent(new CustomEvent<Object>("wave-blip-profile-requested", init));
+  }
+
+  private static String participantInitials(String participantId) {
+    String value = participantId == null ? "" : participantId.trim();
+    if (value.isEmpty()) {
+      return "?";
+    }
+    String local = value;
+    int at = local.indexOf('@');
+    if (at > 0) {
+      local = local.substring(0, at);
+    }
+    String[] parts = local.split("[^A-Za-z0-9]+");
+    StringBuilder initials = new StringBuilder(2);
+    for (String part : parts) {
+      if (part == null || part.isEmpty()) {
+        continue;
+      }
+      initials.append(Character.toUpperCase(part.charAt(0)));
+      if (initials.length() == 2) {
+        break;
+      }
+    }
+    if (initials.length() == 0) {
+      initials.append(Character.toUpperCase(value.charAt(0)));
+    }
+    return initials.toString();
   }
 
   private void publishWaveHeaderActions(J2clSelectedWaveModel model, String waveId) {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -249,6 +249,10 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   min-height: 30px;
 }
 
+.sidecar-selected-participants [role="listitem"] {
+  display: inline-flex;
+}
+
 .sidecar-selected-participant-avatar {
   width: 28px;
   height: 28px;

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -242,6 +242,33 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   margin: 10px 0 0;
 }
 
+.sidecar-selected-participants[role="list"] {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+}
+
+.sidecar-selected-participant-avatar {
+  width: 28px;
+  height: 28px;
+  border: 1px solid #d7e3ef;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e0f2fe, #f8fafc);
+  color: #075985;
+  cursor: pointer;
+  font: 700 11px / 1 Arial, sans-serif;
+  padding: 0;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.sidecar-selected-participant-avatar:hover,
+.sidecar-selected-participant-avatar:focus-visible {
+  border-color: #0077b6;
+  box-shadow: 0 0 0 2px rgba(0, 119, 182, 0.14);
+  outline: none;
+}
+
 .sidecar-selected-content {
   display: grid;
   gap: 0;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -207,6 +207,63 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void renderSelectedWaveParticipantsAsAvatarButtons() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(
+        selectedModel(
+            "example.com/w+participants",
+            Arrays.asList("alice@example.com", "bob@example.com")));
+
+    HTMLElement participants = (HTMLElement) host.querySelector(".sidecar-selected-participants");
+    Assert.assertNotNull(participants);
+    Assert.assertFalse(participants.hidden);
+    Assert.assertEquals("list", participants.getAttribute("role"));
+    Assert.assertFalse(
+        "Participant strip should not expose the old comma-separated label",
+        participants.textContent.contains("Participants:"));
+    elemental2.dom.NodeList<elemental2.dom.Element> avatars =
+        participants.querySelectorAll("[data-selected-participant-avatar]");
+    Assert.assertEquals(2, avatars.length);
+    HTMLElement first = (HTMLElement) avatars.item(0);
+    Assert.assertEquals("alice@example.com", first.getAttribute("data-participant-id"));
+    Assert.assertEquals("Open alice@example.com profile", first.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void renderPublishesParticipantsToProfileOverlay() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    HTMLElement overlay = (HTMLElement) DomGlobal.document.createElement("wavy-profile-overlay");
+    DomGlobal.document.body.appendChild(overlay);
+    try {
+      J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+      view.render(
+          selectedModel(
+              "example.com/w+profile",
+              Arrays.asList("alice@example.com", "bob@example.com")));
+
+      Object participantsObject = Js.asPropertyMap(overlay).get("participants");
+      Assert.assertTrue(JsArray.isArray(participantsObject));
+      JsArray<?> participants = Js.uncheckedCast(participantsObject);
+      Assert.assertEquals(2, participants.length);
+      Assert.assertEquals(
+          "alice@example.com",
+          Js.asPropertyMap(participants.getAt(0)).get("id"));
+      Assert.assertEquals(
+          "alice@example.com",
+          Js.asPropertyMap(participants.getAt(0)).get("displayName"));
+    } finally {
+      if (overlay.parentElement != null) {
+        overlay.parentElement.removeChild(overlay);
+      }
+    }
+  }
+
+  @Test
   public void renderDisablesHeaderActionsWithoutWriteSession() {
     assumeBrowserDom();
     HTMLElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -230,6 +230,8 @@ public class J2clSelectedWaveViewChromeTest {
     HTMLElement first = (HTMLElement) avatars.item(0);
     Assert.assertEquals("alice@example.com", first.getAttribute("data-participant-id"));
     Assert.assertEquals("Open alice@example.com profile", first.getAttribute("aria-label"));
+    Assert.assertNull("avatar button keeps native button semantics", first.getAttribute("role"));
+    Assert.assertEquals("listitem", first.parentElement.getAttribute("role"));
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-01-j2cl-participant-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-participant-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-01-j2cl-participant-parity",
+  "version": "Issue #1164",
+  "date": "2026-05-01",
+  "title": "J2CL participant parity",
+  "summary": "Improves J2CL participant avatars, profile popup content, and add-participant suggestions toward GWT parity.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Renders selected-wave participants as avatar buttons instead of raw text.",
+        "Populates the participant profile overlay with selected-wave participants so profile cards show real participant identifiers.",
+        "Adds icon-style wave header actions and frequent-contact suggestions for adding participants."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1164.

## Summary
- Render selected-wave participants as compact avatar buttons and publish the same participant data to `wavy-profile-overlay`.
- Make profile fallback badges show the requested participant id instead of generic “Unknown participant”.
- Convert wave header action controls to visible SVG icon buttons with accessible labels.
- Load frequent contacts from `/contacts?timestamp=0` for the add-participant dialog and append selected suggestions into the draft.

## Verification
- `npm test -- --files test/wavy-wave-header-actions.test.js test/wavy-profile-overlay.test.js`
- `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check`
- `bash scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave`
- `bash scripts/worktree-boot.sh --port 9904`
- `PORT=9904 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-1164-participant-parity-20260501/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-1164-participant-parity-20260501/wave/config/jaas.config' bash scripts/wave-smoke.sh start && PORT=9904 bash scripts/wave-smoke.sh check`
- Browser: registered local `codex1164@local.net`, opened `/?view=j2cl-root&q=in%3Ainbox&wave=local.net%2Fw%2Bxtf2ygzm6vsqA`, verified participant avatar strip, profile overlay title/body, visible SVG header icons, and `/contacts?timestamp=0` returned `200` with empty contacts for the fresh account.

Claude review was not used per current instruction; self-review plus PR review comments only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected-wave participants now display as interactive avatar buttons that open profiles.
  * Header actions use icon-style buttons with accessible labels.
  * Add-participant dialog shows frequent-contact suggestions and prevents duplicates.
  * Profile overlay now shows clearer participant identity and gracefully handles unknown authors.

* **Documentation**
  * Added a user-facing changelog entry summarizing these UI updates.

* **Tests**
  * UI tests added/updated to cover participant strip, overlay behavior, and contact suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->