### PR TITLE
Fix J2CL thread chrome parity

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1167-threading-inline-blip-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1167-threading-inline-blip-parity.md
@@ -1,0 +1,140 @@
+# J2CL Threading And Inline Blip Parity Plan
+
+Issue: #1167
+Parent tracker: #904
+Worktree: `/Users/vega/devroot/worktrees/issue-1167-threading-parity-20260501`
+Branch: `codex/issue-1167-threading-parity-20260501`
+
+## Goal
+
+Bring the J2CL read-surface thread UI closer to GWT parity by fixing the visible threading affordance gaps reported in the May 1 audit: inline threads should not look like detached full replies, thread controls should be compact icon affordances rather than large text rows, the reply-count badge should not consume vertical space under the blip body, and opening reply affordances must preserve scroll position.
+
+## Current Findings
+
+- `J2clReadSurfaceDomRenderer` already nests reply blips into sibling `.thread.inline-thread.j2cl-read-thread` containers and mirrors collapse state to the parent `wave-blip`.
+- `wave-blip` still renders a body-level `△ N` inline-reply chip under every blip with replies. This is the visible diamond-like control the audit says takes too much vertical space.
+- `enhanceInlineThread()` inserts a full-width text button with `Collapse thread` / `Expand thread` as the first child of each inline thread. That creates extra vertical rows between parent and child blips.
+- The root reply affordance is a large full-width `Click here to reply` button. The user audit describes a `+` under a blip consuming vertical space and sometimes scrolling to the bottom; the root/inline compose mounting path needs explicit scroll-anchor preservation.
+- `J2clReadBlipContent.parseRawSnapshot()` currently strips all non-image tags into text. It does not preserve `<reply>` inline anchors, so a thread that GWT can attach at an inline anchor can only be attached after the parent blip in J2CL today.
+- GWT reference seams for inline replies are `InlineAnchorLiveRenderer`, `InlineAnchorStaticRenderer`, `ReplyManager`, and `FullDomRenderer`; those separate inline anchors from default anchors and move reply threads to inline anchors when present.
+
+## Scope Boundary
+
+This issue should fix the J2CL client-side rendering and interaction parity for already-delivered thread metadata. It should not change server fragment storage, wavelet persistence, or the write delta format unless a red test proves the client cannot represent the required anchor with existing fragment data.
+
+## Dependency
+
+PR #1172 touches `J2clReadSurfaceDomRenderer.java` and `sidecar.css`. Because #1167 will also touch the read renderer and sidecar CSS, implementation should start after #1172 merges, or the #1167 branch must be rebased onto the merge commit before code changes are made.
+
+## Implementation Tasks
+
+### Task 1: Red Tests For Compact Thread Chrome
+
+Files:
+- `j2cl/lit/src/elements/wave-blip.js`
+- `j2cl/lit/test/wave-blip.test.js`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+Tests:
+- Add a Lit regression proving `wave-blip reply-count="2"` no longer renders `[data-inline-reply-chip="true"]` under the body.
+- Add a Lit regression proving the header chevron is an icon button with accessible labels and emits a thread-toggle/drill event without adding vertical body content.
+- Add a Java DOM regression proving `.j2cl-read-thread-toggle` renders as compact icon-only text (`+`, `-`, or chevron glyph) with aria-labels, not visible `Collapse thread` / `Expand thread` text rows.
+
+Expected red result:
+- Current `wave-blip` renders `△ N` under the body.
+- Current renderer inserts text `Collapse thread`.
+
+### Task 2: Replace Body-Level Reply Count With Header/Gutter Controls
+
+Files:
+- `j2cl/lit/src/elements/wave-blip.js`
+- `j2cl/lit/test/wave-blip.test.js`
+
+Changes:
+- Remove the body-level inline-reply chip from normal read-surface rendering.
+- Keep `reply-count` as the source of truth for whether the header/gutter control is visible.
+- Make the existing chevron affordance accessible and eventful, either by converting it to a compact button or by wrapping it with an invisible accessible button while preserving the current visual.
+- Preserve `wave-blip-drill-in-requested` semantics if the depth-navigation path still consumes that event.
+
+Acceptance:
+- No `△ N` block appears under a normal blip.
+- Reply count remains visible or available in the compact header/gutter affordance.
+- Keyboard users can focus and activate the thread affordance.
+
+### Task 3: Compact The Inline Thread Toggle Row
+
+Files:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- `j2cl/src/main/webapp/assets/sidecar.css`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+Changes:
+- Keep the existing collapse state model and `aria-expanded` contract.
+- Change inserted thread toggle visible text from `Collapse thread` / `Expand thread` to compact icon text while keeping full aria-labels.
+- Position/style the toggle as a small gutter control so it does not create a full-width spacer between parent and inline child blips.
+- Ensure collapse state still mirrors onto the parent `wave-blip` via `data-thread-collapsed`.
+
+Acceptance:
+- No full-width `Collapse thread` text row appears between blips.
+- Collapse/expand remains mouse and keyboard accessible.
+- Parent chevron/gutter state remains synchronized.
+
+### Task 4: Preserve Scroll Anchor Around Reply Affordances
+
+Files:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- `j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js`
+- `j2cl/lit/test/wavy-wave-root-reply-trigger.test.js`
+- Relevant compose-mount controller tests under `j2cl/lit/test/` or J2CL Java controller tests.
+
+Changes:
+- Add tests proving activating a root or blip reply affordance does not force scroll-to-bottom unless the user explicitly opens the bottom wave-root composer.
+- If the current full-width root reply trigger remains, restyle it as a compact `+`/reply icon with an accessible label.
+- Preserve scroll anchor before compose mount and restore it after mount when the originating trigger is not the bottom-of-wave trigger.
+
+Acceptance:
+- Clicking reply under/near a blip does not jump the viewport to the bottom.
+- The bottom wave-root affordance may still reveal the bottom composer, but the behavior is explicit and labelled.
+
+### Task 5: Inline Anchor Representation
+
+Files:
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java`
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java`
+- `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+Changes:
+- Add a narrow parsed representation for `<reply id="...">...</reply>` anchors if selected-wave raw snapshots contain them.
+- Render inline thread anchors inside the blip body when an anchor exists for a thread.
+- Keep default-anchor behavior for threads with no inline anchor.
+
+Acceptance:
+- A blip snapshot containing a `<reply>` anchor renders the associated reply thread at the inline anchor location instead of only after the parent blip.
+- A thread without an inline anchor continues to render after the parent blip.
+- Malformed or missing anchors degrade safely to current default placement.
+
+### Task 6: Verification And PR
+
+Required verification:
+- Red proof from `sbt --batch j2clSearchTest` and/or focused Lit tests before implementation.
+- `python3 scripts/assemble-changelog.py`
+- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+- `git diff --check`
+- `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`
+- Browser sanity against `/?view=j2cl-root` or a local fixture proving no body-level thread badge, compact icon controls, working collapse/expand, and no unexpected scroll jump.
+
+## Self-Review
+
+- Scope is intentionally split: compact chrome and scroll preservation are mandatory first; inline anchor representation is included but should only be implemented after confirming the selected-wave fragment data actually carries reply anchors.
+- The plan preserves existing data contracts (`reply-count`, `data-thread-collapsed`, `wave-blip-drill-in-requested`) unless red tests prove a new event is needed.
+- The plan avoids server/storage changes and treats malformed manifests/anchors as safe fallback to current default placement.
+- Placeholder scan: no TBD/TODO placeholders remain.
+
+## Execution Note
+
+- The implemented slice fixes the visible thread chrome and plus-affordance scroll gap: the body-level reply-count chip is removed, the header chevron is keyboard-accessible, inline-thread collapse rows are icon-sized, and non-root inline composer mount restores its scroll anchor.
+- The existing renderer already nests child blips by parent/thread metadata. A scan of the shared local file store found no `<reply id="...">` raw fragment anchors to drive a safe inline-anchor placement change in this slice, so Task 5 remains gated on real fragment evidence or a dedicated fixture issue.
+- Browser verification found that the read-surface preview route's JavaScript hydration currently replaces the server fixture with an empty selected-wave state. The no-JS server-rendered preview still proves the fixture markup has no body-level reply chip or text collapse rows; Lit browser tests cover the interactive upgraded controls.

--- a/docs/superpowers/plans/2026-05-01-issue-1167-threading-inline-blip-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1167-threading-inline-blip-parity.md
@@ -2,7 +2,7 @@
 
 Issue: #1167
 Parent tracker: #904
-Worktree: `/Users/vega/devroot/worktrees/issue-1167-threading-parity-20260501`
+Worktree: `<local-worktrees>/issue-1167-threading-parity-20260501`
 Branch: `codex/issue-1167-threading-parity-20260501`
 
 ## Goal

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -16,8 +16,8 @@ import "./wavy-task-affordance.js";
  * - F-2 needs to layer on top: a header with the author display name
  *   + relative timestamp + full ISO datetime tooltip (F.1 / F.2 / F.3),
  *   a per-blip toolbar with Reply / Edit / Link / overflow that reveals
- *   on focus or hover (F.4 / F.5 / F.6 / F.7), an inline-reply chip when
- *   the blip has children (F.10 + R-3.7 G.1 drill-in), and a `has-mention`
+ *   on focus or hover (F.4 / F.5 / F.6 / F.7), a compact thread affordance
+ *   when the blip has children (F.10 + R-3.7 G.1 drill-in), and a `has-mention`
  *   reflection so the wave-nav-row can navigate by @-mentions (E.6 / E.7).
  *
  * Plugin slot contract (R-3.1 step 8 + plugin-slot reservation):
@@ -54,7 +54,7 @@ import "./wavy-task-affordance.js";
  * - `wave-blip-profile-requested` — `{detail: {blipId, authorId}}`.
  *   Emitted from the avatar click for the L.1 profile overlay.
  * - `wave-blip-drill-in-requested` — `{detail: {blipId, waveId}}`.
- *   Emitted from the inline-reply chip click for the R-3.7 G.1 drill-in.
+ *   Emitted from the compact thread chevron for the R-3.7 G.1 drill-in.
  */
 export class WaveBlip extends LitElement {
   static properties = {
@@ -149,9 +149,15 @@ export class WaveBlip extends LitElement {
     .thread-chevron {
       flex: 0 0 auto;
       width: 16px;
+      height: 20px;
       text-align: center;
       font: var(--wavy-type-label, 11px / 1.35 Arial, sans-serif);
       color: #718096;
+      background: transparent;
+      border: 0;
+      border-radius: var(--wavy-radius-sm, 4px);
+      cursor: pointer;
+      padding: 0;
       user-select: none;
     }
     :host([focused]) .thread-chevron {
@@ -167,6 +173,10 @@ export class WaveBlip extends LitElement {
      * with children, so the glyph is purely a visual cue here. */
     .thread-chevron[hidden] {
       display: none;
+    }
+    .thread-chevron:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
     }
     .avatar {
       flex: 0 0 auto;
@@ -227,21 +237,6 @@ export class WaveBlip extends LitElement {
      * through descendants even when descendants set text-decoration
      * none, so visual isolation must come from DOM placement rather
      * than from a defensive rule. */
-    .inline-reply-chip {
-      display: inline-block;
-      margin-top: 6px;
-      padding: 6px 10px;
-      border-radius: 8px;
-      border: 1.5px dashed #e2e8f0;
-      background: #f0f4f8;
-      color: #718096;
-      font: italic 13px / 1.35 Arial, sans-serif;
-      cursor: pointer;
-    }
-    .inline-reply-chip:focus-visible {
-      outline: none;
-      box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
-    }
     /* When the wrapper carries the has-mention attr, paint a cyan
      * accent rail down the left so the mention navigation (E.6 / E.7)
      * has a visual cue without reusing the unread-dot geometry. */
@@ -549,7 +544,7 @@ export class WaveBlip extends LitElement {
     );
   }
 
-  _onChipClick(event) {
+  _onThreadChevronClick(event) {
     event.stopPropagation();
     this.dispatchEvent(
       new CustomEvent("wave-blip-drill-in-requested", {
@@ -591,29 +586,20 @@ export class WaveBlip extends LitElement {
 
   render() {
     const tooltip = this.postedAtIso || this.postedAt;
-    const chip =
-      this.replyCount > 0
-        ? html`<button
-            type="button"
-            class="inline-reply-chip"
-            data-inline-reply-chip="true"
-            aria-label=${`Drill into ${this.replyCount} replies under this blip`}
-            @click=${this._onChipClick}
-          >
-            △ ${this.replyCount}
-          </button>`
-        : null;
     const isRoot = this.blipDepth === "root";
     const timestampSuffix = isRoot && this.postedAt ? " · root" : "";
     const palette = this._palette();
     const hasReplies = this.replyCount > 0;
     const visuallyFocused = this._visuallyFocused();
     const chevron = hasReplies
-      ? html`<span
+      ? html`<button
+          type="button"
           class="thread-chevron"
           data-thread-chevron="true"
-          aria-hidden="true"
-        >${this._chevronGlyph()}</span>`
+          aria-label=${`Drill into ${this.replyCount} replies under this blip`}
+          aria-expanded=${String(!this.threadCollapsed)}
+          @click=${this._onThreadChevronClick}
+        >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;
 
     return html`
@@ -676,7 +662,6 @@ export class WaveBlip extends LitElement {
         </div>
         <div class="body">
           <slot></slot>
-          ${chip}
         </div>
         <slot name="blip-extension" slot="blip-extension"></slot>
         <slot name="reactions" slot="reactions"></slot>

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -591,12 +591,13 @@ export class WaveBlip extends LitElement {
     const palette = this._palette();
     const hasReplies = this.replyCount > 0;
     const visuallyFocused = this._visuallyFocused();
+    const replyNoun = this.replyCount === 1 ? "reply" : "replies";
     const chevron = hasReplies
       ? html`<button
           type="button"
           class="thread-chevron"
           data-thread-chevron="true"
