### PR TITLE
Fix J2CL task affordance parity

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1165-editor-mentions-tasks-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1165-editor-mentions-tasks-parity.md
@@ -1,0 +1,85 @@
+# Issue #1165 Editor, Mentions, And Task Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the J2CL editor-toolbar, mention autocomplete, and task-behavior parity gaps reported against GWT.
+
+**Architecture:** Keep the current Lit/J2CL inline composer architecture. Treat toolbar visibility/icon mode and mention autocomplete as current-code verification slices, then narrow implementation to the remaining task semantics gap: J2CL must not expose a per-blip "Task" toggle that marks the whole blip body as complete when the user did not create a GWT-style task item.
+
+**Tech Stack:** J2CL Java views/controllers, Lit elements under `j2cl/lit`, SBT-only verification, and changelog fragments under `wave/config/changelog.d/`.
+
+---
+
+## Current Findings
+
+- `wavy-format-toolbar` already hides by default and only shows from `selectionDescriptor` with a non-collapsed bounding rect; its toolbar buttons already render SVG icons.
+- `wavy-composer` already opens `mention-suggestion-popover` for `@`, filters the `participants` property, inserts mention chips, and serializes them as `mention/user` rich components.
+- `J2clComposeSurfaceView` already forwards `model.getParticipantAddresses()` into the legacy reply element and active inline composer, including the fresh mount path.
+- `wave-blip` still mounts `wavy-task-affordance` on every blip, and `wavy-task-affordance` exposes a visible `Task` toggle. Clicking it emits `wave-blip-task-toggled`; `wave-blip` mirrors that into `data-task-completed`, and CSS applies `line-through` to `.body`. This matches the user report that clicking `Task` strikes the whole blip text.
+- `J2clRichContentDeltaFactory.taskToggleRequest()` currently writes `task/done` over the entire blip body. That is not the same as a GWT-style inline task item created in edit mode.
+
+## Task 1: Toolbar Visibility And Icon Parity Guard
+
+**Files:**
+- Modify: `j2cl/lit/test/wavy-format-toolbar.test.js`
+- Optionally modify: `j2cl/lit/src/elements/wavy-format-toolbar.js`
+
+- [ ] Add a regression test that a newly mounted `wavy-format-toolbar` is hidden before any selection descriptor is supplied.
+- [ ] Add a regression test that a collapsed selection hides the toolbar after it was visible.
+- [ ] Add a regression test that all non-select toolbar actions use SVG icon buttons and keep accessible labels without visible text labels.
+- [ ] Run `cd j2cl/lit && npm test -- --files test/wavy-format-toolbar.test.js`.
+- [ ] If any assertion fails, fix only the failing toolbar behavior without changing action ids or `wavy-format-toolbar-action` event payloads.
+
+## Task 2: Mention Participant Source Guard
+
+**Files:**
+- Modify: `j2cl/lit/test/wavy-composer.test.js`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceViewTest.java`
+- Optionally modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+
+- [ ] Add or confirm Lit coverage that typing `@` opens suggestions sourced from the `participants` property, not from global contacts.
+- [ ] Add or confirm Java view coverage that a freshly opened inline composer receives `model.getParticipantAddresses()` before the next full render.
+- [ ] Add a regression assertion that a participant selected from the mention popover emits `wavy-composer-mention-picked` with `address`, `displayName`, and `chipTextOffset`.
+- [ ] Run `cd j2cl/lit && npm test -- --files test/wavy-composer.test.js`.
+- [ ] Run `sbt --batch Test/compile j2clSearchTest`.
+- [ ] If current coverage already proves the behavior, keep code unchanged and document the evidence in the issue/PR.
+
+## Task 3: Remove Whole-Blip Task Toggle Semantics
+
+**Files:**
+- Modify: `j2cl/lit/src/elements/wave-blip.js`
+- Modify: `j2cl/lit/src/elements/wavy-task-affordance.js`
+- Modify: `j2cl/lit/test/wave-blip.test.js`
+- Modify: `j2cl/lit/test/wavy-task-affordance.test.js`
+- Optionally modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- Optionally modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+- [ ] Write failing Lit tests that a default blip does not show a visible `Task` text toggle.
+- [ ] Write failing Lit tests that toggling any remaining task control does not apply `line-through` to the whole `.body`.
+- [ ] Keep persisted task metadata visible only as task metadata/status affordance for blips that actually carry task annotations.
+- [ ] Remove or disable the whole-blip `wave-blip-task-toggled` path for generic blips. If a control remains, make it an icon-only metadata/details affordance and do not emit a completion toggle for the entire body.
+- [ ] Keep task insertion in edit mode inside `wavy-composer` via `insert-task`; this is the GWT-like path for creating task content.
+- [ ] Run `cd j2cl/lit && npm test -- --files test/wave-blip.test.js test/wavy-task-affordance.test.js test/wavy-composer.test.js`.
+- [ ] Run `sbt --batch Test/compile j2clSearchTest`.
+
+## Task 4: Changelog And Browser Verification
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-05-01-j2cl-editor-mentions-tasks-parity.json`
+- Update issue comments with verification evidence.
+
+- [ ] Add a new changelog fragment under `wave/config/changelog.d/`; do not hand-edit `wave/config/changelog.json`.
+- [ ] Run `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check`.
+- [ ] Run broader verification: `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`.
+- [ ] Run local browser verification on `/?view=j2cl-root`:
+  - Select text in an active inline composer and confirm the formatting toolbar appears only in edit/selection context.
+  - Type `@` in the composer and confirm wave participants appear as mention suggestions.
+  - Confirm normal blips no longer expose a `Task` text button that strikes through the whole blip.
+- [ ] Post the exact verification commands and browser evidence to #1165 before opening the PR.
+
+## Self-Review
+
+- Scope stays inside #1165. Attachment thumbnail sizing remains #1166; inline blip/thread structure remains #1167.
+- The plan does not remove mention or rich-format features that already exist; it guards them with tests and fixes only observed regressions.
+- The risky behavior is task semantics, because current J2CL stores and renders a whole-blip task/done annotation. The conservative fix is to stop exposing that as a generic visible task toggle and keep task creation in the editor path.
+- Changelog handling follows repo policy: add a fragment under `wave/config/changelog.d/`, never hand-edit generated `wave/config/changelog.json`.

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -317,6 +317,7 @@ export class WaveBlip extends LitElement {
     this.taskAssignee = "";
     this.taskDueDate = "";
     this.bodySize = 0;
+    this._taskPresent = false;
     this.blipDepth = "";
     this.threadCollapsed = false;
     this.dataBlipAuthor = "";
@@ -350,6 +351,16 @@ export class WaveBlip extends LitElement {
     }
     if (changedProperties.has("focused")) {
       this.dataBlipFocused = this.focused ? "true" : null;
+    }
+    // Once any task attribute arrives the affordance must stay mounted even
+    // if taskCompleted is later cleared by an optimistic reopen toggle.
+    if (
+      !this._taskPresent &&
+      (this.taskCompleted ||
+        String(this.taskAssignee || "").trim() ||
+        String(this.taskDueDate || "").trim())
+    ) {
+      this._taskPresent = true;
     }
     super.willUpdate(changedProperties);
   }
