### PR TITLE
Fix J2CL attachment thumbnail parity

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
@@ -10,7 +10,7 @@
 
 ---
 
-### File Map
+## File Map
 
 - Modify: `j2cl/src/main/webapp/assets/sidecar.css`
   - Adds read-surface attachment layout and size caps for `.j2cl-read-attachment-preview` under `[data-display-size="small|medium|large"]`.
@@ -24,7 +24,7 @@
 - Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
   - New user-facing changelog fragment. Do not hand-edit `wave/config/changelog.json`; assemble/validate via scripts.
 
-### Task 1: Red Tests For Preview URL And Size Bounds
+## Task 1: Red Tests For Preview URL And Size Bounds
 
 **Files:**
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
@@ -104,7 +104,7 @@ sbt --batch 'testOnly org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderM
 
 Expected: fail because medium/large previews still use `/attachment/...` and preview images do not carry cap attributes.
 
-### Task 2: Implement Thumbnail Preview Selection And Cap Metadata
+## Task 2: Implement Thumbnail Preview Selection And Cap Metadata
 
 **Files:**
 - Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java`
@@ -162,7 +162,7 @@ preview.setAttribute("height", String.valueOf(attachmentPreviewHeight(displaySiz
 
 Run the same focused tests from Task 1. Expected: pass.
 
-### Task 3: Add J2CL Attachment CSS Size Rules
+## Task 3: Add J2CL Attachment CSS Size Rules
 
 **Files:**
 - Modify: `j2cl/src/main/webapp/assets/sidecar.css`
@@ -219,7 +219,7 @@ Add:
 
 If no CSS test harness exists, rely on browser verification and `git diff --check`; do not invent a fragile parser.
 
-### Task 4: Changelog And Verification
+## Task 4: Changelog And Verification
 
 **Files:**
 - Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
@@ -275,7 +275,7 @@ Browser verify against `/?view=j2cl-root` by injecting/rendering a J2CL attachme
 - large preview maxes at 600x400 and never exceeds panel width
 - preview `src` uses `/thumbnail/`, open/download links keep `/attachment/`
 
-### Self-Review
+## Self-Review
 
 - Spec coverage: The plan covers thumbnail source selection, display-size bounds, oversized image containment, tests, changelog, and browser/manual evidence.
 - Scope control: The plan does not touch upload flow, metadata fetch authorization, attachment storage, or #1167 thread behavior.

--- a/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
@@ -1,0 +1,283 @@
+# J2CL Attachment Thumbnail Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make J2CL read-surface attachments respect GWT-compatible thumbnail and small/medium/large display-size bounds.
+
+**Architecture:** The Java read renderer already emits `data-display-size` and attachment classes, and `J2clAttachmentRenderModel` already chooses thumbnail URLs for small/card attachments. The missing parity layer is CSS and explicit renderer hooks that cap preview images the same way GWT `Thumbnail.css` caps `.display-size-small|medium|large .itimg`: 120x80, 300x200, 600x400.
+
+**Tech Stack:** J2CL Java renderer tests, Lit/static CSS in `j2cl/src/main/webapp/assets/sidecar.css`, SBT verification, changelog fragments.
+
+---
+
+### File Map
+
+- Modify: `j2cl/src/main/webapp/assets/sidecar.css`
+  - Adds read-surface attachment layout and size caps for `.j2cl-read-attachment-preview` under `[data-display-size="small|medium|large"]`.
+  - Ensures oversized images cannot exceed the wave panel width.
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+  - Adds explicit `width`/`height` metadata attributes on image previews so tests and browser diagnostics can prove the selected cap.
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+  - Adds/extends DOM tests for image preview source, display-size attributes, and max-dimension attributes.
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
+  - Updates model expectation so medium/large inline images use thumbnails as the preview source and keep the full attachment URL only for open/download.
+- Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
+  - New user-facing changelog fragment. Do not hand-edit `wave/config/changelog.json`; assemble/validate via scripts.
+
+### Task 1: Red Tests For Preview URL And Size Bounds
+
+**Files:**
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+- [ ] **Step 1: Change the model test to expect thumbnail previews for medium images**
+
+In `mediumImageUsesOriginalAttachmentUrl`, change the test name to `mediumImageUsesThumbnailPreviewAndAttachmentOpenUrl` and assert:
+
+```java
+Assert.assertTrue(model.isInlineImage());
+Assert.assertEquals("medium", model.getDisplaySize());
+Assert.assertEquals("/thumbnail/example.com/att+hero", model.getSourceUrl());
+Assert.assertEquals("/attachment/example.com/att+hero", model.getOpenUrl());
+Assert.assertEquals("/attachment/example.com/att+hero", model.getDownloadUrl());
+```
+
+- [ ] **Step 2: Add renderer assertions for medium preview caps**
+
+In `renderWindowEntriesIncludeKeyboardReachableAttachmentControls`, after `Assert.assertNotNull(tile.querySelector("img"));`, bind `HTMLElement preview = (HTMLElement) tile.querySelector("img");` and assert:
+
+```java
+Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
+Assert.assertEquals("300", preview.getAttribute("width"));
+Assert.assertEquals("200", preview.getAttribute("height"));
+Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
+```
+
+- [ ] **Step 3: Add a large image renderer test**
+
+Add a test named `largeImagePreviewCarriesGwtCompatibleBounds`:
+
+```java
+@Test
+public void largeImagePreviewCarriesGwtCompatibleBounds() {
+  assumeBrowserDom();
+  HTMLDivElement host = createHost();
+  J2clAttachmentRenderModel attachment =
+      J2clAttachmentRenderModel.fromMetadata(
+          "example.com/att+large",
+          "Large diagram",
+          "large",
+          attachmentMetadata(
+              "example.com/att+large",
+              "large.png",
+              "image/png",
+              "/attachment/example.com/att+large",
+              "/thumbnail/example.com/att+large",
+              new J2clAttachmentMetadata.ImageMetadata(2400, 1600),
+              false));
+
+  Assert.assertTrue(
+      new J2clReadSurfaceDomRenderer(host)
+          .render(
+              Arrays.asList(
+                  new J2clReadBlip("b+root", "Root text", Arrays.asList(attachment))),
+              Collections.<String>emptyList()));
+
+  HTMLElement tile =
+      (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+large']");
+  HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
+  Assert.assertEquals("large", tile.getAttribute("data-display-size"));
+  Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
+  Assert.assertEquals("600", preview.getAttribute("width"));
+  Assert.assertEquals("400", preview.getAttribute("height"));
+  Assert.assertEquals("large", preview.getAttribute("data-display-size"));
+}
+```
+
+- [ ] **Step 4: Run red tests**
+
+Run:
+
+```bash
+sbt --batch 'testOnly org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModelTest' 'testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest'
+```
+
+Expected: fail because medium/large previews still use `/attachment/...` and preview images do not carry cap attributes.
+
+### Task 2: Implement Thumbnail Preview Selection And Cap Metadata
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+
+- [ ] **Step 1: Keep full URL for open/download, thumbnail URL for preview**
+
+In `J2clAttachmentRenderModel.fromMetadata`, replace inline-image source selection with thumbnail-first preview selection:
+
+```java
+String sourceUrl =
+    firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
+```
+
+Keep `openUrl` and `downloadUrl` as `metadata.getAttachmentUrl()`.
+
+- [ ] **Step 2: Add cap helpers to the renderer**
+
+Add helpers near `renderAttachment`:
+
+```java
+private static int attachmentPreviewWidth(String displaySize) {
+  if ("large".equals(displaySize)) {
+    return 600;
+  }
+  if ("medium".equals(displaySize)) {
+    return 300;
+  }
+  return 120;
+}
+
+private static int attachmentPreviewHeight(String displaySize) {
+  if ("large".equals(displaySize)) {
+    return 400;
+  }
+  if ("medium".equals(displaySize)) {
+    return 200;
+  }
+  return 80;
+}
+```
+
+- [ ] **Step 3: Stamp preview size attributes**
+
+In `renderAttachment`, after setting preview `src`, add:
+
+```java
+String displaySize = model.getDisplaySize();
+preview.setAttribute("data-display-size", displaySize);
+preview.setAttribute("width", String.valueOf(attachmentPreviewWidth(displaySize)));
+preview.setAttribute("height", String.valueOf(attachmentPreviewHeight(displaySize)));
+```
+
+- [ ] **Step 4: Run green tests**
+
+Run the same focused tests from Task 1. Expected: pass.
+
+### Task 3: Add J2CL Attachment CSS Size Rules
+
+**Files:**
+- Modify: `j2cl/src/main/webapp/assets/sidecar.css`
+
+- [ ] **Step 1: Add read attachment CSS after `.j2cl-read-blip-content`**
+
+Add:
+
+```css
+.j2cl-read-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 0 3.35em;
+  max-width: calc(100% - 3.35em);
+}
+
+.j2cl-read-attachment {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.j2cl-read-attachment-inline-image,
+.j2cl-read-attachment-card {
+  display: inline-grid;
+  gap: 4px;
+}
+
+.j2cl-read-attachment-preview {
+  display: block;
+  height: auto;
+  max-width: min(100%, var(--j2cl-attachment-max-width, 120px));
+  max-height: var(--j2cl-attachment-max-height, 80px);
+  object-fit: contain;
+}
+
+.j2cl-read-attachment[data-display-size="small"] {
+  --j2cl-attachment-max-width: 120px;
+  --j2cl-attachment-max-height: 80px;
+}
+
+.j2cl-read-attachment[data-display-size="medium"] {
+  --j2cl-attachment-max-width: 300px;
+  --j2cl-attachment-max-height: 200px;
+}
+
+.j2cl-read-attachment[data-display-size="large"] {
+  --j2cl-attachment-max-width: 600px;
+  --j2cl-attachment-max-height: 400px;
+}
+```
+
+- [ ] **Step 2: Add a CSS regression test by static grep if no CSS test harness exists**
+
+If no CSS test harness exists, rely on browser verification and `git diff --check`; do not invent a fragile parser.
+
+### Task 4: Changelog And Verification
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
+
+- [ ] **Step 1: Add changelog fragment**
+
+Create:
+
+```json
+{
+  "releaseId": "2026-05-01-j2cl-attachment-thumbnail-parity",
+  "version": "Issue #1166",
+  "date": "2026-05-01",
+  "title": "J2CL attachment thumbnail parity",
+  "summary": "Aligns J2CL attachment previews with GWT thumbnail and display-size behavior.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Uses thumbnail previews for J2CL read-surface image attachments while keeping full-size attachment URLs for open and download actions.",
+        "Caps J2CL small, medium, and large attachment previews to GWT-compatible dimensions so oversized images do not break the wave panel."
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run full required verification**
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py
+python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json
+git diff --check
+sbt --batch compile Test/compile j2clSearchTest j2clLitTest
+```
+
+- [ ] **Step 3: Browser sanity**
+
+Run file-store setup and local server:
+
+```bash
+scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave
+bash scripts/worktree-boot.sh --port 9916
+PORT=9916 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-1166-attachment-parity-20260501/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-1166-attachment-parity-20260501/wave/config/jaas.config' bash scripts/wave-smoke.sh start
+PORT=9916 bash scripts/wave-smoke.sh check
+```
+
+Browser verify against `/?view=j2cl-root` by injecting/rendering a J2CL attachment fixture or opening an existing attachment wave:
+- small preview maxes at 120x80
+- medium preview maxes at 300x200
+- large preview maxes at 600x400 and never exceeds panel width
+- preview `src` uses `/thumbnail/`, open/download links keep `/attachment/`
+
+### Self-Review
+
+- Spec coverage: The plan covers thumbnail source selection, display-size bounds, oversized image containment, tests, changelog, and browser/manual evidence.
+- Scope control: The plan does not touch upload flow, metadata fetch authorization, attachment storage, or #1167 thread behavior.
+- Placeholder scan: No TBD/TODO placeholders remain. Browser verification has concrete acceptance bullets because the exact local wave may vary.
+- Type consistency: Java tests and renderer code use existing classes and helper names already present in the codebase.

--- a/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
@@ -16,9 +16,9 @@
   - Adds read-surface attachment layout and size caps for `.j2cl-read-attachment-preview` under `[data-display-size="small|medium|large"]`.
   - Ensures oversized images cannot exceed the wave panel width.
 - Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
-  - Adds explicit `width`/`height` metadata attributes on image previews so tests and browser diagnostics can prove the selected cap.
+  - Keeps explicit `data-display-size` metadata on image previews so tests and browser diagnostics can prove the selected cap without presentation attributes that can upscale smaller thumbnails.
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
-  - Adds/extends DOM tests for image preview source, display-size attributes, and max-dimension attributes.
+  - Adds/extends DOM tests for image preview source and display-size attributes.
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
   - Updates model expectation so medium/large inline images use thumbnails as the preview source and keep the full attachment URL only for open/download.
 - Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
@@ -48,18 +48,16 @@ In `renderWindowEntriesIncludeKeyboardReachableAttachmentControls`, after `Asser
 
 ```java
 Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
-Assert.assertEquals("300", preview.getAttribute("width"));
-Assert.assertEquals("200", preview.getAttribute("height"));
 Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
 ```
 
 - [ ] **Step 3: Add a large image renderer test**
 
-Add a test named `largeImagePreviewCarriesGwtCompatibleBounds`:
+Add a test named `largeImagePreviewUsesThumbnailAndDataDisplaySize`:
 
 ```java
 @Test
-public void largeImagePreviewCarriesGwtCompatibleBounds() {
+public void largeImagePreviewUsesThumbnailAndDataDisplaySize() {
   assumeBrowserDom();
   HTMLDivElement host = createHost();
   J2clAttachmentRenderModel attachment =
@@ -88,8 +86,6 @@ public void largeImagePreviewCarriesGwtCompatibleBounds() {
   HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
   Assert.assertEquals("large", tile.getAttribute("data-display-size"));
   Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
-  Assert.assertEquals("600", preview.getAttribute("width"));
-  Assert.assertEquals("400", preview.getAttribute("height"));
   Assert.assertEquals("large", preview.getAttribute("data-display-size"));
 }
 ```
@@ -102,7 +98,7 @@ Run:
 sbt --batch 'testOnly org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModelTest' 'testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest'
 ```
 
-Expected: fail because medium/large previews still use `/attachment/...` and preview images do not carry cap attributes.
+Expected: fail because medium/large previews still use `/attachment/...` and preview images do not carry the selected display-size metadata.
 
 ## Task 2: Implement Thumbnail Preview Selection And Cap Metadata
 
@@ -121,44 +117,16 @@ String sourceUrl =
 
 Keep `openUrl` and `downloadUrl` as `metadata.getAttachmentUrl()`.
 
-- [ ] **Step 2: Add cap helpers to the renderer**
-
-Add helpers near `renderAttachment`:
-
-```java
-private static int attachmentPreviewWidth(String displaySize) {
-  if ("large".equals(displaySize)) {
-    return 600;
-  }
-  if ("medium".equals(displaySize)) {
-    return 300;
-  }
-  return 120;
-}
-
-private static int attachmentPreviewHeight(String displaySize) {
-  if ("large".equals(displaySize)) {
-    return 400;
-  }
-  if ("medium".equals(displaySize)) {
-    return 200;
-  }
-  return 80;
-}
-```
-
-- [ ] **Step 3: Stamp preview size attributes**
+- [ ] **Step 2: Stamp preview display-size metadata**
 
 In `renderAttachment`, after setting preview `src`, add:
 
 ```java
 String displaySize = model.getDisplaySize();
 preview.setAttribute("data-display-size", displaySize);
-preview.setAttribute("width", String.valueOf(attachmentPreviewWidth(displaySize)));
-preview.setAttribute("height", String.valueOf(attachmentPreviewHeight(displaySize)));
 ```
 
-- [ ] **Step 4: Run green tests**
+- [ ] **Step 3: Run green tests**
 
 Run the same focused tests from Task 1. Expected: pass.
 

--- a/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make J2CL read-surface attachments respect GWT-compatible source selection and small/medium/large display-size bounds.
 
-**Architecture:** The Java read renderer already emits `data-display-size` and attachment classes. GWT `AttachmentDisplayLayout.decide()` uses attachment URLs for medium/large inline images and thumbnail URLs for small tiles or non-image attachment cards. The missing parity layer is CSS and explicit renderer hooks that cap preview images the same way GWT `Thumbnail.css` caps `.display-size-small|medium|large .itimg`: 120x80, 300x200, 600x400.
+**Architecture:** The Java read renderer already emits `data-display-size` and attachment classes. GWT `AttachmentDisplayLayout.decide()` uses attachment URLs for medium/large inline images and thumbnail URLs for small tiles or non-image attachment cards. J2CL follows that source priority while preserving safe fallback to the alternate URL when metadata is incomplete. The missing parity layer is CSS and explicit renderer hooks that cap preview images the same way GWT `Thumbnail.css` caps `.display-size-small|medium|large .itimg`: 120x80, 300x200, 600x400.
 
 **Tech Stack:** J2CL Java renderer tests, Lit/static CSS in `j2cl/src/main/webapp/assets/sidecar.css`, SBT verification, changelog fragments.
 
@@ -20,7 +20,7 @@
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
   - Adds/extends DOM tests for image preview source and display-size attributes.
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
-  - Updates model expectation so medium/large inline images use attachment URLs as the preview source while small/card attachments use thumbnails with safe attachment fallback.
+  - Updates model expectation so medium/large inline images prefer attachment URLs with thumbnail fallback, while small/card attachments prefer thumbnails with safe attachment fallback.
 - Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
   - New user-facing changelog fragment. Do not hand-edit `wave/config/changelog.json`; assemble/validate via scripts.
 
@@ -108,12 +108,12 @@ Expected: fail because preview images do not carry the selected display-size met
 
 - [ ] **Step 1: Match GWT preview source selection**
 
-In `J2clAttachmentRenderModel.fromMetadata`, use attachment URLs for medium/large inline images, and thumbnail-first fallback for small/card attachments:
+In `J2clAttachmentRenderModel.fromMetadata`, use attachment-first fallback for medium/large inline images, and thumbnail-first fallback for small/card attachments:
 
 ```java
 String sourceUrl =
     inlineImage
-        ? safeUrl(metadata.getAttachmentUrl())
+        ? firstNonEmpty(safeUrl(metadata.getAttachmentUrl()), safeUrl(metadata.getThumbnailUrl()))
         : firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 ```
 
@@ -243,7 +243,7 @@ Browser verify against `/?view=j2cl-root` by injecting/rendering a J2CL attachme
 - small preview maxes at 120x80
 - medium preview maxes at 300x200
 - large preview maxes at 600x400 and never exceeds panel width
-- preview `src` matches GWT source selection: `/attachment/` for medium/large inline images, `/thumbnail/` for small/card previews when available
+- preview `src` matches GWT source priority: `/attachment/` for medium/large inline images with safe thumbnail fallback, `/thumbnail/` for small/card previews with safe attachment fallback
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1166-attachment-thumbnail-parity.md
@@ -1,10 +1,10 @@
-# J2CL Attachment Thumbnail Parity Implementation Plan
+# J2CL Attachment Display-Size Parity Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make J2CL read-surface attachments respect GWT-compatible thumbnail and small/medium/large display-size bounds.
+**Goal:** Make J2CL read-surface attachments respect GWT-compatible source selection and small/medium/large display-size bounds.
 
-**Architecture:** The Java read renderer already emits `data-display-size` and attachment classes, and `J2clAttachmentRenderModel` already chooses thumbnail URLs for small/card attachments. The missing parity layer is CSS and explicit renderer hooks that cap preview images the same way GWT `Thumbnail.css` caps `.display-size-small|medium|large .itimg`: 120x80, 300x200, 600x400.
+**Architecture:** The Java read renderer already emits `data-display-size` and attachment classes. GWT `AttachmentDisplayLayout.decide()` uses attachment URLs for medium/large inline images and thumbnail URLs for small tiles or non-image attachment cards. The missing parity layer is CSS and explicit renderer hooks that cap preview images the same way GWT `Thumbnail.css` caps `.display-size-small|medium|large .itimg`: 120x80, 300x200, 600x400.
 
 **Tech Stack:** J2CL Java renderer tests, Lit/static CSS in `j2cl/src/main/webapp/assets/sidecar.css`, SBT verification, changelog fragments.
 
@@ -20,7 +20,7 @@
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
   - Adds/extends DOM tests for image preview source and display-size attributes.
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
-  - Updates model expectation so medium/large inline images use thumbnails as the preview source and keep the full attachment URL only for open/download.
+  - Updates model expectation so medium/large inline images use attachment URLs as the preview source while small/card attachments use thumbnails with safe attachment fallback.
 - Create: `wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json`
   - New user-facing changelog fragment. Do not hand-edit `wave/config/changelog.json`; assemble/validate via scripts.
 
@@ -30,14 +30,14 @@
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java`
 - Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
 
-- [ ] **Step 1: Change the model test to expect thumbnail previews for medium images**
+- [ ] **Step 1: Change the model test to expect GWT-compatible medium image sources**
 
-In `mediumImageUsesOriginalAttachmentUrl`, change the test name to `mediumImageUsesThumbnailPreviewAndAttachmentOpenUrl` and assert:
+In `mediumImageUsesOriginalAttachmentUrl`, change the test name to `mediumInlineImageUsesAttachmentUrlForBothPreviewAndOpen` and assert:
 
 ```java
 Assert.assertTrue(model.isInlineImage());
 Assert.assertEquals("medium", model.getDisplaySize());
-Assert.assertEquals("/thumbnail/example.com/att+hero", model.getSourceUrl());
+Assert.assertEquals("/attachment/example.com/att+hero", model.getSourceUrl());
 Assert.assertEquals("/attachment/example.com/att+hero", model.getOpenUrl());
 Assert.assertEquals("/attachment/example.com/att+hero", model.getDownloadUrl());
 ```
@@ -47,17 +47,17 @@ Assert.assertEquals("/attachment/example.com/att+hero", model.getDownloadUrl());
 In `renderWindowEntriesIncludeKeyboardReachableAttachmentControls`, after `Assert.assertNotNull(tile.querySelector("img"));`, bind `HTMLElement preview = (HTMLElement) tile.querySelector("img");` and assert:
 
 ```java
-Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
+Assert.assertEquals("/attachment/example.com/att+hero", preview.getAttribute("src"));
 Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
 ```
 
 - [ ] **Step 3: Add a large image renderer test**
 
-Add a test named `largeImagePreviewUsesThumbnailAndDataDisplaySize`:
+Add a test named `largeInlineImageUsesAttachmentUrlAndDataDisplaySize`:
 
 ```java
 @Test
-public void largeImagePreviewUsesThumbnailAndDataDisplaySize() {
+public void largeInlineImageUsesAttachmentUrlAndDataDisplaySize() {
   assumeBrowserDom();
   HTMLDivElement host = createHost();
   J2clAttachmentRenderModel attachment =
@@ -85,7 +85,7 @@ public void largeImagePreviewUsesThumbnailAndDataDisplaySize() {
       (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+large']");
   HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
   Assert.assertEquals("large", tile.getAttribute("data-display-size"));
-  Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
+  Assert.assertEquals("/attachment/example.com/att+large", preview.getAttribute("src"));
   Assert.assertEquals("large", preview.getAttribute("data-display-size"));
 }
 ```
@@ -98,21 +98,23 @@ Run:
 sbt --batch 'testOnly org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModelTest' 'testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest'
 ```
 
-Expected: fail because medium/large previews still use `/attachment/...` and preview images do not carry the selected display-size metadata.
+Expected: fail because preview images do not carry the selected display-size metadata and CSS does not yet enforce GWT-compatible bounds.
 
-## Task 2: Implement Thumbnail Preview Selection And Cap Metadata
+## Task 2: Implement GWT Source Selection And Cap Metadata
 
 **Files:**
 - Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java`
 - Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
 
-- [ ] **Step 1: Keep full URL for open/download, thumbnail URL for preview**
+- [ ] **Step 1: Match GWT preview source selection**
 
-In `J2clAttachmentRenderModel.fromMetadata`, replace inline-image source selection with thumbnail-first preview selection:
+In `J2clAttachmentRenderModel.fromMetadata`, use attachment URLs for medium/large inline images, and thumbnail-first fallback for small/card attachments:
 
 ```java
 String sourceUrl =
-    firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
+    inlineImage
+        ? safeUrl(metadata.getAttachmentUrl())
+        : firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 ```
 
 Keep `openUrl` and `downloadUrl` as `metadata.getAttachmentUrl()`.
@@ -201,13 +203,13 @@ Create:
   "releaseId": "2026-05-01-j2cl-attachment-thumbnail-parity",
   "version": "Issue #1166",
   "date": "2026-05-01",
-  "title": "J2CL attachment thumbnail parity",
-  "summary": "Aligns J2CL attachment previews with GWT thumbnail and display-size behavior.",
+  "title": "J2CL attachment display-size parity",
+  "summary": "Aligns J2CL attachment previews with GWT source selection and display-size behavior.",
   "sections": [
     {
       "type": "fix",
       "items": [
-        "Uses thumbnail previews for J2CL read-surface image attachments while keeping full-size attachment URLs for open and download actions.",
+        "Uses GWT-compatible preview sources: attachment URLs for medium and large inline images, and thumbnail URLs for small tiles and attachment cards.",
         "Caps J2CL small, medium, and large attachment previews to GWT-compatible dimensions so oversized images do not break the wave panel."
       ]
     }
@@ -241,11 +243,11 @@ Browser verify against `/?view=j2cl-root` by injecting/rendering a J2CL attachme
 - small preview maxes at 120x80
 - medium preview maxes at 300x200
 - large preview maxes at 600x400 and never exceeds panel width
-- preview `src` uses `/thumbnail/`, open/download links keep `/attachment/`
+- preview `src` matches GWT source selection: `/attachment/` for medium/large inline images, `/thumbnail/` for small/card previews when available
 
 ## Self-Review
 
-- Spec coverage: The plan covers thumbnail source selection, display-size bounds, oversized image containment, tests, changelog, and browser/manual evidence.
+- Spec coverage: The plan covers GWT-compatible source selection, display-size bounds, oversized image containment, tests, changelog, and browser/manual evidence.
 - Scope control: The plan does not touch upload flow, metadata fetch authorization, attachment storage, or #1167 thread behavior.
 - Placeholder scan: No TBD/TODO placeholders remain. Browser verification has concrete acceptance bullets because the exact local wave may vary.
 - Type consistency: Java tests and renderer code use existing classes and helper names already present in the codebase.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -105,9 +105,11 @@ public final class J2clAttachmentRenderModel {
     // matching GWT's AttachmentDisplayLayout.SourceKind.ATTACHMENT path. Small previews and
     // non-image attachments prefer the thumbnail URL with a fallback to the attachment URL,
     // matching GWT's SourceKind.THUMBNAIL path.
-    String sourceUrl = inlineImage
-        ? safeUrl(metadata.getAttachmentUrl())
-        : firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
+    String sourceUrl =
+        inlineImage
+            ? safeUrl(metadata.getAttachmentUrl())
+            : firstNonEmpty(
+                safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 
     return new J2clAttachmentRenderModel(
         normalizedAttachmentId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -101,7 +101,8 @@ public final class J2clAttachmentRenderModel {
                 || DISPLAY_LARGE.equals(normalizedDisplaySize));
     String effectiveDisplaySize =
         image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
-    String sourceUrl = firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
+    String sourceUrl =
+        firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 
     return new J2clAttachmentRenderModel(
         normalizedAttachmentId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -101,13 +101,15 @@ public final class J2clAttachmentRenderModel {
                 || DISPLAY_LARGE.equals(normalizedDisplaySize));
     String effectiveDisplaySize =
         image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
-    // Inline images (medium/large with known dimensions) use the full attachment URL directly,
-    // matching GWT's AttachmentDisplayLayout.SourceKind.ATTACHMENT path. Small previews and
+    // Inline images (medium/large with known dimensions) prefer the full attachment URL,
+    // matching GWT's AttachmentDisplayLayout.SourceKind.ATTACHMENT path, but keep a thumbnail
+    // fallback so incomplete metadata can still render a safe preview. Small previews and
     // non-image attachments prefer the thumbnail URL with a fallback to the attachment URL,
     // matching GWT's SourceKind.THUMBNAIL path.
     String sourceUrl =
         inlineImage
-            ? safeUrl(metadata.getAttachmentUrl())
+            ? firstNonEmpty(
+                safeUrl(metadata.getAttachmentUrl()), safeUrl(metadata.getThumbnailUrl()))
             : firstNonEmpty(
                 safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -101,10 +101,7 @@ public final class J2clAttachmentRenderModel {
                 || DISPLAY_LARGE.equals(normalizedDisplaySize));
     String effectiveDisplaySize =
         image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
-    String sourceUrl =
-        inlineImage
-            ? firstNonEmpty(metadata.getAttachmentUrl(), metadata.getThumbnailUrl())
-            : firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
+    String sourceUrl = firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
 
     return new J2clAttachmentRenderModel(
         normalizedAttachmentId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -101,7 +101,7 @@ public final class J2clAttachmentRenderModel {
                 || DISPLAY_LARGE.equals(normalizedDisplaySize));
     String effectiveDisplaySize =
         image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
-    String sourceUrl = firstNonEmpty(metadata.getThumbnailUrl(), metadata.getAttachmentUrl());
+    String sourceUrl = firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 
     return new J2clAttachmentRenderModel(
         normalizedAttachmentId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -101,8 +101,13 @@ public final class J2clAttachmentRenderModel {
                 || DISPLAY_LARGE.equals(normalizedDisplaySize));
     String effectiveDisplaySize =
         image && !hasImageDimensions ? DISPLAY_SMALL : normalizedDisplaySize;
-    String sourceUrl =
-        firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
+    // Inline images (medium/large with known dimensions) use the full attachment URL directly,
+    // matching GWT's AttachmentDisplayLayout.SourceKind.ATTACHMENT path. Small previews and
+    // non-image attachments prefer the thumbnail URL with a fallback to the attachment URL,
+    // matching GWT's SourceKind.THUMBNAIL path.
+    String sourceUrl = inlineImage
+        ? safeUrl(metadata.getAttachmentUrl())
+        : firstNonEmpty(safeUrl(metadata.getThumbnailUrl()), safeUrl(metadata.getAttachmentUrl()));
 
     return new J2clAttachmentRenderModel(
         normalizedAttachmentId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1520,8 +1520,12 @@ public final class J2clReadSurfaceDomRenderer {
 
     if (!model.getSourceUrl().isEmpty()) {
       HTMLElement preview = (HTMLElement) DomGlobal.document.createElement("img");
+      String displaySize = model.getDisplaySize();
       preview.className = "j2cl-read-attachment-preview";
       preview.setAttribute("src", model.getSourceUrl());
+      preview.setAttribute("data-display-size", displaySize);
+      preview.setAttribute("width", String.valueOf(attachmentPreviewWidth(displaySize)));
+      preview.setAttribute("height", String.valueOf(attachmentPreviewHeight(displaySize)));
       preview.setAttribute("referrerpolicy", "no-referrer");
       if (model.isInlineImage()) {
         preview.setAttribute("alt", model.getCaption());
@@ -1578,6 +1582,26 @@ public final class J2clReadSurfaceDomRenderer {
       attachment.appendChild(actions);
     }
     return attachment;
+  }
+
+  private static int attachmentPreviewWidth(String displaySize) {
+    if ("large".equals(displaySize)) {
+      return 600;
+    }
+    if ("medium".equals(displaySize)) {
+      return 300;
+    }
+    return 120;
+  }
+
+  private static int attachmentPreviewHeight(String displaySize) {
+    if ("large".equals(displaySize)) {
+      return 400;
+    }
+    if ("medium".equals(displaySize)) {
+      return 200;
+    }
+    return 80;
   }
 
   private HTMLElement renderAttachmentLink(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1524,8 +1524,6 @@ public final class J2clReadSurfaceDomRenderer {
       preview.className = "j2cl-read-attachment-preview";
       preview.setAttribute("src", model.getSourceUrl());
       preview.setAttribute("data-display-size", displaySize);
-      preview.setAttribute("width", String.valueOf(attachmentPreviewWidth(displaySize)));
-      preview.setAttribute("height", String.valueOf(attachmentPreviewHeight(displaySize)));
       preview.setAttribute("referrerpolicy", "no-referrer");
       if (model.isInlineImage()) {
         preview.setAttribute("alt", model.getCaption());
@@ -1582,26 +1580,6 @@ public final class J2clReadSurfaceDomRenderer {
       attachment.appendChild(actions);
     }
     return attachment;
-  }
-
-  private static int attachmentPreviewWidth(String displaySize) {
-    if ("large".equals(displaySize)) {
-      return 600;
-    }
-    if ("medium".equals(displaySize)) {
-      return 300;
-    }
-    return 120;
-  }
-
-  private static int attachmentPreviewHeight(String displaySize) {
-    if ("large".equals(displaySize)) {
-      return 400;
-    }
-    if ("medium".equals(displaySize)) {
-      return 200;
-    }
-    return 80;
   }
 
   private HTMLElement renderAttachmentLink(

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -368,6 +368,48 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   word-break: normal;
 }
 
+.j2cl-read-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 0 3.35em;
+  max-width: calc(100% - 3.35em);
+}
+
+.j2cl-read-attachment {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.j2cl-read-attachment-inline-image,
+.j2cl-read-attachment-card {
+  display: inline-grid;
+  gap: 4px;
+}
+
+.j2cl-read-attachment-preview {
+  display: block;
+  height: auto;
+  max-height: var(--j2cl-attachment-max-height, 80px);
+  max-width: min(100%, var(--j2cl-attachment-max-width, 120px));
+  object-fit: contain;
+}
+
+.j2cl-read-attachment[data-display-size="small"] {
+  --j2cl-attachment-max-height: 80px;
+  --j2cl-attachment-max-width: 120px;
+}
+
+.j2cl-read-attachment[data-display-size="medium"] {
+  --j2cl-attachment-max-height: 200px;
+  --j2cl-attachment-max-width: 300px;
+}
+
+.j2cl-read-attachment[data-display-size="large"] {
+  --j2cl-attachment-max-height: 400px;
+  --j2cl-attachment-max-width: 600px;
+}
+
 .j2cl-read-mention-chip {
   background: #e8f0fe;
   border-radius: 3px;

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 @J2clTestInput(J2clAttachmentRenderModelTest.class)
 public class J2clAttachmentRenderModelTest {
   @Test
-  public void mediumImageUsesOriginalAttachmentUrl() {
+  public void mediumImageUsesThumbnailPreviewAndAttachmentOpenUrl() {
     J2clAttachmentRenderModel model =
         J2clAttachmentRenderModel.fromMetadata(
             "example.com/att+hero",
@@ -24,8 +24,9 @@ public class J2clAttachmentRenderModelTest {
 
     Assert.assertTrue(model.isInlineImage());
     Assert.assertEquals("medium", model.getDisplaySize());
-    Assert.assertEquals("/attachment/example.com/att+hero", model.getSourceUrl());
+    Assert.assertEquals("/thumbnail/example.com/att+hero", model.getSourceUrl());
     Assert.assertEquals("/attachment/example.com/att+hero", model.getOpenUrl());
+    Assert.assertEquals("/attachment/example.com/att+hero", model.getDownloadUrl());
     Assert.assertEquals("hero.png", model.getDownloadFileName());
     Assert.assertEquals("Open attachment hero.png (image/png)", model.getOpenLabel());
     Assert.assertEquals("Download attachment hero.png (image/png)", model.getDownloadLabel());
@@ -188,7 +189,7 @@ public class J2clAttachmentRenderModelTest {
                 new J2clAttachmentMetadata.ImageMetadata(320, 200),
                 false));
 
-    Assert.assertEquals("https://cdn.example.test/https.png", accepted.getSourceUrl());
+    Assert.assertEquals("https://cdn.example.test/https-thumb.png", accepted.getSourceUrl());
     Assert.assertTrue(accepted.isInlineImage());
     Assert.assertEquals("", rejected.getOpenUrl());
     Assert.assertFalse(rejected.canOpen());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -33,6 +33,29 @@ public class J2clAttachmentRenderModelTest {
   }
 
   @Test
+  public void mediumInlineImageFallsBackToThumbnailWhenAttachmentUrlMissing() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            metadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(model.isInlineImage());
+    Assert.assertEquals("medium", model.getDisplaySize());
+    Assert.assertEquals("/thumbnail/example.com/att+hero", model.getSourceUrl());
+    Assert.assertEquals("", model.getOpenUrl());
+    Assert.assertFalse(model.canOpen());
+  }
+
+  @Test
   public void nonImageStaysCardBasedAndUsesThumbnailSource() {
     J2clAttachmentRenderModel model =
         J2clAttachmentRenderModel.fromMetadata(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -161,6 +161,27 @@ public class J2clAttachmentRenderModelTest {
   }
 
   @Test
+  public void unsafeThumbnailFallsBackToSafeAttachmentPreview() {
+    J2clAttachmentRenderModel model =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+fallback",
+            "Fallback",
+            "medium",
+            metadata(
+                "example.com/att+fallback",
+                "fallback.png",
+                "image/png",
+                "/attachment/example.com/att+fallback",
+                "http://cdn.example.test/fallback-thumb.png",
+                new J2clAttachmentMetadata.ImageMetadata(640, 480),
+                false));
+
+    Assert.assertTrue(model.isInlineImage());
+    Assert.assertEquals("/attachment/example.com/att+fallback", model.getSourceUrl());
+    Assert.assertEquals("/attachment/example.com/att+fallback", model.getOpenUrl());
+  }
+
+  @Test
   public void httpsUrlsAreAcceptedAndControlCharactersAreRejected() {
     J2clAttachmentRenderModel accepted =
         J2clAttachmentRenderModel.fromMetadata(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 @J2clTestInput(J2clAttachmentRenderModelTest.class)
 public class J2clAttachmentRenderModelTest {
   @Test
-  public void mediumImageUsesThumbnailPreviewAndAttachmentOpenUrl() {
+  public void mediumInlineImageUsesAttachmentUrlForBothPreviewAndOpen() {
     J2clAttachmentRenderModel model =
         J2clAttachmentRenderModel.fromMetadata(
             "example.com/att+hero",
@@ -24,7 +24,7 @@ public class J2clAttachmentRenderModelTest {
 
     Assert.assertTrue(model.isInlineImage());
     Assert.assertEquals("medium", model.getDisplaySize());
-    Assert.assertEquals("/thumbnail/example.com/att+hero", model.getSourceUrl());
+    Assert.assertEquals("/attachment/example.com/att+hero", model.getSourceUrl());
     Assert.assertEquals("/attachment/example.com/att+hero", model.getOpenUrl());
     Assert.assertEquals("/attachment/example.com/att+hero", model.getDownloadUrl());
     Assert.assertEquals("hero.png", model.getDownloadFileName());
@@ -210,7 +210,7 @@ public class J2clAttachmentRenderModelTest {
                 new J2clAttachmentMetadata.ImageMetadata(320, 200),
                 false));
 
-    Assert.assertEquals("https://cdn.example.test/https-thumb.png", accepted.getSourceUrl());
+    Assert.assertEquals("https://cdn.example.test/https.png", accepted.getSourceUrl());
     Assert.assertTrue(accepted.isInlineImage());
     Assert.assertEquals("", rejected.getOpenUrl());
     Assert.assertFalse(rejected.canOpen());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModelTest.java
@@ -161,12 +161,12 @@ public class J2clAttachmentRenderModelTest {
   }
 
   @Test
-  public void unsafeThumbnailFallsBackToSafeAttachmentPreview() {
+  public void unsafeSmallThumbnailFallsBackToSafeAttachmentPreview() {
     J2clAttachmentRenderModel model =
         J2clAttachmentRenderModel.fromMetadata(
             "example.com/att+fallback",
             "Fallback",
-            "medium",
+            "small",
             metadata(
                 "example.com/att+fallback",
                 "fallback.png",
@@ -176,7 +176,8 @@ public class J2clAttachmentRenderModelTest {
                 new J2clAttachmentMetadata.ImageMetadata(640, 480),
                 false));
 
-    Assert.assertTrue(model.isInlineImage());
+    Assert.assertFalse(model.isInlineImage());
+    Assert.assertEquals("small", model.getDisplaySize());
     Assert.assertEquals("/attachment/example.com/att+fallback", model.getSourceUrl());
     Assert.assertEquals("/attachment/example.com/att+fallback", model.getOpenUrl());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -844,8 +844,6 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLElement preview = (HTMLElement) tile.querySelector("img");
     Assert.assertNotNull(preview);
     Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
-    Assert.assertEquals("300", preview.getAttribute("width"));
-    Assert.assertEquals("200", preview.getAttribute("height"));
     Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
 
     HTMLElement open =
@@ -872,7 +870,7 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
-  public void largeImagePreviewCarriesGwtCompatibleBounds() {
+  public void largeImagePreviewUsesThumbnailAndDataDisplaySize() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
     J2clAttachmentRenderModel attachment =
@@ -901,8 +899,6 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
     Assert.assertEquals("large", tile.getAttribute("data-display-size"));
     Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
-    Assert.assertEquals("600", preview.getAttribute("width"));
-    Assert.assertEquals("400", preview.getAttribute("height"));
     Assert.assertEquals("large", preview.getAttribute("data-display-size"));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -843,7 +843,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("medium", tile.getAttribute("data-display-size"));
     HTMLElement preview = (HTMLElement) tile.querySelector("img");
     Assert.assertNotNull(preview);
-    Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
+    Assert.assertEquals("/attachment/example.com/att+hero", preview.getAttribute("src"));
     Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
 
     HTMLElement open =
@@ -870,7 +870,7 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
-  public void largeImagePreviewUsesThumbnailAndDataDisplaySize() {
+  public void largeInlineImageUsesAttachmentUrlAndDataDisplaySize() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
     J2clAttachmentRenderModel attachment =
@@ -898,7 +898,7 @@ public class J2clReadSurfaceDomRendererTest {
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+large']");
     HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
     Assert.assertEquals("large", tile.getAttribute("data-display-size"));
-    Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
+    Assert.assertEquals("/attachment/example.com/att+large", preview.getAttribute("src"));
     Assert.assertEquals("large", preview.getAttribute("data-display-size"));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -841,7 +841,12 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(tile);
     Assert.assertEquals("example.com/att+hero", tile.getAttribute("data-attachment-id"));
     Assert.assertEquals("medium", tile.getAttribute("data-display-size"));
-    Assert.assertNotNull(tile.querySelector("img"));
+    HTMLElement preview = (HTMLElement) tile.querySelector("img");
+    Assert.assertNotNull(preview);
+    Assert.assertEquals("/thumbnail/example.com/att+hero", preview.getAttribute("src"));
+    Assert.assertEquals("300", preview.getAttribute("width"));
+    Assert.assertEquals("200", preview.getAttribute("height"));
+    Assert.assertEquals("medium", preview.getAttribute("data-display-size"));
 
     HTMLElement open =
         (HTMLElement) tile.querySelector("[data-j2cl-attachment-open='true']");
@@ -864,6 +869,41 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("Open attachment hero.png (image/png)", open.getAttribute("aria-label"));
     Assert.assertEquals(
         "Download attachment hero.png (image/png)", download.getAttribute("aria-label"));
+  }
+
+  @Test
+  public void largeImagePreviewCarriesGwtCompatibleBounds() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+large",
+            "Large diagram",
+            "large",
+            attachmentMetadata(
+                "example.com/att+large",
+                "large.png",
+                "image/png",
+                "/attachment/example.com/att+large",
+                "/thumbnail/example.com/att+large",
+                new J2clAttachmentMetadata.ImageMetadata(2400, 1600),
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(
+                    new J2clReadBlip("b+root", "Root text", Arrays.asList(attachment))),
+                Collections.<String>emptyList()));
+
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+large']");
+    HTMLElement preview = (HTMLElement) tile.querySelector(".j2cl-read-attachment-preview");
+    Assert.assertEquals("large", tile.getAttribute("data-display-size"));
+    Assert.assertEquals("/thumbnail/example.com/att+large", preview.getAttribute("src"));
+    Assert.assertEquals("600", preview.getAttribute("width"));
+    Assert.assertEquals("400", preview.getAttribute("height"));
+    Assert.assertEquals("large", preview.getAttribute("data-display-size"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -289,7 +289,7 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertTrue(attachment.canOpen());
     Assert.assertTrue(attachment.canDownload());
     Assert.assertEquals("/attachments/hero.png", attachment.getOpenUrl());
-    Assert.assertEquals("/attachments/hero.png", attachment.getSourceUrl());
+    Assert.assertEquals("/thumbnails/hero.png", attachment.getSourceUrl());
     Assert.assertEquals(
         attachment, state.getReadWindowEntries().get(0).getAttachments().get(0));
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -289,7 +289,7 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertTrue(attachment.canOpen());
     Assert.assertTrue(attachment.canDownload());
     Assert.assertEquals("/attachments/hero.png", attachment.getOpenUrl());
-    Assert.assertEquals("/thumbnails/hero.png", attachment.getSourceUrl());
+    Assert.assertEquals("/attachments/hero.png", attachment.getSourceUrl());
     Assert.assertEquals(
         attachment, state.getReadWindowEntries().get(0).getAttachments().get(0));
   }

--- a/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
@@ -2,13 +2,13 @@
   "releaseId": "2026-05-01-j2cl-attachment-thumbnail-parity",
   "version": "Issue #1166",
   "date": "2026-05-01",
-  "title": "J2CL attachment thumbnail parity",
-  "summary": "Aligns J2CL attachment previews with GWT thumbnail and display-size behavior.",
+  "title": "J2CL attachment display-size parity",
+  "summary": "Aligns J2CL attachment previews with GWT source selection and display-size behavior.",
   "sections": [
     {
       "type": "fix",
       "items": [
-        "Uses thumbnail previews for J2CL read-surface image attachments while keeping full-size attachment URLs for open and download actions.",
+        "Uses GWT-compatible preview sources: attachment URLs for medium and large inline images, and thumbnail URLs for small tiles and attachment cards.",
         "Caps J2CL small, medium, and large attachment previews to GWT-compatible dimensions so oversized images do not break the wave panel."
       ]
     }

--- a/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-attachment-thumbnail-parity",
+  "version": "Issue #1166",
+  "date": "2026-05-01",
+  "title": "J2CL attachment thumbnail parity",
+  "summary": "Aligns J2CL attachment previews with GWT thumbnail and display-size behavior.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Uses thumbnail previews for J2CL read-surface image attachments while keeping full-size attachment URLs for open and download actions.",
+        "Caps J2CL small, medium, and large attachment previews to GWT-compatible dimensions so oversized images do not break the wave panel."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-attachment-thumbnail-parity.json
@@ -8,7 +8,7 @@
     {
       "type": "fix",
       "items": [
-        "Uses GWT-compatible preview sources: attachment URLs for medium and large inline images, and thumbnail URLs for small tiles and attachment cards.",
+        "Uses GWT-compatible preview source priority: attachment URLs for medium and large inline images with thumbnail fallback, and thumbnail URLs for small tiles and attachment cards with attachment fallback.",
         "Caps J2CL small, medium, and large attachment previews to GWT-compatible dimensions so oversized images do not break the wave panel."
       ]
     }


### PR DESCRIPTION
## Summary
- makes J2CL read-surface image attachment previews use thumbnail URLs while open/download actions keep full attachment URLs
- adds GWT-compatible preview cap metadata: small 120x80, medium 300x200, large 600x400
- adds J2CL sidecar CSS so oversized previews do not render at natural/original size or overflow the wave panel

Closes #1166
Part of #904

## Verification
- Red proof: `sbt --batch j2clSearchTest` failed before the implementation on `J2clAttachmentRenderModelTest.mediumImageUsesThumbnailPreviewAndAttachmentOpenUrl`, expected `/thumbnail/...` but got `/attachment/...`.
- `sbt --batch j2clSearchTest` passed after the fix.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check && sbt --batch compile Test/compile j2clSearchTest j2clLitTest` passed.
- Browser sanity fixture against actual `sidecar.css`: small rendered 120x80, medium 300x200, large rendered 500x333 inside a 500px panel with CSS max `min(100%, 600px)` and max-height 400px.

## Review
- Self-review only, per current instruction not to use Claude Code. No placeholder scan findings or scope expansion found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment previews now prefer thumbnails for inline/preview tiles while keeping full-resolution files for open/download.
  * Preview images carry explicit display-size metadata (small/medium/large) to ensure consistent sizing.
  * Preview dimensions are capped per display-size to prevent oversized images from breaking panel layout and preserve visual spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->