-          aria-label=${`Drill into ${this.replyCount} replies under this blip`}
+          aria-label=${`Drill into ${this.replyCount} ${replyNoun} under this blip`}
           @click=${this._onThreadChevronClick}
         >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -597,7 +597,6 @@ export class WaveBlip extends LitElement {
           class="thread-chevron"
           data-thread-chevron="true"
           aria-label=${`Drill into ${this.replyCount} replies under this blip`}
-          aria-expanded=${String(!this.threadCollapsed)}
           @click=${this._onThreadChevronClick}
         >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -1,8 +1,8 @@
 import { LitElement, css, html } from "lit";
 
 /**
- * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5) bottom-of-wave
- * "Click here to reply" affordance (J.1 from the GWT inventory).
+ * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5) compact
+ * bottom-of-wave reply affordance (J.1 from the GWT inventory).
  *
  * Mounted at the bottom of the read surface. Clicking dispatches a
  * `wave-root-reply-requested` CustomEvent with `{detail: {waveId}}`.
@@ -22,22 +22,24 @@ export class WavyWaveRootReplyTrigger extends LitElement {
 
   static styles = css`
     :host {
-      display: block;
-      padding: var(--wavy-spacing-3, 12px) 0;
+      display: inline-flex;
+      padding: var(--wavy-spacing-1, 4px) 0;
     }
     :host([hidden]) {
       display: none;
     }
     button {
-      width: 100%;
-      padding: var(--wavy-spacing-3, 12px);
-      border-radius: var(--wavy-radius-card, 12px);
-      border: 1px dashed var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
-      background: transparent;
-      color: var(--wavy-text-quiet, rgba(232, 240, 255, 0.42));
-      font: var(--wavy-type-body, 0.9375rem / 1.55 sans-serif);
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      border-radius: var(--wavy-radius-pill, 999px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.24));
+      background: var(--wavy-surface-raised, rgba(255, 255, 255, 0.92));
+      color: var(--wavy-signal-cyan, #0077b6);
+      font: var(--wavy-type-label, 0.875rem / 1 sans-serif);
+      font-weight: 700;
       cursor: pointer;
-      text-align: left;
+      text-align: center;
     }
     button:hover {
       border-color: var(--wavy-signal-cyan, #22d3ee);
@@ -73,10 +75,10 @@ export class WavyWaveRootReplyTrigger extends LitElement {
       <button
         type="button"
         data-wave-root-reply-trigger
-        aria-label="Click here to reply to the wave"
+        aria-label="Reply to the wave"
         @click=${this._onClick}
       >
-        Click here to reply
+        +
       </button>
     `;
   }

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -182,6 +182,17 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w7");
   });
 
+  it("uses singular grammar for a one-reply chevron aria-label", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b7a" data-wave-id="w7" author-name="A" reply-count="1">
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
+    expect(chevron.getAttribute("aria-label")).to.equal("Drill into 1 reply under this blip");
+  });
+
   it("avatar click emits wave-blip-profile-requested with author id", async () => {
     const el = await fixture(html`
       <wave-blip

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -149,7 +149,7 @@ describe("<wave-blip>", () => {
     expect(ev.composed).to.be.true;
   });
 
-  it("renders the inline-reply chip only when reply-count > 0", async () => {
+  it("does not render a body-level inline-reply chip when reply-count > 0", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b6" data-wave-id="w6" author-name="A">x</wave-blip>
     `);
@@ -158,12 +158,10 @@ describe("<wave-blip>", () => {
 
     el.replyCount = 4;
     await el.updateComplete;
-    const chip = el.renderRoot.querySelector("[data-inline-reply-chip='true']");
-    expect(chip).to.exist;
-    expect(chip.textContent.trim()).to.contain("4");
+    expect(el.renderRoot.querySelector("[data-inline-reply-chip='true']")).to.not.exist;
   });
 
-  it("inline-reply chip click emits wave-blip-drill-in-requested with blip context", async () => {
+  it("compact thread chevron click emits wave-blip-drill-in-requested with blip context", async () => {
     const el = await fixture(html`
       <wave-blip
         data-blip-id="b7"
@@ -175,8 +173,10 @@ describe("<wave-blip>", () => {
       </wave-blip>
     `);
     await el.updateComplete;
-    const chip = el.renderRoot.querySelector("[data-inline-reply-chip='true']");
-    setTimeout(() => chip.click(), 0);
+    const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
+    expect(chevron).to.exist;
+    expect(chevron.getAttribute("aria-label")).to.equal("Drill into 2 replies under this blip");
+    setTimeout(() => chevron.click(), 0);
     const ev = await oneEvent(el, "wave-blip-drill-in-requested");
     expect(ev.detail.blipId).to.equal("b7");
     expect(ev.detail.waveId).to.equal("w7");

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -13,13 +13,14 @@ function ensureWavyTokensLoaded() {
 before(() => ensureWavyTokensLoaded());
 
 describe("<wavy-wave-root-reply-trigger>", () => {
-  it("renders the J.1 click-to-reply button", async () => {
+  it("renders the J.1 compact reply button", async () => {
     const el = await fixture(html`
       <wavy-wave-root-reply-trigger wave-id="w1"></wavy-wave-root-reply-trigger>
     `);
     const button = el.renderRoot.querySelector("[data-wave-root-reply-trigger]");
     expect(button).to.exist;
-    expect(button.textContent.trim()).to.match(/Click here to reply/);
+    expect(button.textContent.trim()).to.equal("+");
+    expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
   });
 
   it("emits wave-root-reply-requested with the wave id on click", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -526,6 +526,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
         event -> setProperty(formatToolbar, "selectionDescriptor", eventDetail(event)));
 
     HTMLElement mountPoint = locateInlineMountPoint(key);
+    HTMLElement scrollAnchor =
+        key.isEmpty() ? null : nearestScrollableAncestor(mountPoint != null ? mountPoint : replyElement);
+    double scrollTopBeforeMount = scrollAnchor == null ? 0 : scrollAnchor.scrollTop;
     if (mountPoint != null) {
       mountPoint.appendChild(composer);
     } else {
@@ -538,6 +541,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // Project current model state onto the new composer.
     mirrorComposerStateFromReplyElement(composer);
     composer.dispatchEvent(new Event("composer-focus-request"));
+    if (scrollAnchor != null) {
+      scrollAnchor.scrollTop = scrollTopBeforeMount;
+    }
   }
 
   private void closeInlineComposer(String blipId) {
@@ -561,6 +567,18 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     }
     return (HTMLElement)
         DomGlobal.document.querySelector("wave-blip[data-blip-id=\"" + blipId + "\"]");
+  }
+
+  private static HTMLElement nearestScrollableAncestor(HTMLElement element) {
+    HTMLElement current = element;
+    while (current != null && current != DomGlobal.document.body) {
+      if (current.scrollHeight > current.clientHeight) {
+        return current;
+      }
+      current =
+          current.parentElement instanceof HTMLElement ? (HTMLElement) current.parentElement : null;
+    }
+    return null;
   }
 
   private void mirrorComposerState(HTMLElement composer, J2clComposeSurfaceModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1814,6 +1814,8 @@ public final class J2clReadSurfaceDomRenderer {
             "aria-label",
             (thread.classList.contains("j2cl-read-thread-collapsed") ? "Expand " : "Collapse ")
                 + label);
+        existingButton.textContent =
+            thread.classList.contains("j2cl-read-thread-collapsed") ? "+" : "\u2212";
       }
       return;
     }
@@ -1824,7 +1826,7 @@ public final class J2clReadSurfaceDomRenderer {
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     button.setAttribute("aria-expanded", "true");
     button.setAttribute("aria-label", "Collapse " + label);
-    button.textContent = "Collapse thread";
+    button.textContent = "\u2212";
     button.addEventListener("click", event -> toggleThread(thread, button));
     thread.insertBefore(button, thread.firstChild);
   }
@@ -1873,13 +1875,13 @@ public final class J2clReadSurfaceDomRenderer {
       thread.setAttribute("data-j2cl-thread-collapsed", "true");
       button.setAttribute("aria-expanded", "false");
       button.setAttribute("aria-label", "Expand " + threadLabel(thread));
-      button.textContent = "Expand thread";
+      button.textContent = "+";
     } else {
       thread.classList.remove("j2cl-read-thread-collapsed");
       thread.removeAttribute("data-j2cl-thread-collapsed");
       button.setAttribute("aria-expanded", "true");
       button.setAttribute("aria-label", "Collapse " + threadLabel(thread));
-      button.textContent = "Collapse thread";
+      button.textContent = "\u2212";
     }
     // V-4 (#1102): mirror collapse state onto the parent wave-blip so
     // the chevron glyph (triangle-down/right) reflects the actual

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -311,16 +311,20 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
 
 .j2cl-read-thread-toggle {
   align-self: start;
-  background: #f0f4f8;
-  border: 1px dashed #e2e8f0;
-  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid #dbeafe;
+  border-radius: 999px;
   color: #718096;
   cursor: pointer;
-  font: inherit;
-  font-size: 0.86rem;
+  font: var(--wavy-type-label, 11px / 1.35 Arial, sans-serif);
+  font-size: 0.78rem;
   font-weight: 700;
-  margin: 0 0 10px;
-  padding: 6px 12px;
+  height: 20px;
+  justify-self: start;
+  line-height: 1;
+  margin: -2px 0 2px 1.15em;
+  padding: 0;
+  width: 20px;
 }
 
 .j2cl-read-thread-toggle:hover,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -70,6 +70,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
         "Collapse inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("−", toggle.textContent);
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
@@ -86,6 +87,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("+", toggle.textContent);
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-01-j2cl-thread-chrome-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-thread-chrome-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-thread-chrome-parity",
+  "version": "Issue #1167",
+  "date": "2026-05-01",
+  "title": "J2CL thread chrome parity",
+  "summary": "Compacts J2CL thread affordances so inline replies no longer consume extra blip-body space.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Moves reply-thread drill-in from the body-level diamond chip to the compact blip-header chevron.",
+        "Replaces full-width inline-thread collapse rows with small accessible icon controls."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Refs #1167
Parent tracker: #904

This PR fixes the visible J2CL thread chrome gaps from the May 1 parity audit:

- Removes the body-level `△ N` reply/thread-count chip that consumed vertical space under blip bodies.
- Converts the header thread chevron into an accessible icon button that preserves the existing `wave-blip-drill-in-requested` event.
- Replaces full-width inline-thread `Collapse thread` / `Expand thread` rows with compact `−` / `+` controls while keeping full `aria-label` and `aria-expanded` semantics.
- Compacts the bottom wave-root reply trigger to a small `+` affordance.
- Preserves the scroll anchor when mounting a non-root inline composer so clicking a blip reply affordance does not jump to the bottom.
- Documents the #1167 plan and execution caveat: true `<reply id="...">` inline-anchor placement remains gated on real fragment evidence; a shared local file-store scan found no such raw anchors for this slice.

## Verification

- `cd j2cl/lit && npm test -- --files test/wavy-wave-root-reply-trigger.test.js test/wave-blip.test.js` -> 38 passed, 0 failed.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check && sbt --batch compile Test/compile j2clSearchTest j2clLitTest` -> passed; `j2clLitTest` reported 64 files / 808 passed.
- `bash scripts/worktree-boot.sh --port 9947 --shared-file-store` -> staged worktree assets and linked shared local file store.
- `PORT=9947 JAVA_OPTS='-Djava.util.logging.config.file=/Users/vega/devroot/worktrees/issue-1167-threading-parity-20260501/wave/config/wiab-logging.conf -Djava.security.auth.login.config=/Users/vega/devroot/worktrees/issue-1167-threading-parity-20260501/wave/config/jaas.config' bash scripts/wave-smoke.sh start` -> `PROBE_HTTP=200`, `READY`.
- No-JS Playwright sanity on `http://127.0.0.1:9947/?view=j2cl-root&q=read-surface-preview` as local user `codex1167.mon8yswn@local.net` -> signed-in shell true, 7 `wave-blip` nodes, 0 `[data-inline-reply-chip]`, no visible `Collapse thread` / `Expand thread` text.
- `PORT=9947 bash scripts/wave-smoke.sh stop` -> stopped server on port 9947.

## Notes

A hydrated browser pass showed an existing preview-route limitation: with JavaScript enabled, the read-surface preview fixture is replaced by an empty selected-wave state. This PR does not broaden into that route-hydration bug; the interactive upgraded controls are covered by Lit browser tests, and the server-rendered preview markup was checked with JavaScript disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves scroll position when opening an inline composer.

* **Improvements**
  * Compacted thread UI: drill-in moved to a header chevron, full-width reply trigger replaced by a small "+" button, and thread toggles use pill-shaped glyph controls.
  * Updated accessibility labels for thread interactions.

* **Tests**
  * Updated tests to validate new chevron/plus controls and toggle glyphs.

* **Documentation**
  * Added a plan describing staged parity work and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->