### PR TITLE
fix: enforce J2CL publicity toggle authorization parity

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1511,9 +1511,13 @@ public final class J2clComposeSurfaceController {
     submitWaveHeaderAction(
         expectedWaveId,
         "compose.publicity_toggled",
-        (address, session) ->
-            deltaFactory.createPublicityToggleRequest(
-                address, session, sharedDomainParticipantForSession(session), makePublic));
+        (address, session) -> {
+          if (!canTogglePublicity(address, session, makePublic)) {
+            throw new IllegalStateException("Publicity toggle not allowed for this user/session.");
+          }
+          return deltaFactory.createPublicityToggleRequest(
+              address, session, sharedDomainParticipantForSession(session), makePublic);
+        });
   }
 
   public void onLockStateToggleRequested(
@@ -1580,6 +1584,42 @@ public final class J2clComposeSurfaceController {
         error -> recordWaveHeaderActionTelemetry(telemetryEventName, "failure-bootstrap"));
   }
 
+
+  private static boolean canTogglePublicity(
+      String address, J2clSidecarWriteSession session, boolean makePublic) {
+    if (session == null) {
+      return false;
+    }
+    List<String> participants = session.getParticipantIds();
+    if (participants == null || participants.isEmpty()) {
+      return false;
+    }
+    String normalizedAddress = normalizeParticipantAddress(address);
+    String creator = normalizeParticipantAddress(participants.get(0));
+    if (normalizedAddress.isEmpty() || creator.isEmpty() || !normalizedAddress.equals(creator)) {
+      return false;
+    }
+    if (makePublic && isDirectMessageParticipants(participants)) {
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean isDirectMessageParticipants(List<String> participants) {
+    int userParticipants = 0;
+    for (String participant : participants) {
+      String normalized = normalizeParticipantAddress(participant);
+      if (normalized.isEmpty() || normalized.startsWith("@")) {
+        continue;
+      }
+      userParticipants++;
+    }
+    return userParticipants <= 2;
+  }
+
+  private static String normalizeParticipantAddress(String participant) {
+    return participant == null ? "" : participant.trim().toLowerCase(Locale.ROOT);
+  }
   private static String sharedDomainParticipantForSession(J2clSidecarWriteSession session) {
     if (session == null || session.getSelectedWaveId() == null) {
       return "";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1614,7 +1614,7 @@ public final class J2clComposeSurfaceController {
       }
       userParticipants++;
     }
-    return userParticipants <= 2;
+    return userParticipants == 2;
   }
 
   private static String normalizeParticipantAddress(String participant) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -457,7 +457,7 @@ public final class J2clComposeSurfaceController {
   }
 
   private interface WaveHeaderActionRequestBuilder {
-    SidecarSubmitRequest create(String address, J2clSidecarWriteSession session);
+    SidecarSubmitRequest create(SidecarSessionBootstrap bootstrap, J2clSidecarWriteSession session);
   }
 
   public static final class AttachmentFileSelection {
@@ -1503,20 +1503,20 @@ public final class J2clComposeSurfaceController {
     submitWaveHeaderAction(
         expectedWaveId,
         "compose.participants_added",
-        (address, session) ->
-            deltaFactory.createAddParticipantRequest(address, session, participantsToAdd));
+        (bootstrap, session) ->
+            deltaFactory.createAddParticipantRequest(bootstrap.getAddress(), session, participantsToAdd));
   }
 
   public void onPublicityToggleRequested(final String expectedWaveId, final boolean makePublic) {
     submitWaveHeaderAction(
         expectedWaveId,
         "compose.publicity_toggled",
-        (address, session) -> {
-          if (!canTogglePublicity(address, session, makePublic)) {
+        (bootstrap, session) -> {
+          if (!canTogglePublicity(bootstrap.getAddress(), bootstrap.isAdmin(), session, makePublic)) {
             throw new IllegalStateException("Publicity toggle not allowed for this user/session.");
           }
           return deltaFactory.createPublicityToggleRequest(
-              address, session, sharedDomainParticipantForSession(session), makePublic);
+              bootstrap.getAddress(), session, sharedDomainParticipantForSession(session), makePublic);
         });
   }
 
@@ -1527,7 +1527,7 @@ public final class J2clComposeSurfaceController {
     submitWaveHeaderAction(
         expectedWaveId,
         "compose.lock_toggled",
-        (address, session) -> deltaFactory.createLockStateRequest(address, session, current, next));
+        (bootstrap, session) -> deltaFactory.createLockStateRequest(bootstrap.getAddress(), session, current, next));
   }
 
   private void submitWaveHeaderAction(
@@ -1564,7 +1564,7 @@ public final class J2clComposeSurfaceController {
           notifyCurrentUserAddress(bootstrap.getAddress());
           SidecarSubmitRequest request;
           try {
-            request = requestBuilder.create(bootstrap.getAddress(), submitSession);
+            request = requestBuilder.create(bootstrap, submitSession);
           } catch (RuntimeException e) {
             recordWaveHeaderActionTelemetry(telemetryEventName, "failure-build");
             return;
@@ -1586,7 +1586,7 @@ public final class J2clComposeSurfaceController {
 
 
   private static boolean canTogglePublicity(
-      String address, J2clSidecarWriteSession session, boolean makePublic) {
+      String address, boolean isAdmin, J2clSidecarWriteSession session, boolean makePublic) {
     if (session == null) {
       return false;
     }
@@ -1595,8 +1595,11 @@ public final class J2clComposeSurfaceController {
       return false;
     }
     String normalizedAddress = normalizeParticipantAddress(address);
+    if (normalizedAddress.isEmpty()) {
+      return false;
+    }
     String creator = normalizeParticipantAddress(participants.get(0));
-    if (normalizedAddress.isEmpty() || creator.isEmpty() || !normalizedAddress.equals(creator)) {
+    if (!isAdmin && (creator.isEmpty() || !normalizedAddress.equals(creator))) {
       return false;
     }
     if (makePublic && isDirectMessageParticipants(participants)) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -14,19 +14,26 @@ public final class SidecarSessionBootstrap {
   // through from the bootstrap JSON's session.features array. Empty list
   // when the field is absent or signed-out.
   private final List<String> enabledFeatures;
+  private final boolean admin;
 
   public SidecarSessionBootstrap(String address, String websocketAddress) {
-    this(address, websocketAddress, Collections.<String>emptyList());
+    this(address, websocketAddress, Collections.<String>emptyList(), false);
   }
 
   public SidecarSessionBootstrap(
       String address, String websocketAddress, List<String> enabledFeatures) {
+    this(address, websocketAddress, enabledFeatures, false);
+  }
+
+  public SidecarSessionBootstrap(
+      String address, String websocketAddress, List<String> enabledFeatures, boolean admin) {
     this.address = address;
     this.websocketAddress = websocketAddress;
     this.enabledFeatures =
         enabledFeatures == null
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(enabledFeatures));
+    this.admin = admin;
   }
 
   public String getAddress() {
@@ -50,6 +57,11 @@ public final class SidecarSessionBootstrap {
   /** Convenience: returns true when {@code flag} is in {@link #getEnabledFeatures}. */
   public boolean isFeatureEnabled(String flag) {
     return enabledFeatures.contains(flag);
+  }
+
+  /** Returns true when the signed-in user has server-admin or owner privileges. */
+  public boolean isAdmin() {
+    return admin;
   }
 
   public static boolean usesCompatibleCookieHost(String pageHostname, String websocketAddress) {
@@ -136,7 +148,17 @@ public final class SidecarSessionBootstrap {
     if (socketAddress.isEmpty() || "null".equals(socketAddress)) {
       throw new IllegalArgumentException("Bootstrap JSON did not include a socket address");
     }
-    return new SidecarSessionBootstrap(address, socketAddress, extractFeatures(session));
+    boolean isAdmin = extractIsAdmin(session);
+    return new SidecarSessionBootstrap(address, socketAddress, extractFeatures(session), isAdmin);
+  }
+
+  private static boolean extractIsAdmin(Map<String, Object> session) {
+    Object roleValue = session.get("role");
+    if (!(roleValue instanceof String)) {
+      return false;
+    }
+    String role = (String) roleValue;
+    return "admin".equals(role) || "owner".equals(role);
   }
 
   /**

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3928,7 +3928,12 @@ public class J2clComposeSurfaceControllerTest {
             waveId -> { },
             telemetry);
     controller.start();
-    openWaveForReply(controller);
+    // user@example.com is the creator so canTogglePublicity passes; the
+    // gateway error response then triggers the failure-submit path.
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession(
+            "example.com/w+1", "chan-1", 44L, "ABCD", "b+root",
+            Arrays.asList("user@example.com")));
 
     controller.onPublicityToggleRequested("example.com/w+1", true);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3842,6 +3842,75 @@ public class J2clComposeSurfaceControllerTest {
         gateway.lastSubmitRequest.getDeltaJson().contains("\"2\":\"EFGH\""));
   }
 
+
+  @Test
+  public void publicityToggleBlockedForNonCreator() {
+    FakeGateway gateway = new FakeGateway();
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            telemetry);
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession(
+            "example.com/w+1",
+            "chan-1",
+            44L,
+            "ABCD",
+            "b+root",
+            Arrays.asList("alice@example.com", "bob@example.com")));
+
+    controller.onPublicityToggleRequested("example.com/w+1", true);
+
+    Assert.assertEquals(0, gateway.submitCalls);
+    Assert.assertTrue(
+        telemetry.events().stream()
+            .anyMatch(
+                e ->
+                    "compose.publicity_toggled".equals(e.getName())
+                        && "failure-build".equals(e.getFields().get("outcome"))));
+  }
+
+  @Test
+  public void publicityToggleBlockedWhenMakingDirectMessagePublic() {
+    FakeGateway gateway = new FakeGateway();
+    RecordingTelemetrySink telemetry = new RecordingTelemetrySink();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            J2clComposeSurfaceController.richContentDeltaFactory("seed"),
+            waveId -> { },
+            waveId -> { },
+            telemetry);
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession(
+            "example.com/w+1",
+            "chan-1",
+            44L,
+            "ABCD",
+            "b+root",
+            Arrays.asList("bob@example.com", "alice@example.com")));
+
+    controller.onPublicityToggleRequested("example.com/w+1", true);
+
+    Assert.assertEquals(0, gateway.submitCalls);
+    Assert.assertTrue(
+        telemetry.events().stream()
+            .anyMatch(
+                e ->
+                    "compose.publicity_toggled".equals(e.getName())
+                        && "failure-build".equals(e.getFields().get("outcome"))));
+  }
+
   @Test
   public void waveHeaderActionSubmitErrorRecordsFailureTelemetry() {
     RecordingTelemetrySink telemetry = new RecordingTelemetrySink();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3864,7 +3864,8 @@ public class J2clComposeSurfaceControllerTest {
             44L,
             "ABCD",
             "b+root",
-            Arrays.asList("alice@example.com", "bob@example.com")));
+            // alice is the creator; user@example.com is a non-creator participant
+            Arrays.asList("alice@example.com", "user@example.com", "bob@example.com")));
 
     controller.onPublicityToggleRequested("example.com/w+1", true);
 
@@ -3898,7 +3899,8 @@ public class J2clComposeSurfaceControllerTest {
             44L,
             "ABCD",
             "b+root",
-            Arrays.asList("bob@example.com", "alice@example.com")));
+            // user@example.com is the creator; alice is the one other participant (2-person DM)
+            Arrays.asList("user@example.com", "alice@example.com")));
 
     controller.onPublicityToggleRequested("example.com/w+1", true);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -3751,7 +3751,11 @@ public class J2clComposeSurfaceControllerTest {
             waveId -> { },
             waveId -> { });
     controller.start();
-    openWaveForReply(controller);
+    // creator must be the bootstrap user so canTogglePublicity passes
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession(
+            "example.com/w+1", "chan-1", 44L, "ABCD", "b+root",
+            Arrays.asList("user@example.com")));
 
     controller.onPublicityToggleRequested("example.com/w+1", true);
     assertContains(gateway.lastSubmitRequest.getDeltaJson(), "{\"1\":\"@example.com\"}");


### PR DESCRIPTION
### Motivation
- The J2CL header action path allowed any participant with a write session to request making a wave public/private, which omitted the GWT parity checks that restrict publicity toggles to the wave creator (or admin) and block making DMs public. 
- This could result in unauthorized participants adding/removing the shared-domain participant and exposing private or DM contents to a domain. 
- The change restores the intended authorization policy at the controller level to prevent confidentiality breaches.

### Description
- Gate the publicity-toggle flow in `J2clComposeSurfaceController.onPublicityToggleRequested` to call a new `canTogglePublicity(...)` guard that verifies the session, participant list, and that the requester is the creator, and blocks `makePublic` for DM-shaped participant sets. 
- Add helper functions `isDirectMessageParticipants(...)` and `normalizeParticipantAddress(...)` to detect DM-shaped waves and normalize addresses. 
- Add focused unit tests in `J2clComposeSurfaceControllerTest` that assert a non-creator cannot toggle publicity and that attempting to make a DM public is blocked and records `failure-build` telemetry. 

### Testing
- Ran frontend build: `cd j2cl/lit && npm run build` and the build completed successfully. 
- Attempted to run Java unit tests with Maven: `mvn -pl j2cl -Dtest=J2clComposeSurfaceControllerTest test -DskipITs` but the reactor/module selector failed in this environment and the test run did not execute. 
- Attempted `sbt "j2cl/test:compile"` to compile J2CL tests but `sbt` is not installed in the container so compilation could not be performed here. 
- Unit tests were added to cover the rejected paths but could not be executed end-to-end in this environment due to missing build tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3880b8ba88331a9b69314a17b3e87)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened publicity toggle restrictions: only the wave creator can change publicity.
  * Blocking attempts to make direct-message conversations public and rejecting invalid publicity requests.
  * Failed toggle attempts are now reliably recorded for diagnostics.

* **Tests**
  * Added regression tests ensuring non-creators and DM-publish attempts are blocked and telemetry records failure outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->