@@ -449,11 +460,7 @@ export class WaveBlip extends LitElement {
   }
 
   _hasTaskAffordance() {
-    return Boolean(
-      this.taskCompleted ||
-        String(this.taskAssignee || "").trim() ||
-        String(this.taskDueDate || "").trim()
-    );
+    return this._taskPresent;
   }
 
   _onAvatarClick(event) {
@@ -551,6 +558,8 @@ export class WaveBlip extends LitElement {
     // taskCompleted property so the strikethrough CSS updates immediately
     // without waiting for the model to round-trip through the server.
     this.taskCompleted = event.detail.completed;
+    // Keep presence flag set — reopening a task must not hide the affordance.
+    this._taskPresent = true;
   }
 
   _buildPermalink() {

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -110,6 +110,9 @@ export class WaveBlip extends LitElement {
     taskCompleted: { type: Boolean, attribute: "data-task-completed", reflect: true },
     taskAssignee: { type: String, attribute: "data-task-assignee", reflect: true },
     taskDueDate: { type: String, attribute: "data-task-due-date", reflect: true },
+    // Renderer sets this whenever a task/done annotation exists (regardless of value).
+    // Survives full DOM rebuilds so reopened tasks keep the affordance mounted.
+    taskPresent: { type: Boolean, attribute: "data-task-present", reflect: false },
     bodySize: { type: Number, attribute: "data-blip-doc-size", reflect: true }
   };
 
@@ -316,6 +319,7 @@ export class WaveBlip extends LitElement {
     this.taskCompleted = false;
     this.taskAssignee = "";
     this.taskDueDate = "";
+    this.taskPresent = false;
     this.bodySize = 0;
     this._taskPresent = false;
     this.blipDepth = "";
@@ -352,11 +356,14 @@ export class WaveBlip extends LitElement {
     if (changedProperties.has("focused")) {
       this.dataBlipFocused = this.focused ? "true" : null;
     }
-    // Once any task attribute arrives the affordance must stay mounted even
-    // if taskCompleted is later cleared by an optimistic reopen toggle.
+    // Once any task signal arrives the affordance stays mounted even after a full
+    // DOM rebuild (renderWindow clears host.innerHTML). taskPresent (data-task-present)
+    // is the renderer-backed sticky signal that survives rebuild for reopened tasks
+    // with no assignee/due-date (where all three mutable task attributes are absent).
     if (
       !this._taskPresent &&
-      (this.taskCompleted ||
+      (this.taskPresent ||
+        this.taskCompleted ||
         String(this.taskAssignee || "").trim() ||
         String(this.taskDueDate || "").trim())
     ) {

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -255,17 +255,6 @@ export class WaveBlip extends LitElement {
     :host([has-mention]) {
       position: relative;
     }
-    /* F-3.S2 (#1038, R-5.4 step 4): completed tasks fade the body via
-     * the F-0 quiet text token and apply a strikethrough so the blip
-     * card visually communicates the closed state without re-painting
-     * the wavy envelope. The strikethrough lives on the body wrapper
-     * inside the host so the metadata header (author + timestamp)
-     * stays legible. */
-    :host([data-task-completed]) .body {
-      color: #767676;
-      text-decoration: line-through;
-      text-decoration-color: #767676;
-    }
     .body {
       margin-left: 3.35em;
       min-height: 1.5em;
@@ -459,6 +448,14 @@ export class WaveBlip extends LitElement {
     return this.focused || this.getAttribute("tabindex") === "0";
   }
 
+  _hasTaskAffordance() {
+    return Boolean(
+      this.taskCompleted ||
+        String(this.taskAssignee || "").trim() ||
+        String(this.taskDueDate || "").trim()
+    );
+  }
+
   _onAvatarClick(event) {
     event.stopPropagation();
     this.dispatchEvent(
@@ -644,19 +641,21 @@ export class WaveBlip extends LitElement {
             @wave-blip-toolbar-link=${this._onLinkClick}
             @wave-blip-toolbar-delete=${this._onDeleteClick}
           ></wave-blip-toolbar>
-          <span class="task-affordance-slot" data-task-affordance-slot>
-            <wavy-task-affordance
-              data-blip-id=${this.blipId}
-              data-wave-id=${this.waveId}
-              ?data-task-completed=${this.taskCompleted}
-              data-task-assignee=${this.taskAssignee || ""}
-              data-task-due-date=${this.taskDueDate || ""}
-              data-blip-doc-size=${ifDefined(this.bodySize > 0 ? String(this.bodySize) : undefined)}
-              .bodySize=${this.bodySize || 0}
-              .participants=${this._participants}
-              @wave-blip-task-toggled=${this._onTaskToggled}
-            ></wavy-task-affordance>
-          </span>
+          ${this._hasTaskAffordance()
+            ? html`<span class="task-affordance-slot" data-task-affordance-slot>
+                <wavy-task-affordance
+                  data-blip-id=${this.blipId}
+                  data-wave-id=${this.waveId}
+                  ?data-task-completed=${this.taskCompleted}
+                  data-task-assignee=${this.taskAssignee || ""}
+                  data-task-due-date=${this.taskDueDate || ""}
+                  data-blip-doc-size=${ifDefined(this.bodySize > 0 ? String(this.bodySize) : undefined)}
+                  .bodySize=${this.bodySize || 0}
+                  .participants=${this._participants}
+                  @wave-blip-task-toggled=${this._onTaskToggled}
+                ></wavy-task-affordance>
+              </span>`
+            : ""}
           </span>
         </div>
         <div class="body">

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -132,8 +132,8 @@ export class WavyTaskAffordance extends LitElement {
     this.participants = [];
     this._announceText = "";
     this._popoverOpen = false;
-    this.labelToggleOpen = "Task";
-    this.labelToggleDone = "✓ Done";
+    this.labelToggleOpen = "☐";
+    this.labelToggleDone = "☑";
     this.labelAriaCheck = "Mark task complete";
     this.labelAriaUncheck = "Mark task open";
     this.labelDetails = "Edit task details";

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -444,6 +444,7 @@ describe("<wave-blip>", () => {
     `);
     await el.updateComplete;
     const affordance = el.renderRoot.querySelector("wavy-task-affordance");
+    await affordance.updateComplete;
     const toggle = affordance.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
     let captured = null;
     el.addEventListener("wave-blip-task-toggled", (e) => {

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -345,9 +345,23 @@ describe("<wave-blip>", () => {
   });
 
   // F-3.S2 (#1038, R-5.4) per-blip task integration.
-  it("mounts <wavy-task-affordance> next to the toolbar in the metadata slot", async () => {
+  it("does not mount a generic task affordance on normal blips", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b20" data-wave-id="w20" author-name="A"></wave-blip>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.equal(null);
+    expect(el.renderRoot.textContent).to.not.include("Task");
+  });
+
+  it("mounts <wavy-task-affordance> only when task state is present", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b20"
+        data-wave-id="w20"
+        author-name="A"
+        data-task-assignee="alice@example.com"
+      ></wave-blip>
     `);
     await el.updateComplete;
     const slot = el.renderRoot.querySelector('[data-task-affordance-slot]');
@@ -360,7 +374,12 @@ describe("<wave-blip>", () => {
 
   it("keeps task affordances out of visible focus flow until the blip is active", async () => {
     const el = await fixture(html`
-      <wave-blip data-blip-id="b20a" data-wave-id="w20a" author-name="A"></wave-blip>
+      <wave-blip
+        data-blip-id="b20a"
+        data-wave-id="w20a"
+        author-name="A"
+        data-task-completed
+      ></wave-blip>
     `);
     await el.updateComplete;
     const slot = el.renderRoot.querySelector('[data-task-affordance-slot]');
@@ -390,7 +409,12 @@ describe("<wave-blip>", () => {
 
   it("re-emits wave-blip-task-toggled from the inner affordance with full detail", async () => {
     const el = await fixture(html`
-      <wave-blip data-blip-id="b22" data-wave-id="w22" data-blip-doc-size="17"></wave-blip>
+      <wave-blip
+        data-blip-id="b22"
+        data-wave-id="w22"
+        data-blip-doc-size="17"
+        data-task-assignee="alice@example.com"
+      ></wave-blip>
     `);
     await el.updateComplete;
     const affordance = el.renderRoot.querySelector("wavy-task-affordance");
@@ -409,13 +433,7 @@ describe("<wave-blip>", () => {
     });
   });
 
-  // J-UI-6 (#1084, R-5.4): when the read renderer writes
-  // data-task-completed onto the host (because the wavelet's task/done
-  // annotation is true), the body wrapper inside the shadow root must
-  // pick up the line-through styling. Computed-style assertions are the
-  // most stable way to test this — the CSS rule sets text-decoration on
-  // ".body" inside :host([data-task-completed]).
-  it("paints the body with line-through when data-task-completed is set", async () => {
+  it("does not strike through the whole body when data-task-completed is set", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b30" data-wave-id="w30" data-task-completed>
         Body text
@@ -425,12 +443,7 @@ describe("<wave-blip>", () => {
     const body = el.renderRoot.querySelector(".body");
     expect(body).to.exist;
     const style = getComputedStyle(body);
-    // Browsers serialise text-decoration as either the legacy single-line
-    // form ("line-through") or the modern shorthand
-    // ("line-through ..."), so just check that line-through is present.
-    expect(style.textDecorationLine || style.textDecoration).to.contain(
-      "line-through"
-    );
+    expect(style.textDecorationLine || style.textDecoration).to.not.contain("line-through");
   });
 
   it("propagates taskAssignee + taskDueDate to the inner affordance", async () => {

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -418,6 +418,21 @@ describe("<wave-blip>", () => {
     expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
   });
 
+  it("keeps task affordance mounted after DOM rebuild via data-task-present (reopened task)", async () => {
+    // Simulate the renderWindow DOM-rebuild path: the renderer emits data-task-present
+    // so a reopened task with no assignee/due-date keeps its affordance visible even
+    // though _taskPresent is lost when the old <wave-blip> node was destroyed.
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b21c"
+        data-wave-id="w21c"
+        data-task-present
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
+  });
+
   it("re-emits wave-blip-task-toggled from the inner affordance with full detail", async () => {
     const el = await fixture(html`
       <wave-blip

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -407,6 +407,17 @@ describe("<wave-blip>", () => {
     expect(el.hasAttribute("data-task-completed")).to.equal(false);
   });
 
+  it("keeps task affordance mounted after an optimistic reopen toggle", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b21b" data-wave-id="w21b" data-task-completed></wave-blip>
+    `);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
+    el.taskCompleted = false;
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
+  });
+
   it("re-emits wave-blip-task-toggled from the inner affordance with full detail", async () => {
     const el = await fixture(html`
       <wave-blip

--- a/j2cl/lit/test/wavy-task-affordance.test.js
+++ b/j2cl/lit/test/wavy-task-affordance.test.js
@@ -19,6 +19,8 @@ describe("<wavy-task-affordance>", () => {
     const details = el.renderRoot.querySelector('[data-task-details-trigger="true"]');
     expect(toggle).to.exist;
     expect(details).to.exist;
+    expect(toggle.textContent.trim()).to.equal("☐");
+    expect(toggle.textContent.trim()).to.not.equal("Task");
     expect(toggle.getAttribute("aria-checked")).to.equal("false");
     expect(toggle.getAttribute("role")).to.equal("checkbox");
     expect(details.getAttribute("aria-haspopup")).to.equal("dialog");
@@ -31,6 +33,7 @@ describe("<wavy-task-affordance>", () => {
     `);
     const toggle = el.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
     const cs = getComputedStyle(toggle);
+    expect(toggle.textContent.trim()).to.equal("☐");
     expect(cs.backgroundColor).to.equal("rgb(241, 243, 244)");
     expect(cs.color).to.equal("rgb(95, 99, 104)");
     expect(cs.borderRadius).to.equal("999px");
@@ -43,6 +46,7 @@ describe("<wavy-task-affordance>", () => {
       <wavy-task-affordance data-blip-id="b1" data-task-completed></wavy-task-affordance>
     `);
     const toggle = el.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
+    expect(toggle.textContent.trim()).to.equal("☑");
     const cs = getComputedStyle(toggle);
     expect(cs.backgroundColor).to.equal("rgb(255, 244, 229)");
     expect(cs.color).to.equal("rgb(154, 103, 0)");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -78,6 +78,14 @@ public final class J2clReadBlip {
    * need this to retain across the body before closing the annotation.
    */
   private final int bodyItemCount;
+  /**
+   * True when a {@code task/done} annotation is present on this blip
+   * (regardless of its value). Differentiates a reopened task blip
+   * (taskDone=false, annotation present) from a non-task blip (annotation
+   * absent). Required so the renderer can emit {@code data-task-present}
+   * and keep the task affordance mounted across full DOM rebuilds.
+   */
+  private final boolean isTask;
 
   public J2clReadBlip(String blipId, String text) {
     this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
@@ -206,6 +214,32 @@ public final class J2clReadBlip {
       String taskAssignee,
       long taskDueTimestamp,
       int bodyItemCount) {
+    this(
+        blipId, text, attachments, authorId, authorDisplayName, lastModifiedTimeMillis,
+        parentBlipId, threadId, unread, hasMention, deleted, taskDone, taskAssignee,
+        taskDueTimestamp, bodyItemCount,
+        /* isTask= */ taskDone
+            || (taskAssignee != null && !taskAssignee.trim().isEmpty())
+            || (taskDueTimestamp != J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP));
+  }
+
+  public J2clReadBlip(
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean deleted,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
     this.attachments =
@@ -224,6 +258,7 @@ public final class J2clReadBlip {
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
     this.bodyItemCount = Math.max(0, bodyItemCount);
+    this.isTask = isTask;
   }
 
   /** Builder-style copy that flips the unread flag without re-typing the rest. */
@@ -246,7 +281,8 @@ public final class J2clReadBlip {
         taskDone,
         taskAssignee,
         taskDueTimestamp,
-        bodyItemCount);
+        bodyItemCount,
+        isTask);
   }
 
   /**
@@ -274,7 +310,8 @@ public final class J2clReadBlip {
         nextTaskDone,
         taskAssignee,
         taskDueTimestamp,
-        bodyItemCount);
+        bodyItemCount,
+        true);
   }
 
   public String getBlipId() {
@@ -327,6 +364,11 @@ public final class J2clReadBlip {
    */
   public boolean isDeleted() {
     return deleted;
+  }
+
+  /** True when a {@code task/done} annotation is present (regardless of value). */
+  public boolean isTask() {
+    return isTask;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -19,6 +19,7 @@ public final class J2clReadBlipContent {
 
   private final String text;
   private final List<J2clAttachmentRenderModel> attachments;
+  private final boolean hasTask;
   private final boolean taskDone;
   private final String taskAssignee;
   private final long taskDueTimestamp;
@@ -27,6 +28,7 @@ public final class J2clReadBlipContent {
   private J2clReadBlipContent(
       String text,
       List<J2clAttachmentRenderModel> attachments,
+      boolean hasTask,
       boolean taskDone,
       String taskAssignee,
       long taskDueTimestamp,
@@ -36,6 +38,7 @@ public final class J2clReadBlipContent {
         attachments == null
             ? Collections.<J2clAttachmentRenderModel>emptyList()
             : Collections.unmodifiableList(new ArrayList<J2clAttachmentRenderModel>(attachments));
+    this.hasTask = hasTask;
     this.taskDone = taskDone;
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
@@ -89,6 +92,7 @@ public final class J2clReadBlipContent {
     return new J2clReadBlipContent(
         decodeEntities(stripTags(visibleText.toString())),
         attachments,
+        annotations.hasTask,
         annotations.taskDone,
         annotations.taskAssignee,
         annotations.taskDueTimestamp,
@@ -101,6 +105,10 @@ public final class J2clReadBlipContent {
 
   public List<J2clAttachmentRenderModel> getAttachments() {
     return attachments;
+  }
+
+  public boolean isTask() {
+    return hasTask;
   }
 
   public boolean isTaskDone() {
@@ -293,6 +301,7 @@ public final class J2clReadBlipContent {
   private static void applyAnnotationValue(
       String key, String value, AnnotationSnapshot snapshot) {
     if (TASK_DONE_ANNOTATION.equals(key)) {
+      snapshot.hasTask = true;
       snapshot.taskDone = "true".equals(value);
     } else if (TASK_ASSIGNEE_ANNOTATION.equals(key)) {
       snapshot.taskAssignee = value == null ? "" : value.trim();
@@ -357,6 +366,7 @@ public final class J2clReadBlipContent {
   }
 
   private static final class AnnotationSnapshot {
+    private boolean hasTask;
     private boolean taskDone;
     private String taskAssignee = "";
     private long taskDueTimestamp = J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1084,7 +1084,8 @@ public final class J2clReadSurfaceDomRenderer {
         blip.isTaskDone(),
         blip.getTaskAssignee(),
         blip.getTaskDueTimestamp(),
-        blip.getBodyItemCount());
+        blip.getBodyItemCount(),
+        blip.isTask());
 
     // The renderer doesn't know the parent wave id (it lives one layer up
     // in J2clSelectedWaveView). The view sets `data-wave-id` on the host
@@ -1241,7 +1242,8 @@ public final class J2clReadSurfaceDomRenderer {
       boolean modelTaskDone,
       String taskAssignee,
       long taskDueTimestamp,
-      int bodyItemCount) {
+      int bodyItemCount,
+      boolean isTask) {
     if (element == null) {
       return;
     }
@@ -1264,6 +1266,15 @@ public final class J2clReadSurfaceDomRenderer {
         // Apply the optimistic value over the (still-stale) model.
         taskDone = optimistic.done;
       }
+    }
+    // data-task-present survives a full DOM rebuild (renderWindow clears host.innerHTML).
+    // Without it a reopened task blip with no assignee/due-date would lose the affordance
+    // because all three task attributes are absent and _taskPresent stays false on the
+    // freshly-created <wave-blip> element.
+    if (isTask || taskDone) {
+      element.setAttribute("data-task-present", "");
+    } else {
+      element.removeAttribute("data-task-present");
     }
     if (taskDone) {
       element.setAttribute("data-task-completed", "");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -38,6 +38,8 @@ public final class J2clReadWindowEntry {
   private final long taskDueTimestamp;
   /** Issue #1129: see {@link J2clReadBlip#getBodyItemCount()}. */
   private final int bodyItemCount;
+  /** See {@link J2clReadBlip#isTask()}: true when a task/done annotation is present. */
+  private final boolean isTask;
 
   private J2clReadWindowEntry(
       String segment,
@@ -58,6 +60,35 @@ public final class J2clReadWindowEntry {
       String taskAssignee,
       long taskDueTimestamp,
       int bodyItemCount) {
+    this(
+        segment, fromVersion, toVersion, blipId, text, attachments, loaded,
+        authorId, authorDisplayName, lastModifiedTimeMillis, parentBlipId, threadId,
+        unread, hasMention, taskDone, taskAssignee, taskDueTimestamp, bodyItemCount,
+        /* isTask= */ taskDone
+            || (taskAssignee != null && !taskAssignee.trim().isEmpty())
+            || (taskDueTimestamp != J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP));
+  }
+
+  private J2clReadWindowEntry(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      boolean loaded,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
@@ -79,6 +110,7 @@ public final class J2clReadWindowEntry {
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
     this.bodyItemCount = Math.max(0, bodyItemCount);
+    this.isTask = isTask;
   }
 
   public static J2clReadWindowEntry loaded(
@@ -220,6 +252,34 @@ public final class J2clReadWindowEntry {
       String taskAssignee,
       long taskDueTimestamp,
       int bodyItemCount) {
+    return loadedWithTaskMetadata(
+        segment, fromVersion, toVersion, blipId, text, attachments,
+        authorId, authorDisplayName, lastModifiedTimeMillis, parentBlipId, threadId,
+        unread, hasMention, taskDone, taskAssignee, taskDueTimestamp, bodyItemCount,
+        /* isTask= */ taskDone
+            || (taskAssignee != null && !taskAssignee.trim().isEmpty())
+            || (taskDueTimestamp != J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP));
+  }
+
+  public static J2clReadWindowEntry loadedWithTaskMetadata(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask) {
     return new J2clReadWindowEntry(
         segment,
         fromVersion,
@@ -238,7 +298,8 @@ public final class J2clReadWindowEntry {
         taskDone,
         taskAssignee,
         taskDueTimestamp,
-        bodyItemCount);
+        bodyItemCount,
+        isTask);
   }
 
   public static J2clReadWindowEntry placeholder(
@@ -287,7 +348,8 @@ public final class J2clReadWindowEntry {
         taskDone,
         taskAssignee,
         taskDueTimestamp,
-        bodyItemCount);
+        bodyItemCount,
+        isTask);
   }
 
   /**
@@ -316,7 +378,8 @@ public final class J2clReadWindowEntry {
         nextTaskDone,
         taskAssignee,
         taskDueTimestamp,
-        bodyItemCount);
+        bodyItemCount,
+        true);
   }
 
   public String getSegment() {
@@ -374,6 +437,11 @@ public final class J2clReadWindowEntry {
 
   public boolean hasMention() {
     return hasMention;
+  }
+
+  /** See {@link J2clReadBlip#isTask()}: true when a task/done annotation is present. */
+  public boolean isTask() {
+    return isTask;
   }
 
   /** J-UI-6 (#1084, R-5.4): see {@link J2clReadBlip#isTaskDone()}. */

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -787,6 +787,7 @@ public final class J2clSelectedWaveProjector {
     boolean hasMention = preserveFallbackBooleans ? fallback.hasMention() : blip.hasMention();
     boolean deleted = preserveFallbackBooleans ? fallback.isDeleted() : blip.isDeleted();
     boolean taskDone = preserveFallbackBooleans ? fallback.isTaskDone() : blip.isTaskDone();
+    boolean isTask = preserveFallbackBooleans ? fallback.isTask() : blip.isTask();
     if (Objects.equals(authorId, blip.getAuthorId())
         && Objects.equals(authorDisplayName, blip.getAuthorDisplayName())
         && lastModified == blip.getLastModifiedTimeMillis()
@@ -796,6 +797,7 @@ public final class J2clSelectedWaveProjector {
         && hasMention == blip.hasMention()
         && deleted == blip.isDeleted()
         && taskDone == blip.isTaskDone()
+        && isTask == blip.isTask()
         && Objects.equals(taskAssignee, blip.getTaskAssignee())
         && taskDueTimestamp == blip.getTaskDueTimestamp()) {
       return blip;
@@ -816,7 +818,7 @@ public final class J2clSelectedWaveProjector {
         taskAssignee,
         taskDueTimestamp,
         blip.getBodyItemCount(),
-        blip.isTask());
+        isTask);
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -564,7 +564,8 @@ public final class J2clSelectedWaveProjector {
               /* taskDone= */ documentTaskDone(document),
               /* taskAssignee= */ documentTaskAssignee(document),
               /* taskDueTimestamp= */ documentTaskDueTimestamp(document),
-              /* bodyItemCount= */ document.getBodyItemCount()));
+              /* bodyItemCount= */ document.getBodyItemCount(),
+              /* isTask= */ documentHasTask(document)));
     }
     return blips;
   }
@@ -622,7 +623,8 @@ public final class J2clSelectedWaveProjector {
               /* taskDone= */ documentTaskDone(doc),
               /* taskAssignee= */ documentTaskAssignee(doc),
               /* taskDueTimestamp= */ documentTaskDueTimestamp(doc),
-              /* bodyItemCount= */ doc.getBodyItemCount()));
+              /* bodyItemCount= */ doc.getBodyItemCount(),
+              /* isTask= */ documentHasTask(doc)));
     }
     return enriched;
   }
@@ -676,7 +678,8 @@ public final class J2clSelectedWaveProjector {
                 blip.isTaskDone(),
                 blip.getTaskAssignee(),
                 blip.getTaskDueTimestamp(),
-                blip.getBodyItemCount()));
+                blip.getBodyItemCount(),
+                blip.isTask()));
       } else {
         patched.add(blip);
       }
@@ -812,7 +815,8 @@ public final class J2clSelectedWaveProjector {
         taskDone,
         taskAssignee,
         taskDueTimestamp,
-        blip.getBodyItemCount());
+        blip.getBodyItemCount(),
+        blip.isTask());
   }
 
   /**
@@ -901,7 +905,8 @@ public final class J2clSelectedWaveProjector {
               existing.isTaskDone(),
               existing.getTaskAssignee(),
               existing.getTaskDueTimestamp(),
-              existing.getBodyItemCount()));
+              existing.getBodyItemCount(),
+              existing.isTask()));
     }
     // Append any blip that the manifest didn't reference so we don't
     // silently drop content from non-conversational data documents.
@@ -981,7 +986,8 @@ public final class J2clSelectedWaveProjector {
               blip.isTaskDone(),
               blip.getTaskAssignee(),
               blip.getTaskDueTimestamp(),
-              blip.getBodyItemCount());
+              blip.getBodyItemCount(),
+              blip.isTask());
       enriched.add(next);
       changed = true;
     }
@@ -1059,6 +1065,24 @@ public final class J2clSelectedWaveProjector {
       done = "true".equals(range.getValue());
     }
     return done;
+  }
+
+  /**
+   * True when a {@code task/done} annotation range is present on the document,
+   * regardless of its value. Differentiates a reopened task blip
+   * (task/done=false, annotation present) from a non-task blip (annotation
+   * absent), so the renderer can keep the task affordance mounted after reopen.
+   */
+  static boolean documentHasTask(SidecarSelectedWaveDocument document) {
+    if (document == null || document.getAnnotationRanges() == null) {
+      return false;
+    }
+    for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
+      if (range != null && "task/done".equals(range.getKey())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -399,7 +399,8 @@ public final class J2clSelectedWaveViewportState {
                 /* taskDone= */ content.isTaskDone(),
                 /* taskAssignee= */ content.getTaskAssignee(),
                 /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
-                entry.getBodyItemCount()));
+                entry.getBodyItemCount(),
+                /* isTask= */ content.isTask()));
       } else {
         readBlips.add(
             new J2clReadBlip(
@@ -450,7 +451,8 @@ public final class J2clSelectedWaveViewportState {
                   /* taskDone= */ content.isTaskDone(),
                   /* taskAssignee= */ content.getTaskAssignee(),
                   /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
-                  entry.getBodyItemCount()));
+                  entry.getBodyItemCount(),
+                  /* isTask= */ content.isTask()));
         } else {
           windowEntries.add(
               J2clReadWindowEntry.loadedWithTaskMetadata(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -173,6 +173,7 @@ public class J2clReadBlipContentTest {
                 + "<?a \"task/done\" \"task/assignee\" \"task/dueTs\"?></body>");
 
     Assert.assertEquals("Review launch", parsed.getText());
+    Assert.assertTrue(parsed.isTask());
     Assert.assertTrue(parsed.isTaskDone());
     Assert.assertEquals("alice@local.net", parsed.getTaskAssignee());
     Assert.assertEquals(1777593600000L, parsed.getTaskDueTimestamp());
@@ -185,6 +186,7 @@ public class J2clReadBlipContentTest {
             "<body><?a \"task/done\"=\"false\"?>Review launch"
                 + "<?a \"task/done\"?></body>");
 
+    Assert.assertTrue("task/done=false annotation → isTask must be true", parsed.isTask());
     Assert.assertFalse(parsed.isTaskDone());
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -351,10 +351,55 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLElement element = blip(host, "b+done");
     Assert.assertNotNull(element);
     Assert.assertTrue(element.hasAttribute("data-task-completed"));
+    Assert.assertTrue(
+        "data-task-present must be set when isTask=true (task blip)",
+        element.hasAttribute("data-task-present"));
     Assert.assertEquals(
         "bob@example.com", element.getAttribute("data-task-assignee"));
     Assert.assertEquals(
         "2024-05-01", element.getAttribute("data-task-due-date"));
+  }
+
+  @Test
+  public void renderWindowSetsDataTaskPresentForReopenedTaskWithNoMetadata() {
+    // Regression: after a full DOM rebuild (renderWindow clears host.innerHTML),
+    // a reopened task blip with taskDone=false AND no assignee/due-date must still
+    // carry data-task-present so the Lit _taskPresent field can be set to true on
+    // the freshly created <wave-blip> element, keeping the affordance mounted.
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry reopened =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+reopened",
+            0L,
+            12L,
+            "b+reopened",
+            "Follow up",
+            java.util.Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+            /* bodyItemCount= */ 5,
+            /* isTask= */ true);
+
+    Assert.assertTrue(renderer.renderWindow(java.util.Arrays.asList(reopened)));
+
+    HTMLElement element = blip(host, "b+reopened");
+    Assert.assertNotNull(element);
+    Assert.assertFalse(
+        "reopened task must not have data-task-completed",
+        element.hasAttribute("data-task-completed"));
+    Assert.assertTrue(
+        "reopened task must carry data-task-present so Lit can keep affordance mounted",
+        element.hasAttribute("data-task-present"));
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-01-j2cl-editor-mentions-tasks-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-editor-mentions-tasks-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-editor-mentions-tasks-parity",
+  "version": "Issue #1165",
+  "date": "2026-05-01",
+  "title": "J2CL editor and task parity",
+  "summary": "Improves J2CL editor and task affordances toward GWT parity.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Stops normal J2CL blips from exposing a generic Task text toggle that strikes through the whole blip.",
+        "Keeps existing task controls icon-style while preserving task metadata and completion events for real task blips."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1165.
Parent: #1161
Tracker: #904

## Summary
- removes the default visible per-blip `Task` text toggle from normal J2CL blips
- keeps task affordance rendering only for blips that carry task state and switches the default toggle labels to icon-style checkbox glyphs
- stops `data-task-completed` from striking through the entire blip body
- adds parity tests and a changelog fragment

## Review
- Self-review completed; Claude Code review intentionally not used per current instruction.
- Will address PR review comments directly.

## Verification
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js test/wavy-task-affordance.test.js test/wavy-composer.test.js test/wavy-format-toolbar.test.js` passed: 119 tests, 0 failures.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check` passed.
- `sbt --batch compile Test/compile j2clSearchTest j2clLitTest` passed; Lit suite: 800 tests, 0 failures.
- Local server smoke on port 9915 passed for GWT root, J2CL root shell, sidecar, webclient, and health endpoints.
- Browser verification against `http://127.0.0.1:9915/?view=j2cl-root&q=in%3Ainbox`: normal `wave-blip` did not mount a task affordance or expose `Task` text; completed task blip kept body `text-decoration-line: none`; standalone task affordances rendered `☐` and `☑` with accessible labels.

## Notes
- During browser verification I reproduced the unrelated J2CL `New Wave` rail gap from the broader audit: the visible button did not open the hidden create form for a fresh account. I did not widen this #1165 PR; that remains under the open parity audit/follow-up issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task toggle controls now display checkbox-style icons (☐ / ☑) for improved clarity.

* **Bug Fixes**
  * Task affordances render only when task-related data exists.
  * Completed-task styling no longer applies strikethrough to the entire message body.
  * Task affordances reliably reappear after reopen or renderer rebuild scenarios.

* **Documentation**
  * Added a plan outlining task/mention parity gaps and acceptance criteria; includes changelog guidance.

* **Tests**
  * Updated tests to assert conditional affordance rendering, visible glyphs, and no body strikethrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->